### PR TITLE
ci: move eligible jobs to Blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
     - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-4vcpu-ubuntu-2204
     - blacksmith-4vcpu-windows-2025
+    - blacksmith-6vcpu-macos-15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,12 +473,12 @@ jobs:
     needs: [changes, build-ui]
     if: ${{ always() && (needs.changes.outputs.source_changed != 'true' || needs.build-ui.result == 'success') }}
     continue-on-error: ${{ matrix.platform.non_blocking }}
-    runs-on: ${{ needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && matrix.platform.runner || 'ubuntu-latest' }}
+    runs-on: ${{ needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && matrix.platform.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
     strategy:
       matrix:
         platform:
           - name: macOS
-            runner: macos-14
+            runner: blacksmith-6vcpu-macos-15
             setup: echo "No extra deps needed on macOS"
             run_on_pr: false
             non_blocking: false

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -68,7 +68,7 @@ jobs:
   build:
     name: Build ${{ inputs.target_os == 'linux' && 'Linux x64' || inputs.target_os == 'macos' && 'macOS' || 'Windows x64' }} binary
     needs: [resolve-pr]
-    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-14' || 'blacksmith-4vcpu-windows-2025' }}
+    runs-on: ${{ inputs.target_os == 'linux' && 'blacksmith-4vcpu-ubuntu-2204' || inputs.target_os == 'macos' && 'blacksmith-6vcpu-macos-15' || 'blacksmith-4vcpu-windows-2025' }}
     env:
       NTERACT_BUILD_GIT_HASH: ${{ needs.resolve-pr.outputs.head_sha }}
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -41,6 +41,7 @@ jobs:
   native:
     name: Native package (${{ matrix.target }})
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # npm trusted publishing / provenance requires GitHub-hosted runners.
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -51,9 +52,6 @@ jobs:
           - target: linux-x64-gnu
             runner: ubuntu-latest
           - target: win32-x64-msvc
-            # npm provenance / sigstore requires GitHub-hosted runners.
-            # Publishing from a self-hosted (Blacksmith) Windows runner fails
-            # with: "Unsupported GitHub Actions runner environment: self-hosted".
             runner: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -101,6 +99,7 @@ jobs:
     name: Wrapper package
     needs: [native]
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # npm trusted publishing / provenance requires GitHub-hosted runners.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -170,6 +169,7 @@ jobs:
     name: Pi package
     needs: [wrapper]
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # npm trusted publishing / provenance requires GitHub-hosted runners.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -249,7 +249,7 @@ jobs:
 
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
-    runs-on: macos-14
+    runs-on: blacksmith-6vcpu-macos-15
     needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
@@ -942,7 +942,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-14
+          - runner: blacksmith-6vcpu-macos-15
             target: aarch64-apple-darwin
             sccache: false
           - runner: macos-14


### PR DESCRIPTION
## Summary

- Move eligible GitHub-hosted runner labels to Blacksmith runners.
- Use Blacksmith macOS ARM64 runners for non-Intel macOS work.
- Keep GitHub-hosted runners where required for Intel macOS release artifacts and npm trusted publishing/provenance.

## Verification

- `actionlint .github/workflows/build.yml .github/workflows/pr-binary-generation.yml .github/workflows/publish-npm.yml .github/workflows/release-common.yml`
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
