### PR TITLE
fix(runtimed-node): append source cells by default

### DIFF
--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -195,8 +195,11 @@ pub struct RunCellOptions {
 pub struct CreateCellOptions {
     /// Cell source type: `"code"` (default), `"markdown"`, or `"raw"`.
     pub cell_type: Option<String>,
-    /// Insert after this cell, or omit to insert at the beginning.
+    /// Insert after this cell, or omit to append at the end.
     pub after_cell_id: Option<String>,
+    /// Position to insert at. Omit to append; 0 prepends; out-of-range appends.
+    /// Cannot be combined with `afterCellId`.
+    pub index: Option<i64>,
 }
 
 /// Options for `Session.setCell()`.
@@ -881,9 +884,10 @@ impl Session {
         let opts = options.unwrap_or_default();
         let cell_type = normalize_cell_type(opts.cell_type)?;
         let (handle, peer_label) = session_handle_and_label(&self.state).await?;
+        let after_cell_id = insertion_anchor(&handle, opts.after_cell_id.as_deref(), opts.index)?;
         let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
         handle
-            .add_cell_with_source(&cell_id, &cell_type, opts.after_cell_id.as_deref(), &source)
+            .add_cell_with_source(&cell_id, &cell_type, after_cell_id.as_deref(), &source)
             .map_err(to_napi_err)?;
         notebook_sync::presence::emit_cursor_at_end(&handle, &cell_id, &source, Some(&peer_label))
             .await;
@@ -1625,11 +1629,60 @@ async fn add_source_cell(
 ) -> Result<String> {
     let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
     let (handle, peer_label) = session_handle_and_label(state).await?;
+    let after_cell_id = insertion_anchor(&handle, None, None)?;
     handle
-        .add_cell_with_source(&cell_id, cell_type, None, source)
+        .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
         .map_err(to_napi_err)?;
     notebook_sync::presence::emit_cursor_at_end(&handle, &cell_id, source, Some(&peer_label)).await;
     Ok(cell_id)
+}
+
+fn insertion_anchor(
+    handle: &DocHandle,
+    after_cell_id: Option<&str>,
+    index: Option<i64>,
+) -> Result<Option<String>> {
+    if after_cell_id.is_some() && index.is_some() {
+        return Err(Error::from_reason(
+            "index and afterCellId cannot both be set",
+        ));
+    }
+
+    if let Some(after_cell_id) = after_cell_id {
+        return Ok(Some(after_cell_id.to_string()));
+    }
+
+    if index.is_some() {
+        return insertion_anchor_from_order(&handle.get_cell_ids(), None, index);
+    }
+
+    Ok(handle.last_cell_id())
+}
+
+fn insertion_anchor_from_order(
+    cell_ids: &[String],
+    after_cell_id: Option<&str>,
+    index: Option<i64>,
+) -> Result<Option<String>> {
+    if after_cell_id.is_some() && index.is_some() {
+        return Err(Error::from_reason(
+            "index and afterCellId cannot both be set",
+        ));
+    }
+
+    if let Some(after_cell_id) = after_cell_id {
+        return Ok(Some(after_cell_id.to_string()));
+    }
+
+    if let Some(index) = index {
+        if index <= 0 {
+            return Ok(None);
+        }
+        let clamped = (index as usize).min(cell_ids.len());
+        return Ok(cell_ids.get(clamped.saturating_sub(1)).cloned());
+    }
+
+    Ok(cell_ids.last().cloned())
 }
 
 fn dependency_fingerprint_for_handle(handle: &DocHandle) -> Option<String> {
@@ -2086,6 +2139,41 @@ mod tests {
         let err = normalize_cell_type(Some("sql".to_string())).unwrap_err();
         assert!(err.reason.contains("Invalid cell_type"));
         assert!(err.reason.contains("code, markdown, raw"));
+    }
+
+    #[test]
+    fn insertion_anchor_defaults_to_append() {
+        let cells = vec!["cell-1".to_string(), "cell-2".to_string()];
+        assert_eq!(
+            insertion_anchor_from_order(&cells, None, None)
+                .unwrap()
+                .as_deref(),
+            Some("cell-2"),
+        );
+        assert_eq!(
+            insertion_anchor_from_order(&cells, Some("cell-1"), None)
+                .unwrap()
+                .as_deref(),
+            Some("cell-1"),
+        );
+        assert!(insertion_anchor_from_order(&cells, None, Some(0))
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            insertion_anchor_from_order(&cells, None, Some(1))
+                .unwrap()
+                .as_deref(),
+            Some("cell-1"),
+        );
+        assert_eq!(
+            insertion_anchor_from_order(&cells, None, Some(99))
+                .unwrap()
+                .as_deref(),
+            Some("cell-2"),
+        );
+
+        let err = insertion_anchor_from_order(&cells, Some("cell-1"), Some(0)).unwrap_err();
+        assert!(err.reason.contains("cannot both be set"));
     }
 
     #[test]

--- a/packages/runtimed-node/README.md
+++ b/packages/runtimed-node/README.md
@@ -87,15 +87,17 @@ sessions.
 - `Session.listCells()` and `Session.getCell(cellId)` inspect notebook cells.
 - `Session.createCell(source, options)`, `Session.setCell(cellId, options)`,
   `Session.deleteCell(cellId)`, and `Session.moveCell(cellId, options)` provide
-  direct notebook editing without MCP JSON round-trips.
+  direct notebook editing without MCP JSON round-trips. `createCell()` appends
+  by default; pass `index: 0` to prepend or `afterCellId` to insert after
+  another cell.
 - `Session.executeCell(cellId, options)` runs an existing code cell.
 - `Session.showNotebook()` opens the session in nteract Desktop when a display
   is available.
 - `Session.interruptKernel()`, `Session.shutdownKernel()`, and
   `Session.restartKernel()` manage the running kernel.
 - `Session.shutdownNotebook()` shuts down this notebook room and closes the session.
-- `Session.runCell(source, options)` creates, runs, and waits for a cell.
-- `Session.queueCell(source, options)` queues a cell and returns IDs.
+- `Session.runCell(source, options)` appends, runs, and waits for a cell.
+- `Session.queueCell(source, options)` appends a cell, queues it, and returns IDs.
 - `Session.waitForExecution(executionId, options)` waits for queued work.
   Pass `onUpdate(progress)` to receive resolved output snapshots while the
   execution is still running.

--- a/packages/runtimed-node/scripts/smoke-api.cjs
+++ b/packages/runtimed-node/scripts/smoke-api.cjs
@@ -57,11 +57,24 @@ async function main() {
 
     const cellId = await session.createCell("x = 1");
     assert.match(cellId, /^cell-/, "createCell() returns a generated cell ID");
+    const secondCellId = await session.createCell("y = 2");
+    const prependedCellId = await session.createCell("# heading", {
+      cellType: "markdown",
+      index: 0,
+    });
 
     const cells = await session.listCells();
     assert(
       cells.some((cell) => cell.id === cellId),
       "created cell is listed",
+    );
+    const createdCells = cells.filter((cell) =>
+      [cellId, secondCellId, prependedCellId].includes(cell.id),
+    );
+    assert.deepEqual(
+      createdCells.map((cell) => cell.id),
+      [prependedCellId, cellId, secondCellId],
+      "createCell() appends by default and supports explicit prepend",
     );
 
     assert.equal(await session.setCell(cellId, { source: "x = 2" }), true);
@@ -76,6 +89,12 @@ async function main() {
 
     assert.equal(await session.deleteCell(cellId), true, "deleteCell() deletes existing cell");
     assert.equal(await session.getCell(cellId), null, "deleted cell is absent");
+    assert.equal(await session.deleteCell(secondCellId), true, "deleteCell() deletes second cell");
+    assert.equal(
+      await session.deleteCell(prependedCellId),
+      true,
+      "deleteCell() deletes prepended cell",
+    );
 
     assert.equal(await session.shutdownNotebook(), true, "shutdownNotebook() evicts room");
     const after = await rt.listActiveNotebooks();

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -129,7 +129,12 @@ export interface CellSnapshot {
 
 export interface CreateCellOptions {
   cellType?: "code" | "markdown" | "raw";
-  afterCellId?: string | null;
+  /** Omit to append at the end. 0 prepends; out-of-range values append. */
+  index?: number;
+  /**
+   * Insert after this cell. Cannot be combined with index.
+   */
+  afterCellId?: string;
 }
 
 export interface SetCellOptions {

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -116,7 +116,7 @@ class Session {
   }
 
   moveCell(cellId, afterCellId) {
-    return this._native.moveCell(cellId, { afterCellId: afterCellId ?? null });
+    return this._native.moveCell(cellId, afterCellId == null ? undefined : { afterCellId });
   }
 
   executeCell(cellId, options) {


### PR DESCRIPTION
## Summary

- Make `@runtimed/node` source-created cells append by default, matching MCP and Python behavior.
- Add `createCell({ index })` support for explicit positional insertion while preserving `afterCellId` for anchored insertion.
- Cover default append and explicit prepend in the daemon-backed Node smoke test.

## Verification

- `cargo xtask lint --fix`
- `cargo check --tests -p runtimed-node`
- `RUSTFLAGS='-C link-arg=-undefined -C link-arg=dynamic_lookup' cargo test -p runtimed-node`
- `pnpm --dir packages/runtimed-node build:debug`
- `pnpm --dir packages/runtimed-node smoke`
- `pnpm --dir packages/runtimed-node smoke:api`
- `node --check packages/runtimed-node/src/session.cjs`
- `git diff --check`
