### PR TITLE
ci: harden Tauri CLI installation

### DIFF
--- a/.github/actions/install-tauri-cli/action.yml
+++ b/.github/actions/install-tauri-cli/action.yml
@@ -1,5 +1,5 @@
 name: Install Tauri CLI
-description: Install cargo-tauri on Windows via upstream release asset with source-build fallback.
+description: Install cargo-tauri via upstream release asset with source-build fallback.
 
 inputs:
   version:
@@ -10,10 +10,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Tauri CLI
+    - name: Install Tauri CLI (Windows)
+      if: runner.os == 'Windows'
       shell: pwsh
       env:
         TAURI_CLI_VERSION: ${{ inputs.version }}
       run: |
         Set-ExecutionPolicy Unrestricted -Scope Process -Force
         ./scripts/ci/install-tauri-cli.ps1
+    - name: Install Tauri CLI (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        TAURI_CLI_VERSION: ${{ inputs.version }}
+      run: bash ./scripts/ci/install-tauri-cli.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,11 +366,8 @@ jobs:
       - name: Clippy (notebook crate)
         run: cargo clippy -p notebook --all-targets -- -D warnings
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install tauri-cli
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Upload Linux Rust binaries
         uses: actions/upload-artifact@v7

--- a/.github/workflows/dx-bootstrap-e2e.yml
+++ b/.github/workflows/dx-bootstrap-e2e.yml
@@ -82,11 +82,8 @@ jobs:
 
       - uses: ./.github/actions/build-runtime-artifacts
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install tauri-cli
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Build MCP output widget
         run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -100,42 +100,8 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
-      - name: Install cargo-binstall (Unix)
-        if: runner.os != 'Windows'
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
-      - name: Install tauri-cli (Unix)
-        if: runner.os != 'Windows'
-        run: cargo binstall tauri-cli --no-confirm --locked --force
-
-      - name: Install tauri-cli (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $ProgressPreference = "SilentlyContinue"
-          $version = "2.11.0"
-          $target = "x86_64-pc-windows-msvc"
-          $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $HOME ".cargo" }
-          $cargoBin = Join-Path $cargoHome "bin"
-          New-Item -ItemType Directory -Force -Path $cargoBin | Out-Null
-          Add-Content -Path $env:GITHUB_PATH -Value $cargoBin
-          $env:PATH = "$cargoBin;$env:PATH"
-          $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
-          try {
-            $url = "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v$version/cargo-tauri-$target.zip"
-            $zip = Join-Path $tmp "cargo-tauri.zip"
-            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
-            Expand-Archive -Path $zip -DestinationPath $tmp -Force
-            Copy-Item -Path (Join-Path $tmp "cargo-tauri.exe") -Destination (Join-Path $cargoBin "cargo-tauri.exe") -Force
-          } catch {
-            Write-Warning "Direct Tauri CLI download failed: $_"
-            cargo install tauri-cli --version $version --locked --force
-          } finally {
-            Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
-          }
-          cargo tauri --version
+      - name: Install tauri-cli
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Bake PR + commit into version
         id: version

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -279,11 +279,8 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Import Apple signing certificate
         env:
@@ -456,11 +453,8 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Import Apple signing certificate
         env:
@@ -638,12 +632,9 @@ jobs:
         run: pnpm build
 
       - name: Install cargo-binstall
-        shell: pwsh
-        env:
-          BINSTALL_VERSION: v1.18.1
-        run: |
-          Set-ExecutionPolicy Unrestricted -Scope Process -Force
-          iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
+        uses: cargo-bins/cargo-binstall@v1.19.1
+        with:
+          version: "v1.18.1"
 
       - name: Install Tauri CLI
         uses: ./.github/actions/install-tauri-cli
@@ -820,11 +811,8 @@ jobs:
       - name: Build frontend
         run: pnpm build
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked --force
+        uses: ./.github/actions/install-tauri-cli
 
       - name: Set version in tauri.conf.json
         run: |

--- a/scripts/ci/install-tauri-cli.sh
+++ b/scripts/ci/install-tauri-cli.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${TAURI_CLI_VERSION:-2.11.0}"
+cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+cargo_bin="$cargo_home/bin"
+mkdir -p "$cargo_bin"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$cargo_bin" >>"$GITHUB_PATH"
+fi
+export PATH="$cargo_bin:$PATH"
+
+target=""
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64 | Darwin-aarch64)
+    target="aarch64-apple-darwin"
+    ;;
+  Darwin-x86_64)
+    target="x86_64-apple-darwin"
+    ;;
+  Linux-x86_64)
+    target="x86_64-unknown-linux-gnu"
+    ;;
+esac
+
+install_from_release() {
+  if [[ -z "$target" ]]; then
+    echo "No prebuilt Tauri CLI asset mapping for $(uname -s)-$(uname -m)"
+    return 1
+  fi
+
+  local archive_ext="zip"
+  if [[ "$target" == *linux* ]]; then
+    archive_ext="tgz"
+  fi
+
+  local asset="cargo-tauri-$target.$archive_ext"
+  local url="https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v$version/$asset"
+  local tmp
+  tmp="$(mktemp -d)"
+
+  echo "Installing Tauri CLI v$version for $target from $url"
+  if ! curl --retry 5 --retry-all-errors --connect-timeout 15 -fsSL "$url" -o "$tmp/$asset"; then
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  case "$archive_ext" in
+    zip)
+      unzip -q -o "$tmp/$asset" -d "$tmp"
+      ;;
+    tgz)
+      tar -xzf "$tmp/$asset" -C "$tmp"
+      ;;
+  esac
+
+  local cargo_tauri
+  cargo_tauri="$(find "$tmp" -type f -name cargo-tauri -print -quit)"
+  if [[ -z "$cargo_tauri" ]]; then
+    echo "Downloaded archive did not contain cargo-tauri"
+    rm -rf "$tmp"
+    return 1
+  fi
+
+  cp "$cargo_tauri" "$cargo_bin/cargo-tauri"
+  chmod +x "$cargo_bin/cargo-tauri"
+  rm -rf "$tmp"
+}
+
+if ! install_from_release; then
+  echo "::warning::Direct Tauri CLI download failed; falling back to cargo install tauri-cli --version $version"
+  cargo install tauri-cli --version "$version" --locked --force
+fi
+
+cargo tauri --version


### PR DESCRIPTION
## Summary

- replace raw `cargo-binstall` + `cargo binstall tauri-cli` setup with the shared Tauri CLI install action
- extend the action so Unix runners download Tauri's prebuilt `cargo-tauri` release asset with retry behavior and fall back to `cargo install`
- switch the remaining Windows `cargo-binstall` setup for `trusted-signing-cli` to the upstream `cargo-bins/cargo-binstall` action

## Context

Nightly run https://github.com/nteract/nteract/actions/runs/26104053882/job/76765468272 failed after the raw `raw.githubusercontent.com` installer call hit DNS resolution failure, leaving `cargo binstall` unavailable for the next step.

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
- `tmpdir="$(mktemp -d)"; CARGO_HOME="$tmpdir" TAURI_CLI_VERSION=2.11.0 bash scripts/ci/install-tauri-cli.sh; rm -rf "$tmpdir"`
- `shellcheck scripts/ci/install-tauri-cli.sh`
- `actionlint .github/workflows/release-common.yml .github/workflows/build.yml .github/workflows/pr-binary-generation.yml .github/workflows/dx-bootstrap-e2e.yml`
- `git diff --check HEAD~1 HEAD`
