### PR TITLE
feat(isolated): route interaction_state over JSON-RPC

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a32ff66614783be6f2ab946ab9200bf5d0e43fc2c704cfb0e3270058658fa88
-size 1476940
+oid sha256:9c2290e0429c5032c23d84d18096fac9f30b327dfcc6d7a1780f4e96979c7e62
+size 1477022

--- a/src/components/isolated/__tests__/isolated-frame-controller.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-controller.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import type { FrameLifecycleState } from "../isolated-frame-controller";
 import { IsolatedFrameController } from "../isolated-frame-controller";
 import {
+  NTERACT_INTERACTION_STATE,
   NTERACT_LINK_CLICK,
   NTERACT_RENDERER_READY,
   NTERACT_RENDER_OUTPUT,
@@ -137,18 +138,18 @@ describe("IsolatedFrameController", () => {
   });
 
   describe("send queue", () => {
-    it("queues a non-JSON-RPC message (interaction_state) until ready", () => {
+    it("queues interaction_state until ready, then flushes via JSON-RPC", () => {
       const controller = new IsolatedFrameController({
         iframe: iframe.element,
         rendererCode: "/*code*/",
         rendererCss: "body{}",
       });
-      // Pre-ready: raw postMessage must not slip through immediately.
+      // Pre-ready: nothing must slip through immediately.
       controller.send({ type: "interaction_state", payload: { active: true } });
-      const preReadyInteraction = iframe.posts.filter(
-        (p) => (p.message as { type?: string }).type === "interaction_state",
+      const preReady = iframe.posts.filter(
+        (p) => (p.message as { method?: string }).method === NTERACT_INTERACTION_STATE,
       );
-      expect(preReadyInteraction).toHaveLength(0);
+      expect(preReady).toHaveLength(0);
 
       dispatchFromIframe(iframe, { type: "ready" });
       dispatchFromIframe(iframe, {
@@ -156,14 +157,23 @@ describe("IsolatedFrameController", () => {
         method: NTERACT_RENDERER_READY,
         params: {},
       });
-      const postReadyInteraction = iframe.posts.filter(
-        (p) => (p.message as { type?: string }).type === "interaction_state",
+      const postReady = iframe.posts.filter(
+        (p) => (p.message as { method?: string }).method === NTERACT_INTERACTION_STATE,
       );
-      expect(postReadyInteraction).toHaveLength(1);
-      expect(postReadyInteraction[0].message).toEqual({
-        type: "interaction_state",
-        payload: { active: true },
+      expect(postReady).toHaveLength(1);
+      expect((postReady[0].message as { params: unknown }).params).toEqual({ active: true });
+      controller.dispose();
+    });
+
+    it("throws on send() with a type that has no JSON-RPC method", () => {
+      const controller = new IsolatedFrameController({
+        iframe: iframe.element,
+        rendererCode: "/*code*/",
+        rendererCss: "body{}",
       });
+      expect(() =>
+        controller.send({ type: "unknown" as never, payload: {} as never } as never),
+      ).toThrow(/no JSON-RPC method/);
       controller.dispose();
     });
 

--- a/src/components/isolated/__tests__/type-to-method.test.ts
+++ b/src/components/isolated/__tests__/type-to-method.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for TYPE_TO_METHOD mapping in isolated-frame.tsx.
+ * Tests for the TYPE_TO_METHOD mapping in `IsolatedFrameController`.
  *
- * Verifies that every legacy message type that goes through send()
- * has a corresponding JSON-RPC method mapping, and that the mapping
- * values match the constants in rpc-methods.ts.
+ * Verifies that every `ParentToIframeMessage.type` value has a JSON-RPC
+ * method mapping, and that the values match the constants in
+ * `rpc-methods.ts`. The table is duplicated here so the test catches
+ * drift between the controller's mapping and the canonical method names.
  */
 
 import { describe, expect, it } from "vite-plus/test";
@@ -13,19 +14,20 @@ import {
   NTERACT_COMM_CLOSE,
   NTERACT_COMM_MSG,
   NTERACT_COMM_OPEN,
-  NTERACT_WIDGET_SNAPSHOT,
   NTERACT_EVAL,
   NTERACT_INSTALL_RENDERER,
+  NTERACT_INTERACTION_STATE,
   NTERACT_PING,
   NTERACT_RENDER_OUTPUT,
   NTERACT_SEARCH,
   NTERACT_SEARCH_NAVIGATE,
   NTERACT_THEME,
+  NTERACT_WIDGET_SNAPSHOT,
   NTERACT_WIDGET_STATE,
 } from "../rpc-methods";
 
-// Duplicated from isolated-frame.tsx to test in isolation
-// If this gets out of sync, the test will fail and remind us to update
+// Duplicated from isolated-frame-controller.ts to test in isolation.
+// If this gets out of sync, the test will fail and remind us to update.
 const TYPE_TO_METHOD: Record<string, string> = {
   render: NTERACT_RENDER_OUTPUT,
   theme: NTERACT_THEME,
@@ -41,11 +43,11 @@ const TYPE_TO_METHOD: Record<string, string> = {
   widget_snapshot: NTERACT_WIDGET_SNAPSHOT,
   bridge_ready: NTERACT_BRIDGE_READY,
   widget_state: NTERACT_WIDGET_STATE,
+  interaction_state: NTERACT_INTERACTION_STATE,
 };
 
 describe("TYPE_TO_METHOD mapping", () => {
-  it("maps all host→iframe legacy types to JSON-RPC methods", () => {
-    // Every legacy type that CommBridgeManager or IsolatedFrame.send() uses
+  it("covers every host→iframe message type", () => {
     const requiredTypes = [
       "render",
       "theme",
@@ -61,10 +63,11 @@ describe("TYPE_TO_METHOD mapping", () => {
       "widget_snapshot",
       "bridge_ready",
       "widget_state",
+      "interaction_state",
     ];
 
     for (const type of requiredTypes) {
-      expect(TYPE_TO_METHOD[type], `Missing mapping for legacy type "${type}"`).toBeDefined();
+      expect(TYPE_TO_METHOD[type], `Missing mapping for type "${type}"`).toBeDefined();
     }
   });
 
@@ -88,6 +91,7 @@ describe("TYPE_TO_METHOD mapping", () => {
     expect(TYPE_TO_METHOD.widget_snapshot).toBe("nteract/widgetSnapshot");
     expect(TYPE_TO_METHOD.bridge_ready).toBe("nteract/bridgeReady");
     expect(TYPE_TO_METHOD.widget_state).toBe("nteract/widgetState");
+    expect(TYPE_TO_METHOD.interaction_state).toBe("nteract/interactionState");
   });
 
   it("has no duplicate method values", () => {

--- a/src/components/isolated/isolated-frame-controller.ts
+++ b/src/components/isolated/isolated-frame-controller.ts
@@ -50,6 +50,7 @@ import {
   NTERACT_EVAL,
   NTERACT_EVAL_RESULT,
   NTERACT_INSTALL_RENDERER,
+  NTERACT_INTERACTION_STATE,
   NTERACT_LINK_CLICK,
   NTERACT_MOUSE_DOWN,
   NTERACT_PING,
@@ -93,6 +94,7 @@ const TYPE_TO_METHOD: Record<string, string> = {
   widget_snapshot: NTERACT_WIDGET_SNAPSHOT,
   bridge_ready: NTERACT_BRIDGE_READY,
   widget_state: NTERACT_WIDGET_STATE,
+  interaction_state: NTERACT_INTERACTION_STATE,
 };
 
 // ── Public types ─────────────────────────────────────────────────────
@@ -218,15 +220,15 @@ export const ISOLATED_FRAME_SANDBOX =
 // ── Controller ───────────────────────────────────────────────────────
 
 /**
- * Internal queued message. JSON-RPC sends carry a `method`/`params` pair
- * and are flushed via `rpc.notify()`. Raw sends carry the original
- * `ParentToIframeMessage` (for types with no JSON-RPC method, e.g.
- * `interaction_state`) and are flushed via postMessage so the iframe-side
- * bootstrap handler picks them up.
+ * Internal queued message. Every entry is a JSON-RPC notification; the
+ * controller drains them through `rpc.notify()` once the renderer reports
+ * ready. There is no raw-postMessage queue because every member of
+ * `ParentToIframeMessage` has a JSON-RPC method in `TYPE_TO_METHOD`.
  */
-type QueuedSend =
-  | { kind: "rpc"; method: string; params?: unknown }
-  | { kind: "raw"; message: ParentToIframeMessage };
+interface QueuedSend {
+  method: string;
+  params?: unknown;
+}
 
 export class IsolatedFrameController {
   private readonly iframe: HTMLIFrameElement;
@@ -297,9 +299,7 @@ export class IsolatedFrameController {
 
   /**
    * Generic outbound send. Maps `{ type, payload }` shapes onto their
-   * JSON-RPC method names. Types with no JSON-RPC method (currently
-   * `interaction_state`) are queued and flushed as raw postMessages once
-   * the renderer reports ready.
+   * JSON-RPC method names and queues the notification.
    *
    * Prefer the typed helpers (`render`, `setTheme`, etc.) over this; the
    * generic path exists for adapters that need to forward an
@@ -307,17 +307,16 @@ export class IsolatedFrameController {
    */
   send(message: ParentToIframeMessage): void {
     const method = TYPE_TO_METHOD[message.type];
-    if (method) {
-      const params = "payload" in message ? message.payload : undefined;
-      this.enqueue(method, params);
-      return;
+    if (!method) {
+      // Every member of `ParentToIframeMessage` is in `TYPE_TO_METHOD`. If
+      // this fires, a new message type was added to the union without a
+      // matching method entry.
+      throw new Error(
+        `IsolatedFrameController.send: no JSON-RPC method for type "${message.type}"`,
+      );
     }
-    // No JSON-RPC method (e.g. `interaction_state`). Queue as a raw
-    // postMessage and flush after the renderer is ready so the iframe-side
-    // handler picks it up. Without this gate, an early `interaction_state`
-    // would land before the renderer-bundle listener is installed and get
-    // dropped.
-    this.enqueueRaw(message);
+    const params = "payload" in message ? message.payload : undefined;
+    this.enqueue(method, params);
   }
 
   render(payload: RenderPayload): void {
@@ -412,18 +411,10 @@ export class IsolatedFrameController {
 
   private enqueue(method: string, params: unknown): void {
     if (this.state !== "ready" || !this.rpc) {
-      this.pending.push({ kind: "rpc", method, params });
+      this.pending.push({ method, params });
       return;
     }
     this.rpc.notify(method, params);
-  }
-
-  private enqueueRaw(message: ParentToIframeMessage): void {
-    if (this.state !== "ready") {
-      this.pending.push({ kind: "raw", message });
-      return;
-    }
-    this.iframe.contentWindow?.postMessage(message, "*");
   }
 
   private flushPending(): void {
@@ -431,11 +422,7 @@ export class IsolatedFrameController {
     const drain = this.pending;
     this.pending = [];
     for (const item of drain) {
-      if (item.kind === "rpc") {
-        this.rpc.notify(item.method, item.params);
-      } else {
-        this.iframe.contentWindow?.postMessage(item.message, "*");
-      }
+      this.rpc.notify(item.method, item.params);
     }
   }
 

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -35,6 +35,7 @@ export const NTERACT_WIDGET_STATE = "nteract/widgetState" as const;
 // Host → Iframe (Notifications) — additional
 export const NTERACT_THEME = "nteract/theme" as const;
 export const NTERACT_PING = "nteract/ping" as const;
+export const NTERACT_INTERACTION_STATE = "nteract/interactionState" as const;
 
 // Iframe → Host (Notifications)
 export const NTERACT_READY = "nteract/ready" as const;
@@ -100,6 +101,11 @@ export interface NteractRenderBatchParams {
 
 export interface NteractSearchNavigateParams {
   matchIndex: number;
+}
+
+export interface NteractInteractionStateParams {
+  /** Whether the parent wrapper has handed pointer/wheel interaction to the iframe. */
+  active: boolean;
 }
 
 export interface NteractCommOpenParams {

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -22,6 +22,7 @@ import { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
 import {
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_INSTALL_RENDERER,
+  NTERACT_INTERACTION_STATE,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
@@ -250,6 +251,9 @@ function setupMessageListener() {
   });
   rpcTransport.onNotification(NTERACT_THEME, (params) => {
     messageHandler?.("theme", params);
+  });
+  rpcTransport.onNotification(NTERACT_INTERACTION_STATE, (params) => {
+    messageHandler?.("interaction_state", params);
   });
   rpcTransport.onNotification(NTERACT_INSTALL_RENDERER, (params) => {
     const { code, css } = params as { code: string; css?: string };


### PR DESCRIPTION
Routes `interaction_state` over JSON-RPC instead of raw postMessage. Follow-up to #2781.

Adds `nteract/interactionState` to the method table, registers a notification handler in the iframe-side renderer entry that dispatches to the existing React message handler, and removes the `enqueueRaw` branch from `IsolatedFrameController`. Every member of `ParentToIframeMessage` now maps to a JSON-RPC method, so `send()` either enqueues a notification or throws on an unknown type - no silent drop path.

## Why

After #2781 landed, `interaction_state` was the only post-bundle message still going raw. Parent→iframe `eval`/`theme`/`search` have to stay raw because the bootstrap script in `frame.html` handles them before the JSON-RPC bundle is installed, but `interaction_state` is only handled inside the bundle, so it migrates cleanly.

This also collapses the controller's send queue back to a single shape (`{ method, params }`) instead of the discriminated union with a raw fallback.

## Caller change

None. `OutputArea.tsx` still calls `frameRef.current?.send({ type: "interaction_state", payload: { active } })`. The change is purely in the transport beneath it.

## Bundle refresh

Includes `apps/notebook/src/renderer-plugins/isolated-renderer.js` regenerated via `cargo xtask renderer-plugins` so the iframe-side handler ships in the artifact.

## Test plan

- [x] `pnpm test:run src/` - 996 tests pass
- [x] `cargo xtask lint --fix` - clean
- [x] Controller test now asserts `interaction_state` lands as a JSON-RPC notification with method `nteract/interactionState`, not a raw postMessage
- [x] New test asserts `send()` with an unmapped type throws (enforces the invariant that every union member has a method)
- [x] `type-to-method.test.ts` updated to cover `interaction_state` in its required-types list
- [ ] Manual smoke: open a notebook with a Sift output, toggle interaction, confirm the iframe responds
