### PR TITLE
fix(runtime): source shell startup env for kernels

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -54,27 +54,34 @@ function secondsToSlider(secs: number): number {
   return Math.max(0, Math.min(SLIDER_STEPS, Math.round(position)));
 }
 
-/** Keep Alive slider - exponential scale from 5s to 7 days */
-function KeepAliveSlider({
-  value,
-  onChange,
+function RuntimeSection({
+  keepAliveSecs,
+  onKeepAliveSecsChange,
+  redactEnvValuesInOutputs,
+  onRedactEnvValuesInOutputsChange,
+  importShellEnvironment,
+  onImportShellEnvironmentChange,
 }: {
-  value: number;
-  onChange: (value: number) => void;
+  keepAliveSecs: number;
+  onKeepAliveSecsChange: (value: number) => void;
+  redactEnvValuesInOutputs: boolean;
+  onRedactEnvValuesInOutputsChange: (value: boolean) => void;
+  importShellEnvironment: boolean;
+  onImportShellEnvironmentChange: (value: boolean) => void;
 }) {
-  const [localValue, setLocalValue] = useState(value);
+  const [localValue, setLocalValue] = useState(keepAliveSecs);
 
   useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
+    setLocalValue(keepAliveSecs);
+  }, [keepAliveSecs]);
 
   const sliderPosition = secondsToSlider(localValue);
 
   return (
-    <div className="space-y-3 pt-4 border-t border-border/50">
+    <div className="space-y-4 pt-4 border-t border-border/50">
       <div>
         <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          Runtimes
+          Runtime
         </span>
       </div>
       <div className="space-y-1">
@@ -95,12 +102,49 @@ function KeepAliveSlider({
           max={SLIDER_STEPS}
           step={1}
           onValueChange={(v) => setLocalValue(sliderToSeconds(v[0]))}
-          onValueCommit={(v) => onChange(sliderToSeconds(v[0]))}
+          onValueCommit={(v) => onKeepAliveSecsChange(sliderToSeconds(v[0]))}
         />
       </div>
       <div className="flex justify-between text-[10px] text-muted-foreground/70">
         <span>5s</span>
         <span>7 days</span>
+      </div>
+
+      <div className="space-y-3 pt-2">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-0.5">
+            <span className="text-sm text-foreground">Redact environment values in outputs</span>
+            <p className="text-[10px] text-muted-foreground/70">
+              Masks eligible environment variable values for newly launched or restarted kernels
+            </p>
+          </div>
+          <Switch
+            checked={redactEnvValuesInOutputs}
+            onCheckedChange={onRedactEnvValuesInOutputsChange}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-0.5">
+            <span className="text-sm text-foreground">Import shell environment into kernels</span>
+            <p className="text-[10px] text-muted-foreground/70">
+              Passes your shell startup env vars (API keys, tokens) to newly launched kernels. Pair
+              with redaction to keep values out of outputs.
+            </p>
+          </div>
+          <Switch
+            checked={importShellEnvironment}
+            onCheckedChange={onImportShellEnvironmentChange}
+          />
+        </div>
+
+        {importShellEnvironment && !redactEnvValuesInOutputs ? (
+          <div className="text-[10px] text-amber-600 dark:text-amber-400 pl-3 border-l-2 border-amber-500/40">
+            Warning: shell env vars will flow to kernels and into outputs unredacted. Turn on
+            "Redact environment values in outputs" to scrub them from cell results and the blob
+            store.
+          </div>
+        ) : null}
       </div>
     </div>
   );
@@ -465,16 +509,18 @@ export default function App() {
           </div>
         </div>
 
-        {/* Runtimes */}
-        <KeepAliveSlider value={keepAliveSecs} onChange={setKeepAliveSecs} />
-
-        <PrivacySection
-          telemetryEnabled={telemetryEnabled}
-          onTelemetryChange={setTelemetryEnabled}
+        <RuntimeSection
+          keepAliveSecs={keepAliveSecs}
+          onKeepAliveSecsChange={setKeepAliveSecs}
           redactEnvValuesInOutputs={redactEnvValuesInOutputs}
           onRedactEnvValuesInOutputsChange={setRedactEnvValuesInOutputs}
           importShellEnvironment={importShellEnvironment}
           onImportShellEnvironmentChange={setImportShellEnvironment}
+        />
+
+        <PrivacySection
+          telemetryEnabled={telemetryEnabled}
+          onTelemetryChange={setTelemetryEnabled}
           installId={installId}
           onRotate={rotateInstallId}
           lastDaemonPingAt={lastDaemonPingAt}

--- a/apps/notebook/settings/sections/Privacy.tsx
+++ b/apps/notebook/settings/sections/Privacy.tsx
@@ -8,10 +8,6 @@ import { Switch } from "@/components/ui/switch";
 interface PrivacySectionProps {
   telemetryEnabled: boolean;
   onTelemetryChange: (value: boolean) => void;
-  redactEnvValuesInOutputs: boolean;
-  onRedactEnvValuesInOutputsChange: (value: boolean) => void;
-  importShellEnvironment: boolean;
-  onImportShellEnvironmentChange: (value: boolean) => void;
   installId: string;
   onRotate: () => Promise<string | null>;
   lastDaemonPingAt: number | null;
@@ -39,10 +35,6 @@ function openOrFallThrough(url: string) {
 export function PrivacySection({
   telemetryEnabled,
   onTelemetryChange,
-  redactEnvValuesInOutputs,
-  onRedactEnvValuesInOutputsChange,
-  importShellEnvironment,
-  onImportShellEnvironmentChange,
   installId,
   onRotate,
   lastDaemonPingAt,
@@ -84,45 +76,6 @@ export function PrivacySection({
             </div>
           }
         />
-
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-0.5">
-            <span className="text-xs text-muted-foreground">
-              Redact environment values in outputs
-            </span>
-            <p className="text-[10px] text-muted-foreground/70">
-              Masks eligible environment variable values for newly launched or restarted kernels
-            </p>
-          </div>
-          <Switch
-            checked={redactEnvValuesInOutputs}
-            onCheckedChange={onRedactEnvValuesInOutputsChange}
-          />
-        </div>
-
-        <div className="flex items-center justify-between gap-3">
-          <div className="space-y-0.5">
-            <span className="text-xs text-muted-foreground">
-              Import shell environment into kernels
-            </span>
-            <p className="text-[10px] text-muted-foreground/70">
-              Passes your login shell's env vars (API keys, tokens) to newly launched kernels. Pair
-              with redaction above to keep values out of outputs.
-            </p>
-          </div>
-          <Switch
-            checked={importShellEnvironment}
-            onCheckedChange={onImportShellEnvironmentChange}
-          />
-        </div>
-
-        {importShellEnvironment && !redactEnvValuesInOutputs ? (
-          <div className="text-[10px] text-amber-600 dark:text-amber-400 pl-3 border-l-2 border-amber-500/40">
-            Warning: shell env vars will flow to kernels and into outputs unredacted. Turn on
-            "Redact environment values in outputs" above to scrub them from cell results and the
-            blob store.
-          </div>
-        ) : null}
 
         <div className="space-y-1.5">
           <div className="flex items-center justify-between gap-3">

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -308,7 +308,7 @@ pub struct SyncedSettings {
     #[serde(default = "default_redact_env_values_in_outputs")]
     pub redact_env_values_in_outputs: bool,
 
-    /// Merge the daemon's captured login-shell env into each kernel launch's
+    /// Merge the daemon's captured shell startup env into each kernel launch's
     /// `env_vars`. Combined with `redact_env_values_in_outputs`, the user's
     /// shell secrets reach the kernel but stay out of outputs and the blob
     /// store. Default `true` to match Jupyter's behavior, but redacted on the

--- a/crates/runtimed/src/shell_env_overlay.rs
+++ b/crates/runtimed/src/shell_env_overlay.rs
@@ -1,4 +1,4 @@
-//! Capture the user's login-shell environment once at daemon startup. The
+//! Capture the user's shell startup environment once at daemon startup. The
 //! daemon's own process env is never modified; the overlay is injected into
 //! each `LaunchKernel`/`RestartKernel` RPC's `env_vars` field so the toggle
 //! is honored per-launch without a runtime-agent respawn.
@@ -8,7 +8,13 @@ use tracing::warn;
 #[cfg(unix)]
 const CAPTURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 #[cfg(unix)]
-const SHELL_CAPTURE_SCRIPT: &str = "env -0";
+const DEFAULT_SHELL_CAPTURE_SCRIPT: &str = "env -0";
+#[cfg(unix)]
+const BASH_CAPTURE_SCRIPT: &str =
+    "printf '\\0'; if [ -r \"$HOME/.bashrc\" ]; then . \"$HOME/.bashrc\" >/dev/null 2>&1; fi; env -0";
+#[cfg(unix)]
+const ZSH_CAPTURE_SCRIPT: &str =
+    "printf '\\0'; if [[ -r \"$HOME/.zshrc\" ]]; then source \"$HOME/.zshrc\" >/dev/null 2>&1; fi; env -0";
 
 /// Env vars the daemon or the surrounding process tree manages directly. The
 /// overlay must not stomp these on the kernel `Command`:
@@ -158,7 +164,7 @@ impl ShellEnvOverlay {
         match capture_inner() {
             Ok(overlay) => {
                 tracing::info!(
-                    "[shell-env-overlay] captured {} entries from login shell",
+                    "[shell-env-overlay] captured {} entries from shell startup",
                     overlay.len()
                 );
                 overlay
@@ -209,9 +215,10 @@ fn capture_inner() -> Result<ShellEnvOverlay, String> {
     use std::process::{Command, Stdio};
 
     let shell = std::env::var_os("SHELL").unwrap_or_else(|| std::ffi::OsString::from("/bin/zsh"));
+    let script = capture_script_for_shell(&shell);
 
     let mut cmd = Command::new(&shell);
-    cmd.args(["-l", "-c", SHELL_CAPTURE_SCRIPT])
+    cmd.args(["-l", "-c", script])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -250,20 +257,33 @@ fn capture_inner() -> Result<ShellEnvOverlay, String> {
         Err(_) => {
             kill_group_and_wait(pid, &mut child);
             return Err(format!(
-                "login shell capture timed out after {CAPTURE_TIMEOUT:?}"
+                "shell startup capture timed out after {CAPTURE_TIMEOUT:?}"
             ));
         }
     };
 
     match child.wait() {
         Ok(status) if !status.success() => {
-            return Err(format!("login shell exited with status {status}"));
+            return Err(format!("shell startup capture exited with status {status}"));
         }
         Err(e) => return Err(format!("wait on shell: {e}")),
         _ => {}
     }
 
     Ok(ShellEnvOverlay::parse_null_separated(&buf))
+}
+
+#[cfg(unix)]
+fn capture_script_for_shell(shell: &std::ffi::OsStr) -> &'static str {
+    let shell_name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    match shell_name {
+        "bash" => BASH_CAPTURE_SCRIPT,
+        "zsh" => ZSH_CAPTURE_SCRIPT,
+        _ => DEFAULT_SHELL_CAPTURE_SCRIPT,
+    }
 }
 
 #[cfg(unix)]
@@ -329,7 +349,7 @@ mod tests {
         let overlay = ShellEnvOverlay::capture();
         assert!(
             !overlay.is_empty(),
-            "expected at least one entry from login shell"
+            "expected at least one entry from shell startup"
         );
         let has_path = overlay.entries().iter().any(|(k, _)| k == "PATH");
         assert!(has_path, "expected PATH in captured shell env");
@@ -406,6 +426,23 @@ mod tests {
         let env = overlay.build_kernel_env_vars("/daemon/bin");
         // No user PATH => kernel inherits daemon PATH naturally; we don't set it.
         assert!(!env.contains_key("PATH"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn zsh_capture_sources_zshrc_before_env_dump() {
+        let script = capture_script_for_shell(std::ffi::OsStr::new("/bin/zsh"));
+        assert!(script.contains(".zshrc"));
+        assert!(script.contains("env -0"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unknown_shells_use_plain_env_capture() {
+        assert_eq!(
+            capture_script_for_shell(std::ffi::OsStr::new("/usr/bin/fish")),
+            DEFAULT_SHELL_CAPTURE_SCRIPT,
+        );
     }
 
     #[test]

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -91,7 +91,7 @@ export type SyncedSettings = {
    */
   redact_env_values_in_outputs: boolean;
   /**
-   * Merge the daemon's captured login-shell env into each kernel launch's
+   * Merge the daemon's captured shell startup env into each kernel launch's
    * `env_vars`. Combined with `redact_env_values_in_outputs`, the user's
    * shell secrets reach the kernel but stay out of outputs and the blob
    * store. Default `true` to match Jupyter's behavior, but redacted on the


### PR DESCRIPTION
## Summary

- move environment redaction/import controls from Privacy into the Runtime settings section
- capture zsh and bash startup rc files when importing shell environment into kernels
- update synced settings comments from login-shell env to shell startup env

## Verification

- `cargo test -p runtimed shell_env_overlay --lib`
- `pnpm --dir apps/notebook build`
- `cargo fmt --check`
- `cargo xtask lint --fix`

## Notes

Existing daemons need a restart before newly captured shell startup values are available to newly launched or restarted kernels.
