### PR TITLE
test(runtimed): integration coverage for reaper LRU cap + reservation + path coalesce

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3907,7 +3907,11 @@ impl Daemon {
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
             tick.tick().await;
-            self.ghost_room_reaper_sweep(RESIDENT_ROOM_TTL_SECS).await;
+            self.ghost_room_reaper_sweep_with_cap(
+                RESIDENT_ROOM_TTL_SECS,
+                MAX_RESIDENT_PEERLESS_ROOMS,
+            )
+            .await;
         }
     }
 
@@ -3934,17 +3938,25 @@ impl Daemon {
         self.notebook_rooms.len().await
     }
 
+    /// One sweep at production cap. Convenience wrapper around
+    /// `ghost_room_reaper_sweep_with_cap` for tests that only want to
+    /// drive the TTL layer.
+    pub async fn ghost_room_reaper_sweep(self: &Arc<Self>, ttl_secs: u64) {
+        self.ghost_room_reaper_sweep_with_cap(ttl_secs, MAX_RESIDENT_PEERLESS_ROOMS)
+            .await
+    }
+
     /// One sweep of the resident-room reaper. Extracted so tests can
     /// drive the reaper synchronously without waiting on
-    /// `REAPER_INTERVAL`. Public so integration tests (separate crate)
-    /// can drive a sweep.
+    /// `REAPER_INTERVAL`, and so they can pick a tiny `cap` to
+    /// exercise the LRU overflow path. Public so integration tests
+    /// (separate crate) can drive a sweep.
     ///
     /// Selection has two layers:
     ///   1. **TTL**: every peer-less room older than `ttl_secs`.
-    ///   2. **Count cap**: if peer-less rooms outnumber
-    ///      `MAX_RESIDENT_PEERLESS_ROOMS`, the oldest overflow rooms
-    ///      are reaped regardless of TTL.
-    pub async fn ghost_room_reaper_sweep(self: &Arc<Self>, ttl_secs: u64) {
+    ///   2. **Count cap**: if peer-less rooms outnumber `cap`, the
+    ///      oldest overflow rooms are reaped regardless of TTL.
+    pub async fn ghost_room_reaper_sweep_with_cap(self: &Arc<Self>, ttl_secs: u64, cap: usize) {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -3988,22 +4000,21 @@ impl Daemon {
             .collect();
 
         // Count-cap layer: oldest-first overflow rooms.
-        let overflow: std::collections::HashSet<uuid::Uuid> =
-            if peerless.len() > MAX_RESIDENT_PEERLESS_ROOMS {
-                let mut by_age: Vec<&uuid::Uuid> =
-                    peerless.iter().map(|(uuid, _, _, _)| uuid).collect();
-                by_age.sort_by_key(|uuid| {
-                    peerless
-                        .iter()
-                        .find(|(u, _, _, _)| u == *uuid)
-                        .map(|(_, _, ts, _)| *ts)
-                        .unwrap_or(u64::MAX)
-                });
-                let cull = peerless.len() - MAX_RESIDENT_PEERLESS_ROOMS;
-                by_age.into_iter().take(cull).copied().collect()
-            } else {
-                std::collections::HashSet::new()
-            };
+        let overflow: std::collections::HashSet<uuid::Uuid> = if peerless.len() > cap {
+            let mut by_age: Vec<&uuid::Uuid> =
+                peerless.iter().map(|(uuid, _, _, _)| uuid).collect();
+            by_age.sort_by_key(|uuid| {
+                peerless
+                    .iter()
+                    .find(|(u, _, _, _)| u == *uuid)
+                    .map(|(_, _, ts, _)| *ts)
+                    .unwrap_or(u64::MAX)
+            });
+            let cull = peerless.len() - cap;
+            by_age.into_iter().take(cull).copied().collect()
+        } else {
+            std::collections::HashSet::new()
+        };
 
         let candidates: Vec<(
             uuid::Uuid,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3505,6 +3505,65 @@ async fn find_room_by_path_returns_none_when_not_indexed() {
     assert!(found.is_none());
 }
 
+/// PR 2 contract: when two callers race to insert a room for the
+/// same path with different UUIDs (both saw `find_room_by_path ==
+/// None`), the loser coalesces onto the winner's room rather than
+/// erroring with `PathAlreadyOpen`. The combined registry is what
+/// makes that joinable — both inserts contend for the same lock.
+#[tokio::test]
+async fn registry_insert_coalesces_concurrent_path_racers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    let shared_path = tmp.path().join("shared.ipynb");
+
+    let winner_uuid = Uuid::new_v4();
+    let winner_room = Arc::new(NotebookRoom::new_fresh(
+        winner_uuid,
+        Some(shared_path.clone()),
+        tmp.path(),
+        blob_store.clone(),
+        false,
+    ));
+    let loser_uuid = Uuid::new_v4();
+    let loser_room = Arc::new(NotebookRoom::new_fresh(
+        loser_uuid,
+        Some(shared_path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    // Winner gets in first.
+    let winner_outcome = rooms
+        .insert_or_get(winner_uuid, winner_room.clone(), Some(&shared_path))
+        .await
+        .expect("winner insert should succeed");
+    assert!(matches!(winner_outcome, InsertOutcome::Inserted(_, _)));
+
+    // Loser arrives with a different UUID but the same path. The
+    // registry must coalesce onto the winner's room rather than
+    // failing with PathAlreadyOpen.
+    let loser_outcome = rooms
+        .insert_or_get(loser_uuid, loser_room.clone(), Some(&shared_path))
+        .await
+        .expect("loser must coalesce, not error");
+    assert!(
+        matches!(loser_outcome, InsertOutcome::Existing(_, _)),
+        "racing path insert must return Existing for the winner's room"
+    );
+    let (returned, _guard) = loser_outcome.into_parts();
+    assert!(
+        Arc::ptr_eq(&returned, &winner_room),
+        "loser must receive the winner's Arc, not its own"
+    );
+
+    // The registry holds exactly one room and one path binding.
+    assert_eq!(rooms.len().await, 1);
+    assert_eq!(rooms.path_count().await, 1);
+    assert_eq!(rooms.peek_path_uuid(&shared_path).await, Some(winner_uuid));
+}
+
 // ── C1 regression: NotebookSync path handshake must reuse existing room ──
 
 /// Verify that the pattern used by the NotebookSync handshake — consulting

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1896,6 +1896,288 @@ async fn test_peer_reconnect_bumps_generation() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
+/// PR 2 contract: when the count of peer-less rooms exceeds the cap,
+/// the reaper evicts the oldest peer-less rooms by
+/// `last_kernel_torn_down_at` regardless of TTL. The two
+/// most-recently-torn-down rooms must survive a cap=2 sweep over 3
+/// idle rooms.
+#[tokio::test]
+async fn test_resident_room_reaper_lru_cap_evicts_oldest() {
+    use std::sync::atomic::Ordering;
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    config.room_eviction_delay_ms = Some(0);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_for_inspect = daemon.clone();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    // Create three notebooks; disconnect each so the kernel teardown
+    // task stamps `last_kernel_torn_down_at`. The Vec preserves
+    // creation order (oldest first).
+    let mut notebook_ids: Vec<String> = Vec::new();
+    for tag in ["a", "b", "c"] {
+        let result = connect::connect_create(
+            socket_path.clone(),
+            "python",
+            None,
+            tag,
+            false,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        let notebook_id = result.info.notebook_id.clone();
+        let client = result.handle;
+        assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
+        client.confirm_sync().await.unwrap();
+        notebook_ids.push(notebook_id);
+        // `client` drops here -> peer disconnect.
+    }
+
+    // Wait for every room to be peer-less and stamped. Then backdate
+    // their timestamps in creation order so `a < b < c` even on a
+    // fast machine where the stamps could land in the same second.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let mut ready = 0;
+        for id in &notebook_ids {
+            let uuid = uuid::Uuid::parse_str(id).unwrap();
+            if let Some(room) = daemon_for_inspect.test_get_room(uuid).await {
+                let no_peers = room.connections.active_peers.load(Ordering::Relaxed) == 0;
+                let stamped = room
+                    .connections
+                    .last_kernel_torn_down_at
+                    .load(Ordering::Relaxed)
+                    != 0;
+                if no_peers && stamped {
+                    ready += 1;
+                }
+            }
+        }
+        if ready == notebook_ids.len() {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("not all rooms reached peer-less + stamped within 5s");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    for (offset, id) in notebook_ids.iter().enumerate() {
+        let uuid = uuid::Uuid::parse_str(id).unwrap();
+        let room = daemon_for_inspect.test_get_room(uuid).await.unwrap();
+        // a = oldest (now - 30), b = middle (now - 20), c = newest (now - 10).
+        let ts = now_secs - 30 + (offset as u64) * 10;
+        room.connections
+            .last_kernel_torn_down_at
+            .store(ts, Ordering::Relaxed);
+    }
+
+    // Sweep with a long TTL (so none have aged out) and cap=2. The
+    // overflow layer must drop exactly the oldest room (`a`).
+    daemon_for_inspect
+        .ghost_room_reaper_sweep_with_cap(24 * 3600, 2)
+        .await;
+
+    assert_eq!(
+        daemon_for_inspect.test_room_count().await,
+        2,
+        "cap=2 must leave exactly two rooms resident"
+    );
+    let uuid_a = uuid::Uuid::parse_str(&notebook_ids[0]).unwrap();
+    let uuid_b = uuid::Uuid::parse_str(&notebook_ids[1]).unwrap();
+    let uuid_c = uuid::Uuid::parse_str(&notebook_ids[2]).unwrap();
+    assert!(
+        daemon_for_inspect.test_get_room(uuid_a).await.is_none(),
+        "oldest peer-less room must be reaped"
+    );
+    assert!(
+        daemon_for_inspect.test_get_room(uuid_b).await.is_some(),
+        "middle peer-less room must survive"
+    );
+    assert!(
+        daemon_for_inspect.test_get_room(uuid_c).await.is_some(),
+        "newest peer-less room must survive"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+/// PR 2 contract: active rooms (peers > 0) are exempt from both the
+/// TTL layer and the count cap. A cap of 1 with three connected
+/// notebooks must leave all three resident.
+#[tokio::test]
+async fn test_resident_room_reaper_lru_cap_exempts_active() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_for_inspect = daemon.clone();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    // Hold three clients connected so each room has active_peers == 1.
+    let mut clients = Vec::new();
+    for tag in ["a", "b", "c"] {
+        let result = connect::connect_create(
+            socket_path.clone(),
+            "python",
+            None,
+            tag,
+            false,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        let client = result.handle;
+        assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
+        clients.push(client);
+    }
+
+    assert_eq!(daemon_for_inspect.test_room_count().await, 3);
+
+    // Sweep with cap=1 and TTL=0. The selection pass filters by
+    // `active_peers == 0`, so all three active rooms must survive.
+    daemon_for_inspect
+        .ghost_room_reaper_sweep_with_cap(0, 1)
+        .await;
+    assert_eq!(
+        daemon_for_inspect.test_room_count().await,
+        3,
+        "active rooms must not be reaped regardless of cap"
+    );
+
+    drop(clients);
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+/// PR 2 contract: an outstanding reservation blocks the reaper even
+/// when the room is past TTL. Simulates the handshake window where
+/// a connection has cloned the room's `Arc` but not yet incremented
+/// `active_peers`.
+#[tokio::test]
+async fn test_resident_room_reaper_skips_reserved_room() {
+    use std::sync::atomic::Ordering;
+
+    let temp_dir = TempDir::new().unwrap();
+    let mut config = test_config(&temp_dir);
+    config.room_eviction_delay_ms = Some(0);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_for_inspect = daemon.clone();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let notebook_id;
+    {
+        let result = connect::connect_create(
+            socket_path.clone(),
+            "python",
+            None,
+            "test",
+            false,
+            None,
+            vec![],
+        )
+        .await
+        .unwrap();
+        notebook_id = result.info.notebook_id.clone();
+        let client = result.handle;
+        assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
+    }
+
+    let uuid = uuid::Uuid::parse_str(&notebook_id).unwrap();
+
+    // Wait for kernel teardown + stamp.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(room) = daemon_for_inspect.test_get_room(uuid).await {
+            if room
+                .connections
+                .last_kernel_torn_down_at
+                .load(Ordering::Relaxed)
+                != 0
+                && room.connections.active_peers.load(Ordering::Relaxed) == 0
+            {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("kernel teardown did not stamp within 5s");
+        }
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    // Backdate so the room is past TTL, then bump the reservation
+    // counter directly to simulate an in-flight handshake.
+    {
+        let room = daemon_for_inspect.test_get_room(uuid).await.unwrap();
+        let backdated = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .saturating_sub(25 * 3600);
+        room.connections
+            .last_kernel_torn_down_at
+            .store(backdated, Ordering::Relaxed);
+        room.connections
+            .reservations
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    // TTL would normally take the room, but `reservations > 0` blocks
+    // the commit-time predicate.
+    daemon_for_inspect.ghost_room_reaper_sweep(24 * 3600).await;
+    assert_eq!(
+        daemon_for_inspect.test_room_count().await,
+        1,
+        "reaper must skip rooms with outstanding reservations"
+    );
+
+    // Drop the reservation; the next sweep removes the room.
+    {
+        let room = daemon_for_inspect.test_get_room(uuid).await.unwrap();
+        room.connections
+            .reservations
+            .fetch_sub(1, Ordering::Relaxed);
+    }
+    daemon_for_inspect.ghost_room_reaper_sweep(24 * 3600).await;
+    assert_eq!(
+        daemon_for_inspect.test_room_count().await,
+        0,
+        "reaper must remove the room once the reservation drops"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
 #[tokio::test]
 async fn test_notebook_cell_delete_propagation() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -2017,11 +2017,17 @@ async fn test_resident_room_reaper_lru_cap_evicts_oldest() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
-/// PR 2 contract: active rooms (peers > 0) are exempt from both the
-/// TTL layer and the count cap. A cap of 1 with three connected
-/// notebooks must leave all three resident.
+/// PR 2 contract: the `active_peers > 0` check exempts a room even
+/// when it has a stale teardown stamp — the brief window during a
+/// fast reconnect where the timestamp has not yet been zeroed. To
+/// pin that check, force a non-zero stamp on each connected room
+/// before sweeping so the timestamp filter doesn't short-circuit;
+/// only the active-peers predicate stands between the rooms and the
+/// reaper.
 #[tokio::test]
 async fn test_resident_room_reaper_lru_cap_exempts_active() {
+    use std::sync::atomic::Ordering;
+
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);
     let socket_path = config.socket_path.clone();
@@ -2037,6 +2043,7 @@ async fn test_resident_room_reaper_lru_cap_exempts_active() {
 
     // Hold three clients connected so each room has active_peers == 1.
     let mut clients = Vec::new();
+    let mut notebook_ids = Vec::new();
     for tag in ["a", "b", "c"] {
         let result = connect::connect_create(
             socket_path.clone(),
@@ -2049,6 +2056,7 @@ async fn test_resident_room_reaper_lru_cap_exempts_active() {
         )
         .await
         .unwrap();
+        notebook_ids.push(result.info.notebook_id.clone());
         let client = result.handle;
         assert!(wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await);
         clients.push(client);
@@ -2056,8 +2064,25 @@ async fn test_resident_room_reaper_lru_cap_exempts_active() {
 
     assert_eq!(daemon_for_inspect.test_room_count().await, 3);
 
-    // Sweep with cap=1 and TTL=0. The selection pass filters by
-    // `active_peers == 0`, so all three active rooms must survive.
+    // Force a non-zero teardown stamp on every room so the selection
+    // pass's timestamp filter doesn't short-circuit. The
+    // `active_peers > 0` check is what should keep them resident.
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    for (offset, id) in notebook_ids.iter().enumerate() {
+        let uuid = uuid::Uuid::parse_str(id).unwrap();
+        let room = daemon_for_inspect.test_get_room(uuid).await.unwrap();
+        let ts = now_secs - 30 + (offset as u64) * 10;
+        room.connections
+            .last_kernel_torn_down_at
+            .store(ts, Ordering::Relaxed);
+    }
+
+    // Sweep with cap=1 and TTL=0. With stamps in place, only the
+    // `active_peers > 0` filter stands between these rooms and the
+    // reaper. All three must survive.
     daemon_for_inspect
         .ghost_room_reaper_sweep_with_cap(0, 1)
         .await;


### PR DESCRIPTION
Integration coverage for the reaper that landed in #2752. Four tests, each exercises a path that was previously only covered by visual inspection.

| Test | Asserts |
|------|---------|
| `test_resident_room_reaper_lru_cap_evicts_oldest` | 3 peer-less rooms with backdated stamps and cap=2: the oldest gets reaped, the two newest survive. Covers the LRU overflow layer that runs even when TTL hasn't elapsed. |
| `test_resident_room_reaper_lru_cap_exempts_active` | cap=1 and TTL=0 with 3 connected rooms: all three survive. Confirms `active_peers > 0` filters out at selection before any cap math. |
| `test_resident_room_reaper_skips_reserved_room` | past-TTL room with `reservations > 0`: survives. Drop to zero and the next sweep removes it. Locks in the reservation gate against the in-flight handshake window. |
| `registry_insert_coalesces_concurrent_path_racers` | Two racers minting different UUIDs for the same path: the loser coalesces onto the winner's room as `InsertOutcome::Existing` instead of erroring with `PathAlreadyOpen`. Regression test for the codex P2 fix on #2752. |

## Design call

The cap was a private constant (`MAX_RESIDENT_PEERLESS_ROOMS = 32`). Driving the LRU layer from a test would otherwise need 33 rooms per test, which is slow. Threaded a `cap` parameter through `ghost_room_reaper_sweep_with_cap(ttl, cap)` and kept the old `ghost_room_reaper_sweep(ttl)` as a thin wrapper around the production constant, so the four pre-existing PR 1 tests don't move. This is the same shape the eventual "config knobs" follow-up will use.

## Test plan

- [x] `cargo test -p runtimed --test integration test_resident_room_reaper` — three new tests pass
- [x] `cargo test -p runtimed --lib registry_insert_coalesces_concurrent_path_racers` — registry coalesce test passes
- [x] `cargo xtask lint --fix`
- [x] `cargo clippy -p runtimed --all-targets -- -D warnings`
- [x] All 4 pre-existing reaper integration tests still pass (`test_ghost_reaper_*`, `test_peer_reconnect_bumps_generation`, `test_room_remains_resident_after_kernel_teardown`)

## Out of scope

Plan listed 15 reaper scenarios; this PR ships the four highest-value ones. The remainder (flush-failure abort, aborted-reap autosave restart, untitled `.automerge` survives reap, blob-GC + reaper interaction) can land in stacked PRs as the daemon test infra grows.
