### PR TITLE
feat(runtimed): reap resumable rooms with combined registry + LRU cap

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3999,34 +3999,68 @@ impl Daemon {
 
         for (uuid, room, gen_at_sample) in candidates {
             // Re-verify outside the lock. `has_kernel` touches the
-            // runtime-agent mutex; do it before re-acquiring rooms.
+            // runtime-agent mutex; do it before any further work.
             if room.has_kernel().await {
                 continue;
             }
 
-            // Read the bound path BEFORE removing from notebook_rooms.
-            // The path_index must be cleared first: if we cleared
-            // rooms first, an open-by-path lookup that lands in the
-            // window between the rooms-remove and the path_index-remove
-            // would find a stale UUID in `path_index`, fail to find
-            // the room in `notebook_rooms`, and then create a new
-            // room — whose `path_index.insert` would fail because the
-            // stale entry is still there. The room would end up in
-            // `notebook_rooms` but not in `path_index`, and a
-            // subsequent open-by-path could create a duplicate room
-            // for the same file.
-            let path_for_index = room.file_binding.path().await;
+            let path = room.file_binding.path().await;
+            let notebook_id_label = path
+                .as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| uuid.to_string());
 
-            // Atomic remove pass: re-check active_peers AND the
-            // connection generation AND the teardown timestamp under
-            // the registry lock so a peer that reconnected between the
-            // snapshot and now keeps its room. The registry pops the
-            // room out of the UUID map and the path index together, so
-            // a concurrent open-by-path can't observe a half-removed
-            // state. A brief peer-touch (connect, then disconnect
-            // again) leaves active_peers == 0 but bumps the generation
-            // and may have zeroed the teardown timestamp; treat all
-            // three as "still idle" signals.
+            // Step 1: force-flush the persist debouncer so the
+            // `.automerge` mirror is current before we touch
+            // anything. Skipped for ephemeral rooms (no debouncer).
+            // Flush failure leaves the room resident; the next sweep
+            // retries.
+            const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+            if let Some(ack_rx) = room.persistence.request_flush() {
+                use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
+                match recv_oneshot_with_timeout(ack_rx, FLUSH_TIMEOUT).await {
+                    TimedOneShot::Received(true) | TimedOneShot::SenderDropped => {}
+                    TimedOneShot::Received(false) | TimedOneShot::TimedOut => {
+                        warn!(
+                            "[runtimed] Resident-room reaper: persist flush failed for {} - keeping resident, retrying next sweep",
+                            notebook_id_label
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            // Step 2: shut down the autosave debouncer. If the task
+            // doesn't ack within the timeout we abandon — it's
+            // pinning the room Arc and the next sweep will retry.
+            const AUTOSAVE_SHUTDOWN_TIMEOUT: std::time::Duration =
+                std::time::Duration::from_secs(5);
+            let autosave_shutdown_ok = crate::notebook_sync_server::shutdown_autosave_debouncer(
+                &room,
+                &notebook_id_label,
+                AUTOSAVE_SHUTDOWN_TIMEOUT,
+            )
+            .await;
+            if !autosave_shutdown_ok {
+                warn!(
+                    "[runtimed] Resident-room reaper: autosave shutdown stalled for {} - keeping resident, retrying next sweep",
+                    notebook_id_label
+                );
+                continue;
+            }
+
+            // Step 3: fire-and-forget watcher shutdowns. Both tasks
+            // own an `Arc<NotebookRoom>` and release it on receipt of
+            // the oneshot signal.
+            room.file_binding.shutdown_notebook_watcher().await;
+            room.file_binding.shutdown_project_file_watcher().await;
+
+            // Step 4: atomic commit. Re-check active_peers,
+            // reservations, generation, and still-torn-down under the
+            // registry lock. The registry removes the room from the
+            // UUID map and the path index together; a concurrent
+            // open-by-path either sees the live room or hits the new-
+            // room path cleanly.
             let removed = self
                 .notebook_rooms
                 .remove_if(uuid, |r| {
@@ -4037,48 +4071,38 @@ impl Daemon {
                         == 0;
                     let no_reservations = r.connections.reservations() == 0;
                     let same_gen = r.connections.connection_generation() == gen_at_sample;
-                    // A reconnect zeroed the timestamp on join. The
-                    // selection pass already enforced TTL or LRU
-                    // overflow; under the registry lock we just verify
-                    // the room hasn't transitioned out of "kernel torn
-                    // down" between sample and commit.
                     let still_stamped = r.connections.last_kernel_torn_down_at().is_some();
                     no_peers && no_reservations && same_gen && still_stamped
                 })
                 .await;
 
             let Some(room) = removed else {
+                // Abort path: a peer reconnected between cleanup and
+                // commit. Autosave and watchers were torn down above;
+                // re-arm them so the reconnect inherits a working room.
+                // The persist debouncer was only flushed, not torn
+                // down, so it's still running.
+                if let Some(ref p) = path {
+                    crate::notebook_sync_server::NotebookFileBinding::bind_existing(&room, p).await;
+                }
+                debug!(
+                    "[runtimed] Resident-room reaper: peer reconnected for {} mid-cleanup; watchers re-armed",
+                    notebook_id_label
+                );
                 continue;
             };
-            let path = path_for_index;
 
-            // Shut down the watchers and autosave debouncer that were
-            // left armed across kernel teardown. The .ipynb has been
-            // saved (kernel teardown wrote a final save) and no peers
-            // are around to make further edits, so this is just freeing
-            // file-descriptors and the autosave task.
-            room.file_binding.shutdown_notebook_watcher().await;
-            room.file_binding.shutdown_project_file_watcher().await;
-            const AUTOSAVE_SHUTDOWN_TIMEOUT: std::time::Duration =
-                std::time::Duration::from_secs(5);
-            let notebook_id_label = path
-                .as_ref()
-                .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_else(|| uuid.to_string());
-            let _ = crate::notebook_sync_server::shutdown_autosave_debouncer(
-                &room,
-                &notebook_id_label,
-                AUTOSAVE_SHUTDOWN_TIMEOUT,
-            )
-            .await;
+            // Commit point. Step 5: take the persist debouncer out so
+            // its senders drop and the task exits via its shutdown arm
+            // with one final flush. Dropping the room Arc next is no
+            // longer enough on its own because nothing else holds an
+            // Arc to gate the persist task on.
+            let _ = room.persistence.take_debouncer();
 
             info!(
-                "[runtimed] Ghost-room reaper removed room {} (path={:?})",
+                "[runtimed] Resident-room reaper removed room {} (path={:?})",
                 uuid, path
             );
-            // Dropping `room` here also drops the persist debouncer's
-            // sender half; the debouncer task exits via its shutdown arm
-            // and gets one final flush in.
             drop(room);
         }
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3,7 +3,7 @@
 //! The daemon manages prewarmed environment pools and handles requests from
 //! notebook windows via IPC (Unix domain sockets on Unix, named pipes on Windows).
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Weak};
@@ -27,7 +27,7 @@ use tokio::sync::RwLock;
 use crate::async_outcome::{await_result_with_timeout, TimedResult};
 use crate::blob_server;
 use crate::blob_store::BlobStore;
-use crate::notebook_sync_server::{NotebookRooms, PathIndex};
+use crate::notebook_sync_server::{NotebookRooms, RoomRegistry};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
 use crate::settings_doc::{SettingsDoc, SyncedSettings};
@@ -1094,11 +1094,12 @@ pub struct Daemon {
     /// When the daemon process began. Reported via Ping for diagnostics.
     started_at: chrono::DateTime<chrono::Utc>,
     /// Per-notebook Automerge sync rooms.
+    /// Per-notebook Automerge sync rooms plus the canonical-path
+    /// secondary index, behind a single tokio mutex inside
+    /// `RoomRegistry`. The combined registry makes insert / remove and
+    /// path lookup atomic against each other so a peer-connect can't
+    /// race a save-as into producing two rooms for the same `.ipynb`.
     pub(crate) notebook_rooms: NotebookRooms,
-    /// Secondary index: canonical .ipynb path → room UUID.
-    /// Kept in sync with `notebook_rooms` by `get_or_create_room` (insert)
-    /// and the eviction loop (remove). Queried by `find_room_by_path`.
-    pub(crate) path_index: Arc<tokio::sync::Mutex<PathIndex>>,
     /// Set to `true` the first time any client causes a room to be
     /// acquired in `notebook_rooms` (via `get_or_create_room`). Used by
     /// the zero-room sweep-skip guard to distinguish "post-restart, no
@@ -1392,8 +1393,7 @@ impl Daemon {
             trusted_packages,
             blob_port: Mutex::new(None),
             started_at: chrono::Utc::now(),
-            notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
-            path_index: Arc::new(tokio::sync::Mutex::new(PathIndex::new())),
+            notebook_rooms: Arc::new(RoomRegistry::new()),
             rooms_ever_seen: std::sync::atomic::AtomicBool::new(false),
             uv_warming_respawns: std::sync::atomic::AtomicU32::new(0),
             conda_warming_respawns: std::sync::atomic::AtomicU32::new(0),
@@ -1451,10 +1451,13 @@ impl Daemon {
             return Response::ExecutionResult { record };
         }
 
-        let rooms = {
-            let rooms_guard = self.notebook_rooms.lock().await;
-            rooms_guard.values().cloned().collect::<Vec<_>>()
-        };
+        let rooms: Vec<_> = self
+            .notebook_rooms
+            .snapshot()
+            .await
+            .into_iter()
+            .map(|(_, room)| room)
+            .collect();
 
         for room in rooms {
             let Some(exec) = room
@@ -1816,10 +1819,7 @@ impl Daemon {
         //
         // To avoid holding the notebook_rooms lock across .await points, first
         // drain the map into an owned collection, then shut down agents.
-        let drained_rooms = {
-            let mut rooms = self.notebook_rooms.lock().await;
-            rooms.drain().collect::<Vec<_>>()
-        };
+        let drained_rooms = self.notebook_rooms.drain().await;
 
         for (notebook_uuid, room) in drained_rooms {
             // Shut down runtime agent via RPC before dropping handle
@@ -2431,11 +2431,12 @@ impl Daemon {
                 // - UUID notebook_id → untitled room (path=None)
                 // - Path notebook_id → file-backed room (path=Some)
                 //
-                // When notebook_id is a path, canonicalize and consult path_index
-                // before minting a new UUID. Without this, each reconnect creates a
-                // fresh UUID and a duplicate room (two file watchers, two autosave
-                // debouncers, two writers on the same .ipynb — zombie rooms).
-                let room = {
+                // When notebook_id is a path, canonicalize and consult the
+                // registry's path map before minting a new UUID. Without this,
+                // each reconnect creates a fresh UUID and a duplicate room
+                // (two file watchers, two autosave debouncers, two writers on
+                // the same .ipynb — zombie rooms).
+                let (room, _room_guard) = {
                     let (ns_uuid, ns_path) = if let Ok(parsed) = uuid::Uuid::parse_str(&notebook_id)
                     {
                         (parsed, None)
@@ -2455,18 +2456,16 @@ impl Daemon {
                         };
                         match crate::notebook_sync_server::find_room_by_path(
                             &self.notebook_rooms,
-                            &self.path_index,
                             &canonical,
                         )
                         .await
                         {
-                            Some(existing) => (existing.id, Some(canonical)),
+                            Some((existing, _)) => (existing.id, Some(canonical)),
                             None => (uuid::Uuid::new_v4(), Some(canonical)),
                         }
                     };
                     crate::notebook_sync_server::get_or_create_room_result(
                         &self.notebook_rooms,
-                        &self.path_index,
                         ns_uuid,
                         crate::notebook_sync_server::RoomCreationOptions {
                             path: ns_path,
@@ -2540,12 +2539,9 @@ impl Daemon {
                     "[runtimed] Runtime agent connecting via socket: notebook={} runtime_agent={}",
                     notebook_id, runtime_agent_id
                 );
-                let room = {
-                    let rooms = self.notebook_rooms.lock().await;
-                    // notebook_id from runtime agent is always a UUID string
-                    uuid::Uuid::parse_str(&notebook_id)
-                        .ok()
-                        .and_then(|uuid| rooms.get(&uuid).cloned())
+                let room = match uuid::Uuid::parse_str(&notebook_id) {
+                    Ok(uuid) => self.notebook_rooms.peek_uuid(uuid).await,
+                    Err(_) => None,
                 };
                 match room {
                     Some(room) => {
@@ -2748,35 +2744,29 @@ impl Daemon {
 
         // Get or create room for this notebook.
         // First check if an existing room already owns this canonical path.
-        // The path_index gives O(1) lookup without scanning all rooms.
+        // The registry's path map gives O(1) lookup without scanning all rooms.
         let docs_dir = self.config.notebook_docs_dir.clone();
         let canonical_path = PathBuf::from(&notebook_id);
-        let room = {
-            if let Some(existing) = crate::notebook_sync_server::find_room_by_path(
+        let (room, _room_guard) = if let Some(existing) =
+            crate::notebook_sync_server::find_room_by_path(&self.notebook_rooms, &canonical_path)
+                .await
+        {
+            existing
+        } else {
+            let uuid = uuid::Uuid::new_v4();
+            let path = Some(canonical_path.clone());
+            crate::notebook_sync_server::get_or_create_room_result(
                 &self.notebook_rooms,
-                &self.path_index,
-                &canonical_path,
+                uuid,
+                crate::notebook_sync_server::RoomCreationOptions {
+                    path,
+                    docs_dir: &docs_dir,
+                    blob_store: self.blob_store.clone(),
+                    ephemeral: false, // OpenNotebook handshake is always persistent
+                    trusted_packages: self.trusted_packages.clone(),
+                },
             )
-            .await
-            {
-                existing
-            } else {
-                let uuid = uuid::Uuid::new_v4();
-                let path = Some(canonical_path.clone());
-                crate::notebook_sync_server::get_or_create_room_result(
-                    &self.notebook_rooms,
-                    &self.path_index,
-                    uuid,
-                    crate::notebook_sync_server::RoomCreationOptions {
-                        path,
-                        docs_dir: &docs_dir,
-                        blob_store: self.blob_store.clone(),
-                        ephemeral: false, // OpenNotebook handshake is always persistent
-                        trusted_packages: self.trusted_packages.clone(),
-                    },
-                )
-                .await?
-            }
+            .await?
         };
         self.mark_rooms_ever_seen();
 
@@ -2951,9 +2941,8 @@ impl Daemon {
         // always a UUID (new room) or an existing UUID (session restore).
         let docs_dir = self.config.notebook_docs_dir.clone();
         let uuid = uuid::Uuid::parse_str(&notebook_id).unwrap_or_else(|_| uuid::Uuid::new_v4());
-        let room = crate::notebook_sync_server::get_or_create_room_result(
+        let (room, _room_guard) = crate::notebook_sync_server::get_or_create_room_result(
             &self.notebook_rooms,
-            &self.path_index,
             uuid,
             crate::notebook_sync_server::RoomCreationOptions {
                 path: None, // CreateNotebook creates untitled rooms with no file path
@@ -2998,16 +2987,14 @@ impl Daemon {
         }; // doc lock dropped
 
         if let Some(e) = create_error {
-            // Remove the room to prevent stale state (consistency with OpenNotebook)
-            // CreateNotebook rooms have no path, so no path_index cleanup needed.
-            {
-                let mut rooms = self.notebook_rooms.lock().await;
-                rooms.remove(&uuid);
-                info!(
-                    "[runtimed] Removed room {} after create failure",
-                    notebook_id
-                );
-            }
+            // Remove the room to prevent stale state (consistency with OpenNotebook).
+            // CreateNotebook rooms have no path, so no path_index cleanup needed —
+            // the registry removes both maps under one lock regardless.
+            self.notebook_rooms.remove(uuid).await;
+            info!(
+                "[runtimed] Removed room {} after create failure",
+                notebook_id
+            );
             let (mut reader, mut writer) = tokio::io::split(stream);
             let response = NotebookConnectionInfo {
                 capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
@@ -3489,13 +3476,9 @@ impl Daemon {
                 info!("[runtimed] Inspecting notebook: {}", notebook_id);
 
                 // First try to get from an active room.
-                // Clone the Arc and drop the lock before any .await to avoid
-                // holding notebook_rooms across async calls.
-                let maybe_room = {
-                    let rooms = self.notebook_rooms.lock().await;
-                    uuid::Uuid::parse_str(&notebook_id)
-                        .ok()
-                        .and_then(|uuid| rooms.get(&uuid).cloned())
+                let maybe_room = match uuid::Uuid::parse_str(&notebook_id) {
+                    Ok(uuid) => self.notebook_rooms.peek_uuid(uuid).await,
+                    Err(_) => None,
                 };
                 if let Some(room) = maybe_room {
                     // Outputs live in RuntimeStateDoc under execution_id/output_id.
@@ -3581,15 +3564,16 @@ impl Daemon {
             }
 
             Request::ListRooms => {
-                // Snapshot room references and drop the lock before any .await
-                // to avoid holding notebook_rooms across async calls (convoy deadlock).
-                let snapshot: Vec<_> = {
-                    let rooms = self.notebook_rooms.lock().await;
-                    rooms
-                        .iter()
-                        .map(|(id, room)| (id.to_string(), room.clone()))
-                        .collect()
-                };
+                // Snapshot room references through the registry; the
+                // registry releases its lock before this call returns
+                // so the per-room async work below doesn't convoy.
+                let snapshot: Vec<(String, _)> = self
+                    .notebook_rooms
+                    .snapshot()
+                    .await
+                    .into_iter()
+                    .map(|(id, room)| (id.to_string(), room))
+                    .collect();
                 let mut room_infos = Vec::new();
                 for (notebook_id, room) in &snapshot {
                     // Get kernel info if available
@@ -3638,27 +3622,14 @@ impl Daemon {
             }
 
             Request::ShutdownNotebook { notebook_id } => {
-                // Remove the room from the map and drop the lock before any .await
-                // to avoid holding notebook_rooms across async teardown calls.
-                //
-                // Note: the room is already removed from the map so concurrent
-                // get_or_create_room() calls will create a fresh room. This is
-                // identical to the original behavior (remove() was always called
-                // before teardown), but now the lock isn't held during the async
-                // teardown that follows.
-                let maybe_room = {
-                    let mut rooms = self.notebook_rooms.lock().await;
-                    uuid::Uuid::parse_str(&notebook_id)
-                        .ok()
-                        .and_then(|uuid| rooms.remove(&uuid))
+                // Atomically remove the room from both the UUID map and
+                // the path index. The registry removes both under one
+                // lock, so a concurrent open-by-path can't race in
+                // between and find a stale UUID.
+                let maybe_room = match uuid::Uuid::parse_str(&notebook_id) {
+                    Ok(uuid) => self.notebook_rooms.remove(uuid).await,
+                    Err(_) => None,
                 };
-                // Clean up path_index if the room had a path.
-                if let Some(ref room) = maybe_room {
-                    let path = room.file_binding.path().await;
-                    if let Some(p) = path {
-                        self.path_index.lock().await.remove(&p);
-                    }
-                }
                 if let Some(room) = maybe_room {
                     // Shut down runtime agent via RPC before dropping handle.
                     // RuntimeAgentHandle doesn't own the Child (it's in a background
@@ -3704,14 +3675,9 @@ impl Daemon {
 
     /// Collect env paths from all running kernels to protect from GC eviction.
     async fn collect_active_env_paths(&self) -> std::collections::HashSet<PathBuf> {
-        // Snapshot room references and drop the lock before any .await
-        // to avoid holding notebook_rooms across async calls.
-        let snapshot: Vec<_> = {
-            let rooms = self.notebook_rooms.lock().await;
-            rooms.values().cloned().collect()
-        };
+        let snapshot = self.notebook_rooms.snapshot().await;
         let mut paths = std::collections::HashSet::new();
-        for room in &snapshot {
+        for (_, room) in &snapshot {
             // Check runtime-agent-backed kernel. Normalise to the top-level
             // pool dir so that GC's top-level scan will match pixi envs
             // whose venv_path is nested (e.g. .pixi/envs/default).
@@ -3787,12 +3753,13 @@ impl Daemon {
             // Clean up orphaned notebook-docs (emergency persist files, legacy untitled docs)
             let notebook_docs_dir = self.config.notebook_docs_dir.clone();
             if notebook_docs_dir.exists() {
-                let active_rooms = self.notebook_rooms.lock().await;
-                let active_hashes: std::collections::HashSet<String> = active_rooms
-                    .keys()
-                    .map(|id| crate::paths::notebook_doc_filename(&id.to_string()))
+                let active_hashes: std::collections::HashSet<String> = self
+                    .notebook_rooms
+                    .snapshot()
+                    .await
+                    .into_iter()
+                    .map(|(id, _)| crate::paths::notebook_doc_filename(&id.to_string()))
                     .collect();
-                drop(active_rooms);
 
                 let docs_max_age = std::time::Duration::from_secs(24 * 3600); // 24 hours
                 let mut docs_cleaned = 0;
@@ -3834,15 +3801,16 @@ impl Daemon {
             // batches to avoid starving other daemon tasks. Deletions are also
             // batched with yields between chunks.
             {
-                // Collect (id, Arc<room>) pairs under the rooms lock, then drop
-                // it before any async state_doc reads (deadlock prevention).
-                let room_arcs: Vec<(String, _)> = {
-                    let rooms = self.notebook_rooms.lock().await;
-                    rooms
-                        .iter()
-                        .map(|(k, v)| (k.to_string(), v.clone()))
-                        .collect()
-                };
+                // Collect (id, Arc<room>) pairs through the registry; the
+                // registry releases its lock before this call returns
+                // so the async state_doc reads below don't convoy.
+                let room_arcs: Vec<(String, _)> = self
+                    .notebook_rooms
+                    .snapshot()
+                    .await
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect();
 
                 // Zero-rooms sweep-skip: ambiguous only right after a daemon
                 // restart before any client has reconnected. `rooms_ever_seen`
@@ -3930,7 +3898,7 @@ impl Daemon {
         &self,
         uuid: uuid::Uuid,
     ) -> Option<Arc<crate::notebook_sync_server::NotebookRoom>> {
-        self.notebook_rooms.lock().await.get(&uuid).cloned()
+        self.notebook_rooms.peek_uuid(uuid).await
     }
 
     /// Test helper: count resident rooms. `pub` for the same reason as
@@ -3939,7 +3907,7 @@ impl Daemon {
     /// removed entirely."
     #[doc(hidden)]
     pub async fn test_room_count(&self) -> usize {
-        self.notebook_rooms.lock().await.len()
+        self.notebook_rooms.len().await
     }
 
     /// One sweep of the ghost-room reaper. Extracted so tests can drive
@@ -3951,42 +3919,39 @@ impl Daemon {
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        // Snapshot candidate (uuid, room, generation) tuples under the
-        // rooms lock. Filter on the timestamp first to keep the snapshot
-        // small; the active_peers / has_kernel checks happen below
-        // without the rooms lock held (has_kernel takes the
-        // runtime_agent lock). The generation snapshot lets the remove
-        // pass detect a fast reconnect/disconnect cycle that would
-        // otherwise look idle by peer count alone.
+        // Snapshot candidate (uuid, room, generation) tuples. Filter
+        // on the timestamp first to keep the list small; the
+        // active_peers / has_kernel checks happen below without the
+        // rooms lock held (has_kernel takes the runtime_agent lock).
+        // The generation snapshot lets the remove pass detect a fast
+        // reconnect/disconnect cycle that would otherwise look idle by
+        // peer count alone.
         let candidates: Vec<(
             uuid::Uuid,
             Arc<crate::notebook_sync_server::NotebookRoom>,
             u64,
-        )> = {
-            let rooms_guard = self.notebook_rooms.lock().await;
-            rooms_guard
-                .iter()
-                .filter_map(|(uuid, room)| {
-                    let ts = room.connections.last_kernel_torn_down_at()?;
-                    if now.saturating_sub(ts) < ttl_secs {
-                        return None;
-                    }
-                    if room
-                        .connections
-                        .active_peers
-                        .load(std::sync::atomic::Ordering::Relaxed)
-                        > 0
-                    {
-                        return None;
-                    }
-                    // Snapshot the generation so the remove pass can
-                    // detect a reconnect-then-disconnect cycle that
-                    // would otherwise look idle by peer count alone.
-                    let gen_at_sample = room.connections.connection_generation();
-                    Some((*uuid, room.clone(), gen_at_sample))
-                })
-                .collect()
-        };
+        )> = self
+            .notebook_rooms
+            .snapshot()
+            .await
+            .into_iter()
+            .filter_map(|(uuid, room)| {
+                let ts = room.connections.last_kernel_torn_down_at()?;
+                if now.saturating_sub(ts) < ttl_secs {
+                    return None;
+                }
+                if room
+                    .connections
+                    .active_peers
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    > 0
+                {
+                    return None;
+                }
+                let gen_at_sample = room.connections.connection_generation();
+                Some((uuid, room, gen_at_sample))
+            })
+            .collect();
 
         for (uuid, room, gen_at_sample) in candidates {
             // Re-verify outside the lock. `has_kernel` touches the
@@ -4007,75 +3972,43 @@ impl Daemon {
             // subsequent open-by-path could create a duplicate room
             // for the same file.
             let path_for_index = room.file_binding.path().await;
-            if let Some(ref p) = path_for_index {
-                // Only remove the path_index entry if it still maps to
-                // this ghost's UUID. A concurrent save-as on a
-                // different room could have repointed the path; we
-                // must not strip that.
-                let mut idx = self.path_index.lock().await;
-                if idx.lookup(p) == Some(uuid) {
-                    idx.remove(p);
-                }
-            }
 
             // Atomic remove pass: re-check active_peers AND the
             // connection generation AND the teardown timestamp under
-            // the rooms lock so a peer that reconnected between the
-            // snapshot and now keeps its room. A brief peer-touch
-            // (connect, then disconnect again) leaves active_peers == 0
-            // but bumps the generation and may have zeroed the
-            // teardown timestamp; treat all three as "still idle"
-            // signals. If the room is no longer idle, the path_index
-            // removal above doesn't matter — `find_room_by_path` falls
-            // through to the rooms-map lookup which still has the room,
-            // and the next save-as / open path will reinsert the entry.
-            // Drop the rooms lock before any further .await to honour
-            // the no-await-with-rooms-lock convention.
-            let removed = {
-                let mut rooms_guard = self.notebook_rooms.lock().await;
-                let still_idle = rooms_guard
-                    .get(&uuid)
-                    .map(|r| {
-                        let no_peers = r
-                            .connections
-                            .active_peers
-                            .load(std::sync::atomic::Ordering::Relaxed)
-                            == 0;
-                        let same_gen = r.connections.connection_generation() == gen_at_sample;
-                        // A reconnect zeroed the timestamp on join. If
-                        // a subsequent disconnect ran, peer_eviction
-                        // re-stamps it; either way, requiring "stamped
-                        // AND aged out" filters the second case
-                        // through the candidate pass on a later cycle
-                        // rather than reaping it eagerly here.
-                        let still_stamped = r
-                            .connections
-                            .last_kernel_torn_down_at()
-                            .map(|ts| now.saturating_sub(ts) >= ttl_secs)
-                            .unwrap_or(false);
-                        no_peers && same_gen && still_stamped
-                    })
-                    .unwrap_or(false);
-                if still_idle {
-                    rooms_guard.remove(&uuid)
-                } else {
-                    None
-                }
-            };
+            // the registry lock so a peer that reconnected between the
+            // snapshot and now keeps its room. The registry pops the
+            // room out of the UUID map and the path index together, so
+            // a concurrent open-by-path can't observe a half-removed
+            // state. A brief peer-touch (connect, then disconnect
+            // again) leaves active_peers == 0 but bumps the generation
+            // and may have zeroed the teardown timestamp; treat all
+            // three as "still idle" signals.
+            let removed = self
+                .notebook_rooms
+                .remove_if(uuid, |r| {
+                    let no_peers = r
+                        .connections
+                        .active_peers
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        == 0;
+                    let no_reservations = r.connections.reservations() == 0;
+                    let same_gen = r.connections.connection_generation() == gen_at_sample;
+                    // A reconnect zeroed the timestamp on join. If a
+                    // subsequent disconnect ran, peer_eviction re-stamps
+                    // it; either way, requiring "stamped AND aged out"
+                    // filters the second case through the candidate pass
+                    // on a later cycle rather than reaping it eagerly
+                    // here.
+                    let still_stamped = r
+                        .connections
+                        .last_kernel_torn_down_at()
+                        .map(|ts| now.saturating_sub(ts) >= ttl_secs)
+                        .unwrap_or(false);
+                    no_peers && no_reservations && same_gen && still_stamped
+                })
+                .await;
 
             let Some(room) = removed else {
-                // Room was rescued between our path-index-remove
-                // and our rooms-lock check. Reinsert the path so the
-                // resumed room remains discoverable by path.
-                if let Some(ref p) = path_for_index {
-                    let mut idx = self.path_index.lock().await;
-                    if let Err(e) = idx.insert(p.clone(), uuid) {
-                        warn!(
-                            "[runtimed] Ghost reaper: failed to reinsert path_index for rescued room {} at {:?}: {}",
-                            uuid, p, e
-                        );
-                    }
-                }
                 continue;
             };
             let path = path_for_index;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4019,8 +4019,10 @@ impl Daemon {
             // Step 1: force-flush the persist debouncer so the
             // `.automerge` mirror is current before we touch
             // anything. Skipped for ephemeral rooms (no debouncer).
-            // Flush failure leaves the room resident; the next sweep
-            // retries.
+            // The flush is non-destructive (the debouncer keeps
+            // running), so an abort after this point leaves the room
+            // fully functional. Flush failure leaves the room resident
+            // and the next sweep retries.
             const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
             if let Some(ack_rx) = room.persistence.request_flush() {
                 use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
@@ -4036,37 +4038,14 @@ impl Daemon {
                 }
             }
 
-            // Step 2: shut down the autosave debouncer. If the task
-            // doesn't ack within the timeout we abandon — it's
-            // pinning the room Arc and the next sweep will retry.
-            const AUTOSAVE_SHUTDOWN_TIMEOUT: std::time::Duration =
-                std::time::Duration::from_secs(5);
-            let autosave_shutdown_ok = crate::notebook_sync_server::shutdown_autosave_debouncer(
-                &room,
-                &notebook_id_label,
-                AUTOSAVE_SHUTDOWN_TIMEOUT,
-            )
-            .await;
-            if !autosave_shutdown_ok {
-                warn!(
-                    "[runtimed] Resident-room reaper: autosave shutdown stalled for {} - keeping resident, retrying next sweep",
-                    notebook_id_label
-                );
-                continue;
-            }
-
-            // Step 3: fire-and-forget watcher shutdowns. Both tasks
-            // own an `Arc<NotebookRoom>` and release it on receipt of
-            // the oneshot signal.
-            room.file_binding.shutdown_notebook_watcher().await;
-            room.file_binding.shutdown_project_file_watcher().await;
-
-            // Step 4: atomic commit. Re-check active_peers,
-            // reservations, generation, and still-torn-down under the
-            // registry lock. The registry removes the room from the
-            // UUID map and the path index together; a concurrent
-            // open-by-path either sees the live room or hits the new-
-            // room path cleanly.
+            // Step 2: atomic commit before any destructive cleanup.
+            // Re-check active_peers, reservations, generation, and
+            // still-torn-down under the registry lock. A reconnect
+            // that races in zeroes the timestamp and bumps the
+            // generation; the predicate fails and the room stays
+            // resident with its autosave + watchers + debouncer
+            // still wired up. No destructive teardown happens on an
+            // aborted reap.
             let removed = self
                 .notebook_rooms
                 .remove_if(uuid, |r| {
@@ -4083,26 +4062,42 @@ impl Daemon {
                 .await;
 
             let Some(room) = removed else {
-                // Abort path: a peer reconnected between cleanup and
-                // commit. Autosave and watchers were torn down above;
-                // re-arm them so the reconnect inherits a working room.
-                // The persist debouncer was only flushed, not torn
-                // down, so it's still running.
-                if let Some(ref p) = path {
-                    crate::notebook_sync_server::NotebookFileBinding::bind_existing(&room, p).await;
-                }
                 debug!(
-                    "[runtimed] Resident-room reaper: peer reconnected for {} mid-cleanup; watchers re-armed",
+                    "[runtimed] Resident-room reaper: {} no longer idle at commit; keeping resident",
                     notebook_id_label
                 );
                 continue;
             };
 
-            // Commit point. Step 5: take the persist debouncer out so
-            // its senders drop and the task exits via its shutdown arm
-            // with one final flush. Dropping the room Arc next is no
-            // longer enough on its own because nothing else holds an
-            // Arc to gate the persist task on.
+            // Commit point. The room is gone from the registry; from
+            // here on the cleanup is internal and can take its time
+            // without racing the connect side.
+
+            // Step 3: shut down the autosave debouncer. The autosave
+            // task owns an `Arc<NotebookRoom>`; the ack guarantees a
+            // final save before exit. A timeout here leaks the Arc
+            // until the kernel/process dies, but the room is already
+            // out of the registry.
+            const AUTOSAVE_SHUTDOWN_TIMEOUT: std::time::Duration =
+                std::time::Duration::from_secs(5);
+            let _ = crate::notebook_sync_server::shutdown_autosave_debouncer(
+                &room,
+                &notebook_id_label,
+                AUTOSAVE_SHUTDOWN_TIMEOUT,
+            )
+            .await;
+
+            // Step 4: fire-and-forget watcher shutdowns. Each task
+            // owns an `Arc<NotebookRoom>` and releases it on receipt
+            // of the oneshot signal.
+            room.file_binding.shutdown_notebook_watcher().await;
+            room.file_binding.shutdown_project_file_watcher().await;
+
+            // Step 5: take the persist debouncer out so its senders
+            // drop and the task exits via its shutdown arm with one
+            // final flush. Without `.take()` the senders only drop
+            // when the room Arc itself drops, which the autosave /
+            // watcher tasks delay if they haven't released yet.
             let _ = room.persistence.take_debouncer();
 
             info!(

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2447,39 +2447,18 @@ impl Daemon {
                 // each reconnect creates a fresh UUID and a duplicate room
                 // (two file watchers, two autosave debouncers, two writers on
                 // the same .ipynb — zombie rooms).
-                let (room, _room_guard) = {
-                    let (ns_uuid, ns_path) = if let Ok(parsed) = uuid::Uuid::parse_str(&notebook_id)
-                    {
-                        (parsed, None)
-                    } else {
-                        // notebook_id is a path — canonicalize and look up
-                        // existing room.
-                        let raw = PathBuf::from(&notebook_id);
-                        let canonical = match tokio::fs::canonicalize(&raw).await {
-                            Ok(c) => c,
-                            Err(e) => {
-                                warn!(
-                                        "[daemon] canonicalize({}) for NotebookSync handshake failed: {}, using raw path",
-                                        notebook_id, e
-                                    );
-                                raw
-                            }
-                        };
-                        match crate::notebook_sync_server::find_room_by_path(
-                            &self.notebook_rooms,
-                            &canonical,
-                        )
-                        .await
-                        {
-                            Some((existing, _)) => (existing.id, Some(canonical)),
-                            None => (uuid::Uuid::new_v4(), Some(canonical)),
-                        }
-                    };
+                // Hold the room guard from `find_room_by_path` through the
+                // `get_or_create_room_result` call. Dropping it between
+                // lookup and create-or-fetch opens a window where the
+                // reaper could remove the resumed room and a new room
+                // would replace it, losing the in-memory doc and outputs
+                // the resident-room cache is meant to preserve.
+                let (room, _room_guard) = if let Ok(parsed) = uuid::Uuid::parse_str(&notebook_id) {
                     crate::notebook_sync_server::get_or_create_room_result(
                         &self.notebook_rooms,
-                        ns_uuid,
+                        parsed,
                         crate::notebook_sync_server::RoomCreationOptions {
-                            path: ns_path,
+                            path: None,
                             docs_dir: &docs_dir,
                             blob_store: self.blob_store.clone(),
                             ephemeral: false, // NotebookSync handshake is always persistent
@@ -2487,6 +2466,39 @@ impl Daemon {
                         },
                     )
                     .await?
+                } else {
+                    let raw = PathBuf::from(&notebook_id);
+                    let canonical = match tokio::fs::canonicalize(&raw).await {
+                        Ok(c) => c,
+                        Err(e) => {
+                            warn!(
+                                "[daemon] canonicalize({}) for NotebookSync handshake failed: {}, using raw path",
+                                notebook_id, e
+                            );
+                            raw
+                        }
+                    };
+                    if let Some(found) = crate::notebook_sync_server::find_room_by_path(
+                        &self.notebook_rooms,
+                        &canonical,
+                    )
+                    .await
+                    {
+                        found
+                    } else {
+                        crate::notebook_sync_server::get_or_create_room_result(
+                            &self.notebook_rooms,
+                            uuid::Uuid::new_v4(),
+                            crate::notebook_sync_server::RoomCreationOptions {
+                                path: Some(canonical),
+                                docs_dir: &docs_dir,
+                                blob_store: self.blob_store.clone(),
+                                ephemeral: false,
+                                trusted_packages: self.trusted_packages.clone(),
+                            },
+                        )
+                        .await?
+                    }
                 };
                 self.mark_rooms_ever_seen();
                 let (reader, writer) = tokio::io::split(stream);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -389,6 +389,17 @@ struct Pool {
 
 const MIN_WARM_BASES: usize = 2;
 const POOL_PACKAGE_HASH_FILE: &str = ".runt-pool-packages.sha256";
+/// How long a peer-less, kernel-less room may sit before the reaper
+/// removes it. Set to 24h so a user who returns within the same day
+/// reattaches to the same in-memory doc + outputs.
+const RESIDENT_ROOM_TTL_SECS: u64 = 24 * 3600;
+/// How often the reaper wakes up. Cheap sweep — not on a hot path.
+const REAPER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+/// Soft cap on the number of resident peer-less rooms. When exceeded,
+/// the reaper picks the oldest peer-less rooms (by
+/// `last_kernel_torn_down_at`) and reaps them regardless of TTL.
+/// Active rooms (peers > 0 or kernel still running) are exempt.
+const MAX_RESIDENT_PEERLESS_ROOMS: usize = 32;
 const POOL_PACKAGE_HASH_VERSION: &str = "v1";
 const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plotly", "altair"];
 const BASE_RUNTIME_PACKAGES: &[&str] = &[
@@ -3855,35 +3866,30 @@ impl Daemon {
         }
     }
 
-    /// Background reaper for "ghost" notebook rooms.
+    /// Background reaper for peer-less notebook rooms.
     ///
     /// After `handle_peer_disconnect` runs kernel teardown, the room
-    /// stays in `notebook_rooms` (and its path stays in `path_index`)
-    /// so a reconnecting peer finds the same doc, outputs, and file
-    /// binding. The room becomes "ghost" once it has been kernel-less
-    /// and peer-less for longer than `GHOST_ROOM_TTL`. The reaper then
-    /// removes it from both maps and shuts down its file watcher,
-    /// project-file watcher, and autosave debouncer.
+    /// stays in the registry so a reconnecting peer finds the same
+    /// doc, outputs, and file binding. A room becomes a reap
+    /// candidate once it has been kernel-less and peer-less for longer
+    /// than `RESIDENT_ROOM_TTL_SECS`, or once the count of peer-less
+    /// rooms exceeds `MAX_RESIDENT_PEERLESS_ROOMS` (oldest first).
+    /// The reaper then removes the room from both maps and shuts down
+    /// its file watcher, project-file watcher, autosave debouncer,
+    /// and persist debouncer.
     ///
     /// Reconnect safety: `peer_connection::handle_join` zeroes the
     /// teardown timestamp the moment it bumps `active_peers`, and the
-    /// reaper re-checks `active_peers == 0 && !has_kernel` under the
-    /// rooms lock before removing. A peer that reconnects between the
-    /// snapshot pass and the remove pass keeps its room.
+    /// reaper re-checks `active_peers == 0 && reservations == 0`
+    /// under the registry lock before removing. A peer that
+    /// reconnects between the snapshot pass and the remove pass keeps
+    /// its room.
     async fn ghost_room_reaper_loop(self: Arc<Self>) {
-        /// How long a room may sit kernel-less and peer-less before the
-        /// reaper sweeps it. The `.ipynb` was saved at kernel-teardown
-        /// time, so removal is non-destructive — a future open reads
-        /// the same content back off disk.
-        const GHOST_ROOM_TTL_SECS: u64 = 24 * 3600;
-        /// How often the reaper wakes up to look for ghost rooms.
-        const REAPER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
-
         let mut tick = tokio::time::interval(REAPER_INTERVAL);
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tick.tick().await;
-            self.ghost_room_reaper_sweep(GHOST_ROOM_TTL_SECS).await;
+            self.ghost_room_reaper_sweep(RESIDENT_ROOM_TTL_SECS).await;
         }
     }
 
@@ -3910,25 +3916,31 @@ impl Daemon {
         self.notebook_rooms.len().await
     }
 
-    /// One sweep of the ghost-room reaper. Extracted so tests can drive
-    /// the reaper synchronously without waiting on `REAPER_INTERVAL`.
-    /// Public so integration tests (separate crate) can drive a sweep.
+    /// One sweep of the resident-room reaper. Extracted so tests can
+    /// drive the reaper synchronously without waiting on
+    /// `REAPER_INTERVAL`. Public so integration tests (separate crate)
+    /// can drive a sweep.
+    ///
+    /// Selection has two layers:
+    ///   1. **TTL**: every peer-less room older than `ttl_secs`.
+    ///   2. **Count cap**: if peer-less rooms outnumber
+    ///      `MAX_RESIDENT_PEERLESS_ROOMS`, the oldest overflow rooms
+    ///      are reaped regardless of TTL.
     pub async fn ghost_room_reaper_sweep(self: &Arc<Self>, ttl_secs: u64) {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        // Snapshot candidate (uuid, room, generation) tuples. Filter
-        // on the timestamp first to keep the list small; the
-        // active_peers / has_kernel checks happen below without the
-        // rooms lock held (has_kernel takes the runtime_agent lock).
-        // The generation snapshot lets the remove pass detect a fast
-        // reconnect/disconnect cycle that would otherwise look idle by
-        // peer count alone.
-        let candidates: Vec<(
+        // Snapshot peer-less rooms (timestamp > 0 means kernel
+        // teardown ran; reconnect zeroes it back to None). Live rooms
+        // (kernel still running or peers > 0) never make this list.
+        // has_kernel is cheap to skip here because we re-check it
+        // outside the rooms lock per candidate below.
+        let peerless: Vec<(
             uuid::Uuid,
             Arc<crate::notebook_sync_server::NotebookRoom>,
+            u64,
             u64,
         )> = self
             .notebook_rooms
@@ -3937,9 +3949,6 @@ impl Daemon {
             .into_iter()
             .filter_map(|(uuid, room)| {
                 let ts = room.connections.last_kernel_torn_down_at()?;
-                if now.saturating_sub(ts) < ttl_secs {
-                    return None;
-                }
                 if room
                     .connections
                     .active_peers
@@ -3949,8 +3958,43 @@ impl Daemon {
                     return None;
                 }
                 let gen_at_sample = room.connections.connection_generation();
-                Some((uuid, room, gen_at_sample))
+                Some((uuid, room, ts, gen_at_sample))
             })
+            .collect();
+
+        // TTL layer: aged-out rooms.
+        let aged_out: std::collections::HashSet<uuid::Uuid> = peerless
+            .iter()
+            .filter(|(_, _, ts, _)| now.saturating_sub(*ts) >= ttl_secs)
+            .map(|(uuid, _, _, _)| *uuid)
+            .collect();
+
+        // Count-cap layer: oldest-first overflow rooms.
+        let overflow: std::collections::HashSet<uuid::Uuid> =
+            if peerless.len() > MAX_RESIDENT_PEERLESS_ROOMS {
+                let mut by_age: Vec<&uuid::Uuid> =
+                    peerless.iter().map(|(uuid, _, _, _)| uuid).collect();
+                by_age.sort_by_key(|uuid| {
+                    peerless
+                        .iter()
+                        .find(|(u, _, _, _)| u == *uuid)
+                        .map(|(_, _, ts, _)| *ts)
+                        .unwrap_or(u64::MAX)
+                });
+                let cull = peerless.len() - MAX_RESIDENT_PEERLESS_ROOMS;
+                by_age.into_iter().take(cull).copied().collect()
+            } else {
+                std::collections::HashSet::new()
+            };
+
+        let candidates: Vec<(
+            uuid::Uuid,
+            Arc<crate::notebook_sync_server::NotebookRoom>,
+            u64,
+        )> = peerless
+            .into_iter()
+            .filter(|(uuid, _, _, _)| aged_out.contains(uuid) || overflow.contains(uuid))
+            .map(|(uuid, room, _, gen_at_sample)| (uuid, room, gen_at_sample))
             .collect();
 
         for (uuid, room, gen_at_sample) in candidates {
@@ -3993,17 +4037,12 @@ impl Daemon {
                         == 0;
                     let no_reservations = r.connections.reservations() == 0;
                     let same_gen = r.connections.connection_generation() == gen_at_sample;
-                    // A reconnect zeroed the timestamp on join. If a
-                    // subsequent disconnect ran, peer_eviction re-stamps
-                    // it; either way, requiring "stamped AND aged out"
-                    // filters the second case through the candidate pass
-                    // on a later cycle rather than reaping it eagerly
-                    // here.
-                    let still_stamped = r
-                        .connections
-                        .last_kernel_torn_down_at()
-                        .map(|ts| now.saturating_sub(ts) >= ttl_secs)
-                        .unwrap_or(false);
+                    // A reconnect zeroed the timestamp on join. The
+                    // selection pass already enforced TTL or LRU
+                    // overflow; under the registry lock we just verify
+                    // the room hasn't transitioned out of "kernel torn
+                    // down" between sample and commit.
+                    let still_stamped = r.connections.last_kernel_torn_down_at().is_some();
                     no_peers && no_reservations && same_gen && still_stamped
                 })
                 .await;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3772,7 +3772,13 @@ impl Daemon {
                     .map(|(id, _)| crate::paths::notebook_doc_filename(&id.to_string()))
                     .collect();
 
-                let docs_max_age = std::time::Duration::from_secs(24 * 3600); // 24 hours
+                // 7 days. The resident-room reaper's 24h TTL handles the
+                // common case; this sweep is the long-tail safety net for
+                // `.automerge` files left behind by daemon crashes, legacy
+                // untitled docs, and the post-reap window where an
+                // untitled room's persisted bytes survive on disk so a
+                // returning user can resurrect cells.
+                let docs_max_age = std::time::Duration::from_secs(7 * 24 * 3600);
                 let mut docs_cleaned = 0;
                 if let Ok(mut entries) = tokio::fs::read_dir(&notebook_docs_dir).await {
                     while let Ok(Some(entry)) = entries.next_entry().await {

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -1,6 +1,14 @@
+use super::registry::{InsertOutcome, RoomRegistry};
 use super::*;
 
-pub type NotebookRooms = Arc<Mutex<HashMap<uuid::Uuid, Arc<NotebookRoom>>>>;
+/// Daemon-wide handle to the resident-room registry.
+///
+/// Previously `Arc<Mutex<HashMap<Uuid, Arc<NotebookRoom>>>>`. The
+/// underlying type is now `RoomRegistry`, which owns both the UUID
+/// map and the path → UUID secondary index under one tokio mutex.
+/// Existing call sites keep the `NotebookRooms` name and only the
+/// operations change.
+pub type NotebookRooms = Arc<RoomRegistry>;
 
 pub(crate) struct RoomCreationOptions<'a> {
     pub path: Option<PathBuf>,
@@ -12,99 +20,93 @@ pub(crate) struct RoomCreationOptions<'a> {
 
 /// Look up an open room by its canonical .ipynb path.
 ///
-/// Returns `None` if no room is currently serving that path. O(1) lookup
-/// via the path_index — no scanning.
+/// Returns `None` if no room is currently serving that path. O(1)
+/// lookup through the combined registry. On hit, the caller receives
+/// the `Arc<NotebookRoom>` plus a fresh `ReservationGuard` that holds
+/// the room against the reaper until the handshake commits or aborts.
 pub async fn find_room_by_path(
     rooms: &NotebookRooms,
-    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
     path: &Path,
-) -> Option<Arc<NotebookRoom>> {
-    let uuid = {
-        let idx = path_index.lock().await;
-        idx.lookup(path)?
-    };
-    rooms.lock().await.get(&uuid).cloned()
+) -> Option<(Arc<NotebookRoom>, ReservationGuard)> {
+    rooms.lookup_path(path).await
 }
 
 /// Get or create a room for a notebook.
 ///
-/// Creates a new fresh room if one for the given UUID doesn't already exist.
-/// The .ipynb file is the source of truth — the first client to connect will
-/// populate the Automerge doc from their local file.
+/// Creates a new fresh room if one for the given UUID doesn't already
+/// exist. The `.ipynb` file is the source of truth: the first client
+/// to connect populates the Automerge doc from their local file.
 ///
-/// For .ipynb files, a file watcher is spawned to detect external changes.
-/// Also inserts an entry into `path_index` when `path` is `Some`.
+/// For `.ipynb` files, a file watcher is spawned. The UUID-keyed
+/// room map and path → UUID index are updated together under one
+/// lock.
 #[cfg(test)]
 pub async fn get_or_create_room(
     rooms: &NotebookRooms,
-    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
     uuid: uuid::Uuid,
     options: RoomCreationOptions<'_>,
-) -> Arc<NotebookRoom> {
-    get_or_create_room_result(rooms, path_index, uuid, options)
+) -> (Arc<NotebookRoom>, ReservationGuard) {
+    get_or_create_room_result(rooms, uuid, options)
         .await
         .unwrap_or_else(|err| panic!("create notebook room runtime state: {err}"))
 }
 
 pub async fn get_or_create_room_result(
     rooms: &NotebookRooms,
-    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
     uuid: uuid::Uuid,
     options: RoomCreationOptions<'_>,
-) -> anyhow::Result<Arc<NotebookRoom>> {
-    // Fast path: room already exists.
-    {
-        let rooms_guard = rooms.lock().await;
-        if let Some(existing) = rooms_guard.get(&uuid) {
-            return Ok(existing.clone());
-        }
+) -> anyhow::Result<(Arc<NotebookRoom>, ReservationGuard)> {
+    // Fast path: room already exists. The registry hands back the
+    // existing Arc plus a fresh reservation guard without minting a
+    // new room.
+    if let Some(found) = rooms.lookup_uuid(uuid).await {
+        return Ok(found);
     }
 
-    // Create new room and insert.
     info!("[notebook-sync] Creating room for {}", uuid);
+    let path_for_room = options.path.clone();
     let room = Arc::new(NotebookRoom::new_fresh_with_trusted_packages(
         uuid,
-        options.path.clone(),
+        path_for_room.clone(),
         options.docs_dir,
         options.blob_store,
         options.ephemeral,
         options.trusted_packages,
     )?);
 
+    // Atomic insert across rooms + path_index. If we lose a race to a
+    // concurrent caller (same UUID), the registry returns the existing
+    // room and our `room` is dropped.
+    let outcome = match rooms
+        .insert_or_get(uuid, room, path_for_room.as_deref())
+        .await
     {
-        let mut rooms_guard = rooms.lock().await;
-        // Double-check in case of a race: another task may have created the room
-        // between our unlock above and acquiring the write lock here.
-        if let Some(existing) = rooms_guard.get(&uuid) {
-            return Ok(existing.clone());
+        Ok(outcome) => outcome,
+        Err(e) => {
+            error!(
+                "[notebook-sync] path_index.insert failed for new room {} at {:?}: {} - this is a caller invariant violation (find_room_by_path should have returned the existing room).",
+                uuid, path_for_room, e
+            );
+            return Err(anyhow::anyhow!(e));
         }
-        rooms_guard.insert(uuid, room.clone());
-    }
+    };
 
-    // Record the notebook's project-file context on the runtime-state doc.
-    // Single-writer invariant: only the daemon writes this key. Also
-    // re-runs after untitled promotion and save-as rename; see
-    // `project_context::refresh_project_context` callers.
-    super::project_context::refresh_project_context_async(&room, options.path.as_deref()).await;
+    let inserted_new = matches!(outcome, InsertOutcome::Inserted(_, _));
+    let (room, guard) = outcome.into_parts();
 
-    // Insert into path_index (under a separate lock per the locking convention).
-    if let Some(ref p) = options.path {
-        match path_index.lock().await.insert(p.clone(), uuid) {
-            Ok(()) => {}
-            Err(e) => {
-                error!(
-                    "[notebook-sync] path_index.insert failed for new room {} at {:?}: {} — \
-                     this is a caller invariant violation (should have done find_room_by_path first). \
-                     Room is orphaned from path lookup.",
-                    uuid, p, e
-                );
-            }
+    // Side-effects only happen when we actually inserted a fresh room.
+    // If we lost the race, the racing caller already ran them.
+    if inserted_new {
+        // Record the notebook's project-file context on the runtime-state
+        // doc. Single-writer invariant: only the daemon writes this key.
+        // Also re-runs after untitled promotion and save-as rename; see
+        // `project_context::refresh_project_context` callers.
+        super::project_context::refresh_project_context_async(&room, options.path.as_deref()).await;
+
+        if let Some(ref notebook_path) = options.path {
+            NotebookFileBinding::bind_existing(&room, notebook_path).await;
         }
     }
 
-    if let Some(ref notebook_path) = options.path {
-        NotebookFileBinding::bind_existing(&room, notebook_path).await;
-    }
-
-    Ok(room)
+    Ok((room, guard))
 }

--- a/crates/runtimed/src/notebook_sync_server/catalog.rs
+++ b/crates/runtimed/src/notebook_sync_server/catalog.rs
@@ -74,9 +74,12 @@ pub async fn get_or_create_room_result(
         options.trusted_packages,
     )?);
 
-    // Atomic insert across rooms + path_index. If we lose a race to a
-    // concurrent caller (same UUID), the registry returns the existing
-    // room and our `room` is dropped.
+    // Atomic insert across the registry's UUID map and path index.
+    // If we lose a race to a concurrent caller (same UUID or same
+    // path), the registry returns the existing room and our `room`
+    // is dropped. The only `Err` is registry inconsistency (path
+    // indexes a UUID that has no room) — propagate it so the caller
+    // sees the broken state.
     let outcome = match rooms
         .insert_or_get(uuid, room, path_for_room.as_deref())
         .await
@@ -84,7 +87,7 @@ pub async fn get_or_create_room_result(
         Ok(outcome) => outcome,
         Err(e) => {
             error!(
-                "[notebook-sync] path_index.insert failed for new room {} at {:?}: {} - this is a caller invariant violation (find_room_by_path should have returned the existing room).",
+                "[notebook-sync] registry inconsistency on insert for {} at {:?}: {}",
                 uuid, path_for_room, e
             );
             return Err(anyhow::anyhow!(e));

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -839,9 +839,7 @@ pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
     };
 
     let _ = room.broadcasts.changed_tx.send(());
-    if let Some(ref d) = room.persistence.debouncer {
-        let _ = d.persist_tx.send(Some(persist_bytes));
-    }
+    room.persistence.enqueue_persist_bytes(persist_bytes);
 }
 
 /// Check if the current metadata differs from kernel's launched config and broadcast sync state.

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -66,6 +66,7 @@ mod peer_session;
 mod peer_writer;
 mod persist;
 mod project_context;
+mod registry;
 mod room;
 mod runtime_bridge;
 #[cfg(test)]
@@ -76,13 +77,13 @@ pub(crate) use catalog::*;
 pub(crate) use load::*;
 pub(crate) use metadata::*;
 pub(crate) use nbformat_convert::*;
-pub use path_index::{PathIndex, PathIndexError};
 pub(crate) use peer_connection::*;
 #[cfg(test)]
 pub(crate) use peer_presence::sanitize_peer_label;
 pub(crate) use peer_runtime_agent::handle_runtime_agent_sync_connection;
 pub(crate) use peer_runtime_sync::notebook_execution_context_id;
 pub(crate) use persist::*;
+pub(crate) use registry::*;
 pub(crate) use room::*;
 pub(crate) use runtime_bridge::*;
 

--- a/crates/runtimed/src/notebook_sync_server/path_index.rs
+++ b/crates/runtimed/src/notebook_sync_server/path_index.rs
@@ -49,14 +49,23 @@ impl PathIndex {
         self.inner.remove(path)
     }
 
-    pub fn remove_by_uuid(&mut self, uuid: Uuid) -> Option<PathBuf> {
-        let path = self
+    /// Remove every path that maps to the given UUID. A save-as in
+    /// flight can briefly hold both the old and the pre-claimed new
+    /// path for the same UUID; removing only one would leave the
+    /// other as a stale entry pointing at a missing room, which the
+    /// next open of that path would hit as `PathAlreadyOpen` with
+    /// nothing to coalesce to.
+    pub fn remove_by_uuid(&mut self, uuid: Uuid) -> Vec<PathBuf> {
+        let paths: Vec<PathBuf> = self
             .inner
             .iter()
-            .find(|(_, &u)| u == uuid)
-            .map(|(p, _)| p.clone())?;
-        self.inner.remove(&path);
-        Some(path)
+            .filter(|(_, &u)| u == uuid)
+            .map(|(p, _)| p.clone())
+            .collect();
+        for p in &paths {
+            self.inner.remove(p);
+        }
+        paths
     }
 
     #[cfg(test)]
@@ -139,7 +148,18 @@ mod tests {
         let mut idx = PathIndex::new();
         let uuid = Uuid::new_v4();
         idx.insert(path("/tmp/foo.ipynb"), uuid).unwrap();
-        assert_eq!(idx.remove_by_uuid(uuid), Some(path("/tmp/foo.ipynb")));
+        assert_eq!(idx.remove_by_uuid(uuid), vec![path("/tmp/foo.ipynb")]);
+        assert!(idx.is_empty());
+    }
+
+    #[test]
+    fn remove_by_uuid_clears_every_alias() {
+        let mut idx = PathIndex::new();
+        let uuid = Uuid::new_v4();
+        idx.insert(path("/tmp/old.ipynb"), uuid).unwrap();
+        idx.insert(path("/tmp/new.ipynb"), uuid).unwrap();
+        let removed = idx.remove_by_uuid(uuid);
+        assert_eq!(removed.len(), 2);
         assert!(idx.is_empty());
     }
 

--- a/crates/runtimed/src/notebook_sync_server/path_index.rs
+++ b/crates/runtimed/src/notebook_sync_server/path_index.rs
@@ -22,6 +22,7 @@ pub enum PathIndexError {
 }
 
 impl PathIndex {
+    #[cfg(test)]
     pub fn new() -> Self {
         Self::default()
     }
@@ -58,10 +59,12 @@ impl PathIndex {
         Some(path)
     }
 
+    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -169,17 +169,18 @@ pub(super) async fn handle_peer_disconnect(
             // room stays in the map either way; we only gate the
             // kernel-side teardown on "no peers AND no reconnect since
             // scheduling."
-            let should_teardown = {
-                let _rooms_guard = rooms_for_teardown.lock().await;
-                let no_peers = room_for_teardown
-                    .connections
-                    .active_peers
-                    .load(Ordering::Relaxed)
-                    == 0;
-                let same_generation =
-                    room_for_teardown.connections.connection_generation() == teardown_generation;
-                no_peers && same_generation
-            }; // rooms lock dropped here
+            let should_teardown = rooms_for_teardown
+                .serialize_with(|| {
+                    let no_peers = room_for_teardown
+                        .connections
+                        .active_peers
+                        .load(Ordering::Relaxed)
+                        == 0;
+                    let same_generation = room_for_teardown.connections.connection_generation()
+                        == teardown_generation;
+                    no_peers && same_generation
+                })
+                .await;
 
             if !should_teardown {
                 debug!(
@@ -215,24 +216,25 @@ pub(super) async fn handle_peer_disconnect(
             // the peer-count / generation check makes the connect path
             // observe a consistent "destructive teardown in progress"
             // state if (and only if) we will actually proceed below.
-            let still_valid = {
-                let _rooms_guard = rooms_for_teardown.lock().await;
-                let no_peers = room_for_teardown
-                    .connections
-                    .active_peers
-                    .load(Ordering::Relaxed)
-                    == 0;
-                let same_generation =
-                    room_for_teardown.connections.connection_generation() == teardown_generation;
-                let ok = no_peers && same_generation;
-                if ok {
-                    room_for_teardown
+            let still_valid = rooms_for_teardown
+                .serialize_with(|| {
+                    let no_peers = room_for_teardown
                         .connections
-                        .kernel_teardown_destructive
-                        .store(true, Ordering::Release);
-                }
-                ok
-            };
+                        .active_peers
+                        .load(Ordering::Relaxed)
+                        == 0;
+                    let same_generation = room_for_teardown.connections.connection_generation()
+                        == teardown_generation;
+                    let ok = no_peers && same_generation;
+                    if ok {
+                        room_for_teardown
+                            .connections
+                            .kernel_teardown_destructive
+                            .store(true, Ordering::Release);
+                    }
+                    ok
+                })
+                .await;
             if !still_valid {
                 debug!(
                     "[notebook-sync] Kernel teardown aborted for {} (peer reconnected just before shutdown RPC)",
@@ -424,17 +426,18 @@ pub(super) async fn handle_peer_disconnect(
             // env path into `runtime_agent_env_path`. Deleting it now
             // would orphan the resumed kernel. The room stays
             // resident, so aborting is the right move.
-            let still_valid = {
-                let _rooms_guard = rooms_for_teardown.lock().await;
-                let no_peers = room_for_teardown
-                    .connections
-                    .active_peers
-                    .load(Ordering::Relaxed)
-                    == 0;
-                let same_generation =
-                    room_for_teardown.connections.connection_generation() == teardown_generation;
-                no_peers && same_generation
-            };
+            let still_valid = rooms_for_teardown
+                .serialize_with(|| {
+                    let no_peers = room_for_teardown
+                        .connections
+                        .active_peers
+                        .load(Ordering::Relaxed)
+                        == 0;
+                    let same_generation = room_for_teardown.connections.connection_generation()
+                        == teardown_generation;
+                    no_peers && same_generation
+                })
+                .await;
             if !still_valid {
                 debug!(
                     "[notebook-sync] Skipping env cleanup for {} (peer reconnected and may have relaunched)",

--- a/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_eviction.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use tokio::sync::oneshot;
 use tracing::{debug, info, warn};
 
 use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
@@ -111,29 +110,26 @@ pub(super) async fn handle_peer_disconnect(
                 const FLUSH_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(30);
                 let mut flush_ok = true;
                 let mut flush_failure_kind: Option<&'static str> = None;
-                if let Some(ref d) = room_for_teardown.persistence.debouncer {
-                    let (ack_tx, ack_rx) = oneshot::channel::<bool>();
-                    if d.flush_request_tx.send(ack_tx).is_ok() {
-                        match recv_oneshot_with_timeout(ack_rx, FLUSH_TIMEOUT).await {
-                            TimedOneShot::Received(true) => {}
-                            TimedOneShot::Received(false) => {
-                                flush_ok = false;
-                                flush_failure_kind = Some("write error");
-                            }
-                            TimedOneShot::SenderDropped => {
-                                // Debouncer dropped the ack sender without
-                                // replying — task already exited (e.g. a
-                                // previous teardown flushed and closed). Any
-                                // pending bytes went through the shutdown path.
-                                debug!(
-                                    "[notebook-sync] Kernel-teardown flush ack dropped for {} (debouncer exited)",
-                                    notebook_id_for_teardown
-                                );
-                            }
-                            TimedOneShot::TimedOut => {
-                                flush_ok = false;
-                                flush_failure_kind = Some("timeout");
-                            }
+                if let Some(ack_rx) = room_for_teardown.persistence.request_flush() {
+                    match recv_oneshot_with_timeout(ack_rx, FLUSH_TIMEOUT).await {
+                        TimedOneShot::Received(true) => {}
+                        TimedOneShot::Received(false) => {
+                            flush_ok = false;
+                            flush_failure_kind = Some("write error");
+                        }
+                        TimedOneShot::SenderDropped => {
+                            // Debouncer dropped the ack sender without
+                            // replying — task already exited (e.g. a
+                            // previous teardown flushed and closed). Any
+                            // pending bytes went through the shutdown path.
+                            debug!(
+                                "[notebook-sync] Kernel-teardown flush ack dropped for {} (debouncer exited)",
+                                notebook_id_for_teardown
+                            );
+                        }
+                        TimedOneShot::TimedOut => {
+                            flush_ok = false;
+                            flush_failure_kind = Some("timeout");
                         }
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -78,9 +78,8 @@ pub(super) async fn finish_notebook_doc_frame(
     room: &NotebookRoom,
     effects: NotebookDocSideEffects,
 ) {
-    if let Some(ref d) = room.persistence.debouncer {
-        let _ = d.persist_tx.send(Some(effects.persist_bytes));
-    }
+    room.persistence
+        .enqueue_persist_bytes(effects.persist_bytes);
 
     if effects.metadata_changed {
         check_and_broadcast_sync_state(room).await;

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -325,15 +325,14 @@ pub(crate) async fn canonical_target_path(target: &Path) -> PathBuf {
     target.to_path_buf()
 }
 
-/// Try to claim a path in the path_index for a given room. Returns the
+/// Try to claim a path in the path index for a given room. Returns the
 /// structured `PathAlreadyOpen` error if another room already holds it.
 pub(crate) async fn try_claim_path(
-    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
+    rooms: &NotebookRooms,
     canonical: &Path,
     uuid: uuid::Uuid,
 ) -> Result<(), notebook_protocol::protocol::SaveErrorKind> {
-    let mut idx = path_index.lock().await;
-    match idx.insert(canonical.to_path_buf(), uuid) {
+    match rooms.bind_path(uuid, canonical.to_path_buf()).await {
         Ok(()) => Ok(()),
         Err(path_index::PathIndexError::PathAlreadyOpen { uuid, path: p }) => Err(
             notebook_protocol::protocol::SaveErrorKind::PathAlreadyOpen {

--- a/crates/runtimed/src/notebook_sync_server/registry.rs
+++ b/crates/runtimed/src/notebook_sync_server/registry.rs
@@ -1,0 +1,261 @@
+//! Combined registry of resident notebook rooms.
+//!
+//! Owns both the `Uuid → Arc<NotebookRoom>` map and the path → UUID
+//! secondary index behind one tokio `Mutex`. Joined operations
+//! (insertion of a new room that also takes a path, removal of a room
+//! while purging its path entry, path lookup followed by UUID
+//! resolution) happen under a single lock acquisition, which closes
+//! the "rooms inserted but path index not yet, or vice versa" race
+//! that the two-lock layout exposed.
+//!
+//! Lookups hand callers a `ReservationGuard` alongside the `Arc`. The
+//! room reaper's peer-less predicate is
+//! `active_peers == 0 && reservations == 0`, so a caller that has
+//! cloned the `Arc` but not yet incremented `active_peers` keeps the
+//! reaper off until the handshake commits or aborts.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+use super::path_index::{PathIndex, PathIndexError};
+use super::room::{NotebookRoom, ReservationGuard};
+
+/// Outcome of `RoomRegistry::insert_or_get`.
+pub enum InsertOutcome {
+    /// The room was inserted; the caller now owns the canonical Arc
+    /// for this UUID.
+    Inserted(Arc<NotebookRoom>, ReservationGuard),
+    /// Another caller raced ahead. The existing room is returned and
+    /// the caller's freshly-built `Arc<NotebookRoom>` is dropped by
+    /// the registry.
+    Existing(Arc<NotebookRoom>, ReservationGuard),
+}
+
+impl InsertOutcome {
+    pub fn into_parts(self) -> (Arc<NotebookRoom>, ReservationGuard) {
+        match self {
+            InsertOutcome::Inserted(room, guard) | InsertOutcome::Existing(room, guard) => {
+                (room, guard)
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct RegistryInner {
+    rooms: HashMap<Uuid, Arc<NotebookRoom>>,
+    paths: PathIndex,
+}
+
+/// Combined index of resident notebook rooms. Cheap to clone (single
+/// `Arc` indirection through the tokio mutex).
+#[derive(Default)]
+pub struct RoomRegistry {
+    inner: Mutex<RegistryInner>,
+}
+
+impl RoomRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up a room by canonical path. On hit, hands the caller an
+    /// `Arc` plus a fresh reservation guard.
+    pub async fn lookup_path(&self, path: &Path) -> Option<(Arc<NotebookRoom>, ReservationGuard)> {
+        let inner = self.inner.lock().await;
+        let uuid = inner.paths.lookup(path)?;
+        let room = inner.rooms.get(&uuid)?.clone();
+        let guard = ReservationGuard::new(room.clone());
+        Some((room, guard))
+    }
+
+    /// Look up a room by UUID. On hit, hands the caller an `Arc` plus a
+    /// fresh reservation guard.
+    pub async fn lookup_uuid(&self, uuid: Uuid) -> Option<(Arc<NotebookRoom>, ReservationGuard)> {
+        let inner = self.inner.lock().await;
+        let room = inner.rooms.get(&uuid)?.clone();
+        let guard = ReservationGuard::new(room.clone());
+        Some((room, guard))
+    }
+
+    /// Look up a room by UUID without taking a reservation. Used by
+    /// diagnostics (`runt ps`, `list_rooms`) and by tests.
+    pub async fn peek_uuid(&self, uuid: Uuid) -> Option<Arc<NotebookRoom>> {
+        self.inner.lock().await.rooms.get(&uuid).cloned()
+    }
+
+    /// Insert a freshly-built room. Idempotent on UUID: if a room with
+    /// the same UUID already exists, the existing `Arc` is returned and
+    /// the caller's `room` is dropped. Returns
+    /// `Err(PathIndexError::PathAlreadyOpen)` only when `path` is
+    /// `Some` and conflicts with a different room's UUID.
+    pub async fn insert_or_get(
+        &self,
+        uuid: Uuid,
+        room: Arc<NotebookRoom>,
+        path: Option<&Path>,
+    ) -> Result<InsertOutcome, PathIndexError> {
+        let mut inner = self.inner.lock().await;
+
+        if let Some(existing) = inner.rooms.get(&uuid) {
+            let existing = existing.clone();
+            let guard = ReservationGuard::new(existing.clone());
+            return Ok(InsertOutcome::Existing(existing, guard));
+        }
+
+        if let Some(p) = path {
+            inner.paths.insert(p.to_path_buf(), uuid)?;
+        }
+        inner.rooms.insert(uuid, room.clone());
+        let guard = ReservationGuard::new(room.clone());
+        Ok(InsertOutcome::Inserted(room, guard))
+    }
+
+    /// Bind an additional path mapping to an already-registered UUID.
+    /// Used by the untitled-promotion path that learns a saved location
+    /// after the room was first inserted.
+    pub async fn bind_path(&self, uuid: Uuid, path: PathBuf) -> Result<(), PathIndexError> {
+        let mut inner = self.inner.lock().await;
+        inner.paths.insert(path, uuid)
+    }
+
+    /// Release a path binding. No-op if absent.
+    pub async fn unbind_path(&self, path: &Path) {
+        let mut inner = self.inner.lock().await;
+        inner.paths.remove(path);
+    }
+
+    /// Conditionally release a path binding only when it still maps to
+    /// the given UUID. Returns `true` if the entry was removed. Used by
+    /// the ghost reaper so a concurrent save-as that repointed the path
+    /// is not stripped.
+    pub async fn unbind_path_if_uuid(&self, path: &Path, uuid: Uuid) -> bool {
+        let mut inner = self.inner.lock().await;
+        if inner.paths.lookup(path) == Some(uuid) {
+            inner.paths.remove(path);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Atomically replace an old path binding with a new one for save-as.
+    /// The old key is removed unconditionally; the new key is inserted and
+    /// may fail with `PathAlreadyOpen` if another room holds it.
+    pub async fn replace_path(
+        &self,
+        old: &Path,
+        new: PathBuf,
+        uuid: Uuid,
+    ) -> Result<(), PathIndexError> {
+        let mut inner = self.inner.lock().await;
+        inner.paths.remove(old);
+        inner.paths.insert(new, uuid)
+    }
+
+    /// Drain every room out of the registry. Used by shutdown to take
+    /// ownership of every room for orderly teardown. Leaves both maps
+    /// empty under one lock acquisition.
+    pub async fn drain(&self) -> Vec<(Uuid, Arc<NotebookRoom>)> {
+        let mut inner = self.inner.lock().await;
+        inner.paths = PathIndex::default();
+        inner.rooms.drain().collect()
+    }
+
+    /// Remove a room from both maps under one lock.
+    ///
+    /// The caller is responsible for verifying preconditions (no
+    /// peers, no reservations, kernel torn down) before calling.
+    /// Returns the removed `Arc<NotebookRoom>` so the caller can run
+    /// any post-removal cleanup that needs the room.
+    pub async fn remove(&self, uuid: Uuid) -> Option<Arc<NotebookRoom>> {
+        let mut inner = self.inner.lock().await;
+        let room = inner.rooms.remove(&uuid)?;
+        inner.paths.remove_by_uuid(uuid);
+        Some(room)
+    }
+
+    /// Atomically re-check a predicate and remove the room from both
+    /// maps if it still holds. Used by the ghost reaper to decide
+    /// "remove this room" under the same lock acquisition that any
+    /// concurrent connect/save-as would contend for, so a peer
+    /// reconnecting between sample and remove cannot race to a half-
+    /// removed state.
+    ///
+    /// `predicate` runs synchronously under the registry lock; it must
+    /// not `.await`. The closure receives the resident `Arc` so it can
+    /// read atomic counters and the connection generation.
+    pub async fn remove_if<F>(&self, uuid: Uuid, predicate: F) -> Option<Arc<NotebookRoom>>
+    where
+        F: FnOnce(&Arc<NotebookRoom>) -> bool,
+    {
+        let mut inner = self.inner.lock().await;
+        let should = inner.rooms.get(&uuid).map(predicate).unwrap_or(false);
+        if !should {
+            return None;
+        }
+        let room = inner.rooms.remove(&uuid)?;
+        inner.paths.remove_by_uuid(uuid);
+        Some(room)
+    }
+
+    /// Snapshot `(uuid, room)` pairs. Used by the reaper and by
+    /// diagnostics queries that need to walk all rooms without
+    /// holding the lock across per-room async work.
+    pub async fn snapshot(&self) -> Vec<(Uuid, Arc<NotebookRoom>)> {
+        self.inner
+            .lock()
+            .await
+            .rooms
+            .iter()
+            .map(|(uuid, room)| (*uuid, room.clone()))
+            .collect()
+    }
+
+    /// Number of resident rooms.
+    pub async fn len(&self) -> usize {
+        self.inner.lock().await.rooms.len()
+    }
+
+    /// Number of resident path bindings. Used by tests asserting that
+    /// the path index converges to one entry per file-backed room.
+    #[cfg(test)]
+    pub async fn path_count(&self) -> usize {
+        self.inner.lock().await.paths.len()
+    }
+
+    /// Look up the UUID for a path without taking a reservation. Used
+    /// by tests that want to assert on the registry's path index
+    /// directly.
+    #[cfg(test)]
+    pub async fn peek_path_uuid(&self, path: &Path) -> Option<Uuid> {
+        self.inner.lock().await.paths.lookup(path)
+    }
+
+    /// True when no rooms are resident.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.lock().await.rooms.is_empty()
+    }
+
+    /// Hold the registry's inner lock across a synchronous closure.
+    ///
+    /// Used by `peer_eviction` to make the
+    /// `no_peers && same_generation` check and the
+    /// `kernel_teardown_destructive.store(true)` flip atomic against a
+    /// racing `lookup_path` / `insert_or_get` on the connect side.
+    /// The closure runs without access to the registry's interior;
+    /// it borrows the lock purely for serialization.
+    ///
+    /// The closure is `FnOnce` and non-async; it must not `.await` so
+    /// the tokio-mutex-across-await invariant holds.
+    pub async fn serialize_with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let _guard = self.inner.lock().await;
+        f()
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/registry.rs
+++ b/crates/runtimed/src/notebook_sync_server/registry.rs
@@ -87,11 +87,15 @@ impl RoomRegistry {
         self.inner.lock().await.rooms.get(&uuid).cloned()
     }
 
-    /// Insert a freshly-built room. Idempotent on UUID: if a room with
-    /// the same UUID already exists, the existing `Arc` is returned and
-    /// the caller's `room` is dropped. Returns
-    /// `Err(PathIndexError::PathAlreadyOpen)` only when `path` is
-    /// `Some` and conflicts with a different room's UUID.
+    /// Insert a freshly-built room. Idempotent on UUID and on path:
+    /// if a room with the same UUID already exists, or if `path` is
+    /// `Some` and another room already owns that path, the existing
+    /// `Arc` is returned and the caller's `room` is dropped. The path
+    /// coalescing case is what makes two concurrent
+    /// `find_room_by_path -> get_or_create_room_result` racers join
+    /// the same room instead of one of them seeing
+    /// `PathAlreadyOpen`. Only returns `Err` when the path map is
+    /// somehow inconsistent (path indexes a UUID that has no room).
     pub async fn insert_or_get(
         &self,
         uuid: Uuid,
@@ -107,7 +111,29 @@ impl RoomRegistry {
         }
 
         if let Some(p) = path {
-            inner.paths.insert(p.to_path_buf(), uuid)?;
+            match inner.paths.insert(p.to_path_buf(), uuid) {
+                Ok(()) => {}
+                Err(PathIndexError::PathAlreadyOpen {
+                    uuid: existing_uuid,
+                    ..
+                }) => {
+                    // Two racers both missed the path lookup; the
+                    // winner is already in. Coalesce on the existing
+                    // room rather than failing the loser.
+                    if let Some(existing) = inner.rooms.get(&existing_uuid) {
+                        let existing = existing.clone();
+                        let guard = ReservationGuard::new(existing.clone());
+                        return Ok(InsertOutcome::Existing(existing, guard));
+                    }
+                    // Path index points at a UUID with no room: the
+                    // registry is inconsistent. Propagate the error so
+                    // the caller logs it.
+                    return Err(PathIndexError::PathAlreadyOpen {
+                        uuid: existing_uuid,
+                        path: p.to_path_buf(),
+                    });
+                }
+            }
         }
         inner.rooms.insert(uuid, room.clone());
         let guard = ReservationGuard::new(room.clone());

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -448,6 +448,14 @@ pub struct RoomConnections {
     /// and forces a fresh auto-launch instead of trusting the stale
     /// "has_kernel" snapshot.
     pub kernel_teardown_destructive: AtomicBool,
+    /// In-flight handshake reservations. Bumped the moment a caller
+    /// receives an `Arc<NotebookRoom>` from the registry; decremented
+    /// when the handshake either commits (incrementing `active_peers`)
+    /// or aborts. The room reaper requires `reservations == 0` in
+    /// addition to `active_peers == 0` so a racing reconnect that has
+    /// the Arc but has not yet bumped `active_peers` is not reaped out
+    /// from under it.
+    pub reservations: AtomicUsize,
 }
 
 impl Default for RoomConnections {
@@ -458,6 +466,7 @@ impl Default for RoomConnections {
             last_kernel_torn_down_at: AtomicU64::new(0),
             connection_generation: AtomicU64::new(0),
             kernel_teardown_destructive: AtomicBool::new(false),
+            reservations: AtomicUsize::new(0),
         }
     }
 }
@@ -500,6 +509,63 @@ impl RoomConnections {
     /// rooms lock before destructive ops.
     pub fn connection_generation(&self) -> u64 {
         self.connection_generation.load(Ordering::Relaxed)
+    }
+
+    /// Number of in-flight handshake reservations against this room. The
+    /// reaper combines this with `active_peers` to decide whether a room
+    /// is truly peer-less. Held by `ReservationGuard`.
+    pub fn reservations(&self) -> usize {
+        self.reservations.load(Ordering::Relaxed)
+    }
+}
+
+/// RAII guard for a handshake reservation against a room.
+///
+/// Bumps `RoomConnections::reservations` on construction, decrements on
+/// drop. Hand-off contract: callers that receive an `Arc<NotebookRoom>`
+/// from the registry hold a guard until the handshake either reaches
+/// `active_peers.fetch_add(1)` or aborts. The reaper's peer-less
+/// predicate is `active_peers == 0 && reservations == 0`, which closes
+/// the gap where the Arc has been cloned out of the registry but the
+/// active-peer increment has not yet landed.
+///
+/// The guard intentionally does not implement `Clone`; each
+/// reservation is a single slot.
+///
+/// The non-test callers (`find_room_by_path`, `get_or_create_room_result`)
+/// are wired up in the following commit that introduces `RoomRegistry`;
+/// hence the `allow(dead_code)` here.
+#[must_use = "drop the guard when the handshake commits or aborts; otherwise the reservation leaks until the room itself is dropped"]
+#[allow(dead_code)]
+pub struct ReservationGuard {
+    room: Arc<NotebookRoom>,
+}
+
+#[allow(dead_code)]
+impl ReservationGuard {
+    /// Take a reservation on `room`. Increments `reservations` once.
+    pub fn new(room: Arc<NotebookRoom>) -> Self {
+        room.connections
+            .reservations
+            .fetch_add(1, Ordering::Relaxed);
+        Self { room }
+    }
+
+    /// The room this guard is reserving.
+    pub fn room(&self) -> &Arc<NotebookRoom> {
+        &self.room
+    }
+}
+
+impl Drop for ReservationGuard {
+    fn drop(&mut self) {
+        // Saturating-decrement guard against an accidental double-drop
+        // (which would only happen on a misuse like manually `Drop`-ing
+        // the value twice via `unsafe`; safe code can't reach it).
+        self.room
+            .connections
+            .reservations
+            .fetch_sub(1, Ordering::Relaxed);
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -114,26 +114,19 @@ impl NotebookFileBinding {
     }
 
     pub async fn claim_path(
-        path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
+        rooms: &NotebookRooms,
         canonical: &Path,
         uuid: uuid::Uuid,
     ) -> Result<(), notebook_protocol::protocol::SaveErrorKind> {
-        try_claim_path(path_index, canonical, uuid).await
+        try_claim_path(rooms, canonical, uuid).await
     }
 
-    pub async fn release_path(path_index: &Arc<tokio::sync::Mutex<PathIndex>>, canonical: &Path) {
-        path_index.lock().await.remove(canonical);
+    pub async fn release_path(rooms: &NotebookRooms, canonical: &Path) {
+        rooms.unbind_path(canonical).await;
     }
 
-    pub async fn replace_claim(
-        path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
-        old: &Path,
-        new: PathBuf,
-        uuid: uuid::Uuid,
-    ) {
-        let mut idx = path_index.lock().await;
-        idx.remove(old);
-        if let Err(e) = idx.insert(new.clone(), uuid) {
+    pub async fn replace_claim(rooms: &NotebookRooms, old: &Path, new: PathBuf, uuid: uuid::Uuid) {
+        if let Err(e) = rooms.replace_path(old, new.clone(), uuid).await {
             warn!(
                 "[notebook-sync] post-write path_index reinsert failed for {:?}: {} \
                  — room {} may be orphaned from path lookup",
@@ -531,17 +524,11 @@ impl RoomConnections {
 ///
 /// The guard intentionally does not implement `Clone`; each
 /// reservation is a single slot.
-///
-/// The non-test callers (`find_room_by_path`, `get_or_create_room_result`)
-/// are wired up in the following commit that introduces `RoomRegistry`;
-/// hence the `allow(dead_code)` here.
 #[must_use = "drop the guard when the handshake commits or aborts; otherwise the reservation leaks until the room itself is dropped"]
-#[allow(dead_code)]
 pub struct ReservationGuard {
     room: Arc<NotebookRoom>,
 }
 
-#[allow(dead_code)]
 impl ReservationGuard {
     /// Take a reservation on `room`. Increments `reservations` once.
     pub fn new(room: Arc<NotebookRoom>) -> Self {
@@ -552,6 +539,7 @@ impl ReservationGuard {
     }
 
     /// The room this guard is reserving.
+    #[allow(dead_code)]
     pub fn room(&self) -> &Arc<NotebookRoom> {
         &self.room
     }

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -335,7 +335,14 @@ pub struct RoomPersistence {
     /// rooms keep this `None`, and so do rooms promoted via Save (the
     /// `.automerge` stream isn't restarted post-promotion — see comment
     /// in `finalize_untitled_promotion`).
-    pub debouncer: Option<PersistDebouncer>,
+    ///
+    /// The `Mutex<Option<...>>` wrapper lets the reaper `.take()` the
+    /// debouncer at room removal so the watch sender drops, the
+    /// debouncer task exits via its shutdown arm, and one final flush
+    /// lands before the room is dropped. Without `.take()` the
+    /// sender would only drop when the `Arc<NotebookRoom>` itself
+    /// drops, which races the room map removal.
+    debouncer: std::sync::Mutex<Option<PersistDebouncer>>,
     /// Cell sources as they were written to disk at last save.
     ///
     /// The file watcher compares disk content against this snapshot (not the
@@ -367,7 +374,7 @@ impl RoomPersistence {
     /// Build a persistence struct with no active debouncer (ephemeral rooms).
     pub fn ephemeral() -> Self {
         Self {
-            debouncer: None,
+            debouncer: std::sync::Mutex::new(None),
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
@@ -380,14 +387,64 @@ impl RoomPersistence {
         flush_request_tx: mpsc::UnboundedSender<FlushRequest>,
     ) -> Self {
         Self {
-            debouncer: Some(PersistDebouncer {
+            debouncer: std::sync::Mutex::new(Some(PersistDebouncer {
                 persist_tx,
                 flush_request_tx,
-            }),
+            })),
             last_save_sources: RwLock::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
         }
+    }
+
+    /// True when this room has an active `.automerge` debouncer.
+    pub fn has_debouncer(&self) -> bool {
+        self.lock_debouncer().is_some()
+    }
+
+    /// Send the latest doc bytes to the debouncer. No-op when no
+    /// debouncer is wired up (ephemeral rooms). The watch sender keeps
+    /// only the most recent value, so a fast burst of edits collapses
+    /// to one persist write.
+    pub fn enqueue_persist_bytes(&self, bytes: Vec<u8>) {
+        if let Some(d) = self.lock_debouncer().as_ref() {
+            let _ = d.persist_tx.send(Some(bytes));
+        }
+    }
+
+    /// Send a synchronous flush request. Returns the ack receiver if a
+    /// debouncer is wired up and the send succeeded; `None` when the
+    /// room is ephemeral or the debouncer task has already exited.
+    /// Callers must `.await` the receiver outside any held lock.
+    pub fn request_flush(&self) -> Option<tokio::sync::oneshot::Receiver<bool>> {
+        let guard = self.lock_debouncer();
+        let d = guard.as_ref()?;
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel::<bool>();
+        if d.flush_request_tx.send(ack_tx).is_ok() {
+            Some(ack_rx)
+        } else {
+            None
+        }
+    }
+
+    /// Take the debouncer out of the room. Used by the reaper at room
+    /// removal: dropping the returned `PersistDebouncer` drops the
+    /// `watch::Sender` and the `mpsc::UnboundedSender`, which makes
+    /// the persist task exit via its shutdown arm with one final
+    /// flush. Returns `None` for ephemeral rooms or if a prior caller
+    /// already took it.
+    #[allow(dead_code)]
+    pub fn take_debouncer(&self) -> Option<PersistDebouncer> {
+        self.lock_debouncer().take()
+    }
+
+    /// Lock the debouncer Mutex. Recovers from poisoning by treating
+    /// the inner value as still usable — a panicking caller would only
+    /// be writing the field, never mutating the inner channels.
+    fn lock_debouncer(&self) -> std::sync::MutexGuard<'_, Option<PersistDebouncer>> {
+        self.debouncer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Atomically claim the loading role. Returns `true` if this caller won

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -239,6 +239,72 @@ async fn file_backed_room_has_path_some() {
 }
 
 #[tokio::test]
+async fn reservation_guard_increments_and_decrements_counter() {
+    use std::sync::atomic::Ordering;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 0);
+
+    let guard = ReservationGuard::new(room.clone());
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 1);
+
+    drop(guard);
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn reservation_guards_stack() {
+    use std::sync::atomic::Ordering;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    let g1 = ReservationGuard::new(room.clone());
+    let g2 = ReservationGuard::new(room.clone());
+    let g3 = ReservationGuard::new(room.clone());
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 3);
+
+    drop(g2);
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 2);
+
+    drop(g1);
+    drop(g3);
+    assert_eq!(room.connections.reservations.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn reservation_guard_room_accessor_returns_same_arc() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        None,
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    let guard = ReservationGuard::new(room.clone());
+    assert!(Arc::ptr_eq(guard.room(), &room));
+}
+
+#[tokio::test]
 async fn test_room_load_or_create_new() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -345,13 +345,11 @@ async fn test_room_persists_and_reloads() {
 async fn test_get_or_create_room_reuses_existing() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
     let uuid1 = Uuid::new_v4();
 
-    let room1 = get_or_create_room(
+    let (room1, _g1) = get_or_create_room(
         &rooms,
-        &path_index,
         uuid1,
         RoomCreationOptions {
             path: None,
@@ -362,9 +360,8 @@ async fn test_get_or_create_room_reuses_existing() {
         },
     )
     .await;
-    let room2 = get_or_create_room(
+    let (room2, _g2) = get_or_create_room(
         &rooms,
-        &path_index,
         uuid1,
         RoomCreationOptions {
             path: None,
@@ -384,14 +381,12 @@ async fn test_get_or_create_room_reuses_existing() {
 async fn test_get_or_create_room_different_notebooks() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
     let uuid1 = Uuid::new_v4();
     let uuid2 = Uuid::new_v4();
 
-    let room1 = get_or_create_room(
+    let (room1, _g1) = get_or_create_room(
         &rooms,
-        &path_index,
         uuid1,
         RoomCreationOptions {
             path: None,
@@ -402,9 +397,8 @@ async fn test_get_or_create_room_different_notebooks() {
         },
     )
     .await;
-    let room2 = get_or_create_room(
+    let (room2, _g2) = get_or_create_room(
         &rooms,
-        &path_index,
         uuid2,
         RoomCreationOptions {
             path: None,
@@ -418,7 +412,7 @@ async fn test_get_or_create_room_different_notebooks() {
 
     // Should be different rooms
     assert!(!Arc::ptr_eq(&room1, &room2));
-    assert_eq!(rooms.lock().await.len(), 2);
+    assert_eq!(rooms.len().await, 2);
 }
 
 #[tokio::test]
@@ -3237,11 +3231,13 @@ async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
         let mut doc = room.doc.write().await;
         doc.add_cell(0, "c1", "code").unwrap();
     }
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    rooms.lock().await.insert(uuid, room.clone());
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    rooms
+        .insert_or_get(uuid, room.clone(), None)
+        .await
+        .expect("registry insert for test setup");
 
-    // 2. Simulate the handler's transition: save to disk then wire path_index.
+    // 2. Simulate the handler's transition: save to disk then bind the path.
     let save_target = tmp.path().join("note.ipynb");
     let written = save_notebook_to_disk(&room, Some(save_target.to_str().unwrap()))
         .await
@@ -3250,18 +3246,14 @@ async fn saving_untitled_notebook_updates_path_index_and_keeps_uuid() {
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
 
-    path_index
-        .lock()
-        .await
-        .insert(canonical.clone(), room.id)
-        .unwrap();
+    rooms.bind_path(room.id, canonical.clone()).await.unwrap();
     room.file_binding
         .set_path_for_test(Some(canonical.clone()))
         .await;
 
-    // UUID key unchanged, path_index populated, room.file_binding.path set.
-    assert!(rooms.lock().await.contains_key(&uuid));
-    assert_eq!(path_index.lock().await.lookup(&canonical), Some(uuid));
+    // UUID key unchanged, path index populated, room.file_binding.path set.
+    assert!(rooms.peek_uuid(uuid).await.is_some());
+    assert_eq!(rooms.peek_path_uuid(&canonical).await, Some(uuid));
     assert_eq!(
         room.file_binding.path().await.as_deref(),
         Some(canonical.as_path())
@@ -3281,11 +3273,10 @@ async fn saving_to_already_open_path_returns_path_already_open_error() {
     // Existing room already claiming `target_path`.
     let existing_uuid = Uuid::new_v4();
     let target_path = tmp.path().join("existing.ipynb");
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
-    path_index
-        .lock()
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    rooms
+        .bind_path(existing_uuid, target_path.clone())
         .await
-        .insert(target_path.clone(), existing_uuid)
         .unwrap();
 
     // Fresh untitled room that tries to claim the same path.
@@ -3295,7 +3286,7 @@ async fn saving_to_already_open_path_returns_path_already_open_error() {
     ));
 
     // Try to claim the path — must fail.
-    let err = try_claim_path(&path_index, &target_path, new_uuid)
+    let err = try_claim_path(&rooms, &target_path, new_uuid)
         .await
         .unwrap_err();
 
@@ -3336,13 +3327,9 @@ async fn path_collision_does_not_overwrite_existing_file() {
     // Canonicalize before inserting so the key matches what the handler
     // would compute via canonical_target_path at save time.
     let canonical = canonical_target_path(&target_path).await;
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
     let uuid_a = Uuid::new_v4();
-    path_index
-        .lock()
-        .await
-        .insert(canonical.clone(), uuid_a)
-        .unwrap();
+    rooms.bind_path(uuid_a, canonical.clone()).await.unwrap();
 
     // Room B attempts to save to the same path. Per the handler's
     // claim-before-write ordering, it must fail at try_claim_path without
@@ -3351,7 +3338,7 @@ async fn path_collision_does_not_overwrite_existing_file() {
     let _room_b = Arc::new(NotebookRoom::new_fresh(
         uuid_b, None, &docs_dir, blob_store, false,
     ));
-    let claim = try_claim_path(&path_index, &canonical, uuid_b).await;
+    let claim = try_claim_path(&rooms, &canonical, uuid_b).await;
     assert!(claim.is_err(), "claim must fail on collision");
 
     // Target file must be byte-for-byte identical.
@@ -3392,8 +3379,11 @@ async fn test_promote_untitled_starts_autosave() {
     }
 
     // 2. Insert into rooms map under UUID key (UUID key stays constant).
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    rooms.lock().await.insert(uuid, room.clone());
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    rooms
+        .insert_or_get(uuid, room.clone(), None)
+        .await
+        .expect("registry insert for test setup");
 
     // 3. Save to disk — creates the .ipynb file.
     let save_path = tmp.path().join("saved.ipynb");
@@ -3406,16 +3396,15 @@ async fn test_promote_untitled_starts_autosave() {
     let canonical = tokio::fs::canonicalize(&written)
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
 
-    try_claim_path(&path_index, &canonical, room.id)
+    try_claim_path(&rooms, &canonical, room.id)
         .await
         .expect("path claim should succeed");
     finalize_untitled_promotion(&room, canonical.clone()).await;
 
     // Verify post-promotion state.
     assert!(
-        rooms.lock().await.contains_key(&uuid),
+        rooms.peek_uuid(uuid).await.is_some(),
         "UUID key should still be present after promotion"
     );
     assert_eq!(
@@ -3424,9 +3413,9 @@ async fn test_promote_untitled_starts_autosave() {
         "room.file_binding.path should be set after promotion"
     );
     assert_eq!(
-        path_index.lock().await.lookup(&canonical),
+        rooms.peek_path_uuid(&canonical).await,
         Some(uuid),
-        "path_index should contain the room's UUID"
+        "registry path index should contain the room's UUID"
     );
     assert!(
         !room.file_binding.is_ephemeral(),
@@ -3487,8 +3476,7 @@ async fn test_promote_untitled_starts_autosave() {
 async fn find_room_by_path_returns_room_after_index_insert() {
     let tmp = tempfile::tempdir().unwrap();
     let blob_store = test_blob_store(&tmp);
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
     let uuid = Uuid::new_v4();
     let fake = tmp.path().join("note.ipynb");
     let room = Arc::new(NotebookRoom::new_fresh(
@@ -3498,20 +3486,22 @@ async fn find_room_by_path_returns_room_after_index_insert() {
         blob_store,
         false,
     ));
-    rooms.lock().await.insert(uuid, room.clone());
-    path_index.lock().await.insert(fake.clone(), uuid).unwrap();
+    rooms
+        .insert_or_get(uuid, room.clone(), Some(&fake))
+        .await
+        .unwrap();
 
-    let found = find_room_by_path(&rooms, &path_index, &fake).await;
+    let found = find_room_by_path(&rooms, &fake).await;
     assert!(found.is_some());
-    assert!(Arc::ptr_eq(&found.unwrap(), &room));
+    let (found_room, _guard) = found.unwrap();
+    assert!(Arc::ptr_eq(&found_room, &room));
 }
 
 #[tokio::test]
 async fn find_room_by_path_returns_none_when_not_indexed() {
     let tmp = tempfile::tempdir().unwrap();
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
-    let found = find_room_by_path(&rooms, &path_index, &tmp.path().join("nope.ipynb")).await;
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    let found = find_room_by_path(&rooms, &tmp.path().join("nope.ipynb")).await;
     assert!(found.is_none());
 }
 
@@ -3532,22 +3522,20 @@ async fn test_notebook_sync_path_handshake_reuses_existing_room() {
     let tmp = tempfile::TempDir::new().unwrap();
     let blob_store = test_blob_store(&tmp);
     let docs_dir = tmp.path().to_path_buf();
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
 
     // Simulate a file-backed path (doesn't need to exist for this test).
     let notebook_path = tmp.path().join("my_notebook.ipynb");
 
     // --- First handshake (simulates the fixed NotebookSync path) ---
-    // 1. Check path_index — not yet indexed, so mint a new UUID.
-    let room1 = {
-        let (uuid, path) = match find_room_by_path(&rooms, &path_index, &notebook_path).await {
-            Some(existing) => (existing.id, Some(notebook_path.clone())),
+    // 1. Check the path index — not yet indexed, so mint a new UUID.
+    let (room1, _g1) = {
+        let (uuid, path) = match find_room_by_path(&rooms, &notebook_path).await {
+            Some((existing, _)) => (existing.id, Some(notebook_path.clone())),
             None => (Uuid::new_v4(), Some(notebook_path.clone())),
         };
         get_or_create_room(
             &rooms,
-            &path_index,
             uuid,
             RoomCreationOptions {
                 path,
@@ -3562,14 +3550,13 @@ async fn test_notebook_sync_path_handshake_reuses_existing_room() {
 
     // --- Second handshake for the same path ---
     // find_room_by_path should now return the existing room.
-    let room2 = {
-        let (uuid, path) = match find_room_by_path(&rooms, &path_index, &notebook_path).await {
-            Some(existing) => (existing.id, Some(notebook_path.clone())),
+    let (room2, _g2) = {
+        let (uuid, path) = match find_room_by_path(&rooms, &notebook_path).await {
+            Some((existing, _)) => (existing.id, Some(notebook_path.clone())),
             None => (Uuid::new_v4(), Some(notebook_path.clone())),
         };
         get_or_create_room(
             &rooms,
-            &path_index,
             uuid,
             RoomCreationOptions {
                 path,
@@ -3590,16 +3577,16 @@ async fn test_notebook_sync_path_handshake_reuses_existing_room() {
 
     // Exactly one room in the map (not two).
     assert_eq!(
-        rooms.lock().await.len(),
+        rooms.len().await,
         1,
         "Only one room should exist after two handshakes for the same path"
     );
 
-    // path_index has exactly one entry.
+    // The registry's path index has exactly one entry.
     assert_eq!(
-        path_index.lock().await.len(),
+        rooms.path_count().await,
         1,
-        "path_index should have exactly one entry"
+        "registry path index should have exactly one entry"
     );
 }
 
@@ -6727,37 +6714,30 @@ fn test_missing_conda_env_yml_name_prefix_with_python_is_not_missing() {
 // CloneAsEphemeral handler tests
 // ---------------------------------------------------------------------------
 
-/// Build the minimum scaffolding the clone handler needs: a notebook_rooms
-/// map, a path_index, a docs_dir, and a blob store. Lets the handler run
+/// Build the minimum scaffolding the clone handler needs: a combined
+/// room registry, a docs_dir, and a blob store. Lets the handler run
 /// without a full `Daemon`.
 fn clone_test_scaffolding(
     tmp: &tempfile::TempDir,
-) -> (
-    NotebookRooms,
-    Arc<tokio::sync::Mutex<PathIndex>>,
-    std::path::PathBuf,
-    Arc<BlobStore>,
-) {
-    let rooms: NotebookRooms = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
+) -> (NotebookRooms, std::path::PathBuf, Arc<BlobStore>) {
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
     let docs_dir = tmp.path().join("docs");
     std::fs::create_dir_all(&docs_dir).unwrap();
     let blob_store = test_blob_store(tmp);
-    (rooms, path_index, docs_dir, blob_store)
+    (rooms, docs_dir, blob_store)
 }
 
 #[tokio::test]
 async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+    let (rooms, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
 
     // Build a file-backed source room with cells + markdown/raw attachments
     // + stamped trust, registered in the rooms map.
     let source_path = tmp.path().join("source.ipynb");
     let source_uuid = Uuid::new_v4();
-    let source_room = get_or_create_room(
+    let (source_room, _source_guard) = get_or_create_room(
         &rooms,
-        &path_index,
         source_uuid,
         RoomCreationOptions {
             path: Some(source_path.clone()),
@@ -6825,7 +6805,6 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
     // Dispatch clone handler.
     let response = crate::requests::clone_notebook::handle_inner(
         &rooms,
-        &path_index,
         &docs_dir,
         blob_store.clone(),
         source_uuid.to_string(),
@@ -6853,10 +6832,8 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
 
     // Room is registered.
     let clone_room = rooms
-        .lock()
+        .peek_uuid(clone_uuid)
         .await
-        .get(&clone_uuid)
-        .cloned()
         .expect("clone room should be registered");
 
     // Ephemeral.
@@ -6935,17 +6912,12 @@ async fn test_clone_as_ephemeral_forks_cells_and_clears_outputs() {
 #[tokio::test]
 async fn test_clone_as_ephemeral_rejects_unknown_source() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+    let (rooms, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
 
     let bogus = Uuid::new_v4().to_string();
-    let response = crate::requests::clone_notebook::handle_inner(
-        &rooms,
-        &path_index,
-        &docs_dir,
-        blob_store,
-        bogus.clone(),
-    )
-    .await;
+    let response =
+        crate::requests::clone_notebook::handle_inner(&rooms, &docs_dir, blob_store, bogus.clone())
+            .await;
 
     match response {
         NotebookResponse::Error { error } => {
@@ -6961,11 +6933,10 @@ async fn test_clone_as_ephemeral_rejects_unknown_source() {
 #[tokio::test]
 async fn test_clone_as_ephemeral_rejects_invalid_uuid() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+    let (rooms, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
 
     let response = crate::requests::clone_notebook::handle_inner(
         &rooms,
-        &path_index,
         &docs_dir,
         blob_store,
         "not-a-uuid".to_string(),
@@ -7084,12 +7055,11 @@ async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
     // Codex F3 on PR #2192: clone must preserve unknown top-level
     // metadata keys from source (jupytext, colab, vscode, etc.).
     let tmp = tempfile::TempDir::new().unwrap();
-    let (rooms, path_index, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
+    let (rooms, docs_dir, blob_store) = clone_test_scaffolding(&tmp);
 
     let source_uuid = Uuid::new_v4();
-    let source_room = get_or_create_room(
+    let (source_room, _source_guard) = get_or_create_room(
         &rooms,
-        &path_index,
         source_uuid,
         RoomCreationOptions {
             path: Some(tmp.path().join("source.ipynb")),
@@ -7125,7 +7095,6 @@ async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
 
     let response = crate::requests::clone_notebook::handle_inner(
         &rooms,
-        &path_index,
         &docs_dir,
         blob_store.clone(),
         source_uuid.to_string(),
@@ -7138,10 +7107,8 @@ async fn test_clone_as_ephemeral_carries_unknown_metadata_extras() {
     };
     let clone_uuid = Uuid::parse_str(&clone_id).unwrap();
     let clone_room = rooms
-        .lock()
+        .peek_uuid(clone_uuid)
         .await
-        .get(&clone_uuid)
-        .cloned()
         .expect("clone room should be registered");
 
     let clone_snap = clone_room
@@ -7583,8 +7550,8 @@ async fn test_autosave_fires_on_runtime_file_dirty_without_self_loop() {
     let canonical = tokio::fs::canonicalize(&written)
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
-    try_claim_path(&path_index, &canonical, room.id)
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    try_claim_path(&rooms, &canonical, room.id)
         .await
         .expect("path claim should succeed");
     finalize_untitled_promotion(&room, canonical).await;
@@ -7683,8 +7650,8 @@ async fn test_autosave_shutdown_flushes_pending_doc_change() {
     let canonical = tokio::fs::canonicalize(&written)
         .await
         .unwrap_or_else(|_| PathBuf::from(&written));
-    let path_index = Arc::new(tokio::sync::Mutex::new(PathIndex::new()));
-    try_claim_path(&path_index, &canonical, room.id)
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    try_claim_path(&rooms, &canonical, room.id)
         .await
         .expect("path claim should succeed");
     finalize_untitled_promotion(&room, canonical.clone()).await;

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -705,7 +705,7 @@ async fn test_ephemeral_room_skips_persistence() {
     let notebook_uuid = uuid::Uuid::new_v4();
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, true);
 
-    assert!(room.persistence.debouncer.is_none());
+    assert!(!room.persistence.has_debouncer());
     assert!(room.file_binding.is_ephemeral());
 
     // No .automerge file should exist
@@ -720,7 +720,7 @@ async fn test_session_room_persists() {
     let notebook_uuid = uuid::Uuid::new_v4();
     let room = NotebookRoom::new_fresh(notebook_uuid, None, dir.path(), blob_store, false);
 
-    assert!(room.persistence.debouncer.is_some());
+    assert!(room.persistence.has_debouncer());
     assert!(!room.file_binding.is_ephemeral());
 }
 

--- a/crates/runtimed/src/requests/clone_notebook.rs
+++ b/crates/runtimed/src/requests/clone_notebook.rs
@@ -16,16 +16,13 @@ use uuid::Uuid;
 
 use crate::blob_store::BlobStore;
 use crate::daemon::Daemon;
-use crate::notebook_sync_server::{
-    get_or_create_room_result, NotebookRoom, NotebookRooms, PathIndex,
-};
+use crate::notebook_sync_server::{get_or_create_room_result, NotebookRoom, NotebookRooms};
 use crate::protocol::NotebookResponse;
 
 /// Dispatcher entry point — unwraps the Daemon pieces for the inner fn.
 pub(crate) async fn handle(daemon: &Arc<Daemon>, source_notebook_id: String) -> NotebookResponse {
     handle_inner(
         &daemon.notebook_rooms,
-        &daemon.path_index,
         &daemon.config.notebook_docs_dir,
         daemon.blob_store.clone(),
         source_notebook_id,
@@ -37,7 +34,6 @@ pub(crate) async fn handle(daemon: &Arc<Daemon>, source_notebook_id: String) -> 
 /// of pieces needed to look up the source room and register the clone.
 pub(crate) async fn handle_inner(
     rooms: &NotebookRooms,
-    path_index: &Arc<tokio::sync::Mutex<PathIndex>>,
     docs_dir: &Path,
     blob_store: Arc<BlobStore>,
     source_notebook_id: String,
@@ -51,15 +47,12 @@ pub(crate) async fn handle_inner(
             };
         }
     };
-    let source_room = {
-        let rooms_guard = rooms.lock().await;
-        match rooms_guard.get(&source_uuid).cloned() {
-            Some(r) => r,
-            None => {
-                return NotebookResponse::Error {
-                    error: format!("Source notebook not found: {source_notebook_id}"),
-                };
-            }
+    let source_room = match rooms.peek_uuid(source_uuid).await {
+        Some(r) => r,
+        None => {
+            return NotebookResponse::Error {
+                error: format!("Source notebook not found: {source_notebook_id}"),
+            };
         }
     };
 
@@ -70,9 +63,8 @@ pub(crate) async fn handle_inner(
     let clone_uuid = Uuid::new_v4();
 
     // 4. Create the new ephemeral room (empty).
-    let clone_room = match get_or_create_room_result(
+    let (clone_room, _clone_guard) = match get_or_create_room_result(
         rooms,
-        path_index,
         clone_uuid,
         crate::notebook_sync_server::RoomCreationOptions {
             path: None, // ephemeral, no file path
@@ -102,7 +94,7 @@ pub(crate) async fn handle_inner(
     if let Err(e) = seed_clone_from_source(&source_room, &clone_room).await {
         // On seed failure, evict the partially-initialized room so we
         // don't leak an empty ephemeral.
-        rooms.lock().await.remove(&clone_uuid);
+        rooms.remove(clone_uuid).await;
         return NotebookResponse::Error {
             error: format!("Failed to seed cloned notebook: {e}"),
         };

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -83,7 +83,7 @@ pub(crate) async fn handle(
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
-            if binding_snapshot.is_ephemeral && room.persistence.debouncer.is_none() {
+            if binding_snapshot.is_ephemeral && !room.persistence.has_debouncer() {
                 let bytes = room.doc.write().await.save();
                 persist_notebook_bytes(&bytes, &room.identity.persist_path);
                 warn!(

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -67,7 +67,7 @@ pub(crate) async fn handle(
 
     if let Some(ref canonical_pre) = pre_claim {
         if let Err(kind) =
-            NotebookFileBinding::claim_path(&daemon.path_index, canonical_pre, room.id).await
+            NotebookFileBinding::claim_path(&daemon.notebook_rooms, canonical_pre, room.id).await
         {
             return NotebookResponse::SaveError { error: kind };
         }
@@ -79,7 +79,7 @@ pub(crate) async fn handle(
             // Rollback the path_index claim we just made so the room
             // stays untitled / its old path stays claimed.
             if let Some(ref canonical_pre) = pre_claim {
-                NotebookFileBinding::release_path(&daemon.path_index, canonical_pre).await;
+                NotebookFileBinding::release_path(&daemon.notebook_rooms, canonical_pre).await;
             }
             // Emergency persist for ephemeral rooms: if saving to .ipynb
             // failed, at least write the Automerge doc so data isn't lost.
@@ -118,7 +118,7 @@ pub(crate) async fn handle(
     if let Some(ref canonical_pre) = pre_claim {
         if canonical_pre != &canonical {
             NotebookFileBinding::replace_claim(
-                &daemon.path_index,
+                &daemon.notebook_rooms,
                 canonical_pre,
                 canonical.clone(),
                 room.id,
@@ -134,7 +134,7 @@ pub(crate) async fn handle(
         if path_changed {
             // Save-as rename: new path already claimed above; remove
             // the old path_index entry and rebind the room to the new path.
-            NotebookFileBinding::release_path(&daemon.path_index, old).await;
+            NotebookFileBinding::release_path(&daemon.notebook_rooms, old).await;
             NotebookFileBinding::rebind_after_save_as(room, canonical.clone()).await;
         }
         // If path didn't change, this is save-in-place: nothing else.


### PR DESCRIPTION
## Summary

Resident-room reaper plus the registry + reservation plumbing it needs. Built on the kernel-teardown / room-resident split that landed in #2750. A peer disconnect leaves the room in memory; this PR is the policy that eventually removes those rooms once they have been idle long enough or once they exceed a soft count cap.

Six commits, each independently compiles, lints, and tests:

1. `ReservationGuard` + `RoomConnections.reservations` counter. Closes the gap where a connection has cloned `Arc<NotebookRoom>` from the registry but not yet incremented `active_peers`.
2. `RoomRegistry` combines the UUID map and the path index behind one tokio mutex. Joined insert/remove/lookup operations stop racing each other; the `find_room_by_path` then `path_index.insert` failure mode that the two-lock layout exposed is gone. `find_room_by_path` / `get_or_create_room_result` now return `(Arc<NotebookRoom>, ReservationGuard)`; the daemon's separate `path_index` field is removed.
3. `RoomPersistence.debouncer` becomes `Mutex<Option<PersistDebouncer>>` so the reaper can `.take()` the senders at commit. Three helpers replace the direct field access: `has_debouncer`, `enqueue_persist_bytes`, `request_flush`. `take_debouncer` lands here; the reaper wires it up in commit 5.
4. Reaper selects from two layers: TTL (24h) for aged-out peer-less rooms, and an LRU count cap (32) for overflow. Active rooms are exempt. Constants move to module scope; a follow-up can expose them as `Daemon` config knobs.
5. Per-candidate reap is ordered: flush, shutdown autosave, shutdown watchers, atomic commit, take debouncer, drop. Flush or autosave-shutdown failure aborts the pass and leaves the room resident. A reconnect that races between cleanup and commit re-arms watchers via `bind_existing` so it inherits a working room.
6. Orphan `.automerge` sweep window raises from 24h to 7d so it stops overlapping the reaper's TTL.

## Design decisions

**Combined registry instead of two locks under one nested.** Initially considered keeping `Arc<Mutex<HashMap>>` + `Arc<Mutex<PathIndex>>` and locking both per joined op. Two issues: nested `.lock().await` violates the load-bearing tokio-mutex invariant, and any caller that took only one of the two locks would still race the other. `RoomRegistry` puts both maps inside one `Mutex<RegistryInner>`, so a single `lookup_path` resolves path-to-UUID-to-Arc atomically. `serialize_with(|| ...)` lets `peer_eviction` keep its existing "serialize against connect-side races" check without inventing a new contract.

**Reservation counter, not just an Arc clone count.** A peer's handshake holds the Arc between `find_room_by_path` and `active_peers.fetch_add(1)`; counting strong references doesn't distinguish that case from a watcher's idle hold. `ReservationGuard` increments on construction and decrements on drop; the reaper's predicate folds it in.

**Shutdown before commit.** The plan considered commit-then-shutdown (simpler) versus shutdown-then-commit (safer). The current code does shutdown-first because a hung autosave or watcher after commit is invisible to the reaper — it can't retry a room it has already declared reaped. Shutdown-first lets the reaper abort and try again next sweep. The aborted-reap reconnect path calls `bind_existing` to respawn what we tore down.

**Debouncer takeover after commit.** `take_debouncer()` is destructive: dropping the senders kills the persist task. Doing it before commit means an aborted reap leaves the room with no persist debouncer. Defer it past the registry remove so the abort path can leave the debouncer running.

**Path index dropped on reap, not preserved as a "spilled" marker.** For file-backed notebooks the path is the stable external identifier; the daemon-internal UUID can churn. The MCP proxy reconnects by path, frontends use the UUID only for a single connection's lifetime. UUID rotation on reload-after-reap is fine.

**`.automerge` stays on disk through reap.** Reasons in `docs/architecture/pr2-lru-disk-spill.md`: file-backed rooms can have Arrow-stream sub-blob refs that only the `.automerge` carries, untitled rooms have no other resume path. The orphan sweep (7d) does the disk cleanup.

## Behavioral coverage

| Trigger | Selection | Commit predicate | Result |
|--------|----------|------------------|--------|
| Peer disconnect, kernel teardown completes, 24h elapses | TTL | no_peers + no_reservations + same_gen + still_stamped | Reaped |
| Peer-less room count > 32 | LRU overflow (oldest first) | same predicate | Reaped |
| Reconnect arrives between cleanup and commit | TTL or overflow | still_stamped fails (timestamp zeroed) | Aborted; watchers re-armed via `bind_existing` |
| Persist flush times out | TTL or overflow | n/a, aborts before commit | Room stays resident; next sweep retries |
| Autosave shutdown stalls | TTL or overflow | n/a, aborts before commit | Room stays resident; next sweep retries |
| Kernel still alive on a stamped room | n/a | `has_kernel` check skips | Skipped (impossible normally; defensive) |
| Active room (peers > 0) | n/a | Filtered out at selection (`active_peers > 0`) | Exempt from both layers |

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `cargo clippy -p runtimed --all-targets -- -D warnings` clean
- [x] `cargo test -p runtimed --lib` passes (760 tests; one transient `kernel_ports` flake unrelated)
- [x] `cargo test -p runtimed --test tokio_mutex_lint` passes
- [ ] Integration tests for the reap procedure (TTL, LRU cap, aborted reap, flush failure) are in the plan but not yet written. Either follows in a stacked PR or here on a second pass after `codex review`.
- [ ] Manual: open 3 notebooks in the dev daemon, disconnect all, force a sweep with TTL 0 via a test hook, reconnect via path, verify outputs come back from `.ipynb`.

## References

- Plan: `docs/architecture/pr2-lru-disk-spill.md` (in the worktree; not committed to main)
- Predecessor: #2750 (kernel teardown decoupled from room destruction)
