### PR TITLE
fix(ci): repair macos rustup shims in releases

### DIFF
--- a/.github/actions/repair-macos-rust-toolchain/action.yml
+++ b/.github/actions/repair-macos-rust-toolchain/action.yml
@@ -1,0 +1,25 @@
+name: Repair macOS Rust toolchain
+description: Reinstall rustup shims after macOS runner/cache restores can shadow cargo with rustup-init
+
+runs:
+  using: composite
+  steps:
+    - name: Repair rustup shims
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # The 20260512 macOS arm64 image can expose rustup-init where cargo or
+        # rustup shims should be, and rust-cache may restore that into ~/.cargo/bin.
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none --profile minimal
+
+        echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        export PATH="$HOME/.cargo/bin:$PATH"
+
+        rustup toolchain install --profile minimal
+        rustup show active-toolchain
+        type -a cargo rustup rustc
+        cargo --version
+        rustup --version
+        rustc --version

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -199,12 +199,14 @@ jobs:
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
 
-      - name: Install cross-compilation targets
-        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
-
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-release"
+
+      - uses: ./.github/actions/repair-macos-rust-toolchain
+
+      - name: Install cross-compilation targets
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8
@@ -264,6 +266,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-notebook-arm64"
+
+      - uses: ./.github/actions/repair-macos-rust-toolchain
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8
@@ -431,12 +435,14 @@ jobs:
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
 
-      - name: Install cross-compilation target
-        run: rustup target add x86_64-apple-darwin
-
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "macos-notebook-x64"
+
+      - uses: ./.github/actions/repair-macos-rust-toolchain
+
+      - name: Install cross-compilation target
+        run: rustup target add x86_64-apple-darwin
 
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8
@@ -950,9 +956,6 @@ jobs:
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
 
-      - name: Install compilation target
-        run: rustup target add ${{ matrix.platform.target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "python-${{ matrix.platform.target }}"
@@ -965,6 +968,12 @@ jobs:
         if: matrix.platform.sccache
         uses: ./.github/actions/sccache-warmup
 
+      - uses: ./.github/actions/repair-macos-rust-toolchain
+        if: runner.os == 'macOS'
+
+      - name: Install compilation target
+        run: rustup target add ${{ matrix.platform.target }}
+
       - name: Download WASM artifacts
         uses: actions/download-artifact@v8
         with:
@@ -973,17 +982,6 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
-
-      - name: Restore Rust toolchain PATH (macOS)
-        if: runner.os == 'macOS'
-        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Verify Rust toolchain PATH (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          type -a cargo rustup
-          cargo --version
-          rustup --version
 
       - name: Build runtimed binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

- add a reusable release action that reinstalls upstream rustup shims on macOS after `Swatinem/rust-cache`
- run that repair in the macOS release executable, notebook, and Python wheel jobs
- move macOS target installation after the repair so target setup does not use the broken cached/Homebrew shim

## Context

The latest nightly run is still on `macos-14-arm64/20260512.0058.1` and fails after cache restore with `cargo` resolving to `rustup-init`:

- `release / Build macOS Executables`: `cargo build ...` -> `Usage: rustup-init[EXE]`
- `release / Build macOS x64 Notebook`: `cargo binstall ...` -> `Usage: rustup-init[EXE]`

This matches the upstream runner-images rustup regression tracked in actions/runner-images#14097. The latest published macOS 14 arm64 image is still `20260512.0058.1`, so rerunning is still image/cache lottery rather than a durable release unblock.

## Verification

- `actionlint .github/workflows/release-common.yml`
- `cargo xtask lint --fix`
