### PR TITLE
fix(runtimed): unblock headless conda/uv kernels stuck on AwaitingTrust

### DIFF
--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -278,6 +278,75 @@ fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::V
                     info.insert("error_details".into(), serde_json::json!(details));
                 }
             }
+
+            // Surface the trust block so callers can see why a kernel hasn't
+            // launched yet. The `status` and `needs_approval` fields are
+            // already in `RuntimeState.trust`; we project them through and
+            // add a remediation hint when the kernel is parked in
+            // `AwaitingTrust` so an MCP client knows the exact follow-up
+            // call to make. Notebooks loaded from disk hit this when their
+            // dep set isn't in the local allowlist — review `dependencies`
+            // (e.g. via `get_dependencies` / `manage_dependencies`) before
+            // approving so a sketchy package name like `canhazpassword`
+            // doesn't sail through silently.
+            if !state.trust.status.is_empty() {
+                let mut trust_obj = serde_json::Map::new();
+                trust_obj.insert("status".into(), serde_json::json!(state.trust.status));
+                trust_obj.insert(
+                    "needs_approval".into(),
+                    serde_json::json!(state.trust.needs_approval),
+                );
+                if !state.trust.approved_uv_dependencies.is_empty() {
+                    trust_obj.insert(
+                        "approved_uv_dependencies".into(),
+                        serde_json::json!(state.trust.approved_uv_dependencies),
+                    );
+                }
+                if !state.trust.approved_conda_dependencies.is_empty() {
+                    trust_obj.insert(
+                        "approved_conda_dependencies".into(),
+                        serde_json::json!(state.trust.approved_conda_dependencies),
+                    );
+                }
+                if !state.trust.approved_conda_channels.is_empty() {
+                    trust_obj.insert(
+                        "approved_conda_channels".into(),
+                        serde_json::json!(state.trust.approved_conda_channels),
+                    );
+                }
+                if !state.trust.approved_pixi_dependencies.is_empty() {
+                    trust_obj.insert(
+                        "approved_pixi_dependencies".into(),
+                        serde_json::json!(state.trust.approved_pixi_dependencies),
+                    );
+                }
+                if !state.trust.approved_pixi_pypi_dependencies.is_empty() {
+                    trust_obj.insert(
+                        "approved_pixi_pypi_dependencies".into(),
+                        serde_json::json!(state.trust.approved_pixi_pypi_dependencies),
+                    );
+                }
+                if !state.trust.approved_pixi_channels.is_empty() {
+                    trust_obj.insert(
+                        "approved_pixi_channels".into(),
+                        serde_json::json!(state.trust.approved_pixi_channels),
+                    );
+                }
+                info.insert("trust".into(), serde_json::Value::Object(trust_obj));
+            }
+            if matches!(
+                state.kernel.lifecycle,
+                runtime_doc::RuntimeLifecycle::AwaitingTrust
+            ) {
+                info.insert(
+                    "next_action".into(),
+                    serde_json::json!({
+                        "tool": "manage_dependencies",
+                        "args": { "trust": true },
+                        "reason": "Kernel launch is parked at awaiting_trust because the notebook's declared dependencies are not in the local trusted-package allowlist. Inspect the dependency list (e.g. with get_dependencies) before approving; call manage_dependencies with trust=true to grant approval and unblock launch.",
+                    }),
+                );
+            }
         }
         Err(_) => {
             info.insert("kernel_status".into(), serde_json::json!("unknown"));

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3065,6 +3065,25 @@ impl Daemon {
                 .await;
         }
 
+        // Re-evaluate trust now that the doc is populated (and possibly
+        // post-seed) so `room.trust_state` and the runtime state doc reflect
+        // reality before we answer the handshake. Without this, `trust_state`
+        // is still whatever room creation initialized it to (empty doc →
+        // NoDependencies) and the handshake reply would lie when seeding
+        // failed, or when the deps weren't auto-approved (session restore,
+        // empty deps from caller).
+        crate::notebook_sync_server::check_and_update_trust_state(&room).await;
+
+        // Read the resolved trust state for the handshake reply. Mirrors
+        // the OpenNotebook handler so both paths produce the same shape.
+        let needs_trust_approval = {
+            let trust_state = room.trust_state.read().await;
+            !matches!(
+                trust_state.status,
+                runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
+            )
+        };
+
         // Send NotebookConnectionInfo response.
         // Always send the room's UUID on the wire, even when the caller
         // provided a notebook_id_hint — room.id is the canonical source.
@@ -3078,7 +3097,7 @@ impl Daemon {
             capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
             notebook_id: room.id.to_string(),
             cell_count,
-            needs_trust_approval: false,
+            needs_trust_approval,
             error: None,
             ephemeral,
             notebook_path,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -5800,6 +5800,10 @@ mod tests {
             blob_store_dir: temp_dir.path().join("blobs"),
             execution_store_dir: temp_dir.path().join("executions"),
             notebook_docs_dir: temp_dir.path().join("notebook-docs"),
+            // Mirror the integration helper: scope the trust DB per-temp-dir
+            // so parallel daemon unit tests can't contaminate each other's
+            // allowlists through the shared default path.
+            trusted_packages_db_path: temp_dir.path().join("trusted-packages.sqlite"),
             uv_pool_size: 0,
             conda_pool_size: 0,
             pixi_pool_size: 0,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -410,6 +410,7 @@ const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plot
 ///     declares them, and
 ///   - installing them eagerly into every pool env would balloon the
 ///     prewarm cost (scipy in particular pulls BLAS/LAPACK).
+///
 /// They still land in the env when a notebook declares them as inline
 /// deps; this constant just controls trust seeding.
 const DEFAULT_TRUSTED_EXTRA_PACKAGES: &[&str] = &["numpy", "scipy"];

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2988,9 +2988,10 @@ impl Daemon {
         // Populate the room's doc with the empty notebook content — but only if the
         // room is empty. If a persisted doc was loaded (session restore with notebook_id
         // hint), the room already has cells and we skip creation.
-        let (cell_count, create_error) = {
+        let (cell_count, create_error, freshly_created) = {
             let mut doc = room.doc.write().await;
             let mut err = None;
+            let mut fresh = false;
             if doc.cell_count() > 0 {
                 // Room already has content (loaded from persisted doc)
                 info!(
@@ -3007,13 +3008,15 @@ impl Daemon {
                     package_manager,
                     &dependencies,
                 ) {
-                    Ok(_) => {}
+                    Ok(_) => {
+                        fresh = true;
+                    }
                     Err(e) => {
                         err = Some(e);
                     }
                 }
             }
-            (doc.cell_count(), err)
+            (doc.cell_count(), err, fresh)
         }; // doc lock dropped
 
         if let Some(e) = create_error {
@@ -3045,13 +3048,19 @@ impl Daemon {
             *mode = environment_mode;
         }
 
-        // When the caller explicitly passed deps to CreateNotebook, the tool
-        // call is itself the consent event — auto-seed those names into the
-        // trusted-package allowlist so the auto-launch path doesn't stall on
-        // AwaitingTrust with no human in the loop. Notebooks loaded from
-        // disk (OpenNotebook) go nowhere near this code and still gate on
-        // the trust dialog.
-        if !dependencies.is_empty() {
+        // When the caller explicitly passed deps to CreateNotebook AND we
+        // actually populated a fresh doc from those deps, the tool call is
+        // the consent event — auto-seed those names into the trusted-package
+        // allowlist so the auto-launch path doesn't stall on AwaitingTrust
+        // with no human in the loop.
+        //
+        // Session restores (cell_count > 0 going in) deliberately don't seed:
+        // the request's `dependencies` array is ignored when reopening a
+        // persisted doc, and approving the doc's restored dep list would let
+        // a CreateNotebook handshake silently grant trust to whatever was on
+        // disk. Restore goes through the same trust-dialog path as
+        // OpenNotebook instead.
+        if freshly_created && !dependencies.is_empty() {
             crate::notebook_sync_server::seed_trust_from_doc_metadata(&room, "mcp_create_notebook")
                 .await;
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -401,15 +401,18 @@ const REAPER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 
 /// Active rooms (peers > 0 or kernel still running) are exempt.
 const MAX_RESIDENT_PEERLESS_ROOMS: usize = 32;
 const POOL_PACKAGE_HASH_VERSION: &str = "v1";
-const DEFAULT_DATA_PACKAGES: &[&str] = &[
-    "pandas",
-    "polars",
-    "numpy",
-    "scipy",
-    "matplotlib",
-    "plotly",
-    "altair",
-];
+const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plotly", "altair"];
+/// Extra package names that get auto-approved in the trusted-package
+/// allowlist on daemon start, but are NOT installed into prewarmed pool
+/// envs. Use this for foundational deps that data-science agents reach
+/// for routinely (numpy, scipy) where:
+///   - the trust gap would otherwise stall every fresh notebook that
+///     declares them, and
+///   - installing them eagerly into every pool env would balloon the
+///     prewarm cost (scipy in particular pulls BLAS/LAPACK).
+/// They still land in the env when a notebook declares them as inline
+/// deps; this constant just controls trust seeding.
+const DEFAULT_TRUSTED_EXTRA_PACKAGES: &[&str] = &["numpy", "scipy"];
 const BASE_RUNTIME_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
@@ -1384,6 +1387,9 @@ impl Daemon {
                     }
                     if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_DATA_PACKAGES) {
                         warn!("[trusted-packages] Failed to seed default data packages ({ecosystem}): {e}");
+                    }
+                    if let Err(e) = store.seed_defaults(ecosystem, DEFAULT_TRUSTED_EXTRA_PACKAGES) {
+                        warn!("[trusted-packages] Failed to seed extra trusted packages ({ecosystem}): {e}");
                     }
                 }
                 store
@@ -5535,6 +5541,42 @@ mod tests {
         }
         assert!(packages.iter().any(|pkg| pkg == "nbformat"));
         assert!(packages.iter().any(|pkg| pkg == "pyarrow>=14"));
+    }
+
+    /// `DEFAULT_TRUSTED_EXTRA_PACKAGES` are seeded into the allowlist on
+    /// daemon start but must NOT prewarm into pool envs. Scipy in
+    /// particular pulls BLAS/LAPACK and pushed CI pool builds past the
+    /// 150s readiness budget when it accidentally landed in
+    /// `DEFAULT_DATA_PACKAGES`. Lock the split so a future edit doesn't
+    /// silently regress prewarm cost.
+    #[test]
+    fn test_trusted_extras_do_not_appear_in_prewarmed_packages() {
+        let with_data = uv_prewarmed_packages(&[], true);
+        let without_data = uv_prewarmed_packages(&[], false);
+        for pkg in DEFAULT_TRUSTED_EXTRA_PACKAGES {
+            assert!(
+                !with_data.iter().any(|candidate| candidate == pkg),
+                "trust-extra {pkg} leaked into uv prewarm (default_data_packages=true)"
+            );
+            assert!(
+                !without_data.iter().any(|candidate| candidate == pkg),
+                "trust-extra {pkg} leaked into uv prewarm (default_data_packages=false)"
+            );
+        }
+
+        let conda_with = conda_prewarmed_packages(&[], true);
+        let conda_without = conda_prewarmed_packages(&[], false);
+        for pkg in DEFAULT_TRUSTED_EXTRA_PACKAGES {
+            assert!(!conda_with.iter().any(|candidate| candidate == pkg));
+            assert!(!conda_without.iter().any(|candidate| candidate == pkg));
+        }
+
+        let pixi_with = pixi_prewarmed_packages(&[], true);
+        let pixi_without = pixi_prewarmed_packages(&[], false);
+        for pkg in DEFAULT_TRUSTED_EXTRA_PACKAGES {
+            assert!(!pixi_with.iter().any(|candidate| candidate == pkg));
+            assert!(!pixi_without.iter().any(|candidate| candidate == pkg));
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -401,7 +401,15 @@ const REAPER_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5 * 
 /// Active rooms (peers > 0 or kernel still running) are exempt.
 const MAX_RESIDENT_PEERLESS_ROOMS: usize = 32;
 const POOL_PACKAGE_HASH_VERSION: &str = "v1";
-const DEFAULT_DATA_PACKAGES: &[&str] = &["pandas", "polars", "matplotlib", "plotly", "altair"];
+const DEFAULT_DATA_PACKAGES: &[&str] = &[
+    "pandas",
+    "polars",
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "plotly",
+    "altair",
+];
 const BASE_RUNTIME_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
@@ -3037,8 +3045,18 @@ impl Daemon {
             *mode = environment_mode;
         }
 
+        // When the caller explicitly passed deps to CreateNotebook, the tool
+        // call is itself the consent event — auto-seed those names into the
+        // trusted-package allowlist so the auto-launch path doesn't stall on
+        // AwaitingTrust with no human in the loop. Notebooks loaded from
+        // disk (OpenNotebook) go nowhere near this code and still gate on
+        // the trust dialog.
+        if !dependencies.is_empty() {
+            crate::notebook_sync_server::seed_trust_from_doc_metadata(&room, "mcp_create_notebook")
+                .await;
+        }
+
         // Send NotebookConnectionInfo response.
-        // Trust approval is handled later via CRDT trust state, not at creation time.
         // Always send the room's UUID on the wire, even when the caller
         // provided a notebook_id_hint — room.id is the canonical source.
         let (reader, mut writer) = tokio::io::split(stream);

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -822,9 +822,12 @@ pub fn create_empty_notebook(
         dependencies,
     );
 
-    // Seeded deps land as plain dep metadata. The notebook arrives Untrusted
-    // until the user approves them through the regular trust dialog; the
-    // allowlist write at approval time is what makes future opens silent.
+    // Seeded deps land as plain dep metadata. By default the notebook arrives
+    // Untrusted and the trust dialog drives the allowlist write. The
+    // `CreateNotebook` handshake path seeds the allowlist directly when deps
+    // were explicit on the request — the caller already supplied them, so the
+    // tool call itself is the consent event. See `handle_create_notebook` and
+    // `seed_trust_from_doc_metadata`.
 
     doc.set_metadata_snapshot(&metadata_snapshot)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -42,6 +42,42 @@ pub(crate) fn write_trust_to_runtime_state(room: &NotebookRoom, trust: &TrustSta
     }
 }
 
+/// Seed the trusted-package allowlist with the dependency names declared in
+/// the room's current notebook metadata, attributing the approval to `source`.
+///
+/// The caller is asserting that the deps already in the doc came from a
+/// consent-bearing channel (e.g., an explicit `dependencies` arg on an MCP
+/// `create_notebook` tool call). Skips silently when the doc has no metadata
+/// snapshot yet or carries no deps. Errors are logged, not propagated — the
+/// notebook still works without seeding, it just falls back to the trust
+/// dialog.
+pub(crate) async fn seed_trust_from_doc_metadata(room: &NotebookRoom, source: &str) {
+    let snapshot = {
+        let doc = room.doc.read().await;
+        doc.get_metadata_snapshot()
+    };
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    let mut metadata = std::collections::HashMap::new();
+    if let Ok(runt_value) = serde_json::to_value(&snapshot.runt) {
+        metadata.insert("runt".to_string(), runt_value);
+    }
+    let info = runt_trust::extract_trust_info(&metadata);
+
+    if matches!(info.status, runt_trust::TrustStatus::NoDependencies) {
+        return;
+    }
+
+    if let Err(e) = room.trusted_packages.add_from_info(&info, source) {
+        warn!(
+            "[trusted-packages] Failed to seed deps for room {} from {}: {}",
+            room.id, source, e
+        );
+    }
+}
+
 fn runtime_trust_state(trust: &TrustState) -> TrustRuntimeState {
     TrustRuntimeState {
         status: trust_status_str(&trust.status).to_string(),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -698,6 +698,120 @@ async fn test_new_fresh_untitled_trust_from_doc() {
     );
 }
 
+/// Auto-trust path for MCP `create_notebook` with explicit deps. Seeding
+/// the doc-declared deps into the allowlist must promote the room from
+/// Untrusted → Trusted on the next `check_and_update_trust_state`, so the
+/// auto-launch path can fire without a human-in-the-loop trust dialog.
+#[tokio::test]
+async fn test_seed_trust_from_doc_metadata_promotes_to_trusted() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let store =
+        crate::trusted_packages::TrustedPackageStore::open(tmp.path().join("trusted.sqlite"))
+            .unwrap();
+
+    let notebook_uuid = Uuid::new_v4();
+    let room = Arc::new(
+        NotebookRoom::new_fresh_with_trusted_packages(
+            notebook_uuid,
+            None,
+            tmp.path(),
+            blob_store,
+            true,
+            store,
+        )
+        .unwrap(),
+    );
+
+    // Populate the doc with explicit deps (mirrors create_empty_notebook).
+    let snapshot = snapshot_with_uv(vec!["pandas".to_string(), "scipy".to_string()]);
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&snapshot).unwrap();
+    }
+
+    // Before seeding: trust check on the doc's deps must fail.
+    let pre_info = runt_trust::extract_trust_info(&snapshot_metadata_hashmap(&snapshot));
+    assert!(
+        !room
+            .trusted_packages
+            .all_dependencies_approved(&pre_info)
+            .unwrap(),
+        "fresh store should not approve un-seeded deps"
+    );
+
+    crate::notebook_sync_server::seed_trust_from_doc_metadata(&room, "mcp_create_notebook").await;
+
+    // After seeding: same deps must approve, and re-verifying from snapshot
+    // resolves to Trusted.
+    let post_info = runt_trust::extract_trust_info(&snapshot_metadata_hashmap(&snapshot));
+    assert!(
+        room.trusted_packages
+            .all_dependencies_approved(&post_info)
+            .unwrap(),
+        "deps must approve after seed_trust_from_doc_metadata"
+    );
+    let verified =
+        crate::notebook_sync_server::verify_trust_from_snapshot(&snapshot, &room.trusted_packages);
+    assert_eq!(verified.status, runt_trust::TrustStatus::Trusted);
+}
+
+/// No-op path: a freshly created notebook with no declared deps must not
+/// touch the allowlist when seeded. NoDependencies short-circuits before
+/// the store write so a brand-new untitled notebook doesn't get a
+/// phantom "mcp_create_notebook" trust row.
+#[tokio::test]
+async fn test_seed_trust_from_doc_metadata_skips_when_no_deps() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let store =
+        crate::trusted_packages::TrustedPackageStore::open(tmp.path().join("trusted.sqlite"))
+            .unwrap();
+
+    let notebook_uuid = Uuid::new_v4();
+    let room = Arc::new(
+        NotebookRoom::new_fresh_with_trusted_packages(
+            notebook_uuid,
+            None,
+            tmp.path(),
+            blob_store,
+            true,
+            store,
+        )
+        .unwrap(),
+    );
+
+    let snapshot = snapshot_with_uv(vec![]);
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&snapshot).unwrap();
+    }
+
+    crate::notebook_sync_server::seed_trust_from_doc_metadata(&room, "mcp_create_notebook").await;
+
+    // An unrelated dep must still not approve — the seed call should have
+    // been a no-op.
+    let probe = runt_trust::TrustInfo {
+        status: runt_trust::TrustStatus::Untrusted,
+        uv_dependencies: vec!["pandas".to_string()],
+        approved_uv_dependencies: vec![],
+        conda_dependencies: vec![],
+        approved_conda_dependencies: vec![],
+        conda_channels: vec![],
+        approved_conda_channels: vec![],
+        pixi_dependencies: vec![],
+        approved_pixi_dependencies: vec![],
+        pixi_pypi_dependencies: vec![],
+        approved_pixi_pypi_dependencies: vec![],
+        pixi_channels: vec![],
+        approved_pixi_channels: vec![],
+    };
+    assert!(!room
+        .trusted_packages
+        .all_dependencies_approved(&probe)
+        .unwrap());
+}
+
 #[tokio::test(start_paused = true)]
 async fn test_ephemeral_room_skips_persistence() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -82,6 +82,14 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         blob_store_dir: temp_dir.path().join("blobs"),
         execution_store_dir: temp_dir.path().join("executions"),
         notebook_docs_dir: temp_dir.path().join("notebook-docs"),
+        // Isolate the trusted-package allowlist per-temp-dir. The default
+        // points at the shared `daemon_base_dir().join("trusted-packages.sqlite")`,
+        // which means any test that approves deps (via the regular trust
+        // dialog OR the `CreateNotebook` auto-seed path) leaks rows across
+        // the suite. Tests that assert "this dep is NOT trusted" can then
+        // false-pass on a developer machine and false-fail on CI depending
+        // on what ran before them.
+        trusted_packages_db_path: temp_dir.path().join("trusted-packages.sqlite"),
         uv_pool_size: 0, // Don't create real envs in tests
         conda_pool_size: 0,
         max_age_secs: 3600,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -3574,6 +3574,85 @@ async fn test_create_notebook_default_manager_with_deps() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
+/// `CreateNotebook` with explicit deps auto-seeds the trusted-package
+/// allowlist (the tool call is the consent event). The handshake
+/// `needs_trust_approval` must reflect the post-seed trust state so
+/// clients reading it don't surface a stale "approval required" banner.
+#[tokio::test]
+async fn test_create_notebook_with_deps_reports_no_trust_approval_needed() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec!["scipy".to_string()],
+    )
+    .await
+    .expect("create with explicit deps should succeed");
+
+    assert!(
+        !result.info.needs_trust_approval,
+        "CreateNotebook with explicit deps auto-seeds trust; handshake should report no approval needed"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+/// `CreateNotebook` with no deps must report `needs_trust_approval: false`
+/// (the trust state resolves to `NoDependencies`). Locks the wire shape
+/// for the empty-deps path so a refactor of the create-handshake trust
+/// re-evaluation can't silently regress to the pre-fix hardcoded `false`
+/// that ignored the actual room state.
+#[tokio::test]
+async fn test_create_notebook_with_no_deps_reports_no_trust_approval_needed() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "test",
+        false,
+        None,
+        vec![],
+    )
+    .await
+    .expect("create with no deps should succeed");
+
+    assert!(
+        !result.info.needs_trust_approval,
+        "no deps → trust=NoDependencies → handshake reports no approval needed"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
 /// `notebook-sync::connect` clients (runt-mcp, runtimed-py, integration tests)
 /// get an auto-heartbeat that fires from `sync_task::run`'s biased select. A
 /// quiet but live peer must survive past the daemon's idle_peer_timeout solely


### PR DESCRIPTION
Found via headless gremlin runs against the latest nightly: any MCP `create_notebook` call that included a dep missing from the local allowlist parked the kernel at `awaiting_trust` forever. Headless callers (nightly gremlins, Claude Code) have no way to click through a trust dialog, so the notebook just sat there until the request timed out.

Three pieces of the fix.

## Design decisions

**Why `numpy` and `scipy`** — both are foundational deps for any data persona, but neither was in the seed list. On my machine the gremlin's request for `conda + [pandas, numpy, matplotlib]` failed because the audit log showed every `pypi:*` user-approval over the past month but zero `conda:*` user-approvals — no one's ever clicked through a conda trust dialog, so `conda:numpy` never made it into the allowlist. Adding them to `DEFAULT_DATA_PACKAGES` seeds both ecosystems on daemon start. Pool envs already pulled `numpy` transitively via `pandas/matplotlib`, so the only meaningful install delta is `scipy`.

**Why auto-trust on `CreateNotebook` deps** — when an MCP tool call passes `dependencies: ["pandas", ...]` explicitly, the tool call itself is the consent event. The Claude Code UI (or whatever MCP host) approves the tool invocation; by the time bytes hit the daemon the caller has already opted in to those deps. `OpenNotebook` goes nowhere near this code — a downloaded notebook with a sketchy dep like `canhazpassword` still surfaces through the regular trust dialog.

**Why a `next_action` hint instead of changing tool schemas** — the existing `manage_dependencies` tool already accepts `trust: true` to grant approval. The gremlin didn't reach for it because the `awaiting_trust` response was a dead end. Surfacing the trust state + remediation hint in `runtime.trust` and `runtime.next_action` makes the available path visible to any caller looking at the response. Tool descriptions are untouched, so no tool-cache update needed.

## Behavioral coverage

| Scenario | Trust path | Outcome |
|---|---|---|
| `create_notebook` + explicit deps, no prior trust | seed via `mcp_create_notebook` | auto-launch |
| `create_notebook` + no deps | `NoDependencies` short-circuit, no seed | auto-launch |
| `create_notebook` + already-approved deps | seed is a no-op (`ON CONFLICT DO NOTHING`) | auto-launch |
| `open_notebook` of a downloaded `.ipynb` | unchanged, hits trust dialog | `awaiting_trust` until human approves |
| Any path that ends `awaiting_trust` | unchanged kernel state | response now includes `runtime.trust` + `runtime.next_action` pointing at `manage_dependencies({trust: true})` |

## Pool env impact

`DEFAULT_DATA_PACKAGES` participates in the pool-package hash (`expected_pool_package_hash`). The const change invalidates existing pool envs; next daemon start rebuilds them with the new list. `numpy` was already a transitive dep of `pandas`/`matplotlib`, so the practical install delta is `scipy` (~50MB per env).

## Test plan

- [x] `cargo check -p runtimed -p runt-mcp`
- [x] `cargo test -p runtimed --lib trusted_packages` (10/10)
- [x] `cargo test -p runtimed --lib daemon` (100/100)
- [x] `cargo test -p runtimed --lib notebook_sync_server` (291/291, includes the two new auto-trust tests)
- [x] `cargo test -p runt-mcp --lib` (120/120)
- [ ] Re-run the data-scientist gremlin against a daemon built from this branch and confirm conda + numpy launches without stalling.

## Tests added

- `test_seed_trust_from_doc_metadata_promotes_to_trusted` — populates the doc with explicit deps, calls the helper, verifies the trust check now resolves to `Trusted`.
- `test_seed_trust_from_doc_metadata_skips_when_no_deps` — empty dep list short-circuits via `NoDependencies` and doesn't write phantom rows to the allowlist.
