### PR TITLE
ci: tighten npm policy permissions

### DIFF
--- a/.github/workflows/dx-bootstrap-e2e.yml
+++ b/.github/workflows/dx-bootstrap-e2e.yml
@@ -40,6 +40,9 @@ on:
       - "rust-toolchain.toml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ onlyBuiltDependencies:
 minimumReleaseAge: 1440
 blockExoticSubdeps: true
 trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 10080
 catalog:
   vite: npm:@voidzero-dev/vite-plus-core@0.1.16
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.16


### PR DESCRIPTION
## Summary

- keep pnpm `trustPolicy: no-downgrade` enforcement active instead of ignoring trust checks after one week
- add read-only default `GITHUB_TOKEN` permissions to `dx-bootstrap-e2e.yml`

## Verification

- `pnpm install --frozen-lockfile --lockfile-only`
- `actionlint .github/workflows/dx-bootstrap-e2e.yml`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `cargo xtask lint --fix`
