### PR TITLE
fix(notebook): support inline uv python override

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -319,6 +319,7 @@ function AppContent() {
     loading: depsLoading,
     addDependency,
     removeDependency,
+    setRequiresPython,
     clearAllDependencies: clearAllUvDeps,
     pyprojectInfo,
     pyprojectDeps,
@@ -1756,6 +1757,7 @@ function AppContent() {
               loading={depsLoading}
               onAdd={addDependency}
               onRemove={removeDependency}
+              onSetRequiresPython={setRequiresPython}
               syncState={uvDerivedSyncState}
               onSyncNow={handleSyncDeps}
               pyprojectInfo={pyprojectInfo}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -1,5 +1,5 @@
 import { Check, Download, FileText, Info, Plus, RefreshCw, X } from "lucide-react";
-import { type KeyboardEvent, useCallback, useState } from "react";
+import { type KeyboardEvent, useCallback, useEffect, useState } from "react";
 import type { EnvSyncState, PyProjectDeps, PyProjectInfo } from "../hooks/useDependencies";
 
 interface DependencyHeaderProps {
@@ -8,6 +8,7 @@ interface DependencyHeaderProps {
   loading: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
+  onSetRequiresPython?: (version: string | null) => Promise<void>;
   // Environment sync state
   syncState?: EnvSyncState | null;
   onSyncNow?: () => Promise<boolean>;
@@ -30,6 +31,7 @@ export function DependencyHeader({
   loading,
   onAdd,
   onRemove,
+  onSetRequiresPython,
   syncState,
   onSyncNow,
   pyprojectInfo,
@@ -40,6 +42,11 @@ export function DependencyHeader({
   justSynced,
 }: DependencyHeaderProps) {
   const [newDep, setNewDep] = useState("");
+  const [pythonSpec, setPythonSpec] = useState(requiresPython ?? "");
+
+  useEffect(() => {
+    setPythonSpec(requiresPython ?? "");
+  }, [requiresPython]);
 
   const handleAdd = useCallback(async () => {
     if (newDep.trim()) {
@@ -56,6 +63,24 @@ export function DependencyHeader({
       }
     },
     [handleAdd],
+  );
+
+  const commitPythonSpec = useCallback(async () => {
+    if (!onSetRequiresPython) return;
+    const next = pythonSpec.trim();
+    const current = requiresPython ?? "";
+    if (next === current) return;
+    await onSetRequiresPython(next || null);
+  }, [onSetRequiresPython, pythonSpec, requiresPython]);
+
+  const handlePythonKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitPythonSpec();
+      }
+    },
+    [commitPythonSpec],
   );
 
   return (
@@ -198,10 +223,29 @@ export function DependencyHeader({
         )}
 
         {/* Python version */}
-        {requiresPython && (
-          <div className="mb-2 text-xs text-muted-foreground">
-            Python: <span className="font-mono">{requiresPython}</span>
-          </div>
+        {isUsingProjectEnv ? (
+          requiresPython && (
+            <div className="mb-2 text-xs text-muted-foreground">
+              Python: <span className="font-mono">{requiresPython}</span>
+            </div>
+          )
+        ) : (
+          <label className="mb-3 flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="shrink-0">Python</span>
+            <input
+              type="text"
+              value={pythonSpec}
+              onChange={(e) => setPythonSpec(e.target.value)}
+              onBlur={commitPythonSpec}
+              onKeyDown={handlePythonKeyDown}
+              placeholder=">=3.13"
+              data-testid="uv-python-input"
+              className="w-40 rounded border bg-background px-2 py-1 font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              disabled={loading || !onSetRequiresPython}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
         )}
 
         {/* Dependencies list (read-only when using project env) */}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -8,7 +8,7 @@ interface DependencyHeaderProps {
   loading: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
-  onSetRequiresPython?: (version: string | null) => Promise<void>;
+  onSetRequiresPython: (version: string | null) => Promise<void>;
   // Environment sync state
   syncState?: EnvSyncState | null;
   onSyncNow?: () => Promise<boolean>;
@@ -66,7 +66,6 @@ export function DependencyHeader({
   );
 
   const commitPythonSpec = useCallback(async () => {
-    if (!onSetRequiresPython) return;
     const next = pythonSpec.trim();
     const current = requiresPython ?? "";
     if (next === current) return;
@@ -241,7 +240,7 @@ export function DependencyHeader({
               placeholder=">=3.13"
               data-testid="uv-python-input"
               className="w-40 rounded border bg-background px-2 py-1 font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-              disabled={loading || !onSetRequiresPython}
+              disabled={loading}
               autoComplete="off"
               spellCheck={false}
             />

--- a/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
+++ b/apps/notebook/src/components/KernelLaunchErrorBanner.tsx
@@ -1,4 +1,5 @@
-import { AlertCircle, RotateCw, X } from "lucide-react";
+import { AlertCircle, Check, Copy, RotateCw, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { KERNEL_ERROR_REASON, type RuntimeLifecycle } from "runtimed";
 import { Button } from "@/components/ui/button";
 
@@ -66,6 +67,17 @@ export function KernelLaunchErrorBanner({
   onRetry,
   onDismiss,
 }: KernelLaunchErrorBannerProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setCopied(false);
+  }, [errorDetails]);
+
+  const copyDetails = useCallback(async () => {
+    await navigator.clipboard.writeText(errorDetails);
+    setCopied(true);
+  }, [errorDetails]);
+
   return (
     <div className="flex items-start gap-3 border-b border-red-600/50 bg-red-600/10 px-3 py-2 text-xs text-red-900 dark:text-red-200">
       <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5 text-red-600 dark:text-red-400" />
@@ -76,6 +88,16 @@ export function KernelLaunchErrorBanner({
         </pre>
       </div>
       <div className="flex flex-shrink-0 items-center gap-1">
+        <Button
+          size="sm"
+          variant="secondary"
+          className="h-6 px-2 text-xs bg-red-100 text-red-900 hover:bg-red-200 dark:bg-red-900/40 dark:text-red-100 dark:hover:bg-red-900/60"
+          onClick={copyDetails}
+          data-testid="copy-kernel-launch-error"
+        >
+          {copied ? <Check className="h-3 w-3 mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
+          {copied ? "Copied" : "Copy"}
+        </Button>
         <Button
           size="sm"
           variant="secondary"

--- a/apps/notebook/src/components/__tests__/dependency-header.test.tsx
+++ b/apps/notebook/src/components/__tests__/dependency-header.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { DependencyHeader } from "../DependencyHeader";
+
+function renderDependencyHeader(props: Partial<Parameters<typeof DependencyHeader>[0]> = {}) {
+  const defaults = {
+    dependencies: [],
+    requiresPython: null,
+    loading: false,
+    onAdd: vi.fn().mockResolvedValue(undefined),
+    onRemove: vi.fn().mockResolvedValue(undefined),
+    onSetRequiresPython: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return render(<DependencyHeader {...defaults} {...props} />);
+}
+
+describe("DependencyHeader", () => {
+  it("commits a trimmed Python constraint on Enter", async () => {
+    const user = userEvent.setup();
+    const onSetRequiresPython = vi.fn().mockResolvedValue(undefined);
+    renderDependencyHeader({ onSetRequiresPython });
+
+    await user.type(screen.getByTestId("uv-python-input"), "  >=3.12,<3.13  {Enter}");
+
+    await waitFor(() => {
+      expect(onSetRequiresPython).toHaveBeenCalledWith(">=3.12,<3.13");
+    });
+  });
+
+  it("clears the Python constraint when the field is emptied", async () => {
+    const user = userEvent.setup();
+    const onSetRequiresPython = vi.fn().mockResolvedValue(undefined);
+    renderDependencyHeader({ requiresPython: ">=3.13", onSetRequiresPython });
+
+    const input = screen.getByTestId("uv-python-input");
+    await user.clear(input);
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(onSetRequiresPython).toHaveBeenCalledWith(null);
+    });
+  });
+});

--- a/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
+++ b/apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx
@@ -61,6 +61,27 @@ describe("KernelLaunchErrorBanner", () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
+  it("copies the launch details", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <KernelLaunchErrorBanner
+        errorDetails={STDERR_TAIL}
+        onRetry={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTestId("copy-kernel-launch-error"));
+    expect(writeText).toHaveBeenCalledWith(STDERR_TAIL);
+    expect(screen.getByText("Copied")).toBeInTheDocument();
+  });
+
   it("invokes onDismiss when the X is clicked", async () => {
     const user = userEvent.setup();
     const onDismiss = vi.fn();

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -159,6 +159,15 @@ pub fn compute_env_hash(deps: &UvDependencies, env_id: Option<&str>) -> String {
     hex::encode(hash)[..16].to_string()
 }
 
+fn uv_python_request(requires_python: &str) -> Option<String> {
+    let request = requires_python.trim();
+    if request.is_empty() {
+        None
+    } else {
+        Some(request.to_string())
+    }
+}
+
 /// Prepare a virtual environment with the given dependencies.
 ///
 /// Uses cached environments when possible (keyed by dependency hash).
@@ -245,11 +254,8 @@ pub async fn prepare_environment_in(
     venv_cmd.current_dir(cache_dir);
 
     if let Some(ref py_version) = deps.requires_python {
-        let version = py_version
-            .trim_start_matches(|c: char| !c.is_ascii_digit())
-            .to_string();
-        if !version.is_empty() {
-            venv_cmd.arg("--python").arg(&version);
+        if let Some(version) = uv_python_request(py_version) {
+            venv_cmd.arg("--python").arg(version);
         }
     }
 
@@ -487,11 +493,8 @@ pub async fn prepare_environment_unified(
     venv_cmd.current_dir(cache_dir);
 
     if let Some(ref py_version) = deps.requires_python {
-        let version = py_version
-            .trim_start_matches(|c: char| !c.is_ascii_digit())
-            .to_string();
-        if !version.is_empty() {
-            venv_cmd.arg("--python").arg(&version);
+        if let Some(version) = uv_python_request(py_version) {
+            venv_cmd.arg("--python").arg(version);
         }
     }
 
@@ -1190,6 +1193,16 @@ mod tests {
             s.contains("runt-nightly") || s.contains("runt"),
             "got {s:?}"
         );
+    }
+
+    #[test]
+    fn uv_python_request_preserves_version_constraints() {
+        assert_eq!(uv_python_request("3.12").as_deref(), Some("3.12"));
+        assert_eq!(
+            uv_python_request(">=3.12,<3.13").as_deref(),
+            Some(">=3.12,<3.13")
+        );
+        assert_eq!(uv_python_request("   "), None);
     }
 
     #[test]

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -14,6 +14,14 @@ use kernel_env::progress::{EnvProgressPhase, ProgressHandler};
 use runtime_doc::RuntimeStateHandle;
 
 const CRDT_PROGRESS_MIN_INTERVAL: Duration = Duration::from_millis(250);
+const DEFAULT_INLINE_UV_REQUIRES_PYTHON: &str = ">=3.13";
+
+fn inline_uv_requires_python(requires_python: Option<&str>) -> &str {
+    requires_python
+        .map(str::trim)
+        .filter(|spec| !spec.is_empty())
+        .unwrap_or(DEFAULT_INLINE_UV_REQUIRES_PYTHON)
+}
 
 #[derive(Default)]
 struct CrdtProgressWriteState {
@@ -179,12 +187,13 @@ pub(crate) fn inline_deps_with_conda_required_packages(deps: &[String]) -> Vec<S
 ///
 pub async fn prepare_uv_inline_env(
     deps: &[String],
+    requires_python: Option<&str>,
     prerelease: Option<&str>,
     handler: Arc<dyn ProgressHandler>,
 ) -> Result<PreparedEnv> {
     let uv_deps = kernel_env::UvDependencies {
         dependencies: inline_deps_with_required_packages(deps),
-        requires_python: Some(">=3.13".to_string()),
+        requires_python: Some(inline_uv_requires_python(requires_python).to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
 
@@ -242,16 +251,18 @@ pub async fn prepare_conda_inline_env(
 pub async fn claim_pool_env_for_uv_inline_cache(
     env: &mut crate::PooledEnv,
     deps: &[String],
+    requires_python: Option<&str>,
     prerelease: Option<&str>,
 ) {
     let uv_deps = kernel_env::UvDependencies {
         dependencies: inline_deps_with_required_packages(deps),
-        requires_python: Some(">=3.13".to_string()),
+        requires_python: Some(inline_uv_requires_python(requires_python).to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
     let hash = kernel_env::uv::compute_env_hash(&uv_deps, None);
     let target = inline_cache_dir().join(&hash);
     rename_env_to_target(&mut env.venv_path, &mut env.python_path, target).await;
+    kernel_env::gc::touch_last_used(&env.venv_path).await;
 }
 
 /// Rename a pool-derived Conda env to the inline-cache hash location. See
@@ -569,12 +580,13 @@ pub fn compare_deps_to_pool(inline_deps: &[String], pool_packages: &[String]) ->
 /// today's layout before the kernel boots.
 pub async fn check_uv_inline_cache(
     deps: &[String],
+    requires_python: Option<&str>,
     prerelease: Option<&str>,
     bootstrap_dx: bool,
 ) -> Option<PreparedEnv> {
     let uv_deps = kernel_env::UvDependencies {
         dependencies: inline_deps_with_required_packages(deps),
-        requires_python: Some(">=3.13".to_string()),
+        requires_python: Some(inline_uv_requires_python(requires_python).to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
 

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -226,6 +226,18 @@ pub(crate) fn get_inline_uv_deps(snapshot: &NotebookMetadataSnapshot) -> Option<
     None
 }
 
+/// Extract UV Python version constraint from a metadata snapshot.
+pub(crate) fn get_inline_uv_requires_python(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
+    snapshot
+        .runt
+        .uv
+        .as_ref()
+        .and_then(|uv| uv.requires_python.as_deref())
+        .map(str::trim)
+        .filter(|spec| !spec.is_empty())
+        .map(str::to_string)
+}
+
 /// Extract UV prerelease strategy from a metadata snapshot.
 pub(crate) fn get_inline_uv_prerelease(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
     snapshot
@@ -2307,25 +2319,17 @@ pub(crate) async fn reset_starting_state(
         .await;
 }
 
-fn env_progress_type_for_source(env_source: &str) -> &'static str {
-    // Current environment-prepare failures are Python package-manager paths.
-    // Keep unknown/legacy Python sources on the UV rail, which is also the
-    // historical fallback package manager.
-    if env_source.starts_with("conda:") {
-        "conda"
-    } else if env_source.starts_with("pixi:") {
-        "pixi"
-    } else {
-        "uv"
-    }
-}
-
 /// Publish a pre-spawn environment preparation failure into RuntimeStateDoc.
 ///
 /// Request callers already receive an error response, but the UI's persistent
-/// state comes from RuntimeStateDoc. Without this write, clients stay in a
-/// starting lifecycle after a solver/install failure and render only
+/// state comes from RuntimeStateDoc. Without the kernel-state write, clients
+/// stay in a starting lifecycle after a solver/install failure and render only
 /// "Initializing".
+///
+/// Clear `env.progress` instead of also writing an error progress event: the
+/// kernel error details are the durable failure surface, and duplicating the
+/// same text through progress creates a second banner for the same launch
+/// failure.
 ///
 /// Current call sites are Python environment preparation paths, so this writes
 /// Python kernel info. Other runtime families should add a runtime-aware
@@ -2336,14 +2340,10 @@ pub(crate) fn publish_environment_launch_error(
     reason: Option<KernelErrorReason>,
     details: &str,
 ) {
-    let progress_value = serde_json::json!({
-        "phase": "error",
-        "message": details,
-    });
     if let Err(e) = room.state.with_doc(|sd| {
         sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, reason, Some(details))?;
         sd.set_kernel_info("python", "python", env_source)?;
-        sd.set_env_progress(env_progress_type_for_source(env_source), &progress_value)?;
+        sd.clear_env_progress()?;
         Ok(())
     }) {
         error!(
@@ -2436,11 +2436,20 @@ pub(crate) fn sync_environment_agent_communication_error_response(
 /// Returns `Ok((PooledEnv, actual_packages))` on success, `Err(())` on failure.
 pub(crate) async fn try_uv_pool_for_inline_deps(
     deps: &[String],
+    requires_python: Option<&str>,
     daemon: &std::sync::Arc<crate::daemon::Daemon>,
     room: &NotebookRoom,
     progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler>,
 ) -> Result<(crate::PooledEnv, Vec<String>), ()> {
     let effective_deps = crate::inline_env::inline_deps_with_required_packages(deps);
+
+    if requires_python
+        .map(str::trim)
+        .is_some_and(|spec| !spec.is_empty())
+    {
+        debug!("[notebook-sync] UV inline deps pin Python, skipping pool reuse");
+        return Err(());
+    }
 
     // Quick pre-check: if any dep has version specifiers, skip pool entirely
     // (avoids consuming a pool env we'd have to discard)
@@ -2482,7 +2491,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
             // before releasing the lease — otherwise the sweep races
             // with the launch handler's later `runtime_agent_env_path`
             // write and can delete the env mid-launch.
-            crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None).await;
+            crate::inline_env::claim_pool_env_for_uv_inline_cache(
+                &mut env,
+                deps,
+                requires_python,
+                None,
+            )
+            .await;
             {
                 let mut ep = room.runtime_agent_env_path.write().await;
                 *ep = Some(env.venv_path.clone());
@@ -2510,8 +2525,13 @@ pub(crate) async fn try_uv_pool_for_inline_deps(
                     // the next restart cache-hits. See #2089 / #2083.
                     // Same claim-best-effort caveat as the Subset arm —
                     // install runtime ownership before releasing.
-                    crate::inline_env::claim_pool_env_for_uv_inline_cache(&mut env, deps, None)
-                        .await;
+                    crate::inline_env::claim_pool_env_for_uv_inline_cache(
+                        &mut env,
+                        deps,
+                        requires_python,
+                        None,
+                    )
+                    .await;
                     {
                         let mut ep = room.runtime_agent_env_path.write().await;
                         *ep = Some(env.venv_path.clone());
@@ -3173,8 +3193,13 @@ pub(crate) async fn auto_launch_kernel(
                 "[notebook-sync] Preparing cached UV env for PEP 723 deps: {:?}",
                 deps
             );
-            match crate::inline_env::prepare_uv_inline_env(deps, None, progress_handler.clone())
-                .await
+            match crate::inline_env::prepare_uv_inline_env(
+                deps,
+                None,
+                None,
+                progress_handler.clone(),
+            )
+            .await
             {
                 Ok(prepared) => {
                     info!(
@@ -3210,14 +3235,21 @@ pub(crate) async fn auto_launch_kernel(
             let prerelease = metadata_snapshot
                 .as_ref()
                 .and_then(get_inline_uv_prerelease);
+            let requires_python = metadata_snapshot
+                .as_ref()
+                .and_then(get_inline_uv_requires_python);
 
             // Fast path: check inline env cache first (instant on hit).
             // `check_uv_inline_cache` re-vendors the launcher on hit when
             // bootstrap_dx is on, so a stale pre-0.2.0 cache entry is
             // brought up to today's layout before the kernel boots.
-            if let Some(cached) =
-                crate::inline_env::check_uv_inline_cache(&deps, prerelease.as_deref(), bootstrap_dx)
-                    .await
+            if let Some(cached) = crate::inline_env::check_uv_inline_cache(
+                &deps,
+                requires_python.as_deref(),
+                prerelease.as_deref(),
+                bootstrap_dx,
+            )
+            .await
             {
                 info!(
                     "[notebook-sync] UV inline cache hit at {:?}",
@@ -3232,8 +3264,14 @@ pub(crate) async fn auto_launch_kernel(
                 (env, Some(deps))
             } else if prerelease.is_none() {
                 // Try pool reuse for bare deps without prerelease
-                match try_uv_pool_for_inline_deps(&deps, &daemon, room, progress_handler.clone())
-                    .await
+                match try_uv_pool_for_inline_deps(
+                    &deps,
+                    requires_python.as_deref(),
+                    &daemon,
+                    room,
+                    progress_handler.clone(),
+                )
+                .await
                 {
                     Ok((env, pool_pkgs)) => {
                         let mut pooled = env;
@@ -3248,6 +3286,7 @@ pub(crate) async fn auto_launch_kernel(
                         );
                         match crate::inline_env::prepare_uv_inline_env(
                             &deps,
+                            requires_python.as_deref(),
                             prerelease.as_deref(),
                             progress_handler.clone(),
                         )
@@ -3290,6 +3329,7 @@ pub(crate) async fn auto_launch_kernel(
                 );
                 match crate::inline_env::prepare_uv_inline_env(
                     &deps,
+                    requires_python.as_deref(),
                     prerelease.as_deref(),
                     progress_handler.clone(),
                 )

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -7575,10 +7575,18 @@ async fn reset_starting_state_error_variant_writes_details() {
 }
 
 #[tokio::test]
-async fn publish_environment_launch_error_writes_kernel_and_env_progress() {
+async fn publish_environment_launch_error_writes_kernel_error_and_clears_env_progress() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, _) = test_room_with_path(&tmp, "env-prepare-failure.ipynb");
     let details = "Failed to prepare conda inline environment: no candidates for pywidget";
+    room.state
+        .with_doc(|sd| {
+            sd.set_env_progress(
+                "conda",
+                &serde_json::json!({ "phase": "solving", "spec_count": 5 }),
+            )
+        })
+        .unwrap();
 
     publish_environment_launch_error(
         &room,
@@ -7600,14 +7608,7 @@ async fn publish_environment_launch_error_writes_kernel_and_env_progress() {
     assert_eq!(state.kernel.error_details.as_deref(), Some(details));
     assert_eq!(state.kernel.language, "python");
     assert_eq!(state.kernel.env_source, "conda:inline");
-    assert_eq!(
-        state.env.progress,
-        Some(serde_json::json!({
-            "env_type": "conda",
-            "phase": "error",
-            "message": details,
-        }))
-    );
+    assert_eq!(state.env.progress, None);
 }
 
 #[test]

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -30,12 +30,13 @@ use crate::notebook_sync_server::{
     captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
     extract_pixi_toml_deps, format_conda_env_yml_build_details, get_inline_conda_channels,
     get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps, get_inline_uv_prerelease,
-    missing_conda_env_yml_decision, project_environment_build_approved,
-    promote_inline_deps_to_project, publish_environment_launch_error,
-    publish_kernel_state_presence, reset_starting_state, reset_starting_state_with_outcome,
-    resolve_metadata_snapshot, send_runtime_agent_request_with_kernel_ports,
-    try_conda_pool_for_inline_deps, try_uv_pool_for_inline_deps, unified_env_on_disk,
-    CapturedEnvRuntime, NotebookRoom, ResetOutcome,
+    get_inline_uv_requires_python, missing_conda_env_yml_decision,
+    project_environment_build_approved, promote_inline_deps_to_project,
+    publish_environment_launch_error, publish_kernel_state_presence, reset_starting_state,
+    reset_starting_state_with_outcome, resolve_metadata_snapshot,
+    send_runtime_agent_request_with_kernel_ports, try_conda_pool_for_inline_deps,
+    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
+    ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -698,6 +699,7 @@ pub(crate) async fn handle(
             match crate::inline_env::prepare_uv_inline_env(
                 &deps,
                 None,
+                None,
                 launch_progress_handler.clone(),
             )
             .await
@@ -747,14 +749,21 @@ pub(crate) async fn handle(
             let prerelease = metadata_snapshot
                 .as_ref()
                 .and_then(get_inline_uv_prerelease);
+            let requires_python = metadata_snapshot
+                .as_ref()
+                .and_then(get_inline_uv_requires_python);
 
             // Fast path: check inline env cache first (instant on hit).
             // `check_uv_inline_cache` re-vendors the launcher on hit when
             // bootstrap_dx is on, so stale pre-0.2.0 envs are brought up
             // to today's layout before the kernel boots.
-            if let Some(cached) =
-                crate::inline_env::check_uv_inline_cache(&deps, prerelease.as_deref(), bootstrap_dx)
-                    .await
+            if let Some(cached) = crate::inline_env::check_uv_inline_cache(
+                &deps,
+                requires_python.as_deref(),
+                prerelease.as_deref(),
+                bootstrap_dx,
+            )
+            .await
             {
                 info!(
                     "[notebook-sync] LaunchKernel: UV inline cache hit at {:?}",
@@ -771,6 +780,7 @@ pub(crate) async fn handle(
                 // Try pool reuse for bare deps without prerelease
                 match try_uv_pool_for_inline_deps(
                     &deps,
+                    requires_python.as_deref(),
                     daemon,
                     room,
                     launch_progress_handler.clone(),
@@ -790,6 +800,7 @@ pub(crate) async fn handle(
                         );
                         match crate::inline_env::prepare_uv_inline_env(
                             &deps,
+                            requires_python.as_deref(),
                             prerelease.as_deref(),
                             launch_progress_handler.clone(),
                         )
@@ -827,6 +838,7 @@ pub(crate) async fn handle(
                 );
                 match crate::inline_env::prepare_uv_inline_env(
                     &deps,
+                    requires_python.as_deref(),
                     prerelease.as_deref(),
                     launch_progress_handler.clone(),
                 )


### PR DESCRIPTION
## Summary

- Add an editable Python constraint field to the inline UV dependency UI.
- Route notebook `requires-python` through inline UV cache/build paths, preserving full UV constraints such as `>=3.12,<3.13`.
- Skip UV pool reuse when Python is pinned and refresh `.last-used` after claiming a pooled env into the inline cache hash path.
- Collapse environment preparation failures onto the red kernel launch error banner and add a copy button for the full details.

## Testing

- `vp check --fix`
- `cargo fmt --check`
- `git diff --check`
- `pnpm test:run apps/notebook/src/components/__tests__/kernel-launch-error-banner.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/dependency-header.test.tsx`
- `pnpm exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo test -p kernel-env uv_python_request_preserves_version_constraints`
- `cargo test -p runtimed publish_environment_launch_error_writes_kernel_error_and_clears_env_progress`
