### PR TITLE
fix(runtimed): tolerate no internet for pixi:toml kernel launches

### DIFF
--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -1189,7 +1189,7 @@ pub async fn pixi_info(manifest_path: &std::path::Path) -> Result<PixiInfoResult
 /// direct Python launch without the `pixi run` wrapper.
 ///
 /// `extra_env` is applied to the spawned `pixi` subprocess (not to the
-/// returned activation vars). Use this to set `PIXI_FROZEN=1` when offline
+/// returned activation vars). Use this to set `PIXI_FROZEN=true` when offline
 /// so pixi does not try to refresh the lockfile from the network.
 pub async fn pixi_shell_hook(
     manifest_path: &std::path::Path,

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -1187,9 +1187,14 @@ pub async fn pixi_info(manifest_path: &std::path::Path) -> Result<PixiInfoResult
 ///
 /// These env vars can be applied to a `Command` with `cmd.envs()` for
 /// direct Python launch without the `pixi run` wrapper.
+///
+/// `extra_env` is applied to the spawned `pixi` subprocess (not to the
+/// returned activation vars). Use this to set `PIXI_FROZEN=1` when offline
+/// so pixi does not try to refresh the lockfile from the network.
 pub async fn pixi_shell_hook(
     manifest_path: &std::path::Path,
     environment: Option<&str>,
+    extra_env: &std::collections::HashMap<String, String>,
 ) -> Result<std::collections::HashMap<String, String>> {
     let pixi_path = get_pixi_path().await?;
     let mut cmd = tokio::process::Command::new(&pixi_path);
@@ -1197,6 +1202,9 @@ pub async fn pixi_shell_hook(
     cmd.arg(manifest_path);
     if let Some(env_name) = environment {
         cmd.args(["--environment", env_name]);
+    }
+    for (key, value) in extra_env {
+        cmd.env(key, value);
     }
 
     let output = cmd

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -545,8 +545,22 @@ impl KernelConnection for JupyterKernel {
                         } else {
                             "ipykernel_launcher"
                         };
+                        // Forward launch-config env vars (e.g. PIXI_FROZEN=1
+                        // when the daemon-side prepare needed frozen mode)
+                        // to the shell-hook subprocess. The bottom of this
+                        // function also applies them to the final kernel
+                        // command, but shell-hook runs first and would
+                        // otherwise hit the network without them.
+                        let shell_hook_env: std::collections::HashMap<String, String> =
+                            config.env_vars.iter().cloned().collect();
                         if let Some(ref manifest) = manifest_path {
-                            match kernel_launch::tools::pixi_shell_hook(manifest, None).await {
+                            match kernel_launch::tools::pixi_shell_hook(
+                                manifest,
+                                None,
+                                &shell_hook_env,
+                            )
+                            .await
+                            {
                                 Ok(env_vars) => {
                                     let python = env_vars
                                         .get("CONDA_PREFIX")

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -545,7 +545,7 @@ impl KernelConnection for JupyterKernel {
                         } else {
                             "ipykernel_launcher"
                         };
-                        // Forward launch-config env vars (e.g. PIXI_FROZEN=1
+                        // Forward launch-config env vars (e.g. PIXI_FROZEN=true
                         // when the daemon-side prepare needed frozen mode)
                         // to the shell-hook subprocess. The bottom of this
                         // function also applies them to the final kernel

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -44,6 +44,7 @@ pub mod notebook_sync_server;
 pub mod output_prep;
 pub mod output_store;
 pub mod paths;
+pub(crate) mod pixi_project;
 pub mod process_groups;
 pub mod project_file;
 pub(crate) mod requests;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -3681,6 +3681,7 @@ pub(crate) async fn auto_launch_kernel(
     };
 
     let mut uv_pyproject_offline = false;
+    let mut pixi_toml_frozen = false;
     if matches!(env_source, EnvSource::Pyproject) {
         match crate::uv_project::prepare_uv_pyproject_environment(
             notebook_path_opt.as_deref(),
@@ -3697,6 +3698,36 @@ pub(crate) async fn auto_launch_kernel(
             }
             Err(e) => {
                 let details = format!("Failed to prepare UV project environment: {e}");
+                error!("[notebook-sync] {}", details);
+                reset_and_publish_environment_launch_error(
+                    room,
+                    env_source.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                )
+                .await;
+                return;
+            }
+        }
+    } else if matches!(env_source, EnvSource::PixiToml) {
+        let outcome = crate::pixi_project::prepare_pixi_toml_environment(
+            notebook_path_opt.as_deref(),
+            progress_handler.clone(),
+        )
+        .await;
+        // Always clear the `ProjectPreparing` env progress the probe may
+        // have published; without this a successful fallback launch leaves
+        // "preparing pixi" pinned in the UI after the kernel is idle.
+        if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
+            warn!("[runtime-state] {}", e);
+        }
+        match outcome {
+            crate::pixi_project::PixiPrepareOutcome::SkipOrOnline => {}
+            crate::pixi_project::PixiPrepareOutcome::Frozen => {
+                pixi_toml_frozen = true;
+            }
+            crate::pixi_project::PixiPrepareOutcome::OfflineUnrecoverable(e) => {
+                let details = format!("Failed to prepare pixi:toml environment: {e}");
                 error!("[notebook-sync] {}", details);
                 reset_and_publish_environment_launch_error(
                     room,
@@ -3914,7 +3945,9 @@ pub(crate) async fn auto_launch_kernel(
                 }
 
                 // Send LaunchKernel RPC via the runtime agent's sync connection
-                let launch_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+                let mut launch_env_vars =
+                    crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+                launch_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
                 match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: kernel_type.to_string(),

--- a/crates/runtimed/src/pixi_project.rs
+++ b/crates/runtimed/src/pixi_project.rs
@@ -1,0 +1,335 @@
+//! Helpers for `pixi:toml` launches.
+//!
+//! Project-backed pixi kernels activate the user's pixi environment via
+//! `pixi shell-hook`. That call can hit the network when pixi decides the
+//! lockfile needs to refresh, so this module mirrors `uv_project` and adds
+//! an offline-tolerant prepare probe: if `pixi shell-hook` fails with
+//! network or DNS markers, retry with `PIXI_FROZEN=1` so pixi uses the
+//! lockfile as-is. When the retry succeeds, callers propagate the frozen
+//! signal through the kernel launch so the runtime-agent-side
+//! `pixi shell-hook` and the fallback `pixi run` also stay offline.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use kernel_env::{EnvProgressPhase, ProgressHandler};
+use tracing::{info, warn};
+
+use crate::uv_project::is_network_failure;
+
+/// Result of probing a `pixi:toml` environment before kernel launch.
+pub(crate) enum PixiPrepareOutcome {
+    /// No pixi manifest under the notebook tree, or `pixi shell-hook`
+    /// succeeded without `PIXI_FROZEN`, or the probe failed for a
+    /// non-network reason (the caller should let the downstream launch
+    /// surface its own error rather than treat this as a hard fail).
+    SkipOrOnline,
+    /// `pixi shell-hook` hit a network failure and the frozen retry
+    /// succeeded. Propagate `PIXI_FROZEN=true` through the LaunchKernel
+    /// RPC so the runtime-agent-side calls also stay offline.
+    Frozen,
+    /// `pixi shell-hook` hit a network failure AND the frozen retry also
+    /// failed: we are offline and the lockfile/env isn't materialized
+    /// enough to launch. Caller should surface this as a hard error
+    /// rather than letting the launch fail deeper in the stack.
+    OfflineUnrecoverable(anyhow::Error),
+}
+
+/// Env vars that switch `pixi` into frozen mode (lockfile-only, no network
+/// refresh). Returned alongside the prepare outcome so callers can attach
+/// it to the LaunchKernel RPC's `env_vars` map without losing the offline
+/// decision between daemon and runtime agent.
+pub(crate) fn pixi_frozen_env_vars(frozen: bool) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+    if frozen {
+        // `PIXI_FROZEN` parses as a bool (`true`/`false`), not `1`. Pixi
+        // rejects `PIXI_FROZEN=1` with `invalid value '1' for '--frozen'`.
+        env.insert("PIXI_FROZEN".to_string(), "true".to_string());
+    }
+    env
+}
+
+/// Probe the `pixi:toml` environment before kernel launch.
+///
+/// - If `pixi shell-hook` succeeds online, returns `SkipOrOnline`.
+/// - If it hits a network failure but a `PIXI_FROZEN=true` retry succeeds,
+///   returns `Frozen` so the caller propagates the flag to the kernel
+///   launch.
+/// - If both attempts fail with a network error, returns
+///   `OfflineUnrecoverable` so the caller can publish an actionable error
+///   instead of falling through to a launch that re-hits the network.
+/// - Non-network probe failures (e.g. malformed pixi.toml) also return
+///   `SkipOrOnline`: the existing launch path produces a better-typed
+///   error than this probe can.
+pub(crate) async fn prepare_pixi_toml_environment(
+    notebook_path: Option<&Path>,
+    progress_handler: Arc<dyn ProgressHandler>,
+) -> PixiPrepareOutcome {
+    let Some(manifest_path) = locate_pixi_manifest(notebook_path) else {
+        return PixiPrepareOutcome::SkipOrOnline;
+    };
+    let project_path_label = manifest_path.display().to_string();
+
+    progress_handler.on_progress(
+        "pixi",
+        EnvProgressPhase::ProjectPreparing {
+            source: "pixi:toml".to_string(),
+            project_path: project_path_label.clone(),
+        },
+    );
+
+    info!(
+        "[pixi-project] Preparing pixi:toml environment via shell-hook: project={}",
+        project_path_label
+    );
+    let started = Instant::now();
+    let empty: HashMap<String, String> = HashMap::new();
+    let initial_err =
+        match kernel_launch::tools::pixi_shell_hook(&manifest_path, None, &empty).await {
+            Ok(_) => {
+                info!(
+                    "[pixi-project] pixi:toml environment ready: project={} elapsed_ms={}",
+                    project_path_label,
+                    started.elapsed().as_millis()
+                );
+                return PixiPrepareOutcome::SkipOrOnline;
+            }
+            Err(e) => e,
+        };
+
+    let initial_stderr = format!("{initial_err}");
+    if !is_network_failure(&initial_stderr) {
+        // Non-network probe failure. Let the downstream launch produce its
+        // own (typed) error rather than synthesizing one here.
+        warn!(
+            "[pixi-project] pixi shell-hook probe failed for non-network reason; continuing to launch: project={} err={}",
+            project_path_label,
+            initial_stderr.trim()
+        );
+        return PixiPrepareOutcome::SkipOrOnline;
+    }
+
+    warn!(
+        "[pixi-project] pixi shell-hook hit network failure; retrying frozen: project={} stderr={}",
+        project_path_label,
+        initial_stderr.trim()
+    );
+
+    let frozen = pixi_frozen_env_vars(true);
+    match kernel_launch::tools::pixi_shell_hook(&manifest_path, None, &frozen).await {
+        Ok(_) => {
+            info!(
+                "[pixi-project] pixi:toml environment ready from lockfile (frozen): project={} elapsed_ms={}",
+                project_path_label,
+                started.elapsed().as_millis()
+            );
+            PixiPrepareOutcome::Frozen
+        }
+        Err(_) => {
+            // Frozen retry failed too. Surface the ORIGINAL network error:
+            // it names the actual cause (no internet), whereas the frozen
+            // retry failure typically just says the env can't be activated.
+            PixiPrepareOutcome::OfflineUnrecoverable(initial_err)
+        }
+    }
+}
+
+fn locate_pixi_manifest(notebook_path: Option<&Path>) -> Option<std::path::PathBuf> {
+    locate_pixi_manifest_with_home(notebook_path?, dirs::home_dir())
+}
+
+/// Walks up from the notebook directory and picks the closest pixi
+/// manifest. At each directory level `pixi.toml` wins over `pyproject.toml`
+/// with `[tool.pixi]`, and a bare `pyproject.toml` without `[tool.pixi]`
+/// is skipped (it's not our concern). Mirrors the boundaries of
+/// `crate::project_file::find_nearest_project_file` (stops at `.git` or
+/// the home directory) so the probe targets the same project the launch
+/// path will end up activating.
+///
+/// The `home_dir` parameter is plumbed through for tests; production
+/// callers should pass `dirs::home_dir()`.
+fn locate_pixi_manifest_with_home(
+    notebook_path: &Path,
+    home_dir: Option<std::path::PathBuf>,
+) -> Option<std::path::PathBuf> {
+    let start_dir = if notebook_path.is_file() {
+        notebook_path.parent()?
+    } else {
+        notebook_path
+    };
+    let mut current = start_dir.to_path_buf();
+    loop {
+        if let Some(ref home) = home_dir {
+            if current == *home {
+                return None;
+            }
+        }
+
+        // Match the launch path: `find_nearest_project_file` checks
+        // pyproject.toml before pixi.toml in its tiebreaker, and treats
+        // pyproject.toml-with-[tool.pixi] as a pixi manifest. So at the
+        // same level pyproject-with-[tool.pixi] wins over pixi.toml; a
+        // bare pyproject.toml drops out of the launch's PixiToml filter,
+        // but the fallback `pixi run` ends up auto-detecting a sibling
+        // pixi.toml from the cwd, so we still return pixi.toml here when
+        // one is present.
+        let pyproject = current.join("pyproject.toml");
+        if pyproject.exists() && crate::project_file::pyproject_has_pixi_section(&pyproject) {
+            return Some(pyproject);
+        }
+        let pixi = current.join("pixi.toml");
+        if pixi.exists() {
+            return Some(pixi);
+        }
+        if pyproject.exists() {
+            // Bare pyproject (no [tool.pixi]) without a sibling pixi.toml:
+            // the launch's PixiToml filter drops it and `pixi run`
+            // auto-detection from this cwd has nothing to grab onto. Stop
+            // walking so the probe doesn't target an unrelated ancestor.
+            return None;
+        }
+
+        if current.join(".git").exists() {
+            return None;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pixi_frozen_env_vars_set_pixi_frozen_when_true() {
+        let on = pixi_frozen_env_vars(true);
+        // Pixi parses PIXI_FROZEN as a bool; the literal "1" is rejected.
+        assert_eq!(on.get("PIXI_FROZEN"), Some(&"true".to_string()));
+        assert_eq!(on.len(), 1);
+        assert!(pixi_frozen_env_vars(false).is_empty());
+    }
+
+    #[test]
+    fn locate_pixi_manifest_finds_pixi_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = tmp.path().join("pixi.toml");
+        std::fs::write(&manifest, "[project]\nname=\"x\"\n").unwrap();
+        let notebook = tmp.path().join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(
+            locate_pixi_manifest_with_home(&notebook, None),
+            Some(manifest)
+        );
+    }
+
+    #[test]
+    fn locate_pixi_manifest_finds_pyproject_with_tool_pixi() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = tmp.path().join("pyproject.toml");
+        std::fs::write(
+            &manifest,
+            "[project]\nname=\"x\"\nversion=\"0.0.1\"\n\n[tool.pixi]\nchannels=[\"conda-forge\"]\n",
+        )
+        .unwrap();
+        let notebook = tmp.path().join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(
+            locate_pixi_manifest_with_home(&notebook, None),
+            Some(manifest)
+        );
+    }
+
+    #[test]
+    fn locate_pixi_manifest_prefers_pixi_toml_over_bare_pyproject() {
+        // A directory with both a bare `pyproject.toml` (no [tool.pixi])
+        // and a `pixi.toml` should resolve to the pixi.toml.
+        let tmp = tempfile::tempdir().unwrap();
+        let pyproject = tmp.path().join("pyproject.toml");
+        std::fs::write(&pyproject, "[project]\nname=\"x\"\nversion=\"0.0.1\"\n").unwrap();
+        let pixi_toml = tmp.path().join("pixi.toml");
+        std::fs::write(&pixi_toml, "[project]\nname=\"y\"\n").unwrap();
+        let notebook = tmp.path().join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(
+            locate_pixi_manifest_with_home(&notebook, None),
+            Some(pixi_toml)
+        );
+    }
+
+    #[test]
+    fn locate_pixi_manifest_skips_bare_pyproject() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = tmp.path().join("pyproject.toml");
+        std::fs::write(&manifest, "[project]\nname=\"x\"\nversion=\"0.0.1\"\n").unwrap();
+        let notebook = tmp.path().join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(locate_pixi_manifest_with_home(&notebook, None), None);
+    }
+
+    #[test]
+    fn locate_pixi_manifest_prefers_pyproject_with_tool_pixi_over_sibling_pixi_toml() {
+        // Matches the launch path: `find_nearest_project_file` returns
+        // pyproject (with [tool.pixi]) before pixi.toml at the same level,
+        // and the launch activates THAT pyproject as the pixi project.
+        // The probe must target the same manifest, or the frozen decision
+        // applies to the wrong env.
+        let tmp = tempfile::tempdir().unwrap();
+        let pyproject = tmp.path().join("pyproject.toml");
+        std::fs::write(
+            &pyproject,
+            "[project]\nname=\"x\"\nversion=\"0.0.1\"\n\n[tool.pixi]\nchannels=[\"conda-forge\"]\n",
+        )
+        .unwrap();
+        let pixi_toml = tmp.path().join("pixi.toml");
+        std::fs::write(&pixi_toml, "[project]\nname=\"y\"\n").unwrap();
+        let notebook = tmp.path().join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(
+            locate_pixi_manifest_with_home(&notebook, None),
+            Some(pyproject)
+        );
+    }
+
+    #[test]
+    fn locate_pixi_manifest_prefers_closer_pyproject_over_ancestor_pixi_toml() {
+        // Nested layout: ancestor has pixi.toml, nested dir has
+        // pyproject.toml with [tool.pixi]. The launch path activates the
+        // nested project (closer wins), so the probe must too.
+        let tmp = tempfile::tempdir().unwrap();
+        let ancestor_pixi = tmp.path().join("pixi.toml");
+        std::fs::write(&ancestor_pixi, "[project]\nname=\"outer\"\n").unwrap();
+        let nested_dir = tmp.path().join("nested");
+        std::fs::create_dir_all(&nested_dir).unwrap();
+        let nested_pyproject = nested_dir.join("pyproject.toml");
+        std::fs::write(
+            &nested_pyproject,
+            "[project]\nname=\"inner\"\nversion=\"0.0.1\"\n\n[tool.pixi]\nchannels=[\"conda-forge\"]\n",
+        )
+        .unwrap();
+        let notebook = nested_dir.join("nb.ipynb");
+        std::fs::write(&notebook, "{}").unwrap();
+        assert_eq!(
+            locate_pixi_manifest_with_home(&notebook, None),
+            Some(nested_pyproject)
+        );
+    }
+
+    #[test]
+    fn pixi_network_failure_format_trips_is_network_failure() {
+        // Captured from `pixi shell-hook` against an unresolvable channel
+        // host. rattler bubbles up reqwest's error chain, so the markers
+        // overlap with uv's despite the different surface tooling.
+        let stderr = "Error:   × failed to solve requirements of environment 'default'
+  ├─▶   × Request failed after 3 retries
+  ├─▶ error sending request for url (https://no-such-host.invalid/conda)
+  ├─▶ client error (Connect)
+  ├─▶ dns error
+  ├─▶ failed to lookup address information: nodename nor servname provided";
+        assert!(is_network_failure(stderr));
+    }
+}

--- a/crates/runtimed/src/pixi_project.rs
+++ b/crates/runtimed/src/pixi_project.rs
@@ -4,7 +4,7 @@
 //! `pixi shell-hook`. That call can hit the network when pixi decides the
 //! lockfile needs to refresh, so this module mirrors `uv_project` and adds
 //! an offline-tolerant prepare probe: if `pixi shell-hook` fails with
-//! network or DNS markers, retry with `PIXI_FROZEN=1` so pixi uses the
+//! network or DNS markers, retry with `PIXI_FROZEN=true` so pixi uses the
 //! lockfile as-is. When the retry succeeds, callers propagate the frozen
 //! signal through the kernel launch so the runtime-agent-side
 //! `pixi shell-hook` and the fallback `pixi run` also stay offline.
@@ -141,9 +141,10 @@ fn locate_pixi_manifest(notebook_path: Option<&Path>) -> Option<std::path::PathB
 }
 
 /// Walks up from the notebook directory and picks the closest pixi
-/// manifest. At each directory level `pixi.toml` wins over `pyproject.toml`
-/// with `[tool.pixi]`, and a bare `pyproject.toml` without `[tool.pixi]`
-/// is skipped (it's not our concern). Mirrors the boundaries of
+/// manifest. At each directory level `pyproject.toml` with `[tool.pixi]`
+/// wins over sibling `pixi.toml`, and a bare `pyproject.toml` without
+/// `[tool.pixi]` is skipped when no sibling `pixi.toml` exists. Mirrors
+/// the boundaries of
 /// `crate::project_file::find_nearest_project_file` (stops at `.git` or
 /// the home directory) so the probe targets the same project the launch
 /// path will end up activating.

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -134,7 +134,7 @@ pub fn detect_project_file(notebook_path: &Path) -> Option<DetectedProjectFile> 
 }
 
 /// Check if a pyproject.toml contains a `[tool.pixi]` section.
-fn pyproject_has_pixi_section(path: &Path) -> bool {
+pub(crate) fn pyproject_has_pixi_section(path: &Path) -> bool {
     std::fs::read_to_string(path)
         .map(|c| c.contains("[tool.pixi]") || c.contains("[tool.pixi."))
         .unwrap_or(false)

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -1299,6 +1299,7 @@ pub(crate) async fn handle(
     };
 
     let mut uv_pyproject_offline = false;
+    let mut pixi_toml_frozen = false;
     if matches!(parsed_resolved, EnvSource::Pyproject) {
         match crate::uv_project::prepare_uv_pyproject_environment(
             notebook_path.as_deref(),
@@ -1315,6 +1316,36 @@ pub(crate) async fn handle(
             }
             Err(e) => {
                 let details = format!("Failed to prepare UV project environment: {e}");
+                error!("[notebook-sync] {}", details);
+                reset_starting_state(room, None).await;
+                publish_environment_launch_error(
+                    room,
+                    parsed_resolved.as_str(),
+                    Some(KernelErrorReason::EnvironmentPrepareFailed),
+                    &details,
+                );
+                return NotebookResponse::Error { error: details };
+            }
+        }
+    } else if matches!(parsed_resolved, EnvSource::PixiToml) {
+        let outcome = crate::pixi_project::prepare_pixi_toml_environment(
+            notebook_path.as_deref(),
+            launch_progress_handler.clone(),
+        )
+        .await;
+        // Always clear the `ProjectPreparing` env progress the probe may
+        // have published; without this a successful fallback launch leaves
+        // "preparing pixi" pinned in the UI after the kernel is idle.
+        if let Err(e) = room.state.with_doc(|sd| sd.clear_env_progress()) {
+            warn!("[runtime-state] {}", e);
+        }
+        match outcome {
+            crate::pixi_project::PixiPrepareOutcome::SkipOrOnline => {}
+            crate::pixi_project::PixiPrepareOutcome::Frozen => {
+                pixi_toml_frozen = true;
+            }
+            crate::pixi_project::PixiPrepareOutcome::OfflineUnrecoverable(e) => {
+                let details = format!("Failed to prepare pixi:toml environment: {e}");
                 error!("[notebook-sync] {}", details);
                 reset_starting_state(room, None).await;
                 publish_environment_launch_error(
@@ -1460,7 +1491,8 @@ pub(crate) async fn handle(
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
         if has_runtime_agent {
             info!("[notebook-sync] Agent connected — sending RestartKernel");
-            let restart_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+            let mut restart_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+            restart_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
             match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                 notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
                     kernel_type: resolved_kernel_type.clone(),
@@ -1608,7 +1640,9 @@ pub(crate) async fn handle(
                 }
 
                 // Send LaunchKernel RPC
-                let launch_env_vars = crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+                let mut launch_env_vars =
+                    crate::uv_project::uv_offline_env_vars(uv_pyproject_offline);
+                launch_env_vars.extend(crate::pixi_project::pixi_frozen_env_vars(pixi_toml_frozen));
                 match send_runtime_agent_request_with_kernel_ports(room, |kernel_ports| {
                     notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                         kernel_type: resolved_kernel_type.clone(),


### PR DESCRIPTION
## What changed

`pixi:toml` kernel launches now tolerate no internet, mirroring the `uv:pyproject` fix in #2740. Before the kernel launches, the daemon runs a `pixi shell-hook` probe against the project manifest. If it fails with a network/DNS error, the probe retries with `PIXI_FROZEN=true` so pixi uses the lockfile as-is. When the frozen retry succeeds, that env var is propagated through the `LaunchKernel`/`RestartKernel` RPCs so the runtime-agent-side `pixi shell-hook` AND the fallback `pixi run` also stay offline. If both probe attempts hit a network failure, the launch fails with a typed `EnvironmentPrepareFailed` carrying the original DNS error - that's the actionable signal, not a confusing "env not activated" from the frozen retry.

## Why

After #2740 fixed uv:pyproject, pixi:toml was the next-biggest offline gap. `pixi shell-hook` and `pixi run` both refresh the lockfile from the network by default, so a notebook in a pixi-managed project hard-failed with the same DNS error pattern when wifi was off, even when the env was fully materialized under `.pixi/envs/`.

The pixi knob is `PIXI_FROZEN` (`--frozen` on the CLI). One catch: pixi parses it as a bool (`true`/`false`), not the `1` we use for `UV_OFFLINE`. Trying `PIXI_FROZEN=1` errors with `invalid value '1' for '--frozen'`. The test `pixi_frozen_env_vars_set_pixi_frozen_when_true` pins this.

## Design notes

- **Three-state outcome.** `prepare_pixi_toml_environment` returns `PixiPrepareOutcome::{SkipOrOnline, Frozen, OfflineUnrecoverable}`. `SkipOrOnline` covers both "no pixi manifest found" and "probe failed for non-network reasons" (let the launch surface its own typed error). `Frozen` propagates `PIXI_FROZEN=true`. `OfflineUnrecoverable` aborts the launch with the original network error; falling through to the launch in this case would just hit the same DNS failure deeper in the stack.
- **Manifest detection matches the launch.** `locate_pixi_manifest` is a custom walker (not `find_nearest_project_file`) because the probe must target the SAME manifest the launch will activate. The rules at each directory level:
  1. `pyproject.toml` with `[tool.pixi]` > sibling `pixi.toml` (matches `find_nearest_project_file`'s tiebreaker for pixi-backed pyprojects).
  2. `pixi.toml` if no pyproject (or only a bare pyproject without `[tool.pixi]`).
  3. Bare `pyproject.toml` without `[tool.pixi]` and no sibling pixi.toml: stop walking. The launch's `PixiToml` filter drops this case and the fallback `pixi run` from the notebook's cwd has nothing to auto-detect, so the probe should not walk further up.
  4. Nested layouts: closer manifest wins (we don't reach into an ancestor pixi.toml when the notebook lives under a `[tool.pixi]` pyproject).
- **`pixi_shell_hook` API change.** Added an `extra_env: &HashMap<String, String>` parameter so the probe can set `PIXI_FROZEN` on the spawned `pixi` subprocess specifically. The runtime-agent-side caller passes `config.env_vars` converted to a HashMap, so `PIXI_FROZEN` flows from the RPC into both the shell-hook subprocess and (via the existing `cmd.env` loop) the kernel python subprocess.
- **UI progress cleared on every path.** The probe writes a `ProjectPreparing` env-progress phase. Without explicit cleanup, a successful fallback launch would leave "preparing pixi" pinned in the UI even after the kernel is idle. Both call sites clear progress unconditionally after the probe.

## Files touched

- `crates/runtimed/src/pixi_project.rs` (new) - prepare probe, frozen env-var helper, manifest walker, tests.
- `crates/runtimed/src/lib.rs` - register new module.
- `crates/runtimed/src/project_file.rs` - expose `pyproject_has_pixi_section` as `pub(crate)` for the walker.
- `crates/kernel-launch/src/tools.rs` - `pixi_shell_hook` accepts extra env vars.
- `crates/runtimed/src/jupyter_kernel.rs` - pass `config.env_vars` (as HashMap) to `pixi_shell_hook` so `PIXI_FROZEN` reaches the shell-hook subprocess.
- `crates/runtimed/src/requests/launch_kernel.rs` - call prepare for pixi:toml on both `LaunchKernel` and `RestartKernel`; thread `PIXI_FROZEN` into env_vars; clear progress on all probe outcomes.
- `crates/runtimed/src/notebook_sync_server/metadata.rs` - same for `auto_launch_kernel`.

## Test plan

- [x] `cargo xtask lint --fix` clean.
- [x] `cargo test -p runtimed --lib` - 731 tests pass.
- [x] 8 new pixi_project tests cover: frozen env-var value, network-failure detector against captured pixi/rattler stderr, and the five manifest-resolution cases (bare pixi.toml, pyproject-with-[tool.pixi], bare pyproject skip, pixi.toml > bare pyproject at same level, pyproject-with-[tool.pixi] > sibling pixi.toml at same level, closer pyproject > ancestor pixi.toml).
- [x] Manual repro: `PIXI_FROZEN=true pixi shell-hook --manifest-path ~/example-project/pixi.toml --json` succeeds against the local lockfile.
- [x] Codex review iterated to clean. Each pass flagged a real correctness issue (lost offline state at launch, missed pyproject-with-tool.pixi, stale UI progress, wrong manifest in nested/mixed layouts, wrong manifest at sibling level). All addressed.
- [ ] End-to-end repro with wifi off against a real pixi project: open a `.ipynb` and confirm kernel starts.
