### PR TITLE
docs(runtimed-client): explain why daemon.json fallback stays

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1040,8 +1040,10 @@ where
                 .to_string();
 
             // Verify the running daemon version matches what we intended to install.
-            // `query_daemon_info` is socket-first with a `daemon.json`
-            // fallback for the one-release compat window.
+            // `query_daemon_info` is socket-first; the `daemon.json` fallback
+            // covers the moment immediately after `runtimed install` when the
+            // restarted daemon may briefly be reachable but not yet serving
+            // `GetDaemonInfo` cleanly.
             let running_version = runtimed_client::singleton::query_daemon_info(
                 runt_workspace::default_socket_path(),
             )
@@ -1402,7 +1404,9 @@ where
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only).
         // `query_daemon_info` is socket-first with a `daemon.json`
-        // fallback for the one-release compat window.
+        // fallback. The fallback is how we read the version of a pre-2.2.0
+        // daemon that doesn't speak `GetDaemonInfo`; without it we'd skip
+        // the upgrade and wedge on the next v4 handshake.
         if !runt_workspace::is_dev_mode() {
             let running_version = runtimed_client::singleton::query_daemon_info(
                 runt_workspace::default_socket_path(),

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -58,17 +58,21 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
 /// Get daemon info, preferring the socket-based `GetDaemonInfo` request
 /// and falling back to the on-disk `daemon.json` sidecar.
 ///
-/// This is the intended replacement for `get_running_daemon_info()` —
-/// the socket is the source of truth (the daemon fills the response
-/// from live state, so the result can't be stale the way the file
-/// can). The file is read only when the socket query fails, which
-/// happens when an older daemon doesn't recognise the new request.
-/// Once every daemon in the wild knows `GetDaemonInfo`, the fallback
-/// (and the whole file) can be deleted.
+/// The socket is the source of truth — the daemon fills the response
+/// from live state, so it can't go stale the way the file can. The file
+/// is read only when the socket query fails, which means the running
+/// daemon predates `GetDaemonInfo` (#1803, 2026-04-15 — pre-2.2.0-stable).
 ///
-/// `socket_path` pins which daemon is being queried. The fallback
-/// reads `daemon.json` from the **same directory as the socket**, so
-/// callers that pin a non-default daemon (tests, worktree isolation,
+/// The fallback is what lets `ensure_daemon_via_sidecar` discover an old
+/// daemon's version and decide to upgrade it. Without the fallback, that
+/// path returns `None`, the upgrade is skipped, and the new app then
+/// fails its v4 handshake against the old daemon — leaving the user
+/// wedged. Keep the fallback until we're confident no pre-#1803 daemons
+/// are still running.
+///
+/// `socket_path` pins which daemon is being queried. The fallback reads
+/// `daemon.json` from the **same directory as the socket**, so callers
+/// that pin a non-default daemon (tests, worktree isolation,
 /// cross-channel lookups) still resolve to the correct instance — not
 /// the process's default namespace.
 pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<DaemonInfo> {


### PR DESCRIPTION
## Summary

- Doc-only. No behavior change.
- Replaces the \"transitional shim, can be deleted once everyone has \`GetDaemonInfo\`\" framing on \`query_daemon_info\` with what the fallback actually does.
- Annotates the two \`crates/notebook/src/lib.rs\` call sites so the upgrade-flow dependency is visible without chasing references.

## Why

While surveying protocol cruft for possible deletion, this looked like an easy delete. Reading \`ensure_daemon_via_sidecar\` showed it isn't: the daemon.json fallback is how a new app reads the version of a pre-2.2.0 daemon that doesn't speak \`GetDaemonInfo\`. Without it, that path returns \`None\`, the upgrade is skipped, and the new app then fails its v4 handshake against the old daemon — user wedged. Anchor the why in the code so the next cleanup pass doesn't repeat the mistake.

## Test plan

- [ ] Doc-only diff; no tests required.
- [ ] \`cargo xtask lint --fix\` clean locally.