### PR TITLE
feat(widgets): drop legacy sendUpdate buffers + free superseded ephemeral blobs

### DIFF
--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -1,4 +1,11 @@
-import { expect, test, type FrameLocator, type Locator, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type FrameLocator,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
 import {
   ensureCodeCell,
   executeCell,
@@ -20,7 +27,9 @@ test.describe("jupyter-scatter lasso selection", () => {
     mcp = null;
   });
 
-  test("round-trips a lasso selection through binary widget comm buffers", async ({ page }) => {
+  test("round-trips a lasso selection through binary widget comm buffers", async ({
+    page,
+  }, testInfo) => {
     test.setTimeout(240_000);
 
     const notebookId = crypto.randomUUID();
@@ -74,6 +83,7 @@ test.describe("jupyter-scatter lasso selection", () => {
     await expect
       .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
       .toBeGreaterThan(0);
+    await attachLassoScreenshots(testInfo, page, plotSurface);
 
     const selectionCellId = await mcp.createCell("# jscatter selection probe");
     await waitForCellCount(page, 2);
@@ -128,6 +138,17 @@ async function dragLassoAroundCenter(page: Page, canvas: Locator) {
   }
   await page.mouse.up();
   await page.waitForTimeout(750);
+}
+
+async function attachLassoScreenshots(testInfo: TestInfo, page: Page, plotSurface: Locator) {
+  await testInfo.attach("jscatter-after-lasso-page", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+  await testInfo.attach("jscatter-after-lasso-canvas", {
+    body: await plotSurface.screenshot(),
+    contentType: "image/png",
+  });
 }
 
 function parseSelectionCount(text: string | null, marker: string): number {

--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -71,6 +71,11 @@ test.describe("jupyter-scatter lasso selection", () => {
     await expect
       .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
       .toBeGreaterThan(0);
+    // The frontend selection write reaches Python via the kernel comm queue.
+    // Give that comm_msg a turn before sending the execute_request that reads
+    // jpl.selection, otherwise CI can race the backend verification cell ahead
+    // of the widget update.
+    await page.waitForTimeout(2_000);
 
     await mcp.createCell("print('jscatter-selection-count', len(jpl.selection))");
     await waitForCellCount(page, 2);

--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -21,6 +21,8 @@ test.describe("jupyter-scatter lasso selection", () => {
   });
 
   test("round-trips a lasso selection through binary widget comm buffers", async ({ page }) => {
+    test.setTimeout(240_000);
+
     const notebookId = crypto.randomUUID();
     await openNotebookRoom(page, notebookId);
     await waitForKernelStatus(page, "idle", 120_000);

--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -6,6 +6,7 @@ import {
   setCellSource,
   waitForCellCount,
   waitForCodeCellContaining,
+  waitForCellSourceContaining,
   waitForKernelStatus,
   waitForOutputContaining,
 } from "./helpers";
@@ -71,21 +72,11 @@ test.describe("jupyter-scatter lasso selection", () => {
     await expect
       .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
       .toBeGreaterThan(0);
-    // The frontend selection write reaches Python via the kernel comm queue.
-    // Give that comm_msg a turn before sending the execute_request that reads
-    // jpl.selection, otherwise CI can race the backend verification cell ahead
-    // of the widget update.
-    await page.waitForTimeout(2_000);
 
-    await mcp.createCell("print('jscatter-selection-count', len(jpl.selection))");
+    const selectionCellId = await mcp.createCell("# jscatter selection probe");
     await waitForCellCount(page, 2);
-    const selectionCell = await waitForCodeCellContaining(page, "jscatter-selection-count");
-
-    await executeCell(selectionCell);
-    const output = await waitForOutputContaining(selectionCell, "jscatter-selection-count", 60_000);
-    await expect
-      .poll(async () => parseSelectionCount(await output.textContent()), { timeout: 60_000 })
-      .toBeGreaterThan(0);
+    const selectionCell = await waitForCodeCellContaining(page, "jscatter selection probe");
+    await waitForBackendSelectionCount(page, mcp, selectionCellId, selectionCell);
 
     await expect
       .poll(() => getFrontendSelectionCount(page), { timeout: 30_000 })
@@ -137,9 +128,38 @@ async function dragLassoAroundCenter(page: Page, canvas: Locator) {
   await page.waitForTimeout(750);
 }
 
-function parseSelectionCount(text: string | null): number {
-  const match = text?.match(/jscatter-selection-count\s+(\d+)/);
+function parseSelectionCount(text: string | null, marker: string): number {
+  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = text?.match(new RegExp(`${escapedMarker}\\s+(\\d+)`));
   return match ? Number(match[1]) : 0;
+}
+
+async function waitForBackendSelectionCount(
+  page: Page,
+  mcp: McpPeer,
+  selectionCellId: string,
+  selectionCell: Locator,
+) {
+  const deadline = Date.now() + 120_000;
+  let attempt = 0;
+  let lastCount = 0;
+
+  while (Date.now() < deadline) {
+    attempt += 1;
+    const marker = `jscatter-selection-count-${attempt}-${crypto.randomUUID()}`;
+    await mcp.setCell(selectionCellId, `print('${marker}', len(jpl.selection))`);
+    await waitForCellSourceContaining(selectionCell, marker, 30_000);
+
+    await executeCell(selectionCell);
+    await waitForKernelStatus(page, "idle", 60_000);
+    const output = await waitForOutputContaining(selectionCell, marker, 60_000);
+    lastCount = parseSelectionCount(await output.textContent(), marker);
+    if (lastCount > 0) return;
+
+    await page.waitForTimeout(1_000);
+  }
+
+  expect(lastCount).toBeGreaterThan(0);
 }
 
 async function getFrontendSelectionCount(page: Page): Promise<number> {

--- a/apps/notebook/e2e/jscatter-lasso.spec.ts
+++ b/apps/notebook/e2e/jscatter-lasso.spec.ts
@@ -65,7 +65,7 @@ test.describe("jupyter-scatter lasso selection", () => {
     const plotSurface = widgetFrame.locator("canvas").first();
     await expect(plotSurface).toBeVisible({ timeout: 120_000 });
 
-    await selectLassoTool(page, scatterCell, widgetFrame);
+    await selectLassoTool(widgetFrame);
     await dragLassoAroundCenter(page, plotSurface);
     await page.waitForTimeout(3_000);
     await expect
@@ -88,7 +88,7 @@ test.describe("jupyter-scatter lasso selection", () => {
   });
 });
 
-async function selectLassoTool(page: Page, cell: Locator, widgetFrame: FrameLocator) {
+async function selectLassoTool(widgetFrame: FrameLocator) {
   const namedButton = widgetFrame.getByRole("button", { name: /activate lasso selection/i });
   if ((await namedButton.count()) > 0) {
     await namedButton.click();
@@ -105,11 +105,11 @@ async function selectLassoTool(page: Page, cell: Locator, widgetFrame: FrameLoca
     return;
   }
 
-  const cellBox = await cell.boundingBox();
-  const canvasBox = await cell.locator("iframe").first().boundingBox();
-  if (!cellBox || !canvasBox) throw new Error("jscatter output is missing layout boxes");
-
-  await page.mouse.click(cellBox.x + 28, canvasBox.y + 72);
+  throw new Error(
+    "Could not find lasso tool: tried role=button[name=lasso] and " +
+      "[title|aria-label*=lasso]. jscatter toolbar may have changed; " +
+      "update selectLassoTool fallbacks.",
+  );
 }
 
 async function dragLassoAroundCenter(page: Page, canvas: Locator) {
@@ -139,22 +139,11 @@ function parseSelectionCount(text: string | null): number {
 
 async function getFrontendSelectionCount(page: Page): Promise<number> {
   return await page.evaluate(() => {
-    const store = (window as unknown as { __nteractWidgetStore?: unknown }).__nteractWidgetStore as
-      | {
-          getSnapshot?: () => Map<
-            string,
-            { state?: { selection?: { view?: { byteLength?: number }; shape?: unknown } } }
-          >;
-        }
-      | undefined;
-    const models = store?.getSnapshot?.();
-    if (!models) return 0;
-    for (const model of models.values()) {
-      const shape = model.state?.selection?.shape;
-      if (Array.isArray(shape) && typeof shape[0] === "number") return shape[0];
-      const byteLength = model.state?.selection?.view?.byteLength;
-      if (typeof byteLength === "number") return byteLength;
-    }
-    return 0;
+    const testApi = (
+      window as unknown as {
+        __nteractWidgetTest?: { selectionCountForComm(commId: string | null): number | null };
+      }
+    ).__nteractWidgetTest;
+    return testApi?.selectionCountForComm(null) ?? 0;
   });
 }

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -487,9 +487,28 @@ function AppContent() {
       updateManager.updateAndPersist(commId, patch);
     };
     w.__nteractWidgetStore = widgetStore;
+    w.__nteractWidgetTest = {
+      selectionCountForComm(commId: string | null): number | null {
+        const models =
+          commId === null
+            ? Array.from(widgetStore.getSnapshot().values())
+            : [widgetStore.getModel(commId)];
+        for (const model of models) {
+          const selection = model?.state.selection as
+            | { view?: { byteLength?: number }; shape?: unknown }
+            | undefined;
+          const shape = selection?.shape;
+          if (Array.isArray(shape) && typeof shape[0] === "number") return shape[0];
+          const byteLength = selection?.view?.byteLength;
+          if (typeof byteLength === "number") return byteLength;
+        }
+        return null;
+      },
+    };
     return () => {
       delete w.__nteractWidgetUpdate;
       delete w.__nteractWidgetStore;
+      delete w.__nteractWidgetTest;
     };
   }, [widgetStore]);
 

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -18,18 +18,35 @@ use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use notebook_protocol::protocol::BlobDurability;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::time::sleep;
 use tracing::debug;
 
 /// Maximum blob size accepted by `put()` (100 MiB).
 pub const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
 /// Maximum bytes retained in the ephemeral in-memory layer (64 MiB).
 pub const EPHEMERAL_BLOB_CAP_BYTES: usize = 64 * 1024 * 1024;
+const BLOB_FILE_LOCK_RETRY_MS: u64 = 10;
+const BLOB_FILE_LOCK_STALE_SECS: u64 = 60;
+const BLOB_FILE_LOCK_TIMEOUT_SECS: u64 = 10;
+
+struct BlobFileLock {
+    path: PathBuf,
+    file: Option<std::fs::File>,
+}
+
+impl Drop for BlobFileLock {
+    fn drop(&mut self) {
+        self.file.take();
+        std::fs::remove_file(&self.path).ok();
+    }
+}
 
 /// Metadata stored alongside each blob.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,6 +68,13 @@ fn merged_durability(existing: BlobDurability, incoming: BlobDurability) -> Blob
     } else {
         BlobDurability::Ephemeral
     }
+}
+
+fn lock_is_stale(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .and_then(|modified| modified.elapsed().map_err(io::Error::other))
+        .is_ok_and(|age| age > Duration::from_secs(BLOB_FILE_LOCK_STALE_SECS))
 }
 
 #[derive(Debug)]
@@ -314,6 +338,7 @@ impl BlobStore {
         durability: BlobDurability,
     ) -> io::Result<BlobDurability> {
         let (shard_dir, blob_path, meta_path) = self.paths(hash);
+        let _lock = self.acquire_blob_file_lock(&shard_dir, &meta_path).await?;
 
         // Fast path: both files already present.
         // If the caller provides a different media_type than what's stored,
@@ -341,8 +366,6 @@ impl BlobStore {
             }
             return Ok(durability);
         }
-
-        tokio::fs::create_dir_all(&shard_dir).await?;
 
         // --- Blob ---
         // Write to a temp file and atomically rename into place.
@@ -434,6 +457,48 @@ impl BlobStore {
 
     fn memory_cap(&self) -> usize {
         self.inner.memory_cap
+    }
+
+    async fn acquire_blob_file_lock(
+        &self,
+        shard_dir: &Path,
+        meta_path: &Path,
+    ) -> io::Result<BlobFileLock> {
+        tokio::fs::create_dir_all(shard_dir).await?;
+        let lock_path = meta_path.with_extension("lock");
+        let started = Instant::now();
+
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(file) => {
+                    return Ok(BlobFileLock {
+                        path: lock_path,
+                        file: Some(file),
+                    });
+                }
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                    if lock_is_stale(&lock_path) {
+                        std::fs::remove_file(&lock_path).ok();
+                        continue;
+                    }
+                    if started.elapsed() >= Duration::from_secs(BLOB_FILE_LOCK_TIMEOUT_SECS) {
+                        return Err(io::Error::new(
+                            io::ErrorKind::WouldBlock,
+                            format!(
+                                "timed out acquiring blob file lock at {}",
+                                lock_path.display()
+                            ),
+                        ));
+                    }
+                    sleep(Duration::from_millis(BLOB_FILE_LOCK_RETRY_MS)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Retrieve blob bytes by hash. Returns `None` if not found.
@@ -533,7 +598,8 @@ impl BlobStore {
             return Ok(false);
         }
 
-        let (_, blob_path, meta_path) = self.paths(hash);
+        let (shard_dir, blob_path, meta_path) = self.paths(hash);
+        let _lock = self.acquire_blob_file_lock(&shard_dir, &meta_path).await?;
         let disk_was_ephemeral = match tokio::fs::read_to_string(&meta_path).await {
             Ok(json) => serde_json::from_str::<BlobMeta>(&json)
                 .map(|meta| meta.durability == BlobDurability::Ephemeral)

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -37,6 +37,20 @@ pub struct BlobMeta {
     pub media_type: String,
     pub size: u64,
     pub created_at: DateTime<Utc>,
+    #[serde(default = "default_blob_durability")]
+    pub durability: BlobDurability,
+}
+
+fn default_blob_durability() -> BlobDurability {
+    BlobDurability::Durable
+}
+
+fn merged_durability(existing: BlobDurability, incoming: BlobDurability) -> BlobDurability {
+    if existing == BlobDurability::Durable || incoming == BlobDurability::Durable {
+        BlobDurability::Durable
+    } else {
+        BlobDurability::Ephemeral
+    }
 }
 
 #[derive(Debug)]
@@ -70,6 +84,7 @@ impl MemoryEntry {
             media_type: self.media_type.clone(),
             size: self.data.len() as u64,
             created_at: self.created_at,
+            durability: self.durability,
         }
     }
 }
@@ -97,9 +112,19 @@ impl MemoryLayer {
             return;
         }
 
-        if let Some(existing) = self.entries.remove(&hash) {
-            self.total_bytes = self.total_bytes.saturating_sub(existing.data.len());
-        }
+        let durability = match self.entries.remove(&hash) {
+            Some(existing) => {
+                self.total_bytes = self.total_bytes.saturating_sub(existing.data.len());
+                if existing.durability == BlobDurability::Durable
+                    || durability == BlobDurability::Durable
+                {
+                    BlobDurability::Durable
+                } else {
+                    BlobDurability::Ephemeral
+                }
+            }
+            None => durability,
+        };
 
         // Re-putting the same content leaves a stale order entry behind. The
         // sequence check in eviction skips those stale entries without scanning.
@@ -208,8 +233,10 @@ impl BlobStore {
     /// Store `data` with an explicit durability hint.
     ///
     /// `Durable` writes through to disk and primes the in-memory layer.
-    /// `Ephemeral` prefers memory-only storage and falls back to disk when one
-    /// blob is larger than the memory cap.
+    /// `Ephemeral` is also written to disk because runtime agents run in a
+    /// separate process and must be able to rehydrate frontend-uploaded comm
+    /// buffers by hash. The durability metadata keeps those disk records
+    /// eligible for `delete_if_ephemeral` once superseded.
     pub async fn put_with_durability(
         &self,
         data: &[u8],
@@ -232,34 +259,45 @@ impl BlobStore {
 
         match durability {
             BlobDurability::Durable => {
-                self.put_disk(&hash, data, media_type, created_at).await?;
+                let effective_durability = self
+                    .put_disk(&hash, data, media_type, created_at, BlobDurability::Durable)
+                    .await?;
                 self.insert_memory(
                     &hash,
                     Bytes::copy_from_slice(data),
                     media_type,
                     created_at,
-                    BlobDurability::Durable,
+                    effective_durability,
                 );
                 Ok(hash)
             }
             BlobDurability::Ephemeral => {
+                let effective_durability = self
+                    .put_disk(
+                        &hash,
+                        data,
+                        media_type,
+                        created_at,
+                        BlobDurability::Ephemeral,
+                    )
+                    .await?;
                 if data.len() > self.memory_cap() {
                     // A single entry larger than the cap can never be cached
-                    // without violating the budget, so keep it durable-only.
+                    // without violating the budget, so leave it as disk-only
+                    // ephemeral content until supersession or sweep cleanup.
                     debug!(
                         blob = %hash,
                         bytes = data.len(),
                         cap = self.memory_cap(),
-                        "ephemeral blob exceeds memory cap; writing to disk"
+                        "ephemeral blob exceeds memory cap; keeping disk-only"
                     );
-                    self.put_disk(&hash, data, media_type, created_at).await?;
                 } else {
                     self.insert_memory(
                         &hash,
                         Bytes::copy_from_slice(data),
                         media_type,
                         created_at,
-                        BlobDurability::Ephemeral,
+                        effective_durability,
                     );
                 }
                 Ok(hash)
@@ -273,7 +311,8 @@ impl BlobStore {
         data: &[u8],
         media_type: &str,
         created_at: DateTime<Utc>,
-    ) -> io::Result<()> {
+        durability: BlobDurability,
+    ) -> io::Result<BlobDurability> {
         let (shard_dir, blob_path, meta_path) = self.paths(hash);
 
         // Fast path: both files already present.
@@ -283,18 +322,24 @@ impl BlobStore {
         if blob_path.exists() && meta_path.exists() {
             if let Ok(existing_meta_json) = tokio::fs::read_to_string(&meta_path).await {
                 if let Ok(existing_meta) = serde_json::from_str::<BlobMeta>(&existing_meta_json) {
-                    if existing_meta.media_type != media_type {
+                    let updated_durability =
+                        merged_durability(existing_meta.durability, durability);
+                    if existing_meta.media_type != media_type
+                        || existing_meta.durability != updated_durability
+                    {
                         let updated = BlobMeta {
                             media_type: media_type.to_string(),
+                            durability: updated_durability,
                             ..existing_meta
                         };
                         if let Ok(json) = serde_json::to_string(&updated) {
                             tokio::fs::write(&meta_path, json).await.ok();
                         }
                     }
+                    return Ok(updated_durability);
                 }
             }
-            return Ok(());
+            return Ok(durability);
         }
 
         tokio::fs::create_dir_all(&shard_dir).await?;
@@ -332,6 +377,7 @@ impl BlobStore {
             media_type: media_type.to_string(),
             size: data.len() as u64,
             created_at,
+            durability,
         };
         let meta_json = serde_json::to_string(&meta).map_err(io::Error::other)?;
 
@@ -347,7 +393,7 @@ impl BlobStore {
                 tokio::fs::remove_file(&tmp_meta).await.ok();
                 if meta_path.exists() {
                     // Concurrent writer placed metadata — done.
-                    return Ok(());
+                    return Ok(durability);
                 }
                 // Metadata write truly failed. If *we* created the blob (not a
                 // concurrent writer), remove it to avoid leaving orphaned data.
@@ -358,7 +404,7 @@ impl BlobStore {
             }
         }
 
-        Ok(())
+        Ok(durability)
     }
 
     fn insert_memory(
@@ -465,7 +511,7 @@ impl BlobStore {
         Ok(existed || existed_in_memory)
     }
 
-    /// Delete a blob only when the in-memory entry is known ephemeral.
+    /// Delete a blob only when it is known ephemeral.
     ///
     /// Durable entries are left intact because they may be referenced by
     /// outputs, attachments, or another durable path with the same hash.
@@ -474,19 +520,34 @@ impl BlobStore {
             return Ok(false);
         }
 
-        let removed = {
+        let (memory_was_ephemeral, memory_was_durable) = {
             let mut memory = self.memory_layer();
-            if memory
-                .get(hash)
-                .is_some_and(|entry| entry.durability == BlobDurability::Ephemeral)
-            {
-                memory.remove(hash)
-            } else {
-                false
+            match memory.get(hash).map(|entry| entry.durability) {
+                Some(BlobDurability::Ephemeral) => (memory.remove(hash), false),
+                Some(BlobDurability::Durable) => (false, true),
+                None => (false, false),
             }
         };
 
-        Ok(removed)
+        if memory_was_durable {
+            return Ok(false);
+        }
+
+        let (_, blob_path, meta_path) = self.paths(hash);
+        let disk_was_ephemeral = match tokio::fs::read_to_string(&meta_path).await {
+            Ok(json) => serde_json::from_str::<BlobMeta>(&json)
+                .map(|meta| meta.durability == BlobDurability::Ephemeral)
+                .unwrap_or(false),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => false,
+            Err(e) => return Err(e),
+        };
+
+        if disk_was_ephemeral {
+            tokio::fs::remove_file(&blob_path).await.ok();
+            tokio::fs::remove_file(&meta_path).await.ok();
+        }
+
+        Ok(memory_was_ephemeral || disk_was_ephemeral)
     }
 
     /// List all blob hashes in the store.
@@ -564,6 +625,14 @@ mod tests {
     fn disk_blob_exists(store: &BlobStore, hash: &str) -> bool {
         let (_, blob_path, meta_path) = store.paths(hash);
         blob_path.exists() && meta_path.exists()
+    }
+
+    async fn disk_blob_durability(store: &BlobStore, hash: &str) -> Option<BlobDurability> {
+        let (_, _, meta_path) = store.paths(hash);
+        let json = tokio::fs::read_to_string(meta_path).await.ok()?;
+        serde_json::from_str::<BlobMeta>(&json)
+            .ok()
+            .map(|meta| meta.durability)
     }
 
     #[tokio::test]
@@ -734,7 +803,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn put_ephemeral_lives_in_memory_not_disk() {
+    async fn put_ephemeral_is_disk_backed_for_runtime_agent() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);
 
@@ -748,8 +817,18 @@ mod tests {
             .unwrap();
 
         assert!(store.memory_contains_for_test(&hash));
-        assert!(!disk_blob_exists(&store, &hash));
+        assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(
+            disk_blob_durability(&store, &hash).await,
+            Some(BlobDurability::Ephemeral)
+        );
         assert_eq!(store.get(&hash).await.unwrap().unwrap(), b"ephemeral");
+
+        let runtime_agent_store = test_store(&dir);
+        assert_eq!(
+            runtime_agent_store.get(&hash).await.unwrap().unwrap(),
+            b"ephemeral"
+        );
     }
 
     #[tokio::test]
@@ -767,7 +846,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_ephemeral_after_eviction_returns_none() {
+    async fn get_ephemeral_after_memory_eviction_falls_back_to_disk() {
         let dir = TempDir::new().unwrap();
         let store = test_store_with_cap(&dir, 2);
 
@@ -785,8 +864,8 @@ mod tests {
             .unwrap();
 
         assert!(!store.memory_contains_for_test(&evicted));
-        assert!(!disk_blob_exists(&store, &evicted));
-        assert!(store.get(&evicted).await.unwrap().is_none());
+        assert!(disk_blob_exists(&store, &evicted));
+        assert_eq!(store.get(&evicted).await.unwrap().unwrap(), b"a");
     }
 
     #[tokio::test]
@@ -844,6 +923,12 @@ mod tests {
         assert_eq!(hash, hash2);
         assert!(store.memory_contains_for_test(&hash));
         assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(
+            disk_blob_durability(&store, &hash).await,
+            Some(BlobDurability::Durable)
+        );
+        assert!(!store.delete_if_ephemeral(&hash).await.unwrap());
+        assert!(disk_blob_exists(&store, &hash));
     }
 
     #[tokio::test]
@@ -855,7 +940,11 @@ mod tests {
             .put_with_durability(b"same", "text/plain", BlobDurability::Ephemeral)
             .await
             .unwrap();
-        assert!(!disk_blob_exists(&store, &hash));
+        assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(
+            disk_blob_durability(&store, &hash).await,
+            Some(BlobDurability::Ephemeral)
+        );
 
         let hash2 = store
             .put_with_durability(b"same", "text/plain", BlobDurability::Durable)
@@ -865,6 +954,10 @@ mod tests {
         assert_eq!(hash, hash2);
         assert!(store.memory_contains_for_test(&hash));
         assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(
+            disk_blob_durability(&store, &hash).await,
+            Some(BlobDurability::Durable)
+        );
     }
 
     #[tokio::test]
@@ -901,6 +994,24 @@ mod tests {
 
         assert!(store.delete_if_ephemeral(&hash).await.unwrap());
         assert!(!store.memory_contains_for_test(&hash));
+        assert!(!disk_blob_exists(&store, &hash));
+        assert!(store.get(&hash).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_if_ephemeral_removes_disk_only_ephemeral() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store_with_cap(&dir, 2);
+        let hash = store
+            .put_with_durability(b"oversize", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(!store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+
+        assert!(store.delete_if_ephemeral(&hash).await.unwrap());
+        assert!(!disk_blob_exists(&store, &hash));
         assert!(store.get(&hash).await.unwrap().is_none());
     }
 

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -60,6 +60,7 @@ struct MemoryEntry {
     data: Bytes,
     media_type: String,
     created_at: DateTime<Utc>,
+    durability: BlobDurability,
     seq: u64,
 }
 
@@ -84,7 +85,14 @@ impl MemoryLayer {
         }
     }
 
-    fn insert(&mut self, hash: String, data: Bytes, media_type: String, created_at: DateTime<Utc>) {
+    fn insert(
+        &mut self,
+        hash: String,
+        data: Bytes,
+        media_type: String,
+        created_at: DateTime<Utc>,
+        durability: BlobDurability,
+    ) {
         if data.len() > self.cap {
             return;
         }
@@ -105,6 +113,7 @@ impl MemoryLayer {
                 data,
                 media_type,
                 created_at,
+                durability,
                 seq,
             },
         );
@@ -224,7 +233,13 @@ impl BlobStore {
         match durability {
             BlobDurability::Durable => {
                 self.put_disk(&hash, data, media_type, created_at).await?;
-                self.insert_memory(&hash, Bytes::copy_from_slice(data), media_type, created_at);
+                self.insert_memory(
+                    &hash,
+                    Bytes::copy_from_slice(data),
+                    media_type,
+                    created_at,
+                    BlobDurability::Durable,
+                );
                 Ok(hash)
             }
             BlobDurability::Ephemeral => {
@@ -239,7 +254,13 @@ impl BlobStore {
                     );
                     self.put_disk(&hash, data, media_type, created_at).await?;
                 } else {
-                    self.insert_memory(&hash, Bytes::copy_from_slice(data), media_type, created_at);
+                    self.insert_memory(
+                        &hash,
+                        Bytes::copy_from_slice(data),
+                        media_type,
+                        created_at,
+                        BlobDurability::Ephemeral,
+                    );
                 }
                 Ok(hash)
             }
@@ -340,9 +361,22 @@ impl BlobStore {
         Ok(())
     }
 
-    fn insert_memory(&self, hash: &str, data: Bytes, media_type: &str, created_at: DateTime<Utc>) {
+    fn insert_memory(
+        &self,
+        hash: &str,
+        data: Bytes,
+        media_type: &str,
+        created_at: DateTime<Utc>,
+        durability: BlobDurability,
+    ) {
         let mut memory = self.memory_layer();
-        memory.insert(hash.to_string(), data, media_type.to_string(), created_at);
+        memory.insert(
+            hash.to_string(),
+            data,
+            media_type.to_string(),
+            created_at,
+            durability,
+        );
     }
 
     fn memory_layer(&self) -> MutexGuard<'_, MemoryLayer> {
@@ -429,6 +463,30 @@ impl BlobStore {
             tokio::fs::remove_file(&meta_path).await.ok();
         }
         Ok(existed || existed_in_memory)
+    }
+
+    /// Delete a blob only when the in-memory entry is known ephemeral.
+    ///
+    /// Durable entries are left intact because they may be referenced by
+    /// outputs, attachments, or another durable path with the same hash.
+    pub async fn delete_if_ephemeral(&self, hash: &str) -> io::Result<bool> {
+        if !Self::validate_hash(hash) {
+            return Ok(false);
+        }
+
+        let removed = {
+            let mut memory = self.memory_layer();
+            if memory
+                .get(hash)
+                .is_some_and(|entry| entry.durability == BlobDurability::Ephemeral)
+            {
+                memory.remove(hash)
+            } else {
+                false
+            }
+        };
+
+        Ok(removed)
     }
 
     /// List all blob hashes in the store.
@@ -830,5 +888,43 @@ mod tests {
         assert!(!store.memory_contains_for_test(&first));
         assert!(store.memory_contains_for_test(&second));
         assert!(store.memory_contains_for_test(&third));
+    }
+
+    #[tokio::test]
+    async fn delete_if_ephemeral_removes_ephemeral_only() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let hash = store
+            .put_with_durability(b"ephemeral", "text/plain", BlobDurability::Ephemeral)
+            .await
+            .unwrap();
+
+        assert!(store.delete_if_ephemeral(&hash).await.unwrap());
+        assert!(!store.memory_contains_for_test(&hash));
+        assert!(store.get(&hash).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_if_ephemeral_skips_durable() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let hash = store
+            .put_with_durability(b"durable", "text/plain", BlobDurability::Durable)
+            .await
+            .unwrap();
+
+        assert!(!store.delete_if_ephemeral(&hash).await.unwrap());
+        assert!(store.memory_contains_for_test(&hash));
+        assert!(disk_blob_exists(&store, &hash));
+        assert_eq!(store.get(&hash).await.unwrap().unwrap(), b"durable");
+    }
+
+    #[tokio::test]
+    async fn delete_if_ephemeral_returns_false_for_unknown_hash() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+        let missing = "a".repeat(64);
+
+        assert!(!store.delete_if_ephemeral(&missing).await.unwrap());
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -302,7 +302,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn put_blob_ephemeral_success_keeps_blob_out_of_disk_store() {
+    async fn put_blob_ephemeral_success_keeps_blob_visible_to_other_store_instances() {
         let body = b"abc";
         let sha256 = hex::encode(Sha256::digest(body));
         let request_payload = payload_with_durability(
@@ -325,7 +325,13 @@ mod tests {
             blob_store.get(&sha256).await.unwrap().as_deref(),
             Some(&body[..])
         );
-        assert!(!disk_blob_exists(&blob_store, &sha256));
+        assert!(disk_blob_exists(&blob_store, &sha256));
+
+        let other_store = BlobStore::new(_tmp.path().join("blobs"));
+        assert_eq!(
+            other_store.get(&sha256).await.unwrap().as_deref(),
+            Some(&body[..])
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -365,7 +365,14 @@ pub async fn run_runtime_agent(
                                                         Vec::new()
                                                     }
                                                 };
-                                                Ok(Some((queued, comm_updates)))
+                                                let comms_after = sd.read_state().comms;
+                                                let superseded_hashes =
+                                                    superseded_content_ref_hashes_by_comm(
+                                                        &comms_before,
+                                                        &comms_after,
+                                                        &comm_updates,
+                                                    );
+                                                Ok(Some((queued, comm_updates, superseded_hashes)))
                                             }
                                             Ok(_) => Ok(None),
                                             Err(e) => {
@@ -380,10 +387,19 @@ pub async fn run_runtime_agent(
 
                                     // Async work outside the lock
                                     match sync_result {
-                                        Ok(Some((queued, comm_updates))) => {
+                                        Ok(Some((
+                                            queued,
+                                            comm_updates,
+                                            superseded_hashes_by_comm,
+                                        ))) => {
                                             if !comm_updates.is_empty() {
                                                 if let Some(ref mut k) = kernel {
                                                     for (comm_id, delta) in &comm_updates {
+                                                        let superseded_hashes =
+                                                            superseded_hashes_by_comm
+                                                                .get(comm_id)
+                                                                .cloned()
+                                                                .unwrap_or_default();
                                                         let Some(update) = prepare_comm_update(
                                                             comm_id,
                                                             delta,
@@ -392,6 +408,12 @@ pub async fn run_runtime_agent(
                                                         )
                                                         .await
                                                         else {
+                                                            free_superseded_ephemeral_blobs(
+                                                                &ctx.blob_store,
+                                                                comm_id,
+                                                                &superseded_hashes,
+                                                            )
+                                                            .await;
                                                             continue;
                                                         };
                                                         let RehydratedCommUpdate {
@@ -415,6 +437,12 @@ pub async fn run_runtime_agent(
                                                                         comm_id, &hash,
                                                                     );
                                                                 }
+                                                                free_superseded_ephemeral_blobs(
+                                                                    &ctx.blob_store,
+                                                                    comm_id,
+                                                                    &superseded_hashes,
+                                                                )
+                                                                .await;
                                                             }
                                                             Err(e) => {
                                                                 warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
@@ -1461,6 +1489,64 @@ fn diff_comm_state(
     updates
 }
 
+fn superseded_content_ref_hashes_by_comm(
+    before: &HashMap<String, CommDocEntry>,
+    after: &HashMap<String, CommDocEntry>,
+    comm_updates: &[(String, serde_json::Value)],
+) -> HashMap<String, Vec<String>> {
+    // BlobStore is content-addressed across the document, so identical hashes
+    // still referenced by another comm must stay live.
+    let live_hashes_after = content_ref_hashes_in_comms(after);
+    let mut superseded = HashMap::new();
+
+    for (comm_id, _) in comm_updates {
+        let Some(before_entry) = before.get(comm_id) else {
+            continue;
+        };
+        let mut hashes = HashSet::new();
+        for (_, hash) in collect_content_refs(&before_entry.state) {
+            if !live_hashes_after.contains(&hash) {
+                hashes.insert(hash);
+            }
+        }
+        if !hashes.is_empty() {
+            superseded.insert(comm_id.clone(), hashes.into_iter().collect());
+        }
+    }
+
+    superseded
+}
+
+fn content_ref_hashes_in_comms(comms: &HashMap<String, CommDocEntry>) -> HashSet<String> {
+    let mut hashes = HashSet::new();
+    for entry in comms.values() {
+        for (_, hash) in collect_content_refs(&entry.state) {
+            hashes.insert(hash);
+        }
+    }
+    hashes
+}
+
+async fn free_superseded_ephemeral_blobs(blob_store: &BlobStore, comm_id: &str, hashes: &[String]) {
+    for hash in hashes {
+        match blob_store.delete_if_ephemeral(hash).await {
+            Ok(true) => {
+                debug!(
+                    "[runtime-agent] Freed superseded ephemeral blob {} for comm_id={}",
+                    hash, comm_id
+                );
+            }
+            Ok(false) => {}
+            Err(e) => {
+                warn!(
+                    "[runtime-agent] Failed to free superseded ephemeral blob {} for comm_id={}: {}",
+                    hash, comm_id, e
+                );
+            }
+        }
+    }
+}
+
 struct RehydratedCommUpdate {
     state: serde_json::Value,
     buffer_paths: Vec<Vec<String>>,
@@ -1618,7 +1704,7 @@ mod tests {
     use crate::output_prep::queue_command_channels;
     use crate::protocol::CompletionItem;
     use anyhow::Result;
-    use notebook_protocol::protocol::LaunchedEnvConfig;
+    use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
 
     /// Minimal mock kernel for testing queue/state logic without ZeroMQ.
@@ -1683,6 +1769,18 @@ mod tests {
             true
         }
         fn update_launched_uv_deps(&mut self, _: Vec<String>) {}
+    }
+
+    fn comm_entry(state: serde_json::Value) -> CommDocEntry {
+        CommDocEntry {
+            target_name: "jupyter.widget".to_string(),
+            model_module: "anywidget".to_string(),
+            model_name: "AnyModel".to_string(),
+            state,
+            outputs: Vec::new(),
+            seq: 0,
+            capture_msg_id: String::new(),
+        }
     }
 
     /// Build test fixtures: RuntimeAgentContext + KernelState wired to the same doc.
@@ -2033,5 +2131,184 @@ mod tests {
         let update = prepare_comm_update("comm-a", &delta, &blob_store, &mut suppressor).await;
 
         assert!(update.is_none());
+    }
+
+    #[tokio::test]
+    async fn prepare_comm_update_or_supersession_frees_replaced_ephemeral_blob() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put_with_durability(
+                b"old",
+                "application/octet-stream",
+                BlobDurability::Ephemeral,
+            )
+            .await
+            .unwrap();
+        let before_state = serde_json::json!({
+            "selection": {
+                "view": { "blob": hash, "size": 3, "media_type": "application/octet-stream" }
+            }
+        });
+        let after_state = serde_json::json!({ "selection": null });
+        let before = HashMap::from([("comm-a".to_string(), comm_entry(before_state))]);
+        let after = HashMap::from([("comm-a".to_string(), comm_entry(after_state))]);
+        let updates = vec![(
+            "comm-a".to_string(),
+            serde_json::json!({ "selection": null }),
+        )];
+
+        let superseded = superseded_content_ref_hashes_by_comm(&before, &after, &updates);
+        free_superseded_ephemeral_blobs(&blob_store, "comm-a", superseded.get("comm-a").unwrap())
+            .await;
+
+        assert!(blob_store.get(&hash).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn supersession_keeps_durable_blob() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put_with_durability(b"old", "application/octet-stream", BlobDurability::Durable)
+            .await
+            .unwrap();
+        let before_state = serde_json::json!({
+            "selection": {
+                "view": { "blob": hash, "size": 3, "media_type": "application/octet-stream" }
+            }
+        });
+        let after_state = serde_json::json!({ "selection": null });
+        let before = HashMap::from([("comm-a".to_string(), comm_entry(before_state))]);
+        let after = HashMap::from([("comm-a".to_string(), comm_entry(after_state))]);
+        let updates = vec![(
+            "comm-a".to_string(),
+            serde_json::json!({ "selection": null }),
+        )];
+
+        let superseded = superseded_content_ref_hashes_by_comm(&before, &after, &updates);
+        free_superseded_ephemeral_blobs(&blob_store, "comm-a", superseded.get("comm-a").unwrap())
+            .await;
+
+        assert_eq!(
+            blob_store.get(&hash).await.unwrap().as_deref(),
+            Some(&b"old"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn supersession_handles_within_comm_path_move() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put_with_durability(
+                b"old",
+                "application/octet-stream",
+                BlobDurability::Ephemeral,
+            )
+            .await
+            .unwrap();
+        let content_ref = serde_json::json!({ "blob": hash, "size": 3, "media_type": "application/octet-stream" });
+        let before_state = serde_json::json!({ "a": { "view": content_ref.clone() } });
+        let after_state = serde_json::json!({ "b": { "view": content_ref } });
+        let before = HashMap::from([("comm-a".to_string(), comm_entry(before_state))]);
+        let after = HashMap::from([("comm-a".to_string(), comm_entry(after_state))]);
+        let updates = vec![(
+            "comm-a".to_string(),
+            serde_json::json!({ "a": null, "b": {} }),
+        )];
+
+        let superseded = superseded_content_ref_hashes_by_comm(&before, &after, &updates);
+
+        assert!(superseded.get("comm-a").is_none_or(Vec::is_empty));
+        assert_eq!(
+            blob_store.get(&hash).await.unwrap().as_deref(),
+            Some(&b"old"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn supersession_keeps_hash_referenced_by_another_comm() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put_with_durability(
+                b"old",
+                "application/octet-stream",
+                BlobDurability::Ephemeral,
+            )
+            .await
+            .unwrap();
+        let content_ref = serde_json::json!({ "blob": hash, "size": 3, "media_type": "application/octet-stream" });
+        let before = HashMap::from([
+            (
+                "comm-a".to_string(),
+                comm_entry(serde_json::json!({ "selection": { "view": content_ref.clone() } })),
+            ),
+            (
+                "comm-b".to_string(),
+                comm_entry(serde_json::json!({ "selection": { "view": content_ref.clone() } })),
+            ),
+        ]);
+        let after = HashMap::from([
+            (
+                "comm-a".to_string(),
+                comm_entry(serde_json::json!({ "selection": null })),
+            ),
+            (
+                "comm-b".to_string(),
+                comm_entry(serde_json::json!({ "selection": { "view": content_ref } })),
+            ),
+        ]);
+        let updates = vec![(
+            "comm-a".to_string(),
+            serde_json::json!({ "selection": null }),
+        )];
+
+        let superseded = superseded_content_ref_hashes_by_comm(&before, &after, &updates);
+
+        assert!(superseded.get("comm-a").is_none_or(Vec::is_empty));
+        assert_eq!(
+            blob_store.get(&hash).await.unwrap().as_deref(),
+            Some(&b"old"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn supersession_skipped_on_kernel_send_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let blob_store = BlobStore::new(temp.path().join("blobs"));
+        let hash = blob_store
+            .put_with_durability(
+                b"old",
+                "application/octet-stream",
+                BlobDurability::Ephemeral,
+            )
+            .await
+            .unwrap();
+        let before_state = serde_json::json!({
+            "selection": {
+                "view": { "blob": hash, "size": 3, "media_type": "application/octet-stream" }
+            }
+        });
+        let after_state = serde_json::json!({ "selection": null });
+        let before = HashMap::from([("comm-a".to_string(), comm_entry(before_state))]);
+        let after = HashMap::from([("comm-a".to_string(), comm_entry(after_state))]);
+        let updates = vec![(
+            "comm-a".to_string(),
+            serde_json::json!({ "selection": null }),
+        )];
+
+        let superseded = superseded_content_ref_hashes_by_comm(&before, &after, &updates);
+        assert_eq!(superseded.get("comm-a"), Some(&vec![hash.clone()]));
+        // Production only calls free_superseded_ephemeral_blobs after a
+        // successful send_comm_update or an echo-suppressed update. A failed
+        // kernel send keeps the blob available for a possible retry.
+        let _kernel_send_failed = true;
+
+        assert_eq!(
+            blob_store.get(&hash).await.unwrap().as_deref(),
+            Some(&b"old"[..])
+        );
     }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -408,6 +408,10 @@ pub async fn run_runtime_agent(
                                                         )
                                                         .await
                                                         else {
+                                                            // The doc supersession already happened; even though no
+                                                            // kernel send is needed for an echo, stale ephemeral blobs
+                                                            // can be freed here. Failed kernel sends skip this cleanup
+                                                            // below so the bytes remain available for a retry.
                                                             free_superseded_ephemeral_blobs(
                                                                 &ctx.blob_store,
                                                                 comm_id,
@@ -2304,7 +2308,6 @@ mod tests {
         // Production only calls free_superseded_ephemeral_blobs after a
         // successful send_comm_update or an echo-suppressed update. A failed
         // kernel send keeps the blob available for a possible retry.
-        let _kernel_send_failed = true;
 
         assert_eq!(
             blob_store.get(&hash).await.unwrap().as_deref(),

--- a/src/components/isolated/__tests__/comm-bridge-manager.test.ts
+++ b/src/components/isolated/__tests__/comm-bridge-manager.test.ts
@@ -102,7 +102,7 @@ describe("CommBridgeManager", () => {
   beforeEach(() => {
     mockStore = createMockStore();
     mockFrame = createMockFrame();
-    sendUpdate = vi.fn();
+    sendUpdate = vi.fn().mockResolvedValue(undefined);
     sendCustom = vi.fn();
     closeComm = vi.fn();
     vi.clearAllMocks();
@@ -332,7 +332,7 @@ describe("CommBridgeManager", () => {
       });
 
       expect(mockStore.store.updateModel).toHaveBeenCalledWith("comm-1", { value: 42 });
-      expect(sendUpdate).toHaveBeenCalledWith("comm-1", { value: 42 }, undefined);
+      expect(sendUpdate).toHaveBeenCalledWith("comm-1", { value: 42 });
     });
 
     it("processes widget_comm_msg with custom method", () => {

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -24,11 +24,7 @@ function filterBufferPathsToKeys(
 }
 
 // Type for sending messages to kernel
-type SendUpdate = (
-  commId: string,
-  state: Record<string, unknown>,
-  buffers?: ArrayBuffer[],
-) => void | Promise<void>;
+type SendUpdate = (commId: string, state: Record<string, unknown>) => Promise<void>;
 
 type SendCustom = (
   commId: string,
@@ -302,19 +298,16 @@ export class CommBridgeManager {
       // Set flag to prevent echoing this update back to iframe
       this.isProcessingIframeUpdate = true;
       try {
-        // Update parent store first (so UI stays in sync). Outgoing
-        // `buffers` are in flight to the kernel; they're not a new
-        // bufferPaths manifest so we leave that field untouched.
+        // Update parent store first (so UI stays in sync). Binary state leaves
+        // travel inside `data` and are extracted by WidgetUpdateManager.
         this.store.updateModel(commId, data);
         // Update our tracked state
         const current = this.previousState.get(commId) ?? {};
         this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...data }));
         // Then forward to kernel
-        void Promise.resolve(this.sendUpdateToKernel(commId, data, buffers)).catch(
-          (error: unknown) => {
-            console.error("[widgets] failed to persist iframe widget state update:", error);
-          },
-        );
+        void this.sendUpdateToKernel(commId, data).catch((error: unknown) => {
+          console.error("[widgets] failed to persist iframe widget state update:", error);
+        });
       } finally {
         this.isProcessingIframeUpdate = false;
       }

--- a/src/components/widgets/__tests__/widget-update-manager.test.ts
+++ b/src/components/widgets/__tests__/widget-update-manager.test.ts
@@ -129,17 +129,6 @@ describe("WidgetUpdateManager", () => {
       expect(writerCalls[0].patch).toEqual({ value: 20 });
     });
 
-    it("flushes immediately for binary buffers", () => {
-      const { manager, writerCalls } = setup();
-
-      const buffer = new ArrayBuffer(8);
-      manager.updateAndPersist("comm-1", { value: 42 }, [buffer]);
-
-      // Flushed immediately, no debounce
-      expect(writerCalls).toHaveLength(1);
-      expect(writerCalls[0].patch).toEqual({ value: 42 });
-    });
-
     it("uploads extracted binary leaves before writing ContentRefs to CRDT", async () => {
       const uploadCalls: Array<{ bytes: number[]; mediaType: string; durability?: string }> = [];
       const contentRef: ContentRef = {

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -211,11 +211,7 @@ type EventCallback = (...args: unknown[]) => void;
  * daemon shell channel as a Jupyter `comm_msg(method: "custom")`.
  */
 export interface AFMProxyOutbound {
-  sendUpdate: (
-    commId: string,
-    state: Record<string, unknown>,
-    buffers?: ArrayBuffer[],
-  ) => Promise<void>;
+  sendUpdate: (commId: string, state: Record<string, unknown>) => Promise<void>;
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
 }
 
@@ -512,8 +508,7 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
         // the widget (event listeners, timers) always see the current
         // sendUpdate/sendCustom without triggering this effect to re-run.
         const outboundProxy: AFMProxyOutbound = {
-          sendUpdate: (commId, state, buffers) =>
-            outboundRef.current.sendUpdate(commId, state, buffers),
+          sendUpdate: (commId, state) => outboundRef.current.sendUpdate(commId, state),
           sendCustom: (commId, content, buffers) =>
             outboundRef.current.sendCustom(commId, content, buffers),
         };

--- a/src/components/widgets/use-comm-router.ts
+++ b/src/components/widgets/use-comm-router.ts
@@ -74,11 +74,7 @@ export interface UseCommRouterOptions {
 
 export interface UseCommRouterReturn {
   /** Send a state update to the kernel */
-  sendUpdate: (
-    commId: string,
-    state: Record<string, unknown>,
-    buffers?: ArrayBuffer[],
-  ) => Promise<void>;
+  sendUpdate: (commId: string, state: Record<string, unknown>) => Promise<void>;
   /** Send a custom message to the kernel */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel */
@@ -161,12 +157,9 @@ export function useCommRouter({
     managerRef.current = updateManager;
   });
 
-  const sendUpdate = useCallback(
-    (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => {
-      return managerRef.current.updateAndPersist(commId, state, buffers);
-    },
-    [],
-  );
+  const sendUpdate = useCallback((commId: string, state: Record<string, unknown>) => {
+    return managerRef.current.updateAndPersist(commId, state);
+  }, []);
 
   const sendCustom = useCallback(
     (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => {

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -34,11 +34,7 @@ import {
 interface WidgetStoreContextValue {
   store: WidgetStore;
   /** Send a state update to the kernel. Routed through WidgetUpdateManager. */
-  sendUpdate: (
-    commId: string,
-    state: Record<string, unknown>,
-    buffers?: ArrayBuffer[],
-  ) => Promise<void>;
+  sendUpdate: (commId: string, state: Record<string, unknown>) => Promise<void>;
   /** Send a custom message (method: "custom") via the daemon shell channel. */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel via the daemon shell channel. */

--- a/src/components/widgets/widget-update-manager.ts
+++ b/src/components/widgets/widget-update-manager.ts
@@ -125,18 +125,8 @@ export class WidgetUpdateManager {
    * are uploaded to blob storage. The optimistic store update keeps the
    * original DataView/typed-array values so active widgets don't flicker.
    */
-  async updateAndPersist(
-    commId: string,
-    patch: Record<string, unknown>,
-    buffers?: ArrayBuffer[],
-  ): Promise<void> {
+  async updateAndPersist(commId: string, patch: Record<string, unknown>): Promise<void> {
     const extracted = extractCommBuffers(patch);
-
-    if (buffers?.length && extracted.buffers.length) {
-      console.warn(
-        "[widgets] update supplied both extracted binary leaves and legacy buffers; using extracted leaves",
-      );
-    }
 
     // 1. Instant store update — UI reflects change immediately
     this.getStore()?.updateModel(commId, patch);
@@ -165,13 +155,7 @@ export class WidgetUpdateManager {
     // 3. Accumulate JSON-only patch
     this.enqueuePending(commId, extracted.jsonPatch);
 
-    // 4. Legacy binary buffers — preserve the old immediate-flush behavior.
-    if (buffers?.length) {
-      this.flushComm(commId);
-      return;
-    }
-
-    // 5. Debounced flush — reset timer on each update
+    // 4. Debounced flush — reset timer on each update
     const existing_timer = this.flushTimers.get(commId);
     if (existing_timer !== undefined) {
       clearTimeout(existing_timer);

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -83,7 +83,7 @@ export interface WidgetBridgeClient {
    * Send a state update to the parent (to be forwarded to kernel).
    * Called when a widget's state changes due to user interaction.
    */
-  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendUpdate: (commId: string, state: Record<string, unknown>) => void;
 
   /**
    * Send a custom message to the parent (to be forwarded to kernel).
@@ -178,16 +178,13 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
   return {
     store,
 
-    sendUpdate(commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) {
+    sendUpdate(commId: string, state: Record<string, unknown>) {
       // Update local store immediately for responsive UI (optimistic update).
-      // Outgoing `buffers` go over the wire to the kernel; they don't shape
-      // the inbound bufferPaths metadata the store tracks.
       store.updateModel(commId, state);
       transport.notify(NTERACT_WIDGET_COMM_MSG, {
         commId,
         method: "update",
         data: state,
-        buffers,
       });
     },
 

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -36,7 +36,7 @@ import { createWidgetBridgeClient, type WidgetBridgeClient } from "./widget-brid
 interface IframeWidgetStoreContextValue {
   store: WidgetStore;
   /** Send a state update to the parent (which forwards to kernel) */
-  sendUpdate: (commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  sendUpdate: (commId: string, state: Record<string, unknown>) => void;
   /** Send a custom message to the parent (which forwards to kernel) */
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel via parent */
@@ -111,12 +111,8 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
   const mainContextValue = useMemo(
     () => ({
       store: client.store,
-      sendUpdate: async (
-        commId: string,
-        state: Record<string, unknown>,
-        buffers?: ArrayBuffer[],
-      ) => {
-        client.sendUpdate(commId, state, buffers);
+      sendUpdate: async (commId: string, state: Record<string, unknown>) => {
+        client.sendUpdate(commId, state);
       },
       sendCustom: client.sendCustom,
       closeComm: client.closeComm,


### PR DESCRIPTION
## Summary

- drop the legacy `buffers` argument from widget `sendUpdate` paths while keeping custom comm buffers intact
- add the E2E-only widget selection helper and make the jscatter lasso fallback fail loudly when toolbar detection changes
- add `BlobStore::delete_if_ephemeral` and free superseded ephemeral widget blobs after successful kernel sends or echo-suppressed updates
- keep ephemeral PutBlob uploads visible to process-isolated runtime agents with disk-backed durability metadata, while preserving durable same-hash content
- serialize blob disk metadata updates and ephemeral disk cleanup with per-blob lock files

## Verification

- `cargo xtask lint --fix`
- `pnpm test -- --run src/components/widgets/__tests__/widget-update-manager.test.ts src/components/isolated/__tests__/comm-bridge-manager.test.ts src/components/widgets/__tests__/afm-model-proxy.test.ts`
- `cargo test -p runtimed blob_store --lib`
- `cargo test -p runtimed blob_store -- --nocapture`
- `cargo test -p runtimed put_blob -- --nocapture`
- `cargo test -p runtimed runtime_agent::tests::prepare_comm_update --lib`
- `cargo test -p runtimed runtime_agent::tests::supersession --lib`
- `cargo test -p runtimed supersession -- --nocapture`
- `RUNTIMED_VITE_PORT=6893 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/jscatter-lasso.spec.ts`
- `RUNTIMED_VITE_PORT=6894 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/noisy-output-interrupt.spec.ts e2e/jscatter-lasso.spec.ts`
- `RUNTIMED_VITE_PORT=6897 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/jscatter-lasso.spec.ts`
- `RUNTIMED_VITE_PORT=6898 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/jscatter-lasso.spec.ts`
- `RUNTIMED_VITE_PORT=6899 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/jscatter-lasso.spec.ts`
- `RUNTIMED_VITE_PORT=6901 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/jscatter-lasso.spec.ts`
