### PR TITLE
fix(runtime): avoid false execution pointer clears

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -540,7 +540,7 @@ impl DocHandle {
     /// This is the notebook adapter input for the shared execution-view
     /// projector. It intentionally returns only document-native pointers; the
     /// runtime execution entries stay in RuntimeStateDoc.
-    pub fn get_cell_execution_pointers(&self) -> Vec<(String, Option<String>)> {
+    pub fn get_cell_execution_pointers(&self) -> Result<Vec<(String, Option<String>)>, SyncError> {
         let cell_ids: Vec<String> = self
             .snapshot_rx
             .borrow()
@@ -549,20 +549,15 @@ impl DocHandle {
             .map(|cell| cell.id.clone())
             .collect();
 
-        let Ok(state) = self.doc.lock() else {
-            return cell_ids
-                .into_iter()
-                .map(|cell_id| (cell_id, None))
-                .collect();
-        };
+        let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
 
-        cell_ids
+        Ok(cell_ids
             .into_iter()
             .map(|cell_id| {
                 let execution_id = read_execution_id(&state.doc, &cell_id);
                 (cell_id, execution_id)
             })
-            .collect()
+            .collect())
     }
 
     /// Get a single cell's execution count (e.g. "5" or "null").

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -579,6 +579,34 @@ mod tests {
     }
 
     #[test]
+    fn cell_execution_pointers_report_poisoned_lock() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.set_execution_id("cell-1", Some("exec-1")).unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        let shared = handle.shared_state().clone();
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let _ = std::panic::catch_unwind(move || {
+            let _guard = shared.lock().unwrap();
+            panic!("poison shared doc state");
+        });
+        std::panic::set_hook(previous_hook);
+
+        assert!(matches!(
+            handle.get_cell_execution_pointers(),
+            Err(SyncError::LockPoisoned)
+        ));
+    }
+
+    #[test]
     fn test_convenience_set_metadata_snapshot() {
         let (handle, _changed_rx, _cmd_rx) = test_handle();
 

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -552,7 +552,10 @@ impl Session {
         let task = spawn_event_task(async move {
             let mut projector = ExecutionViewProjector::default();
             let state = runtime_rx.borrow().clone();
-            let changeset = projector.project_all(handle.get_cell_execution_pointers(), &state);
+            let changeset = match handle.get_cell_execution_pointers() {
+                Ok(cell_pointers) => projector.project_all(cell_pointers, &state),
+                Err(_) => projector.project_runtime(&state),
+            };
             if !changeset.is_empty() {
                 emit_json(&tsfn, &changeset);
             }
@@ -563,8 +566,14 @@ impl Session {
                         if changed.is_err() {
                             break;
                         }
-                        let state = runtime_rx.borrow().clone();
-                        let changeset = projector.project_all(handle.get_cell_execution_pointers(), &state);
+                        let state = runtime_rx.borrow_and_update().clone();
+                        let changeset = match handle.get_cell_execution_pointers() {
+                            Ok(cell_pointers) => projector.project_all(cell_pointers, &state),
+                            Err(_) => {
+                                projector.reset();
+                                projector.project_runtime(&state)
+                            }
+                        };
                         if !changeset.is_empty() {
                             emit_json(&tsfn, &changeset);
                         }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1481,10 +1481,11 @@ impl AsyncSession {
         let rs = handle
             .get_runtime_state()
             .map_err(|e| to_py_err(format!("{}", e)))?;
+        let cell_pointers = handle
+            .get_cell_execution_pointers()
+            .map_err(|e| to_py_err(format!("{}", e)))?;
         let mut projector = runtime_doc::ExecutionViewProjector::default();
-        Ok(projector
-            .project_all(handle.get_cell_execution_pointers(), &rs)
-            .into())
+        Ok(projector.project_all(cell_pointers, &rs).into())
     }
 
     /// Whether the session is connected (sync read — no future needed).

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -89,8 +89,29 @@ type QueuedExecution = {
   executionId: string;
 };
 
+type ExecutionViewSnapshot = {
+  execution_count: number | null;
+  status: string;
+  success: boolean | null;
+  output_ids: string[];
+};
+
+type ExecutionViewChangeset = {
+  execution_upserts?: Array<[executionId: string, snapshot: ExecutionViewSnapshot]>;
+};
+
+type SubscriptionLike = {
+  unsubscribe?: () => void;
+  dispose?: () => void;
+};
+
+type ObservableLike<T> = {
+  subscribe(next: (value: T) => void): SubscriptionLike;
+};
+
 type Session = {
   readonly notebookId: string;
+  readonly executionViewChanges$?: ObservableLike<ExecutionViewChangeset>;
   runCell(
     source: string,
     opts?: { timeoutMs?: number; cellType?: string; onUpdate?: (progress: CellResult) => void },
@@ -649,6 +670,27 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
   let session: Session | null = null;
   let opening: Promise<Session> | null = null;
   let nextExecCount: number | null = 1;
+  let executionViewSubscription: SubscriptionLike | null = null;
+
+  function disposeExecutionViewTracking(): void {
+    const sub = executionViewSubscription;
+    executionViewSubscription = null;
+    sub?.unsubscribe?.();
+    sub?.dispose?.();
+  }
+
+  function trackExecutionView(sess: Session): void {
+    disposeExecutionViewTracking();
+    executionViewSubscription =
+      sess.executionViewChanges$?.subscribe((changeset) => {
+        for (const [, snapshot] of changeset.execution_upserts ?? []) {
+          const count = snapshot.execution_count;
+          if (typeof count === "number") {
+            nextExecCount = Math.max(nextExecCount ?? 1, count + 1);
+          }
+        }
+      }) ?? null;
+  }
 
   async function addDependenciesAndSync(sess: Session, packages: string[]): Promise<void> {
     const unique = Array.from(new Set(packages.map((pkg) => pkg.trim()).filter(Boolean)));
@@ -689,6 +731,7 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
         description: "pi Python REPL",
         dependencies,
       });
+      trackExecutionView(session);
       return session;
     })();
     try {
@@ -951,6 +994,7 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
       const old = session;
       session = null;
       nextExecCount = 1;
+      disposeExecutionViewTracking();
       if (old) {
         try {
           if (old.shutdownNotebook) {
@@ -968,6 +1012,7 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    disposeExecutionViewTracking();
     if (session) {
       try {
         if (session.shutdownNotebook) {


### PR DESCRIPTION
## Summary

- return `SyncError::LockPoisoned` from the notebook execution-pointer adapter instead of synthesizing `(cell_id, None)` entries
- update Node and Python execution-view consumers to respect that fallible adapter
- consume runtime-state watch updates when the Node execution-view subscriber folds runtime state into a notebook tick
- wire `@nteract/pi` to `Session.executionViewChanges$` so its next execution prompt tracks the shared Rust materialized view

## Verification

- `cargo test -p notebook-sync cell_execution_pointers_report_poisoned_lock`
- `cargo test -p notebook-sync`
- `cargo clippy -p notebook-sync -p runtimed-node -p runtimed-py --all-targets -- -D warnings`
- `pnpm --filter @nteract/pi pack:dry-run`
- `cargo xtask lint --fix`
