### PR TITLE
ci: restore macOS cargo path before wheel build

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -974,6 +974,17 @@ jobs:
         with:
           skip-wasm: true
 
+      - name: Restore Rust toolchain PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Rust toolchain PATH (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          type -a cargo rustup
+          cargo --version
+          rustup --version
+
       - name: Build runtimed binary (Unix)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
## Summary

- restore `$HOME/.cargo/bin` to the macOS GitHub Actions PATH after the runtime-artifact setup step
- print `cargo` and `rustup` resolution before the Python wheel job builds the bundled `runtimed` binary

## Context

The nightly Python wheel job started resolving `cargo build ...` to a binary that prints `rustup-init` usage on the newer `macos-14-arm64` runner image. The preceding Rust setup and target install succeeded, so this patch is a narrow CI guard around the path mutation between `build-runtime-artifacts` and the binary build.

## Verification

- `git diff --check origin/main..HEAD`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-common.yml"); puts "ok"'`
