### PR TITLE
feat(runtimed): add PutBlob multipart uploads

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -367,7 +367,7 @@ mod tests {
             put_blob.single_frame_max,
             frame_size_limits(notebook_wire::frame_types::PUT_BLOB).cap as u64
         );
-        assert!(!put_blob.multipart);
+        assert!(put_blob.multipart);
         assert!(put_blob.ephemeral_supported);
     }
 

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -135,7 +135,7 @@ impl ProtocolCapabilities {
             put_blob: Some(PutBlobCapability {
                 version: 1,
                 single_frame_max: put_blob_limits.cap as u64,
-                multipart: false,
+                multipart: true,
                 ephemeral_supported: true,
             }),
         }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -250,7 +250,23 @@ pub enum BlobUploadErrorKind {
     OverCap,
     TooManyInFlight,
     InvalidHeader,
+    UnknownUpload,
+    PartSizeMismatch,
+    PartHashMismatch,
+    DuplicatePartConflict,
+    ManifestMismatch,
+    FinalHashMismatch,
+    OverPeerBudget,
+    SessionExpired,
     Io { message: String },
+}
+
+/// One manifest entry supplied when completing a multipart blob upload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BlobUploadPart {
+    pub part_number: u32,
+    pub sha256: String,
+    pub size: u64,
 }
 
 /// Successful one-shot PutBlob upload result returned to callers.
@@ -288,6 +304,13 @@ pub enum PutBlobHeader {
         durability: Option<BlobDurability>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         purpose: Option<String>,
+    },
+    Part {
+        id: String,
+        upload_id: String,
+        part_number: u32,
+        size: u64,
+        sha256: String,
     },
 }
 
@@ -352,6 +375,7 @@ impl PutBlobHeader {
     pub fn id(&self) -> &str {
         match self {
             PutBlobHeader::Put { id, .. } => id,
+            PutBlobHeader::Part { id, .. } => id,
         }
     }
 }
@@ -530,6 +554,27 @@ pub enum NotebookRequest {
     /// Get the full Automerge document bytes from the daemon's canonical doc.
     /// Used by the frontend to bootstrap its WASM Automerge peer.
     GetDocBytes {},
+
+    /// Begin a peer-scoped multipart blob upload.
+    CreateBlobUpload {
+        media_type: String,
+        size: u64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sha256: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        part_size: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        purpose: Option<String>,
+    },
+
+    /// Publish a completed multipart upload into the content-addressed store.
+    CompleteBlobUpload {
+        upload_id: String,
+        parts: Vec<BlobUploadPart>,
+    },
+
+    /// Abort a peer-scoped multipart upload and discard staged parts.
+    AbortBlobUpload { upload_id: String },
 }
 
 /// Responses from daemon to notebook app.
@@ -637,6 +682,23 @@ pub enum NotebookResponse {
         size: u64,
         media_type: String,
     },
+
+    /// Multipart blob upload was created.
+    BlobUploadCreated {
+        upload_id: String,
+        part_size: u64,
+        expires_at: String,
+    },
+
+    /// Multipart blob part bytes were staged.
+    BlobPartStored {
+        upload_id: String,
+        part_number: u32,
+        sha256: String,
+    },
+
+    /// Multipart blob upload was aborted.
+    BlobUploadAborted { upload_id: String },
 
     /// Blob upload failed before publishing bytes.
     BlobUploadError { reason: BlobUploadErrorKind },
@@ -1272,6 +1334,34 @@ mod tests {
             (
                 "get_doc_bytes",
                 serde_json::json!({ "action": "get_doc_bytes" }),
+            ),
+            (
+                "create_blob_upload",
+                serde_json::json!({
+                    "action": "create_blob_upload",
+                    "media_type": "application/octet-stream",
+                    "size": 12,
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "part_size": 8,
+                    "purpose": "comm-buffer",
+                }),
+            ),
+            (
+                "complete_blob_upload",
+                serde_json::json!({
+                    "action": "complete_blob_upload",
+                    "upload_id": "upload-1",
+                    "parts": [
+                        { "part_number": 1, "sha256": "0000000000000000000000000000000000000000000000000000000000000000", "size": 12 }
+                    ],
+                }),
+            ),
+            (
+                "abort_blob_upload",
+                serde_json::json!({
+                    "action": "abort_blob_upload",
+                    "upload_id": "upload-1",
+                }),
             ),
             (
                 "send_comm",

--- a/crates/notebook-protocol/src/typescript.rs
+++ b/crates/notebook-protocol/src/typescript.rs
@@ -26,6 +26,9 @@ pub const NOTEBOOK_REQUEST_TYPES: &[&str] = &[
     "approve_trust",
     "approve_project_environment",
     "get_doc_bytes",
+    "create_blob_upload",
+    "complete_blob_upload",
+    "abort_blob_upload",
 ];
 
 pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
@@ -48,6 +51,9 @@ pub const NOTEBOOK_RESPONSE_RESULTS: &[&str] = &[
     "sync_environment_failed",
     "doc_bytes",
     "blob_stored",
+    "blob_upload_created",
+    "blob_part_stored",
+    "blob_upload_aborted",
     "blob_upload_error",
 ];
 
@@ -127,6 +133,12 @@ export interface CommRequestMessage {{
   channel: string;
 }}
 
+export interface BlobUploadPart {{
+  part_number: number;
+  sha256: string;
+  size: number;
+}}
+
 export type NotebookRequest =
   | {{
       type: "launch_kernel";
@@ -162,7 +174,17 @@ export type NotebookRequest =
   | {{ type: "sync_environment"; guard?: DependencyGuard | null }}
   | {{ type: "approve_trust"; observed_heads?: string[] | null }}
   | {{ type: "approve_project_environment"; project_file_path?: string | null }}
-  | {{ type: "get_doc_bytes" }};
+  | {{ type: "get_doc_bytes" }}
+  | {{
+      type: "create_blob_upload";
+      media_type: string;
+      size: number;
+      sha256?: string | null;
+      part_size?: number | null;
+      purpose?: string | null;
+    }}
+  | {{ type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }}
+  | {{ type: "abort_blob_upload"; upload_id: string }};
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {{
@@ -214,6 +236,9 @@ export type NotebookResponse =
   | {{ result: "sync_environment_failed"; error: string; needs_restart: boolean }}
   | {{ result: "doc_bytes"; bytes: number[] }}
   | {{ result: "blob_stored"; hash: string; size: number; media_type: string }}
+  | {{ result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }}
+  | {{ result: "blob_part_stored"; upload_id: string; part_number: number; sha256: string }}
+  | {{ result: "blob_upload_aborted"; upload_id: string }}
   | {{ result: "blob_upload_error"; reason: BlobUploadErrorKind }};
 
 /**
@@ -236,6 +261,14 @@ export type BlobUploadErrorKind =
   | {{ kind: "over_cap" }}
   | {{ kind: "too_many_in_flight" }}
   | {{ kind: "invalid_header" }}
+  | {{ kind: "unknown_upload" }}
+  | {{ kind: "part_size_mismatch" }}
+  | {{ kind: "part_hash_mismatch" }}
+  | {{ kind: "duplicate_part_conflict" }}
+  | {{ kind: "manifest_mismatch" }}
+  | {{ kind: "final_hash_mismatch" }}
+  | {{ kind: "over_peer_budget" }}
+  | {{ kind: "session_expired" }}
   | {{ kind: "io"; message: string }};
 
 export type BlobDurability = "durable" | "ephemeral";

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -29,6 +29,7 @@ use sha2::{Digest, Sha256};
 use crate::error::SyncError;
 
 const PUT_BLOB_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const PUT_BLOB_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Commands for the relay task — only socket I/O operations.
 ///
@@ -272,7 +273,17 @@ impl RelayHandle {
                 upload_id,
                 part_size,
                 ..
-            } => (upload_id, part_size as usize),
+            } if part_size > 0 => (upload_id, part_size as usize),
+            NotebookResponse::BlobUploadCreated {
+                upload_id,
+                part_size,
+                ..
+            } => {
+                self.abort_blob_upload_best_effort(&upload_id).await;
+                return Err(SyncError::Protocol(format!(
+                    "Invalid multipart blob part_size: {part_size}"
+                )));
+            }
             NotebookResponse::BlobUploadError { reason } => {
                 return Err(SyncError::BlobUpload(reason));
             }
@@ -285,7 +296,15 @@ impl RelayHandle {
 
         let mut manifest = Vec::new();
         for (index, chunk) in bytes.chunks(part_size).enumerate() {
-            let part_number = (index + 1) as u32;
+            let part_number = match u32::try_from(index + 1) {
+                Ok(part_number) => part_number,
+                Err(_) => {
+                    self.abort_blob_upload_best_effort(&upload_id).await;
+                    return Err(SyncError::Protocol(
+                        "multipart blob upload exceeds u32 part count".to_string(),
+                    ));
+                }
+            };
             let part_sha256 = hex::encode(Sha256::digest(chunk));
             let id = uuid::Uuid::new_v4().to_string();
             let header = PutBlobHeader::Part {
@@ -295,9 +314,21 @@ impl RelayHandle {
                 size: chunk.len() as u64,
                 sha256: part_sha256.clone(),
             };
-            let response = self
-                .send_put_blob_frame(id, header.encode_frame(chunk)?)
-                .await?;
+            let frame = match header.encode_frame(chunk) {
+                Ok(frame) => frame,
+                Err(error) => {
+                    self.abort_blob_upload_best_effort(&upload_id).await;
+                    return Err(error.into());
+                }
+            };
+            let response = self.send_put_blob_frame(id, frame).await;
+            let response = match response {
+                Ok(response) => response,
+                Err(error) => {
+                    self.abort_blob_upload_best_effort(&upload_id).await;
+                    return Err(error);
+                }
+            };
             match response {
                 NotebookResponse::BlobPartStored {
                     upload_id: response_upload_id,
@@ -314,9 +345,11 @@ impl RelayHandle {
                     });
                 }
                 NotebookResponse::BlobUploadError { reason } => {
+                    self.abort_blob_upload_best_effort(&upload_id).await;
                     return Err(SyncError::BlobUpload(reason));
                 }
                 other => {
+                    self.abort_blob_upload_best_effort(&upload_id).await;
                     return Err(SyncError::Protocol(format!(
                         "Unexpected response for PutBlob part: {other:?}"
                     )));
@@ -324,13 +357,21 @@ impl RelayHandle {
             }
         }
 
-        match self
+        let complete_response = match self
             .send_request(NotebookRequest::CompleteBlobUpload {
-                upload_id,
+                upload_id: upload_id.clone(),
                 parts: manifest,
             })
-            .await?
+            .await
         {
+            Ok(response) => response,
+            Err(error) => {
+                self.abort_blob_upload_best_effort(&upload_id).await;
+                return Err(error);
+            }
+        };
+
+        match complete_response {
             NotebookResponse::BlobStored {
                 hash,
                 size,
@@ -340,10 +381,43 @@ impl RelayHandle {
                 size,
                 media_type,
             }),
-            NotebookResponse::BlobUploadError { reason } => Err(SyncError::BlobUpload(reason)),
-            other => Err(SyncError::Protocol(format!(
-                "Unexpected response for complete_blob_upload: {other:?}"
-            ))),
+            NotebookResponse::BlobUploadError { reason } => {
+                self.abort_blob_upload_best_effort(&upload_id).await;
+                Err(SyncError::BlobUpload(reason))
+            }
+            other => {
+                self.abort_blob_upload_best_effort(&upload_id).await;
+                Err(SyncError::Protocol(format!(
+                    "Unexpected response for complete_blob_upload: {other:?}"
+                )))
+            }
+        }
+    }
+
+    async fn abort_blob_upload_best_effort(&self, upload_id: &str) {
+        let id = uuid::Uuid::new_v4().to_string();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(RelayCommand::SendRequest {
+                id: id.clone(),
+                request: NotebookRequest::AbortBlobUpload {
+                    upload_id: upload_id.to_string(),
+                },
+                required_heads: Vec::new(),
+                reply: reply_tx,
+                broadcast_tx: None,
+            })
+            .await
+            .is_err()
+        {
+            return;
+        }
+        if tokio::time::timeout(PUT_BLOB_ABORT_TIMEOUT, crate::reply::recv(reply_rx))
+            .await
+            .is_err()
+        {
+            let _ = self.cmd_tx.send(RelayCommand::CancelRequest { id }).await;
         }
     }
 

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -21,7 +21,8 @@
 use tokio::sync::{broadcast, mpsc, oneshot};
 
 use notebook_protocol::protocol::{
-    NotebookBroadcast, NotebookRequest, NotebookResponse, PutBlobHeader, PutBlobResult,
+    BlobUploadPart, NotebookBroadcast, NotebookRequest, NotebookResponse, PutBlobHeader,
+    PutBlobResult,
 };
 use sha2::{Digest, Sha256};
 
@@ -246,6 +247,127 @@ impl RelayHandle {
             other => Err(SyncError::Protocol(format!(
                 "Unexpected response for PutBlob: {other:?}"
             ))),
+        }
+    }
+
+    /// Upload bytes to the daemon blob store using multipart PutBlob frames.
+    pub async fn put_blob_multipart(
+        &self,
+        bytes: &[u8],
+        media_type: &str,
+    ) -> Result<PutBlobResult, SyncError> {
+        let expected_sha256 = hex::encode(Sha256::digest(bytes));
+        let created = self
+            .send_request(NotebookRequest::CreateBlobUpload {
+                media_type: media_type.to_string(),
+                size: bytes.len() as u64,
+                sha256: Some(expected_sha256),
+                part_size: None,
+                purpose: None,
+            })
+            .await?;
+
+        let (upload_id, part_size) = match created {
+            NotebookResponse::BlobUploadCreated {
+                upload_id,
+                part_size,
+                ..
+            } => (upload_id, part_size as usize),
+            NotebookResponse::BlobUploadError { reason } => {
+                return Err(SyncError::BlobUpload(reason));
+            }
+            other => {
+                return Err(SyncError::Protocol(format!(
+                    "Unexpected response for create_blob_upload: {other:?}"
+                )));
+            }
+        };
+
+        let mut manifest = Vec::new();
+        for (index, chunk) in bytes.chunks(part_size).enumerate() {
+            let part_number = (index + 1) as u32;
+            let part_sha256 = hex::encode(Sha256::digest(chunk));
+            let id = uuid::Uuid::new_v4().to_string();
+            let header = PutBlobHeader::Part {
+                id: id.clone(),
+                upload_id: upload_id.clone(),
+                part_number,
+                size: chunk.len() as u64,
+                sha256: part_sha256.clone(),
+            };
+            let response = self
+                .send_put_blob_frame(id, header.encode_frame(chunk)?)
+                .await?;
+            match response {
+                NotebookResponse::BlobPartStored {
+                    upload_id: response_upload_id,
+                    part_number: response_part_number,
+                    sha256,
+                } if response_upload_id == upload_id
+                    && response_part_number == part_number
+                    && sha256 == part_sha256 =>
+                {
+                    manifest.push(BlobUploadPart {
+                        part_number,
+                        sha256: part_sha256,
+                        size: chunk.len() as u64,
+                    });
+                }
+                NotebookResponse::BlobUploadError { reason } => {
+                    return Err(SyncError::BlobUpload(reason));
+                }
+                other => {
+                    return Err(SyncError::Protocol(format!(
+                        "Unexpected response for PutBlob part: {other:?}"
+                    )));
+                }
+            }
+        }
+
+        match self
+            .send_request(NotebookRequest::CompleteBlobUpload {
+                upload_id,
+                parts: manifest,
+            })
+            .await?
+        {
+            NotebookResponse::BlobStored {
+                hash,
+                size,
+                media_type,
+            } => Ok(PutBlobResult {
+                blob: hash,
+                size,
+                media_type,
+            }),
+            NotebookResponse::BlobUploadError { reason } => Err(SyncError::BlobUpload(reason)),
+            other => Err(SyncError::Protocol(format!(
+                "Unexpected response for complete_blob_upload: {other:?}"
+            ))),
+        }
+    }
+
+    async fn send_put_blob_frame(
+        &self,
+        id: String,
+        frame: Vec<u8>,
+    ) -> Result<NotebookResponse, SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(RelayCommand::SendPutBlob {
+                id: id.clone(),
+                frame,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+
+        match tokio::time::timeout(PUT_BLOB_TIMEOUT, crate::reply::recv(reply_rx)).await {
+            Ok(reply) => reply,
+            Err(_) => {
+                let _ = self.cmd_tx.send(RelayCommand::CancelRequest { id }).await;
+                Err(SyncError::Timeout)
+            }
         }
     }
 

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -394,6 +394,32 @@ mod tests {
         (handle, daemon_read, daemon_write)
     }
 
+    async fn recv_request_for_test(
+        daemon_read: &mut tokio::io::ReadHalf<tokio::io::DuplexStream>,
+    ) -> NotebookRequestEnvelope {
+        let frame = connection::recv_typed_frame(daemon_read)
+            .await
+            .expect("read request frame")
+            .expect("request frame");
+        assert_eq!(frame.frame_type, NotebookFrameType::Request);
+        serde_json::from_slice(&frame.payload).expect("parse request")
+    }
+
+    async fn send_response_for_test(
+        daemon_write: &mut tokio::io::WriteHalf<tokio::io::DuplexStream>,
+        id: Option<String>,
+        response: NotebookResponse,
+    ) {
+        let envelope = NotebookResponseEnvelope { id, response };
+        connection::send_typed_frame(
+            daemon_write,
+            NotebookFrameType::Response,
+            &serde_json::to_vec(&envelope).unwrap(),
+        )
+        .await
+        .expect("send response");
+    }
+
     #[tokio::test]
     async fn relay_handle_put_blob_one_shot_routes_response_by_id() {
         let (handle, mut daemon_read, mut daemon_write) = spawn_relay_for_test().await;
@@ -618,5 +644,122 @@ mod tests {
                 media_type: "text/plain".to_string(),
             }
         );
+    }
+
+    #[tokio::test]
+    async fn relay_handle_put_blob_multipart_rejects_zero_part_size_and_aborts() {
+        let (handle, mut daemon_read, mut daemon_write) = spawn_relay_for_test().await;
+        let upload = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.put_blob_multipart(b"abcdef", "text/plain").await }
+        });
+
+        let create_envelope = recv_request_for_test(&mut daemon_read).await;
+        let create_id = create_envelope.id.clone().expect("create id");
+        match create_envelope.request {
+            NotebookRequest::CreateBlobUpload { .. } => {}
+            other => panic!("unexpected create request: {other:?}"),
+        }
+        send_response_for_test(
+            &mut daemon_write,
+            Some(create_id),
+            NotebookResponse::BlobUploadCreated {
+                upload_id: "upload-zero".to_string(),
+                part_size: 0,
+                expires_at: "2026-05-13T00:00:00Z".to_string(),
+            },
+        )
+        .await;
+
+        let abort_envelope = recv_request_for_test(&mut daemon_read).await;
+        let abort_id = abort_envelope.id.clone().expect("abort id");
+        match abort_envelope.request {
+            NotebookRequest::AbortBlobUpload { upload_id } => {
+                assert_eq!(upload_id, "upload-zero");
+            }
+            other => panic!("unexpected abort request: {other:?}"),
+        }
+        send_response_for_test(
+            &mut daemon_write,
+            Some(abort_id),
+            NotebookResponse::BlobUploadAborted {
+                upload_id: "upload-zero".to_string(),
+            },
+        )
+        .await;
+
+        let error = upload
+            .await
+            .expect("join upload")
+            .expect_err("upload returns protocol error");
+        match error {
+            SyncError::Protocol(message) => {
+                assert!(message.contains("part_size: 0"), "{message}");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn relay_handle_put_blob_multipart_aborts_after_part_error() {
+        let (handle, mut daemon_read, mut daemon_write) = spawn_relay_for_test().await;
+        let upload = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.put_blob_multipart(b"abcdef", "text/plain").await }
+        });
+
+        let create_envelope = recv_request_for_test(&mut daemon_read).await;
+        let create_id = create_envelope.id.clone().expect("create id");
+        send_response_for_test(
+            &mut daemon_write,
+            Some(create_id),
+            NotebookResponse::BlobUploadCreated {
+                upload_id: "upload-fail".to_string(),
+                part_size: 3,
+                expires_at: "2026-05-13T00:00:00Z".to_string(),
+            },
+        )
+        .await;
+
+        let part_frame = connection::recv_typed_frame(&mut daemon_read)
+            .await
+            .expect("read part frame")
+            .expect("part frame");
+        assert_eq!(part_frame.frame_type, NotebookFrameType::PutBlob);
+        let (part_header, _) = PutBlobHeader::try_parse(&part_frame.payload).expect("parse part");
+        send_response_for_test(
+            &mut daemon_write,
+            Some(part_header.id().to_string()),
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::PartHashMismatch,
+            },
+        )
+        .await;
+
+        let abort_envelope = recv_request_for_test(&mut daemon_read).await;
+        let abort_id = abort_envelope.id.clone().expect("abort id");
+        match abort_envelope.request {
+            NotebookRequest::AbortBlobUpload { upload_id } => {
+                assert_eq!(upload_id, "upload-fail");
+            }
+            other => panic!("unexpected abort request: {other:?}"),
+        }
+        send_response_for_test(
+            &mut daemon_write,
+            Some(abort_id),
+            NotebookResponse::BlobUploadAborted {
+                upload_id: "upload-fail".to_string(),
+            },
+        )
+        .await;
+
+        let error = upload
+            .await
+            .expect("join upload")
+            .expect_err("upload returns part error");
+        match error {
+            SyncError::BlobUpload(BlobUploadErrorKind::PartHashMismatch) => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -367,6 +367,7 @@ pub fn request_timeout(request: &NotebookRequest) -> Duration {
 mod tests {
     use super::*;
     use notebook_protocol::protocol::{BlobUploadErrorKind, PutBlobHeader, PutBlobResult};
+    use sha2::{Digest, Sha256};
 
     async fn spawn_relay_for_test() -> (
         crate::relay::RelayHandle,
@@ -424,6 +425,7 @@ mod tests {
                     "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
                 );
             }
+            PutBlobHeader::Part { .. } => panic!("expected one-shot PutBlob header"),
         }
 
         let response = NotebookResponseEnvelope {
@@ -482,5 +484,139 @@ mod tests {
             SyncError::BlobUpload(BlobUploadErrorKind::TooManyInFlight) => {}
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn relay_handle_put_blob_multipart_sequences_control_and_part_frames() {
+        let (handle, mut daemon_read, mut daemon_write) = spawn_relay_for_test().await;
+        let upload = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.put_blob_multipart(b"abcdef", "text/plain").await }
+        });
+
+        let create_frame = connection::recv_typed_frame(&mut daemon_read)
+            .await
+            .expect("read create request")
+            .expect("create request");
+        assert_eq!(create_frame.frame_type, NotebookFrameType::Request);
+        let create_envelope: NotebookRequestEnvelope =
+            serde_json::from_slice(&create_frame.payload).expect("parse create request");
+        let create_id = create_envelope.id.clone().expect("create id");
+        match create_envelope.request {
+            NotebookRequest::CreateBlobUpload {
+                media_type,
+                size,
+                part_size,
+                ..
+            } => {
+                assert_eq!(media_type, "text/plain");
+                assert_eq!(size, 6);
+                assert_eq!(part_size, None);
+            }
+            other => panic!("unexpected create request: {other:?}"),
+        }
+        let create_response = NotebookResponseEnvelope {
+            id: Some(create_id),
+            response: NotebookResponse::BlobUploadCreated {
+                upload_id: "upload-1".to_string(),
+                part_size: 3,
+                expires_at: "2026-05-13T00:00:00Z".to_string(),
+            },
+        };
+        connection::send_typed_frame(
+            &mut daemon_write,
+            NotebookFrameType::Response,
+            &serde_json::to_vec(&create_response).unwrap(),
+        )
+        .await
+        .expect("send create response");
+
+        for expected in [(1, b"abc".as_slice()), (2, b"def".as_slice())] {
+            let frame = connection::recv_typed_frame(&mut daemon_read)
+                .await
+                .expect("read part frame")
+                .expect("part frame");
+            assert_eq!(frame.frame_type, NotebookFrameType::PutBlob);
+            let (header, body) = PutBlobHeader::try_parse(&frame.payload).expect("parse part");
+            let (part_number, expected_body) = expected;
+            assert_eq!(body, expected_body);
+            let id = header.id().to_string();
+            let sha256 = hex::encode(Sha256::digest(expected_body));
+            match header {
+                PutBlobHeader::Part {
+                    upload_id,
+                    part_number: actual_part_number,
+                    size,
+                    sha256: header_sha256,
+                    ..
+                } => {
+                    assert_eq!(upload_id, "upload-1");
+                    assert_eq!(actual_part_number, part_number);
+                    assert_eq!(size, expected_body.len() as u64);
+                    assert_eq!(header_sha256, sha256);
+                }
+                PutBlobHeader::Put { .. } => panic!("expected multipart part header"),
+            }
+            let response = NotebookResponseEnvelope {
+                id: Some(id),
+                response: NotebookResponse::BlobPartStored {
+                    upload_id: "upload-1".to_string(),
+                    part_number,
+                    sha256,
+                },
+            };
+            connection::send_typed_frame(
+                &mut daemon_write,
+                NotebookFrameType::Response,
+                &serde_json::to_vec(&response).unwrap(),
+            )
+            .await
+            .expect("send part response");
+        }
+
+        let complete_frame = connection::recv_typed_frame(&mut daemon_read)
+            .await
+            .expect("read complete request")
+            .expect("complete request");
+        assert_eq!(complete_frame.frame_type, NotebookFrameType::Request);
+        let complete_envelope: NotebookRequestEnvelope =
+            serde_json::from_slice(&complete_frame.payload).expect("parse complete request");
+        let complete_id = complete_envelope.id.clone().expect("complete id");
+        match complete_envelope.request {
+            NotebookRequest::CompleteBlobUpload { upload_id, parts } => {
+                assert_eq!(upload_id, "upload-1");
+                assert_eq!(parts.len(), 2);
+                assert_eq!(parts[0].part_number, 1);
+                assert_eq!(parts[0].size, 3);
+                assert_eq!(parts[1].part_number, 2);
+                assert_eq!(parts[1].size, 3);
+            }
+            other => panic!("unexpected complete request: {other:?}"),
+        }
+        let complete_response = NotebookResponseEnvelope {
+            id: Some(complete_id),
+            response: NotebookResponse::BlobStored {
+                hash: "final-hash".to_string(),
+                size: 6,
+                media_type: "text/plain".to_string(),
+            },
+        };
+        connection::send_typed_frame(
+            &mut daemon_write,
+            NotebookFrameType::Response,
+            &serde_json::to_vec(&complete_response).unwrap(),
+        )
+        .await
+        .expect("send complete response");
+
+        let result = upload.await.expect("join upload").expect("upload succeeds");
+        assert_eq!(
+            result,
+            PutBlobResult {
+                blob: "final-hash".to_string(),
+                size: 6,
+                media_type: "text/plain".to_string(),
+            }
+        );
     }
 }

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -25,6 +25,7 @@ use chrono::{DateTime, Utc};
 use notebook_protocol::protocol::BlobDurability;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;
 use tracing::debug;
 
@@ -428,6 +429,143 @@ impl BlobStore {
         }
 
         Ok(durability)
+    }
+
+    /// Store a blob by streaming already-staged part files into the
+    /// content-addressed namespace.
+    ///
+    /// The caller supplies the expected final digest and byte count. The store
+    /// re-hashes while copying so a corrupt or mismatched staging manifest never
+    /// publishes a partial blob.
+    pub async fn put_part_files_with_hash(
+        &self,
+        parts: &[PathBuf],
+        media_type: &str,
+        expected_size: u64,
+        expected_hash: &str,
+        durability: BlobDurability,
+    ) -> io::Result<String> {
+        if !Self::validate_hash(expected_hash) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected multipart blob hash is not a valid sha256 hex digest",
+            ));
+        }
+
+        let created_at = Utc::now();
+        let (shard_dir, blob_path, meta_path) = self.paths(expected_hash);
+        let _lock = self.acquire_blob_file_lock(&shard_dir, &meta_path).await?;
+
+        if blob_path.exists() && meta_path.exists() {
+            if let Ok(existing_meta_json) = tokio::fs::read_to_string(&meta_path).await {
+                if let Ok(existing_meta) = serde_json::from_str::<BlobMeta>(&existing_meta_json) {
+                    let updated_durability =
+                        merged_durability(existing_meta.durability, durability);
+                    if existing_meta.media_type != media_type
+                        || existing_meta.durability != updated_durability
+                    {
+                        let updated = BlobMeta {
+                            media_type: media_type.to_string(),
+                            durability: updated_durability,
+                            ..existing_meta
+                        };
+                        if let Ok(json) = serde_json::to_string(&updated) {
+                            tokio::fs::write(&meta_path, json).await.ok();
+                        }
+                    }
+                    return Ok(expected_hash.to_string());
+                }
+            }
+            return Ok(expected_hash.to_string());
+        }
+
+        let tmp_blob = shard_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        let mut out = tokio::fs::File::create(&tmp_blob).await?;
+        let mut hasher = Sha256::new();
+        let mut total_size = 0_u64;
+        let mut buf = vec![0_u8; 64 * 1024];
+
+        for part_path in parts {
+            let mut input = tokio::fs::File::open(part_path).await?;
+            loop {
+                let read = input.read(&mut buf).await?;
+                if read == 0 {
+                    break;
+                }
+                total_size = total_size.checked_add(read as u64).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "multipart blob size overflow")
+                })?;
+                hasher.update(&buf[..read]);
+                out.write_all(&buf[..read]).await?;
+            }
+        }
+        out.flush().await?;
+        out.sync_all().await?;
+        drop(out);
+
+        if total_size != expected_size {
+            tokio::fs::remove_file(&tmp_blob).await.ok();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "final size mismatch: got {} bytes, expected {}",
+                    total_size, expected_size
+                ),
+            ));
+        }
+
+        let actual_hash = hex::encode(hasher.finalize());
+        if actual_hash != expected_hash {
+            tokio::fs::remove_file(&tmp_blob).await.ok();
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("final hash mismatch: got {actual_hash}, expected {expected_hash}"),
+            ));
+        }
+
+        let we_wrote_blob;
+        match tokio::fs::rename(&tmp_blob, &blob_path).await {
+            Ok(()) => {
+                we_wrote_blob = true;
+            }
+            Err(e) => {
+                tokio::fs::remove_file(&tmp_blob).await.ok();
+                if blob_path.exists() {
+                    we_wrote_blob = false;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+
+        let meta = BlobMeta {
+            media_type: media_type.to_string(),
+            size: expected_size,
+            created_at,
+            durability,
+        };
+        let meta_json = serde_json::to_string(&meta).map_err(io::Error::other)?;
+        let tmp_meta = shard_dir.join(format!(".tmp.{}.meta", uuid::Uuid::new_v4()));
+        match async {
+            tokio::fs::write(&tmp_meta, meta_json).await?;
+            tokio::fs::rename(&tmp_meta, &meta_path).await
+        }
+        .await
+        {
+            Ok(()) => {}
+            Err(e) => {
+                tokio::fs::remove_file(&tmp_meta).await.ok();
+                if meta_path.exists() {
+                    return Ok(expected_hash.to_string());
+                }
+                if we_wrote_blob {
+                    tokio::fs::remove_file(&blob_path).await.ok();
+                }
+                return Err(e);
+            }
+        }
+
+        Ok(expected_hash.to_string())
     }
 
     fn insert_memory(

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -1,11 +1,17 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use notebook_protocol::connection::NotebookFrameType;
 use notebook_protocol::protocol::{
-    BlobDurability, BlobUploadErrorKind, NotebookResponse, NotebookResponseEnvelope, PutBlobHeader,
+    BlobDurability, BlobUploadErrorKind, BlobUploadPart, NotebookRequest, NotebookResponse,
+    NotebookResponseEnvelope, PutBlobHeader,
 };
 use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
@@ -13,6 +19,112 @@ use super::peer_writer::PeerWriter;
 use crate::blob_store::BlobStore;
 
 const PUT_BLOB_QUEUE_CAPACITY: usize = 1;
+const DEFAULT_MULTIPART_PART_SIZE: u64 = 8 * 1024 * 1024;
+const MAX_MULTIPART_PART_SIZE: u64 = 32 * 1024 * 1024;
+const MAX_PEER_STAGED_BYTES: u64 = 256 * 1024 * 1024;
+const MULTIPART_UPLOAD_TTL: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Clone)]
+pub(super) struct MultipartUploadState {
+    inner: Arc<Mutex<MultipartUploadRegistry>>,
+}
+
+struct MultipartUploadRegistry {
+    uploads_root: PathBuf,
+    uploads: HashMap<String, UploadSession>,
+    staged_bytes: u64,
+    budget_bytes: u64,
+    ttl: Duration,
+}
+
+struct UploadSession {
+    upload_id: String,
+    media_type: String,
+    expected_size: u64,
+    expected_sha256: Option<String>,
+    part_size: u64,
+    expires_at: DateTime<Utc>,
+    dir: PathBuf,
+    parts: BTreeMap<u32, StagedPart>,
+    active_part: bool,
+    completing: bool,
+}
+
+#[derive(Clone)]
+struct StagedPart {
+    sha256: String,
+    size: u64,
+    path: PathBuf,
+}
+
+struct CompletionPlan {
+    upload_id: String,
+    media_type: String,
+    expected_size: u64,
+    expected_sha256: Option<String>,
+    part_paths: Vec<PathBuf>,
+    cleanup_dir: PathBuf,
+}
+
+impl Drop for MultipartUploadRegistry {
+    fn drop(&mut self) {
+        for upload in self.uploads.values() {
+            std::fs::remove_dir_all(&upload.dir).ok();
+        }
+    }
+}
+
+impl MultipartUploadState {
+    pub(super) fn new(blob_store: &BlobStore) -> Self {
+        Self::with_options(
+            blob_store.root().join("uploads"),
+            MAX_PEER_STAGED_BYTES,
+            MULTIPART_UPLOAD_TTL,
+        )
+    }
+
+    fn with_options(uploads_root: PathBuf, budget_bytes: u64, ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(MultipartUploadRegistry {
+                uploads_root,
+                uploads: HashMap::new(),
+                staged_bytes: 0,
+                budget_bytes,
+                ttl,
+            })),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, MultipartUploadRegistry> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn sweep_expired(&self) -> Vec<PathBuf> {
+        let now = Utc::now();
+        let mut registry = self.lock();
+        let expired = registry
+            .uploads
+            .iter()
+            .filter(|(_upload_id, upload)| upload.expires_at <= now)
+            .map(|(upload_id, _upload)| upload_id.clone())
+            .collect::<Vec<_>>();
+        expired
+            .into_iter()
+            .filter_map(|upload_id| registry.remove_upload(&upload_id).map(|upload| upload.dir))
+            .collect()
+    }
+}
+
+impl MultipartUploadRegistry {
+    fn remove_upload(&mut self, upload_id: &str) -> Option<UploadSession> {
+        let upload = self.uploads.remove(upload_id)?;
+        let upload_bytes = upload.parts.values().map(|part| part.size).sum::<u64>();
+        self.staged_bytes = self.staged_bytes.saturating_sub(upload_bytes);
+        Some(upload)
+    }
+}
 
 pub(super) struct PutBlobWorker {
     tx: mpsc::Sender<Vec<u8>>,
@@ -29,6 +141,7 @@ impl Drop for PutBlobWorker {
 pub(super) fn spawn_put_blob_worker(
     blob_store: Arc<BlobStore>,
     peer_writer: PeerWriter,
+    multipart_uploads: MultipartUploadState,
     notebook_id: String,
     peer_id: String,
 ) -> PutBlobWorker {
@@ -43,7 +156,9 @@ pub(super) fn spawn_put_blob_worker(
                 notebook_id,
                 payload.len()
             );
-            let result = handle_put_blob_frame(&payload, &blob_store, &peer_writer).await;
+            let result =
+                handle_put_blob_frame(&payload, &blob_store, &peer_writer, &multipart_uploads)
+                    .await;
             worker_in_flight.store(false, Ordering::Release);
             result?;
         }
@@ -97,6 +212,7 @@ pub(crate) async fn handle_put_blob_frame(
     payload: &[u8],
     blob_store: &Arc<BlobStore>,
     peer_writer: &PeerWriter,
+    multipart_uploads: &MultipartUploadState,
 ) -> anyhow::Result<()> {
     let (header, body) = match PutBlobHeader::try_parse(payload) {
         Ok(parsed) => parsed,
@@ -158,9 +274,508 @@ pub(crate) async fn handle_put_blob_frame(
                 }
             }
         }
+        PutBlobHeader::Part {
+            id,
+            upload_id,
+            part_number,
+            size,
+            sha256,
+        } => {
+            debug!(
+                "[notebook-sync] PutBlob part id={} upload_id={} part_number={} size={}",
+                id, upload_id, part_number, size
+            );
+            if body.len() as u64 != size {
+                send_blob_upload_error(
+                    peer_writer,
+                    Some(id),
+                    BlobUploadErrorKind::PartSizeMismatch,
+                )?;
+                return Ok(());
+            }
+
+            let actual_sha256 = hex::encode(Sha256::digest(body));
+            if actual_sha256 != sha256 {
+                send_blob_upload_error(
+                    peer_writer,
+                    Some(id),
+                    BlobUploadErrorKind::PartHashMismatch,
+                )?;
+                return Ok(());
+            }
+
+            match begin_part_upload(multipart_uploads, &upload_id, part_number, size, &sha256) {
+                PartBegin::Ready { path } => {
+                    if let Err(error) = write_staged_part(&path, body).await {
+                        warn!("[notebook-sync] PutBlob part write failed: {}", error);
+                        let _ = finish_part_upload(
+                            multipart_uploads,
+                            &upload_id,
+                            part_number,
+                            size,
+                            &sha256,
+                            path,
+                            false,
+                        );
+                        send_blob_upload_error(
+                            peer_writer,
+                            Some(id),
+                            BlobUploadErrorKind::Io {
+                                message: error.to_string(),
+                            },
+                        )?;
+                        return Ok(());
+                    }
+
+                    match finish_part_upload(
+                        multipart_uploads,
+                        &upload_id,
+                        part_number,
+                        size,
+                        &sha256,
+                        path,
+                        true,
+                    ) {
+                        Ok(()) => {
+                            send_blob_response(
+                                peer_writer,
+                                Some(id),
+                                NotebookResponse::BlobPartStored {
+                                    upload_id,
+                                    part_number,
+                                    sha256,
+                                },
+                            )?;
+                        }
+                        Err(reason) => {
+                            send_blob_upload_error(peer_writer, Some(id), reason)?;
+                        }
+                    }
+                }
+                PartBegin::AlreadyStored => {
+                    send_blob_response(
+                        peer_writer,
+                        Some(id),
+                        NotebookResponse::BlobPartStored {
+                            upload_id,
+                            part_number,
+                            sha256,
+                        },
+                    )?;
+                }
+                PartBegin::Error(reason) => {
+                    send_blob_upload_error(peer_writer, Some(id), reason)?;
+                }
+            }
+        }
     }
 
     Ok(())
+}
+
+pub(super) async fn maybe_handle_blob_upload_request(
+    multipart_uploads: &MultipartUploadState,
+    blob_store: &Arc<BlobStore>,
+    request: &NotebookRequest,
+) -> Option<NotebookResponse> {
+    match request {
+        NotebookRequest::CreateBlobUpload {
+            media_type,
+            size,
+            sha256,
+            part_size,
+            purpose,
+        } => Some(
+            handle_create_blob_upload(
+                multipart_uploads,
+                media_type.clone(),
+                *size,
+                sha256.clone(),
+                *part_size,
+                purpose.clone(),
+            )
+            .await,
+        ),
+        NotebookRequest::CompleteBlobUpload { upload_id, parts } => {
+            Some(handle_complete_blob_upload(multipart_uploads, blob_store, upload_id, parts).await)
+        }
+        NotebookRequest::AbortBlobUpload { upload_id } => {
+            Some(handle_abort_blob_upload(multipart_uploads, upload_id).await)
+        }
+        _ => None,
+    }
+}
+
+enum PartBegin {
+    Ready { path: PathBuf },
+    AlreadyStored,
+    Error(BlobUploadErrorKind),
+}
+
+async fn cleanup_upload_dirs(paths: Vec<PathBuf>) {
+    for path in paths {
+        tokio::fs::remove_dir_all(path).await.ok();
+    }
+}
+
+async fn handle_create_blob_upload(
+    multipart_uploads: &MultipartUploadState,
+    media_type: String,
+    size: u64,
+    sha256: Option<String>,
+    part_size: Option<u64>,
+    _purpose: Option<String>,
+) -> NotebookResponse {
+    cleanup_upload_dirs(multipart_uploads.sweep_expired()).await;
+
+    let part_size = part_size.unwrap_or(DEFAULT_MULTIPART_PART_SIZE);
+    if part_size == 0 || part_size > MAX_MULTIPART_PART_SIZE {
+        return NotebookResponse::BlobUploadError {
+            reason: BlobUploadErrorKind::OverCap,
+        };
+    }
+    if size > MAX_PEER_STAGED_BYTES {
+        return NotebookResponse::BlobUploadError {
+            reason: BlobUploadErrorKind::OverPeerBudget,
+        };
+    }
+    if sha256.as_deref().is_some_and(|hash| !is_sha256_hex(hash)) {
+        return NotebookResponse::BlobUploadError {
+            reason: BlobUploadErrorKind::FinalHashMismatch,
+        };
+    }
+
+    let upload_id = uuid::Uuid::new_v4().to_string();
+    let (dir, expires_at) = {
+        let mut registry = multipart_uploads.lock();
+        if !registry.uploads.is_empty()
+            || registry.staged_bytes.saturating_add(size) > registry.budget_bytes
+        {
+            return NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::OverPeerBudget,
+            };
+        }
+        let dir = registry.uploads_root.join(&upload_id);
+        let expires_at = Utc::now()
+            + chrono::Duration::from_std(registry.ttl)
+                .unwrap_or_else(|_| chrono::Duration::hours(1));
+        registry.uploads.insert(
+            upload_id.clone(),
+            UploadSession {
+                upload_id: upload_id.clone(),
+                media_type,
+                expected_size: size,
+                expected_sha256: sha256,
+                part_size,
+                expires_at,
+                dir: dir.clone(),
+                parts: BTreeMap::new(),
+                active_part: false,
+                completing: false,
+            },
+        );
+        (dir, expires_at)
+    };
+
+    if let Err(error) = tokio::fs::create_dir_all(&dir).await {
+        let mut registry = multipart_uploads.lock();
+        registry.remove_upload(&upload_id);
+        return NotebookResponse::BlobUploadError {
+            reason: BlobUploadErrorKind::Io {
+                message: error.to_string(),
+            },
+        };
+    }
+
+    NotebookResponse::BlobUploadCreated {
+        upload_id,
+        part_size,
+        expires_at: expires_at.to_rfc3339(),
+    }
+}
+
+fn begin_part_upload(
+    multipart_uploads: &MultipartUploadState,
+    upload_id: &str,
+    part_number: u32,
+    size: u64,
+    sha256: &str,
+) -> PartBegin {
+    let mut registry = multipart_uploads.lock();
+    let projected_staged_bytes = registry.staged_bytes.saturating_add(size);
+    let budget_bytes = registry.budget_bytes;
+    let Some(upload) = registry.uploads.get_mut(upload_id) else {
+        return PartBegin::Error(BlobUploadErrorKind::UnknownUpload);
+    };
+    if upload.expires_at <= Utc::now() {
+        let dir = registry.remove_upload(upload_id).map(|upload| upload.dir);
+        if let Some(dir) = dir {
+            std::fs::remove_dir_all(dir).ok();
+        }
+        return PartBegin::Error(BlobUploadErrorKind::SessionExpired);
+    }
+    if upload.active_part || upload.completing {
+        return PartBegin::Error(BlobUploadErrorKind::OverPeerBudget);
+    }
+    if size > upload.part_size {
+        return PartBegin::Error(BlobUploadErrorKind::PartSizeMismatch);
+    }
+    if let Some(existing) = upload.parts.get(&part_number) {
+        if existing.sha256 == sha256 && existing.size == size {
+            return PartBegin::AlreadyStored;
+        }
+        return PartBegin::Error(BlobUploadErrorKind::DuplicatePartConflict);
+    }
+    if projected_staged_bytes > budget_bytes {
+        return PartBegin::Error(BlobUploadErrorKind::OverPeerBudget);
+    }
+    upload.active_part = true;
+    PartBegin::Ready {
+        path: upload.dir.join(format!("{part_number}.part")),
+    }
+}
+
+fn is_sha256_hex(hash: &str) -> bool {
+    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn finish_part_upload(
+    multipart_uploads: &MultipartUploadState,
+    upload_id: &str,
+    part_number: u32,
+    size: u64,
+    sha256: &str,
+    path: PathBuf,
+    write_succeeded: bool,
+) -> Result<(), BlobUploadErrorKind> {
+    let mut registry = multipart_uploads.lock();
+    let Some(upload) = registry.uploads.get_mut(upload_id) else {
+        std::fs::remove_file(path).ok();
+        return Err(BlobUploadErrorKind::UnknownUpload);
+    };
+    upload.active_part = false;
+    if !write_succeeded {
+        return Ok(());
+    }
+    if let Some(existing) = upload.parts.get(&part_number) {
+        if existing.sha256 == sha256 && existing.size == size {
+            return Ok(());
+        }
+        std::fs::remove_file(path).ok();
+        return Err(BlobUploadErrorKind::DuplicatePartConflict);
+    }
+
+    upload.parts.insert(
+        part_number,
+        StagedPart {
+            sha256: sha256.to_string(),
+            size,
+            path,
+        },
+    );
+    registry.staged_bytes = registry.staged_bytes.saturating_add(size);
+    Ok(())
+}
+
+async fn write_staged_part(path: &PathBuf, body: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp_path = path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+    match async {
+        tokio::fs::write(&tmp_path, body).await?;
+        tokio::fs::rename(&tmp_path, path).await
+    }
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            tokio::fs::remove_file(&tmp_path).await.ok();
+            Err(error)
+        }
+    }
+}
+
+async fn handle_complete_blob_upload(
+    multipart_uploads: &MultipartUploadState,
+    blob_store: &Arc<BlobStore>,
+    upload_id: &str,
+    parts: &[BlobUploadPart],
+) -> NotebookResponse {
+    cleanup_upload_dirs(multipart_uploads.sweep_expired()).await;
+    let mut plan = match prepare_completion(multipart_uploads, upload_id, parts) {
+        Ok(plan) => plan,
+        Err(reason) => {
+            return NotebookResponse::BlobUploadError { reason };
+        }
+    };
+
+    let final_hash = match plan.expected_sha256.take() {
+        Some(hash) => hash,
+        None => match hash_part_files(&plan.part_paths).await {
+            Ok((hash, size)) if size == plan.expected_size => hash,
+            Ok((_hash, _size)) => {
+                clear_completing(multipart_uploads, &plan.upload_id);
+                return NotebookResponse::BlobUploadError {
+                    reason: BlobUploadErrorKind::ManifestMismatch,
+                };
+            }
+            Err(error) => {
+                clear_completing(multipart_uploads, &plan.upload_id);
+                return NotebookResponse::BlobUploadError {
+                    reason: BlobUploadErrorKind::Io {
+                        message: error.to_string(),
+                    },
+                };
+            }
+        },
+    };
+
+    match blob_store
+        .put_part_files_with_hash(
+            &plan.part_paths,
+            &plan.media_type,
+            plan.expected_size,
+            &final_hash,
+            BlobDurability::Durable,
+        )
+        .await
+    {
+        Ok(hash) => {
+            finish_completion(multipart_uploads, &plan.upload_id);
+            tokio::fs::remove_dir_all(&plan.cleanup_dir).await.ok();
+            NotebookResponse::BlobStored {
+                hash,
+                size: plan.expected_size,
+                media_type: plan.media_type,
+            }
+        }
+        Err(error) => {
+            clear_completing(multipart_uploads, &plan.upload_id);
+            let message = error.to_string();
+            let reason = if message.contains("final hash mismatch") {
+                BlobUploadErrorKind::FinalHashMismatch
+            } else if message.contains("final size mismatch") {
+                BlobUploadErrorKind::ManifestMismatch
+            } else {
+                BlobUploadErrorKind::Io { message }
+            };
+            NotebookResponse::BlobUploadError { reason }
+        }
+    }
+}
+
+fn prepare_completion(
+    multipart_uploads: &MultipartUploadState,
+    upload_id: &str,
+    manifest: &[BlobUploadPart],
+) -> Result<CompletionPlan, BlobUploadErrorKind> {
+    let mut registry = multipart_uploads.lock();
+    let Some(upload) = registry.uploads.get_mut(upload_id) else {
+        return Err(BlobUploadErrorKind::UnknownUpload);
+    };
+    if upload.expires_at <= Utc::now() {
+        let dir = registry.remove_upload(upload_id).map(|upload| upload.dir);
+        if let Some(dir) = dir {
+            std::fs::remove_dir_all(dir).ok();
+        }
+        return Err(BlobUploadErrorKind::SessionExpired);
+    }
+    if upload.active_part || upload.completing {
+        return Err(BlobUploadErrorKind::OverPeerBudget);
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut total_size = 0_u64;
+    let mut part_paths = Vec::with_capacity(manifest.len());
+    for manifest_part in manifest {
+        if !seen.insert(manifest_part.part_number) {
+            return Err(BlobUploadErrorKind::ManifestMismatch);
+        }
+        let Some(staged) = upload.parts.get(&manifest_part.part_number) else {
+            return Err(BlobUploadErrorKind::ManifestMismatch);
+        };
+        if staged.sha256 != manifest_part.sha256 || staged.size != manifest_part.size {
+            return Err(BlobUploadErrorKind::ManifestMismatch);
+        }
+        total_size = total_size
+            .checked_add(staged.size)
+            .ok_or(BlobUploadErrorKind::ManifestMismatch)?;
+        part_paths.push(staged.path.clone());
+    }
+    if total_size != upload.expected_size {
+        return Err(BlobUploadErrorKind::ManifestMismatch);
+    }
+    if upload.parts.len() != manifest.len() {
+        return Err(BlobUploadErrorKind::ManifestMismatch);
+    }
+
+    upload.completing = true;
+    Ok(CompletionPlan {
+        upload_id: upload.upload_id.clone(),
+        media_type: upload.media_type.clone(),
+        expected_size: upload.expected_size,
+        expected_sha256: upload.expected_sha256.clone(),
+        part_paths,
+        cleanup_dir: upload.dir.clone(),
+    })
+}
+
+fn finish_completion(multipart_uploads: &MultipartUploadState, upload_id: &str) {
+    let mut registry = multipart_uploads.lock();
+    registry.remove_upload(upload_id);
+}
+
+fn clear_completing(multipart_uploads: &MultipartUploadState, upload_id: &str) {
+    let mut registry = multipart_uploads.lock();
+    if let Some(upload) = registry.uploads.get_mut(upload_id) {
+        upload.completing = false;
+    }
+}
+
+async fn hash_part_files(paths: &[PathBuf]) -> std::io::Result<(String, u64)> {
+    let mut hasher = Sha256::new();
+    let mut total_size = 0_u64;
+    let mut buf = vec![0_u8; 64 * 1024];
+    for path in paths {
+        let mut file = tokio::fs::File::open(path).await?;
+        loop {
+            let read = file.read(&mut buf).await?;
+            if read == 0 {
+                break;
+            }
+            total_size = total_size.checked_add(read as u64).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "multipart blob size overflow",
+                )
+            })?;
+            hasher.update(&buf[..read]);
+        }
+    }
+    Ok((hex::encode(hasher.finalize()), total_size))
+}
+
+async fn handle_abort_blob_upload(
+    multipart_uploads: &MultipartUploadState,
+    upload_id: &str,
+) -> NotebookResponse {
+    cleanup_upload_dirs(multipart_uploads.sweep_expired()).await;
+    let dir = {
+        let mut registry = multipart_uploads.lock();
+        match registry.remove_upload(upload_id) {
+            Some(upload) => upload.dir,
+            None => {
+                return NotebookResponse::BlobUploadError {
+                    reason: BlobUploadErrorKind::UnknownUpload,
+                };
+            }
+        }
+    };
+    tokio::fs::remove_dir_all(dir).await.ok();
+    NotebookResponse::BlobUploadAborted {
+        upload_id: upload_id.to_string(),
+    }
 }
 
 fn send_blob_upload_error(
@@ -238,6 +853,66 @@ mod tests {
         payload
     }
 
+    fn part_payload(
+        id: &str,
+        upload_id: &str,
+        part_number: u32,
+        sha256: &str,
+        body: &[u8],
+    ) -> Vec<u8> {
+        PutBlobHeader::Part {
+            id: id.to_string(),
+            upload_id: upload_id.to_string(),
+            part_number,
+            size: body.len() as u64,
+            sha256: sha256.to_string(),
+        }
+        .encode_frame(body)
+        .expect("part frame encodes")
+    }
+
+    async fn create_upload(
+        state: &MultipartUploadState,
+        blob_store: &Arc<BlobStore>,
+        body: &[u8],
+        part_size: Option<u64>,
+    ) -> String {
+        let response = handle_create_blob_upload(
+            state,
+            "application/octet-stream".to_string(),
+            body.len() as u64,
+            Some(hex::encode(Sha256::digest(body))),
+            part_size,
+            None,
+        )
+        .await;
+        match response {
+            NotebookResponse::BlobUploadCreated { upload_id, .. } => {
+                assert!(!blob_store.exists(&hex::encode(Sha256::digest(body))));
+                upload_id
+            }
+            other => panic!("unexpected create response: {other:?}"),
+        }
+    }
+
+    async fn run_part_handler(
+        blob_store: &Arc<BlobStore>,
+        state: &MultipartUploadState,
+        payload: &[u8],
+    ) -> NotebookResponseEnvelope {
+        let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
+        let (peer_writer, _writer_task) =
+            super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+        handle_put_blob_frame(payload, blob_store, &peer_writer, state)
+            .await
+            .expect("part handler succeeds");
+        let frame = connection::recv_typed_frame(&mut reader)
+            .await
+            .expect("frame read succeeds")
+            .expect("response frame");
+        serde_json::from_slice(&frame.payload).expect("response envelope")
+    }
+
     fn disk_blob_exists(store: &BlobStore, hash: &str) -> bool {
         let shard_dir = store.root().join(&hash[..2]);
         let rest = &hash[2..];
@@ -259,8 +934,9 @@ mod tests {
         let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
         let (peer_writer, writer_task) =
             super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+        let multipart_uploads = MultipartUploadState::new(&blob_store);
 
-        handle_put_blob_frame(payload, &blob_store, &peer_writer)
+        handle_put_blob_frame(payload, &blob_store, &peer_writer, &multipart_uploads)
             .await
             .expect("handler succeeds");
 
@@ -393,16 +1069,27 @@ mod tests {
         let (mut reader, writer) = tokio::io::duplex(1024 * 1024);
         let (peer_writer, _writer_task) =
             super::super::peer_writer::spawn_peer_writer(writer, "notebook".into(), "peer".into());
+        let multipart_uploads = MultipartUploadState::new(&blob_store);
         let body = b"abc";
         let sha256 = hex::encode(Sha256::digest(body));
         let request_payload = payload("blob-repeat", "text/plain", 3, &sha256, body);
 
-        handle_put_blob_frame(&request_payload, &blob_store, &peer_writer)
-            .await
-            .unwrap();
-        handle_put_blob_frame(&request_payload, &blob_store, &peer_writer)
-            .await
-            .unwrap();
+        handle_put_blob_frame(
+            &request_payload,
+            &blob_store,
+            &peer_writer,
+            &multipart_uploads,
+        )
+        .await
+        .unwrap();
+        handle_put_blob_frame(
+            &request_payload,
+            &blob_store,
+            &peer_writer,
+            &multipart_uploads,
+        )
+        .await
+        .unwrap();
 
         for _ in 0..2 {
             let frame = connection::recv_typed_frame(&mut reader)
@@ -440,10 +1127,22 @@ mod tests {
         let (mut reader_b, writer_b) = tokio::io::duplex(1024 * 1024);
         let (peer_writer_b, _task_b) =
             super::super::peer_writer::spawn_peer_writer(writer_b, "notebook".into(), "b".into());
+        let multipart_uploads_a = MultipartUploadState::new(&blob_store);
+        let multipart_uploads_b = MultipartUploadState::new(&blob_store);
 
         let (result_a, result_b) = tokio::join!(
-            handle_put_blob_frame(&payload_a, &blob_store, &peer_writer_a),
-            handle_put_blob_frame(&payload_b, &blob_store, &peer_writer_b)
+            handle_put_blob_frame(
+                &payload_a,
+                &blob_store,
+                &peer_writer_a,
+                &multipart_uploads_a
+            ),
+            handle_put_blob_frame(
+                &payload_b,
+                &blob_store,
+                &peer_writer_b,
+                &multipart_uploads_b
+            )
         );
         result_a.unwrap();
         result_b.unwrap();
@@ -511,6 +1210,256 @@ mod tests {
             envelope.response,
             NotebookResponse::BlobUploadError {
                 reason: BlobUploadErrorKind::TooManyInFlight
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_upload_success_publishes_only_on_complete() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let state = MultipartUploadState::new(&blob_store);
+        let body = b"abcdef";
+        let final_hash = hex::encode(Sha256::digest(body));
+        let upload_id = create_upload(&state, &blob_store, body, Some(3)).await;
+
+        let first_hash = hex::encode(Sha256::digest(b"abc"));
+        let first = part_payload("part-1", &upload_id, 1, &first_hash, b"abc");
+        let first_response = run_part_handler(&blob_store, &state, &first).await;
+        assert!(matches!(
+            first_response.response,
+            NotebookResponse::BlobPartStored { part_number: 1, .. }
+        ));
+        assert!(!blob_store.exists(&final_hash));
+
+        let second_hash = hex::encode(Sha256::digest(b"def"));
+        let second = part_payload("part-2", &upload_id, 2, &second_hash, b"def");
+        let second_response = run_part_handler(&blob_store, &state, &second).await;
+        assert!(matches!(
+            second_response.response,
+            NotebookResponse::BlobPartStored { part_number: 2, .. }
+        ));
+
+        let response = handle_complete_blob_upload(
+            &state,
+            &blob_store,
+            &upload_id,
+            &[
+                BlobUploadPart {
+                    part_number: 1,
+                    sha256: first_hash,
+                    size: 3,
+                },
+                BlobUploadPart {
+                    part_number: 2,
+                    sha256: second_hash,
+                    size: 3,
+                },
+            ],
+        )
+        .await;
+        match response {
+            NotebookResponse::BlobStored { hash, size, .. } => {
+                assert_eq!(hash, final_hash);
+                assert_eq!(size, 6);
+                assert_eq!(
+                    blob_store.get(&hash).await.unwrap().as_deref(),
+                    Some(&body[..])
+                );
+            }
+            other => panic!("unexpected complete response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn multipart_part_reput_is_idempotent_but_conflict_is_rejected() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let state = MultipartUploadState::new(&blob_store);
+        let upload_id = create_upload(&state, &blob_store, b"abc", Some(3)).await;
+        let sha256 = hex::encode(Sha256::digest(b"abc"));
+        let request = part_payload("part-1", &upload_id, 1, &sha256, b"abc");
+
+        let first = run_part_handler(&blob_store, &state, &request).await;
+        let second = run_part_handler(&blob_store, &state, &request).await;
+        assert!(matches!(
+            first.response,
+            NotebookResponse::BlobPartStored { part_number: 1, .. }
+        ));
+        assert!(matches!(
+            second.response,
+            NotebookResponse::BlobPartStored { part_number: 1, .. }
+        ));
+
+        let conflict_hash = hex::encode(Sha256::digest(b"abd"));
+        let conflict = part_payload("part-conflict", &upload_id, 1, &conflict_hash, b"abd");
+        let conflict_response = run_part_handler(&blob_store, &state, &conflict).await;
+        assert!(matches!(
+            conflict_response.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::DuplicatePartConflict
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_complete_rejects_manifest_mismatch_without_publishing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let state = MultipartUploadState::new(&blob_store);
+        let body = b"abcdef";
+        let final_hash = hex::encode(Sha256::digest(body));
+        let upload_id = create_upload(&state, &blob_store, body, Some(3)).await;
+        let first_hash = hex::encode(Sha256::digest(b"abc"));
+        let first = part_payload("part-1", &upload_id, 1, &first_hash, b"abc");
+        run_part_handler(&blob_store, &state, &first).await;
+
+        let response = handle_complete_blob_upload(
+            &state,
+            &blob_store,
+            &upload_id,
+            &[BlobUploadPart {
+                part_number: 1,
+                sha256: first_hash,
+                size: 3,
+            }],
+        )
+        .await;
+        assert!(matches!(
+            response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::ManifestMismatch
+            }
+        ));
+        assert!(!blob_store.exists(&final_hash));
+    }
+
+    #[tokio::test]
+    async fn multipart_complete_rejects_final_hash_mismatch_without_publishing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let state = MultipartUploadState::new(&blob_store);
+        let body = b"abc";
+        let actual_hash = hex::encode(Sha256::digest(body));
+        let wrong_final_hash = "0".repeat(64);
+        let response = handle_create_blob_upload(
+            &state,
+            "application/octet-stream".to_string(),
+            body.len() as u64,
+            Some(wrong_final_hash.clone()),
+            Some(3),
+            None,
+        )
+        .await;
+        let upload_id = match response {
+            NotebookResponse::BlobUploadCreated { upload_id, .. } => upload_id,
+            other => panic!("unexpected create response: {other:?}"),
+        };
+
+        let part = part_payload("part-1", &upload_id, 1, &actual_hash, body);
+        run_part_handler(&blob_store, &state, &part).await;
+        let response = handle_complete_blob_upload(
+            &state,
+            &blob_store,
+            &upload_id,
+            &[BlobUploadPart {
+                part_number: 1,
+                sha256: actual_hash.clone(),
+                size: 3,
+            }],
+        )
+        .await;
+        assert!(matches!(
+            response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::FinalHashMismatch
+            }
+        ));
+        assert!(!blob_store.exists(&actual_hash));
+        assert!(!blob_store.exists(&wrong_final_hash));
+    }
+
+    #[tokio::test]
+    async fn multipart_abort_removes_upload_and_later_parts_are_unknown() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let state = MultipartUploadState::new(&blob_store);
+        let upload_id = create_upload(&state, &blob_store, b"abc", Some(3)).await;
+
+        let abort = handle_abort_blob_upload(&state, &upload_id).await;
+        assert!(matches!(
+            abort,
+            NotebookResponse::BlobUploadAborted { upload_id: ref id } if id == &upload_id
+        ));
+
+        let sha256 = hex::encode(Sha256::digest(b"abc"));
+        let request = part_payload("part-after-abort", &upload_id, 1, &sha256, b"abc");
+        let response = run_part_handler(&blob_store, &state, &request).await;
+        assert!(matches!(
+            response.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::UnknownUpload
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_upload_ids_are_peer_scoped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let peer_a = MultipartUploadState::new(&blob_store);
+        let peer_b = MultipartUploadState::new(&blob_store);
+        let upload_id = create_upload(&peer_a, &blob_store, b"abc", Some(3)).await;
+
+        let sha256 = hex::encode(Sha256::digest(b"abc"));
+        let request = part_payload("part-cross-peer", &upload_id, 1, &sha256, b"abc");
+        let response = run_part_handler(&blob_store, &peer_b, &request).await;
+        assert!(matches!(
+            response.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::UnknownUpload
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn multipart_budget_and_expiry_are_enforced() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let small_budget = MultipartUploadState::with_options(
+            tmp.path().join("budget-uploads"),
+            2,
+            MULTIPART_UPLOAD_TTL,
+        );
+        let over_budget = handle_create_blob_upload(
+            &small_budget,
+            "application/octet-stream".to_string(),
+            3,
+            Some(hex::encode(Sha256::digest(b"abc"))),
+            Some(3),
+            None,
+        )
+        .await;
+        assert!(matches!(
+            over_budget,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::OverPeerBudget
+            }
+        ));
+
+        let expired = MultipartUploadState::with_options(
+            tmp.path().join("expired-uploads"),
+            MAX_PEER_STAGED_BYTES,
+            Duration::ZERO,
+        );
+        let upload_id = create_upload(&expired, &blob_store, b"abc", Some(3)).await;
+        let sha256 = hex::encode(Sha256::digest(b"abc"));
+        let request = part_payload("part-expired", &upload_id, 1, &sha256, b"abc");
+        let response = run_part_handler(&blob_store, &expired, &request).await;
+        assert!(matches!(
+            response.response,
+            NotebookResponse::BlobUploadError {
+                reason: BlobUploadErrorKind::SessionExpired
             }
         ));
     }

--- a/crates/runtimed/src/notebook_sync_server/blob_upload.rs
+++ b/crates/runtimed/src/notebook_sync_server/blob_upload.rs
@@ -308,7 +308,7 @@ pub(crate) async fn handle_put_blob_frame(
                 PartBegin::Ready { path } => {
                     if let Err(error) = write_staged_part(&path, body).await {
                         warn!("[notebook-sync] PutBlob part write failed: {}", error);
-                        let _ = finish_part_upload(
+                        if let PartFinish::Error { cleanup_file, .. } = finish_part_upload(
                             multipart_uploads,
                             &upload_id,
                             part_number,
@@ -316,7 +316,9 @@ pub(crate) async fn handle_put_blob_frame(
                             &sha256,
                             path,
                             false,
-                        );
+                        ) {
+                            cleanup_upload_file(cleanup_file).await;
+                        }
                         send_blob_upload_error(
                             peer_writer,
                             Some(id),
@@ -336,7 +338,7 @@ pub(crate) async fn handle_put_blob_frame(
                         path,
                         true,
                     ) {
-                        Ok(()) => {
+                        PartFinish::Stored => {
                             send_blob_response(
                                 peer_writer,
                                 Some(id),
@@ -347,7 +349,11 @@ pub(crate) async fn handle_put_blob_frame(
                                 },
                             )?;
                         }
-                        Err(reason) => {
+                        PartFinish::Error {
+                            reason,
+                            cleanup_file,
+                        } => {
+                            cleanup_upload_file(cleanup_file).await;
                             send_blob_upload_error(peer_writer, Some(id), reason)?;
                         }
                     }
@@ -363,7 +369,11 @@ pub(crate) async fn handle_put_blob_frame(
                         },
                     )?;
                 }
-                PartBegin::Error(reason) => {
+                PartBegin::Error {
+                    reason,
+                    cleanup_dir,
+                } => {
+                    cleanup_upload_dir(cleanup_dir).await;
                     send_blob_upload_error(peer_writer, Some(id), reason)?;
                 }
             }
@@ -407,14 +417,44 @@ pub(super) async fn maybe_handle_blob_upload_request(
 }
 
 enum PartBegin {
-    Ready { path: PathBuf },
+    Ready {
+        path: PathBuf,
+    },
     AlreadyStored,
-    Error(BlobUploadErrorKind),
+    Error {
+        reason: BlobUploadErrorKind,
+        cleanup_dir: Option<PathBuf>,
+    },
+}
+
+enum PartFinish {
+    Stored,
+    Error {
+        reason: BlobUploadErrorKind,
+        cleanup_file: Option<PathBuf>,
+    },
+}
+
+struct CompletionError {
+    reason: BlobUploadErrorKind,
+    cleanup_dir: Option<PathBuf>,
 }
 
 async fn cleanup_upload_dirs(paths: Vec<PathBuf>) {
     for path in paths {
         tokio::fs::remove_dir_all(path).await.ok();
+    }
+}
+
+async fn cleanup_upload_dir(path: Option<PathBuf>) {
+    if let Some(path) = path {
+        tokio::fs::remove_dir_all(path).await.ok();
+    }
+}
+
+async fn cleanup_upload_file(path: Option<PathBuf>) {
+    if let Some(path) = path {
+        tokio::fs::remove_file(path).await.ok();
     }
 }
 
@@ -505,29 +545,44 @@ fn begin_part_upload(
     let projected_staged_bytes = registry.staged_bytes.saturating_add(size);
     let budget_bytes = registry.budget_bytes;
     let Some(upload) = registry.uploads.get_mut(upload_id) else {
-        return PartBegin::Error(BlobUploadErrorKind::UnknownUpload);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::UnknownUpload,
+            cleanup_dir: None,
+        };
     };
     if upload.expires_at <= Utc::now() {
         let dir = registry.remove_upload(upload_id).map(|upload| upload.dir);
-        if let Some(dir) = dir {
-            std::fs::remove_dir_all(dir).ok();
-        }
-        return PartBegin::Error(BlobUploadErrorKind::SessionExpired);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::SessionExpired,
+            cleanup_dir: dir,
+        };
     }
     if upload.active_part || upload.completing {
-        return PartBegin::Error(BlobUploadErrorKind::OverPeerBudget);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::OverPeerBudget,
+            cleanup_dir: None,
+        };
     }
     if size > upload.part_size {
-        return PartBegin::Error(BlobUploadErrorKind::PartSizeMismatch);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::PartSizeMismatch,
+            cleanup_dir: None,
+        };
     }
     if let Some(existing) = upload.parts.get(&part_number) {
         if existing.sha256 == sha256 && existing.size == size {
             return PartBegin::AlreadyStored;
         }
-        return PartBegin::Error(BlobUploadErrorKind::DuplicatePartConflict);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::DuplicatePartConflict,
+            cleanup_dir: None,
+        };
     }
     if projected_staged_bytes > budget_bytes {
-        return PartBegin::Error(BlobUploadErrorKind::OverPeerBudget);
+        return PartBegin::Error {
+            reason: BlobUploadErrorKind::OverPeerBudget,
+            cleanup_dir: None,
+        };
     }
     upload.active_part = true;
     PartBegin::Ready {
@@ -547,22 +602,26 @@ fn finish_part_upload(
     sha256: &str,
     path: PathBuf,
     write_succeeded: bool,
-) -> Result<(), BlobUploadErrorKind> {
+) -> PartFinish {
     let mut registry = multipart_uploads.lock();
     let Some(upload) = registry.uploads.get_mut(upload_id) else {
-        std::fs::remove_file(path).ok();
-        return Err(BlobUploadErrorKind::UnknownUpload);
+        return PartFinish::Error {
+            reason: BlobUploadErrorKind::UnknownUpload,
+            cleanup_file: Some(path),
+        };
     };
     upload.active_part = false;
     if !write_succeeded {
-        return Ok(());
+        return PartFinish::Stored;
     }
     if let Some(existing) = upload.parts.get(&part_number) {
         if existing.sha256 == sha256 && existing.size == size {
-            return Ok(());
+            return PartFinish::Stored;
         }
-        std::fs::remove_file(path).ok();
-        return Err(BlobUploadErrorKind::DuplicatePartConflict);
+        return PartFinish::Error {
+            reason: BlobUploadErrorKind::DuplicatePartConflict,
+            cleanup_file: Some(path),
+        };
     }
 
     upload.parts.insert(
@@ -574,7 +633,7 @@ fn finish_part_upload(
         },
     );
     registry.staged_bytes = registry.staged_bytes.saturating_add(size);
-    Ok(())
+    PartFinish::Stored
 }
 
 async fn write_staged_part(path: &PathBuf, body: &[u8]) -> std::io::Result<()> {
@@ -605,8 +664,11 @@ async fn handle_complete_blob_upload(
     cleanup_upload_dirs(multipart_uploads.sweep_expired()).await;
     let mut plan = match prepare_completion(multipart_uploads, upload_id, parts) {
         Ok(plan) => plan,
-        Err(reason) => {
-            return NotebookResponse::BlobUploadError { reason };
+        Err(error) => {
+            cleanup_upload_dir(error.cleanup_dir).await;
+            return NotebookResponse::BlobUploadError {
+                reason: error.reason,
+            };
         }
     };
 
@@ -669,20 +731,26 @@ fn prepare_completion(
     multipart_uploads: &MultipartUploadState,
     upload_id: &str,
     manifest: &[BlobUploadPart],
-) -> Result<CompletionPlan, BlobUploadErrorKind> {
+) -> Result<CompletionPlan, CompletionError> {
     let mut registry = multipart_uploads.lock();
     let Some(upload) = registry.uploads.get_mut(upload_id) else {
-        return Err(BlobUploadErrorKind::UnknownUpload);
+        return Err(CompletionError {
+            reason: BlobUploadErrorKind::UnknownUpload,
+            cleanup_dir: None,
+        });
     };
     if upload.expires_at <= Utc::now() {
         let dir = registry.remove_upload(upload_id).map(|upload| upload.dir);
-        if let Some(dir) = dir {
-            std::fs::remove_dir_all(dir).ok();
-        }
-        return Err(BlobUploadErrorKind::SessionExpired);
+        return Err(CompletionError {
+            reason: BlobUploadErrorKind::SessionExpired,
+            cleanup_dir: dir,
+        });
     }
     if upload.active_part || upload.completing {
-        return Err(BlobUploadErrorKind::OverPeerBudget);
+        return Err(CompletionError {
+            reason: BlobUploadErrorKind::OverPeerBudget,
+            cleanup_dir: None,
+        });
     }
 
     let mut seen = BTreeSet::new();
@@ -690,24 +758,40 @@ fn prepare_completion(
     let mut part_paths = Vec::with_capacity(manifest.len());
     for manifest_part in manifest {
         if !seen.insert(manifest_part.part_number) {
-            return Err(BlobUploadErrorKind::ManifestMismatch);
+            return Err(CompletionError {
+                reason: BlobUploadErrorKind::ManifestMismatch,
+                cleanup_dir: None,
+            });
         }
         let Some(staged) = upload.parts.get(&manifest_part.part_number) else {
-            return Err(BlobUploadErrorKind::ManifestMismatch);
+            return Err(CompletionError {
+                reason: BlobUploadErrorKind::ManifestMismatch,
+                cleanup_dir: None,
+            });
         };
         if staged.sha256 != manifest_part.sha256 || staged.size != manifest_part.size {
-            return Err(BlobUploadErrorKind::ManifestMismatch);
+            return Err(CompletionError {
+                reason: BlobUploadErrorKind::ManifestMismatch,
+                cleanup_dir: None,
+            });
         }
-        total_size = total_size
-            .checked_add(staged.size)
-            .ok_or(BlobUploadErrorKind::ManifestMismatch)?;
+        total_size = total_size.checked_add(staged.size).ok_or(CompletionError {
+            reason: BlobUploadErrorKind::ManifestMismatch,
+            cleanup_dir: None,
+        })?;
         part_paths.push(staged.path.clone());
     }
     if total_size != upload.expected_size {
-        return Err(BlobUploadErrorKind::ManifestMismatch);
+        return Err(CompletionError {
+            reason: BlobUploadErrorKind::ManifestMismatch,
+            cleanup_dir: None,
+        });
     }
     if upload.parts.len() != manifest.len() {
-        return Err(BlobUploadErrorKind::ManifestMismatch);
+        return Err(CompletionError {
+            reason: BlobUploadErrorKind::ManifestMismatch,
+            cleanup_dir: None,
+        });
     }
 
     upload.completing = true;

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -1,4 +1,4 @@
-use super::blob_upload::{enqueue_put_blob, spawn_put_blob_worker};
+use super::blob_upload::{enqueue_put_blob, spawn_put_blob_worker, MultipartUploadState};
 use super::peer_notebook_sync::{
     finish_notebook_doc_frame, forward_notebook_doc_broadcast, handle_notebook_doc_frame,
     queue_doc_sync, NotebookDocFrameOutcome,
@@ -140,16 +140,19 @@ where
     // client is temporarily slow to read daemon frames.
     let (peer_writer, mut writer_task) =
         spawn_peer_writer(writer, notebook_id.clone(), peer_id.to_string());
+    let multipart_uploads = MultipartUploadState::new(&room.blob_store);
     let mut request_worker = spawn_peer_request_worker(
         room.clone(),
         daemon.clone(),
         peer_writer.clone(),
+        multipart_uploads.clone(),
         notebook_id.clone(),
         peer_id.to_string(),
     );
     let mut put_blob_worker = spawn_put_blob_worker(
         room.blob_store.clone(),
         peer_writer.clone(),
+        multipart_uploads,
         notebook_id.clone(),
         peer_id.to_string(),
     );

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -7,6 +7,7 @@ use tracing::{debug, warn};
 
 use notebook_protocol::connection::{self, NotebookFrameType};
 
+use super::blob_upload::{maybe_handle_blob_upload_request, MultipartUploadState};
 use super::NotebookRoom;
 use crate::requests::{handle_notebook_request, request_label};
 
@@ -145,6 +146,7 @@ pub(super) fn spawn_peer_request_worker(
     room: Arc<NotebookRoom>,
     daemon: Arc<crate::daemon::Daemon>,
     writer: PeerWriter,
+    multipart_uploads: MultipartUploadState,
     notebook_id: String,
     peer_id: String,
 ) -> PeerRequestWorker {
@@ -163,7 +165,19 @@ pub(super) fn spawn_peer_request_worker(
 
             let start = std::time::Instant::now();
             let response = match wait_for_required_heads(&room, &envelope.required_heads).await {
-                Ok(()) => handle_notebook_request(&room, envelope.request, daemon.clone()).await,
+                Ok(()) => {
+                    if let Some(response) = maybe_handle_blob_upload_request(
+                        &multipart_uploads,
+                        &room.blob_store,
+                        &envelope.request,
+                    )
+                    .await
+                    {
+                        response
+                    } else {
+                        handle_notebook_request(&room, envelope.request, daemon.clone()).await
+                    }
+                }
                 Err(error) => notebook_protocol::protocol::NotebookResponse::Error { error },
             };
             let elapsed = start.elapsed();

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use notebook_protocol::protocol::BlobUploadErrorKind;
 use tracing::debug;
 
 use crate::daemon::Daemon;
@@ -59,6 +60,9 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
         NotebookRequest::ApproveTrust { .. } => "ApproveTrust",
         NotebookRequest::ApproveProjectEnvironment { .. } => "ApproveProjectEnvironment",
         NotebookRequest::GetDocBytes { .. } => "GetDocBytes",
+        NotebookRequest::CreateBlobUpload { .. } => "CreateBlobUpload",
+        NotebookRequest::CompleteBlobUpload { .. } => "CompleteBlobUpload",
+        NotebookRequest::AbortBlobUpload { .. } => "AbortBlobUpload",
     }
 }
 
@@ -126,5 +130,11 @@ pub(crate) async fn handle_notebook_request(
         }
 
         NotebookRequest::GetDocBytes {} => get_doc_bytes::handle(room).await,
+
+        NotebookRequest::CreateBlobUpload { .. }
+        | NotebookRequest::CompleteBlobUpload { .. }
+        | NotebookRequest::AbortBlobUpload { .. } => NotebookResponse::BlobUploadError {
+            reason: BlobUploadErrorKind::UnknownUpload,
+        },
     }
 }

--- a/packages/runtimed/src/protocol-contract.ts
+++ b/packages/runtimed/src/protocol-contract.ts
@@ -31,6 +31,9 @@ export const NOTEBOOK_REQUEST_TYPES = [
   "approve_trust",
   "approve_project_environment",
   "get_doc_bytes",
+  "create_blob_upload",
+  "complete_blob_upload",
+  "abort_blob_upload",
 ] as const satisfies readonly NotebookRequest["type"][];
 
 export const NOTEBOOK_REQUEST_TYPES_EXHAUSTIVE: MissingUnionMember<
@@ -60,6 +63,9 @@ export const NOTEBOOK_RESPONSE_RESULTS = [
   "sync_environment_failed",
   "doc_bytes",
   "blob_stored",
+  "blob_upload_created",
+  "blob_part_stored",
+  "blob_upload_aborted",
   "blob_upload_error",
 ] as const satisfies readonly NotebookResponse["result"][];
 

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -62,6 +62,12 @@ export interface CommRequestMessage {
   channel: string;
 }
 
+export interface BlobUploadPart {
+  part_number: number;
+  sha256: string;
+  size: number;
+}
+
 export type NotebookRequest =
   | {
       type: "launch_kernel";
@@ -97,7 +103,17 @@ export type NotebookRequest =
   | { type: "sync_environment"; guard?: DependencyGuard | null }
   | { type: "approve_trust"; observed_heads?: string[] | null }
   | { type: "approve_project_environment"; project_file_path?: string | null }
-  | { type: "get_doc_bytes" };
+  | { type: "get_doc_bytes" }
+  | {
+      type: "create_blob_upload";
+      media_type: string;
+      size: number;
+      sha256?: string | null;
+      part_size?: number | null;
+      purpose?: string | null;
+    }
+  | { type: "complete_blob_upload"; upload_id: string; parts: BlobUploadPart[] }
+  | { type: "abort_blob_upload"; upload_id: string };
 
 /** One entry returned by `get_history`. */
 export interface HistoryEntry {
@@ -149,6 +165,9 @@ export type NotebookResponse =
   | { result: "sync_environment_failed"; error: string; needs_restart: boolean }
   | { result: "doc_bytes"; bytes: number[] }
   | { result: "blob_stored"; hash: string; size: number; media_type: string }
+  | { result: "blob_upload_created"; upload_id: string; part_size: number; expires_at: string }
+  | { result: "blob_part_stored"; upload_id: string; part_number: number; sha256: string }
+  | { result: "blob_upload_aborted"; upload_id: string }
   | { result: "blob_upload_error"; reason: BlobUploadErrorKind };
 
 /**
@@ -171,6 +190,14 @@ export type BlobUploadErrorKind =
   | { kind: "over_cap" }
   | { kind: "too_many_in_flight" }
   | { kind: "invalid_header" }
+  | { kind: "unknown_upload" }
+  | { kind: "part_size_mismatch" }
+  | { kind: "part_hash_mismatch" }
+  | { kind: "duplicate_part_conflict" }
+  | { kind: "manifest_mismatch" }
+  | { kind: "final_hash_mismatch" }
+  | { kind: "over_peer_budget" }
+  | { kind: "session_expired" }
   | { kind: "io"; message: string };
 
 export type BlobDurability = "durable" | "ephemeral";

--- a/packages/runtimed/tests/protocol-contract.test.ts
+++ b/packages/runtimed/tests/protocol-contract.test.ts
@@ -34,6 +34,9 @@ describe("protocol contract discriminants", () => {
       "approve_trust",
       "approve_project_environment",
       "get_doc_bytes",
+      "create_blob_upload",
+      "complete_blob_upload",
+      "abort_blob_upload",
     ]);
   });
 
@@ -58,6 +61,9 @@ describe("protocol contract discriminants", () => {
       "sync_environment_failed",
       "doc_bytes",
       "blob_stored",
+      "blob_upload_created",
+      "blob_part_stored",
+      "blob_upload_aborted",
       "blob_upload_error",
     ]);
   });


### PR DESCRIPTION
## Summary

- Adds PutBlob multipart control requests and part-frame protocol support.
- Stages multipart parts per peer under the upload namespace, then publishes atomically by content hash on complete.
- Adds a Rust relay multipart helper plus generated TypeScript request/response bindings.

## Verification

- `cargo xtask lint --fix`
- `cargo xtask clippy`
- `cargo test -p runtimed notebook_sync_server::blob_upload --lib`
- `cargo test -p notebook-protocol --lib`
- `cargo test -p notebook-sync relay_handle_put_blob --lib`
