### PR TITLE
chore(runtimed): remove legacy Handshake::Blob channel

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -194,10 +194,6 @@ mod tests {
             r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v4","working_dir":"/home/user/project"}"#
         );
 
-        // Blob
-        let json = serde_json::to_string(&Handshake::Blob).unwrap();
-        assert_eq!(json, r#"{"channel":"blob"}"#);
-
         // OpenNotebook
         let json = serde_json::to_string(&Handshake::OpenNotebook {
             path: "/home/user/notebook.ipynb".into(),

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -32,9 +32,6 @@ pub enum Handshake {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         initial_metadata: Option<String>,
     },
-    /// Blob store: write blobs, query port.
-    Blob,
-
     /// Open an existing notebook file. Daemon loads from disk, derives notebook_id.
     ///
     /// The daemon returns `NotebookConnectionInfo` before starting sync.

--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -332,7 +332,7 @@ Because the daemon socket is same-UID trusted, treat the runtime-agent handshake
 | `packages/runtimed/src/request-types.ts` | Generated TS request/response protocol unions |
 | `packages/runtimed/src/protocol-contract.ts` | Generated TS discriminant lists for drift tests |
 | `packages/runtimed/src/transport.ts` | TS `FrameType` constants and transport boundary |
-| `crates/runtimed-client/src/protocol.rs` | Daemon-internal `Request` / `Response` / `BlobRequest`, re-exports from `notebook-protocol` |
+| `crates/runtimed-client/src/protocol.rs` | Daemon-internal `Request` / `Response`, re-exports from `notebook-protocol` |
 | `crates/notebook-sync/src/{relay,connect,handle}.rs` | Relay handle, connection setup, `DocHandle` |
 | `crates/runtimed/src/notebook_sync_server/` | Notebook sync server: catalog, room, peer connection/loop/session, writer, metadata |
 | `crates/runtimed/src/requests/` | Notebook request routing handlers |

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -4,8 +4,7 @@
 //! NotebookBroadcast, etc.) are defined in the `notebook-protocol` crate
 //! and re-exported here for backward compatibility.
 //!
-//! Daemon-internal types (Request, Response, BlobRequest,
-//! BlobResponse) are defined here.
+//! Daemon-internal types (Request, Response) are defined here.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -291,28 +290,6 @@ pub struct RoomInfo {
     pub state: RoomState,
 }
 
-/// Blob channel request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "action", rename_all = "snake_case")]
-pub enum BlobRequest {
-    /// Store a blob. The next frame is the raw binary data.
-    Store { media_type: String },
-    /// Query the blob HTTP server port.
-    GetPort,
-}
-
-/// Blob channel response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BlobResponse {
-    /// Blob stored successfully.
-    Stored { hash: String },
-    /// Blob server port.
-    Port { port: u16 },
-    /// Error.
-    Error { error: String },
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -571,34 +548,6 @@ mod tests {
     fn test_invalid_json() {
         let result: Result<Request, _> = serde_json::from_slice(b"not valid json");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_blob_request_store() {
-        let req = BlobRequest::Store {
-            media_type: "image/png".into(),
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("store"));
-        assert!(json.contains("image/png"));
-        let parsed: BlobRequest = serde_json::from_str(&json).unwrap();
-        assert!(matches!(parsed, BlobRequest::Store { .. }));
-    }
-
-    #[test]
-    fn test_blob_request_get_port() {
-        let req = BlobRequest::GetPort;
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("get_port"));
-    }
-
-    #[test]
-    fn test_blob_response_stored() {
-        let resp = BlobResponse::Stored {
-            hash: "abc123".into(),
-        };
-        let json = serde_json::to_string(&resp).unwrap();
-        assert!(json.contains("abc123"));
     }
 
     // Notebook protocol tests

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -29,7 +29,7 @@ use crate::blob_server;
 use crate::blob_store::BlobStore;
 use crate::notebook_sync_server::{NotebookRooms, RoomRegistry};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
-use crate::protocol::{BlobRequest, BlobResponse, Request, Response};
+use crate::protocol::{Request, Response};
 use crate::settings_doc::{SettingsDoc, SyncedSettings};
 use crate::singleton::DaemonLock;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
@@ -2526,7 +2526,6 @@ impl Daemon {
                 )
                 .await
             }
-            Handshake::Blob => self.handle_blob_connection(stream).await,
             Handshake::OpenNotebook { path } => {
                 self.handle_open_notebook(stream, path, client_protocol_version)
                     .await
@@ -3099,56 +3098,6 @@ impl Daemon {
 
             let response = self.clone().handle_request(request).await;
             connection::send_json_frame(&mut stream, &response).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Handle a blob channel connection.
-    ///
-    /// Protocol:
-    /// - `{"action":"store","media_type":"..."}` followed by a raw binary frame
-    ///   -> `{"hash":"..."}`
-    /// - `{"action":"get_port"}` -> `{"port":N}`
-    async fn handle_blob_connection<S>(self: Arc<Self>, mut stream: S) -> anyhow::Result<()>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-    {
-        loop {
-            let request: BlobRequest = match connection::recv_json_frame(&mut stream).await? {
-                Some(req) => req,
-                None => break,
-            };
-
-            match request {
-                BlobRequest::Store { media_type } => {
-                    // Next frame is the raw binary blob data
-                    let data = match connection::recv_frame(&mut stream).await? {
-                        Some(d) => d,
-                        None => break,
-                    };
-
-                    let response = match self.blob_store.put(&data, &media_type).await {
-                        Ok(hash) => BlobResponse::Stored { hash },
-                        Err(e) => BlobResponse::Error {
-                            error: e.to_string(),
-                        },
-                    };
-                    connection::send_json_frame(&mut stream, &response).await?;
-                }
-                BlobRequest::GetPort => {
-                    let response = {
-                        let port = self.blob_port.lock().await;
-                        match *port {
-                            Some(p) => BlobResponse::Port { port: p },
-                            None => BlobResponse::Error {
-                                error: "blob server not running".to_string(),
-                            },
-                        }
-                    };
-                    connection::send_json_frame(&mut stream, &response).await?;
-                }
-            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- remove the legacy `Handshake::Blob` channel variant and serialization test
- remove daemon dispatch/handler code for the old blob side channel
- remove the unused `BlobRequest` and `BlobResponse` daemon-client protocol types and tests

## Notes

`blob_port` still rides in `Response::DaemonInfo`, so callers that discover the HTTP blob server through the main control socket keep working. This does not touch `BlobStore`, the HTTP blob server, PutBlob, multipart PutBlob, durability, or frontend blob handling.

## Verification

- `cargo test -p runtimed -p runtimed-client -p notebook-protocol`
- `cargo xtask lint --fix`
- `grep -rnI "BlobRequest\|BlobResponse\|Handshake::Blob" crates/ apps/ src/`

The non-`-I` grep form also sees an ignored local Mach-O binary under `crates/notebook/binaries/`; tracked source is clean.
