### PR TITLE
chore(release): bump versions for 2.4.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.2.8"
+      "version": "0.2.9"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.2.8"
+      "version": "0.2.9"
     }
   ]
 }

--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -17,7 +17,7 @@ inputs:
   wasm-pack-version:
     description: wasm-pack version to install (must support --profile)
     required: false
-    default: "0.14.0"
+    default: "0.15.0"
   node-version:
     description: Node.js version
     required: false

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: wasm-pack version to install.
     required: false
-    default: "0.14.0"
+    default: "0.15.0"
 
 runs:
   using: composite

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -39,11 +39,10 @@ jobs:
           shared-key: ubuntu-wasm
 
       - name: Install wasm-pack
-        # Pin to 0.14.0+ for `--profile <NAME>` support; see comment in
-        # `.github/workflows/build.yml`.
+        # Pin to match the runtime-artifact builder.
         uses: ./.github/actions/install-wasm-pack
         with:
-          version: 0.14.0
+          version: 0.15.0
 
       - name: Build sift-wasm
         run: wasm-pack build crates/sift-wasm --target web --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "automerge",
  "serde_json",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4193,7 +4193,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs",
  "libc",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "log",
@@ -4577,7 +4577,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-telemetry"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "log",
  "reqwest 0.12.28",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -6963,7 +6963,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -7001,7 +7001,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -7046,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7059,7 +7059,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7073,7 +7073,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7167,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7193,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-outputs"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "base64 0.22.1",
  "notebook-doc",
@@ -7208,7 +7208,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "kernel-env",
  "log",
@@ -7229,7 +7229,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-service"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "dirs",
  "log",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-settings-sync"
-version = "2.4.8"
+version = "2.4.9"
 dependencies = [
  "automerge",
  "log",
@@ -7255,7 +7255,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -7952,7 +7952,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11157,7 +11157,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/nteract-telemetry/Cargo.toml
+++ b/crates/nteract-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-telemetry"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Anonymous phone-home telemetry for nteract Rust binaries"
 repository.workspace = true

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Notebook trust extraction for the per-machine package allowlist"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-outputs/Cargo.toml
+++ b/crates/runtimed-outputs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-outputs"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Output resolution and LLM-friendly output formatting for runtimed"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.4.8"
+version = "2.4.9"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-service/Cargo.toml
+++ b/crates/runtimed-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-service"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Cross-platform service management for the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-settings-sync/Cargo.toml
+++ b/crates/runtimed-settings-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-settings-sync"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Live settings sync client over the runtimed UDS protocol"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.3.8"
+version = "0.3.9"
 edition.workspace = true
 license = "BSD-3-Clause"
 repository = "https://github.com/nteract/nteract"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.4.8"
+version = "2.4.9"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository = "https://github.com/nteract/nteract"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -357,7 +357,7 @@ fn require_cargo_subcommand(name: &str, install_hint: &str) {
 
 const PNPM_INSTALL: &str = "brew install pnpm  (or: npm install -g pnpm)";
 const TAURI_INSTALL: &str = "cargo install tauri-cli";
-const WASM_PACK_INSTALL: &str = "cargo install wasm-pack";
+const WASM_PACK_INSTALL: &str = "cargo install wasm-pack --version 0.15.0 --locked";
 
 fn require_pnpm() {
     require_tool(pnpm_bin(), PNPM_INSTALL);

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Persistent notebook-backed Python REPL for Pi coding agents. Stateful execution, hot dependency sync, zero cold starts.",
   "author": "nteract contributors",
   "icon": "icon.png",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.1.8"
+version = "2.1.9"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.3.8"
+version = "0.3.9"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.4.8"
+version = "2.4.9"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.1.8"
+version = "0.1.9"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.4.8"
+version = "2.4.9"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -39,5 +39,5 @@ if ! command -v clang >/dev/null 2>&1; then
 fi
 
 if ! command -v wasm-pack >/dev/null 2>&1; then
-  cargo install --locked wasm-pack
+  cargo install --locked wasm-pack --version 0.15.0
 fi


### PR DESCRIPTION
## Summary

- bump release/package versions for 2.4.9 across Rust, Python, npm, plugin manifests, and marketplace metadata
- update Cargo.lock to match the bumped workspace crate versions
- pin CI/runtime artifact wasm-pack installs to 0.15.0 and update local setup hints to the same version

## Verification

- `cargo xtask wasm`
- `cargo xtask lint --fix`
- `actionlint .github/workflows/sift-preview.yml`
- `git diff --check`
- `wasm-pack --version` -> `wasm-pack 0.15.0`
- `git lfs status`
