### PR TITLE
chore(notebook): refresh renderer plugin artifact

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0392cb4b791f75c4072f5c3a6c5161d661d2cd6198e2a08a4e755199f975b8b9
-size 1600681
+oid sha256:d32bbeff7e196dcba073ea3e9e0725998427fb83c174a523c31299a8ac8d52c8
+size 1600869


### PR DESCRIPTION
Refreshes the generated `isolated-renderer.css` LFS artifact after running the repository generator from current `origin/main`.

## Verification

- `cargo xtask wasm`
- `cargo xtask lint --fix`

## Notes

The generator only changed `apps/notebook/src/renderer-plugins/isolated-renderer.css`; all other renderer plugin tracked artifacts remained unchanged.
