### PR TITLE
feat(widgets): round-trip frontend binary widget state via PutBlob

### DIFF
--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type FrameLocator, type Locator, type Page } from "@playwright/test";
+import {
+  ensureCodeCell,
+  executeCell,
+  openNotebookRoom,
+  setCellSource,
+  waitForCellCount,
+  waitForCodeCellContaining,
+  waitForKernelStatus,
+  waitForOutputContaining,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test.describe("jupyter-scatter lasso selection", () => {
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("round-trips a lasso selection through binary widget comm buffers", async ({ page }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.manageDependencies(["jupyter-scatter>=1.0,<1.1"]);
+    await waitForKernelStatus(page, "idle", 180_000);
+
+    const scatterCell = await ensureCodeCell(page);
+    await setCellSource(
+      scatterCell,
+      [
+        "import pandas as pd",
+        "import numpy as np",
+        "import jscatter",
+        "",
+        "rng = np.random.default_rng(42)",
+        "df = pd.DataFrame({",
+        "    'mass': rng.random(1000),",
+        "    'speed': rng.random(1000),",
+        "    'pval': rng.random(1000),",
+        "    'group': rng.integers(0, 4, 1000).astype(str),",
+        "})",
+        "jpl = jscatter.plot(",
+        "    data=df,",
+        "    x='mass',",
+        "    y='speed',",
+        "    lasso_initiator=False,",
+        "    lasso_on_long_press=False,",
+        "    lasso_min_dist=1,",
+        "    lasso_type='rectangle',",
+        "    mouse_mode='lasso',",
+        ")",
+        "jpl",
+      ].join("\n"),
+    );
+
+    await executeCell(scatterCell);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const widgetFrame = scatterCell.frameLocator("iframe");
+    const plotSurface = widgetFrame.locator("canvas").first();
+    await expect(plotSurface).toBeVisible({ timeout: 120_000 });
+
+    await selectLassoTool(page, scatterCell, widgetFrame);
+    await dragLassoAroundCenter(page, plotSurface);
+    await page.waitForTimeout(3_000);
+    await expect
+      .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+
+    await mcp.createCell("print('jscatter-selection-count', len(jpl.selection))");
+    await waitForCellCount(page, 2);
+    const selectionCell = await waitForCodeCellContaining(page, "jscatter-selection-count");
+
+    await executeCell(selectionCell);
+    const output = await waitForOutputContaining(selectionCell, "jscatter-selection-count", 60_000);
+    await expect
+      .poll(async () => parseSelectionCount(await output.textContent()), { timeout: 60_000 })
+      .toBeGreaterThan(0);
+
+    await expect
+      .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
+      .toBeGreaterThan(0);
+  });
+});
+
+async function selectLassoTool(page: Page, cell: Locator, widgetFrame: FrameLocator) {
+  const namedButton = widgetFrame.getByRole("button", { name: /activate lasso selection/i });
+  if ((await namedButton.count()) > 0) {
+    await namedButton.click();
+    return;
+  }
+
+  const titleButton = widgetFrame
+    .locator(
+      "button[title*='lasso' i], button[aria-label*='lasso' i], [role='button'][title*='lasso' i], [role='button'][aria-label*='lasso' i]",
+    )
+    .first();
+  if ((await titleButton.count()) > 0) {
+    await titleButton.click();
+    return;
+  }
+
+  const cellBox = await cell.boundingBox();
+  const canvasBox = await cell.locator("iframe").first().boundingBox();
+  if (!cellBox || !canvasBox) throw new Error("jscatter output is missing layout boxes");
+
+  await page.mouse.click(cellBox.x + 28, canvasBox.y + 72);
+}
+
+async function dragLassoAroundCenter(page: Page, canvas: Locator) {
+  const box = await canvas.boundingBox();
+  if (!box) throw new Error("jscatter canvas is missing a layout box");
+
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const points = [
+    [cx - 180, cy - 120],
+    [cx + 180, cy + 120],
+  ] as const;
+
+  await page.mouse.move(points[0][0], points[0][1]);
+  await page.mouse.down();
+  for (const [x, y] of points.slice(1)) {
+    await page.mouse.move(x, y, { steps: 10 });
+  }
+  await page.mouse.up();
+  await page.waitForTimeout(750);
+}
+
+function parseSelectionCount(text: string | null): number {
+  const match = text?.match(/jscatter-selection-count\s+(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
+async function getFrontendSelectionCount(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const store = (window as unknown as { __nteractWidgetStore?: unknown }).__nteractWidgetStore as
+      | {
+          getSnapshot?: () => Map<
+            string,
+            { state?: { selection?: { view?: { byteLength?: number }; shape?: unknown } } }
+          >;
+        }
+      | undefined;
+    const models = store?.getSnapshot?.();
+    if (!models) return 0;
+    for (const model of models.values()) {
+      const shape = model.state?.selection?.shape;
+      if (Array.isArray(shape) && typeof shape[0] === "number") return shape[0];
+      const byteLength = model.state?.selection?.view?.byteLength;
+      if (typeof byteLength === "number") return byteLength;
+    }
+    return 0;
+  });
+}

--- a/apps/notebook/e2e/mcp-peer.ts
+++ b/apps/notebook/e2e/mcp-peer.ts
@@ -92,6 +92,14 @@ export class McpPeer {
     });
   }
 
+  async manageDependencies(dependencies: string[]): Promise<unknown> {
+    return await this.callToolJson("manage_dependencies", {
+      add: dependencies,
+      trust: true,
+      apply: "sync",
+    });
+  }
+
   async close(): Promise<void> {
     for (const [, pending] of this.pending) {
       clearTimeout(pending.timer);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -5,6 +5,7 @@ import {
   type DependencyGuard,
   type GuardedNotebookProvenance,
   NotebookClient,
+  putBlob,
   type SessionStatus,
 } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
@@ -14,7 +15,7 @@ import {
   useWidgetStoreRequired,
   WidgetStoreProvider,
 } from "@/components/widgets/widget-store-context";
-import { WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
+import { type BlobUploader, WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -154,6 +155,19 @@ function resolveCommOutputs(
 
 function AppContent() {
   const host = useNotebookHost();
+  const blobUploader = useMemo<BlobUploader>(
+    () => (bytes, mediaType) => putBlob(host.transport, bytes, mediaType),
+    [host],
+  );
+  _blobUploaderRef = blobUploader;
+  useEffect(
+    () => () => {
+      if (_blobUploaderRef === blobUploader) {
+        _blobUploaderRef = null;
+      }
+    },
+    [blobUploader],
+  );
   const gitInfo = useGitInfo();
   const daemonInfo = useDaemonInfo();
 
@@ -1824,10 +1838,12 @@ function AppErrorFallback(_error: Error, resetErrorBoundary: () => void) {
 // Module-level ref for the widget store (set by AppContent, read by updateManager).
 // This avoids a chicken-and-egg: the manager is created before the store exists.
 let _widgetStoreRef: import("@/components/widgets/widget-store").WidgetStore | null = null;
+let _blobUploaderRef: BlobUploader | null = null;
 
 const updateManager = new WidgetUpdateManager({
   getStore: () => _widgetStoreRef,
   getCrdtWriter: getCrdtCommWriter,
+  getBlobUploader: () => _blobUploaderRef,
 });
 
 function WidgetViewRenderer({ data }: { data: unknown }) {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -195,7 +195,12 @@ fn try_send_comm_update(
     comm_id: String,
     state: serde_json::Value,
 ) {
-    match work_tx.try_send(QueueCommand::SendCommUpdate { comm_id, state }) {
+    match work_tx.try_send(QueueCommand::SendCommUpdate {
+        comm_id,
+        state,
+        buffer_paths: vec![],
+        buffers: vec![],
+    }) {
         Ok(()) => {}
         Err(mpsc::error::TrySendError::Full(QueueCommand::SendCommUpdate { comm_id, .. })) => {
             debug!(
@@ -2974,7 +2979,13 @@ impl KernelConnection for JupyterKernel {
         Ok(())
     }
 
-    async fn send_comm_update(&mut self, comm_id: &str, state: serde_json::Value) -> Result<()> {
+    async fn send_comm_update(
+        &mut self,
+        comm_id: &str,
+        state: serde_json::Value,
+        buffer_paths: Vec<Vec<String>>,
+        buffers: Vec<Vec<u8>>,
+    ) -> Result<()> {
         let shell = self
             .shell_writer
             .as_mut()
@@ -2986,11 +2997,12 @@ impl KernelConnection for JupyterKernel {
                 let mut map = serde_json::Map::new();
                 map.insert("method".to_string(), serde_json::json!("update"));
                 map.insert("state".to_string(), state);
-                map.insert("buffer_paths".to_string(), serde_json::json!([]));
+                map.insert("buffer_paths".to_string(), serde_json::json!(buffer_paths));
                 map
             },
         };
-        let message: jupyter_protocol::JupyterMessage = comm_msg.into();
+        let mut message: jupyter_protocol::JupyterMessage = comm_msg.into();
+        message.buffers = buffers.into_iter().map(Bytes::from).collect();
         shell.send(message).await?;
         debug!(
             "[jupyter-kernel] Sent comm_msg(update) to kernel: comm_id={}",

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -113,6 +113,8 @@ pub trait KernelConnection: Send {
         &mut self,
         comm_id: &str,
         state: serde_json::Value,
+        buffer_paths: Vec<Vec<String>>,
+        buffers: Vec<Vec<u8>>,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Request code completions from the kernel.

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -488,7 +488,13 @@ mod tests {
         async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
             Ok(())
         }
-        async fn send_comm_update(&mut self, _: &str, _: serde_json::Value) -> Result<()> {
+        async fn send_comm_update(
+            &mut self,
+            _: &str,
+            _: serde_json::Value,
+            _: Vec<Vec<String>>,
+            _: Vec<Vec<u8>>,
+        ) -> Result<()> {
             Ok(())
         }
         async fn complete(

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -488,6 +488,8 @@ pub enum QueueCommand {
     SendCommUpdate {
         comm_id: String,
         state: serde_json::Value,
+        buffer_paths: Vec<Vec<String>>,
+        buffers: Vec<Vec<u8>>,
     },
 }
 
@@ -612,12 +614,16 @@ mod tests {
             .try_send(QueueCommand::SendCommUpdate {
                 comm_id: "comm-a".to_string(),
                 state: serde_json::json!({}),
+                buffer_paths: vec![],
+                buffers: vec![],
             })
             .expect("first work item should fit");
         assert!(work_tx
             .try_send(QueueCommand::SendCommUpdate {
                 comm_id: "comm-b".to_string(),
                 state: serde_json::json!({}),
+                buffer_paths: vec![],
+                buffers: vec![],
             })
             .is_err());
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -51,6 +51,9 @@ use crate::kernel_state::KernelState;
 use crate::output_prep::{QueueCommand, QueueCommandReceivers};
 use crate::protocol::QueueEntry;
 
+mod echo_suppression;
+use echo_suppression::EchoSuppressor;
+
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
     state: RuntimeStateHandle,
@@ -121,6 +124,7 @@ pub async fn run_runtime_agent(
     let mut interrupt_handle: Option<crate::jupyter_kernel::InterruptHandle> = None;
     let mut kernel_state = KernelState::new(state.clone());
     let mut seen_execution_ids = HashSet::new();
+    let mut echo_suppressor = EchoSuppressor::default();
     let mut lifecycle_rx: Option<mpsc::UnboundedReceiver<QueueCommand>> = None;
     let mut work_rx: Option<mpsc::Receiver<QueueCommand>> = None;
 
@@ -380,8 +384,41 @@ pub async fn run_runtime_agent(
                                             if !comm_updates.is_empty() {
                                                 if let Some(ref mut k) = kernel {
                                                     for (comm_id, delta) in &comm_updates {
-                                                        if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
-                                                            warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
+                                                        let Some(update) = prepare_comm_update(
+                                                            comm_id,
+                                                            delta,
+                                                            &ctx.blob_store,
+                                                            &mut echo_suppressor,
+                                                        )
+                                                        .await
+                                                        else {
+                                                            continue;
+                                                        };
+                                                        let RehydratedCommUpdate {
+                                                            state,
+                                                            buffer_paths,
+                                                            buffers,
+                                                            content_hashes,
+                                                        } = update;
+                                                        match k
+                                                            .send_comm_update(
+                                                                comm_id,
+                                                                state,
+                                                                buffer_paths,
+                                                                buffers,
+                                                            )
+                                                            .await
+                                                        {
+                                                            Ok(()) => {
+                                                                for hash in content_hashes {
+                                                                    echo_suppressor.record_outgoing(
+                                                                        comm_id, &hash,
+                                                                    );
+                                                                }
+                                                            }
+                                                            Err(e) => {
+                                                                warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -1334,9 +1371,14 @@ async fn handle_queue_command(
         QueueCommand::SendCommUpdate {
             comm_id,
             state: comm_state,
+            buffer_paths,
+            buffers,
         } => {
             if let Some(ref mut k) = kernel {
-                if let Err(e) = k.send_comm_update(&comm_id, comm_state).await {
+                if let Err(e) = k
+                    .send_comm_update(&comm_id, comm_state, buffer_paths, buffers)
+                    .await
+                {
                     warn!("[runtime-agent] Failed to send comm update: {}", e);
                 }
             }
@@ -1419,6 +1461,156 @@ fn diff_comm_state(
     updates
 }
 
+struct RehydratedCommUpdate {
+    state: serde_json::Value,
+    buffer_paths: Vec<Vec<String>>,
+    buffers: Vec<Vec<u8>>,
+    content_hashes: Vec<String>,
+}
+
+async fn prepare_comm_update(
+    comm_id: &str,
+    delta: &serde_json::Value,
+    blob_store: &BlobStore,
+    echo_suppressor: &mut EchoSuppressor,
+) -> Option<RehydratedCommUpdate> {
+    let content_refs = collect_content_refs(delta);
+    if content_refs
+        .iter()
+        .any(|(_, hash)| echo_suppressor.is_recent_echo(comm_id, hash))
+    {
+        debug!(
+            "[runtime-agent] Suppressing echoed binary comm update for comm_id={}",
+            comm_id
+        );
+        return None;
+    }
+
+    let mut state = delta.clone();
+    let mut buffer_paths = Vec::new();
+    let mut buffers = Vec::new();
+    let mut content_hashes = Vec::new();
+
+    for (path, hash) in content_refs {
+        set_json_path(&mut state, &path, serde_json::Value::Null);
+        match blob_store.get(&hash).await {
+            Ok(Some(bytes)) => {
+                buffer_paths.push(path);
+                buffers.push(bytes);
+                content_hashes.push(hash);
+            }
+            Ok(None) => {
+                warn!(
+                    "[runtime-agent] Missing blob {} for widget comm update; skipping buffer",
+                    hash
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "[runtime-agent] Failed to read blob {} for widget comm update: {}",
+                    hash, e
+                );
+            }
+        }
+    }
+
+    Some(RehydratedCommUpdate {
+        state,
+        buffer_paths,
+        buffers,
+        content_hashes,
+    })
+}
+
+fn collect_content_refs(delta: &serde_json::Value) -> Vec<(Vec<String>, String)> {
+    let mut refs = Vec::new();
+    collect_content_refs_at(delta, &mut Vec::new(), &mut refs);
+    refs
+}
+
+fn collect_content_refs_at(
+    value: &serde_json::Value,
+    path: &mut Vec<String>,
+    refs: &mut Vec<(Vec<String>, String)>,
+) {
+    if let Some(hash) = strict_content_ref_hash(value) {
+        refs.push((path.clone(), hash.to_string()));
+        return;
+    }
+
+    match value {
+        serde_json::Value::Object(obj) => {
+            for (key, child) in obj {
+                path.push(key.clone());
+                collect_content_refs_at(child, path, refs);
+                path.pop();
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                path.push(index.to_string());
+                collect_content_refs_at(child, path, refs);
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn strict_content_ref_hash(value: &serde_json::Value) -> Option<&str> {
+    let obj = value.as_object()?;
+    if obj.len() != 3 {
+        return None;
+    }
+    let blob = obj.get("blob")?.as_str()?;
+    let _size = obj.get("size")?.as_u64()?;
+    let _media_type = obj.get("media_type")?.as_str()?;
+    Some(blob)
+}
+
+fn set_json_path(root: &mut serde_json::Value, path: &[String], value: serde_json::Value) {
+    if path.is_empty() {
+        *root = value;
+        return;
+    }
+
+    let mut current = root;
+    for segment in &path[..path.len() - 1] {
+        current = match current {
+            serde_json::Value::Object(obj) => match obj.get_mut(segment) {
+                Some(next) => next,
+                None => return,
+            },
+            serde_json::Value::Array(items) => match segment
+                .parse::<usize>()
+                .ok()
+                .and_then(|index| items.get_mut(index))
+            {
+                Some(next) => next,
+                None => return,
+            },
+            _ => return,
+        };
+    }
+
+    let last = &path[path.len() - 1];
+    match current {
+        serde_json::Value::Object(obj) => {
+            obj.insert(last.clone(), value);
+        }
+        serde_json::Value::Array(items) => {
+            if let Some(slot) = last
+                .parse::<usize>()
+                .ok()
+                .and_then(|index| items.get_mut(index))
+            {
+                *slot = value;
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1451,7 +1643,13 @@ mod tests {
         async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
             Ok(())
         }
-        async fn send_comm_update(&mut self, _: &str, _: serde_json::Value) -> Result<()> {
+        async fn send_comm_update(
+            &mut self,
+            _: &str,
+            _: serde_json::Value,
+            _: Vec<Vec<String>>,
+            _: Vec<Vec<u8>>,
+        ) -> Result<()> {
             Ok(())
         }
         async fn complete(
@@ -1590,6 +1788,8 @@ mod tests {
             .try_send(QueueCommand::SendCommUpdate {
                 comm_id: "comm-a".to_string(),
                 state: serde_json::json!({ "outputs": [] }),
+                buffer_paths: vec![],
+                buffers: vec![],
             })
             .expect("work queue should accept one item");
         lifecycle_tx
@@ -1739,5 +1939,99 @@ mod tests {
         let ec = handle.read(|sd| sd.get_execution("eC").unwrap()).unwrap();
         assert_eq!(ec.status, "done");
         assert_eq!(ec.success, Some(true));
+    }
+
+    #[tokio::test]
+    async fn prepare_comm_update_rehydrates_content_refs_to_buffers() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put(&[1, 2, 3, 4], "application/octet-stream")
+            .await
+            .unwrap();
+        let delta = serde_json::json!({
+            "selection": {
+                "view": {
+                    "blob": hash,
+                    "size": 4,
+                    "media_type": "application/octet-stream"
+                },
+                "dtype": "uint32",
+                "shape": [1]
+            }
+        });
+        let mut suppressor = EchoSuppressor::default();
+
+        let update = prepare_comm_update("comm-a", &delta, &blob_store, &mut suppressor)
+            .await
+            .expect("update should not be suppressed");
+
+        assert_eq!(
+            update.state,
+            serde_json::json!({
+                "selection": {
+                    "view": null,
+                    "dtype": "uint32",
+                    "shape": [1]
+                }
+            })
+        );
+        assert_eq!(
+            update.buffer_paths,
+            vec![vec!["selection".to_string(), "view".to_string()]]
+        );
+        assert_eq!(update.buffers, vec![vec![1, 2, 3, 4]]);
+        assert_eq!(update.content_hashes, vec![hash]);
+    }
+
+    #[tokio::test]
+    async fn prepare_comm_update_ignores_non_strict_content_ref_shape() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put(&[1], "application/octet-stream")
+            .await
+            .unwrap();
+        let delta = serde_json::json!({
+            "value": {
+                "blob": hash,
+                "size": 1,
+                "media_type": "application/octet-stream",
+                "extra": true
+            }
+        });
+        let mut suppressor = EchoSuppressor::default();
+
+        let update = prepare_comm_update("comm-a", &delta, &blob_store, &mut suppressor)
+            .await
+            .expect("update should not be suppressed");
+
+        assert_eq!(update.state, delta);
+        assert!(update.buffer_paths.is_empty());
+        assert!(update.buffers.is_empty());
+        assert!(update.content_hashes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prepare_comm_update_drops_recent_echoes() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put(&[1], "application/octet-stream")
+            .await
+            .unwrap();
+        let delta = serde_json::json!({
+            "selection": {
+                "blob": hash,
+                "size": 1,
+                "media_type": "application/octet-stream"
+            }
+        });
+        let mut suppressor = EchoSuppressor::default();
+        suppressor.record_outgoing("comm-a", &hash);
+
+        let update = prepare_comm_update("comm-a", &delta, &blob_store, &mut suppressor).await;
+
+        assert!(update.is_none());
     }
 }

--- a/crates/runtimed/src/runtime_agent/echo_suppression.rs
+++ b/crates/runtimed/src/runtime_agent/echo_suppression.rs
@@ -1,0 +1,109 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+const ECHO_TTL: Duration = Duration::from_secs(30);
+const MAX_ENTRIES_PER_COMM: usize = 64;
+
+#[derive(Debug, Clone)]
+struct EchoEntry {
+    content_hash: String,
+    recorded_at: Instant,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct EchoSuppressor {
+    buckets: HashMap<String, VecDeque<EchoEntry>>,
+}
+
+impl EchoSuppressor {
+    pub(super) fn record_outgoing(&mut self, comm_id: &str, content_hash: &str) {
+        let now = Instant::now();
+        let bucket = self.buckets.entry(comm_id.to_string()).or_default();
+        evict_expired(bucket, now);
+        while bucket.len() >= MAX_ENTRIES_PER_COMM {
+            bucket.pop_front();
+        }
+        bucket.push_back(EchoEntry {
+            content_hash: content_hash.to_string(),
+            recorded_at: now,
+        });
+    }
+
+    pub(super) fn is_recent_echo(&mut self, comm_id: &str, content_hash: &str) -> bool {
+        let Some(bucket) = self.buckets.get_mut(comm_id) else {
+            return false;
+        };
+        evict_expired(bucket, Instant::now());
+        bucket
+            .iter()
+            .any(|entry| entry.content_hash == content_hash)
+    }
+}
+
+fn evict_expired(bucket: &mut VecDeque<EchoEntry>, now: Instant) {
+    while bucket
+        .front()
+        .is_some_and(|entry| now.duration_since(entry.recorded_at) > ECHO_TTL)
+    {
+        bucket.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn age_first(suppressor: &mut EchoSuppressor, comm_id: &str, age: Duration) {
+        let entry = suppressor
+            .buckets
+            .get_mut(comm_id)
+            .and_then(|bucket| bucket.front_mut())
+            .expect("entry should exist");
+        entry.recorded_at = entry.recorded_at.checked_sub(age).unwrap();
+    }
+
+    #[test]
+    fn immediate_echo_is_recent() {
+        let mut suppressor = EchoSuppressor::default();
+        suppressor.record_outgoing("comm-a", "hash-a");
+
+        assert!(suppressor.is_recent_echo("comm-a", "hash-a"));
+    }
+
+    #[test]
+    fn echo_expires_after_ttl() {
+        let mut suppressor = EchoSuppressor::default();
+        suppressor.record_outgoing("comm-a", "hash-a");
+        age_first(&mut suppressor, "comm-a", Duration::from_secs(31));
+
+        assert!(!suppressor.is_recent_echo("comm-a", "hash-a"));
+    }
+
+    #[test]
+    fn hashes_are_scoped_per_comm() {
+        let mut suppressor = EchoSuppressor::default();
+        suppressor.record_outgoing("comm-a", "hash-a");
+
+        assert!(!suppressor.is_recent_echo("comm-b", "hash-a"));
+    }
+
+    #[test]
+    fn cap_evicts_oldest_entry() {
+        let mut suppressor = EchoSuppressor::default();
+        for index in 0..65 {
+            suppressor.record_outgoing("comm-a", &format!("hash-{index}"));
+        }
+
+        assert!(!suppressor.is_recent_echo("comm-a", "hash-0"));
+        assert!(suppressor.is_recent_echo("comm-a", "hash-1"));
+        assert!(suppressor.is_recent_echo("comm-a", "hash-64"));
+    }
+
+    #[test]
+    fn recorded_outgoing_hash_suppresses_roundtrip_delta() {
+        let mut suppressor = EchoSuppressor::default();
+        suppressor.record_outgoing("comm-a", "hash-a");
+
+        assert!(suppressor.is_recent_echo("comm-a", "hash-a"));
+    }
+}

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -24,7 +24,11 @@ function filterBufferPathsToKeys(
 }
 
 // Type for sending messages to kernel
-type SendUpdate = (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+type SendUpdate = (
+  commId: string,
+  state: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => Promise<void>;
 
 type SendCustom = (
   commId: string,
@@ -306,7 +310,9 @@ export class CommBridgeManager {
         const current = this.previousState.get(commId) ?? {};
         this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...data }));
         // Then forward to kernel
-        this.sendUpdateToKernel(commId, data, buffers);
+        void this.sendUpdateToKernel(commId, data, buffers).catch((error: unknown) => {
+          console.error("[widgets] failed to persist iframe widget state update:", error);
+        });
       } finally {
         this.isProcessingIframeUpdate = false;
       }

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -28,7 +28,7 @@ type SendUpdate = (
   commId: string,
   state: Record<string, unknown>,
   buffers?: ArrayBuffer[],
-) => Promise<void>;
+) => void | Promise<void>;
 
 type SendCustom = (
   commId: string,
@@ -310,9 +310,11 @@ export class CommBridgeManager {
         const current = this.previousState.get(commId) ?? {};
         this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...data }));
         // Then forward to kernel
-        void this.sendUpdateToKernel(commId, data, buffers).catch((error: unknown) => {
-          console.error("[widgets] failed to persist iframe widget state update:", error);
-        });
+        void Promise.resolve(this.sendUpdateToKernel(commId, data, buffers)).catch(
+          (error: unknown) => {
+            console.error("[widgets] failed to persist iframe widget state update:", error);
+          },
+        );
       } finally {
         this.isProcessingIframeUpdate = false;
       }

--- a/src/components/widgets/__tests__/comm-buffer-extraction.test.ts
+++ b/src/components/widgets/__tests__/comm-buffer-extraction.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { extractCommBuffers } from "../comm-buffer-extraction";
+
+function bytes(buffer: ArrayBuffer): number[] {
+  return Array.from(new Uint8Array(buffer));
+}
+
+describe("extractCommBuffers", () => {
+  it("extracts a top-level DataView leaf", () => {
+    const source = new Uint8Array([1, 2, 3, 4]).buffer;
+    const view = new DataView(source);
+
+    const result = extractCommBuffers({ selection: view });
+
+    expect(result.jsonPatch).toEqual({ selection: null });
+    expect(result.bufferPaths).toEqual([["selection"]]);
+    expect(bytes(result.buffers[0])).toEqual([1, 2, 3, 4]);
+  });
+
+  it("extracts a nested typed array", () => {
+    const array = new Uint32Array([7, 11]);
+
+    const result = extractCommBuffers({ nested: { values: array } });
+
+    expect(result.jsonPatch).toEqual({ nested: { values: null } });
+    expect(result.bufferPaths).toEqual([["nested", "values"]]);
+    expect(bytes(result.buffers[0])).toEqual(Array.from(new Uint8Array(array.buffer)));
+  });
+
+  it("preserves the exact byte range for offset typed arrays", () => {
+    const source = new Uint8Array([99, 1, 2, 3, 88]);
+    const view = new Uint8Array(source.buffer, 1, 3);
+
+    const result = extractCommBuffers({ values: view });
+
+    expect(result.jsonPatch).toEqual({ values: null });
+    expect(result.bufferPaths).toEqual([["values"]]);
+    expect(bytes(result.buffers[0])).toEqual([1, 2, 3]);
+  });
+
+  it("extracts a jupyter-scatter style view while preserving metadata", () => {
+    const source = new Uint8Array([4, 5, 6, 7]).buffer;
+
+    const result = extractCommBuffers({
+      selection: {
+        view: new DataView(source),
+        dtype: "uint32",
+        shape: [1],
+      },
+    });
+
+    expect(result.jsonPatch).toEqual({
+      selection: {
+        view: null,
+        dtype: "uint32",
+        shape: [1],
+      },
+    });
+    expect(result.bufferPaths).toEqual([["selection", "view"]]);
+    expect(bytes(result.buffers[0])).toEqual([4, 5, 6, 7]);
+  });
+
+  it("keeps buffer paths in traversal order", () => {
+    const result = extractCommBuffers({
+      first: new Uint8Array([1]),
+      nested: [new Uint8Array([2]), { third: new Uint8Array([3]) }],
+    });
+
+    expect(result.jsonPatch).toEqual({
+      first: null,
+      nested: [null, { third: null }],
+    });
+    expect(result.bufferPaths).toEqual([["first"], ["nested", "0"], ["nested", "1", "third"]]);
+    expect(result.buffers.map(bytes)).toEqual([[1], [2], [3]]);
+  });
+
+  it("does not treat genuine null values as buffers", () => {
+    const result = extractCommBuffers({ selection: null });
+
+    expect(result.jsonPatch).toEqual({ selection: null });
+    expect(result.bufferPaths).toEqual([]);
+    expect(result.buffers).toEqual([]);
+  });
+
+  it("throws on cyclic values", () => {
+    const patch: Record<string, unknown> = {};
+    patch.self = patch;
+
+    expect(() => extractCommBuffers(patch)).toThrow(/cyclic value/);
+  });
+
+  it("throws on unsupported non-json objects", () => {
+    expect(() => extractCommBuffers({ values: new Map() })).toThrow(/unsupported Map value/);
+  });
+});

--- a/src/components/widgets/__tests__/output-widget.test.tsx
+++ b/src/components/widgets/__tests__/output-widget.test.tsx
@@ -37,7 +37,7 @@ describe("OutputWidget", () => {
           store,
           handleMessage: () => {},
           sendMessage: () => {},
-          sendUpdate: () => {},
+          sendUpdate: async () => {},
           sendCustom: () => {},
           closeComm: () => {},
         }}
@@ -85,7 +85,7 @@ describe("OutputWidget", () => {
           store,
           handleMessage: () => {},
           sendMessage: () => {},
-          sendUpdate: () => {},
+          sendUpdate: async () => {},
           sendCustom: () => {},
           closeComm: () => {},
         }}

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -4,11 +4,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { createWidgetStore } from "../widget-store";
-import { WidgetUpdateManager } from "../widget-update-manager";
+import { type BlobUploader, type ContentRef, WidgetUpdateManager } from "../widget-update-manager";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function setup(opts?: { writerAvailable?: boolean }) {
+function setup(opts?: { writerAvailable?: boolean; blobUploader?: BlobUploader }) {
   const store = createWidgetStore();
   const writerCalls: Array<{ commId: string; patch: Record<string, unknown> }> = [];
   const writer = (commId: string, patch: Record<string, unknown>) => {
@@ -19,6 +19,7 @@ function setup(opts?: { writerAvailable?: boolean }) {
   const manager = new WidgetUpdateManager({
     getStore: () => store,
     getCrdtWriter: () => (writerAvailable ? writer : null),
+    getBlobUploader: () => opts?.blobUploader ?? null,
   });
 
   // Pre-create a model so updateModel works
@@ -135,6 +136,98 @@ describe("WidgetUpdateManager", () => {
       manager.updateAndPersist("comm-1", { value: 42 }, [buffer]);
 
       // Flushed immediately, no debounce
+      expect(writerCalls).toHaveLength(1);
+      expect(writerCalls[0].patch).toEqual({ value: 42 });
+    });
+
+    it("uploads extracted binary leaves before writing ContentRefs to CRDT", async () => {
+      const uploadCalls: Array<{ bytes: number[]; mediaType: string }> = [];
+      const contentRef: ContentRef = {
+        blob: "sha256:abc",
+        size: 4,
+        media_type: "application/octet-stream",
+      };
+      const { manager, writerCalls } = setup({
+        blobUploader: async (bytes, mediaType) => {
+          uploadCalls.push({ bytes: Array.from(bytes), mediaType });
+          return contentRef;
+        },
+      });
+
+      await manager.updateAndPersist("comm-1", {
+        selection: {
+          view: new DataView(new Uint8Array([1, 2, 3, 4]).buffer),
+          dtype: "uint32",
+          shape: [1],
+        },
+      });
+
+      expect(uploadCalls).toEqual([{ bytes: [1, 2, 3, 4], mediaType: "application/octet-stream" }]);
+      expect(writerCalls).toHaveLength(1);
+      expect(writerCalls[0].patch).toEqual({
+        selection: {
+          view: contentRef,
+          dtype: "uint32",
+          shape: [1],
+        },
+      });
+    });
+
+    it("retries too_many_in_flight blob uploads", async () => {
+      const contentRef: ContentRef = {
+        blob: "sha256:retry",
+        size: 1,
+        media_type: "application/octet-stream",
+      };
+      let attempts = 0;
+      const { manager, writerCalls } = setup({
+        blobUploader: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw { reason: { kind: "too_many_in_flight" } };
+          }
+          return contentRef;
+        },
+      });
+
+      const pending = manager.updateAndPersist("comm-1", {
+        selection: new Uint8Array([1]),
+      });
+      await vi.advanceTimersByTimeAsync(100);
+      await pending;
+
+      expect(attempts).toBe(2);
+      expect(writerCalls).toHaveLength(1);
+      expect(writerCalls[0].patch).toEqual({ selection: contentRef });
+    });
+
+    it("aborts CRDT writes when blob upload fails permanently", async () => {
+      const error = new Error("blob store unavailable");
+      const { manager, writerCalls } = setup({
+        blobUploader: async () => {
+          throw error;
+        },
+      });
+
+      await expect(
+        manager.updateAndPersist("comm-1", { selection: new Uint8Array([1]) }),
+      ).rejects.toThrow("blob store unavailable");
+
+      expect(writerCalls).toHaveLength(0);
+    });
+
+    it("does not upload pure JSON patches", () => {
+      const blobUploader = vi.fn<BlobUploader>(async () => ({
+        blob: "unused",
+        size: 0,
+        media_type: "application/octet-stream",
+      }));
+      const { manager, writerCalls } = setup({ blobUploader });
+
+      manager.updateAndPersist("comm-1", { value: 42 });
+      vi.advanceTimersByTime(50);
+
+      expect(blobUploader).not.toHaveBeenCalled();
       expect(writerCalls).toHaveLength(1);
       expect(writerCalls[0].patch).toEqual({ value: 42 });
     });

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -211,7 +211,11 @@ type EventCallback = (...args: unknown[]) => void;
  * daemon shell channel as a Jupyter `comm_msg(method: "custom")`.
  */
 export interface AFMProxyOutbound {
-  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendUpdate: (
+    commId: string,
+    state: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
 }
 
@@ -278,7 +282,9 @@ export function createAFMModelProxy(
       // store update + echo suppression. In the iframe it posts a bridge
       // notification to the parent which then takes the same path. Either
       // way, no hand-built comm_msg frame and no shell-channel fallback.
-      outbound.sendUpdate(model.id, patch);
+      void outbound.sendUpdate(model.id, patch).catch((error: unknown) => {
+        console.error("[widgets] failed to persist widget state update:", error);
+      });
 
       for (const key of Object.keys(pendingChanges)) {
         delete pendingChanges[key];

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -282,7 +282,7 @@ export function createAFMModelProxy(
       // store update + echo suppression. In the iframe it posts a bridge
       // notification to the parent which then takes the same path. Either
       // way, no hand-built comm_msg frame and no shell-channel fallback.
-      void outbound.sendUpdate(model.id, patch).catch((error: unknown) => {
+      void Promise.resolve(outbound.sendUpdate(model.id, patch)).catch((error: unknown) => {
         console.error("[widgets] failed to persist widget state update:", error);
       });
 

--- a/src/components/widgets/comm-buffer-extraction.ts
+++ b/src/components/widgets/comm-buffer-extraction.ts
@@ -1,0 +1,122 @@
+export type ExtractedPatch = {
+  jsonPatch: Record<string, unknown>;
+  bufferPaths: string[][];
+  buffers: ArrayBuffer[];
+};
+
+type TraversalState = {
+  bufferPaths: string[][];
+  buffers: ArrayBuffer[];
+  stack: WeakSet<object>;
+};
+
+export function extractCommBuffers(patch: Record<string, unknown>): ExtractedPatch {
+  const state: TraversalState = {
+    bufferPaths: [],
+    buffers: [],
+    stack: new WeakSet(),
+  };
+
+  const jsonPatch = visitValue(patch, [], state);
+
+  if (!isPlainObject(jsonPatch)) {
+    throw new Error("Comm buffer patch must be a plain object");
+  }
+
+  return {
+    jsonPatch: jsonPatch as Record<string, unknown>,
+    bufferPaths: state.bufferPaths,
+    buffers: state.buffers,
+  };
+}
+
+function visitValue(value: unknown, path: string[], state: TraversalState): unknown {
+  if (value === null || isPrimitive(value)) {
+    return value;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return extractBuffer(value.slice(0), path, state);
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    if (!(view.buffer instanceof ArrayBuffer)) {
+      throw unsupportedValue(path, "SharedArrayBuffer-backed views");
+    }
+    return extractBuffer(
+      view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength),
+      path,
+      state,
+    );
+  }
+
+  if (typeof value === "undefined") {
+    throw unsupportedValue(path, "undefined");
+  }
+
+  if (typeof value === "function") {
+    throw unsupportedValue(path, "function");
+  }
+
+  if (typeof value !== "object") {
+    throw unsupportedValue(path, typeof value);
+  }
+
+  if (state.stack.has(value)) {
+    throw new Error(`Cannot extract comm buffers from cyclic value at ${formatPath(path)}`);
+  }
+
+  if (Array.isArray(value)) {
+    state.stack.add(value);
+    const next = value.map((item, index) => visitValue(item, [...path, String(index)], state));
+    state.stack.delete(value);
+    return next;
+  }
+
+  if (!isPlainObject(value)) {
+    throw unsupportedValue(path, value.constructor?.name ?? "object");
+  }
+
+  state.stack.add(value);
+  const next: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    next[key] = visitValue(item, [...path, key], state);
+  }
+  state.stack.delete(value);
+  return next;
+}
+
+function extractBuffer(buffer: ArrayBuffer, path: string[], state: TraversalState): null {
+  state.bufferPaths.push(path);
+  state.buffers.push(buffer);
+  return null;
+}
+
+function isPrimitive(value: unknown): boolean {
+  const valueType = typeof value;
+  return (
+    valueType === "string" ||
+    valueType === "number" ||
+    valueType === "boolean" ||
+    valueType === "bigint"
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function unsupportedValue(path: string[], type: string): Error {
+  return new Error(
+    `Cannot extract comm buffers from unsupported ${type} value at ${formatPath(path)}`,
+  );
+}
+
+function formatPath(path: string[]): string {
+  return path.length === 0 ? "<root>" : path.join(".");
+}

--- a/src/components/widgets/use-comm-router.ts
+++ b/src/components/widgets/use-comm-router.ts
@@ -74,7 +74,11 @@ export interface UseCommRouterOptions {
 
 export interface UseCommRouterReturn {
   /** Send a state update to the kernel */
-  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendUpdate: (
+    commId: string,
+    state: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
   /** Send a custom message to the kernel */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel */

--- a/src/components/widgets/use-comm-router.ts
+++ b/src/components/widgets/use-comm-router.ts
@@ -163,7 +163,7 @@ export function useCommRouter({
 
   const sendUpdate = useCallback(
     (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => {
-      managerRef.current.updateAndPersist(commId, state, buffers);
+      return managerRef.current.updateAndPersist(commId, state, buffers);
     },
     [],
   );

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -34,7 +34,11 @@ import {
 interface WidgetStoreContextValue {
   store: WidgetStore;
   /** Send a state update to the kernel. Routed through WidgetUpdateManager. */
-  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendUpdate: (
+    commId: string,
+    state: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
   /** Send a custom message (method: "custom") via the daemon shell channel. */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel via the daemon shell channel. */

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -12,12 +12,17 @@
  * 3. Stale CRDT echoes overwriting optimistic state
  */
 
+import { extractCommBuffers } from "./comm-buffer-extraction";
 import type { WidgetStore } from "./widget-store";
 
 type CrdtCommWriter = (commId: string, patch: Record<string, unknown>) => void;
+export type ContentRef = { blob: string; size: number; media_type: string };
+export type BlobUploader = (bytes: Uint8Array, mediaType: string) => Promise<ContentRef>;
 
 /** Debounce interval for CRDT writes (ms). */
 const DEBOUNCE_MS = 50;
+const BLOB_RETRY_DELAYS_MS = [100, 300, 900] as const;
+const BLOB_MEDIA_TYPE = "application/octet-stream";
 
 /**
  * Grace period after CRDT flush before clearing optimistic keys (ms).
@@ -67,11 +72,13 @@ function structuralEqual(a: unknown, b: unknown): boolean {
 export interface WidgetUpdateManagerOptions {
   getStore: () => WidgetStore | null;
   getCrdtWriter: () => CrdtCommWriter | null;
+  getBlobUploader?: () => BlobUploader | null;
 }
 
 export class WidgetUpdateManager {
   private readonly getStore: () => WidgetStore | null;
   private readonly getCrdtWriter: () => CrdtCommWriter | null;
+  private readonly getBlobUploader: () => BlobUploader | null;
 
   /** Accumulated patches waiting for debounced flush, per comm. */
   private pendingState = new Map<string, Record<string, unknown>>();
@@ -99,6 +106,7 @@ export class WidgetUpdateManager {
   constructor(opts: WidgetUpdateManagerOptions) {
     this.getStore = opts.getStore;
     this.getCrdtWriter = opts.getCrdtWriter;
+    this.getBlobUploader = opts.getBlobUploader ?? (() => null);
   }
 
   /**
@@ -108,11 +116,23 @@ export class WidgetUpdateManager {
    * text input, etc.). The store update fires subscriptions instantly for
    * responsive UI. The CRDT write is batched per-comm at 50ms.
    *
-   * Binary buffers bypass debouncing and flush immediately. They're outbound
-   * (headed to the kernel) and don't shape the inbound bufferPaths manifest,
-   * so the optimistic store update doesn't carry them.
+   * Binary leaves bypass debouncing and flush immediately after their bytes
+   * are uploaded to blob storage. The optimistic store update keeps the
+   * original DataView/typed-array values so active widgets don't flicker.
    */
-  updateAndPersist(commId: string, patch: Record<string, unknown>, buffers?: ArrayBuffer[]): void {
+  async updateAndPersist(
+    commId: string,
+    patch: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): Promise<void> {
+    const extracted = extractCommBuffers(patch);
+
+    if (buffers?.length && extracted.buffers.length) {
+      console.warn(
+        "[widgets] update supplied both extracted binary leaves and legacy buffers; using extracted leaves",
+      );
+    }
+
     // 1. Instant store update — UI reflects change immediately
     this.getStore()?.updateModel(commId, patch);
 
@@ -131,11 +151,16 @@ export class WidgetUpdateManager {
       trail.push(value);
     }
 
-    // 3. Accumulate patch
-    const existing = this.pendingState.get(commId);
-    this.pendingState.set(commId, existing ? { ...existing, ...patch } : { ...patch });
+    if (extracted.buffers.length > 0) {
+      const persistedPatch = await this.uploadExtractedBuffers(extracted);
+      this.flushImmediate(commId, persistedPatch);
+      return;
+    }
 
-    // 4. Binary buffers — flush immediately (can't merge ArrayBuffers)
+    // 3. Accumulate JSON-only patch
+    this.enqueuePending(commId, extracted.jsonPatch);
+
+    // 4. Legacy binary buffers — preserve the old immediate-flush behavior.
     if (buffers?.length) {
       this.flushComm(commId);
       return;
@@ -235,11 +260,27 @@ export class WidgetUpdateManager {
 
     const patch = this.pendingState.get(commId);
     if (!patch) return;
+    this.writeOrRetry(commId, patch);
+  }
 
+  private flushImmediate(commId: string, patch: Record<string, unknown>): void {
+    const timer = this.flushTimers.get(commId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.flushTimers.delete(commId);
+    }
+
+    const existing = this.pendingState.get(commId);
+    this.pendingState.delete(commId);
+    this.writeOrRetry(commId, existing ? { ...existing, ...patch } : patch);
+  }
+
+  private writeOrRetry(commId: string, patch: Record<string, unknown>): void {
     // If the CRDT writer isn't available yet (early startup), keep the
     // patch queued and retry after the next debounce interval.
     const writer = this.getCrdtWriter();
     if (!writer) {
+      this.pendingState.set(commId, patch);
       this.flushTimers.set(
         commId,
         setTimeout(() => this.flushComm(commId), DEBOUNCE_MS),
@@ -249,7 +290,61 @@ export class WidgetUpdateManager {
 
     this.pendingState.delete(commId);
     writer(commId, patch);
+    this.startEchoGrace(commId);
+  }
 
+  private enqueuePending(commId: string, patch: Record<string, unknown>): void {
+    const existing = this.pendingState.get(commId);
+    this.pendingState.set(commId, existing ? { ...existing, ...patch } : { ...patch });
+  }
+
+  private async uploadExtractedBuffers({
+    jsonPatch,
+    bufferPaths,
+    buffers,
+  }: {
+    jsonPatch: Record<string, unknown>;
+    bufferPaths: string[][];
+    buffers: ArrayBuffer[];
+  }): Promise<Record<string, unknown>> {
+    const uploader = this.getBlobUploader();
+    if (!uploader) {
+      throw new Error("Cannot persist binary widget update without a blob uploader");
+    }
+
+    const contentRefs = await Promise.all(
+      buffers.map((buffer) =>
+        this.uploadWithRetry(uploader, new Uint8Array(buffer), BLOB_MEDIA_TYPE),
+      ),
+    );
+
+    const persistedPatch = structuredClone(jsonPatch) as Record<string, unknown>;
+    for (let i = 0; i < contentRefs.length; i++) {
+      setValueAtPath(persistedPatch, bufferPaths[i], contentRefs[i]);
+    }
+    return persistedPatch;
+  }
+
+  private async uploadWithRetry(
+    uploader: BlobUploader,
+    bytes: Uint8Array,
+    mediaType: string,
+  ): Promise<ContentRef> {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await uploader(bytes, mediaType);
+      } catch (error) {
+        if (!isTooManyInFlight(error) || attempt >= BLOB_RETRY_DELAYS_MS.length) {
+          throw error;
+        }
+        await delay(BLOB_RETRY_DELAYS_MS[attempt]);
+        attempt += 1;
+      }
+    }
+  }
+
+  private startEchoGrace(commId: string): void {
     // Keep optimistic keys alive for a grace period after flush.
     // The CRDT write triggers a sync chain (frontend → daemon →
     // kernel → IOPub echo → CRDT → frontend) that can take 200-500ms.
@@ -267,4 +362,35 @@ export class WidgetUpdateManager {
       }, ECHO_GRACE_MS),
     );
   }
+}
+
+function setValueAtPath(root: Record<string, unknown>, path: string[], value: unknown): void {
+  if (path.length === 0) {
+    throw new Error("Cannot place ContentRef at the root of a comm patch");
+  }
+
+  let current: unknown = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    if (typeof current !== "object" || current === null) {
+      throw new Error(`Cannot place ContentRef at invalid path ${path.join(".")}`);
+    }
+    current = (current as Record<string, unknown>)[path[i]];
+  }
+
+  if (typeof current !== "object" || current === null) {
+    throw new Error(`Cannot place ContentRef at invalid path ${path.join(".")}`);
+  }
+  (current as Record<string, unknown>)[path[path.length - 1]] = value;
+}
+
+function isTooManyInFlight(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("reason" in error)) {
+    return false;
+  }
+  const reason = (error as { reason?: { kind?: unknown } }).reason;
+  return reason?.kind === "too_many_in_flight";
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -111,7 +111,13 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
   const mainContextValue = useMemo(
     () => ({
       store: client.store,
-      sendUpdate: client.sendUpdate,
+      sendUpdate: async (
+        commId: string,
+        state: Record<string, unknown>,
+        buffers?: ArrayBuffer[],
+      ) => {
+        client.sendUpdate(commId, state, buffers);
+      },
       sendCustom: client.sendCustom,
       closeComm: client.closeComm,
     }),


### PR DESCRIPTION
## Summary

Phase 3 of PutBlob comm buffer paths.

Currently included:

- adds a pure frontend comm buffer extraction helper
- covers DataView, typed arrays, jupyter-scatter-style `{ view, dtype, shape }` payloads, traversal order, genuine nulls, and cyclic values
- routes extracted binary widget updates through `putBlob` before CRDT persistence
- writes `ContentRef` leaves into comm state and preserves optimistic widget state without flicker
- retries `too_many_in_flight` uploads and aborts CRDT writes on terminal upload failures
- rehydrates CRDT `ContentRef` leaves back into Jupyter `comm_msg(update)` buffers
- suppresses immediate binary round-trip echoes per comm/hash
- adds a browser E2E that lasso-selects jupyter-scatter points, reads `len(jpl.selection)` from Python, and verifies the frontend selection remains non-empty
- tolerates synchronous isolated iframe update callbacks while preserving async update propagation

## Verification

- `pnpm test:run src/components/widgets/__tests__/comm-buffer-extraction.test.ts`
- `pnpm test:run src/components/widgets/__tests__/comm-buffer-extraction.test.ts src/components/widgets/__tests__/widget-update-manager.test.ts`
- `pnpm test:run src/components/widgets/__tests__/comm-buffer-extraction.test.ts src/components/widgets/__tests__/widget-update-manager.test.ts src/components/widgets/__tests__/output-widget.test.tsx`
- `pnpm test:run src/components/widgets/__tests__/afm-model-proxy.test.ts`
- `pnpm test:run src/components/widgets/__tests__/comm-buffer-extraction.test.ts src/components/widgets/__tests__/widget-update-manager.test.ts src/components/widgets/__tests__/output-widget.test.tsx src/components/widgets/__tests__/afm-model-proxy.test.ts`
- `cargo test -p runtimed runtime_agent --lib`
- `cargo test -p runtimed lifecycle_channel_is_not_backpressured_by_full_work_channel --lib`
- `cargo test -p runtimed comm_update_replay_is_best_effort_when_work_queue_is_full --lib`
- `pnpm test:e2e:browser -- jscatter-lasso.spec.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
