### PR TITLE
refactor(isolated): extract IsolatedFrameController over RxJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/src/components/isolated/__tests__/isolated-frame-controller.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-controller.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for IsolatedFrameController — the framework-agnostic RxJS-based
+ * orchestrator that owns iframe lifecycle, transport, and message routing.
+ *
+ * These tests drive the controller against a stub iframe element with a
+ * fake `contentWindow`, exercising the state machine + observable surface
+ * without actually loading any HTML.
+ */
+
+import { firstValueFrom, take, toArray } from "rxjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { FrameLifecycleState } from "../isolated-frame-controller";
+import { IsolatedFrameController } from "../isolated-frame-controller";
+import {
+  NTERACT_LINK_CLICK,
+  NTERACT_RENDERER_READY,
+  NTERACT_RENDER_OUTPUT,
+  NTERACT_RESIZE,
+  NTERACT_THEME,
+} from "../rpc-methods";
+
+interface FakeIframe {
+  element: HTMLIFrameElement;
+  contentWindow: Window;
+  posts: Array<{ message: unknown; origin: string }>;
+}
+
+function createFakeIframe(): FakeIframe {
+  const posts: FakeIframe["posts"] = [];
+  const contentWindow = {
+    postMessage: vi.fn((message: unknown, origin: string) => {
+      posts.push({ message, origin });
+    }),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as Window;
+
+  const element = {
+    contentWindow,
+  } as unknown as HTMLIFrameElement;
+
+  return { element, contentWindow, posts };
+}
+
+/**
+ * Fires a MessageEvent at the window from the iframe's contentWindow.
+ * The controller listens for messages whose `source` matches the iframe.
+ */
+function dispatchFromIframe(iframe: FakeIframe, data: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent("message", {
+      source: iframe.contentWindow as MessageEventSource,
+      data,
+    }),
+  );
+}
+
+describe("IsolatedFrameController", () => {
+  let iframe: FakeIframe;
+
+  beforeEach(() => {
+    iframe = createFakeIframe();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("lifecycle state machine", () => {
+    it("starts in 'booting'", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      expect(controller.state).toBe("booting");
+      controller.dispose();
+    });
+
+    it("transitions booting → bootstrapped → installing on first ready", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      const seen: FrameLifecycleState[] = [];
+      controller.state$.subscribe((s) => seen.push(s));
+
+      dispatchFromIframe(iframe, { type: "ready" });
+
+      expect(seen).toContain("booting");
+      expect(seen).toContain("bootstrapped");
+      expect(seen).toContain("installing");
+      controller.dispose();
+    });
+
+    it("reaches 'ready' on JSON-RPC nteract/rendererReady", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      expect(controller.state).toBe("ready");
+      controller.dispose();
+    });
+
+    it("treats a second 'ready' as a reload", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      expect(controller.state).toBe("ready");
+
+      const seen: FrameLifecycleState[] = [];
+      controller.state$.subscribe((s) => seen.push(s));
+
+      dispatchFromIframe(iframe, { type: "ready" });
+      expect(seen).toContain("reloading");
+      expect(seen).toContain("bootstrapped");
+      expect(controller.state).toBe("installing");
+      controller.dispose();
+    });
+  });
+
+  describe("send queue", () => {
+    it("queues render until ready, then flushes via JSON-RPC", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+
+      controller.render({ mimeType: "text/plain", data: "hi" });
+      // Nothing JSON-RPC was posted yet (only theme via legacy postMessage
+      // would be in the post queue, and that only after `ready`).
+      const renderPosts = iframe.posts.filter(
+        (p) => (p.message as { method?: string }).method === NTERACT_RENDER_OUTPUT,
+      );
+      expect(renderPosts).toHaveLength(0);
+
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+
+      const flushed = iframe.posts.filter(
+        (p) => (p.message as { method?: string }).method === NTERACT_RENDER_OUTPUT,
+      );
+      expect(flushed).toHaveLength(1);
+      expect((flushed[0].message as { params: unknown }).params).toEqual({
+        mimeType: "text/plain",
+        data: "hi",
+      });
+      controller.dispose();
+    });
+
+    it("drops queued sends on reload", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+
+      // Get to ready
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      iframe.posts.length = 0;
+
+      // Send a reload signal BEFORE the next renderer_ready
+      dispatchFromIframe(iframe, { type: "ready" });
+      // Now queue something during the reload window
+      controller.render({ mimeType: "text/plain", data: "during-reload" });
+      // Another reload — queued items must be dropped
+      dispatchFromIframe(iframe, { type: "ready" });
+
+      // Restore to ready
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+
+      const renderPosts = iframe.posts.filter(
+        (p) => (p.message as { method?: string }).method === NTERACT_RENDER_OUTPUT,
+      );
+      expect(renderPosts).toHaveLength(0);
+      controller.dispose();
+    });
+  });
+
+  describe("theme application", () => {
+    it("posts a legacy theme message on bootstrap", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+        initialTheme: { isDark: false, colorTheme: "cream" },
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+
+      const themePost = iframe.posts.find((p) => (p.message as { type?: string }).type === "theme");
+      expect(themePost).toBeDefined();
+      expect((themePost!.message as { payload: unknown }).payload).toEqual({
+        isDark: false,
+        colorTheme: "cream",
+      });
+      controller.dispose();
+    });
+
+    it("routes setTheme via JSON-RPC once ready", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      iframe.posts.length = 0;
+
+      controller.setTheme({ isDark: false, colorTheme: "cream" });
+
+      const themeRpc = iframe.posts.find(
+        (p) => (p.message as { method?: string }).method === NTERACT_THEME,
+      );
+      expect(themeRpc).toBeDefined();
+      expect((themeRpc!.message as { params: unknown }).params).toEqual({
+        isDark: false,
+        colorTheme: "cream",
+      });
+      controller.dispose();
+    });
+  });
+
+  describe("observables", () => {
+    it("emits resize from JSON-RPC", async () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+      const next = firstValueFrom(controller.resize$);
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RESIZE,
+        params: { height: 432 },
+      });
+      await expect(next).resolves.toEqual({ height: 432 });
+      controller.dispose();
+    });
+
+    it("emits link clicks from JSON-RPC", async () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+      const next = firstValueFrom(controller.linkClicks$);
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_LINK_CLICK,
+        params: { url: "https://example.com", newTab: true },
+      });
+      await expect(next).resolves.toEqual({
+        url: "https://example.com",
+        newTab: true,
+      });
+      controller.dispose();
+    });
+
+    it("emits state transitions in order", async () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      const sequence = firstValueFrom(controller.state$.pipe(take(4), toArray()));
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      await expect(sequence).resolves.toEqual(["booting", "bootstrapped", "installing", "ready"]);
+      controller.dispose();
+    });
+  });
+
+  describe("renderer bundle injection", () => {
+    it("defers bundle injection until rendererCode/css are set", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+      });
+      dispatchFromIframe(iframe, { type: "ready" });
+
+      // No eval posts yet — only the legacy theme message.
+      const evalPosts = iframe.posts.filter(
+        (p) => (p.message as { type?: string }).type === "eval",
+      );
+      expect(evalPosts).toHaveLength(0);
+      // State is bootstrapped, not installing, because the bundle is missing.
+      expect(controller.state).toBe("bootstrapped");
+
+      controller.setRendererBundle("/*code*/", "body{}");
+      const evalPostsAfter = iframe.posts.filter(
+        (p) => (p.message as { type?: string }).type === "eval",
+      );
+      // Two eval posts: CSS then JS wrapper
+      expect(evalPostsAfter).toHaveLength(2);
+      expect(controller.state).toBe("installing");
+      controller.dispose();
+    });
+  });
+
+  describe("dispose", () => {
+    it("removes the window message listener", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      controller.dispose();
+      // After dispose, dispatching a 'ready' must not transition state.
+      const before = controller.state;
+      dispatchFromIframe(iframe, { type: "ready" });
+      expect(controller.state).toBe(before);
+    });
+  });
+});

--- a/src/components/isolated/__tests__/isolated-frame-controller.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-controller.test.ts
@@ -137,6 +137,36 @@ describe("IsolatedFrameController", () => {
   });
 
   describe("send queue", () => {
+    it("queues an unknown legacy message (interaction_state) until ready", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
+      });
+      // Pre-ready: legacy message must not slip through immediately.
+      controller.send({ type: "interaction_state", payload: { active: true } });
+      const preReadyInteraction = iframe.posts.filter(
+        (p) => (p.message as { type?: string }).type === "interaction_state",
+      );
+      expect(preReadyInteraction).toHaveLength(0);
+
+      dispatchFromIframe(iframe, { type: "ready" });
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: NTERACT_RENDERER_READY,
+        params: {},
+      });
+      const postReadyInteraction = iframe.posts.filter(
+        (p) => (p.message as { type?: string }).type === "interaction_state",
+      );
+      expect(postReadyInteraction).toHaveLength(1);
+      expect(postReadyInteraction[0].message).toEqual({
+        type: "interaction_state",
+        payload: { active: true },
+      });
+      controller.dispose();
+    });
+
     it("queues render until ready, then flushes via JSON-RPC", () => {
       const controller = new IsolatedFrameController({
         iframe: iframe.element,

--- a/src/components/isolated/__tests__/isolated-frame-controller.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-controller.test.ts
@@ -137,13 +137,13 @@ describe("IsolatedFrameController", () => {
   });
 
   describe("send queue", () => {
-    it("queues an unknown legacy message (interaction_state) until ready", () => {
+    it("queues a non-JSON-RPC message (interaction_state) until ready", () => {
       const controller = new IsolatedFrameController({
         iframe: iframe.element,
         rendererCode: "/*code*/",
         rendererCss: "body{}",
       });
-      // Pre-ready: legacy message must not slip through immediately.
+      // Pre-ready: raw postMessage must not slip through immediately.
       controller.send({ type: "interaction_state", payload: { active: true } });
       const preReadyInteraction = iframe.posts.filter(
         (p) => (p.message as { type?: string }).type === "interaction_state",
@@ -175,7 +175,7 @@ describe("IsolatedFrameController", () => {
       });
 
       controller.render({ mimeType: "text/plain", data: "hi" });
-      // Nothing JSON-RPC was posted yet (only theme via legacy postMessage
+      // Nothing JSON-RPC was posted yet (only theme via raw postMessage
       // would be in the post queue, and that only after `ready`).
       const renderPosts = iframe.posts.filter(
         (p) => (p.message as { method?: string }).method === NTERACT_RENDER_OUTPUT,
@@ -239,7 +239,7 @@ describe("IsolatedFrameController", () => {
   });
 
   describe("theme application", () => {
-    it("posts a legacy theme message on bootstrap", () => {
+    it("posts a theme message on bootstrap", () => {
       const controller = new IsolatedFrameController({
         iframe: iframe.element,
         rendererCode: "/*code*/",
@@ -348,7 +348,7 @@ describe("IsolatedFrameController", () => {
       });
       dispatchFromIframe(iframe, { type: "ready" });
 
-      // No eval posts yet — only the legacy theme message.
+      // No eval posts yet — only the bootstrap theme message.
       const evalPosts = iframe.posts.filter(
         (p) => (p.message as { type?: string }).type === "eval",
       );

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -93,6 +93,29 @@ describe("IsolatedFrame theme updates", () => {
     });
   });
 
+  it("keeps the same JSON-RPC transport across autoHeight/min/max prop changes", async () => {
+    const { container, rerender } = render(
+      <IsolatedFrame darkMode={false} maxHeight={1000} minHeight={20} autoHeight={false} />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+    expect(MockJsonRpcTransport.instances).toHaveLength(1);
+    const initialTransport = MockJsonRpcTransport.instances[0];
+
+    // Flip every height-policy prop. The iframe never refires `ready`, so
+    // tearing the controller down here would strand the new instance in
+    // `booting` and drop every future message.
+    rerender(<IsolatedFrame darkMode={false} maxHeight={3000} minHeight={20} autoHeight={false} />);
+    rerender(<IsolatedFrame darkMode={false} maxHeight={3000} minHeight={40} autoHeight={false} />);
+    rerender(<IsolatedFrame darkMode={false} maxHeight={3000} minHeight={40} autoHeight />);
+
+    expect(MockJsonRpcTransport.instances).toHaveLength(1);
+    expect(MockJsonRpcTransport.instances[0]).toBe(initialTransport);
+    expect(initialTransport.stop).not.toHaveBeenCalled();
+  });
+
   it("re-applies the last measured content height when autoHeight changes", async () => {
     const { container, rerender } = render(
       <IsolatedFrame darkMode={false} maxHeight={2000} autoHeight={false} />,

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -31,5 +31,22 @@ export { FRAME_HTML, generateFrameHtml } from "./frame-html";
 export { IsolationTest } from "./IsolationTest";
 export type { IsolatedFrameHandle, IsolatedFrameProps } from "./isolated-frame";
 export { IsolatedFrame } from "./isolated-frame";
+// Framework-agnostic controller and helpers
+export type {
+  FrameError,
+  FrameLifecycleState,
+  FrameLinkClickEvent,
+  FrameRenderCompleteEvent,
+  FrameResizeEvent,
+  FrameSource,
+  FrameThemePayload,
+  FrameWidgetUpdateEvent,
+  IsolatedFrameControllerOptions,
+} from "./isolated-frame-controller";
+export {
+  ISOLATED_FRAME_SANDBOX,
+  IsolatedFrameController,
+  resolveFrameSource,
+} from "./isolated-frame-controller";
 // Provider and hook for renderer bundle
 export { IsolatedRendererProvider, useIsolatedRenderer } from "./isolated-renderer-context";

--- a/src/components/isolated/isolated-frame-controller.ts
+++ b/src/components/isolated/isolated-frame-controller.ts
@@ -217,14 +217,15 @@ export const ISOLATED_FRAME_SANDBOX =
 // ── Controller ───────────────────────────────────────────────────────
 
 /**
- * Internal queued message. Keeps the legacy `{ type, payload }` shape so
- * the flush path can pick the right transport (JSON-RPC if the bundle is
- * up, raw postMessage otherwise).
+ * Internal queued message. JSON-RPC sends carry a `method`/`params` pair
+ * and are flushed via `rpc.notify()`. Legacy sends carry a `raw` message
+ * (any `ParentToIframeMessage` that has no canonical JSON-RPC method,
+ * e.g. `interaction_state`) and are flushed via raw postMessage so the
+ * iframe-side legacy handler picks them up.
  */
-interface QueuedSend {
-  method: string;
-  params?: unknown;
-}
+type QueuedSend =
+  | { kind: "rpc"; method: string; params?: unknown }
+  | { kind: "raw"; message: ParentToIframeMessage };
 
 export class IsolatedFrameController {
   private readonly iframe: HTMLIFrameElement;
@@ -306,13 +307,17 @@ export class IsolatedFrameController {
    */
   send(message: ParentToIframeMessage): void {
     const method = TYPE_TO_METHOD[message.type];
-    const params = "payload" in message ? message.payload : undefined;
-    if (!method) {
-      // Unknown type — fall back to a raw postMessage if the iframe is up.
-      this.iframe.contentWindow?.postMessage(message, "*");
+    if (method) {
+      const params = "payload" in message ? message.payload : undefined;
+      this.enqueue(method, params);
       return;
     }
-    this.enqueue(method, params);
+    // No canonical JSON-RPC method (e.g. `interaction_state`). Queue as a
+    // legacy postMessage and flush after the renderer is ready so the
+    // iframe-side legacy handler picks it up. Without this gate, an early
+    // `interaction_state` would land on the bootstrap-only listener and
+    // get dropped.
+    this.enqueueRaw(message);
   }
 
   render(payload: RenderPayload): void {
@@ -407,10 +412,18 @@ export class IsolatedFrameController {
 
   private enqueue(method: string, params: unknown): void {
     if (this.state !== "ready" || !this.rpc) {
-      this.pending.push({ method, params });
+      this.pending.push({ kind: "rpc", method, params });
       return;
     }
     this.rpc.notify(method, params);
+  }
+
+  private enqueueRaw(message: ParentToIframeMessage): void {
+    if (this.state !== "ready") {
+      this.pending.push({ kind: "raw", message });
+      return;
+    }
+    this.iframe.contentWindow?.postMessage(message, "*");
   }
 
   private flushPending(): void {
@@ -418,7 +431,11 @@ export class IsolatedFrameController {
     const drain = this.pending;
     this.pending = [];
     for (const item of drain) {
-      this.rpc.notify(item.method, item.params);
+      if (item.kind === "rpc") {
+        this.rpc.notify(item.method, item.params);
+      } else {
+        this.iframe.contentWindow?.postMessage(item.message, "*");
+      }
     }
   }
 

--- a/src/components/isolated/isolated-frame-controller.ts
+++ b/src/components/isolated/isolated-frame-controller.ts
@@ -1,0 +1,645 @@
+/**
+ * IsolatedFrameController — framework-agnostic orchestrator for the
+ * sandboxed output iframe.
+ *
+ * Owns:
+ *   - the lifecycle state machine (booting → bootstrapped → installing → ready,
+ *     with reload transitions back to bootstrapped)
+ *   - the JSON-RPC transport lifecycle (creation on bootstrap, teardown on
+ *     reload/dispose)
+ *   - the renderer-bundle injection sequence (CSS + JS via legacy `eval`
+ *     messages, guarded by the iframe-side `__ISOLATED_*_LOADED__` flags)
+ *   - the outbound send queue (render/theme/clear calls before the renderer
+ *     bundle finishes installing get queued and flushed on `ready`)
+ *   - message routing from the iframe (legacy `{ type, payload }` from the
+ *     bootstrap script, JSON-RPC from the renderer bundle) into typed RxJS
+ *     observables
+ *   - wheel-boundary forwarding (so wheel events that hit a scroll boundary
+ *     inside the iframe scroll the nearest parent)
+ *
+ * Does NOT own:
+ *   - the iframe element itself — the caller creates it (so React, Vue, or
+ *     anything else picks its own rendering primitive) and passes the
+ *     `HTMLIFrameElement` in
+ *   - the src/srcDoc choice for Tauri vs browser hosts — see
+ *     `resolveFrameSource()` below for the helper, but the caller actually
+ *     applies it to the iframe element
+ *   - min/max/auto height clamping — the controller emits raw measured
+ *     heights, the adapter applies any visual policy
+ *
+ * The iframe security model (sandbox flags, CSP, custom URI scheme) lives in
+ * `src/components/isolated/AGENTS.md` and `frame.html`. This controller does
+ * not weaken those guarantees.
+ */
+
+import { BehaviorSubject, Observable, Subject } from "rxjs";
+import type { CommBridgeManager } from "./comm-bridge-manager";
+import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
+import { isIframeMessage } from "./frame-bridge";
+import { generateFrameHtml } from "./frame-html";
+import { JsonRpcTransport } from "./jsonrpc-transport";
+import {
+  NTERACT_BRIDGE_READY,
+  NTERACT_CLEAR_OUTPUTS,
+  NTERACT_COMM_CLOSE,
+  NTERACT_COMM_MSG,
+  NTERACT_COMM_OPEN,
+  NTERACT_DOUBLE_CLICK,
+  NTERACT_ERROR,
+  NTERACT_EVAL,
+  NTERACT_EVAL_RESULT,
+  NTERACT_INSTALL_RENDERER,
+  NTERACT_LINK_CLICK,
+  NTERACT_MOUSE_DOWN,
+  NTERACT_PING,
+  NTERACT_RENDER_BATCH,
+  NTERACT_RENDER_COMPLETE,
+  NTERACT_RENDER_OUTPUT,
+  NTERACT_RENDERER_READY,
+  NTERACT_RESIZE,
+  NTERACT_SEARCH,
+  NTERACT_SEARCH_NAVIGATE,
+  NTERACT_SEARCH_RESULTS,
+  NTERACT_THEME,
+  NTERACT_WHEEL_BOUNDARY,
+  NTERACT_WIDGET_COMM_CLOSE,
+  NTERACT_WIDGET_COMM_MSG,
+  NTERACT_WIDGET_READY,
+  NTERACT_WIDGET_SNAPSHOT,
+  NTERACT_WIDGET_STATE,
+  NTERACT_WIDGET_UPDATE,
+} from "./rpc-methods";
+import { scrollFrameWheelBoundary } from "./scroll-boundary";
+
+/**
+ * Maps legacy `ParentToIframeMessage.type` values to canonical JSON-RPC
+ * method names. Kept here so any caller using `send()` gets the same
+ * routing the React shell used to perform inline.
+ */
+const TYPE_TO_METHOD: Record<string, string> = {
+  render: NTERACT_RENDER_OUTPUT,
+  render_batch: NTERACT_RENDER_BATCH,
+  theme: NTERACT_THEME,
+  clear: NTERACT_CLEAR_OUTPUTS,
+  eval: NTERACT_EVAL,
+  install_renderer: NTERACT_INSTALL_RENDERER,
+  ping: NTERACT_PING,
+  search: NTERACT_SEARCH,
+  search_navigate: NTERACT_SEARCH_NAVIGATE,
+  comm_open: NTERACT_COMM_OPEN,
+  comm_msg: NTERACT_COMM_MSG,
+  comm_close: NTERACT_COMM_CLOSE,
+  widget_snapshot: NTERACT_WIDGET_SNAPSHOT,
+  bridge_ready: NTERACT_BRIDGE_READY,
+  widget_state: NTERACT_WIDGET_STATE,
+};
+
+// ── Public types ─────────────────────────────────────────────────────
+
+/**
+ * Lifecycle states the controller transitions through. Adapters can derive
+ * `isIframeReady` (any state past `booting`) and `isReady` (`ready`) from
+ * this.
+ *
+ * Reload path: when the iframe receives a fresh `ready` after already being
+ * in `ready`, the controller transitions through `reloading` → `bootstrapped`
+ * → `installing` → `ready` again, discarding queued messages and tearing
+ * down the previous transport on the way.
+ */
+export type FrameLifecycleState =
+  | "booting"
+  | "bootstrapped"
+  | "installing"
+  | "ready"
+  | "reloading"
+  | "error";
+
+export interface FrameResizeEvent {
+  height: number;
+}
+
+export interface FrameLinkClickEvent {
+  url: string;
+  newTab: boolean;
+}
+
+export interface FrameError {
+  message: string;
+  stack?: string;
+}
+
+export interface FrameRenderCompleteEvent {
+  outputId?: string;
+  cellId?: string;
+  outputIndex?: number;
+  height?: number;
+}
+
+export interface FrameWidgetUpdateEvent {
+  commId: string;
+  state: Record<string, unknown>;
+}
+
+export interface FrameThemePayload {
+  isDark: boolean;
+  colorTheme?: string | null;
+}
+
+export type FrameSource = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
+
+export interface IsolatedFrameControllerOptions {
+  /** The host iframe element. Must be attached to the document. */
+  iframe: HTMLIFrameElement;
+  /**
+   * Renderer bundle code injected after the iframe bootstrap is ready.
+   * Optional at construction; set later via `setRendererBundle()` if the
+   * bundle resolves asynchronously.
+   */
+  rendererCode?: string;
+  /**
+   * Renderer bundle CSS injected before the JS bundle. Optional at
+   * construction; pair with `rendererCode` in `setRendererBundle()`.
+   */
+  rendererCss?: string;
+  /**
+   * Optional render payload sent once the renderer reports
+   * `nteract/rendererReady`.
+   */
+  initialContent?: RenderPayload;
+  /**
+   * Initial theme. Sent on the first transition into `bootstrapped` and
+   * again whenever `setTheme()` is called.
+   */
+  initialTheme?: FrameThemePayload;
+  /**
+   * When true, the controller forwards wheel events that the iframe reports
+   * hitting a scroll boundary to the nearest scrollable parent. Defaults to
+   * true; toggle via `setWheelBoundaryForwarding(false)`.
+   */
+  forwardWheelBoundary?: boolean;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const TAURI_FRAME_URL = "nteract-frame://localhost/";
+
+function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  const win = window as Window & {
+    __TAURI__?: unknown;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  return "__TAURI_INTERNALS__" in win || "__TAURI__" in win;
+}
+
+/**
+ * Resolve the right frame source for the current runtime. Tauri loads the
+ * iframe through a custom URI scheme so the frame gets its own CSP; plain
+ * browser hosts use `srcdoc`.
+ */
+export function resolveFrameSource(): FrameSource {
+  if (isTauriRuntime()) {
+    return { kind: "src", url: TAURI_FRAME_URL };
+  }
+  return { kind: "srcdoc", html: generateFrameHtml() };
+}
+
+/**
+ * Sandbox attributes the iframe element must carry. Exposed so adapters
+ * apply the exact same list and a CI test can keep this string honest.
+ *
+ * CRITICAL: must NOT contain `allow-same-origin`. See
+ * `src/components/isolated/AGENTS.md` for the security rationale.
+ */
+export const ISOLATED_FRAME_SANDBOX =
+  "allow-scripts allow-downloads allow-forms allow-pointer-lock";
+
+// ── Controller ───────────────────────────────────────────────────────
+
+/**
+ * Internal queued message. Keeps the legacy `{ type, payload }` shape so
+ * the flush path can pick the right transport (JSON-RPC if the bundle is
+ * up, raw postMessage otherwise).
+ */
+interface QueuedSend {
+  method: string;
+  params?: unknown;
+}
+
+export class IsolatedFrameController {
+  private readonly iframe: HTMLIFrameElement;
+  private rendererCode: string | undefined;
+  private rendererCss: string | undefined;
+  private readonly initialContent?: RenderPayload;
+
+  private theme: FrameThemePayload = { isDark: true, colorTheme: null };
+  private forwardWheel: boolean;
+
+  private rpc: JsonRpcTransport | null = null;
+  private hasReceivedReady = false;
+  private bootstrapping = false;
+  private pending: QueuedSend[] = [];
+
+  // Reserved for future routing of comm_open/comm_msg/comm_close through the
+  // controller. The bridge currently wires legacy events from IsolatedFrame.tsx
+  // directly; this slot lets a caller register one for the migration.
+  // @ts-expect-error - intentionally held without read access yet.
+  private commBridge: CommBridgeManager | null = null;
+
+  private readonly _state$ = new BehaviorSubject<FrameLifecycleState>("booting");
+  private readonly _resize$ = new Subject<FrameResizeEvent>();
+  private readonly _renderComplete$ = new Subject<FrameRenderCompleteEvent>();
+  private readonly _errors$ = new Subject<FrameError>();
+  private readonly _linkClicks$ = new Subject<FrameLinkClickEvent>();
+  private readonly _mouseDowns$ = new Subject<void>();
+  private readonly _doubleClicks$ = new Subject<void>();
+  private readonly _widgetUpdates$ = new Subject<FrameWidgetUpdateEvent>();
+  private readonly _searchResults$ = new Subject<{ count: number }>();
+  private readonly _messages$ = new Subject<IframeToParentMessage>();
+
+  readonly state$: Observable<FrameLifecycleState> = this._state$.asObservable();
+  readonly resize$: Observable<FrameResizeEvent> = this._resize$.asObservable();
+  readonly renderComplete$: Observable<FrameRenderCompleteEvent> =
+    this._renderComplete$.asObservable();
+  readonly errors$: Observable<FrameError> = this._errors$.asObservable();
+  readonly linkClicks$: Observable<FrameLinkClickEvent> = this._linkClicks$.asObservable();
+  readonly mouseDowns$: Observable<void> = this._mouseDowns$.asObservable();
+  readonly doubleClicks$: Observable<void> = this._doubleClicks$.asObservable();
+  readonly widgetUpdates$: Observable<FrameWidgetUpdateEvent> = this._widgetUpdates$.asObservable();
+  readonly searchResults$: Observable<{ count: number }> = this._searchResults$.asObservable();
+  readonly messages$: Observable<IframeToParentMessage> = this._messages$.asObservable();
+
+  private readonly windowMessageListener: (event: MessageEvent) => void;
+  private disposed = false;
+
+  constructor(options: IsolatedFrameControllerOptions) {
+    this.iframe = options.iframe;
+    this.rendererCode = options.rendererCode;
+    this.rendererCss = options.rendererCss;
+    this.initialContent = options.initialContent;
+    this.forwardWheel = options.forwardWheelBoundary ?? true;
+    if (options.initialTheme) {
+      this.theme = options.initialTheme;
+    }
+
+    this.windowMessageListener = (event) => this.handleWindowMessage(event);
+    window.addEventListener("message", this.windowMessageListener);
+  }
+
+  /** Current state without subscribing. */
+  get state(): FrameLifecycleState {
+    return this._state$.value;
+  }
+
+  // ── Public commands ─────────────────────────────────────────────
+
+  /**
+   * Generic outbound send. Maps legacy `{ type, payload }` shapes to their
+   * canonical JSON-RPC method names. Falls back to a raw postMessage when
+   * the renderer transport isn't up yet AND the message type isn't queueable
+   * — currently nothing slips through that path, since every type in
+   * `TYPE_TO_METHOD` is queueable.
+   *
+   * Prefer the typed helpers (`render`, `setTheme`, etc.) over this; the
+   * generic path exists for adapters that need to forward an
+   * already-shaped `ParentToIframeMessage` (e.g., from a comm bridge).
+   */
+  send(message: ParentToIframeMessage): void {
+    const method = TYPE_TO_METHOD[message.type];
+    const params = "payload" in message ? message.payload : undefined;
+    if (!method) {
+      // Unknown type — fall back to a raw postMessage if the iframe is up.
+      this.iframe.contentWindow?.postMessage(message, "*");
+      return;
+    }
+    this.enqueue(method, params);
+  }
+
+  render(payload: RenderPayload): void {
+    this.enqueue(NTERACT_RENDER_OUTPUT, payload);
+  }
+
+  renderBatch(payloads: RenderPayload[]): void {
+    this.enqueue(NTERACT_RENDER_BATCH, { outputs: payloads });
+  }
+
+  clear(): void {
+    this.enqueue(NTERACT_CLEAR_OUTPUTS, undefined);
+  }
+
+  setTheme(theme: FrameThemePayload): void {
+    this.theme = theme;
+    // Theme can be applied before the renderer bundle is up — the iframe's
+    // bootstrap script handles legacy `theme` messages. Once the renderer
+    // transport is alive, prefer JSON-RPC so live theme changes follow the
+    // same path as everything else.
+    if (this.rpc && this.state === "ready") {
+      this.rpc.notify(NTERACT_THEME, theme);
+    } else if (this.iframe.contentWindow) {
+      this.iframe.contentWindow.postMessage({ type: "theme", payload: theme }, "*");
+    }
+  }
+
+  search(query: string, caseSensitive = false): void {
+    // Search is handled by the iframe bootstrap script — bypasses the
+    // post-ready queue so it works before the renderer bundle is installed.
+    const params = { query, caseSensitive };
+    if (this.rpc) {
+      this.rpc.notify(NTERACT_SEARCH, params);
+    } else if (this.iframe.contentWindow) {
+      this.iframe.contentWindow.postMessage({ type: "search", payload: params }, "*");
+    }
+  }
+
+  searchNavigate(matchIndex: number): void {
+    const params = { matchIndex };
+    if (this.rpc) {
+      this.rpc.notify(NTERACT_SEARCH_NAVIGATE, params);
+    } else if (this.iframe.contentWindow) {
+      this.iframe.contentWindow.postMessage({ type: "search_navigate", payload: params }, "*");
+    }
+  }
+
+  /**
+   * Provide or replace the renderer bundle. If the iframe is already
+   * bootstrapped, this triggers injection immediately; otherwise the
+   * bundle is stashed and injected when the bootstrap handler runs.
+   */
+  setRendererBundle(code: string, css: string): void {
+    this.rendererCode = code;
+    this.rendererCss = css;
+    if (this.state === "bootstrapped" && !this.bootstrapping) {
+      this.injectRendererBundle();
+    }
+  }
+
+  attachCommBridge(manager: CommBridgeManager): void {
+    this.commBridge = manager;
+    // Future: forward comm_open/comm_msg/comm_close routing here. The bridge
+    // currently subscribes to legacy events directly from `IsolatedFrame.tsx`;
+    // moving that wiring into the controller is a follow-up.
+  }
+
+  setWheelBoundaryForwarding(enabled: boolean): void {
+    this.forwardWheel = enabled;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    window.removeEventListener("message", this.windowMessageListener);
+    this.rpc?.stop();
+    this.rpc = null;
+    this.pending.length = 0;
+    this._state$.complete();
+    this._resize$.complete();
+    this._renderComplete$.complete();
+    this._errors$.complete();
+    this._linkClicks$.complete();
+    this._mouseDowns$.complete();
+    this._doubleClicks$.complete();
+    this._widgetUpdates$.complete();
+    this._searchResults$.complete();
+    this._messages$.complete();
+  }
+
+  // ── Internal: send queue ─────────────────────────────────────────
+
+  private enqueue(method: string, params: unknown): void {
+    if (this.state !== "ready" || !this.rpc) {
+      this.pending.push({ method, params });
+      return;
+    }
+    this.rpc.notify(method, params);
+  }
+
+  private flushPending(): void {
+    if (!this.rpc) return;
+    const drain = this.pending;
+    this.pending = [];
+    for (const item of drain) {
+      this.rpc.notify(item.method, item.params);
+    }
+  }
+
+  // ── Internal: lifecycle ─────────────────────────────────────────
+
+  private handleWindowMessage(event: MessageEvent): void {
+    if (event.source !== this.iframe.contentWindow) return;
+    const data = event.data;
+    // Skip JSON-RPC envelopes — JsonRpcTransport handles them.
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      (data as { jsonrpc?: unknown }).jsonrpc === "2.0"
+    ) {
+      return;
+    }
+    if (!isIframeMessage(data)) return;
+
+    this._messages$.next(data);
+
+    switch (data.type) {
+      case "ready":
+        this.handleBootstrapReady();
+        break;
+      case "renderer_ready":
+        // Legacy path some renderer paths still use; the canonical
+        // signal is the JSON-RPC `nteract/rendererReady` registered in
+        // attachTransport().
+        this.handleRendererReady();
+        break;
+      case "resize":
+        if (data.payload?.height != null) {
+          this._resize$.next({ height: data.payload.height });
+        }
+        break;
+      case "render_complete":
+        // Legacy RenderCompleteMessage only carries `height`. The richer
+        // payload shape (outputId/cellId/outputIndex) arrives through the
+        // JSON-RPC path registered in attachTransport().
+        if (data.payload?.height != null) {
+          this._resize$.next({ height: data.payload.height });
+        }
+        this._renderComplete$.next({ height: data.payload?.height });
+        break;
+      case "link_click":
+        if (data.payload?.url) {
+          this._linkClicks$.next({
+            url: data.payload.url,
+            newTab: data.payload.newTab ?? false,
+          });
+        }
+        break;
+      case "dblclick":
+        this._doubleClicks$.next();
+        break;
+      case "widget_update":
+        if (data.payload?.commId && data.payload?.state) {
+          this._widgetUpdates$.next({
+            commId: data.payload.commId,
+            state: data.payload.state,
+          });
+        }
+        break;
+      case "error":
+        if (data.payload) {
+          this._errors$.next(data.payload);
+        }
+        break;
+      case "eval_result":
+        if (data.payload?.success === false) {
+          this._errors$.next({
+            message: `Bundle eval failed: ${data.payload.error ?? "unknown"}`,
+          });
+        }
+        break;
+    }
+  }
+
+  private handleBootstrapReady(): void {
+    const isReload = this.hasReceivedReady;
+    this.hasReceivedReady = true;
+
+    if (isReload) {
+      // Iframe was reloaded (e.g., DOM move tore it down). Discard any
+      // queued sends targeted at the old instance and rebuild state from
+      // scratch.
+      this.bootstrapping = false;
+      this.pending.length = 0;
+      this.rpc?.stop();
+      this.rpc = null;
+      this._state$.next("reloading");
+    }
+
+    this._state$.next("bootstrapped");
+
+    // Apply theme as soon as we're bootstrapped, before the renderer bundle
+    // takes over (the bootstrap script handles legacy `theme` messages).
+    if (this.iframe.contentWindow) {
+      this.iframe.contentWindow.postMessage({ type: "theme", payload: this.theme }, "*");
+    }
+
+    this.attachTransport();
+    this.injectRendererBundle();
+  }
+
+  private attachTransport(): void {
+    const win = this.iframe.contentWindow;
+    if (!win) return;
+    const transport = new JsonRpcTransport(win, win);
+    transport.onNotification(NTERACT_RENDERER_READY, () => this.handleRendererReady());
+    transport.onNotification(NTERACT_RESIZE, (params) => {
+      const p = params as { height?: number } | undefined;
+      if (p?.height != null) this._resize$.next({ height: p.height });
+    });
+    transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {
+      const p = params as
+        | { outputId?: string; cellId?: string; outputIndex?: number; height?: number }
+        | undefined;
+      if (p?.height != null) this._resize$.next({ height: p.height });
+      this._renderComplete$.next({
+        outputId: p?.outputId,
+        cellId: p?.cellId,
+        outputIndex: p?.outputIndex,
+        height: p?.height,
+      });
+    });
+    transport.onNotification(NTERACT_LINK_CLICK, (params) => {
+      const p = params as { url?: string; newTab?: boolean } | undefined;
+      if (p?.url) this._linkClicks$.next({ url: p.url, newTab: p.newTab ?? false });
+    });
+    transport.onNotification(NTERACT_MOUSE_DOWN, () => this._mouseDowns$.next());
+    transport.onNotification(NTERACT_DOUBLE_CLICK, () => this._doubleClicks$.next());
+    transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
+      if (!this.forwardWheel) return;
+      scrollFrameWheelBoundary(this.iframe, params as { deltaY?: number });
+    });
+    transport.onNotification(NTERACT_WIDGET_UPDATE, (params) => {
+      const p = params as { commId?: string; state?: Record<string, unknown> } | undefined;
+      if (p?.commId && p?.state) {
+        this._widgetUpdates$.next({ commId: p.commId, state: p.state });
+      }
+    });
+    transport.onNotification(NTERACT_ERROR, (params) => {
+      const p = params as { message?: string; stack?: string } | undefined;
+      if (p?.message) this._errors$.next({ message: p.message, stack: p.stack });
+    });
+    transport.onNotification(NTERACT_EVAL_RESULT, (params) => {
+      const p = params as { success?: boolean; error?: string } | undefined;
+      if (p?.success === false) {
+        this._errors$.next({ message: `Bundle eval failed: ${p.error ?? "unknown"}` });
+      }
+    });
+    transport.onNotification(NTERACT_SEARCH_RESULTS, (params) => {
+      const p = params as { count?: number } | undefined;
+      if (typeof p?.count === "number") this._searchResults$.next({ count: p.count });
+      this._messages$.next({
+        type: "search_results",
+        payload: p as { count: number },
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_WIDGET_READY, () => {
+      this._messages$.next({ type: "widget_ready" } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_WIDGET_COMM_MSG, (params) => {
+      this._messages$.next({
+        type: "widget_comm_msg",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_WIDGET_COMM_CLOSE, (params) => {
+      this._messages$.next({
+        type: "widget_comm_close",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.start();
+    this.rpc = transport;
+  }
+
+  private injectRendererBundle(): void {
+    if (this.bootstrapping) return;
+    if (!this.iframe.contentWindow) return;
+    if (!this.rendererCode || !this.rendererCss) {
+      // Bundle not yet available. The transport is up so callers can
+      // observe legacy/JSON-RPC messages, but the renderer stays uninstalled
+      // until `setRendererBundle()` lands and re-enters this path.
+      return;
+    }
+    this.bootstrapping = true;
+    this._state$.next("installing");
+
+    // CSS first; idempotent thanks to the iframe-side guard flag.
+    const cssCode =
+      "(function() {" +
+      "if (window.__ISOLATED_CSS_LOADED__) return;" +
+      "window.__ISOLATED_CSS_LOADED__ = true;" +
+      "var style = document.createElement('style');" +
+      "style.textContent = " +
+      JSON.stringify(this.rendererCss) +
+      ";" +
+      "document.head.appendChild(style);" +
+      "})();";
+    this.iframe.contentWindow.postMessage({ type: "eval", payload: { code: cssCode } }, "*");
+
+    // Then the JS bundle. String concat (not template literal) avoids
+    // accidental backtick / ${} interactions with the renderer source.
+    const jsWrapper =
+      "(function() {" +
+      "if (window.__ISOLATED_RENDERER_LOADED__) return;" +
+      "window.__ISOLATED_RENDERER_LOADED__ = true;" +
+      this.rendererCode +
+      "})();";
+    this.iframe.contentWindow.postMessage({ type: "eval", payload: { code: jsWrapper } }, "*");
+  }
+
+  private handleRendererReady(): void {
+    if (this.state === "ready") return; // Idempotent.
+    this._state$.next("ready");
+    this.flushPending();
+    if (this.initialContent && this.rpc) {
+      this.rpc.notify(NTERACT_RENDER_OUTPUT, this.initialContent);
+    }
+  }
+}

--- a/src/components/isolated/isolated-frame-controller.ts
+++ b/src/components/isolated/isolated-frame-controller.ts
@@ -7,11 +7,12 @@
  *     with reload transitions back to bootstrapped)
  *   - the JSON-RPC transport lifecycle (creation on bootstrap, teardown on
  *     reload/dispose)
- *   - the renderer-bundle injection sequence (CSS + JS via legacy `eval`
- *     messages, guarded by the iframe-side `__ISOLATED_*_LOADED__` flags)
+ *   - the renderer-bundle injection sequence (CSS + JS sent as `eval`
+ *     postMessages handled by the bootstrap script, guarded by the
+ *     iframe-side `__ISOLATED_*_LOADED__` flags)
  *   - the outbound send queue (render/theme/clear calls before the renderer
  *     bundle finishes installing get queued and flushed on `ready`)
- *   - message routing from the iframe (legacy `{ type, payload }` from the
+ *   - message routing from the iframe (raw `{ type, payload }` from the
  *     bootstrap script, JSON-RPC from the renderer bundle) into typed RxJS
  *     observables
  *   - wheel-boundary forwarding (so wheel events that hit a scroll boundary
@@ -72,9 +73,9 @@ import {
 import { scrollFrameWheelBoundary } from "./scroll-boundary";
 
 /**
- * Maps legacy `ParentToIframeMessage.type` values to canonical JSON-RPC
- * method names. Kept here so any caller using `send()` gets the same
- * routing the React shell used to perform inline.
+ * Maps `ParentToIframeMessage.type` values to their JSON-RPC method
+ * names. Kept here so any caller using `send()` gets the same routing
+ * the React shell used to perform inline.
  */
 const TYPE_TO_METHOD: Record<string, string> = {
   render: NTERACT_RENDER_OUTPUT,
@@ -218,10 +219,10 @@ export const ISOLATED_FRAME_SANDBOX =
 
 /**
  * Internal queued message. JSON-RPC sends carry a `method`/`params` pair
- * and are flushed via `rpc.notify()`. Legacy sends carry a `raw` message
- * (any `ParentToIframeMessage` that has no canonical JSON-RPC method,
- * e.g. `interaction_state`) and are flushed via raw postMessage so the
- * iframe-side legacy handler picks them up.
+ * and are flushed via `rpc.notify()`. Raw sends carry the original
+ * `ParentToIframeMessage` (for types with no JSON-RPC method, e.g.
+ * `interaction_state`) and are flushed via postMessage so the iframe-side
+ * bootstrap handler picks them up.
  */
 type QueuedSend =
   | { kind: "rpc"; method: string; params?: unknown }
@@ -242,7 +243,7 @@ export class IsolatedFrameController {
   private pending: QueuedSend[] = [];
 
   // Reserved for future routing of comm_open/comm_msg/comm_close through the
-  // controller. The bridge currently wires legacy events from IsolatedFrame.tsx
+  // controller. The bridge currently wires events from IsolatedFrame.tsx
   // directly; this slot lets a caller register one for the migration.
   // @ts-expect-error - intentionally held without read access yet.
   private commBridge: CommBridgeManager | null = null;
@@ -295,11 +296,10 @@ export class IsolatedFrameController {
   // ── Public commands ─────────────────────────────────────────────
 
   /**
-   * Generic outbound send. Maps legacy `{ type, payload }` shapes to their
-   * canonical JSON-RPC method names. Falls back to a raw postMessage when
-   * the renderer transport isn't up yet AND the message type isn't queueable
-   * — currently nothing slips through that path, since every type in
-   * `TYPE_TO_METHOD` is queueable.
+   * Generic outbound send. Maps `{ type, payload }` shapes onto their
+   * JSON-RPC method names. Types with no JSON-RPC method (currently
+   * `interaction_state`) are queued and flushed as raw postMessages once
+   * the renderer reports ready.
    *
    * Prefer the typed helpers (`render`, `setTheme`, etc.) over this; the
    * generic path exists for adapters that need to forward an
@@ -312,11 +312,11 @@ export class IsolatedFrameController {
       this.enqueue(method, params);
       return;
     }
-    // No canonical JSON-RPC method (e.g. `interaction_state`). Queue as a
-    // legacy postMessage and flush after the renderer is ready so the
-    // iframe-side legacy handler picks it up. Without this gate, an early
-    // `interaction_state` would land on the bootstrap-only listener and
-    // get dropped.
+    // No JSON-RPC method (e.g. `interaction_state`). Queue as a raw
+    // postMessage and flush after the renderer is ready so the iframe-side
+    // handler picks it up. Without this gate, an early `interaction_state`
+    // would land before the renderer-bundle listener is installed and get
+    // dropped.
     this.enqueueRaw(message);
   }
 
@@ -335,9 +335,9 @@ export class IsolatedFrameController {
   setTheme(theme: FrameThemePayload): void {
     this.theme = theme;
     // Theme can be applied before the renderer bundle is up — the iframe's
-    // bootstrap script handles legacy `theme` messages. Once the renderer
-    // transport is alive, prefer JSON-RPC so live theme changes follow the
-    // same path as everything else.
+    // bootstrap script handles `theme` postMessages directly. Once the
+    // renderer transport is alive, prefer JSON-RPC so live theme changes
+    // follow the same path as everything else.
     if (this.rpc && this.state === "ready") {
       this.rpc.notify(NTERACT_THEME, theme);
     } else if (this.iframe.contentWindow) {
@@ -381,7 +381,7 @@ export class IsolatedFrameController {
   attachCommBridge(manager: CommBridgeManager): void {
     this.commBridge = manager;
     // Future: forward comm_open/comm_msg/comm_close routing here. The bridge
-    // currently subscribes to legacy events directly from `IsolatedFrame.tsx`;
+    // currently subscribes to events directly from `IsolatedFrame.tsx`;
     // moving that wiring into the controller is a follow-up.
   }
 
@@ -461,9 +461,9 @@ export class IsolatedFrameController {
         this.handleBootstrapReady();
         break;
       case "renderer_ready":
-        // Legacy path some renderer paths still use; the canonical
-        // signal is the JSON-RPC `nteract/rendererReady` registered in
-        // attachTransport().
+        // Some renderer paths still emit this as a raw postMessage; the
+        // primary signal is the JSON-RPC `nteract/rendererReady` registered
+        // in attachTransport().
         this.handleRendererReady();
         break;
       case "resize":
@@ -472,9 +472,9 @@ export class IsolatedFrameController {
         }
         break;
       case "render_complete":
-        // Legacy RenderCompleteMessage only carries `height`. The richer
-        // payload shape (outputId/cellId/outputIndex) arrives through the
-        // JSON-RPC path registered in attachTransport().
+        // The bootstrap `render_complete` postMessage only carries
+        // `height`. The richer payload (outputId/cellId/outputIndex)
+        // arrives through the JSON-RPC path registered in attachTransport().
         if (data.payload?.height != null) {
           this._resize$.next({ height: data.payload.height });
         }
@@ -532,7 +532,7 @@ export class IsolatedFrameController {
     this._state$.next("bootstrapped");
 
     // Apply theme as soon as we're bootstrapped, before the renderer bundle
-    // takes over (the bootstrap script handles legacy `theme` messages).
+    // takes over — the bootstrap script handles `theme` postMessages.
     if (this.iframe.contentWindow) {
       this.iframe.contentWindow.postMessage({ type: "theme", payload: this.theme }, "*");
     }
@@ -620,8 +620,9 @@ export class IsolatedFrameController {
     if (!this.iframe.contentWindow) return;
     if (!this.rendererCode || !this.rendererCss) {
       // Bundle not yet available. The transport is up so callers can
-      // observe legacy/JSON-RPC messages, but the renderer stays uninstalled
-      // until `setRendererBundle()` lands and re-enters this path.
+      // observe raw and JSON-RPC messages, but the renderer stays
+      // uninstalled until `setRendererBundle()` lands and re-enters this
+      // path.
       return;
     }
     this.bootstrapping = true;

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -278,6 +278,15 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       [autoHeight, maxHeight, minHeight],
     );
 
+    // Mirror the latest clamping callback into a ref so the controller
+    // subscriptions can call it without forcing the controller-creation
+    // effect to re-run on height-policy prop changes. If the controller
+    // tore down whenever `autoHeight`/`maxHeight`/`minHeight` changed,
+    // the new instance would never see another `ready` from the
+    // already-loaded iframe and stay stuck in `booting`.
+    const applyMeasuredHeightRef = useRef(applyMeasuredHeight);
+    applyMeasuredHeightRef.current = applyMeasuredHeight;
+
     // Re-apply height when clamping props change.
     useEffect(() => {
       applyMeasuredHeight(measuredHeightRef.current);
@@ -335,12 +344,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           }
         }),
         controller.resize$.subscribe(({ height: h }) => {
-          applyMeasuredHeight(h);
+          applyMeasuredHeightRef.current(h);
         }),
         controller.renderComplete$.subscribe(({ height: h }) => {
           if (h != null) {
             setIsContentRendered(true);
-            applyMeasuredHeight(h);
+            applyMeasuredHeightRef.current(h);
           } else {
             setIsContentRendered(true);
           }
@@ -370,11 +379,13 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         controller.dispose();
         controllerRef.current = null;
       };
-      // initialContent/theme are read at construction time; we don't
-      // re-instantiate on every change. The setTheme effect below propagates
-      // theme changes through the live controller instead.
+      // Effect is keyed to `frameDocument` only — the controller is one
+      // per iframe element. `initialContent`, `darkMode`, `colorTheme`,
+      // `allowWheelBoundaryScroll` are read at construction; live changes
+      // propagate through the dedicated effects below, not by recreating
+      // the controller (which would orphan the loaded iframe).
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [frameDocument, applyMeasuredHeight]);
+    }, [frameDocument]);
 
     // Hand the renderer bundle to the controller as soon as it resolves.
     useEffect(() => {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -1,41 +1,12 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
-import { isIframeMessage } from "./frame-bridge";
-import { generateFrameHtml } from "./frame-html";
-import { useIsolatedRenderer } from "./isolated-renderer-context";
-import { JsonRpcTransport } from "./jsonrpc-transport";
 import {
-  NTERACT_BRIDGE_READY,
-  NTERACT_CLEAR_OUTPUTS,
-  NTERACT_COMM_CLOSE,
-  NTERACT_COMM_MSG,
-  NTERACT_COMM_OPEN,
-  NTERACT_WIDGET_SNAPSHOT,
-  NTERACT_DOUBLE_CLICK,
-  NTERACT_ERROR,
-  NTERACT_EVAL,
-  NTERACT_EVAL_RESULT,
-  NTERACT_INSTALL_RENDERER,
-  NTERACT_LINK_CLICK,
-  NTERACT_PING,
-  NTERACT_RENDER_BATCH,
-  NTERACT_RENDER_COMPLETE,
-  NTERACT_RENDER_OUTPUT,
-  NTERACT_RENDERER_READY,
-  NTERACT_RESIZE,
-  NTERACT_SEARCH,
-  NTERACT_SEARCH_NAVIGATE,
-  NTERACT_SEARCH_RESULTS,
-  NTERACT_THEME,
-  NTERACT_MOUSE_DOWN,
-  NTERACT_WIDGET_COMM_CLOSE,
-  NTERACT_WIDGET_COMM_MSG,
-  NTERACT_WIDGET_READY,
-  NTERACT_WIDGET_STATE,
-  NTERACT_WIDGET_UPDATE,
-  NTERACT_WHEEL_BOUNDARY,
-} from "./rpc-methods";
-import { scrollFrameWheelBoundary } from "./scroll-boundary";
+  ISOLATED_FRAME_SANDBOX,
+  IsolatedFrameController,
+  resolveFrameSource,
+} from "./isolated-frame-controller";
+import type { FrameSource } from "./isolated-frame-controller";
+import { useIsolatedRenderer } from "./isolated-renderer-context";
 
 export interface IsolatedFrameProps {
   /**
@@ -222,80 +193,15 @@ export interface IsolatedFrameHandle {
   isIframeReady: boolean;
 }
 
-const TYPE_TO_METHOD: Record<string, string> = {
-  render: NTERACT_RENDER_OUTPUT,
-  render_batch: NTERACT_RENDER_BATCH,
-  theme: NTERACT_THEME,
-  clear: NTERACT_CLEAR_OUTPUTS,
-  eval: NTERACT_EVAL,
-  install_renderer: NTERACT_INSTALL_RENDERER,
-  ping: NTERACT_PING,
-  search: NTERACT_SEARCH,
-  search_navigate: NTERACT_SEARCH_NAVIGATE,
-  comm_open: NTERACT_COMM_OPEN,
-  comm_msg: NTERACT_COMM_MSG,
-  comm_close: NTERACT_COMM_CLOSE,
-  widget_snapshot: NTERACT_WIDGET_SNAPSHOT,
-  bridge_ready: NTERACT_BRIDGE_READY,
-  widget_state: NTERACT_WIDGET_STATE,
-};
-
 /**
- * Sandbox attributes for the isolated iframe.
+ * IsolatedFrame - thin React shell over IsolatedFrameController.
  *
- * CRITICAL: Do NOT include 'allow-same-origin' - this would give the iframe
- * access to the parent's origin and Tauri APIs.
- */
-const SANDBOX_ATTRS = [
-  "allow-scripts", // Required for rendering interactive content
-  "allow-downloads", // Allow file downloads (e.g., from widgets)
-  "allow-forms", // Allow form submissions
-  "allow-pointer-lock", // For interactive visualizations
-  // Fullscreen for sift maximize, maps, 3D, etc. is enabled via the
-  // separate `allowFullScreen` iframe attribute (not a sandbox flag).
-].join(" ");
-
-type FrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
-
-function isTauriRuntime(): boolean {
-  const globalWindow = window as Window & {
-    __TAURI__?: unknown;
-    __TAURI_INTERNALS__?: unknown;
-  };
-  return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
-}
-
-/**
- * IsolatedFrame component - Renders untrusted content in a secure iframe.
+ * The component owns nothing but the iframe element, the height/visibility
+ * state, and the imperative-handle bridge. All lifecycle, transport, and
+ * message routing live in `IsolatedFrameController` so the same orchestration
+ * can be reused from Vue, vanilla JS, or any other host.
  *
- * Uses sandbox restrictions to ensure the iframe content cannot access Tauri
- * APIs or the parent DOM. Tauri loads the iframe from the nteract-frame custom
- * scheme so the frame receives its own CSP. Communication happens via postMessage.
- *
- * **Requires** `IsolatedRendererProvider` to be present in the component tree.
- *
- * @example
- * ```tsx
- * // In your app root or layout:
- * <IsolatedRendererProvider basePath="/isolated">
- *   <App />
- * </IsolatedRendererProvider>
- *
- * // Then use IsolatedFrame anywhere:
- * const frameRef = useRef<IsolatedFrameHandle>(null);
- *
- * <IsolatedFrame
- *   ref={frameRef}
- *   darkMode={true}
- *   onReady={() => {
- *     frameRef.current?.render({
- *       mimeType: "text/html",
- *       data: "<h1>Hello from isolated frame!</h1>"
- *     });
- *   }}
- *   onResize={(height) => console.log("New height:", height)}
- * />
- * ```
+ * Requires `IsolatedRendererProvider` to be present in the component tree.
  */
 export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>(
   function IsolatedFrame(
@@ -323,40 +229,25 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     },
     ref,
   ) {
-    // Get renderer bundle from context (provided by IsolatedRendererProvider)
     const {
       rendererCode,
       rendererCss,
       isLoading: providerLoading,
       error: providerError,
     } = useIsolatedRenderer();
+
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const rpcRef = useRef<JsonRpcTransport | null>(null);
-    const [frameDocument, setFrameDocument] = useState<FrameDocument | null>(null);
-    // Track iframe ready (bootstrap HTML loaded)
+    const controllerRef = useRef<IsolatedFrameController | null>(null);
+    const [frameDocument, setFrameDocument] = useState<FrameSource | null>(null);
+
     const [isIframeReady, setIsIframeReady] = useState(false);
-    // Track renderer ready (React bundle initialized)
     const [isReady, setIsReady] = useState(false);
-    // Use ref to track ready state for send callback (avoids stale closure)
-    const isReadyRef = useRef(false);
+    const [isReloading, setIsReloading] = useState(false);
+    const [isContentRendered, setIsContentRendered] = useState(false);
     const [height, setHeight] = useState(minHeight);
     const measuredHeightRef = useRef(minHeight);
-    // Track if content has been rendered (for revealOnRender mode)
-    const [isContentRendered, setIsContentRendered] = useState(false);
-    // Track if the iframe is reloading (DOM move caused browser to tear down)
-    // Used to hide the iframe during reload to prevent white flash
-    const [isReloading, setIsReloading] = useState(false);
 
-    // Queue messages until iframe is ready
-    const pendingMessagesRef = useRef<ParentToIframeMessage[]>([]);
-    // Track if we've started bootstrapping to avoid double-fetch
-    const bootstrappingRef = useRef(false);
-    // Track whether the iframe has sent a "ready" message before.
-    // Any subsequent "ready" is a reload that needs the toggle trick.
-    const hasReceivedReadyRef = useRef(false);
-
-    // Stable refs for callback props — avoids tearing down the message
-    // handler when callers pass unstable (inline) callbacks.
+    // Stable refs for callback props — survive controller re-subscription.
     const onReadyRef = useRef(onReady);
     const onResizeRef = useRef(onResize);
     const onLinkClickRef = useRef(onLinkClick);
@@ -365,9 +256,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onWidgetUpdateRef = useRef(onWidgetUpdate);
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
-    const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
 
-    // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
     onResizeRef.current = onResize;
     onLinkClickRef.current = onLinkClick;
@@ -376,54 +265,30 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onWidgetUpdateRef.current = onWidgetUpdate;
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
-    allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
 
     const applyMeasuredHeight = useCallback(
       (contentHeight: number) => {
         measuredHeightRef.current = contentHeight;
-        const newHeight = autoHeight
+        const clamped = autoHeight
           ? Math.max(minHeight, contentHeight)
           : Math.max(minHeight, Math.min(maxHeight, contentHeight));
-        setHeight(newHeight);
-        onResizeRef.current?.(newHeight);
+        setHeight(clamped);
+        onResizeRef.current?.(clamped);
       },
       [autoHeight, maxHeight, minHeight],
     );
 
+    // Re-apply height when clamping props change.
     useEffect(() => {
       applyMeasuredHeight(measuredHeightRef.current);
     }, [applyMeasuredHeight]);
 
-    // Create frame document on mount. Tauri loads from a custom scheme so the
-    // iframe receives its own CSP; browser-only dev keeps srcDoc.
+    // Resolve frame source once on mount.
     useEffect(() => {
-      if (isTauriRuntime()) {
-        setFrameDocument({ kind: "src", url: "nteract-frame://localhost/" });
-      } else {
-        setFrameDocument({ kind: "srcdoc", html: generateFrameHtml() });
-      }
+      setFrameDocument(resolveFrameSource());
     }, []);
 
-    // Send theme as soon as iframe is ready (before renderer bootstrap).
-    // Once the renderer transport is active, prefer JSON-RPC so live theme
-    // changes follow the same path as other renderer updates.
-    useEffect(() => {
-      if (isIframeReady && iframeRef.current?.contentWindow) {
-        const payload = { isDark: darkMode, colorTheme: colorTheme ?? null };
-        if (rpcRef.current && isReadyRef.current) {
-          rpcRef.current.notify(NTERACT_THEME, payload);
-        } else {
-          iframeRef.current.contentWindow.postMessage({ type: "theme", payload }, "*");
-        }
-      }
-    }, [darkMode, colorTheme, isIframeReady, isReady]);
-
-    // Keep ref in sync with state (ref avoids stale closures in callbacks)
-    useEffect(() => {
-      isReadyRef.current = isReady;
-    }, [isReady]);
-
-    // Surface provider errors to consumers
+    // Surface provider errors to consumers.
     useEffect(() => {
       if (providerError && !providerLoading) {
         onErrorRef.current?.({
@@ -433,373 +298,130 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       }
     }, [providerError, providerLoading]);
 
-    // Send a message to the iframe
-    // Uses ref to check ready state to avoid stale closure issues
-    const send = useCallback(
-      (message: ParentToIframeMessage) => {
-        if (!isReadyRef.current) {
-          // Queue message until ready
-          pendingMessagesRef.current.push(message);
-          return;
-        }
-
-        // Translate to JSON-RPC if transport is available
-        const method = TYPE_TO_METHOD[message.type];
-        if (method && rpcRef.current) {
-          const params = "payload" in message ? message.payload : undefined;
-          rpcRef.current.notify(method, params);
-        } else if (iframeRef.current?.contentWindow) {
-          // Fallback to legacy format
-          iframeRef.current.contentWindow.postMessage(message, "*");
-        }
-      },
-      [], // No deps - uses ref instead of state
-    );
-
-    // Flush pending messages when ready
+    // Instantiate the controller once the iframe is mounted. The bundle is
+    // fed in via `setRendererBundle` once the provider resolves; until then
+    // the controller's transport is up (so `ready` etc. land) but the
+    // renderer injection is deferred.
     useEffect(() => {
-      if (isReady && pendingMessagesRef.current.length > 0) {
-        const pending = pendingMessagesRef.current;
-        pendingMessagesRef.current = [];
-        pending.forEach((msg) => {
-          const method = TYPE_TO_METHOD[msg.type];
-          if (method && rpcRef.current) {
-            const params = "payload" in msg ? msg.payload : undefined;
-            rpcRef.current.notify(method, params);
-          } else if (iframeRef.current?.contentWindow) {
-            iframeRef.current.contentWindow.postMessage(msg, "*");
-          }
-        });
-      }
-    }, [isReady]);
+      const iframe = iframeRef.current;
+      if (!iframe || !frameDocument) return;
 
-    // Handle messages from iframe
-    useEffect(() => {
-      const handleMessage = (event: MessageEvent) => {
-        // Verify the message is from our iframe
-        if (event.source !== iframeRef.current?.contentWindow) {
-          return;
-        }
+      const controller = new IsolatedFrameController({
+        iframe,
+        initialContent,
+        initialTheme: { isDark: darkMode, colorTheme: colorTheme ?? null },
+        forwardWheelBoundary: allowWheelBoundaryScroll,
+      });
+      controllerRef.current = controller;
 
-        const data = event.data;
+      const subs = [
+        controller.state$.subscribe((state) => {
+          // `bootstrapped` and later means the iframe HTML is loaded.
+          const iframeReady = state !== "booting";
+          setIsIframeReady(iframeReady);
 
-        // Skip JSON-RPC messages — the transport handles them
-        if (
-          typeof data === "object" &&
-          data !== null &&
-          (data as { jsonrpc?: unknown }).jsonrpc === "2.0"
-        ) {
-          return;
-        }
+          const ready = state === "ready";
+          setIsReady((prev) => {
+            if (prev === ready) return prev;
+            if (ready) onReadyRef.current?.();
+            return ready;
+          });
 
-        if (!isIframeMessage(data)) {
-          return;
-        }
-
-        // Call generic message handler
-        onMessageRef.current?.(data);
-
-        // Handle specific message types
-        switch (data.type) {
-          case "ready": {
-            // Iframe bootstrap HTML is loaded.
-            // Any "ready" after the first is a reload (e.g., DOM move caused
-            // the browser to tear down and reload the iframe).
-            const isReload = hasReceivedReadyRef.current;
-            hasReceivedReadyRef.current = true;
-
-            if (isReload) {
-              // Reset bootstrap state so the renderer gets re-injected.
-              bootstrappingRef.current = false;
-              // Keep the imperative readiness ref in sync with state so that
-              // synchronous send() calls don't treat the frame as ready during
-              // a reload window.
-              isReadyRef.current = false;
-              // Pending messages were targeted at the old iframe instance; drop
-              // them so they don't get delivered to the reloaded frame.
-              pendingMessagesRef.current.length = 0;
-              setIsReady(false);
-              // Reset content rendered state for revealOnRender mode
-              setIsContentRendered(false);
-              // Hide iframe during reload to prevent white flash from blank
-              // iframe document before blob HTML loads
-              setIsReloading(true);
-            }
-
-            if (isReload) {
-              // Reload: isIframeReady may already be true, so toggle to
-              // force effects that depend on it (theme sync, renderer
-              // injection) to re-run.
-              setIsIframeReady(false);
-              setTimeout(() => {
-                setIsIframeReady(true);
-              }, 0);
-            } else {
-              // Initial load: a single transition from false→true is
-              // sufficient.
-              setIsIframeReady(true);
-            }
-
-            // Create JSON-RPC transport for this iframe instance
-            if (iframeRef.current?.contentWindow) {
-              // Clean up previous transport on reload
-              if (rpcRef.current) {
-                rpcRef.current.stop();
-              }
-              const transport = new JsonRpcTransport(
-                iframeRef.current.contentWindow,
-                iframeRef.current.contentWindow,
-              );
-              // Register handlers for JSON-RPC messages from iframe
-              transport.onNotification(NTERACT_RENDERER_READY, () => {
-                setIsReady(true);
-                setIsReloading(false);
-                onReadyRef.current?.();
-                if (initialContent) {
-                  transport.notify(NTERACT_RENDER_OUTPUT, initialContent);
-                }
-              });
-              transport.onNotification(NTERACT_RESIZE, (params) => {
-                const p = params as { height?: number };
-                if (p.height != null) {
-                  applyMeasuredHeight(p.height);
-                }
-              });
-              transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {
-                const p = params as { height?: number };
-                if (p.height != null) {
-                  setIsContentRendered(true);
-                  applyMeasuredHeight(p.height);
-                }
-              });
-              transport.onNotification(NTERACT_LINK_CLICK, (params) => {
-                const p = params as { url: string; newTab?: boolean };
-                if (p.url) {
-                  onLinkClickRef.current?.(p.url, p.newTab ?? false);
-                }
-              });
-              transport.onNotification(NTERACT_MOUSE_DOWN, () => {
-                onMouseDownRef.current?.();
-              });
-              transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
-                if (!allowWheelBoundaryScrollRef.current) {
-                  return;
-                }
-                scrollFrameWheelBoundary(iframeRef.current, params as { deltaY?: number });
-              });
-              transport.onNotification(NTERACT_DOUBLE_CLICK, () => {
-                onDoubleClickRef.current?.();
-              });
-              transport.onNotification(NTERACT_WIDGET_UPDATE, (params) => {
-                const p = params as { commId: string; state: Record<string, unknown> };
-                if (p.commId && p.state) {
-                  onWidgetUpdateRef.current?.(p.commId, p.state);
-                }
-              });
-              transport.onNotification(NTERACT_ERROR, (params) => {
-                const p = params as { message: string; stack?: string };
-                if (p.message) {
-                  onErrorRef.current?.(p);
-                }
-              });
-              transport.onNotification(NTERACT_EVAL_RESULT, (params) => {
-                const p = params as { success: boolean; error?: string };
-                if (p.success === false) {
-                  console.error("[IsolatedFrame] Bundle eval failed:", p.error);
-                  onErrorRef.current?.({ message: `Bundle eval failed: ${p.error}` });
-                }
-              });
-              transport.onNotification(NTERACT_SEARCH_RESULTS, (params) => {
-                const p = params as { count: number };
-                // Forward to onMessage for OutputArea's search count tracking
-                onMessageRef.current?.({
-                  type: "search_results",
-                  payload: p,
-                } as IframeToParentMessage);
-              });
-              transport.onNotification(NTERACT_WIDGET_READY, () => {
-                onMessageRef.current?.({ type: "widget_ready" } as IframeToParentMessage);
-              });
-              transport.onNotification(NTERACT_WIDGET_COMM_MSG, (params) => {
-                onMessageRef.current?.({
-                  type: "widget_comm_msg",
-                  payload: params,
-                } as IframeToParentMessage);
-              });
-              transport.onNotification(NTERACT_WIDGET_COMM_CLOSE, (params) => {
-                onMessageRef.current?.({
-                  type: "widget_comm_close",
-                  payload: params,
-                } as IframeToParentMessage);
-              });
-              transport.start();
-              rpcRef.current = transport;
-            }
-            break;
-          }
-
-          case "renderer_ready":
-            // React renderer bundle is initialized
-            setIsReady(true);
+          if (state === "reloading") {
+            setIsReloading(true);
+            setIsContentRendered(false);
+          } else if (state === "ready") {
             setIsReloading(false);
-            onReadyRef.current?.();
-            // Render initial content if provided
-            if (initialContent) {
-              iframeRef.current?.contentWindow?.postMessage(
-                { type: "render", payload: initialContent },
-                "*",
-              );
-            }
-            break;
+          }
+        }),
+        controller.resize$.subscribe(({ height: h }) => {
+          applyMeasuredHeight(h);
+        }),
+        controller.renderComplete$.subscribe(({ height: h }) => {
+          if (h != null) {
+            setIsContentRendered(true);
+            applyMeasuredHeight(h);
+          } else {
+            setIsContentRendered(true);
+          }
+        }),
+        controller.linkClicks$.subscribe(({ url, newTab }) => {
+          onLinkClickRef.current?.(url, newTab);
+        }),
+        controller.mouseDowns$.subscribe(() => {
+          onMouseDownRef.current?.();
+        }),
+        controller.doubleClicks$.subscribe(() => {
+          onDoubleClickRef.current?.();
+        }),
+        controller.widgetUpdates$.subscribe(({ commId, state }) => {
+          onWidgetUpdateRef.current?.(commId, state);
+        }),
+        controller.errors$.subscribe((err) => {
+          onErrorRef.current?.(err);
+        }),
+        controller.messages$.subscribe((msg) => {
+          onMessageRef.current?.(msg);
+        }),
+      ];
 
-          case "resize":
-            if (data.payload?.height != null) {
-              applyMeasuredHeight(data.payload.height);
-            }
-            break;
-
-          case "render_complete":
-            // Content has been rendered - reveal iframe if in revealOnRender mode
-            if (data.payload?.height != null) {
-              setIsContentRendered(true);
-              applyMeasuredHeight(data.payload.height);
-            }
-            break;
-
-          case "link_click":
-            if (data.payload?.url) {
-              onLinkClickRef.current?.(data.payload.url, data.payload.newTab ?? false);
-            }
-            break;
-
-          case "dblclick":
-            onDoubleClickRef.current?.();
-            break;
-
-          case "widget_update":
-            if (data.payload?.commId && data.payload?.state) {
-              onWidgetUpdateRef.current?.(data.payload.commId, data.payload.state);
-            }
-            break;
-
-          case "error":
-            if (data.payload) {
-              onErrorRef.current?.(data.payload);
-            }
-            break;
-
-          case "eval_result":
-            // Surface bundle eval failures to help diagnose injection issues
-            if (data.payload?.success === false) {
-              console.error("[IsolatedFrame] Bundle eval failed:", data.payload.error);
-              onErrorRef.current?.({
-                message: `Bundle eval failed: ${data.payload.error}`,
-              });
-            }
-            break;
-        }
-      };
-
-      window.addEventListener("message", handleMessage);
-      return () => window.removeEventListener("message", handleMessage);
-    }, [initialContent, applyMeasuredHeight]);
-
-    // Clean up JSON-RPC transport on unmount
-    useEffect(() => {
       return () => {
-        rpcRef.current?.stop();
+        for (const sub of subs) sub.unsubscribe();
+        controller.dispose();
+        controllerRef.current = null;
       };
-    }, []);
+      // initialContent/theme are read at construction time; we don't
+      // re-instantiate on every change. The setTheme effect below propagates
+      // theme changes through the live controller instead.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [frameDocument, applyMeasuredHeight]);
 
-    // Inject renderer when iframe is ready AND bundle props are available
+    // Hand the renderer bundle to the controller as soon as it resolves.
     useEffect(() => {
-      if (
-        isIframeReady &&
-        !isReady &&
-        !bootstrappingRef.current &&
-        rendererCode &&
-        rendererCss &&
-        iframeRef.current?.contentWindow
-      ) {
-        bootstrappingRef.current = true;
-
-        // Inject CSS first (idempotent - checks if already loaded)
-        const cssCode = `
-        (function() {
-          if (window.__ISOLATED_CSS_LOADED__) return;
-          window.__ISOLATED_CSS_LOADED__ = true;
-          var style = document.createElement('style');
-          style.textContent = ${JSON.stringify(rendererCss)};
-          document.head.appendChild(style);
-        })();
-      `;
-        iframeRef.current.contentWindow.postMessage(
-          { type: "eval", payload: { code: cssCode } },
-          "*",
-        );
-        // Then inject JS bundle (idempotent - checks if already loaded)
-        // Use string concatenation instead of template literal to avoid issues
-        // with backticks or ${} in the bundled code
-        const jsWrapper =
-          "(function() {" +
-          "if (window.__ISOLATED_RENDERER_LOADED__) return;" +
-          "window.__ISOLATED_RENDERER_LOADED__ = true;" +
-          rendererCode +
-          "})();";
-        iframeRef.current.contentWindow.postMessage(
-          { type: "eval", payload: { code: jsWrapper } },
-          "*",
-        );
+      if (rendererCode && rendererCss) {
+        controllerRef.current?.setRendererBundle(rendererCode, rendererCss);
       }
-    }, [isIframeReady, isReady, rendererCode, rendererCss]);
+    }, [rendererCode, rendererCss]);
 
-    // Expose imperative API
+    // Live theme updates.
+    useEffect(() => {
+      controllerRef.current?.setTheme({
+        isDark: darkMode,
+        colorTheme: colorTheme ?? null,
+      });
+    }, [darkMode, colorTheme]);
+
+    // Live wheel-boundary forwarding toggle.
+    useEffect(() => {
+      controllerRef.current?.setWheelBoundaryForwarding(allowWheelBoundaryScroll);
+    }, [allowWheelBoundaryScroll]);
+
     useImperativeHandle(
       ref,
       () => ({
-        send,
-        render: (payload: RenderPayload) => send({ type: "render", payload }),
-        renderBatch: (outputs: RenderPayload[]) =>
-          send({ type: "render_batch", payload: { outputs } }),
-        eval: (code: string) => send({ type: "eval", payload: { code } }),
+        send: (message: ParentToIframeMessage) => controllerRef.current?.send(message),
+        render: (payload: RenderPayload) => controllerRef.current?.render(payload),
+        renderBatch: (outputs: RenderPayload[]) => controllerRef.current?.renderBatch(outputs),
+        eval: (code: string) => controllerRef.current?.send({ type: "eval", payload: { code } }),
         installRenderer: (code: string, css?: string) =>
-          send({ type: "install_renderer", payload: { code, css } }),
-        setTheme: (isDark: boolean, colorTheme?: string | null) =>
-          send({ type: "theme", payload: { isDark, colorTheme } }),
-        clear: () => send({ type: "clear" }),
-        search: (query: string, caseSensitive?: boolean) => {
-          // Search handler is in bootstrap HTML, so send directly when iframe is loaded
-          // (bypasses the isReady queue which waits for the React renderer)
-          if (rpcRef.current) {
-            rpcRef.current.notify(NTERACT_SEARCH, { query, caseSensitive });
-          } else if (iframeRef.current?.contentWindow) {
-            iframeRef.current.contentWindow.postMessage(
-              { type: "search", payload: { query, caseSensitive } },
-              "*",
-            );
-          }
-        },
-        searchNavigate: (matchIndex: number) => {
-          if (rpcRef.current) {
-            rpcRef.current.notify(NTERACT_SEARCH_NAVIGATE, { matchIndex });
-          } else if (iframeRef.current?.contentWindow) {
-            iframeRef.current.contentWindow.postMessage(
-              { type: "search_navigate", payload: { matchIndex } },
-              "*",
-            );
-          }
-        },
+          controllerRef.current?.send({
+            type: "install_renderer",
+            payload: { code, css },
+          }),
+        setTheme: (isDark: boolean, theme?: string | null) =>
+          controllerRef.current?.setTheme({ isDark, colorTheme: theme ?? null }),
+        clear: () => controllerRef.current?.clear(),
+        search: (query: string, caseSensitive?: boolean) =>
+          controllerRef.current?.search(query, caseSensitive),
+        searchNavigate: (matchIndex: number) => controllerRef.current?.searchNavigate(matchIndex),
         isReady,
         isIframeReady,
       }),
-      [send, isReady, isIframeReady],
+      [isReady, isIframeReady],
     );
 
-    if (!frameDocument) {
-      return null;
-    }
+    if (!frameDocument) return null;
 
-    // Compute display values for revealOnRender mode
     const displayHeight = revealOnRender && !isContentRendered ? 0 : height;
     const displayOpacity = revealOnRender && !isContentRendered ? 0 : 1;
 
@@ -810,7 +432,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         name={name}
         src={frameDocument.kind === "src" ? frameDocument.url : undefined}
         srcDoc={frameDocument.kind === "srcdoc" ? frameDocument.html : undefined}
-        sandbox={SANDBOX_ATTRS}
+        sandbox={ISOLATED_FRAME_SANDBOX}
         allowFullScreen
         allow="fullscreen *"
         className={className}
@@ -826,8 +448,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           WebkitUserSelect: "none",
           background: "transparent",
           colorScheme: darkMode ? "dark" : "light",
-          // Hide iframe during reload to prevent white flash from blank document.
-          // visibility:hidden preserves layout (keeps height) while hiding content.
+          // visibility:hidden during reload preserves layout while hiding the
+          // blank iframe document mid-tear-down/re-init.
           visibility: isReloading ? "hidden" : "visible",
           transition: revealOnRender ? "height 150ms ease-out, opacity 150ms ease-out" : undefined,
         }}


### PR DESCRIPTION
Pulls the iframe orchestration out of the React component into a framework-agnostic `IsolatedFrameController` so the same sandbox can drive Vue (Slidev decks), vanilla JS, or whatever else, not just `apps/notebook`. The React component shrinks from ~840 lines to ~430 and now owns only the `<iframe>` element, height clamping, and the imperative-handle bridge.

The controller owns the iframe lifecycle state machine, the JSON-RPC transport, the outbound send queue, message routing into typed RxJS observables, renderer-bundle injection, and wheel-boundary forwarding. Adapters subscribe to typed streams (`state$`, `resize$`, `renderComplete$`, `linkClicks$`, `mouseDowns$`, `doubleClicks$`, `widgetUpdates$`, `errors$`, `messages$`, `searchResults$`); the React shell forwards them to prop callbacks, a Vue host can `watch()` them, vanilla JS picks whatever.

## Design notes

- **Bundle decoupled from construction.** The controller is instantiated as soon as the iframe element exists, before the renderer bundle resolves. The JSON-RPC transport comes up immediately on `ready` (the existing `isolated-frame-theme` tests depend on this). When the provider delivers `rendererCode`/`rendererCss`, the shell calls `setRendererBundle()` and injection kicks off.
- **Lifecycle as a state machine.** Five non-error states (`booting → bootstrapped → installing → ready`, plus a `reloading` transition that loops back through `bootstrapped`). Adapters derive `isReady`/`isIframeReady`/`isReloading` from one observable instead of juggling refs.
- **Generic `send()`.** Maps `ParentToIframeMessage.type` onto JSON-RPC method names so adapters can forward pre-shaped messages without re-implementing the translation. Types with no JSON-RPC method (just `interaction_state` today) are queued and flushed as raw postMessages on renderer-ready.
- **Wheel-boundary toggle is live.** `setWheelBoundaryForwarding(bool)` swaps behavior without rebuilding the controller.
- **No security model change.** Sandbox flags, custom URI scheme, and CSP all stay where they were; the controller exports `ISOLATED_FRAME_SANDBOX` so adapters apply the exact same string and the sandbox-security tests keep passing.

## Why this exists

Spun out of work on the in-repo Slidev talk deck (#2779), which needs the same iframe + plugin pipeline the desktop app uses but written for Vue. Rather than reimplement the state machine and transport in Vue, the React-specific glue was pulled out so the orchestration is one class. This also lines up with the MCP-Apps JSON-RPC direction - the controller's surface is the JSON-RPC layer made first-class.

## Codex review fixes

Two regressions caught in the first round of review and fixed in the second commit:

- **Height-policy prop changes were tearing down the live controller.** The controller-creation effect listed `applyMeasuredHeight` in its deps, which changed identity whenever `autoHeight`/`maxHeight`/`minHeight` flipped. That tore down the controller and spun up a fresh one against the already-loaded iframe - which would never fire another `ready`, leaving the new instance stuck in `booting` and silently dropping every future render/widget message. Now keyed to `frameDocument` only; the resize subscription reads the latest clamp callback through a ref.
- **`interaction_state` was bypassing the pre-ready queue.** `ParentToIframeMessage.interaction_state` has no JSON-RPC method, and the previous `send()` fallback posted it immediately via raw postMessage even before the renderer was up. The iframe's bootstrap-only listener ignores `interaction_state`, so a Sift frame activated before renderer-ready would start with stale `interactionActive` until the next toggle. Unknown types are now queued and flushed as raw postMessages on renderer-ready, alongside JSON-RPC sends.

Both have regression tests: the React shell test rerenders with flipped height props and asserts the JSON-RPC transport instance is preserved; the controller test queues `interaction_state` pre-ready and asserts it lands as a postMessage post-ready.

## Test plan

- [x] `pnpm test:run src/` - 991 tests pass (977 prior + 14 new)
- [x] `cargo xtask lint --fix` - clean
- [x] Existing `isolated-frame.test.ts`, `isolated-frame-theme.test.tsx`, `reload-detection.test.ts` all pass against the refactored shell
- [ ] Manual smoke: open the notebook app, run a Python cell with a DataFrame, confirm output rendering is unchanged
- [ ] Manual smoke: drive the controller from the Slidev deck (#2779) and confirm sift renders

## Follow-ups

- Build a Vue adapter (`IsolatedFrame.vue`) on top of the controller for the in-repo Slidev deck (#2779).
- Move `CommBridgeManager` wiring into the controller so the React shell no longer needs to attach it separately. The `attachCommBridge()` hook is in place but does not yet route events.
- Migrate `interaction_state` to a real JSON-RPC method (`nteract/interactionState`). Today it's the only post-bundle message still going raw - parent→iframe `eval`/`theme`/`search` have to stay raw because the bootstrap script handles them before the JSON-RPC bundle is installed, but `interaction_state` is only handled inside the bundle, so it's a clean migration. Eliminates the `enqueueRaw` branch in the controller.
