### PR TITLE
feat(blob-store): add ephemeral durability hint

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -156,7 +156,7 @@ function resolveCommOutputs(
 function AppContent() {
   const host = useNotebookHost();
   const blobUploader = useMemo<BlobUploader>(
-    () => (bytes, mediaType) => putBlob(host.transport, bytes, mediaType),
+    () => (bytes, mediaType, durability) => putBlob(host.transport, bytes, mediaType, durability),
     [host],
   );
   _blobUploaderRef = blobUploader;

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -368,6 +368,7 @@ mod tests {
             frame_size_limits(notebook_wire::frame_types::PUT_BLOB).cap as u64
         );
         assert!(!put_blob.multipart);
+        assert!(put_blob.ephemeral_supported);
     }
 
     #[tokio::test]

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -136,6 +136,7 @@ impl ProtocolCapabilities {
                 version: 1,
                 single_frame_max: put_blob_limits.cap as u64,
                 multipart: false,
+                ephemeral_supported: true,
             }),
         }
     }
@@ -150,6 +151,9 @@ pub struct PutBlobCapability {
     pub single_frame_max: u64,
     /// Whether multipart uploads are supported.
     pub multipart: bool,
+    /// Whether `PutBlobHeader::Put.durability = "ephemeral"` is supported.
+    #[serde(default)]
+    pub ephemeral_supported: bool,
 }
 
 /// Server response for `OpenNotebook` and `CreateNotebook` handshakes.

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -264,6 +264,14 @@ pub struct PutBlobResult {
     pub media_type: String,
 }
 
+/// Durability hint for a one-shot PutBlob upload.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BlobDurability {
+    Durable,
+    Ephemeral,
+}
+
 /// Header carried at the start of a binary PutBlob frame.
 ///
 /// The frame payload is `u32 header_len_be | JSON header | raw blob bytes`.
@@ -276,6 +284,8 @@ pub enum PutBlobHeader {
         media_type: String,
         size: u64,
         sha256: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        durability: Option<BlobDurability>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         purpose: Option<String>,
     },
@@ -1081,6 +1091,7 @@ mod tests {
                 size: 3,
                 sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
                     .to_string(),
+                durability: None,
                 purpose: Some("widget-state".to_string()),
             }
         );
@@ -1093,6 +1104,7 @@ mod tests {
             media_type: "application/octet-stream".to_string(),
             size: 3,
             sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".to_string(),
+            durability: Some(BlobDurability::Ephemeral),
             purpose: Some("widget-state".to_string()),
         };
 
@@ -1106,6 +1118,7 @@ mod tests {
         assert_eq!(header_json["id"], "blob-request-encode");
         assert_eq!(header_json["media_type"], "application/octet-stream");
         assert_eq!(header_json["size"], 3);
+        assert_eq!(header_json["durability"], "ephemeral");
         assert_eq!(header_json["purpose"], "widget-state");
 
         let (parsed, body) = PutBlobHeader::try_parse(&frame).unwrap();

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -237,6 +237,8 @@ export type BlobUploadErrorKind =
   | {{ kind: "too_many_in_flight" }}
   | {{ kind: "invalid_header" }}
   | {{ kind: "io"; message: string }};
+
+export type BlobDurability = "durable" | "ephemeral";
 "#
     )
 }

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -209,6 +209,7 @@ impl RelayHandle {
             media_type: media_type.to_string(),
             size: bytes.len() as u64,
             sha256,
+            durability: None,
             purpose: None,
         };
         let frame = header.encode_frame(bytes)?;

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -17,7 +17,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -42,6 +42,7 @@ pub struct BlobMeta {
 #[derive(Debug)]
 struct BlobStoreInner {
     root: PathBuf,
+    memory_cap: usize,
     memory: Mutex<MemoryLayer>,
 }
 
@@ -92,6 +93,8 @@ impl MemoryLayer {
             self.total_bytes = self.total_bytes.saturating_sub(existing.data.len());
         }
 
+        // Re-putting the same content leaves a stale order entry behind. The
+        // sequence check in eviction skips those stale entries without scanning.
         let seq = self.next_seq;
         self.next_seq = self.next_seq.wrapping_add(1);
         self.total_bytes += data.len();
@@ -168,6 +171,7 @@ impl BlobStore {
         Self {
             inner: Arc::new(BlobStoreInner {
                 root,
+                memory_cap: cap,
                 memory: Mutex::new(MemoryLayer::new(cap)),
             }),
         }
@@ -225,6 +229,8 @@ impl BlobStore {
             }
             BlobDurability::Ephemeral => {
                 if data.len() > self.memory_cap() {
+                    // A single entry larger than the cap can never be cached
+                    // without violating the budget, so keep it durable-only.
                     debug!(
                         blob = %hash,
                         bytes = data.len(),
@@ -335,13 +341,19 @@ impl BlobStore {
     }
 
     fn insert_memory(&self, hash: &str, data: Bytes, media_type: &str, created_at: DateTime<Utc>) {
-        let mut memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+        let mut memory = self.memory_layer();
         memory.insert(hash.to_string(), data, media_type.to_string(), created_at);
     }
 
+    fn memory_layer(&self) -> MutexGuard<'_, MemoryLayer> {
+        match self.inner.memory.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
     fn memory_cap(&self) -> usize {
-        let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
-        memory.cap
+        self.inner.memory_cap
     }
 
     /// Retrieve blob bytes by hash. Returns `None` if not found.
@@ -350,7 +362,7 @@ impl BlobStore {
             return Ok(None);
         }
         if let Some(entry) = {
-            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            let memory = self.memory_layer();
             memory.get(hash)
         } {
             return Ok(Some(entry.data.to_vec()));
@@ -369,7 +381,7 @@ impl BlobStore {
             return Ok(None);
         }
         if let Some(entry) = {
-            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            let memory = self.memory_layer();
             memory.get(hash)
         } {
             return Ok(Some(entry.meta()));
@@ -392,7 +404,7 @@ impl BlobStore {
             return false;
         }
         {
-            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            let memory = self.memory_layer();
             if memory.contains(hash) {
                 return true;
             }
@@ -407,7 +419,7 @@ impl BlobStore {
             return Ok(false);
         }
         let existed_in_memory = {
-            let mut memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            let mut memory = self.memory_layer();
             memory.remove(hash)
         };
         let (_, blob_path, meta_path) = self.paths(hash);
@@ -473,7 +485,7 @@ impl BlobStore {
 
     #[cfg(test)]
     fn memory_contains_for_test(&self, hash: &str) -> bool {
-        let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+        let memory = self.memory_layer();
         memory.contains(hash)
     }
 }

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -14,15 +14,22 @@
 //! All writes are atomic: data is written to a temp file in the shard
 //! directory and renamed into place, so readers never see partial writes.
 
+use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use notebook_protocol::protocol::BlobDurability;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tracing::debug;
 
 /// Maximum blob size accepted by `put()` (100 MiB).
 pub const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
+/// Maximum bytes retained in the ephemeral in-memory layer (64 MiB).
+pub const EPHEMERAL_BLOB_CAP_BYTES: usize = 64 * 1024 * 1024;
 
 /// Metadata stored alongside each blob.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,10 +39,121 @@ pub struct BlobMeta {
     pub created_at: DateTime<Utc>,
 }
 
-/// Content-addressed on-disk blob store.
+#[derive(Debug)]
+struct BlobStoreInner {
+    root: PathBuf,
+    memory: Mutex<MemoryLayer>,
+}
+
+#[derive(Debug)]
+struct MemoryLayer {
+    entries: HashMap<String, MemoryEntry>,
+    order: VecDeque<(String, u64)>,
+    total_bytes: usize,
+    cap: usize,
+    next_seq: u64,
+}
+
+#[derive(Debug, Clone)]
+struct MemoryEntry {
+    data: Bytes,
+    media_type: String,
+    created_at: DateTime<Utc>,
+    seq: u64,
+}
+
+impl MemoryEntry {
+    fn meta(&self) -> BlobMeta {
+        BlobMeta {
+            media_type: self.media_type.clone(),
+            size: self.data.len() as u64,
+            created_at: self.created_at,
+        }
+    }
+}
+
+impl MemoryLayer {
+    fn new(cap: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            total_bytes: 0,
+            cap,
+            next_seq: 0,
+        }
+    }
+
+    fn insert(&mut self, hash: String, data: Bytes, media_type: String, created_at: DateTime<Utc>) {
+        if data.len() > self.cap {
+            return;
+        }
+
+        if let Some(existing) = self.entries.remove(&hash) {
+            self.total_bytes = self.total_bytes.saturating_sub(existing.data.len());
+        }
+
+        let seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
+        self.total_bytes += data.len();
+        self.order.push_back((hash.clone(), seq));
+        self.entries.insert(
+            hash,
+            MemoryEntry {
+                data,
+                media_type,
+                created_at,
+                seq,
+            },
+        );
+
+        self.evict_to_cap();
+    }
+
+    fn get(&self, hash: &str) -> Option<MemoryEntry> {
+        self.entries.get(hash).cloned()
+    }
+
+    fn contains(&self, hash: &str) -> bool {
+        self.entries.contains_key(hash)
+    }
+
+    fn remove(&mut self, hash: &str) -> bool {
+        if let Some(entry) = self.entries.remove(hash) {
+            self.total_bytes = self.total_bytes.saturating_sub(entry.data.len());
+            true
+        } else {
+            false
+        }
+    }
+
+    fn evict_to_cap(&mut self) {
+        while self.total_bytes > self.cap {
+            let Some((hash, seq)) = self.order.pop_front() else {
+                break;
+            };
+            let should_remove = self
+                .entries
+                .get(&hash)
+                .is_some_and(|entry| entry.seq == seq);
+            if should_remove {
+                if let Some(entry) = self.entries.remove(&hash) {
+                    debug!(
+                        blob = %hash,
+                        bytes = entry.data.len(),
+                        "evicted blob from ephemeral memory layer"
+                    );
+                    self.total_bytes = self.total_bytes.saturating_sub(entry.data.len());
+                }
+            }
+        }
+    }
+}
+
+/// Content-addressed blob store with durable disk storage and an ephemeral
+/// in-memory layer for transient widget buffers.
 #[derive(Debug, Clone)]
 pub struct BlobStore {
-    root: PathBuf,
+    inner: Arc<BlobStoreInner>,
 }
 
 impl BlobStore {
@@ -43,12 +161,21 @@ impl BlobStore {
     ///
     /// The directory is created lazily on first `put()`.
     pub fn new(root: PathBuf) -> Self {
-        Self { root }
+        Self::with_ephemeral_cap(root, EPHEMERAL_BLOB_CAP_BYTES)
+    }
+
+    fn with_ephemeral_cap(root: PathBuf, cap: usize) -> Self {
+        Self {
+            inner: Arc::new(BlobStoreInner {
+                root,
+                memory: Mutex::new(MemoryLayer::new(cap)),
+            }),
+        }
     }
 
     /// Get the root directory of this blob store.
     pub fn root(&self) -> &Path {
-        &self.root
+        &self.inner.root
     }
 
     /// Store `data` with the given `media_type`.
@@ -61,6 +188,21 @@ impl BlobStore {
     /// the blob or metadata first (e.g. `rename` fails with `AlreadyExists` on
     /// Windows), we detect the existing file and return `Ok(hash)`.
     pub async fn put(&self, data: &[u8], media_type: &str) -> io::Result<String> {
+        self.put_with_durability(data, media_type, BlobDurability::Durable)
+            .await
+    }
+
+    /// Store `data` with an explicit durability hint.
+    ///
+    /// `Durable` writes through to disk and primes the in-memory layer.
+    /// `Ephemeral` prefers memory-only storage and falls back to disk when one
+    /// blob is larger than the memory cap.
+    pub async fn put_with_durability(
+        &self,
+        data: &[u8],
+        media_type: &str,
+        durability: BlobDurability,
+    ) -> io::Result<String> {
         if data.len() > MAX_BLOB_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -73,7 +215,39 @@ impl BlobStore {
         }
 
         let hash = hex::encode(Sha256::digest(data));
-        let (shard_dir, blob_path, meta_path) = self.paths(&hash);
+        let created_at = Utc::now();
+
+        match durability {
+            BlobDurability::Durable => {
+                self.put_disk(&hash, data, media_type, created_at).await?;
+                self.insert_memory(&hash, Bytes::copy_from_slice(data), media_type, created_at);
+                Ok(hash)
+            }
+            BlobDurability::Ephemeral => {
+                if data.len() > self.memory_cap() {
+                    debug!(
+                        blob = %hash,
+                        bytes = data.len(),
+                        cap = self.memory_cap(),
+                        "ephemeral blob exceeds memory cap; writing to disk"
+                    );
+                    self.put_disk(&hash, data, media_type, created_at).await?;
+                } else {
+                    self.insert_memory(&hash, Bytes::copy_from_slice(data), media_type, created_at);
+                }
+                Ok(hash)
+            }
+        }
+    }
+
+    async fn put_disk(
+        &self,
+        hash: &str,
+        data: &[u8],
+        media_type: &str,
+        created_at: DateTime<Utc>,
+    ) -> io::Result<()> {
+        let (shard_dir, blob_path, meta_path) = self.paths(hash);
 
         // Fast path: both files already present.
         // If the caller provides a different media_type than what's stored,
@@ -93,7 +267,7 @@ impl BlobStore {
                     }
                 }
             }
-            return Ok(hash);
+            return Ok(());
         }
 
         tokio::fs::create_dir_all(&shard_dir).await?;
@@ -130,7 +304,7 @@ impl BlobStore {
         let meta = BlobMeta {
             media_type: media_type.to_string(),
             size: data.len() as u64,
-            created_at: Utc::now(),
+            created_at,
         };
         let meta_json = serde_json::to_string(&meta).map_err(io::Error::other)?;
 
@@ -146,7 +320,7 @@ impl BlobStore {
                 tokio::fs::remove_file(&tmp_meta).await.ok();
                 if meta_path.exists() {
                     // Concurrent writer placed metadata — done.
-                    return Ok(hash);
+                    return Ok(());
                 }
                 // Metadata write truly failed. If *we* created the blob (not a
                 // concurrent writer), remove it to avoid leaving orphaned data.
@@ -157,13 +331,29 @@ impl BlobStore {
             }
         }
 
-        Ok(hash)
+        Ok(())
+    }
+
+    fn insert_memory(&self, hash: &str, data: Bytes, media_type: &str, created_at: DateTime<Utc>) {
+        let mut memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+        memory.insert(hash.to_string(), data, media_type.to_string(), created_at);
+    }
+
+    fn memory_cap(&self) -> usize {
+        let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+        memory.cap
     }
 
     /// Retrieve blob bytes by hash. Returns `None` if not found.
     pub async fn get(&self, hash: &str) -> io::Result<Option<Vec<u8>>> {
         if !Self::validate_hash(hash) {
             return Ok(None);
+        }
+        if let Some(entry) = {
+            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            memory.get(hash)
+        } {
+            return Ok(Some(entry.data.to_vec()));
         }
         let (_, blob_path, _) = self.paths(hash);
         match tokio::fs::read(&blob_path).await {
@@ -177,6 +367,12 @@ impl BlobStore {
     pub async fn get_meta(&self, hash: &str) -> io::Result<Option<BlobMeta>> {
         if !Self::validate_hash(hash) {
             return Ok(None);
+        }
+        if let Some(entry) = {
+            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            memory.get(hash)
+        } {
+            return Ok(Some(entry.meta()));
         }
         let (_, _, meta_path) = self.paths(hash);
         match tokio::fs::read_to_string(&meta_path).await {
@@ -195,6 +391,12 @@ impl BlobStore {
         if !Self::validate_hash(hash) {
             return false;
         }
+        {
+            let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            if memory.contains(hash) {
+                return true;
+            }
+        }
         let (_, blob_path, _) = self.paths(hash);
         blob_path.exists()
     }
@@ -204,24 +406,28 @@ impl BlobStore {
         if !Self::validate_hash(hash) {
             return Ok(false);
         }
+        let existed_in_memory = {
+            let mut memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+            memory.remove(hash)
+        };
         let (_, blob_path, meta_path) = self.paths(hash);
         let existed = blob_path.exists();
         if existed {
             tokio::fs::remove_file(&blob_path).await.ok();
             tokio::fs::remove_file(&meta_path).await.ok();
         }
-        Ok(existed)
+        Ok(existed || existed_in_memory)
     }
 
     /// List all blob hashes in the store.
     pub async fn list(&self) -> io::Result<Vec<String>> {
         let mut hashes = Vec::new();
 
-        if !self.root.exists() {
+        if !self.inner.root.exists() {
             return Ok(hashes);
         }
 
-        let mut shard_entries = tokio::fs::read_dir(&self.root).await?;
+        let mut shard_entries = tokio::fs::read_dir(&self.inner.root).await?;
         while let Some(shard) = shard_entries.next_entry().await? {
             if !shard.path().is_dir() {
                 continue;
@@ -254,7 +460,7 @@ impl BlobStore {
     fn paths(&self, hash: &str) -> (PathBuf, PathBuf, PathBuf) {
         let shard = &hash[..2];
         let rest = &hash[2..];
-        let shard_dir = self.root.join(shard);
+        let shard_dir = self.inner.root.join(shard);
         let blob_path = shard_dir.join(rest);
         let meta_path = shard_dir.join(format!("{}.meta", rest));
         (shard_dir, blob_path, meta_path)
@@ -263,6 +469,12 @@ impl BlobStore {
     /// Validate that a hash looks like a 64-character hex string.
     fn validate_hash(hash: &str) -> bool {
         hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())
+    }
+
+    #[cfg(test)]
+    fn memory_contains_for_test(&self, hash: &str) -> bool {
+        let memory = self.inner.memory.lock().expect("blob memory lock poisoned");
+        memory.contains(hash)
     }
 }
 
@@ -273,6 +485,15 @@ mod tests {
 
     fn test_store(dir: &TempDir) -> BlobStore {
         BlobStore::new(dir.path().join("blobs"))
+    }
+
+    fn test_store_with_cap(dir: &TempDir, cap: usize) -> BlobStore {
+        BlobStore::with_ephemeral_cap(dir.path().join("blobs"), cap)
+    }
+
+    fn disk_blob_exists(store: &BlobStore, hash: &str) -> bool {
+        let (_, blob_path, meta_path) = store.paths(hash);
+        blob_path.exists() && meta_path.exists()
     }
 
     #[tokio::test]
@@ -440,5 +661,162 @@ mod tests {
 
         assert_eq!(hash1, hash2);
         assert_eq!(store.get(&hash1).await.unwrap().unwrap(), data);
+    }
+
+    #[tokio::test]
+    async fn put_ephemeral_lives_in_memory_not_disk() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash = store
+            .put_with_durability(
+                b"ephemeral",
+                "application/octet-stream",
+                BlobDurability::Ephemeral,
+            )
+            .await
+            .unwrap();
+
+        assert!(store.memory_contains_for_test(&hash));
+        assert!(!disk_blob_exists(&store, &hash));
+        assert_eq!(store.get(&hash).await.unwrap().unwrap(), b"ephemeral");
+    }
+
+    #[tokio::test]
+    async fn put_durable_lives_in_both_memory_and_disk() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash = store
+            .put_with_durability(b"durable", "text/plain", BlobDurability::Durable)
+            .await
+            .unwrap();
+
+        assert!(store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+    }
+
+    #[tokio::test]
+    async fn get_ephemeral_after_eviction_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store_with_cap(&dir, 2);
+
+        let evicted = store
+            .put_with_durability(b"a", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        store
+            .put_with_durability(b"b", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        store
+            .put_with_durability(b"c", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(!store.memory_contains_for_test(&evicted));
+        assert!(!disk_blob_exists(&store, &evicted));
+        assert!(store.get(&evicted).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn get_durable_after_eviction_falls_back_to_disk() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store_with_cap(&dir, 2);
+
+        let durable = store
+            .put_with_durability(b"a", "text/plain", BlobDurability::Durable)
+            .await
+            .unwrap();
+        store
+            .put_with_durability(b"b", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        store
+            .put_with_durability(b"c", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(!store.memory_contains_for_test(&durable));
+        assert!(disk_blob_exists(&store, &durable));
+        assert_eq!(store.get(&durable).await.unwrap().unwrap(), b"a");
+    }
+
+    #[tokio::test]
+    async fn put_oversize_ephemeral_falls_through_to_disk() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store_with_cap(&dir, 2);
+
+        let hash = store
+            .put_with_durability(b"abc", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(!store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(store.get(&hash).await.unwrap().unwrap(), b"abc");
+    }
+
+    #[tokio::test]
+    async fn put_durable_then_ephemeral_same_hash_keeps_disk_copy() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash = store
+            .put_with_durability(b"same", "text/plain", BlobDurability::Durable)
+            .await
+            .unwrap();
+        let hash2 = store
+            .put_with_durability(b"same", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert_eq!(hash, hash2);
+        assert!(store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+    }
+
+    #[tokio::test]
+    async fn put_ephemeral_then_durable_same_hash_promotes_to_disk() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash = store
+            .put_with_durability(b"same", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        assert!(!disk_blob_exists(&store, &hash));
+
+        let hash2 = store
+            .put_with_durability(b"same", "text/plain", BlobDurability::Durable)
+            .await
+            .unwrap();
+
+        assert_eq!(hash, hash2);
+        assert!(store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+    }
+
+    #[tokio::test]
+    async fn lru_eviction_oldest_first() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store_with_cap(&dir, 2);
+
+        let first = store
+            .put_with_durability(b"a", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        let second = store
+            .put_with_durability(b"b", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+        let third = store
+            .put_with_durability(b"c", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(!store.memory_contains_for_test(&first));
+        assert!(store.memory_contains_for_test(&second));
+        assert!(store.memory_contains_for_test(&third));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use notebook_protocol::connection::NotebookFrameType;
 use notebook_protocol::protocol::{
-    BlobUploadErrorKind, NotebookResponse, NotebookResponseEnvelope, PutBlobHeader,
+    BlobDurability, BlobUploadErrorKind, NotebookResponse, NotebookResponseEnvelope, PutBlobHeader,
 };
 use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
@@ -112,11 +112,13 @@ pub(crate) async fn handle_put_blob_frame(
             media_type,
             size,
             sha256,
+            durability,
             purpose,
         } => {
+            let durability = durability.unwrap_or(BlobDurability::Durable);
             debug!(
-                "[notebook-sync] PutBlob id={} media_type={} size={} purpose={:?}",
-                id, media_type, size, purpose
+                "[notebook-sync] PutBlob id={} media_type={} size={} durability={:?} purpose={:?}",
+                id, media_type, size, durability, purpose
             );
             if body.len() as u64 != size {
                 send_blob_upload_error(peer_writer, Some(id), BlobUploadErrorKind::SizeMismatch)?;
@@ -129,7 +131,10 @@ pub(crate) async fn handle_put_blob_frame(
                 return Ok(());
             }
 
-            match blob_store.put(body, &media_type).await {
+            match blob_store
+                .put_with_durability(body, &media_type, durability)
+                .await
+            {
                 Ok(hash) => {
                     send_blob_response(
                         peer_writer,
@@ -206,12 +211,24 @@ mod tests {
     use notebook_protocol::protocol::{NotebookResponse, NotebookResponseEnvelope};
 
     fn payload(id: &str, media_type: &str, size: u64, sha256: &str, body: &[u8]) -> Vec<u8> {
+        payload_with_durability(id, media_type, size, sha256, body, None)
+    }
+
+    fn payload_with_durability(
+        id: &str,
+        media_type: &str,
+        size: u64,
+        sha256: &str,
+        body: &[u8],
+        durability: Option<BlobDurability>,
+    ) -> Vec<u8> {
         let header = serde_json::json!({
             "op": "put",
             "id": id,
             "media_type": media_type,
             "size": size,
             "sha256": sha256,
+            "durability": durability,
         });
         let header_bytes = serde_json::to_vec(&header).expect("header serializes");
         let mut payload = Vec::new();
@@ -219,6 +236,14 @@ mod tests {
         payload.extend_from_slice(&header_bytes);
         payload.extend_from_slice(body);
         payload
+    }
+
+    fn disk_blob_exists(store: &BlobStore, hash: &str) -> bool {
+        let shard_dir = store.root().join(&hash[..2]);
+        let rest = &hash[2..];
+        let blob_path = shard_dir.join(rest);
+        let meta_path = shard_dir.join(format!("{rest}.meta"));
+        blob_path.exists() && meta_path.exists()
     }
 
     async fn run_handler(
@@ -274,6 +299,33 @@ mod tests {
             }
             other => panic!("unexpected response: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn put_blob_ephemeral_success_keeps_blob_out_of_disk_store() {
+        let body = b"abc";
+        let sha256 = hex::encode(Sha256::digest(body));
+        let request_payload = payload_with_durability(
+            "blob-ephemeral",
+            "application/octet-stream",
+            3,
+            &sha256,
+            body,
+            Some(BlobDurability::Ephemeral),
+        );
+
+        let (_tmp, blob_store, envelope, _writer_task) = run_handler(&request_payload).await;
+
+        assert_eq!(envelope.id.as_deref(), Some("blob-ephemeral"));
+        assert!(matches!(
+            envelope.response,
+            NotebookResponse::BlobStored { ref hash, .. } if hash == &sha256
+        ));
+        assert_eq!(
+            blob_store.get(&sha256).await.unwrap().as_deref(),
+            Some(&body[..])
+        );
+        assert!(!disk_blob_exists(&blob_store, &sha256));
     }
 
     #[tokio::test]

--- a/packages/runtimed/src/blob-upload.ts
+++ b/packages/runtimed/src/blob-upload.ts
@@ -1,5 +1,5 @@
 import { FrameType, type NotebookTransport } from "./transport";
-import type { BlobUploadErrorKind, NotebookResponse } from "./request-types";
+import type { BlobDurability, BlobUploadErrorKind, NotebookResponse } from "./request-types";
 
 export interface PutBlobResult {
   blob: string;
@@ -20,16 +20,27 @@ export async function putBlob(
   transport: NotebookTransport,
   bytes: Uint8Array,
   mediaType: string,
+  durability: BlobDurability = "durable",
 ): Promise<PutBlobResult> {
   const sha256 = await hexHash(bytes);
   const id = crypto.randomUUID();
-  const header = {
+  const header: {
+    op: "put";
+    id: string;
+    media_type: string;
+    size: number;
+    sha256: string;
+    durability?: BlobDurability;
+  } = {
     op: "put",
     id,
     media_type: mediaType,
     size: bytes.byteLength,
     sha256,
   };
+  if (durability !== "durable") {
+    header.durability = durability;
+  }
   const headerBytes = new TextEncoder().encode(JSON.stringify(header));
   const frame = new Uint8Array(4 + headerBytes.length + bytes.byteLength);
   new DataView(frame.buffer, frame.byteOffset, frame.byteLength).setUint32(

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -185,6 +185,7 @@ export {
 // Notebook client
 export { NotebookClient, type NotebookClientOptions, SaveNotebookError } from "./notebook-client";
 export type {
+  BlobDurability,
   BlobUploadErrorKind,
   CommRequestMessage,
   CompletionItem,

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -172,3 +172,5 @@ export type BlobUploadErrorKind =
   | { kind: "too_many_in_flight" }
   | { kind: "invalid_header" }
   | { kind: "io"; message: string };
+
+export type BlobDurability = "durable" | "ephemeral";

--- a/packages/runtimed/tests/blob-upload.test.ts
+++ b/packages/runtimed/tests/blob-upload.test.ts
@@ -69,6 +69,30 @@ describe("putBlob", () => {
     });
   });
 
+  it("includes durability only when explicitly ephemeral", async () => {
+    const bytes = new TextEncoder().encode("abc");
+    const transport = createTransport(async (_frameType, frame, id) => {
+      const { header } = parsePutBlobFrame(frame);
+      expect(header).toEqual({
+        op: "put",
+        id,
+        media_type: "text/plain",
+        size: 3,
+        sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        durability: "ephemeral",
+      });
+
+      return {
+        result: "blob_stored",
+        hash: "hash123",
+        size: 3,
+        media_type: "text/plain",
+      };
+    });
+
+    await putBlob(transport, bytes, "text/plain", "ephemeral");
+  });
+
   it("propagates structured blob upload errors", async () => {
     const transport = createTransport(async () => ({
       result: "blob_upload_error",

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -141,15 +141,15 @@ describe("WidgetUpdateManager", () => {
     });
 
     it("uploads extracted binary leaves before writing ContentRefs to CRDT", async () => {
-      const uploadCalls: Array<{ bytes: number[]; mediaType: string }> = [];
+      const uploadCalls: Array<{ bytes: number[]; mediaType: string; durability?: string }> = [];
       const contentRef: ContentRef = {
         blob: "sha256:abc",
         size: 4,
         media_type: "application/octet-stream",
       };
       const { manager, writerCalls } = setup({
-        blobUploader: async (bytes, mediaType) => {
-          uploadCalls.push({ bytes: Array.from(bytes), mediaType });
+        blobUploader: async (bytes, mediaType, durability) => {
+          uploadCalls.push({ bytes: Array.from(bytes), mediaType, durability });
           return contentRef;
         },
       });
@@ -162,7 +162,9 @@ describe("WidgetUpdateManager", () => {
         },
       });
 
-      expect(uploadCalls).toEqual([{ bytes: [1, 2, 3, 4], mediaType: "application/octet-stream" }]);
+      expect(uploadCalls).toEqual([
+        { bytes: [1, 2, 3, 4], mediaType: "application/octet-stream", durability: "ephemeral" },
+      ]);
       expect(writerCalls).toHaveLength(1);
       expect(writerCalls[0].patch).toEqual({
         selection: {

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -17,7 +17,12 @@ import type { WidgetStore } from "./widget-store";
 
 type CrdtCommWriter = (commId: string, patch: Record<string, unknown>) => void;
 export type ContentRef = { blob: string; size: number; media_type: string };
-export type BlobUploader = (bytes: Uint8Array, mediaType: string) => Promise<ContentRef>;
+export type BlobDurability = "durable" | "ephemeral";
+export type BlobUploader = (
+  bytes: Uint8Array,
+  mediaType: string,
+  durability?: BlobDurability,
+) => Promise<ContentRef>;
 
 /** Debounce interval for CRDT writes (ms). */
 const DEBOUNCE_MS = 50;
@@ -314,7 +319,7 @@ export class WidgetUpdateManager {
 
     const contentRefs = await Promise.all(
       buffers.map((buffer) =>
-        this.uploadWithRetry(uploader, new Uint8Array(buffer), BLOB_MEDIA_TYPE),
+        this.uploadWithRetry(uploader, new Uint8Array(buffer), BLOB_MEDIA_TYPE, "ephemeral"),
       ),
     );
 
@@ -329,11 +334,12 @@ export class WidgetUpdateManager {
     uploader: BlobUploader,
     bytes: Uint8Array,
     mediaType: string,
+    durability: BlobDurability,
   ): Promise<ContentRef> {
     let attempt = 0;
     while (true) {
       try {
-        return await uploader(bytes, mediaType);
+        return await uploader(bytes, mediaType, durability);
       } catch (error) {
         if (!isTooManyInFlight(error) || attempt >= BLOB_RETRY_DELAYS_MS.length) {
           throw error;


### PR DESCRIPTION
## Summary

- adds a `BlobDurability` hint to PutBlob and advertises ephemeral support in the handshake capability
- adds a 64 MiB in-memory layer to `BlobStore`, with durable writes still persisted to disk and ephemeral widget buffers kept memory-only unless oversized
- plumbs widget comm buffer uploads through `putBlob(..., "ephemeral")` while leaving output, attachment, markdown asset, and legacy blob paths durable by default

## Notes

This keeps the Phase 3.5 scope to the stepping-stone LRU from `.context/phase-3.5-task-brief.md`. The per-doc/refcounted ephemeral store and first-read pinning ideas stay as follow-up work.

## Verification

- `cargo xtask lint --fix`
- `cargo clippy -p runtimed --all-targets -- -D warnings`
- `cargo test -p notebook-protocol put_blob --lib`
- `cargo test -p runtimed blob_store --lib`
- `cargo test -p runtimed notebook_sync_server::blob_upload --lib`
- `cargo test -p notebook-sync put_blob --lib`
- `pnpm test -- --run src/components/widgets/__tests__/widget-update-manager.test.ts packages/runtimed/tests/blob-upload.test.ts`
