### PR TITLE
fix(runtimed): tolerate no internet for uv:pyproject kernel launches

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3680,6 +3680,7 @@ pub(crate) async fn auto_launch_kernel(
         (pooled_env, None)
     };
 
+    let mut uv_pyproject_offline = false;
     if matches!(env_source, EnvSource::Pyproject) {
         match crate::uv_project::prepare_uv_pyproject_environment(
             notebook_path_opt.as_deref(),
@@ -3688,7 +3689,8 @@ pub(crate) async fn auto_launch_kernel(
         )
         .await
         {
-            Ok(()) => {
+            Ok(offline) => {
+                uv_pyproject_offline = offline;
                 if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -3912,6 +3914,7 @@ pub(crate) async fn auto_launch_kernel(
                 }
 
                 // Send LaunchKernel RPC via the runtime agent's sync connection
+                let launch_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
                 match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),
@@ -3921,7 +3924,7 @@ pub(crate) async fn auto_launch_kernel(
                             .map(|p| p.to_str().unwrap_or("").to_string()),
                         launched_config: launched_config.clone(),
                         kernel_ports,
-                        env_vars: Default::default(),
+                        env_vars: launch_env_vars.clone(),
                     }
                 })
                 .await

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1298,6 +1298,7 @@ pub(crate) async fn handle(
         (pooled_env, None)
     };
 
+    let mut uv_pyproject_offline = false;
     if matches!(parsed_resolved, EnvSource::Pyproject) {
         match crate::uv_project::prepare_uv_pyproject_environment(
             notebook_path.as_deref(),
@@ -1306,7 +1307,8 @@ pub(crate) async fn handle(
         )
         .await
         {
-            Ok(()) => {
+            Ok(offline) => {
+                uv_pyproject_offline = offline;
                 if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
                     warn!("[runtime-state] {}", e);
                 }
@@ -1458,6 +1460,7 @@ pub(crate) async fn handle(
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
             info!("[notebook-sync] Agent connected — sending RestartKernel");
+            let restart_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
             match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                 notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
                     kernel_type: resolved_kernel_type.clone(),
@@ -1467,7 +1470,7 @@ pub(crate) async fn handle(
                         .map(|p| p.to_str().unwrap_or("").to_string()),
                     launched_config: launched_config.clone(),
                     kernel_ports,
-                    env_vars: Default::default(),
+                    env_vars: restart_env_vars.clone(),
                 }
             })
             .await
@@ -1605,6 +1608,7 @@ pub(crate) async fn handle(
                 }
 
                 // Send LaunchKernel RPC
+                let launch_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
                 match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: resolved_kernel_type.clone(),
@@ -1614,7 +1618,7 @@ pub(crate) async fn handle(
                             .map(|p| p.to_str().unwrap_or("").to_string()),
                         launched_config: launched_config.clone(),
                         kernel_ports,
-                        env_vars: Default::default(),
+                        env_vars: launch_env_vars.clone(),
                     }
                 })
                 .await

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -747,7 +747,7 @@ async fn handle_runtime_agent_request(
             notebook_path,
             launched_config,
             kernel_ports,
-            env_vars: _,
+            env_vars,
         } => {
             info!(
                 "[runtime-agent] LaunchKernel: type={} source={}",
@@ -785,7 +785,7 @@ async fn handle_runtime_agent_request(
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
                 kernel_ports,
-                env_vars: vec![],
+                env_vars: env_vars.into_iter().collect(),
                 pooled_env,
             };
 
@@ -833,7 +833,7 @@ async fn handle_runtime_agent_request(
             notebook_path,
             launched_config,
             kernel_ports,
-            env_vars: _,
+            env_vars,
         } => {
             info!(
                 "[runtime-agent] RestartKernel: type={} source={}",
@@ -889,7 +889,7 @@ async fn handle_runtime_agent_request(
                 notebook_path: notebook_path.as_deref().map(PathBuf::from),
                 launched_config,
                 kernel_ports,
-                env_vars: vec![],
+                env_vars: env_vars.into_iter().collect(),
                 pooled_env,
             };
 

--- a/crates/runtimed/src/uv_project.rs
+++ b/crates/runtimed/src/uv_project.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use anyhow::{Context, Result};
 use kernel_env::{EnvProgressPhase, ProgressHandler};
 use tokio::process::Command;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 
@@ -31,18 +31,22 @@ pub(crate) fn notebook_working_dir(notebook_path: Option<&Path>) -> PathBuf {
     }
 }
 
-fn uv_run_base_args() -> Vec<OsString> {
-    vec![
-        "run".into(),
-        "--with".into(),
-        "ipykernel".into(),
-        "--with".into(),
-        "uv".into(),
-    ]
+fn uv_run_base_args(offline: bool) -> Vec<OsString> {
+    let mut args = vec!["run".into()];
+    if offline {
+        args.push("--offline".into());
+    }
+    args.extend([
+        OsString::from("--with"),
+        OsString::from("ipykernel"),
+        OsString::from("--with"),
+        OsString::from("uv"),
+    ]);
+    args
 }
 
-pub(crate) fn uv_pyproject_prepare_args() -> Vec<OsString> {
-    let mut args = uv_run_base_args();
+pub(crate) fn uv_pyproject_prepare_args(offline: bool) -> Vec<OsString> {
+    let mut args = uv_run_base_args(offline);
     args.extend([
         OsString::from("python"),
         OsString::from("-Xfrozen_modules=off"),
@@ -56,7 +60,7 @@ pub(crate) fn uv_pyproject_kernel_args(
     bootstrap_dx: bool,
     connection_file: &Path,
 ) -> Vec<OsString> {
-    let mut args = uv_run_base_args();
+    let mut args = uv_run_base_args(false);
     let launcher_module = if bootstrap_dx {
         "nteract_kernel_launcher"
     } else {
@@ -83,6 +87,24 @@ fn display_output(output: &[u8]) -> String {
     String::from_utf8_lossy(output).trim().to_string()
 }
 
+/// Returns true when uv stderr looks like a transient network or DNS failure
+/// that can be retried with `--offline` against the local cache.
+pub(crate) fn is_network_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    [
+        "failed to fetch",
+        "error sending request",
+        "client error (connect)",
+        "dns error",
+        "failed to lookup address",
+        "network is unreachable",
+        "temporary failure in name resolution",
+        "no address associated with hostname",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
 fn command_failure_message(
     status: std::process::ExitStatus,
     output: std::process::Output,
@@ -104,11 +126,26 @@ fn command_failure_message(
     }
 }
 
+/// Env vars that switch `uv run` into offline mode for the kernel launch.
+/// Returned alongside the prepare outcome so callers can pass them through
+/// the `LaunchKernel`/`RestartKernel` RPC's `env_vars` map without losing
+/// the offline decision between daemon and runtime agent.
+pub(crate) fn uv_offline_env_vars(offline: bool) -> std::collections::HashMap<String, String> {
+    let mut env = std::collections::HashMap::new();
+    if offline {
+        env.insert("UV_OFFLINE".to_string(), "1".to_string());
+    }
+    env
+}
+
+/// Returns `Ok(true)` when the probe required the `--offline` retry to
+/// succeed, signaling the caller that the kernel launch must also run with
+/// `UV_OFFLINE=1` so `uv run` does not re-resolve against the index.
 pub(crate) async fn prepare_uv_pyproject_environment(
     notebook_path: Option<&Path>,
     bootstrap_dx: bool,
     progress_handler: Arc<dyn ProgressHandler>,
-) -> Result<()> {
+) -> Result<bool> {
     let cwd = notebook_working_dir(notebook_path);
     let project_path = notebook_path
         .and_then(|path| {
@@ -132,16 +169,6 @@ pub(crate) async fn prepare_uv_pyproject_environment(
     let uv_path = kernel_launch::tools::get_uv_path()
         .await
         .context("failed to locate uv executable")?;
-    let mut cmd = Command::new(&uv_path);
-    cmd.args(uv_pyproject_prepare_args());
-    cmd.current_dir(&cwd);
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-    cmd.env("COLUMNS", TERMINAL_COLUMNS_STR);
-    cmd.env("LINES", TERMINAL_LINES_STR);
-    if bootstrap_dx {
-        apply_bootstrap_pythonpath(&mut cmd).await?;
-    }
 
     info!(
         "[uv-project] Preparing UV project environment: project={} cwd={} bootstrap_dx={}",
@@ -150,12 +177,7 @@ pub(crate) async fn prepare_uv_pyproject_environment(
         bootstrap_dx
     );
     let started = Instant::now();
-    let output = cmd.output().await.with_context(|| {
-        format!(
-            "failed to run uv project prepare probe in {}",
-            cwd.display()
-        )
-    })?;
+    let output = run_prepare_probe(&uv_path, &cwd, bootstrap_dx, false).await?;
 
     if output.status.success() {
         info!(
@@ -163,13 +185,58 @@ pub(crate) async fn prepare_uv_pyproject_environment(
             project_path_label,
             started.elapsed().as_millis()
         );
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(command_failure_message(
-            output.status,
-            output
-        )))
+        return Ok(false);
     }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_network_failure(&stderr) {
+        warn!(
+            "[uv-project] uv prepare hit network failure; retrying offline: project={} stderr={}",
+            project_path_label,
+            stderr.trim()
+        );
+        let retry = run_prepare_probe(&uv_path, &cwd, bootstrap_dx, true).await?;
+        if retry.status.success() {
+            info!(
+                "[uv-project] UV project environment ready from local cache (offline): project={} elapsed_ms={}",
+                project_path_label,
+                started.elapsed().as_millis()
+            );
+            return Ok(true);
+        }
+        // Offline retry failed too. Surface the original network error: it
+        // points at the actual cause (no internet) rather than a misleading
+        // "package not in cache" miss from the retry.
+    }
+
+    Err(anyhow::anyhow!(command_failure_message(
+        output.status,
+        output
+    )))
+}
+
+async fn run_prepare_probe(
+    uv_path: &Path,
+    cwd: &Path,
+    bootstrap_dx: bool,
+    offline: bool,
+) -> Result<std::process::Output> {
+    let mut cmd = Command::new(uv_path);
+    cmd.args(uv_pyproject_prepare_args(offline));
+    cmd.current_dir(cwd);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env("COLUMNS", TERMINAL_COLUMNS_STR);
+    cmd.env("LINES", TERMINAL_LINES_STR);
+    if bootstrap_dx {
+        apply_bootstrap_pythonpath(&mut cmd).await?;
+    }
+    cmd.output().await.with_context(|| {
+        format!(
+            "failed to run uv project prepare probe in {}",
+            cwd.display()
+        )
+    })
 }
 
 #[cfg(test)]
@@ -185,7 +252,7 @@ mod tests {
     #[test]
     fn prepare_args_include_base_uv_packages() {
         assert_eq!(
-            args_to_strings(uv_pyproject_prepare_args()),
+            args_to_strings(uv_pyproject_prepare_args(false)),
             vec![
                 "run",
                 "--with",
@@ -198,6 +265,55 @@ mod tests {
                 "import ipykernel",
             ]
         );
+    }
+
+    #[test]
+    fn prepare_args_with_offline_inserts_flag_after_run() {
+        assert_eq!(
+            args_to_strings(uv_pyproject_prepare_args(true)),
+            vec![
+                "run",
+                "--offline",
+                "--with",
+                "ipykernel",
+                "--with",
+                "uv",
+                "python",
+                "-Xfrozen_modules=off",
+                "-c",
+                "import ipykernel",
+            ]
+        );
+    }
+
+    #[test]
+    fn is_network_failure_matches_screenshot_dns_error() {
+        let stderr = r"Failed to prepare UV project environment: uv project environment preparation failed with exit status: 2: error: Request failed after 3 retries
+  Caused by: Failed to fetch: `https://pypi.org/simple/ipykernel/`
+  Caused by: error sending request for url (https://pypi.org/simple/ipykernel/)
+  Caused by: client error (Connect)
+  Caused by: dns error
+  Caused by: failed to lookup address information: nodename nor servname provided, or not known";
+        assert!(is_network_failure(stderr));
+    }
+
+    #[test]
+    fn uv_offline_env_vars_set_uv_offline_when_true() {
+        let on = uv_offline_env_vars(true);
+        assert_eq!(on.get("UV_OFFLINE"), Some(&"1".to_string()));
+        assert_eq!(on.len(), 1);
+        assert!(uv_offline_env_vars(false).is_empty());
+    }
+
+    #[test]
+    fn is_network_failure_ignores_unrelated_errors() {
+        assert!(!is_network_failure(
+            "error: Failed to parse `pyproject.toml`\n  Caused by: TOML parse error"
+        ));
+        assert!(!is_network_failure(
+            "error: Distribution `ipykernel` was not found in the package registry"
+        ));
+        assert!(!is_network_failure(""));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

When `prepare_uv_pyproject_environment` fails with DNS or network markers in uv's stderr, retry the probe with `--offline`. If the retry succeeds, the kernel boots from uv's local cache and the user never sees the failure. The offline decision is then propagated through the `LaunchKernel`/`RestartKernel` RPCs so the runtime agent also sets `UV_OFFLINE=1` on the kernel command, otherwise `uv run` re-resolves against the index at launch time and refails on the same DNS error.

If the offline retry misses the cache too, the **original** network error is surfaced instead of the misleading "package not in cache" miss from the retry.

## Why

Kernel launch in a pyproject directory hard-fails when the user has no internet, even when the venv is already populated. Concrete repro: `~/ipractice` has `pyproject.toml` listing `ipykernel`, a synced `.venv`, and the package is in `~/.cache/uv`. With wifi off, the prepare probe still tries to refresh pypi metadata, hits a DNS failure, and the notebook surfaces:

```
Failed to prepare UV project environment: ... Caused by: dns error
  Caused by: failed to lookup address information: nodename nor servname provided, or not known
```

The cached-env path in `kernel-env/src/uv.rs` already has an `--offline` strategy. The pyproject path didn't.

Measured: `uv run --with ipykernel --with uv python -c "..."` against a populated `.venv` takes **17.2s** online with a fresh-uv download, even when all packages are cached. Without `UV_OFFLINE=1`, the kernel launch retries that same online resolve and re-hits DNS.

## Design notes

- **Retry, not offline-first.** The cached-env path in `uv.rs` tries `--offline` first because its inputs are a pinned deps hash. The pyproject path can't: the user may have edited `pyproject.toml` and expects new packages to install. So we only fall back to `--offline` after a real failure with network markers in stderr.
- **Surface the original error on double-failure.** If offline retry misses the cache, the second error is "package X not available offline," which hides the actual cause. The first error already names the DNS failure - that's what the user needs to act on.
- **Plumb offline through to the kernel launch.** Prepare returning successfully isn't enough: `uv run` may re-resolve at launch. The prepare function now returns `Result<bool>` where `true` means offline retry was needed. Callers (`auto_launch_kernel`, `handle::LaunchKernel`, the in-place `RestartKernel`) thread that bool into the RPC's `env_vars` HashMap as `UV_OFFLINE=1`, and the runtime agent now forwards `env_vars` into `KernelLaunchConfig` instead of dropping it. uv reads `UV_OFFLINE` as equivalent to `--offline`.
- **No false-positive needles.** `is_network_failure` matches uv's specific error prose ("failed to fetch", "dns error", "client error (Connect)", "failed to lookup address", etc.) rather than bare tokens, so a package named `connect` or a path containing `dns` won't trip it.

## Files touched

- `crates/runtimed/src/uv_project.rs` - prepare retry, offline arg builder, env-var helper, stderr matcher, tests.
- `crates/runtimed/src/requests/launch_kernel.rs` - capture offline bool from prepare, attach `UV_OFFLINE=1` to both `LaunchKernel` and `RestartKernel` RPC paths.
- `crates/runtimed/src/notebook_sync_server/metadata.rs` - same for `auto_launch_kernel`.
- `crates/runtimed/src/runtime_agent.rs` - stop dropping the RPC's `env_vars`; convert HashMap → Vec into `KernelLaunchConfig`.

## Test plan

- [x] `cargo xtask lint --fix` clean.
- [x] `cargo test -p runtimed --lib` - 716 tests pass, including new `prepare_args_with_offline_inserts_flag_after_run`, `is_network_failure_matches_screenshot_dns_error`, `is_network_failure_ignores_unrelated_errors`, `uv_offline_env_vars_set_uv_offline_when_true`.
- [x] Manual repro: `uv run --offline --with ipykernel --with uv python -c "import ipykernel"` from `~/ipractice` succeeds against the local cache with no network (ipykernel 7.2.0 from cache).
- [x] Codex review pass on the full diff - no findings on the second pass after threading the offline flag through to the kernel launch.
- [ ] End-to-end repro with wifi off: open a `.ipynb` under `~/ipractice` and confirm the kernel starts instead of erroring.
