### PR TITLE
feat(protocol): add one-shot PutBlob uploads

### DIFF
--- a/.context/2026-04-30-putblob-frame-design.md
+++ b/.context/2026-04-30-putblob-frame-design.md
@@ -1,0 +1,489 @@
+# PutBlob typed frame
+
+**Status:** Draft
+**Date:** 2026-04-30
+**Related:** #1814 (PutBlob frame), #1334 (SSH remote runtimes), #1817 (`dx.attach(path)`), #2284 (URI scheme / daemons as peers), [Securing Notebooks](https://www.nteract.io/blog/security)
+
+## Motivation
+
+nteract has two local daemon surfaces by design:
+
+- **Control:** owner-only Unix socket / Windows named pipe.
+- **Data reads:** GET-only localhost HTTP blob server.
+
+That split is part of the public security story. The socket is the authenticated
+control plane; the HTTP blob server exists so browser and opaque-origin iframe
+renderers can fetch content-addressed bytes. It must stay read-only.
+
+Promoting notebook attachments into the document schema exposed the missing
+write-side primitive. Frontend drag/drop, `dx.attach(path)`, runtime-agent blob
+uploads, and remote daemon peers all need a way to put bytes into the daemon
+blob store without:
+
+- inventing feature-specific upload APIs,
+- putting binary bytes into Automerge changes,
+- base64-expanding binary data through JSON request frames,
+- or opening an HTTP write surface.
+
+`PutBlob` is the socket-native upload primitive. It adds one typed binary frame
+to the existing ordered notebook wire and keeps Automerge payloads opaque.
+
+## Goals
+
+1. Add a general, authenticated blob-write primitive over the existing socket.
+2. Keep the localhost HTTP blob server GET-only.
+3. Preserve the CRDT invariant: Automerge documents store intent, metadata, and
+   blob refs; blob bytes live outside Automerge.
+4. Align with Automerge and samod-style transport boundaries: one ordered byte
+   stream, explicit control/data envelopes, opaque Automerge payloads.
+5. Support small one-shot uploads for image attachments without blocking larger
+   protocol work.
+6. Define multipart-style semantics now so large files do not force a later
+   incompatible redesign.
+
+## Non-goals
+
+- Replacing Automerge sync with automerge-repo or samod.
+- Adding HTTP POST/PUT to the blob server.
+- Solving cloud/browser auth. Future HTTPS transports need their own bearer
+  token / CORS model.
+- Making the blob store mutable. Blobs remain content-addressed and immutable.
+- Implementing resumable cross-process uploads in the first patch.
+- Moving notebook attachment authoring to the daemon. The frontend still owns
+  local editing mutations through WASM; `PutBlob` only stores bytes.
+
+## Current state
+
+The typed notebook frame byte space on `origin/main` is:
+
+| Byte | Frame | Payload |
+|------|-------|---------|
+| `0x00` | AutomergeSync | opaque NotebookDoc Automerge bytes |
+| `0x01` | NotebookRequest | JSON envelope |
+| `0x02` | NotebookResponse | JSON envelope |
+| `0x03` | NotebookBroadcast | JSON |
+| `0x04` | Presence | CBOR |
+| `0x05` | RuntimeStateSync | opaque RuntimeStateDoc Automerge bytes |
+| `0x06` | PoolStateSync | opaque PoolDoc Automerge bytes |
+| `0x07` | SessionControl | JSON |
+
+#1814 originally suggested `0x07` for PutBlob. That value is now taken by
+SessionControl, so PutBlob should be `0x08`.
+
+There is also a separate `Handshake::Blob` socket channel that accepts
+`BlobRequest::Store { media_type }` followed by a raw binary frame. Treat that
+as a compatibility bridge, not the long-term shape. The destination is one
+authenticated notebook/runtime peer stream with typed frames, not one side
+channel per capability.
+
+## Design summary
+
+Add frame type:
+
+| Byte | Frame | Payload |
+|------|-------|---------|
+| `0x08` | PutBlob | binary upload envelope |
+
+`PutBlob` payloads use a short self-describing header followed by raw bytes:
+
+```text
+u32 header_len_be
+header bytes: UTF-8 JSON
+body bytes: raw blob or part bytes
+```
+
+The header carries an `id` so acknowledgements route through the existing
+request/response correlation machinery without embedding binary data in JSON.
+Responses are `NotebookResponse` (`0x02`) frames using new blob-upload response
+variants in `NotebookResponseEnvelope`; `PutBlob` (`0x08`) is data-bearing only.
+Do not add a second response path on `0x08`.
+
+Automerge sync frames remain opaque. Receivers only decode Automerge at the
+document actor boundary. `PutBlob` is a sibling data-plane frame, not an
+Automerge extension.
+
+## Upload modes
+
+Two modes share the same frame type.
+
+### One-shot upload
+
+One frame uploads a complete blob:
+
+```json
+{
+  "op": "put",
+  "id": "request-uuid",
+  "media_type": "image/png",
+  "size": 48291,
+  "sha256": "expected_hex",
+  "purpose": "notebook_attachment"
+}
+```
+
+The frame body is the full blob. The daemon:
+
+1. verifies `body.len() == size`,
+2. validates `sha256`,
+3. stores bytes with `BlobStore::put(body, media_type)`,
+4. responds with:
+
+```json
+{
+  "id": "request-uuid",
+  "result": "blob_stored",
+  "hash": "computed_sha256_hex",
+  "size": 48291,
+  "media_type": "image/png"
+}
+```
+
+`sha256` is required for one-shot uploads. The sender already has the full byte
+buffer in memory, and requiring the expected hash makes validation, retries, and
+dedupe semantics explicit. If a future sender truly cannot compute the hash
+before sending, that should be a separate protocol variant rather than an
+optional field whose absence weakens validation.
+
+This is enough for drag/drop images and other small attachment writes.
+
+Phase 1 one-shot uploads are capped by the `PutBlob` frame cap. With the
+starting caps below, files larger than roughly 32 MiB require Phase 3 multipart
+support even though today's `BlobStore::put` limit is 100 MiB. That tradeoff is
+intentional: image attachment upload should not force the first implementation
+to accept 100 MiB frames in the frame pump.
+
+### Multipart upload
+
+Large uploads use explicit multipart semantics. This is intentionally close to
+S3-style multipart behavior, adapted to a single ordered socket:
+
+1. **Create.** Reserve an upload session.
+2. **Upload parts.** Send independently addressable, idempotent parts.
+3. **Complete.** Atomically assemble and publish the final content-addressed
+   blob after all parts validate.
+4. **Abort.** Delete temporary parts and release the session.
+
+The daemon must never expose a partially uploaded blob by final hash before
+`complete` succeeds.
+
+#### Create
+
+Create is JSON control carried as a normal `NotebookRequest` so it reuses the
+existing request/response routing:
+
+```json
+{
+  "type": "create_blob_upload",
+  "media_type": "application/vnd.apache.parquet",
+  "size": 67108864,
+  "sha256": "optional_expected_final_hex",
+  "part_size": 8388608,
+  "purpose": "dx_attach"
+}
+```
+
+Response:
+
+```json
+{
+  "upload_id": "upload-uuid",
+  "part_size": 8388608,
+  "expires_at": "2026-04-30T20:00:00Z"
+}
+```
+
+#### Upload part
+
+Each part is one `PutBlob` frame:
+
+```json
+{
+  "op": "part",
+  "id": "request-uuid",
+  "upload_id": "upload-uuid",
+  "part_number": 1,
+  "size": 8388608,
+  "sha256": "part_sha256_hex"
+}
+```
+
+The body is exactly the part bytes.
+
+Part semantics:
+
+- `part_number` starts at 1 and is stable.
+- Re-sending the same `part_number` with the same part hash is idempotent.
+- Re-sending the same `part_number` with different bytes is an error.
+- Parts may arrive in order in v1, but the protocol should not require that
+  forever. The `(part_number, size, sha256)` tuple is the durable ordering
+  contract.
+- The receiver acknowledges each part after it is durably staged.
+
+Do not include an `offset` field in v1. Multipart protocols such as S3 assemble
+parts in part-number order; duplicating that with an offset introduces a second
+source of truth and unnecessary validation edge cases.
+
+#### Complete
+
+Complete is JSON control:
+
+```json
+{
+  "type": "complete_blob_upload",
+  "upload_id": "upload-uuid",
+  "parts": [
+    {"part_number": 1, "sha256": "part_sha256_hex", "size": 8388608},
+    {"part_number": 2, "sha256": "part_sha256_hex", "size": 12345}
+  ]
+}
+```
+
+The daemon validates:
+
+- no missing parts,
+- no duplicate part numbers,
+- staged part hash and size match the manifest,
+- concatenated size matches the declared total size,
+- final SHA-256 matches the declared final hash when provided.
+
+Only then does it write or link the final content-addressed blob and respond:
+
+```json
+{
+  "result": "blob_stored",
+  "hash": "final_sha256_hex",
+  "size": 67108864,
+  "media_type": "application/vnd.apache.parquet"
+}
+```
+
+The current `BlobStore::put` rejects blobs above 100 MiB. Multipart does not
+automatically change that storage invariant: either complete rejects final blobs
+above the configured blob size limit, or the multipart implementation lands
+with a deliberate blob-store limit increase and streaming assembly path. Do not
+silently imply that multipart can publish larger-than-supported blobs.
+
+#### Abort and cleanup
+
+Abort is JSON control:
+
+```json
+{"type": "abort_blob_upload", "upload_id": "upload-uuid"}
+```
+
+The daemon also garbage-collects expired upload sessions. Temporary upload parts
+must live outside the content-addressed blob namespace until completion.
+
+### Upload session ownership
+
+Multipart session state is shared across JSON control requests and `PutBlob`
+part frames. Store it in a peer-scoped upload registry owned by the connection
+or peer session, not in global daemon state. The registry tracks:
+
+- `upload_id`,
+- media type and expected final size/hash,
+- negotiated part size and expiry,
+- staged part hashes/sizes,
+- pending byte count.
+
+Peer-scoped state prevents one client from completing or aborting another
+client's upload by guessing an `upload_id`, and gives the daemon a clear place
+to enforce per-peer byte budgets.
+
+## Flow control and fairness
+
+Large uploads must not starve sync, request, presence, or session-control
+traffic.
+
+Rules:
+
+- Keep part frames bounded. Start with an 8 MiB part cap and a 32 MiB absolute
+  `PutBlob` frame cap.
+- Handle `PutBlob` in the main frame loop by enqueueing blob writes to a bounded
+  worker, then return to reading frames.
+- Limit in-flight upload bytes per peer. A good v1 default is one in-flight part
+  per upload and one active upload per peer.
+- Limit staged-but-uncompleted bytes per peer. Expired or aborted sessions must
+  release that budget and delete temporary parts.
+- A peer that exceeds caps gets a structured error response and the frame is
+  discarded after read.
+- Multipart upload is opt-in. Small uploads should not pay the session cost.
+
+This keeps the first implementation small while leaving room for higher
+throughput later.
+
+Implementation requirement: do not let `FramedReader` queue many large
+`PutBlob` frames in memory. Either lower the reader queue capacity for
+blob-enabled connections or make the peer loop apply backpressure before another
+large frame can be enqueued. The one-active-part rule must be enforced by the
+daemon, not trusted to clients.
+
+## Security model
+
+`PutBlob` is allowed only on authenticated socket/pipe connections. Same-machine
+auth remains the OS owner boundary:
+
+- Unix socket: filesystem permissions (`0600`) and parent directory ownership.
+- Windows named pipe: user-scoped pipe ACLs.
+- SSH transport: SSH is the auth boundary.
+- Future HTTPS transport: out of scope until bearer-token/CORS policy exists.
+
+Do not add blob writes to the localhost HTTP server. The HTTP server remains:
+
+- `GET /blob/{sha256}`
+- `GET /plugins/{name}`
+- health-style read endpoints only
+
+This matters because output iframes are intentionally opaque-origin and the blob
+server currently uses localhost HTTP for renderer fetches. A write-capable HTTP
+blob server would create a new browser-origin attack surface.
+
+## CRDT integration
+
+`PutBlob` only stores bytes. It does not mutate NotebookDoc or RuntimeStateDoc by
+itself.
+
+Examples:
+
+- Drag/drop image into a markdown cell:
+  1. frontend uploads bytes with one-shot `PutBlob`,
+  2. daemon returns `{hash, media_type, size}`,
+  3. frontend performs a normal WASM-authored NotebookDoc mutation that inserts
+     or updates the nbformat attachment ref and markdown source.
+- Runtime agent output:
+  1. agent uploads or writes bytes,
+  2. agent writes a RuntimeStateDoc output manifest with `ContentRef::Blob`.
+- Remote daemon peer:
+  1. peer sends needed blobs over `PutBlob`,
+  2. Automerge sync carries refs and document state separately.
+
+This separation avoids treating the blob store as CRDT state while still making
+the CRDT the source of truth for references.
+
+## Capability negotiation
+
+Adding a frame type is not useful unless clients can know it is safe to send.
+
+Add a capability such as:
+
+```json
+{
+  "put_blob": {
+    "version": 1,
+    "single_frame_max": 33554432,
+    "default_part_size": 8388608,
+    "multipart": true
+  }
+}
+```
+
+Expose this as an optional field on both handshake response shapes clients
+already read:
+
+- `ProtocolCapabilities` for direct `NotebookSync` handshakes,
+- `NotebookConnectionInfo` for open/create notebook handshakes.
+
+Clients MUST NOT send `0x08` unless the current connection advertised
+`put_blob`. Older daemons may discard unknown frame types without response, so a
+capability violation can hang. Treat missing capability as "feature unavailable"
+and fall back to existing paths or disable upload features.
+
+Whether this requires bumping `PROTOCOL_VERSION` depends on rollout:
+
+- If `0x08` is optional and capability-gated, it can be additive.
+- If any required client path depends on it, bump the protocol and update
+  frontend/TS contract tests in the same PR.
+
+## Rollout plan
+
+This should not block unrelated notebook or runtime work. Break it into narrow,
+reviewable slices:
+
+### Phase 0: Spec and frame contract
+
+- Land this design.
+- Add `PUT_BLOB = 0x08` constants, TypeScript constants, frame caps, protocol
+  contract tests, and docs.
+- Add capability shape, but no production caller.
+- Add blob-upload `NotebookResponseEnvelope` variants and document that
+  `0x08` never carries responses.
+- Update the Tauri relay and host transport allowlists so frontend-originated
+  `0x08` frames can be forwarded once callers exist.
+
+### Phase 1: One-shot socket upload
+
+- Implement single-frame `op: "put"`.
+- Keep `Handshake::Blob` channel intact.
+- Add a Rust client helper that uploads bytes and returns `{hash, size,
+  media_type}`.
+- Cover with daemon protocol tests and cap/error tests.
+- Enforce `sha256` as required and return structured errors for missing or
+  mismatched hashes.
+
+### Phase 2: Markdown attachment ingestion
+
+- Add a high-level attachment API that takes attachment name, MIME type, and raw
+  bytes.
+- Use one-shot `PutBlob` for the bytes.
+- Write the NotebookDoc mutation through the existing frontend/WASM local edit
+  path.
+- Ship drag/drop images on this path.
+
+### Phase 3: Multipart sessions
+
+- Add create/part/complete/abort.
+- Stage temporary parts outside the blob namespace.
+- Add timeout cleanup and idempotent retry tests.
+- Enforce per-peer staged-byte budgets.
+- Keep final object size within the configured blob-store limit unless that
+  phase explicitly raises the limit and adds streaming assembly support.
+- Start using this for `dx.attach(path)` and large local files.
+
+### Phase 4: Remote peers and legacy cleanup
+
+- Use multipart `PutBlob` for remote runtime / daemon peer blob movement.
+- Deprecate `Handshake::Blob::Store`.
+- Keep `Handshake::Blob::GetPort` or replace it with daemon-info capability
+  depending on the state of the blob-port API at that point.
+
+## Testing
+
+- Protocol contract: Rust and TypeScript frame constants include `PUT_BLOB`.
+- Frame caps: oversized `PutBlob` frames are rejected without corrupting the
+  frame stream.
+- One-shot success: upload bytes, assert blob exists, metadata matches, and the
+  hash is content-addressed.
+- Missing one-shot hash: request fails before publishing a blob.
+- Hash mismatch: declared SHA-256 mismatch returns error and does not publish a
+  blob under the declared hash.
+- Multipart idempotency: repeated identical part succeeds; conflicting repeat
+  fails.
+- Multipart complete: missing, duplicate, wrong-size, wrong-hash, and wrong
+  final-hash manifests fail.
+- Abort/expiry: staged parts are removed and never become readable blobs.
+- Budget: pending multipart bytes are capped per peer and released on abort,
+  completion, expiry, and disconnect.
+- Fairness: a peer uploading parts does not block Automerge sync or request
+  responses behind long blob writes.
+
+## Open questions
+
+1. Should one-shot uploads be internally implemented as a single-part multipart
+   session for code reuse, or should they take the direct `BlobStore::put` fast
+   path?
+2. What is the right default part size on Windows named pipes?
+3. Do we need per-purpose policy caps, e.g. smaller for notebook attachments and
+   larger for `dx.attach`?
+4. When remote daemon peers need missing blobs referenced by Automerge state,
+   should they push eagerly or request blobs lazily by hash?
+
+## Review checklist
+
+- Does the design keep HTTP blob reads separate from socket-authenticated blob
+  writes?
+- Are Automerge sync bytes treated as opaque payloads?
+- Does multipart avoid exposing partial uploads?
+- Does the rollout let image attachments ship without waiting for remote
+  runtime blob replication?
+- Are all frame constants, caps, TS contracts, and protocol docs listed in the
+  implementation phase?

--- a/.context/comm-buffer-paths-blob-upload-plan.md
+++ b/.context/comm-buffer-paths-blob-upload-plan.md
@@ -1,0 +1,234 @@
+# Comm Buffer Paths And Blob Upload Lanes Plan
+
+> **For agentic workers:** This is an evaluation plan, not an execution script. If accepted, turn each phase into small commits and use the repo-local `testing` and `pr-reviewer` workflows before marking a PR ready.
+
+**Goal:** Make browser/frontend-originated widget state updates support Jupyter comm `buffer_paths` without putting binary bytes into Automerge or blocking latency-sensitive notebook traffic.
+
+**Architecture:** Blob upload rides the shared notebook-sync socket as a typed `PutBlob` frame (`0x08`); see `.context/putblob-sequencing-plan.md` and `.context/2026-04-30-putblob-frame-design.md` for the transport. RuntimeStateDoc remains JSON/CRDT state with ContentRefs at binary leaves, and the runtime agent reconstructs Jupyter `comm_msg(update)` buffers before forwarding to the kernel. No separate bulk lane.
+
+**Tech Stack:** TypeScript widget bridge, WASM RuntimeStateDoc bindings, Rust typed notebook frames, daemon/runtime-agent blob store, Jupyter comm protocol.
+
+---
+
+## Current Behavior
+
+Inbound kernel-to-frontend binary widget state already works:
+
+1. Kernel sends `comm_open` / `comm_msg` with `data.state`, `data.buffer_paths`, and binary `buffers`.
+2. `crates/runtimed/src/output_prep.rs::store_widget_buffers` stores buffers in the blob store.
+3. RuntimeStateDoc stores ContentRefs in `comms[comm_id].state`.
+4. WASM `resolve_comm_state` projects ContentRefs to blob URLs plus `bufferPaths`.
+5. `src/isolated-renderer/widget-bridge-client.ts` fetches those URLs and installs `DataView`s before widget code reads state.
+
+Frontend-to-kernel binary widget state does not work yet:
+
+1. anywidget/jscatter calls `model.set("selection", { view: DataView, dtype, shape })`.
+2. The iframe bridge sends the patch to the parent.
+3. `WidgetUpdateManager` eventually calls `handle.set_comm_state_batch(commId, JSON.stringify(patch))`.
+4. `DataView` cannot survive JSON serialization, so `view` becomes `{}`.
+5. The runtime agent diffs RuntimeStateDoc and sends a `comm_msg(update)` with `buffer_paths: []`.
+6. jscatter's Python deserializer expects `value["view"]` to be a real buffer and fails or resets the visible selection.
+
+## Design Principles
+
+- Keep the HTTP blob server read-only.
+- Keep Automerge/RuntimeStateDoc JSON-only: metadata and ContentRefs, not raw bytes.
+- Preserve Jupyter comm semantics: `buffer_paths` belongs to `comm_msg.data` and indexes into `buffers`.
+- Do not route ordinary widget state updates through direct `SendComm` as a workaround; that bypasses the durable CRDT state path and weakens multi-peer behavior.
+- Avoid head-of-line blocking: large `PutBlob` work must be capped and handled with the flow-control rules in `.context/putblob-sequencing-plan.md` so it does not delay interrupts, runtime logs, widget updates, or sync replies.
+
+## Proposed Logical Flow
+
+Frontend-originated binary widget update:
+
+1. Widget code produces a state patch with binary leaves, for example:
+   ```ts
+   {
+     selection: {
+       view: DataView,
+       dtype: "uint32",
+       shape: [123],
+     },
+   }
+   ```
+2. Frontend extracts binary leaves into:
+   ```ts
+   {
+     jsonPatch: {
+       selection: {
+         view: { blob: "...", size: 492, media_type: "application/octet-stream" },
+         dtype: "uint32",
+         shape: [123],
+       },
+     },
+     bufferPaths: [["selection", "view"]],
+   }
+   ```
+3. Each extracted buffer is uploaded through `putBlob(bytes, mediaType, purpose)`.
+4. Frontend writes `jsonPatch` into RuntimeStateDoc and triggers runtime-state sync.
+5. Runtime agent diffs comm state, walks changed values, resolves ContentRefs back into bytes, and sends:
+   ```json
+   {
+     "method": "update",
+     "state": {
+       "selection": {
+         "view": null,
+         "dtype": "uint32",
+         "shape": [123]
+       }
+     },
+     "buffer_paths": [["selection", "view"]]
+   }
+   ```
+   with `buffers[0]` set to the uploaded bytes.
+
+The placeholder at `state.selection.view` should follow Jupyter widget expectations. Existing Python `ipywidgets` removes buffers by replacing leaves with `null`/placeholder JSON and pairing them with `buffer_paths`. Confirm the exact placeholder shape against a real ipywidgets frontend before implementation.
+
+## Transport
+
+Widget buffers ride the shared notebook-sync socket as one-shot `PutBlob` (`0x08`) frames. See `.context/putblob-sequencing-plan.md` for sequencing across all PutBlob consumers (widgets, attachments, `dx.attach`, SSH remote runtimes) and `.context/2026-04-30-putblob-frame-design.md` for wire shape and flow control.
+
+Frontend API exposed by this plan is just the caller-side wrapper:
+
+```ts
+putBlob(bytes: ArrayBuffer, mediaType: string): Promise<{ blob: string; size: number; media_type: string }>
+```
+
+Widget selection buffers (jscatter-style, KB–MB) fit inside the one-shot frame cap; no bulk lane is introduced by this plan. Multipart is deferred to the sequencing plan's Phase 5 and is only reached when `dx.attach` or remote-peer replication needs it.
+
+**Ordering invariant:** the frontend MUST await `putBlob` before writing the ContentRef into RuntimeStateDoc. The local runtime-agent shares the blob-store filesystem and sees bytes immediately on return, but the invariant must hold for future remote agents.
+
+## Phase 1: Contract And Test Reproduction
+
+**Files to inspect or modify:**
+
+- `src/components/widgets/anywidget-view.tsx`
+- `src/isolated-renderer/widget-bridge-client.ts`
+- `src/components/isolated/comm-bridge-manager.ts`
+- `src/components/widgets/widget-update-manager.ts`
+- `apps/notebook/src/App.tsx`
+- `crates/runtimed-wasm/src/lib.rs`
+- `crates/runtimed/src/runtime_agent.rs`
+- `crates/runtimed/src/output_prep.rs`
+- `crates/notebook-protocol/src/protocol.rs`
+- `crates/notebook-wire/src/lib.rs` (frame-type constants live here; there is no `frame_types.rs`)
+
+Tasks:
+
+- [ ] Add a focused unit test proving a frontend patch containing `DataView` currently loses the buffer when passed through the RuntimeStateDoc write path.
+- [ ] Add a fixture for a jscatter-style patch: `{ selection: { view: DataView, dtype: "uint32", shape: [3] } }`.
+- [ ] Confirm the Jupyter placeholder shape for state leaves listed in `buffer_paths`.
+- [ ] Decide whether `bufferPaths` should be explicit from the widget bridge or inferred by scanning `DataView` leaves.
+
+## Phase 2: Frontend Buffer Extraction
+
+Add a frontend helper with one responsibility: convert a widget state patch into JSON plus binary uploads.
+
+Candidate file:
+
+- Create `src/components/widgets/comm-buffer-extraction.ts`
+- Test `src/components/widgets/__tests__/comm-buffer-extraction.test.ts`
+
+Behavior:
+
+- Walk plain objects and arrays.
+- Detect `DataView`, `ArrayBuffer`, and typed arrays.
+- Extract bytes as exact byte ranges, respecting `byteOffset` and `byteLength`.
+- Replace the binary leaf with the chosen Jupyter placeholder.
+- Return `bufferPaths` in the same order as extracted `buffers`.
+- Reject unsupported cyclic/non-cloneable values with a clear error.
+
+## Phase 3: Blob Upload Client
+
+Use the one-shot frontend blob upload API from `.context/putblob-sequencing-plan.md` Phase 2.
+
+Candidate files:
+
+- Create `src/lib/blob-upload-client.ts`
+- Modify the notebook socket/WebSocket transport layer that currently sends typed frames.
+- Add Rust frame support if `PutBlob` frame is not implemented yet.
+
+Behavior:
+
+- `putBlob` computes SHA-256 before upload.
+- Send widget buffers as one-shot `PutBlob` frames.
+- Reject or defer values larger than the advertised one-shot cap; widget state does not introduce a separate bulk lane.
+- Return the existing ContentRef shape: `{ blob, size, media_type }`.
+- Expose capability information so callers know whether binary widget updates are supported.
+
+## Phase 4: RuntimeStateDoc Write Path
+
+Modify the frontend widget update path:
+
+- `WidgetBridgeClient.sendUpdate` should preserve local optimistic `DataView` state for the iframe.
+- `CommBridgeManager.handleWidgetCommMsg` should pass binary-aware state to the parent update path.
+- `WidgetUpdateManager.updateAndPersist` should accept either plain JSON patches or pre-extracted `{ jsonPatch, bufferPaths }`.
+- `apps/notebook/src/App.tsx` should upload buffers before calling `set_comm_state_batch`.
+
+Important boundary:
+
+- RuntimeStateDoc stores ContentRefs only.
+- The frontend WidgetStore can keep `DataView`s for local responsiveness.
+- Echo suppression must compare the user-visible value, not the ContentRef object.
+
+## Phase 5: Runtime Agent Rehydration
+
+Modify the runtime-agent comm diff path:
+
+- `diff_comm_state` currently returns `(comm_id, serde_json::Value)` only.
+- Add a helper that walks each delta, finds ContentRefs at binary leaves, loads bytes from `ctx.blob_store`, replaces those leaves with the Jupyter placeholder, and returns `(state, buffer_paths, buffers)`.
+- Extend `KernelConnection::send_comm_update` to accept buffer paths and buffers.
+- Update `JupyterKernel::send_comm_update` to send real Jupyter comm buffers instead of always emitting `buffer_paths: []`.
+
+This keeps kernel delivery compatible with traitlets serializers such as jscatter's `binary_to_array`.
+
+## Phase 6: (removed)
+
+The original "bulk lane" phase is deleted. If widget buffers ever exceed the one-shot cap, reach for multipart (`.context/putblob-sequencing-plan.md` Phase 5), not a second socket.
+
+## Phase 7: Verification
+
+Targeted tests:
+
+- Frontend extraction tests for `DataView`, typed arrays, nested paths, and arrays.
+- Widget bridge tests proving iframe-originated binary state reaches the parent update manager with paths preserved.
+- WASM/RuntimeStateDoc tests proving ContentRefs at comm state leaves project back to `bufferPaths`.
+- Rust runtime-agent tests proving ContentRefs in a frontend-originated comm delta become Jupyter `buffer_paths + buffers`.
+- Browser E2E with jscatter:
+  1. render scatter,
+  2. lasso points,
+  3. execute `jpl.selection`,
+  4. assert selected indices remain non-empty and the visual selection does not disappear.
+
+Manual checks:
+
+- Lasso selection in nteract.
+- Filter selection in nteract.
+- Existing ipywidgets sliders/buttons still update.
+- Output widgets still render nested plotly/vega/sift outputs.
+- Large stdout/log output remains responsive while a blob upload is active.
+
+Required before commit:
+
+```bash
+cargo xtask lint --fix
+```
+
+## Open Questions
+
+- What exact placeholder should state use at paths listed in `buffer_paths` when forwarding to the kernel?
+- Should frontend extraction infer buffer paths from binary leaves, or should the AFM model proxy track keys that serializers produced?
+- Should `PutBlob` return only `{hash, size, media_type}` or the full ContentRef object?
+- Should widget updates fail hard or degrade to a logged no-op when the connection lacks `put_blob` capability?
+- Do we need multipart now, or is one-shot sufficient until notebook attachments/dx attach land?
+
+## Recommended First PR
+
+After `.context/putblob-sequencing-plan.md` Phase 2 exists, keep the first widget implementation narrow:
+
+1. Add buffer extraction helper and tests.
+2. Add runtime-agent rehydration tests around a synthetic comm delta.
+3. Wire extracted buffers through the one-shot `putBlob` frontend client.
+4. Prove jscatter selection round-trips in a browser E2E.
+
+Defer multipart until one-shot widget buffers are correct.

--- a/.context/putblob-sequencing-plan.md
+++ b/.context/putblob-sequencing-plan.md
@@ -1,0 +1,144 @@
+# PutBlob sequencing plan
+
+**Goal:** Land one socket-native blob-write primitive (`0x08 PutBlob`) that serves widgets, markdown attachments, `dx.attach`, and eventually SSH remote runtimes. Keep it simple, performant, maintainable.
+
+**Related:**
+- #1814 — Add PutBlob frame (this is the implementation)
+- #1334 — SSH remote runtimes (consumer, not a dep)
+- `.context/2026-04-30-putblob-frame-design.md` (the design spec, kept out-of-tree per repo convention)
+- `.context/comm-buffer-paths-blob-upload-plan.md` (widget-side consumer; this plan replaces its "transport lanes" section)
+
+---
+
+## Current state (verified against `main`)
+
+- Frame byte space: `0x00..=0x07` are taken. `0x07` is `SessionControl`. PutBlob = `0x08`. (`crates/notebook-wire/src/lib.rs:9-35`)
+- Frame pump already has per-type caps, size-limit warnings, and a cancel-safe `FramedReader`. (`crates/notebook-wire/src/lib.rs:56-95`, `crates/runtimed/src/runtime_agent.rs:87`)
+- Existing blob write paths:
+  - **Local runtime-agent:** shares the blob-store filesystem with the daemon; uses `Arc<BlobStore>` directly (`crates/runtimed/src/runtime_agent.rs:104`, `crates/runtimed/src/output_prep.rs:208`). No wire traffic. This works for in-process + same-host agents; it does not work for SSH.
+  - **Out-of-process `Handshake::Blob` channel:** second socket connection accepting `BlobRequest::Store { media_type }` + raw binary frame (`crates/runtimed/src/daemon.rs:3098-3148`). No current in-tree caller; kept for back-compat. This is the thing PutBlob deprecates.
+  - **Frontend:** no blob write path at all today. Drag/drop, widget binary state, and `dx.attach` can't upload bytes over the wire.
+- Tauri relay allow-list at `crates/notebook/src/lib.rs:2778` explicitly rejects any outbound frame type outside `{AUTOMERGE_SYNC, REQUEST, PRESENCE, RUNTIME_STATE_SYNC, POOL_STATE_SYNC}` — PutBlob is blocked at the host-transport boundary until that allow-list includes it.
+
+## Design anchor
+
+Use the `.context/2026-04-30-putblob-frame-design.md` spec verbatim:
+
+- Frame `0x08`, body = `u32 header_len | JSON header | bytes`.
+- Responses ride `0x02 Response` via new `NotebookResponse` variants, correlated by `id`.
+- Multipart create/complete/abort ride normal `0x01 Request` JSON — no new response path on `0x08`.
+- Capability: `put_blob { version, single_frame_max, default_part_size, multipart }` advertised in existing handshake capability shapes.
+- Unix-socket / named-pipe owner auth remains the security boundary. HTTP blob server stays GET-only.
+- Blob bytes never enter Automerge.
+
+Two small corrections to lock in from the dive:
+
+1. The draft says "Add a Rust client helper that uploads bytes." That helper already has a near-sibling inside `runtimed-client`; pick one place and don't fork it. Recommendation: put the client inside the notebook-sync connection (so it shares framing/backpressure) and expose a thin `put_blob(bytes, media_type) -> ContentRef` wrapper from `runtimed-client`.
+2. The draft says "Keep `Handshake::Blob` channel intact." Fine for Phase 1, but mark `BlobRequest::Store` as deprecated in doc-comments in the same PR so no new callers appear. `GetPort` has no replacement yet and must stay.
+
+## Why this replaces the widget plan's "transport lanes" idea
+
+`.context/comm-buffer-paths-blob-upload-plan.md` Section "Transport Lanes" proposes a main lane / bulk lane split with a separate Unix socket. That's more machinery than needed:
+
+- The existing notebook socket already has per-type frame caps and fair frame reading; widget selection buffers (~KB) are tiny compared to the 32 MiB single-frame cap the spec proposes.
+- A second socket doubles auth surface, connection lifecycle, reconnection semantics, and handshake-capability plumbing for what is structurally the same concern the frame pump already solves with caps.
+- Multipart (Phase 3 in the spec) is the right answer for "don't block sync behind one huge upload." Per-peer one-active-part + bounded worker (spec §"Flow control and fairness") give the same fairness guarantee with one transport.
+
+**Recommendation:** drop the bulk-lane section from the widget plan. Widget buffers ship on the single shared notebook socket.
+
+## Sequencing
+
+### Phase 0 — land the spec and the frame bytes (day-scale, no behavior)
+
+- [ ] Add `PUT_BLOB = 0x08` constants + `NotebookFrameType::PutBlob` variant + `frame_size_limits` entry (start: cap 32 MiB, warn 8 MiB) in `crates/notebook-wire/src/lib.rs`.
+- [ ] Add TS constant mirror in `crates/notebook-protocol/src/typescript.rs` generated output.
+- [ ] Add blob-upload response variants to `NotebookResponse` (no handler yet).
+- [ ] Add `put_blob` to the capability shapes in `ProtocolCapabilities` + `NotebookConnectionInfo`, default `None`.
+- [ ] Add `0x08` to the Tauri relay allow-list at `crates/notebook/src/lib.rs:2778` so the frontend can send it once callers exist.
+- [ ] Protocol contract tests: constant presence Rust + TS, frame-cap rejection round-trip.
+- [ ] **No production caller in this phase.**
+
+Exit criteria: `cargo xtask lint --fix` clean, `cargo test -p notebook-wire -p notebook-protocol` green, no runtime behavior change.
+
+### Phase 1 — one-shot upload, server side
+
+- [ ] Implement `op: "put"` handling on the notebook-sync connection: read header, validate `size` == body length, verify `sha256`, call `BlobStore::put`, reply with `BlobStored` response.
+- [ ] Advertise `put_blob` capability from the daemon handshake.
+- [ ] Structured errors: `BlobUploadError { id, reason }` with distinct reasons (`size_mismatch`, `hash_mismatch`, `over_cap`, `io`).
+- [ ] Tests: success, size mismatch, hash mismatch, oversize frame, unknown media type passes through, cap enforcement.
+- [ ] Decision-lock on spec open question 1: one-shot takes the direct `BlobStore::put` fast path. Multipart reuses that plus a staging dir; do not collapse them.
+
+Exit criteria: daemon advertises capability, accepts one-shot uploads from a test client, existing `Handshake::Blob::Store` still works.
+
+### Phase 2 — one-shot client (shared)
+
+- [ ] Rust client: `put_blob_one_shot(conn, bytes, media_type) -> Result<BlobStored>` on the notebook-sync connection object. Single source of truth.
+- [ ] Frontend client: `putBlob(bytes, mediaType)` in the existing notebook-socket wrapper. Reuse the typed-frame send path. Gate on capability.
+- [ ] Fallback behavior when capability absent: clear error, no silent drop. Callers pick what to do (widget path: degrade to a no-op warning + log; attachment path: disable drop zone).
+
+Exit criteria: both clients upload to the real daemon. Capability gating verified with a server that omits the capability.
+
+### Phase 3 — widget binary state (first real consumer)
+
+This is the `.context/comm-buffer-paths-blob-upload-plan.md` work, now scoped down:
+
+- [ ] Keep the widget plan's Phase 1 (reproduction test) and Phase 2 (`comm-buffer-extraction.ts`).
+- [ ] Replace its Phase 3 with: call the Phase 2 frontend `putBlob` client. No new transport machinery.
+- [ ] Keep its Phase 4 (RuntimeStateDoc write path) and Phase 5 (runtime-agent rehydration).
+- [ ] Delete its Phase 6 (bulk lane). If it turns out one selection buffer is big enough to matter, revisit *after* Phase 5 of this plan.
+
+Ordering invariant to add to the widget plan: frontend MUST await `putBlob` before writing the ContentRef into RuntimeStateDoc. Otherwise the runtime-agent diff path may resolve a ContentRef whose bytes are not yet durable. (Daemon-local agents see the blob the moment `put` returns because they share the filesystem; this invariant keeps the protocol honest for remote agents too.)
+
+Exit criteria: jscatter lasso round-trips in an E2E.
+
+### Phase 4 — attachments + markdown ingestion
+
+Picks up spec Phase 2. Consumes the same one-shot path. Independent of widgets; can interleave.
+
+### Phase 5 — multipart
+
+Spec Phase 3 verbatim. Required before `dx.attach(path)` can upload files larger than the single-frame cap. Required before SSH remote agents can move big outputs (parquet, images).
+
+Explicit dependencies on prior phases:
+- Peer-scoped upload registry (spec §"Upload session ownership") — keyed by the existing connection identity from handshake.
+- Per-peer byte budget enforcement + expiry GC — shares the bounded-worker pattern from Phase 1.
+
+Exit criteria: `dx.attach` of a 200 MiB parquet lands as a single content-addressed blob, aborts clean, concurrent sync traffic stays responsive.
+
+### Phase 6 — remote peers, legacy cleanup
+
+- [ ] SSH remote runtime-agent switches from "shared `BlobStore` filesystem" to PutBlob over the forwarded socket. This removes the "separate blob-store path / tunneled socket" clause in #1334's blob-upload section.
+- [ ] Deprecate `Handshake::Blob::Store`; keep `GetPort` or migrate callers to a daemon-info capability response.
+
+## Decisions that don't have to wait
+
+These are independent of the phase order but belong in the plan for visibility:
+
+- **Where the client lives:** one Rust client inside the notebook-sync connection object, re-exported through `runtimed-client`. No second helper crate.
+- **One-shot implementation:** direct `BlobStore::put` fast path; multipart is its own staging path. (Resolves spec OQ 1.)
+- **Purpose field:** keep in the header but don't use it for policy in v1. Log + reserve. (Resolves spec OQ 3 by deferring.)
+- **Frame caps:** 32 MiB single-frame, 8 MiB default part. Revisit after the frame pump has real traffic. Named-pipe defaults are identical until measurements say otherwise. (Resolves spec OQ 2 by picking a default and moving on.)
+- **Remote push vs pull:** defer. The SSH phase picks one at implementation time. (Spec OQ 4.)
+
+## What each consumer actually needs
+
+| Consumer | Needs | Phase |
+|---|---|---|
+| Widgets (jscatter-style binary state) | One-shot, small (KB-MB) | 3 |
+| Markdown attachment drag/drop | One-shot, small-medium | 4 |
+| `dx.attach(path)` small files | One-shot | 4 |
+| `dx.attach(path)` large files | Multipart | 5 |
+| Runtime-agent output bytes (local, same host) | Nothing — keeps `Arc<BlobStore>` | — |
+| Runtime-agent output bytes (SSH remote) | Multipart | 6 |
+| Remote-peer blob replication | Multipart + maybe lazy pull | 6 |
+
+## Risks
+
+1. **Echo suppression.** When the runtime agent reads back a ContentRef it originated, it must not re-emit or re-resolve it. Solve in the widget phase (phase 3 of this plan, rehydration step) by tagging resolved bytes by hash and comparing, not by ContentRef identity.
+2. **Capability rollout drift.** A new daemon talking to an old frontend (and vice versa) must not hang. The spec already mandates capability gating; keep the TS contract test that asserts "client refuses to send 0x08 without capability" in Phase 0.
+3. **Framed reader memory pressure.** The reader can buffer several max-size frames before the peer loop dequeues. For PutBlob, clamp queue depth or backpressure before read; spec §"Flow control" calls this out. Land as part of Phase 1 — do not defer.
+4. **Control-plane starvation.** CLAUDE.md invariant: runtime control-plane signals must not share bounded output transport with floods. PutBlob must be on the runtime-sync transport reader but processed through its own bounded worker so `ExecutionDone` / `KernelIdle` don't wait behind a 32 MiB blob write. Belongs in Phase 1.
+
+## First PR (narrow)
+
+Phase 0 only: constants, caps, response variants, capability field, Tauri allow-list, TS contract test, docs. Zero behavior change. This is the smallest reviewable slice and unblocks every downstream phase in parallel.

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -358,6 +358,18 @@ mod tests {
         assert!(info.notebook_path.is_none());
     }
 
+    #[test]
+    fn protocol_capabilities_advertise_put_blob_frame_limit() {
+        let caps = ProtocolCapabilities::v4(Some("0.1.0+abc123".into()));
+        let put_blob = caps.put_blob.expect("PutBlob is advertised");
+        assert_eq!(put_blob.version, 1);
+        assert_eq!(
+            put_blob.single_frame_max,
+            frame_size_limits(notebook_wire::frame_types::PUT_BLOB).cap as u64
+        );
+        assert!(!put_blob.multipart);
+    }
+
     #[tokio::test]
     async fn typed_frame_rejects_oversized_presence() {
         // Presence frames cap at 1 MiB. A desync that happens to land

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -281,6 +281,7 @@ mod tests {
             error: None,
             ephemeral: false,
             notebook_path: None,
+            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
@@ -299,6 +300,7 @@ mod tests {
             error: None,
             ephemeral: false,
             notebook_path: None,
+            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
@@ -315,6 +317,7 @@ mod tests {
             error: None,
             ephemeral: false,
             notebook_path: None,
+            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""needs_trust_approval":true"#));
@@ -330,6 +333,7 @@ mod tests {
             error: Some("File not found".into()),
             ephemeral: false,
             notebook_path: None,
+            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""error":"File not found""#));
@@ -345,6 +349,7 @@ mod tests {
             error: None,
             ephemeral: false,
             notebook_path: Some("/home/user/notebook.ipynb".into()),
+            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));
@@ -445,6 +450,34 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn typed_frame_rejects_oversized_put_blob() {
+        let cap = frame_size_limits(notebook_wire::frame_types::PUT_BLOB).cap;
+        let body_len: u32 = (cap as u32) + 1;
+        let total_len: u32 = body_len + 1;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&total_len.to_be_bytes());
+        buf.push(notebook_wire::frame_types::PUT_BLOB);
+        let mut cursor = std::io::Cursor::new(buf);
+        let err = recv_typed_frame(&mut cursor).await.unwrap_err();
+        assert!(err.to_string().contains("too large for type 0x08"));
+    }
+
+    #[tokio::test]
+    async fn typed_frame_sends_put_blob_under_cap() {
+        let cap = frame_size_limits(notebook_wire::frame_types::PUT_BLOB).cap;
+        let payload = vec![0x42u8; cap];
+        let mut buf = Vec::new();
+        send_typed_frame(&mut buf, NotebookFrameType::PutBlob, &payload)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::PutBlob);
+        assert_eq!(frame.payload.len(), payload.len());
+    }
+
     #[test]
     fn frame_size_limits_cover_every_known_frame_type() {
         // Pin the per-type cap table so a new frame type can't slip in
@@ -461,6 +494,7 @@ mod tests {
             ft::RUNTIME_STATE_SYNC,
             ft::POOL_STATE_SYNC,
             ft::SESSION_CONTROL,
+            ft::PUT_BLOB,
         ] {
             let limits = frame_size_limits(ty);
             assert!(
@@ -537,6 +571,10 @@ mod tests {
         assert_eq!(
             NotebookFrameType::try_from(0x03).unwrap(),
             NotebookFrameType::Broadcast
+        );
+        assert_eq!(
+            NotebookFrameType::try_from(0x08).unwrap(),
+            NotebookFrameType::PutBlob
         );
         assert!(NotebookFrameType::try_from(0xFF).is_err());
     }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -17,7 +17,8 @@ pub use framing::{
 };
 
 pub use handshake::{
-    Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4, PROTOCOL_VERSION,
+    Handshake, NotebookConnectionInfo, ProtocolCapabilities, PutBlobCapability, PROTOCOL_V4,
+    PROTOCOL_VERSION,
 };
 
 #[cfg(windows)]
@@ -270,18 +271,27 @@ mod tests {
 
     #[test]
     fn test_notebook_connection_info_serialization() {
+        fn capabilities(
+            protocol_version: Option<u32>,
+            daemon_version: Option<String>,
+        ) -> ProtocolCapabilities {
+            ProtocolCapabilities {
+                protocol: PROTOCOL_V4.into(),
+                protocol_version,
+                daemon_version,
+                put_blob: None,
+            }
+        }
+
         // Success case (minimal - no optional fields)
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
-            protocol_version: None,
-            daemon_version: None,
+            capabilities: capabilities(None, None),
             notebook_id: "/home/user/notebook.ipynb".into(),
             cell_count: 5,
             needs_trust_approval: false,
             error: None,
             ephemeral: false,
             notebook_path: None,
-            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(
@@ -291,16 +301,13 @@ mod tests {
 
         // With version info
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
-            protocol_version: Some(PROTOCOL_VERSION),
-            daemon_version: Some("0.1.0+abc123".into()),
+            capabilities: capabilities(Some(PROTOCOL_VERSION), Some("0.1.0+abc123".into())),
             notebook_id: "/home/user/notebook.ipynb".into(),
             cell_count: 5,
             needs_trust_approval: false,
             error: None,
             ephemeral: false,
             notebook_path: None,
-            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
@@ -308,48 +315,39 @@ mod tests {
 
         // With trust approval needed
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
-            protocol_version: None,
-            daemon_version: None,
+            capabilities: capabilities(None, None),
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             cell_count: 1,
             needs_trust_approval: true,
             error: None,
             ephemeral: false,
             notebook_path: None,
-            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""needs_trust_approval":true"#));
 
         // Error case
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
-            protocol_version: None,
-            daemon_version: None,
+            capabilities: capabilities(None, None),
             notebook_id: String::new(),
             cell_count: 0,
             needs_trust_approval: false,
             error: Some("File not found".into()),
             ephemeral: false,
             notebook_path: None,
-            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""error":"File not found""#));
 
         // With notebook_path
         let info = NotebookConnectionInfo {
-            protocol: PROTOCOL_V4.into(),
-            protocol_version: None,
-            daemon_version: None,
+            capabilities: capabilities(None, None),
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             cell_count: 5,
             needs_trust_approval: false,
             error: None,
             ephemeral: false,
             notebook_path: Some("/home/user/notebook.ipynb".into()),
-            put_blob: None,
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -106,7 +106,7 @@ pub const PROTOCOL_VERSION: u32 = 4;
 ///
 /// Sent immediately after handshake, before starting sync.
 /// Used by the `NotebookSync` handshake variant.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProtocolCapabilities {
     /// Protocol version string (currently always "v4").
     pub protocol: String,
@@ -123,13 +123,24 @@ pub struct ProtocolCapabilities {
     pub put_blob: Option<PutBlobCapability>,
 }
 
+impl ProtocolCapabilities {
+    pub fn v4(daemon_version: Option<String>) -> Self {
+        Self {
+            protocol: PROTOCOL_V4.to_string(),
+            protocol_version: Some(PROTOCOL_VERSION),
+            daemon_version,
+            put_blob: None,
+        }
+    }
+}
+
 /// PutBlob transport capability advertised during notebook connection setup.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PutBlobCapability {
     /// Capability schema version.
     pub version: u32,
     /// Maximum body size accepted for a single PutBlob frame.
-    pub single_frame_max: usize,
+    pub single_frame_max: u64,
     /// Whether multipart uploads are supported.
     pub multipart: bool,
 }
@@ -140,14 +151,9 @@ pub struct PutBlobCapability {
 /// Contains notebook_id derived by the daemon (from path or generated env_id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version string (currently always "v4").
-    pub protocol: String,
-    /// Numeric protocol version for explicit version checking.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub protocol_version: Option<u32>,
-    /// Daemon version string (e.g., "2.0.0+abc123").
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub daemon_version: Option<String>,
+    /// Shared protocol and capability metadata.
+    #[serde(flatten)]
+    pub capabilities: ProtocolCapabilities,
     /// Notebook identifier derived by the daemon.
     /// For existing files: canonical path.
     /// For new notebooks: generated UUID (env_id).
@@ -166,7 +172,4 @@ pub struct NotebookConnectionInfo {
     /// when `notebook_id_hint` resolves to a room that already has a path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notebook_path: Option<String>,
-    /// Blob upload support advertised by the daemon.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub put_blob: Option<PutBlobCapability>,
 }

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -118,6 +118,20 @@ pub struct ProtocolCapabilities {
     /// Useful for debugging version mismatches.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_version: Option<String>,
+    /// Blob upload support advertised by the daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub put_blob: Option<PutBlobCapability>,
+}
+
+/// PutBlob transport capability advertised during notebook connection setup.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PutBlobCapability {
+    /// Capability schema version.
+    pub version: u32,
+    /// Maximum body size accepted for a single PutBlob frame.
+    pub single_frame_max: usize,
+    /// Whether multipart uploads are supported.
+    pub multipart: bool,
 }
 
 /// Server response for `OpenNotebook` and `CreateNotebook` handshakes.
@@ -152,4 +166,7 @@ pub struct NotebookConnectionInfo {
     /// when `notebook_id_hint` resolves to a room that already has a path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notebook_path: Option<String>,
+    /// Blob upload support advertised by the daemon.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub put_blob: Option<PutBlobCapability>,
 }

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -125,11 +125,18 @@ pub struct ProtocolCapabilities {
 
 impl ProtocolCapabilities {
     pub fn v4(daemon_version: Option<String>) -> Self {
+        let put_blob_limits =
+            notebook_wire::frame_size_limits(notebook_wire::frame_types::PUT_BLOB);
+
         Self {
             protocol: PROTOCOL_V4.to_string(),
             protocol_version: Some(PROTOCOL_VERSION),
             daemon_version,
-            put_blob: None,
+            put_blob: Some(PutBlobCapability {
+                version: 1,
+                single_frame_max: put_blob_limits.cap as u64,
+                multipart: false,
+            }),
         }
     }
 }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -146,14 +146,6 @@ pub struct DependencyGuard {
     pub observed_heads: Vec<String>,
 }
 
-/// Metadata for one multipart blob upload part.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BlobUploadPart {
-    pub part_number: u32,
-    pub sha256: String,
-    pub size: u64,
-}
-
 /// Typed environment kind for sync operations.
 ///
 /// Replaces string-based env_type ("uv", "conda") with a discriminated union
@@ -256,9 +248,7 @@ pub enum BlobUploadErrorKind {
     SizeMismatch,
     HashMismatch,
     OverCap,
-    UnknownUpload,
     InvalidHeader,
-    Unsupported,
     Io { message: String },
 }
 
@@ -436,27 +426,6 @@ pub enum NotebookRequest {
     /// Get the full Automerge document bytes from the daemon's canonical doc.
     /// Used by the frontend to bootstrap its WASM Automerge peer.
     GetDocBytes {},
-
-    /// Create a multipart blob upload session.
-    CreateBlobUpload {
-        media_type: String,
-        size: u64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        sha256: Option<String>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        part_size: Option<u64>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        purpose: Option<String>,
-    },
-
-    /// Complete a multipart blob upload session.
-    CompleteBlobUpload {
-        upload_id: String,
-        parts: Vec<BlobUploadPart>,
-    },
-
-    /// Abort a multipart blob upload session.
-    AbortBlobUpload { upload_id: String },
 }
 
 /// Responses from daemon to notebook app.
@@ -563,20 +532,6 @@ pub enum NotebookResponse {
         hash: String,
         size: u64,
         media_type: String,
-    },
-
-    /// Multipart blob upload session created.
-    BlobUploadCreated {
-        upload_id: String,
-        part_size: u64,
-        expires_at: String,
-    },
-
-    /// Multipart blob upload part accepted.
-    BlobUploadPartAck {
-        upload_id: String,
-        part_number: u32,
-        sha256: String,
     },
 
     /// Blob upload failed before publishing bytes.
@@ -966,44 +921,6 @@ mod tests {
     }
 
     #[test]
-    fn blob_upload_requests_round_trip() {
-        let cases = vec![
-            serde_json::json!({
-                "action": "create_blob_upload",
-                "media_type": "image/png",
-                "size": 1024,
-                "sha256": "a".repeat(64),
-                "part_size": 8192,
-                "purpose": "widget-buffer"
-            }),
-            serde_json::json!({
-                "action": "complete_blob_upload",
-                "upload_id": "upload-1",
-                "parts": [
-                    {
-                        "part_number": 1,
-                        "sha256": "b".repeat(64),
-                        "size": 512
-                    }
-                ]
-            }),
-            serde_json::json!({
-                "action": "abort_blob_upload",
-                "upload_id": "upload-1"
-            }),
-        ];
-
-        for json in cases {
-            let parsed: NotebookRequest =
-                serde_json::from_value(json.clone()).expect("deserialize blob upload request");
-            assert_eq!(
-                serde_json::to_value(parsed).expect("serialize blob upload request"),
-                json
-            );
-        }
-    }
-
-    #[test]
     fn blob_upload_responses_round_trip() {
         let cases = vec![
             serde_json::json!({
@@ -1011,18 +928,6 @@ mod tests {
                 "hash": "c".repeat(64),
                 "size": 1024,
                 "media_type": "image/png"
-            }),
-            serde_json::json!({
-                "result": "blob_upload_created",
-                "upload_id": "upload-1",
-                "part_size": 8192,
-                "expires_at": "2026-05-12T00:00:00Z"
-            }),
-            serde_json::json!({
-                "result": "blob_upload_part_ack",
-                "upload_id": "upload-1",
-                "part_number": 1,
-                "sha256": "d".repeat(64)
             }),
             serde_json::json!({
                 "result": "blob_upload_error",
@@ -1175,29 +1080,6 @@ mod tests {
                         "buffers": [],
                         "channel": "shell",
                     },
-                }),
-            ),
-            (
-                "create_blob_upload",
-                serde_json::json!({
-                    "action": "create_blob_upload",
-                    "media_type": "image/png",
-                    "size": 1024,
-                }),
-            ),
-            (
-                "complete_blob_upload",
-                serde_json::json!({
-                    "action": "complete_blob_upload",
-                    "upload_id": "upload-1",
-                    "parts": [],
-                }),
-            ),
-            (
-                "abort_blob_upload",
-                serde_json::json!({
-                    "action": "abort_blob_upload",
-                    "upload_id": "upload-1",
                 }),
             ),
         ];

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -146,6 +146,14 @@ pub struct DependencyGuard {
     pub observed_heads: Vec<String>,
 }
 
+/// Metadata for one multipart blob upload part.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlobUploadPart {
+    pub part_number: u32,
+    pub sha256: String,
+    pub size: u64,
+}
+
 /// Typed environment kind for sync operations.
 ///
 /// Replaces string-based env_type ("uv", "conda") with a discriminated union
@@ -238,6 +246,19 @@ pub enum SaveErrorKind {
         path: String,
     },
     /// I/O or serialization failure. Message is human-readable.
+    Io { message: String },
+}
+
+/// Structured blob-upload error reasons.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum BlobUploadErrorKind {
+    SizeMismatch,
+    HashMismatch,
+    OverCap,
+    UnknownUpload,
+    InvalidHeader,
+    Unsupported,
     Io { message: String },
 }
 
@@ -415,6 +436,27 @@ pub enum NotebookRequest {
     /// Get the full Automerge document bytes from the daemon's canonical doc.
     /// Used by the frontend to bootstrap its WASM Automerge peer.
     GetDocBytes {},
+
+    /// Create a multipart blob upload session.
+    CreateBlobUpload {
+        media_type: String,
+        size: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha256: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        part_size: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        purpose: Option<String>,
+    },
+
+    /// Complete a multipart blob upload session.
+    CompleteBlobUpload {
+        upload_id: String,
+        parts: Vec<BlobUploadPart>,
+    },
+
+    /// Abort a multipart blob upload session.
+    AbortBlobUpload { upload_id: String },
 }
 
 /// Responses from daemon to notebook app.
@@ -515,6 +557,30 @@ pub enum NotebookResponse {
         /// Raw Automerge document bytes, encoded as a Vec for JSON transport.
         bytes: Vec<u8>,
     },
+
+    /// Blob bytes were stored in the content-addressed blob store.
+    BlobStored {
+        hash: String,
+        size: u64,
+        media_type: String,
+    },
+
+    /// Multipart blob upload session created.
+    BlobUploadCreated {
+        upload_id: String,
+        part_size: u64,
+        expires_at: String,
+    },
+
+    /// Multipart blob upload part accepted.
+    BlobUploadPartAck {
+        upload_id: String,
+        part_number: u32,
+        sha256: String,
+    },
+
+    /// Blob upload failed before publishing bytes.
+    BlobUploadError { reason: BlobUploadErrorKind },
 }
 
 /// Broadcast messages from daemon to all peers in a room.
@@ -899,6 +965,90 @@ mod tests {
         );
     }
 
+    #[test]
+    fn blob_upload_requests_round_trip() {
+        let cases = vec![
+            serde_json::json!({
+                "action": "create_blob_upload",
+                "media_type": "image/png",
+                "size": 1024,
+                "sha256": "a".repeat(64),
+                "part_size": 8192,
+                "purpose": "widget-buffer"
+            }),
+            serde_json::json!({
+                "action": "complete_blob_upload",
+                "upload_id": "upload-1",
+                "parts": [
+                    {
+                        "part_number": 1,
+                        "sha256": "b".repeat(64),
+                        "size": 512
+                    }
+                ]
+            }),
+            serde_json::json!({
+                "action": "abort_blob_upload",
+                "upload_id": "upload-1"
+            }),
+        ];
+
+        for json in cases {
+            let parsed: NotebookRequest =
+                serde_json::from_value(json.clone()).expect("deserialize blob upload request");
+            assert_eq!(
+                serde_json::to_value(parsed).expect("serialize blob upload request"),
+                json
+            );
+        }
+    }
+
+    #[test]
+    fn blob_upload_responses_round_trip() {
+        let cases = vec![
+            serde_json::json!({
+                "result": "blob_stored",
+                "hash": "c".repeat(64),
+                "size": 1024,
+                "media_type": "image/png"
+            }),
+            serde_json::json!({
+                "result": "blob_upload_created",
+                "upload_id": "upload-1",
+                "part_size": 8192,
+                "expires_at": "2026-05-12T00:00:00Z"
+            }),
+            serde_json::json!({
+                "result": "blob_upload_part_ack",
+                "upload_id": "upload-1",
+                "part_number": 1,
+                "sha256": "d".repeat(64)
+            }),
+            serde_json::json!({
+                "result": "blob_upload_error",
+                "reason": {
+                    "kind": "hash_mismatch"
+                }
+            }),
+            serde_json::json!({
+                "result": "blob_upload_error",
+                "reason": {
+                    "kind": "io",
+                    "message": "disk full"
+                }
+            }),
+        ];
+
+        for json in cases {
+            let parsed: NotebookResponse =
+                serde_json::from_value(json.clone()).expect("deserialize blob upload response");
+            assert_eq!(
+                serde_json::to_value(parsed).expect("serialize blob upload response"),
+                json
+            );
+        }
+    }
+
     /// Locks in the exact JSON wire shape that the TypeScript frontend
     /// emits for each `NotebookRequest` variant. The TS `NotebookRequest`
     /// union's discriminator field names must match the Rust variant's
@@ -1025,6 +1175,29 @@ mod tests {
                         "buffers": [],
                         "channel": "shell",
                     },
+                }),
+            ),
+            (
+                "create_blob_upload",
+                serde_json::json!({
+                    "action": "create_blob_upload",
+                    "media_type": "image/png",
+                    "size": 1024,
+                }),
+            ),
+            (
+                "complete_blob_upload",
+                serde_json::json!({
+                    "action": "complete_blob_upload",
+                    "upload_id": "upload-1",
+                    "parts": [],
+                }),
+            ),
+            (
+                "abort_blob_upload",
+                serde_json::json!({
+                    "action": "abort_blob_upload",
+                    "upload_id": "upload-1",
                 }),
             ),
         ];
@@ -1174,6 +1347,7 @@ mod tests {
                     "SESSION_CONTROL".to_string(),
                     notebook_wire::frame_types::SESSION_CONTROL
                 ),
+                ("PUT_BLOB".to_string(), notebook_wire::frame_types::PUT_BLOB),
             ])
         );
     }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -252,6 +252,79 @@ pub enum BlobUploadErrorKind {
     Io { message: String },
 }
 
+/// Header carried at the start of a binary PutBlob frame.
+///
+/// The frame payload is `u32 header_len_be | JSON header | raw blob bytes`.
+/// Phase 1 supports one-shot uploads only.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum PutBlobHeader {
+    Put {
+        id: String,
+        media_type: String,
+        size: u64,
+        sha256: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        purpose: Option<String>,
+    },
+}
+
+/// Structured parse failure for a PutBlob frame payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutBlobPayloadError {
+    pub id: Option<String>,
+    pub reason: BlobUploadErrorKind,
+}
+
+impl PutBlobHeader {
+    pub fn try_parse(payload: &[u8]) -> Result<(Self, &[u8]), PutBlobPayloadError> {
+        if payload.len() < 4 {
+            return Err(PutBlobPayloadError {
+                id: None,
+                reason: BlobUploadErrorKind::InvalidHeader,
+            });
+        }
+
+        let header_len =
+            u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) as usize;
+        let Some(header_end) = 4usize.checked_add(header_len) else {
+            return Err(PutBlobPayloadError {
+                id: None,
+                reason: BlobUploadErrorKind::InvalidHeader,
+            });
+        };
+
+        if header_end > payload.len() {
+            return Err(PutBlobPayloadError {
+                id: None,
+                reason: BlobUploadErrorKind::InvalidHeader,
+            });
+        }
+
+        let header_bytes = &payload[4..header_end];
+        let id = serde_json::from_slice::<serde_json::Value>(header_bytes)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_owned)
+            });
+        let header = serde_json::from_slice(header_bytes).map_err(|_| PutBlobPayloadError {
+            id,
+            reason: BlobUploadErrorKind::InvalidHeader,
+        })?;
+
+        Ok((header, &payload[header_end..]))
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            PutBlobHeader::Put { id, .. } => id,
+        }
+    }
+}
+
 /// Envelope around a `NotebookRequest` carrying a correlation id.
 ///
 /// The id is echoed on the matching `NotebookResponseEnvelope` so the relay
@@ -952,6 +1025,53 @@ mod tests {
                 json
             );
         }
+    }
+
+    #[test]
+    fn put_blob_header_parses_length_prefixed_payload() {
+        let header = serde_json::json!({
+            "op": "put",
+            "id": "blob-request-1",
+            "media_type": "application/octet-stream",
+            "size": 3,
+            "sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            "purpose": "widget-state",
+        });
+        let header_bytes = serde_json::to_vec(&header).unwrap();
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(header_bytes.len() as u32).to_be_bytes());
+        payload.extend_from_slice(&header_bytes);
+        payload.extend_from_slice(b"abc");
+
+        let (parsed, body) = PutBlobHeader::try_parse(&payload).unwrap();
+
+        assert_eq!(body, b"abc");
+        assert_eq!(
+            parsed,
+            PutBlobHeader::Put {
+                id: "blob-request-1".to_string(),
+                media_type: "application/octet-stream".to_string(),
+                size: 3,
+                sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                    .to_string(),
+                purpose: Some("widget-state".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn put_blob_header_reports_invalid_payloads() {
+        let too_short = PutBlobHeader::try_parse(&[0, 0, 0]).unwrap_err();
+        assert_eq!(too_short.id, None);
+        assert_eq!(too_short.reason, BlobUploadErrorKind::InvalidHeader);
+
+        let mut truncated_header = Vec::new();
+        truncated_header.extend_from_slice(&64_u32.to_be_bytes());
+        truncated_header.extend_from_slice(b"{\"op\":\"put\"");
+
+        let truncated = PutBlobHeader::try_parse(&truncated_header).unwrap_err();
+        assert_eq!(truncated.id, None);
+        assert_eq!(truncated.reason, BlobUploadErrorKind::InvalidHeader);
     }
 
     /// Locks in the exact JSON wire shape that the TypeScript frontend

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -248,6 +248,7 @@ pub enum BlobUploadErrorKind {
     SizeMismatch,
     HashMismatch,
     OverCap,
+    TooManyInFlight,
     InvalidHeader,
     Io { message: String },
 }
@@ -301,16 +302,16 @@ impl PutBlobHeader {
             });
         }
 
-        let header_bytes = &payload[4..header_end];
-        let id = serde_json::from_slice::<serde_json::Value>(header_bytes)
-            .ok()
-            .and_then(|value| {
-                value
-                    .get("id")
-                    .and_then(|id| id.as_str())
-                    .map(str::to_owned)
-            });
-        let header = serde_json::from_slice(header_bytes).map_err(|_| PutBlobPayloadError {
+        let header_value: serde_json::Value = serde_json::from_slice(&payload[4..header_end])
+            .map_err(|_| PutBlobPayloadError {
+                id: None,
+                reason: BlobUploadErrorKind::InvalidHeader,
+            })?;
+        let id = header_value
+            .get("id")
+            .and_then(|id| id.as_str())
+            .map(str::to_owned);
+        let header = serde_json::from_value(header_value).map_err(|_| PutBlobPayloadError {
             id,
             reason: BlobUploadErrorKind::InvalidHeader,
         })?;
@@ -1015,6 +1016,12 @@ mod tests {
                     "message": "disk full"
                 }
             }),
+            serde_json::json!({
+                "result": "blob_upload_error",
+                "reason": {
+                    "kind": "too_many_in_flight"
+                }
+            }),
         ];
 
         for json in cases {
@@ -1072,6 +1079,22 @@ mod tests {
         let truncated = PutBlobHeader::try_parse(&truncated_header).unwrap_err();
         assert_eq!(truncated.id, None);
         assert_eq!(truncated.reason, BlobUploadErrorKind::InvalidHeader);
+
+        let missing_op = serde_json::json!({
+            "id": "blob-request-2",
+            "media_type": "application/octet-stream",
+            "size": 3,
+            "sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        });
+        let missing_op_bytes = serde_json::to_vec(&missing_op).unwrap();
+        let mut missing_op_payload = Vec::new();
+        missing_op_payload.extend_from_slice(&(missing_op_bytes.len() as u32).to_be_bytes());
+        missing_op_payload.extend_from_slice(&missing_op_bytes);
+        missing_op_payload.extend_from_slice(b"abc");
+
+        let missing_op = PutBlobHeader::try_parse(&missing_op_payload).unwrap_err();
+        assert_eq!(missing_op.id.as_deref(), Some("blob-request-2"));
+        assert_eq!(missing_op.reason, BlobUploadErrorKind::InvalidHeader);
     }
 
     /// Locks in the exact JSON wire shape that the TypeScript frontend

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -26,6 +26,9 @@ pub const NOTEBOOK_REQUEST_TYPES: &[&str] = &[
     "approve_trust",
     "approve_project_environment",
     "get_doc_bytes",
+    "create_blob_upload",
+    "complete_blob_upload",
+    "abort_blob_upload",
 ];
 
 pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
@@ -47,6 +50,10 @@ pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
     "sync_environment_complete",
     "sync_environment_failed",
     "doc_bytes",
+    "blob_stored",
+    "blob_upload_created",
+    "blob_upload_part_ack",
+    "blob_upload_error",
 ];
 
 pub const SESSION_CONTROL_TYPES: &[&str] = &["sync_status"];
@@ -125,6 +132,12 @@ export interface CommRequestMessage {{
   channel: string;
 }}
 
+export interface BlobUploadPart {{
+  part_number: number;
+  sha256: string;
+  size: number;
+}}
+
 export type NotebookRequest =
   | {{
       type: "launch_kernel";
@@ -160,7 +173,17 @@ export type NotebookRequest =
   | {{ type: "sync_environment"; guard?: DependencyGuard | null }}
   | {{ type: "approve_trust"; observed_heads?: string[] | null }}
   | {{ type: "approve_project_environment"; project_file_path?: string | null }}
-  | {{ type: "get_doc_bytes" }};
+  | {{ type: "get_doc_bytes" }}
+  | {{
+      type: "create_blob_upload";
+      media_type: string;
+      size: number;
+      sha256?: string | null;
+      part_size?: number | null;
+      purpose?: string | null;
+    }}
+  | {{ type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }}
+  | {{ type: "abort_blob_upload"; upload_id: string }};
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {{
@@ -210,7 +233,11 @@ export type NotebookResponse =
     }}
   | {{ result: "sync_environment_complete"; synced_packages: string[] }}
   | {{ result: "sync_environment_failed"; error: string; needs_restart: boolean }}
-  | {{ result: "doc_bytes"; bytes: number[] }};
+  | {{ result: "doc_bytes"; bytes: number[] }}
+  | {{ result: "blob_stored"; hash: string; size: number; media_type: string }}
+  | {{ result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }}
+  | {{ result: "blob_upload_part_ack"; upload_id: string; part_number: number; sha256: string }}
+  | {{ result: "blob_upload_error"; reason: BlobUploadErrorKind }};
 
 /**
  * Structured save failures returned in `NotebookResponse::SaveError`.
@@ -225,6 +252,15 @@ export type SaveErrorKind =
       path: string;
     }}
   | {{ type: "io"; message: string }};
+
+export type BlobUploadErrorKind =
+  | {{ kind: "size_mismatch" }}
+  | {{ kind: "hash_mismatch" }}
+  | {{ kind: "over_cap" }}
+  | {{ kind: "unknown_upload" }}
+  | {{ kind: "invalid_header" }}
+  | {{ kind: "unsupported" }}
+  | {{ kind: "io"; message: string }};
 "#
     )
 }

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -234,6 +234,7 @@ export type BlobUploadErrorKind =
   | {{ kind: "size_mismatch" }}
   | {{ kind: "hash_mismatch" }}
   | {{ kind: "over_cap" }}
+  | {{ kind: "too_many_in_flight" }}
   | {{ kind: "invalid_header" }}
   | {{ kind: "io"; message: string }};
 "#

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -26,9 +26,6 @@ pub const NOTEBOOK_REQUEST_TYPES: &[&str] = &[
     "approve_trust",
     "approve_project_environment",
     "get_doc_bytes",
-    "create_blob_upload",
-    "complete_blob_upload",
-    "abort_blob_upload",
 ];
 
 pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
@@ -51,8 +48,6 @@ pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
     "sync_environment_failed",
     "doc_bytes",
     "blob_stored",
-    "blob_upload_created",
-    "blob_upload_part_ack",
     "blob_upload_error",
 ];
 
@@ -132,12 +127,6 @@ export interface CommRequestMessage {{
   channel: string;
 }}
 
-export interface BlobUploadPart {{
-  part_number: number;
-  sha256: string;
-  size: number;
-}}
-
 export type NotebookRequest =
   | {{
       type: "launch_kernel";
@@ -173,17 +162,7 @@ export type NotebookRequest =
   | {{ type: "sync_environment"; guard?: DependencyGuard | null }}
   | {{ type: "approve_trust"; observed_heads?: string[] | null }}
   | {{ type: "approve_project_environment"; project_file_path?: string | null }}
-  | {{ type: "get_doc_bytes" }}
-  | {{
-      type: "create_blob_upload";
-      media_type: string;
-      size: number;
-      sha256?: string | null;
-      part_size?: number | null;
-      purpose?: string | null;
-    }}
-  | {{ type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }}
-  | {{ type: "abort_blob_upload"; upload_id: string }};
+  | {{ type: "get_doc_bytes" }};
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {{
@@ -235,8 +214,6 @@ export type NotebookResponse =
   | {{ result: "sync_environment_failed"; error: string; needs_restart: boolean }}
   | {{ result: "doc_bytes"; bytes: number[] }}
   | {{ result: "blob_stored"; hash: string; size: number; media_type: string }}
-  | {{ result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }}
-  | {{ result: "blob_upload_part_ack"; upload_id: string; part_number: number; sha256: string }}
   | {{ result: "blob_upload_error"; reason: BlobUploadErrorKind }};
 
 /**
@@ -257,9 +234,7 @@ export type BlobUploadErrorKind =
   | {{ kind: "size_mismatch" }}
   | {{ kind: "hash_mismatch" }}
   | {{ kind: "over_cap" }}
-  | {{ kind: "unknown_upload" }}
   | {{ kind: "invalid_header" }}
-  | {{ kind: "unsupported" }}
   | {{ kind: "io"; message: string }};
 "#
     )

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -294,7 +294,7 @@ fn route_incoming_frame(
 /// response (`0x02`) frames. Frontend requests rely on `0x02` reaching the
 /// JS side so the frontend's pending map can correlate the response.
 ///
-/// Request frames (`0x01`) are never piped outbound to the frontend — the
+/// Request and PutBlob frames are never piped outbound to the frontend — the
 /// frontend sends them; the daemon never emits them to a client.
 fn pipe_frame(frame_tx: &mpsc::UnboundedSender<Vec<u8>>, frame: &connection::TypedNotebookFrame) {
     match frame.frame_type {
@@ -309,9 +309,10 @@ fn pipe_frame(frame_tx: &mpsc::UnboundedSender<Vec<u8>>, frame: &connection::Typ
             bytes.extend_from_slice(&frame.payload);
             let _ = frame_tx.send(bytes);
         }
-        NotebookFrameType::Request => {
+        NotebookFrameType::Request | NotebookFrameType::PutBlob => {
             debug!(
-                "[relay] Not piping Request frame (outbound only) — {} bytes",
+                "[relay] Not piping {:?} frame (outbound only) — {} bytes",
+                frame.frame_type,
                 frame.payload.len()
             );
         }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -669,6 +669,14 @@ impl SyncReactor {
                 Ok(())
             }
 
+            NotebookFrameType::PutBlob => {
+                warn!(
+                    "[notebook-sync] Unexpected PutBlob frame from daemon for {}",
+                    self.io.notebook_id
+                );
+                Ok(())
+            }
+
             NotebookFrameType::RuntimeStateSync => {
                 let msg = match sync::Message::decode(&frame.payload) {
                     Ok(msg) => msg,

--- a/crates/notebook-wire/src/lib.rs
+++ b/crates/notebook-wire/src/lib.rs
@@ -32,6 +32,9 @@ pub mod frame_types {
 
     /// Session-control message (JSON).
     pub const SESSION_CONTROL: u8 = 0x07;
+
+    /// Blob upload payload (`u32 header_len | JSON header | raw bytes`).
+    pub const PUT_BLOB: u8 = 0x08;
 }
 
 const KIB: usize = 1024;
@@ -87,6 +90,10 @@ pub fn frame_size_limits(type_byte: u8) -> FrameSizeLimits {
             cap: MIB,
             warn: 256 * KIB,
         },
+        frame_types::PUT_BLOB => FrameSizeLimits {
+            cap: 32 * MIB,
+            warn: 8 * MIB,
+        },
         _ => FrameSizeLimits {
             cap: MAX_FRAME_SIZE,
             warn: MAX_FRAME_SIZE / 2,
@@ -123,6 +130,8 @@ pub enum NotebookFrameType {
     PoolStateSync = frame_types::POOL_STATE_SYNC,
     /// Session-control message (JSON, server-originated connection status).
     SessionControl = frame_types::SESSION_CONTROL,
+    /// Blob upload payload (`u32 header_len | JSON header | raw bytes`).
+    PutBlob = frame_types::PUT_BLOB,
 }
 
 impl TryFrom<u8> for NotebookFrameType {
@@ -138,6 +147,7 @@ impl TryFrom<u8> for NotebookFrameType {
             frame_types::RUNTIME_STATE_SYNC => Ok(Self::RuntimeStateSync),
             frame_types::POOL_STATE_SYNC => Ok(Self::PoolStateSync),
             frame_types::SESSION_CONTROL => Ok(Self::SessionControl),
+            frame_types::PUT_BLOB => Ok(Self::PutBlob),
             _ => Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("unknown notebook frame type: 0x{:02x}", value),

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2779,7 +2779,8 @@ async fn send_frame_bytes(
         | frame_types::REQUEST
         | frame_types::PRESENCE
         | frame_types::RUNTIME_STATE_SYNC
-        | frame_types::POOL_STATE_SYNC => handle
+        | frame_types::POOL_STATE_SYNC
+        | frame_types::PUT_BLOB => handle
             .forward_frame(frame_type, payload.to_vec())
             .await
             .map_err(|e| format!("send_frame(0x{:02x}): {}", frame_type, e)),

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -746,9 +746,9 @@ impl NotebookConnectionInfo {
     /// Create from the Rust NotebookConnectionInfo type.
     pub fn from_protocol(info: notebook_protocol::connection::NotebookConnectionInfo) -> Self {
         Self {
-            protocol: info.protocol,
-            protocol_version: info.protocol_version,
-            daemon_version: info.daemon_version,
+            protocol: info.capabilities.protocol,
+            protocol_version: info.capabilities.protocol_version,
+            daemon_version: info.capabilities.daemon_version,
             notebook_id: info.notebook_id,
             cell_count: info.cell_count,
             needs_trust_approval: info.needs_trust_approval,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2578,7 +2578,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use notebook_protocol::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, ProtocolCapabilities,
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
@@ -2608,18 +2608,14 @@ impl Daemon {
             writer: &mut W,
             error: String,
         ) -> anyhow::Result<()> {
-            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
-                protocol: proto_str.to_string(),
-                protocol_version: Some(proto_ver),
-                daemon_version: Some(crate::daemon_version().to_string()),
+                capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
                 notebook_id: String::new(),
                 cell_count: 0,
                 needs_trust_approval: false,
                 error: Some(error),
                 ephemeral: false,
                 notebook_path: None,
-                put_blob: None,
             };
             send_json_frame(writer, &response).await?;
             Ok(())
@@ -2863,18 +2859,14 @@ impl Daemon {
         // `notebook_id` variable in this handler is the canonical path string
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let response = NotebookConnectionInfo {
-            protocol: proto_str.to_string(),
-            protocol_version: Some(proto_ver),
-            daemon_version: Some(crate::daemon_version().to_string()),
+            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
             error: None,
             ephemeral: false,
             notebook_path: Some(notebook_id.clone()),
-            put_blob: None,
         };
         send_json_frame(&mut writer, &response).await?;
 
@@ -2924,7 +2916,7 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use notebook_protocol::connection::{
-            send_json_frame, NotebookConnectionInfo, PROTOCOL_V4, PROTOCOL_VERSION,
+            send_json_frame, NotebookConnectionInfo, ProtocolCapabilities,
         };
 
         info!(
@@ -3007,18 +2999,14 @@ impl Daemon {
                 );
             }
             let (mut reader, mut writer) = tokio::io::split(stream);
-            let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
             let response = NotebookConnectionInfo {
-                protocol: proto_str.to_string(),
-                protocol_version: Some(proto_ver),
-                daemon_version: Some(crate::daemon_version().to_string()),
+                capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
                 notebook_id: String::new(),
                 cell_count: 0,
                 needs_trust_approval: false,
                 error: Some(format!("Failed to create notebook: {}", e)),
                 ephemeral: false,
                 notebook_path: None,
-                put_blob: None,
             };
             send_json_frame(&mut writer, &response).await?;
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
@@ -3035,23 +3023,19 @@ impl Daemon {
         // Always send the room's UUID on the wire, even when the caller
         // provided a notebook_id_hint — room.id is the canonical source.
         let (reader, mut writer) = tokio::io::split(stream);
-        let (proto_str, proto_ver) = (PROTOCOL_V4, PROTOCOL_VERSION);
         let notebook_path = room
             .file_binding
             .path()
             .await
             .map(|p| p.to_string_lossy().to_string());
         let response = NotebookConnectionInfo {
-            protocol: proto_str.to_string(),
-            protocol_version: Some(proto_ver),
-            daemon_version: Some(crate::daemon_version().to_string()),
+            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval: false,
             error: None,
             ephemeral,
             notebook_path,
-            put_blob: None,
         };
         send_json_frame(&mut writer, &response).await?;
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2619,6 +2619,7 @@ impl Daemon {
                 error: Some(error),
                 ephemeral: false,
                 notebook_path: None,
+                put_blob: None,
             };
             send_json_frame(writer, &response).await?;
             Ok(())
@@ -2873,6 +2874,7 @@ impl Daemon {
             error: None,
             ephemeral: false,
             notebook_path: Some(notebook_id.clone()),
+            put_blob: None,
         };
         send_json_frame(&mut writer, &response).await?;
 
@@ -3016,6 +3018,7 @@ impl Daemon {
                 error: Some(format!("Failed to create notebook: {}", e)),
                 ephemeral: false,
                 notebook_path: None,
+                put_blob: None,
             };
             send_json_frame(&mut writer, &response).await?;
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
@@ -3048,6 +3051,7 @@ impl Daemon {
             error: None,
             ephemeral,
             notebook_path,
+            put_blob: None,
         };
         send_json_frame(&mut writer, &response).await?;
 

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -1,0 +1,404 @@
+use std::sync::Arc;
+
+use notebook_protocol::connection::NotebookFrameType;
+use notebook_protocol::protocol::{
+    BlobUploadErrorKind, NotebookResponse, NotebookResponseEnvelope, PutBlobHeader,
+};
+use sha2::{Digest, Sha256};
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use super::peer_writer::PeerWriter;
+use crate::blob_store::BlobStore;
+
+const PUT_BLOB_QUEUE_CAPACITY: usize = 1;
+
+pub(super) struct PutBlobWorker {
+    tx: mpsc::Sender<Vec<u8>>,
+    pub(super) handle: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl Drop for PutBlobWorker {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+pub(super) fn spawn_put_blob_worker(
+    blob_store: Arc<BlobStore>,
+    peer_writer: PeerWriter,
+    notebook_id: String,
+    peer_id: String,
+) -> PutBlobWorker {
+    let (tx, mut rx) = mpsc::channel::<Vec<u8>>(PUT_BLOB_QUEUE_CAPACITY);
+    let handle = tokio::spawn(async move {
+        while let Some(payload) = rx.recv().await {
+            debug!(
+                "[notebook-sync] Handling PutBlob peer={} notebook={} payload_bytes={}",
+                peer_id,
+                notebook_id,
+                payload.len()
+            );
+            handle_put_blob_frame(&payload, &blob_store, &peer_writer).await?;
+        }
+        Ok(())
+    });
+    PutBlobWorker { tx, handle }
+}
+
+pub(super) async fn enqueue_put_blob(
+    worker: &PutBlobWorker,
+    payload: Vec<u8>,
+    notebook_id: &str,
+    peer_id: &str,
+) -> anyhow::Result<()> {
+    worker.tx.send(payload).await.map_err(|_| {
+        anyhow::anyhow!(
+            "PutBlob worker stopped for notebook {} peer {}",
+            notebook_id,
+            peer_id
+        )
+    })
+}
+
+pub(crate) async fn handle_put_blob_frame(
+    payload: &[u8],
+    blob_store: &Arc<BlobStore>,
+    peer_writer: &PeerWriter,
+) -> anyhow::Result<()> {
+    let (header, body) = match PutBlobHeader::try_parse(payload) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            send_blob_upload_error(peer_writer, error.id, error.reason)?;
+            return Ok(());
+        }
+    };
+
+    match header {
+        PutBlobHeader::Put {
+            id,
+            media_type,
+            size,
+            sha256,
+            purpose: _,
+        } => {
+            if body.len() as u64 != size {
+                send_blob_upload_error(peer_writer, Some(id), BlobUploadErrorKind::SizeMismatch)?;
+                return Ok(());
+            }
+
+            let actual_sha256 = hex::encode(Sha256::digest(body));
+            if actual_sha256 != sha256 {
+                send_blob_upload_error(peer_writer, Some(id), BlobUploadErrorKind::HashMismatch)?;
+                return Ok(());
+            }
+
+            match blob_store.put(body, &media_type).await {
+                Ok(hash) => {
+                    send_blob_response(
+                        peer_writer,
+                        Some(id),
+                        NotebookResponse::BlobStored {
+                            hash,
+                            size,
+                            media_type,
+                        },
+                    )?;
+                }
+                Err(error) => {
+                    warn!("[notebook-sync] PutBlob store failed: {}", error);
+                    send_blob_upload_error(
+                        peer_writer,
+                        Some(id),
+                        BlobUploadErrorKind::Io {
+                            message: error.to_string(),
+                        },
+                    )?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn send_blob_upload_error(
+    peer_writer: &PeerWriter,
+    id: Option<String>,
+    reason: BlobUploadErrorKind,
+) -> anyhow::Result<()> {
+    send_blob_response(
+        peer_writer,
+        id,
+        NotebookResponse::BlobUploadError { reason },
+    )
+}
+
+fn send_blob_response(
+    peer_writer: &PeerWriter,
+    id: Option<String>,
+    response: NotebookResponse,
+) -> anyhow::Result<()> {
+    peer_writer.send_json(
+        NotebookFrameType::Response,
+        &NotebookResponseEnvelope { id, response },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notebook_protocol::connection;
+    use notebook_protocol::protocol::{NotebookResponse, NotebookResponseEnvelope};
+
+    fn payload(id: &str, media_type: &str, size: u64, sha256: &str, body: &[u8]) -> Vec<u8> {
+        let header = serde_json::json!({
+            "op": "put",
+            "id": id,
+            "media_type": media_type,
+            "size": size,
+            "sha256": sha256,
+        });
+        let header_bytes = serde_json::to_vec(&header).expect("header serializes");
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(header_bytes.len() as u32).to_be_bytes());
+        payload.extend_from_slice(&header_bytes);
+        payload.extend_from_slice(body);
+        payload
+    }
+
+    async fn run_handler(
+        payload: &[u8],
+    ) -> (
+        tempfile::TempDir,
+        Arc<BlobStore>,
+        NotebookResponseEnvelope,
+        super::super::peer_writer::PeerWriterTask,
+    ) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer, writer_task) =
+            super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+
+        handle_put_blob_frame(payload, &blob_store, &peer_writer)
+            .await
+            .expect("handler succeeds");
+
+        let frame = connection::recv_typed_frame(&mut reader)
+            .await
+            .expect("frame read succeeds")
+            .expect("response frame");
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let envelope = serde_json::from_slice(&frame.payload).expect("response envelope");
+
+        (tmp, blob_store, envelope, writer_task)
+    }
+
+    #[tokio::test]
+    async fn put_blob_success_stores_blob_and_replies() {
+        let body = b"abc";
+        let sha256 = hex::encode(Sha256::digest(body));
+        let request_payload = payload("blob-1", "application/octet-stream", 3, &sha256, body);
+
+        let (_tmp, blob_store, envelope, _writer_task) = run_handler(&request_payload).await;
+
+        assert_eq!(envelope.id.as_deref(), Some("blob-1"));
+        match envelope.response {
+            NotebookResponse::BlobStored {
+                hash,
+                size,
+                media_type,
+            } => {
+                assert_eq!(hash, sha256);
+                assert_eq!(size, 3);
+                assert_eq!(media_type, "application/octet-stream");
+                assert_eq!(
+                    blob_store.get(&hash).await.unwrap().as_deref(),
+                    Some(&body[..])
+                );
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn put_blob_hash_mismatch_replies_without_storing() {
+        let wrong_hash = "0".repeat(64);
+        let request_payload = payload("blob-2", "application/octet-stream", 3, &wrong_hash, b"abc");
+
+        let (_tmp, blob_store, envelope, _writer_task) = run_handler(&request_payload).await;
+
+        assert_eq!(envelope.id.as_deref(), Some("blob-2"));
+        assert!(matches!(
+            envelope.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::HashMismatch
+            }
+        ));
+        assert!(blob_store.get(&wrong_hash).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn put_blob_size_mismatch_replies_without_storing() {
+        let body = b"abc";
+        let sha256 = hex::encode(Sha256::digest(body));
+        let request_payload = payload("blob-3", "application/octet-stream", 4, &sha256, body);
+
+        let (_tmp, blob_store, envelope, _writer_task) = run_handler(&request_payload).await;
+
+        assert_eq!(envelope.id.as_deref(), Some("blob-3"));
+        assert!(matches!(
+            envelope.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::SizeMismatch
+            }
+        ));
+        assert!(blob_store.get(&sha256).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn put_blob_invalid_header_replies_with_parse_error() {
+        let mut request_payload = Vec::new();
+        request_payload.extend_from_slice(&64_u32.to_be_bytes());
+        request_payload.extend_from_slice(b"{\"op\":\"put\"");
+
+        let (_tmp, _blob_store, envelope, _writer_task) = run_handler(&request_payload).await;
+
+        assert_eq!(envelope.id, None);
+        assert!(matches!(
+            envelope.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::InvalidHeader
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn put_blob_repeat_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer, _writer_task) =
+            super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+        let body = b"abc";
+        let sha256 = hex::encode(Sha256::digest(body));
+        let request_payload = payload("blob-repeat", "text/plain", 3, &sha256, body);
+
+        handle_put_blob_frame(&request_payload, &blob_store, &peer_writer)
+            .await
+            .unwrap();
+        handle_put_blob_frame(&request_payload, &blob_store, &peer_writer)
+            .await
+            .unwrap();
+
+        for _ in 0..2 {
+            let frame = connection::recv_typed_frame(&mut reader)
+                .await
+                .unwrap()
+                .unwrap();
+            let envelope: NotebookResponseEnvelope =
+                serde_json::from_slice(&frame.payload).unwrap();
+            assert_eq!(envelope.id.as_deref(), Some("blob-repeat"));
+            assert!(matches!(
+                envelope.response,
+                NotebookResponse::BlobStored { ref hash, .. } if hash == &sha256
+            ));
+        }
+        assert_eq!(
+            blob_store.get(&sha256).await.unwrap().as_deref(),
+            Some(&body[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn put_blob_concurrent_two_peers_store_and_reply_independently() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let body_a = b"peer-a";
+        let hash_a = hex::encode(Sha256::digest(body_a));
+        let payload_a = payload("blob-a", "text/plain", body_a.len() as u64, &hash_a, body_a);
+        let body_b = b"peer-b";
+        let hash_b = hex::encode(Sha256::digest(body_b));
+        let payload_b = payload("blob-b", "text/plain", body_b.len() as u64, &hash_b, body_b);
+
+        let (mut reader_a, writer_a) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer_a, _task_a) =
+            super::super::peer_writer::spawn_peer_writer(writer_a, "notebook".into(), "a".into());
+        let (mut reader_b, writer_b) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer_b, _task_b) =
+            super::super::peer_writer::spawn_peer_writer(writer_b, "notebook".into(), "b".into());
+
+        let (result_a, result_b) = tokio::join!(
+            handle_put_blob_frame(&payload_a, &blob_store, &peer_writer_a),
+            handle_put_blob_frame(&payload_b, &blob_store, &peer_writer_b)
+        );
+        result_a.unwrap();
+        result_b.unwrap();
+
+        let frame_a = connection::recv_typed_frame(&mut reader_a)
+            .await
+            .unwrap()
+            .unwrap();
+        let envelope_a: NotebookResponseEnvelope =
+            serde_json::from_slice(&frame_a.payload).unwrap();
+        let frame_b = connection::recv_typed_frame(&mut reader_b)
+            .await
+            .unwrap()
+            .unwrap();
+        let envelope_b: NotebookResponseEnvelope =
+            serde_json::from_slice(&frame_b.payload).unwrap();
+
+        assert_eq!(envelope_a.id.as_deref(), Some("blob-a"));
+        assert!(matches!(
+            envelope_a.response,
+            NotebookResponse::BlobStored { ref hash, .. } if hash == &hash_a
+        ));
+        assert_eq!(envelope_b.id.as_deref(), Some("blob-b"));
+        assert!(matches!(
+            envelope_b.response,
+            NotebookResponse::BlobStored { ref hash, .. } if hash == &hash_b
+        ));
+        assert_eq!(
+            blob_store.get(&hash_a).await.unwrap().as_deref(),
+            Some(&body_a[..])
+        );
+        assert_eq!(
+            blob_store.get(&hash_b).await.unwrap().as_deref(),
+            Some(&body_b[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn put_blob_backpressure_is_per_peer() {
+        let (tx_a, _rx_a) = mpsc::channel(PUT_BLOB_QUEUE_CAPACITY);
+        tx_a.send(vec![1]).await.unwrap();
+        let worker_a = PutBlobWorker {
+            tx: tx_a,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+
+        let (tx_b, mut rx_b) = mpsc::channel(PUT_BLOB_QUEUE_CAPACITY);
+        let worker_b = PutBlobWorker {
+            tx: tx_b,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+
+        let full_peer_send = tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            worker_a.tx.send(vec![2]),
+        )
+        .await;
+        assert!(
+            full_peer_send.is_err(),
+            "peer A PutBlob queue should apply backpressure when full"
+        );
+
+        worker_b
+            .tx
+            .send(vec![3])
+            .await
+            .expect("peer B PutBlob queue should remain independent");
+        assert_eq!(rx_b.try_recv().unwrap(), vec![3]);
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use notebook_protocol::connection::NotebookFrameType;
@@ -15,6 +16,7 @@ const PUT_BLOB_QUEUE_CAPACITY: usize = 1;
 
 pub(super) struct PutBlobWorker {
     tx: mpsc::Sender<Vec<u8>>,
+    in_flight: Arc<AtomicBool>,
     pub(super) handle: tokio::task::JoinHandle<anyhow::Result<()>>,
 }
 
@@ -31,6 +33,8 @@ pub(super) fn spawn_put_blob_worker(
     peer_id: String,
 ) -> PutBlobWorker {
     let (tx, mut rx) = mpsc::channel::<Vec<u8>>(PUT_BLOB_QUEUE_CAPACITY);
+    let in_flight = Arc::new(AtomicBool::new(false));
+    let worker_in_flight = in_flight.clone();
     let handle = tokio::spawn(async move {
         while let Some(payload) = rx.recv().await {
             debug!(
@@ -39,26 +43,54 @@ pub(super) fn spawn_put_blob_worker(
                 notebook_id,
                 payload.len()
             );
-            handle_put_blob_frame(&payload, &blob_store, &peer_writer).await?;
+            let result = handle_put_blob_frame(&payload, &blob_store, &peer_writer).await;
+            worker_in_flight.store(false, Ordering::Release);
+            result?;
         }
         Ok(())
     });
-    PutBlobWorker { tx, handle }
+    PutBlobWorker {
+        tx,
+        in_flight,
+        handle,
+    }
 }
 
-pub(super) async fn enqueue_put_blob(
+pub(super) fn enqueue_put_blob(
     worker: &PutBlobWorker,
+    peer_writer: &PeerWriter,
     payload: Vec<u8>,
     notebook_id: &str,
     peer_id: &str,
 ) -> anyhow::Result<()> {
-    worker.tx.send(payload).await.map_err(|_| {
-        anyhow::anyhow!(
-            "PutBlob worker stopped for notebook {} peer {}",
-            notebook_id,
-            peer_id
-        )
-    })
+    if worker.in_flight.swap(true, Ordering::AcqRel) {
+        send_blob_upload_error(
+            peer_writer,
+            put_blob_request_id(&payload),
+            BlobUploadErrorKind::TooManyInFlight,
+        )?;
+        return Ok(());
+    }
+
+    match worker.tx.try_send(payload) {
+        Ok(()) => Ok(()),
+        Err(mpsc::error::TrySendError::Full(payload)) => {
+            worker.in_flight.store(false, Ordering::Release);
+            send_blob_upload_error(
+                peer_writer,
+                put_blob_request_id(&payload),
+                BlobUploadErrorKind::TooManyInFlight,
+            )
+        }
+        Err(mpsc::error::TrySendError::Closed(_payload)) => {
+            worker.in_flight.store(false, Ordering::Release);
+            anyhow::bail!(
+                "PutBlob worker stopped for notebook {} peer {}",
+                notebook_id,
+                peer_id
+            )
+        }
+    }
 }
 
 pub(crate) async fn handle_put_blob_frame(
@@ -80,8 +112,12 @@ pub(crate) async fn handle_put_blob_frame(
             media_type,
             size,
             sha256,
-            purpose: _,
+            purpose,
         } => {
+            debug!(
+                "[notebook-sync] PutBlob id={} media_type={} size={} purpose={:?}",
+                id, media_type, size, purpose
+            );
             if body.len() as u64 != size {
                 send_blob_upload_error(peer_writer, Some(id), BlobUploadErrorKind::SizeMismatch)?;
                 return Ok(());
@@ -132,6 +168,24 @@ fn send_blob_upload_error(
         id,
         NotebookResponse::BlobUploadError { reason },
     )
+}
+
+fn put_blob_request_id(payload: &[u8]) -> Option<String> {
+    match PutBlobHeader::try_parse(payload) {
+        Ok((header, _body)) => Some(header.id().to_string()),
+        Err(error) => error.id,
+    }
+}
+
+#[cfg(test)]
+impl PutBlobWorker {
+    fn for_test_busy(tx: mpsc::Sender<Vec<u8>>) -> Self {
+        Self {
+            tx,
+            in_flight: Arc::new(AtomicBool::new(true)),
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        }
+    }
 }
 
 fn send_blob_response(
@@ -370,35 +424,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn put_blob_backpressure_is_per_peer() {
-        let (tx_a, _rx_a) = mpsc::channel(PUT_BLOB_QUEUE_CAPACITY);
-        tx_a.send(vec![1]).await.unwrap();
-        let worker_a = PutBlobWorker {
-            tx: tx_a,
-            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
-        };
+    async fn put_blob_busy_worker_replies_without_blocking_peer_loop() {
+        let (worker_tx, _worker_rx) = mpsc::channel(PUT_BLOB_QUEUE_CAPACITY);
+        let worker = PutBlobWorker::for_test_busy(worker_tx);
+        let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer, _writer_task) =
+            super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+        let body = b"abc";
+        let sha256 = hex::encode(Sha256::digest(body));
+        let request_payload = payload("blob-busy", "text/plain", body.len() as u64, &sha256, body);
 
-        let (tx_b, mut rx_b) = mpsc::channel(PUT_BLOB_QUEUE_CAPACITY);
-        let worker_b = PutBlobWorker {
-            tx: tx_b,
-            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
-        };
-
-        let full_peer_send = tokio::time::timeout(
-            std::time::Duration::from_millis(10),
-            worker_a.tx.send(vec![2]),
-        )
-        .await;
+        let start = std::time::Instant::now();
+        enqueue_put_blob(&worker, &peer_writer, request_payload, "notebook", "peer")
+            .expect("busy worker should report a structured response");
         assert!(
-            full_peer_send.is_err(),
-            "peer A PutBlob queue should apply backpressure when full"
+            start.elapsed() < std::time::Duration::from_millis(50),
+            "busy worker should not block the peer loop"
         );
 
-        worker_b
-            .tx
-            .send(vec![3])
+        let frame = connection::recv_typed_frame(&mut reader)
             .await
-            .expect("peer B PutBlob queue should remain independent");
-        assert_eq!(rx_b.try_recv().unwrap(), vec![3]);
+            .unwrap()
+            .unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let envelope: NotebookResponseEnvelope = serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(envelope.id.as_deref(), Some("blob-busy"));
+        assert!(matches!(
+            envelope.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::TooManyInFlight
+            }
+        ));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -48,6 +48,7 @@ use notebook_protocol::connection::{self, NotebookFrameType};
 use runtime_doc::RuntimeStateDoc;
 
 mod attachments;
+mod blob_upload;
 mod catalog;
 mod load;
 mod metadata;

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -201,13 +201,7 @@ where
 
     // Send capabilities response unless already sent via NotebookConnectionInfo.
     if !skip_capabilities {
-        let (proto_str, proto_ver) = (connection::PROTOCOL_V4, connection::PROTOCOL_VERSION);
-        let caps = connection::ProtocolCapabilities {
-            protocol: proto_str.to_string(),
-            protocol_version: Some(proto_ver),
-            daemon_version: Some(crate::daemon_version().to_string()),
-            put_blob: None,
-        };
+        let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()));
         connection::send_json_frame(&mut writer, &caps).await?;
     }
 

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -206,6 +206,7 @@ where
             protocol: proto_str.to_string(),
             protocol_version: Some(proto_ver),
             daemon_version: Some(crate::daemon_version().to_string()),
+            put_blob: None,
         };
         connection::send_json_frame(&mut writer, &caps).await?;
     }

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -338,11 +338,11 @@ where
                             NotebookFrameType::PutBlob => {
                                 enqueue_put_blob(
                                     &put_blob_worker,
+                                    &peer_writer,
                                     frame.payload,
                                     &notebook_id,
                                     peer_id,
-                                )
-                                .await?;
+                                )?;
                             }
                         }
             }

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -1,3 +1,4 @@
+use super::blob_upload::{enqueue_put_blob, spawn_put_blob_worker};
 use super::peer_notebook_sync::{
     finish_notebook_doc_frame, forward_notebook_doc_broadcast, handle_notebook_doc_frame,
     queue_doc_sync, NotebookDocFrameOutcome,
@@ -146,6 +147,12 @@ where
         notebook_id.clone(),
         peer_id.to_string(),
     );
+    let mut put_blob_worker = spawn_put_blob_worker(
+        room.blob_store.clone(),
+        peer_writer.clone(),
+        notebook_id.clone(),
+        peer_id.to_string(),
+    );
 
     // Hand the reader off to a dedicated FramedReader actor before
     // entering the busy `select!` below. `recv_typed_frame`'s internal
@@ -188,6 +195,17 @@ where
                 };
             }
 
+            put_blob_worker_result = &mut put_blob_worker.handle => {
+                return match put_blob_worker_result {
+                    Ok(result) => result,
+                    Err(e) => Err(anyhow::anyhow!(
+                        "PutBlob worker stopped for {}: {}",
+                        notebook_id,
+                        e
+                    )),
+                };
+            }
+
             // Idle peer timeout: no inbound frames within the deadline.
             // Fires when the remote peer is an orphan (process exited without
             // closing the socket) or genuinely idle beyond the configured limit.
@@ -214,7 +232,7 @@ where
                 // responses indefinitely.
                 if matches!(
                     frame.frame_type,
-                    NotebookFrameType::Request | NotebookFrameType::Presence
+                    NotebookFrameType::Request | NotebookFrameType::Presence | NotebookFrameType::PutBlob
                 ) {
                     idle_deadline.as_mut().reset(tokio::time::Instant::now() + idle_peer_timeout);
                 }
@@ -318,9 +336,13 @@ where
                             }
 
                             NotebookFrameType::PutBlob => {
-                                warn!(
-                                    "[notebook-sync] PutBlob frame received before handler is enabled"
-                                );
+                                enqueue_put_blob(
+                                    &put_blob_worker,
+                                    frame.payload,
+                                    &notebook_id,
+                                    peer_id,
+                                )
+                                .await?;
                             }
                         }
             }

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -309,12 +309,17 @@ where
 
                             NotebookFrameType::Response
                             | NotebookFrameType::Broadcast
-                            | NotebookFrameType::SessionControl
-                            | NotebookFrameType::PutBlob => {
+                            | NotebookFrameType::SessionControl => {
                                 // Clients shouldn't send these
                                 warn!(
                                     "[notebook-sync] Unexpected frame type from client: {:?}",
                                     frame.frame_type
+                                );
+                            }
+
+                            NotebookFrameType::PutBlob => {
+                                warn!(
+                                    "[notebook-sync] PutBlob frame received before handler is enabled"
                                 );
                             }
                         }

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -309,7 +309,8 @@ where
 
                             NotebookFrameType::Response
                             | NotebookFrameType::Broadcast
-                            | NotebookFrameType::SessionControl => {
+                            | NotebookFrameType::SessionControl
+                            | NotebookFrameType::PutBlob => {
                                 // Clients shouldn't send these
                                 warn!(
                                     "[notebook-sync] Unexpected frame type from client: {:?}",

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -59,6 +59,9 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
         NotebookRequest::ApproveTrust { .. } => "ApproveTrust",
         NotebookRequest::ApproveProjectEnvironment { .. } => "ApproveProjectEnvironment",
         NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
+        NotebookRequest::CreateBlobUpload { .. } => "CreateBlobUpload",
+        NotebookRequest::CompleteBlobUpload { .. } => "CompleteBlobUpload",
+        NotebookRequest::AbortBlobUpload { .. } => "AbortBlobUpload",
     }
 }
 
@@ -126,5 +129,11 @@ pub(crate) async fn handle_notebook_request(
         }
 
         NotebookRequest::GetDocBytes {} => get_doc_bytes::handle(room).await,
+
+        NotebookRequest::CreateBlobUpload { .. }
+        | NotebookRequest::CompleteBlobUpload { .. }
+        | NotebookRequest::AbortBlobUpload { .. } => NotebookResponse::BlobUploadError {
+            reason: notebook_protocol::protocol::BlobUploadErrorKind::Unsupported,
+        },
     }
 }

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -59,9 +59,6 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
         NotebookRequest::ApproveTrust { .. } => "ApproveTrust",
         NotebookRequest::ApproveProjectEnvironment { .. } => "ApproveProjectEnvironment",
         NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
-        NotebookRequest::CreateBlobUpload { .. } => "CreateBlobUpload",
-        NotebookRequest::CompleteBlobUpload { .. } => "CompleteBlobUpload",
-        NotebookRequest::AbortBlobUpload { .. } => "AbortBlobUpload",
     }
 }
 
@@ -129,11 +126,5 @@ pub(crate) async fn handle_notebook_request(
         }
 
         NotebookRequest::GetDocBytes {} => get_doc_bytes::handle(room).await,
-
-        NotebookRequest::CreateBlobUpload { .. }
-        | NotebookRequest::CompleteBlobUpload { .. }
-        | NotebookRequest::AbortBlobUpload { .. } => NotebookResponse::BlobUploadError {
-            reason: notebook_protocol::protocol::BlobUploadErrorKind::Unsupported,
-        },
     }
 }

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -31,6 +31,9 @@ export const NOTEBOOK_REQUEST_TYPES = [
   "approve_trust",
   "approve_project_environment",
   "get_doc_bytes",
+  "create_blob_upload",
+  "complete_blob_upload",
+  "abort_blob_upload",
 ] as const satisfies readonly NotebookRequest["type"][];
 
 export const NOTEBOOK_REQUEST_TYPES_EXHAUSTIVE: MissingUnionMember<
@@ -59,6 +62,10 @@ export const NOTEBOOK_RESPONSE_RESULTS = [
   "sync_environment_complete",
   "sync_environment_failed",
   "doc_bytes",
+  "blob_stored",
+  "blob_upload_created",
+  "blob_upload_part_ack",
+  "blob_upload_error",
 ] as const satisfies readonly NotebookResponse["result"][];
 
 export const NOTEBOOK_RESPONSE_RESULTS_EXHAUSTIVE: MissingUnionMember<

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -31,9 +31,6 @@ export const NOTEBOOK_REQUEST_TYPES = [
   "approve_trust",
   "approve_project_environment",
   "get_doc_bytes",
-  "create_blob_upload",
-  "complete_blob_upload",
-  "abort_blob_upload",
 ] as const satisfies readonly NotebookRequest["type"][];
 
 export const NOTEBOOK_REQUEST_TYPES_EXHAUSTIVE: MissingUnionMember<
@@ -63,8 +60,6 @@ export const NOTEBOOK_RESPONSE_RESULTS = [
   "sync_environment_failed",
   "doc_bytes",
   "blob_stored",
-  "blob_upload_created",
-  "blob_upload_part_ack",
   "blob_upload_error",
 ] as const satisfies readonly NotebookResponse["result"][];
 

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -169,5 +169,6 @@ export type BlobUploadErrorKind =
   | { kind: "size_mismatch" }
   | { kind: "hash_mismatch" }
   | { kind: "over_cap" }
+  | { kind: "too_many_in_flight" }
   | { kind: "invalid_header" }
   | { kind: "io"; message: string };

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -62,12 +62,6 @@ export interface CommRequestMessage {
   channel: string;
 }
 
-export interface BlobUploadPart {
-  part_number: number;
-  sha256: string;
-  size: number;
-}
-
 export type NotebookRequest =
   | {
       type: "launch_kernel";
@@ -103,17 +97,7 @@ export type NotebookRequest =
   | { type: "sync_environment"; guard?: DependencyGuard | null }
   | { type: "approve_trust"; observed_heads?: string[] | null }
   | { type: "approve_project_environment"; project_file_path?: string | null }
-  | { type: "get_doc_bytes" }
-  | {
-      type: "create_blob_upload";
-      media_type: string;
-      size: number;
-      sha256?: string | null;
-      part_size?: number | null;
-      purpose?: string | null;
-    }
-  | { type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }
-  | { type: "abort_blob_upload"; upload_id: string };
+  | { type: "get_doc_bytes" };
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {
@@ -165,8 +149,6 @@ export type NotebookResponse =
   | { result: "sync_environment_failed"; error: string; needs_restart: boolean }
   | { result: "doc_bytes"; bytes: number[] }
   | { result: "blob_stored"; hash: string; size: number; media_type: string }
-  | { result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }
-  | { result: "blob_upload_part_ack"; upload_id: string; part_number: number; sha256: string }
   | { result: "blob_upload_error"; reason: BlobUploadErrorKind };
 
 /**
@@ -187,7 +169,5 @@ export type BlobUploadErrorKind =
   | { kind: "size_mismatch" }
   | { kind: "hash_mismatch" }
   | { kind: "over_cap" }
-  | { kind: "unknown_upload" }
   | { kind: "invalid_header" }
-  | { kind: "unsupported" }
   | { kind: "io"; message: string };

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -62,6 +62,12 @@ export interface CommRequestMessage {
   channel: string;
 }
 
+export interface BlobUploadPart {
+  part_number: number;
+  sha256: string;
+  size: number;
+}
+
 export type NotebookRequest =
   | {
       type: "launch_kernel";
@@ -97,7 +103,17 @@ export type NotebookRequest =
   | { type: "sync_environment"; guard?: DependencyGuard | null }
   | { type: "approve_trust"; observed_heads?: string[] | null }
   | { type: "approve_project_environment"; project_file_path?: string | null }
-  | { type: "get_doc_bytes" };
+  | { type: "get_doc_bytes" }
+  | {
+      type: "create_blob_upload";
+      media_type: string;
+      size: number;
+      sha256?: string | null;
+      part_size?: number | null;
+      purpose?: string | null;
+    }
+  | { type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }
+  | { type: "abort_blob_upload"; upload_id: string };
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {
@@ -147,7 +163,11 @@ export type NotebookResponse =
     }
   | { result: "sync_environment_complete"; synced_packages: string[] }
   | { result: "sync_environment_failed"; error: string; needs_restart: boolean }
-  | { result: "doc_bytes"; bytes: number[] };
+  | { result: "doc_bytes"; bytes: number[] }
+  | { result: "blob_stored"; hash: string; size: number; media_type: string }
+  | { result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }
+  | { result: "blob_upload_part_ack"; upload_id: string; part_number: number; sha256: string }
+  | { result: "blob_upload_error"; reason: BlobUploadErrorKind };
 
 /**
  * Structured save failures returned in `NotebookResponse::SaveError`.
@@ -162,3 +182,12 @@ export type SaveErrorKind =
       path: string;
     }
   | { type: "io"; message: string };
+
+export type BlobUploadErrorKind =
+  | { kind: "size_mismatch" }
+  | { kind: "hash_mismatch" }
+  | { kind: "over_cap" }
+  | { kind: "unknown_upload" }
+  | { kind: "invalid_header" }
+  | { kind: "unsupported" }
+  | { kind: "io"; message: string };

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -33,6 +33,8 @@ export const FrameType = {
   POOL_STATE_SYNC: 0x06,
   /** SessionControl message (JSON, server-originated connection status). */
   SESSION_CONTROL: 0x07,
+  /** PutBlob payload (header JSON plus raw bytes). */
+  PUT_BLOB: 0x08,
 } as const;
 
 export type FrameTypeValue = (typeof FrameType)[keyof typeof FrameType];

--- a/packages/runtimed/tests/protocol-contract.test.ts
+++ b/packages/runtimed/tests/protocol-contract.test.ts
@@ -57,6 +57,8 @@ describe("protocol contract discriminants", () => {
       "sync_environment_complete",
       "sync_environment_failed",
       "doc_bytes",
+      "blob_stored",
+      "blob_upload_error",
     ]);
   });
 

--- a/packages/runtimed/tests/transport.test.ts
+++ b/packages/runtimed/tests/transport.test.ts
@@ -33,6 +33,7 @@ describe("FrameType constants", () => {
     expect(FrameType.RUNTIME_STATE_SYNC).toBe(0x05);
     expect(FrameType.POOL_STATE_SYNC).toBe(0x06);
     expect(FrameType.SESSION_CONTROL).toBe(0x07);
+    expect(FrameType.PUT_BLOB).toBe(0x08);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds the additive `PUT_BLOB = 0x08` typed-frame contract, per-frame size cap, Rust/TypeScript frame constant coverage, and `put_blob` capability advertisement derived from the frame cap.
- Adds a typed one-shot PutBlob payload parser: `u32 header_len_be | JSON header | raw blob bytes`, with Phase 1 limited to `op: "put"`.
- Wires frontend peer PutBlob frames through a per-peer worker that verifies declared size and SHA-256 before publishing bytes to the content-addressed blob store, then responds with `BlobStored` or `BlobUploadError`.
- Rejects overlapping same-peer PutBlob uploads with `too_many_in_flight` so the peer loop does not wait behind blob work.

## Non-Goals

- No frontend client helper yet.
- No multipart uploads, purpose policy, byte budgets, or legacy blob cleanup.
- No runtime-agent PutBlob path.

## Verification

- `cargo test -p notebook-wire -p notebook-protocol`
- `cargo test -p runtimed notebook_sync_server::blob_upload`
- `cargo check -p runtimed -p notebook`
- `pnpm test:run packages/runtimed/tests/transport.test.ts`
- `cargo xtask lint --fix`
