### PR TITLE
fix(isolated): harden iframe renderer diagnostics

### DIFF
--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -40,6 +40,15 @@ export async function ensureCodeCell(page: Page): Promise<Locator> {
   return existing;
 }
 
+export async function ensureMarkdownCell(page: Page): Promise<Locator> {
+  const existing = page.locator('[data-cell-type="markdown"]').first();
+  if ((await existing.count()) > 0) return existing;
+
+  await page.getByTestId("add-markdown-cell-button").click();
+  await expect(existing).toBeVisible({ timeout: 10_000 });
+  return existing;
+}
+
 export async function setCellSource(cell: Locator, source: string) {
   await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
     const content = node as HTMLElement & {

--- a/apps/notebook/e2e/isolated-rich-output.spec.ts
+++ b/apps/notebook/e2e/isolated-rich-output.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Locator } from "@playwright/test";
 import {
   ensureCodeCell,
+  ensureMarkdownCell,
   executeCell,
   openNotebookRoom,
   setCellSource,
@@ -51,7 +52,75 @@ test.describe("isolated rich output rendering", () => {
     await expect.poll(() => isolatedRootHeight(cell), { timeout: 30_000 }).toBeGreaterThan(20);
 
     expect(isolatedLogs.join("\n")).not.toContain("rendered-empty-after-paint");
+    expect(isolatedLogs.join("\n")).not.toContain("renderer-bundle-pending");
     expect(isolatedLogs.join("\n")).not.toContain("renderer-error");
+  });
+
+  test("renders markdown cells and markdown outputs in isolated iframes", async ({ page }) => {
+    test.setTimeout(180_000);
+
+    const isolatedLogs: string[] = [];
+    page.on("console", (message) => {
+      const text = message.text();
+      if (
+        text.includes("[isolated-frame]") ||
+        text.includes("[isolated-renderer]") ||
+        text.includes("[iframe-libraries]") ||
+        text.includes("[MarkdownCell]") ||
+        text.includes("[OutputArea]")
+      ) {
+        isolatedLogs.push(`[${message.type()}] ${text}`);
+      }
+    });
+
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const markdownCell = await ensureMarkdownCell(page);
+    await setCellSource(
+      markdownCell,
+      "# Rendered Markdown Cell\n\nThis is **bold** markdown.\n\n- cell item",
+    );
+    const markdownEditor = markdownCell.locator('.cm-content[contenteditable="true"]');
+    await markdownEditor.click();
+    await markdownEditor.press("Control+Enter");
+
+    const markdownFrame = markdownCell.frameLocator('[data-slot="isolated-frame"]');
+    await expect(markdownFrame.locator("body")).toContainText("Rendered Markdown Cell", {
+      timeout: 60_000,
+    });
+    await expect(markdownFrame.locator("body")).toContainText("cell item", {
+      timeout: 60_000,
+    });
+    await expect
+      .poll(() => isolatedRootHeight(markdownCell), { timeout: 30_000 })
+      .toBeGreaterThan(20);
+
+    const codeCell = await ensureCodeCell(page);
+    await setCellSource(
+      codeCell,
+      [
+        "from IPython.display import Markdown, display",
+        'display(Markdown("# Markdown Output\\n\\n- output item"))',
+      ].join("\n"),
+    );
+    await executeCell(codeCell);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const outputFrame = codeCell.frameLocator('[data-slot="isolated-frame"]');
+    await expect(outputFrame.locator("body")).toContainText("Markdown Output", {
+      timeout: 60_000,
+    });
+    await expect(outputFrame.locator("body")).toContainText("output item", {
+      timeout: 60_000,
+    });
+    await expect.poll(() => isolatedRootHeight(codeCell), { timeout: 30_000 }).toBeGreaterThan(20);
+
+    const logs = isolatedLogs.join("\n");
+    expect(logs).not.toContain("rendered-empty-after-paint");
+    expect(logs).not.toContain("renderer-bundle-pending");
+    expect(logs).not.toContain("renderer-error");
   });
 });
 

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a32ff66614783be6f2ab946ab9200bf5d0e43fc2c704cfb0e3270058658fa88
-size 1476940
+oid sha256:a71409d0f194a78f694a3afb8cc3afca83dfe9292e5626b4a31c8d7b629a9358
+size 1478464

--- a/apps/renderer-test/e2e/render.spec.ts
+++ b/apps/renderer-test/e2e/render.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { fixtures } from "../src/fixtures";
 
 const FIXTURE_COUNT = fixtures.length;
@@ -15,14 +15,14 @@ test.describe("Renderer plugin fixtures", () => {
       if (text === "Allow attribute will take precedence over 'allowfullscreen'.") return;
       consoleProblems.push(`[${type}] ${text}`);
     });
-    await page.goto("/");
   });
 
   test.afterEach(() => {
     expect(consoleProblems).toEqual([]);
   });
 
-  test("all fixtures render without errors", async ({ page }) => {
+  async function waitForDefaultFixtures(page: Page) {
+    await page.goto("/");
     for (let i = 0; i < FIXTURE_COUNT; i++) {
       const status = page.locator(`[data-testid="fixture-status-${i}"]`);
       await expect(status).toBeVisible({ timeout: 30_000 });
@@ -30,16 +30,14 @@ test.describe("Renderer plugin fixtures", () => {
         timeout: 30_000,
       });
     }
+  }
+
+  test("all fixtures render without errors", async ({ page }) => {
+    await waitForDefaultFixtures(page);
   });
 
   test("iframes have non-zero height", async ({ page }) => {
-    // Wait for all to be ready first
-    for (let i = 0; i < FIXTURE_COUNT; i++) {
-      const status = page.locator(`[data-testid="fixture-status-${i}"]`);
-      await expect(status).toHaveAttribute("data-ready", "true", {
-        timeout: 30_000,
-      });
-    }
+    await waitForDefaultFixtures(page);
 
     const iframes = page.locator("iframe");
     const count = await iframes.count();
@@ -54,12 +52,9 @@ test.describe("Renderer plugin fixtures", () => {
   });
 
   test("iframes contain rendered output DOM", async ({ page }) => {
-    for (let i = 0; i < FIXTURE_COUNT; i++) {
-      const status = page.locator(`[data-testid="fixture-status-${i}"]`);
-      await expect(status).toHaveAttribute("data-ready", "true", {
-        timeout: 30_000,
-      });
+    await waitForDefaultFixtures(page);
 
+    for (let i = 0; i < FIXTURE_COUNT; i++) {
       const root = page.frameLocator(`[data-testid="fixture-frame-${i}"] iframe`).locator("#root");
       await expect(root).toBeAttached();
       const snapshot = await root.evaluate((node) => ({
@@ -70,5 +65,45 @@ test.describe("Renderer plugin fixtures", () => {
       expect(snapshot.childCount).toBeGreaterThan(0);
       expect(snapshot.htmlLength).toBeGreaterThan(20);
     }
+  });
+
+  test("fixtures expose their expected rendered text", async ({ page }) => {
+    await waitForDefaultFixtures(page);
+
+    for (let i = 0; i < FIXTURE_COUNT; i++) {
+      const expectedText = fixtures[i]?.expectedText ?? [];
+      const body = page.frameLocator(`[data-testid="fixture-frame-${i}"] iframe`).locator("body");
+      for (const text of expectedText) {
+        await expect(body).toContainText(text, { timeout: 30_000 });
+      }
+    }
+  });
+
+  test("delayed renderer bundle still renders markdown", async ({ page }) => {
+    await page.goto("/?scenario=delayed-bundle");
+    await expect(page.getByTestId("fixture-status-0")).toHaveAttribute("data-ready", "true", {
+      timeout: 30_000,
+    });
+    const body = page.frameLocator('[data-testid="fixture-frame-0"] iframe').locator("body");
+    await expect(body).toContainText("Markdown Plugin", { timeout: 30_000 });
+    await expect(body).toContainText("Item 1", { timeout: 30_000 });
+  });
+
+  test("empty renderer CSS is a valid loaded bundle", async ({ page }) => {
+    await page.goto("/?scenario=empty-css");
+    await expect(page.getByTestId("fixture-status-0")).toHaveAttribute("data-ready", "true", {
+      timeout: 30_000,
+    });
+    const body = page.frameLocator('[data-testid="fixture-frame-0"] iframe').locator("body");
+    await expect(body).toContainText("Hello from the renderer test app.", { timeout: 30_000 });
+  });
+
+  test("remounting a plugin-backed frame renders again", async ({ page }) => {
+    await page.goto("/?scenario=remount");
+    await expect(page.getByTestId("remount-status")).toHaveAttribute("data-ready-count", "2", {
+      timeout: 30_000,
+    });
+    const body = page.frameLocator('[data-testid="remount-frame"] iframe').locator("body");
+    await expect(body).toContainText("Markdown Plugin", { timeout: 30_000 });
   });
 });

--- a/apps/renderer-test/src/fixtures.ts
+++ b/apps/renderer-test/src/fixtures.ts
@@ -2,6 +2,14 @@ export interface Fixture {
   label: string;
   mimeType: string;
   data: unknown;
+  outputs?: FixtureOutput[];
+  expectedText?: string[];
+}
+
+export interface FixtureOutput {
+  mimeType: string;
+  data: unknown;
+  metadata?: Record<string, unknown>;
 }
 
 export const fixtures: Fixture[] = [
@@ -9,11 +17,41 @@ export const fixtures: Fixture[] = [
     label: "Plain text",
     mimeType: "text/plain",
     data: "Hello from the renderer test app.\nThis is a second line.",
+    expectedText: ["Hello from the renderer test app.", "This is a second line."],
   },
   {
     label: "HTML",
     mimeType: "text/html",
     data: '<h2 style="color: steelblue;">HTML Output</h2><p>Rendered inside an isolated iframe.</p>',
+    expectedText: ["HTML Output", "Rendered inside an isolated iframe."],
+  },
+  {
+    label: "Pandas-like HTML table",
+    mimeType: "text/html",
+    data: [
+      "<table>",
+      "<thead><tr><th></th><th>a</th><th>b</th></tr></thead>",
+      "<tbody><tr><th>0</th><td>1</td><td>3</td></tr><tr><th>1</th><td>2</td><td>4</td></tr></tbody>",
+      "</table>",
+    ].join(""),
+    expectedText: ["a", "b", "1", "4"],
+  },
+  {
+    label: "Stream plus rich output batch",
+    mimeType: "application/vnd.nteract.fixture-batch+json",
+    data: null,
+    outputs: [
+      {
+        mimeType: "text/plain",
+        data: "stream before",
+        metadata: { streamName: "stdout" },
+      },
+      {
+        mimeType: "text/html",
+        data: "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>3</td></tr><tr><td>2</td><td>4</td></tr></tbody></table>",
+      },
+    ],
+    expectedText: ["stream before", "a", "b", "4"],
   },
   {
     label: "JSON",
@@ -23,16 +61,19 @@ export const fixtures: Fixture[] = [
       null,
       2,
     ),
+    expectedText: ["renderer-test", "features", "security"],
   },
   {
     label: "SVG",
     mimeType: "image/svg+xml",
     data: '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100" viewBox="0 0 200 100"><rect width="200" height="100" rx="10" fill="#4f46e5"/><text x="100" y="55" text-anchor="middle" fill="white" font-family="system-ui" font-size="16">SVG Output</text></svg>',
+    expectedText: ["SVG Output"],
   },
   {
     label: "Markdown (plugin)",
     mimeType: "text/markdown",
     data: "# Markdown Plugin\n\nThis is rendered by the **markdown renderer plugin**.\n\n- Item 1\n- Item 2\n- Item 3\n\n```python\nprint('hello')\n```\n",
+    expectedText: ["Markdown Plugin", "Item 1", "print('hello')"],
   },
   {
     label: "Plotly (plugin)",
@@ -55,3 +96,9 @@ export const fixtures: Fixture[] = [
     }),
   },
 ];
+
+export function getFixtureOutputs(fixture: Fixture): FixtureOutput[] {
+  return fixture.outputs ?? [{ mimeType: fixture.mimeType, data: fixture.data }];
+}
+
+export const markdownFixture = fixtures.find((fixture) => fixture.mimeType === "text/markdown")!;

--- a/apps/renderer-test/src/main.tsx
+++ b/apps/renderer-test/src/main.tsx
@@ -3,9 +3,35 @@ import { IsolatedRendererProvider } from "@/components/isolated/isolated-rendere
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { createRoot } from "react-dom/client";
 import { useCallback, useRef, useState } from "react";
-import { fixtures, type Fixture } from "./fixtures";
+import { fixtures, getFixtureOutputs, markdownFixture, type Fixture } from "./fixtures";
 
-function FixtureCard({ fixture, index }: { fixture: Fixture; index: number }) {
+type RendererLoader = () => Promise<{ rendererCode: string; rendererCss: string }>;
+
+const defaultRendererLoader: RendererLoader = () => import("virtual:isolated-renderer");
+
+const delayedRendererLoader = async () => {
+  await new Promise((resolve) => window.setTimeout(resolve, 300));
+  return await import("virtual:isolated-renderer");
+};
+
+const emptyCssRendererLoader = async () => {
+  const bundle = await import("virtual:isolated-renderer");
+  return { rendererCode: bundle.rendererCode, rendererCss: "" };
+};
+
+function FixtureCard({
+  fixture,
+  index,
+  statusTestId,
+  frameTestId,
+  onRendered,
+}: {
+  fixture: Fixture;
+  index: number;
+  statusTestId?: string;
+  frameTestId?: string;
+  onRendered?: () => void;
+}) {
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const injectedRef = useRef(new Set<string>());
   const [ready, setReady] = useState(false);
@@ -15,21 +41,38 @@ function FixtureCard({ fixture, index }: { fixture: Fixture; index: number }) {
     const frame = frameRef.current;
     if (!frame) return;
 
-    // Install plugin if this MIME type needs one
-    if (needsPlugin(fixture.mimeType)) {
-      await injectPluginsForMimes(frame, [fixture.mimeType], injectedRef.current);
+    const outputs = getFixtureOutputs(fixture);
+    const pluginMimes = outputs
+      .map((output) => output.mimeType)
+      .filter((mimeType) => needsPlugin(mimeType));
+    if (pluginMimes.length > 0) {
+      await injectPluginsForMimes(frame, pluginMimes, injectedRef.current);
     }
 
-    // Send the render message
-    frame.render({
-      mimeType: fixture.mimeType,
-      data: fixture.data,
-      cellId: `fixture-${index}`,
-      outputIndex: 0,
-    });
+    if (outputs.length === 1) {
+      const [output] = outputs;
+      frame.render({
+        mimeType: output.mimeType,
+        data: output.data,
+        metadata: output.metadata,
+        cellId: `fixture-${index}`,
+        outputIndex: 0,
+      });
+    } else {
+      frame.renderBatch(
+        outputs.map((output, outputIndex) => ({
+          mimeType: output.mimeType,
+          data: output.data,
+          metadata: output.metadata,
+          cellId: `fixture-${index}`,
+          outputIndex,
+        })),
+      );
+    }
 
     setReady(true);
-  }, [fixture, index]);
+    onRendered?.();
+  }, [fixture, index, onRendered]);
 
   return (
     <div
@@ -53,7 +96,7 @@ function FixtureCard({ fixture, index }: { fixture: Fixture; index: number }) {
         }}
       >
         <span
-          data-testid={`fixture-status-${index}`}
+          data-testid={statusTestId ?? `fixture-status-${index}`}
           data-ready={ready}
           style={{
             width: 8,
@@ -66,7 +109,7 @@ function FixtureCard({ fixture, index }: { fixture: Fixture; index: number }) {
         <code style={{ color: "#6b7280", fontSize: 11 }}>{fixture.mimeType}</code>
         {error && <span style={{ color: "#ef4444", fontSize: 11 }}>{error}</span>}
       </div>
-      <div data-testid={`fixture-frame-${index}`}>
+      <div data-testid={frameTestId ?? `fixture-frame-${index}`}>
         <IsolatedFrame
           ref={frameRef}
           id={`fixture-${index}`}
@@ -80,9 +123,9 @@ function FixtureCard({ fixture, index }: { fixture: Fixture; index: number }) {
   );
 }
 
-function App() {
+function FixtureListApp({ loader = defaultRendererLoader }: { loader?: RendererLoader }) {
   return (
-    <IsolatedRendererProvider loader={() => import("virtual:isolated-renderer")}>
+    <IsolatedRendererProvider loader={loader}>
       <div
         style={{
           maxWidth: 900,
@@ -101,6 +144,60 @@ function App() {
       </div>
     </IsolatedRendererProvider>
   );
+}
+
+function SingleFixtureApp({ fixture, loader }: { fixture: Fixture; loader: RendererLoader }) {
+  return (
+    <IsolatedRendererProvider loader={loader}>
+      <div style={{ maxWidth: 900, margin: "0 auto", padding: "24px 16px" }}>
+        <FixtureCard fixture={fixture} index={0} />
+      </div>
+    </IsolatedRendererProvider>
+  );
+}
+
+function RemountScenarioApp() {
+  const [version, setVersion] = useState(0);
+  const [readyCount, setReadyCount] = useState(0);
+
+  const handleRendered = useCallback(() => {
+    setReadyCount((count) => {
+      const next = count + 1;
+      if (next === 1) {
+        window.setTimeout(() => setVersion(1), 100);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <IsolatedRendererProvider loader={defaultRendererLoader}>
+      <div style={{ maxWidth: 900, margin: "0 auto", padding: "24px 16px" }}>
+        <div data-testid="remount-status" data-ready-count={readyCount} />
+        <FixtureCard
+          key={version}
+          fixture={markdownFixture}
+          index={0}
+          frameTestId="remount-frame"
+          onRendered={handleRendered}
+        />
+      </div>
+    </IsolatedRendererProvider>
+  );
+}
+
+function App() {
+  const scenario = new URLSearchParams(window.location.search).get("scenario");
+  if (scenario === "delayed-bundle") {
+    return <SingleFixtureApp fixture={markdownFixture} loader={delayedRendererLoader} />;
+  }
+  if (scenario === "empty-css") {
+    return <SingleFixtureApp fixture={fixtures[0]!} loader={emptyCssRendererLoader} />;
+  }
+  if (scenario === "remount") {
+    return <RemountScenarioApp />;
+  }
+  return <FixtureListApp />;
 }
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/components/isolated/diagnostics.ts
+++ b/src/components/isolated/diagnostics.ts
@@ -1,0 +1,28 @@
+export type IsolatedDiagnosticLevel = "debug" | "info" | "warn" | "error";
+
+export type IsolatedDiagnosticSource = "isolated-frame" | "isolated-renderer" | "iframe-libraries";
+
+export interface IsolatedDiagnosticEvent {
+  source: IsolatedDiagnosticSource;
+  phase: string;
+  level?: IsolatedDiagnosticLevel;
+  details?: Record<string, unknown>;
+}
+
+export function logIsolatedDiagnostic(event: IsolatedDiagnosticEvent): void {
+  const { source, phase, level = "debug", details = {} } = event;
+  const logger = console[level] ?? console.debug;
+  logger(`[${source}] ${phase}`, details);
+}
+
+export function rendererBundleDetails(
+  rendererCode: string | undefined,
+  rendererCss: string | undefined,
+): Record<string, unknown> {
+  return {
+    hasRendererCode: rendererCode !== undefined,
+    hasRendererCss: rendererCss !== undefined,
+    rendererCodeLength: rendererCode?.length ?? 0,
+    rendererCssLength: rendererCss?.length ?? 0,
+  };
+}

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -16,6 +16,7 @@
  */
 
 import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
+import { logIsolatedDiagnostic } from "@/components/isolated/diagnostics";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 
 interface PluginModule {
@@ -104,9 +105,16 @@ export async function injectPluginsForMimes(
     if (injectedSet.has(mime)) continue;
     const plugin = await loadPluginForMime(mime);
     if (!plugin) continue;
-    console.debug(
-      `[iframe-libraries] installing renderer plugin for "${mime}" (${(plugin.code.length / 1024).toFixed(0)}KB)`,
-    );
+    logIsolatedDiagnostic({
+      source: "iframe-libraries",
+      phase: "renderer-plugin-install-dispatch",
+      details: {
+        mime,
+        codeLength: plugin.code.length,
+        hasCss: plugin.css !== undefined,
+        cssLength: plugin.css?.length ?? 0,
+      },
+    });
     frame.installRenderer(plugin.code, plugin.css);
     injectedSet.add(mime);
   }

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
 import { isIframeMessage } from "./frame-bridge";
+import { logIsolatedDiagnostic, rendererBundleDetails } from "./diagnostics";
 import { generateFrameHtml } from "./frame-html";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
 import { JsonRpcTransport } from "./jsonrpc-transport";
@@ -10,6 +11,7 @@ import {
   NTERACT_COMM_CLOSE,
   NTERACT_COMM_MSG,
   NTERACT_COMM_OPEN,
+  NTERACT_DIAGNOSTIC,
   NTERACT_WIDGET_SNAPSHOT,
   NTERACT_DOUBLE_CLICK,
   NTERACT_ERROR,
@@ -351,6 +353,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const pendingMessagesRef = useRef<ParentToIframeMessage[]>([]);
     // Track if we've started bootstrapping to avoid double-fetch
     const bootstrappingRef = useRef(false);
+    const frameGenerationRef = useRef(0);
     // Track whether the iframe has sent a "ready" message before.
     // Any subsequent "ready" is a reload that needs the toggle trick.
     const hasReceivedReadyRef = useRef(false);
@@ -366,6 +369,27 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
     const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
+
+    const logFrameDiagnostic = useCallback(
+      (
+        phase: string,
+        details: Record<string, unknown> = {},
+        level: "debug" | "info" | "warn" | "error" = "debug",
+      ) => {
+        logIsolatedDiagnostic({
+          source: "isolated-frame",
+          phase,
+          level,
+          details: {
+            frameId: id ?? null,
+            frameName: name ?? null,
+            generation: frameGenerationRef.current,
+            ...details,
+          },
+        });
+      },
+      [id, name],
+    );
 
     // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
@@ -426,6 +450,11 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     // Surface provider errors to consumers
     useEffect(() => {
       if (providerError && !providerLoading) {
+        logFrameDiagnostic(
+          "renderer-bundle-provider-error",
+          { message: providerError.message, stack: providerError.stack },
+          "error",
+        );
         onErrorRef.current?.({
           message: providerError.message,
           stack: providerError.stack,
@@ -507,6 +536,11 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             // the browser to tear down and reload the iframe).
             const isReload = hasReceivedReadyRef.current;
             hasReceivedReadyRef.current = true;
+            frameGenerationRef.current += 1;
+            logFrameDiagnostic("bootstrap-ready", {
+              isReload,
+              ...rendererBundleDetails(rendererCode, rendererCss),
+            });
 
             if (isReload) {
               // Reset bootstrap state so the renderer gets re-injected.
@@ -552,6 +586,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               );
               // Register handlers for JSON-RPC messages from iframe
               transport.onNotification(NTERACT_RENDERER_READY, () => {
+                logFrameDiagnostic("renderer-ready");
                 setIsReady(true);
                 setIsReloading(false);
                 onReadyRef.current?.();
@@ -567,6 +602,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               });
               transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {
                 const p = params as { height?: number };
+                logFrameDiagnostic("render-complete", { height: p.height ?? null });
                 if (p.height != null) {
                   setIsContentRendered(true);
                   applyMeasuredHeight(p.height);
@@ -599,6 +635,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               transport.onNotification(NTERACT_ERROR, (params) => {
                 const p = params as { message: string; stack?: string };
                 if (p.message) {
+                  logFrameDiagnostic("renderer-error", p, "error");
                   onErrorRef.current?.(p);
                 }
               });
@@ -632,6 +669,26 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
                   payload: params,
                 } as IframeToParentMessage);
               });
+              transport.onNotification(NTERACT_DIAGNOSTIC, (params) => {
+                const p = params as {
+                  source?: "isolated-frame" | "isolated-renderer" | "iframe-libraries";
+                  phase?: string;
+                  level?: "debug" | "info" | "warn" | "error";
+                  details?: Record<string, unknown>;
+                };
+                if (!p.phase) return;
+                logIsolatedDiagnostic({
+                  source: p.source ?? "isolated-renderer",
+                  phase: p.phase,
+                  level: p.level,
+                  details: {
+                    frameId: id ?? null,
+                    frameName: name ?? null,
+                    generation: frameGenerationRef.current,
+                    ...p.details,
+                  },
+                });
+              });
               transport.start();
               rpcRef.current = transport;
             }
@@ -640,6 +697,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
           case "renderer_ready":
             // React renderer bundle is initialized
+            logFrameDiagnostic("renderer-ready");
             setIsReady(true);
             setIsReloading(false);
             onReadyRef.current?.();
@@ -661,6 +719,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           case "render_complete":
             // Content has been rendered - reveal iframe if in revealOnRender mode
             if (data.payload?.height != null) {
+              logFrameDiagnostic("render-complete", { height: data.payload.height });
               setIsContentRendered(true);
               applyMeasuredHeight(data.payload.height);
             }
@@ -692,6 +751,11 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             // Surface bundle eval failures to help diagnose injection issues
             if (data.payload?.success === false) {
               console.error("[IsolatedFrame] Bundle eval failed:", data.payload.error);
+              logFrameDiagnostic(
+                "renderer-bundle-eval-failed",
+                { error: data.payload.error },
+                "error",
+              );
               onErrorRef.current?.({
                 message: `Bundle eval failed: ${data.payload.error}`,
               });
@@ -702,7 +766,15 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
       window.addEventListener("message", handleMessage);
       return () => window.removeEventListener("message", handleMessage);
-    }, [initialContent, applyMeasuredHeight]);
+    }, [
+      initialContent,
+      applyMeasuredHeight,
+      id,
+      name,
+      rendererCode,
+      rendererCss,
+      logFrameDiagnostic,
+    ]);
 
     // Clean up JSON-RPC transport on unmount
     useEffect(() => {
@@ -711,17 +783,43 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       };
     }, []);
 
+    useEffect(() => {
+      if (!isIframeReady || isReady || bootstrappingRef.current) return;
+      if (rendererCode !== undefined && rendererCss !== undefined) return;
+      const timer = window.setTimeout(() => {
+        logFrameDiagnostic("renderer-bundle-pending", {
+          providerLoading,
+          providerError: providerError?.message ?? null,
+          ...rendererBundleDetails(rendererCode, rendererCss),
+        });
+      }, 1500);
+
+      return () => window.clearTimeout(timer);
+    }, [
+      isIframeReady,
+      isReady,
+      rendererCode,
+      rendererCss,
+      providerLoading,
+      providerError,
+      logFrameDiagnostic,
+    ]);
+
     // Inject renderer when iframe is ready AND bundle props are available
     useEffect(() => {
       if (
         isIframeReady &&
         !isReady &&
         !bootstrappingRef.current &&
-        rendererCode &&
-        rendererCss &&
+        rendererCode !== undefined &&
+        rendererCss !== undefined &&
         iframeRef.current?.contentWindow
       ) {
         bootstrappingRef.current = true;
+        logFrameDiagnostic(
+          "renderer-bundle-injecting",
+          rendererBundleDetails(rendererCode, rendererCss),
+        );
 
         // Inject CSS first (idempotent - checks if already loaded)
         const cssCode = `
@@ -750,20 +848,38 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           { type: "eval", payload: { code: jsWrapper } },
           "*",
         );
+        logFrameDiagnostic(
+          "renderer-bundle-injected",
+          rendererBundleDetails(rendererCode, rendererCss),
+        );
       }
-    }, [isIframeReady, isReady, rendererCode, rendererCss]);
+    }, [isIframeReady, isReady, rendererCode, rendererCss, logFrameDiagnostic]);
 
     // Expose imperative API
     useImperativeHandle(
       ref,
       () => ({
         send,
-        render: (payload: RenderPayload) => send({ type: "render", payload }),
-        renderBatch: (outputs: RenderPayload[]) =>
-          send({ type: "render_batch", payload: { outputs } }),
+        render: (payload: RenderPayload) => {
+          logFrameDiagnostic("render-dispatched", { mimeType: payload.mimeType });
+          send({ type: "render", payload });
+        },
+        renderBatch: (outputs: RenderPayload[]) => {
+          logFrameDiagnostic("render-batch-dispatched", {
+            outputCount: outputs.length,
+            mimes: outputs.map((output) => output.mimeType),
+          });
+          send({ type: "render_batch", payload: { outputs } });
+        },
         eval: (code: string) => send({ type: "eval", payload: { code } }),
-        installRenderer: (code: string, css?: string) =>
-          send({ type: "install_renderer", payload: { code, css } }),
+        installRenderer: (code: string, css?: string) => {
+          logFrameDiagnostic("renderer-plugin-dispatched", {
+            codeLength: code.length,
+            hasCss: css !== undefined,
+            cssLength: css?.length ?? 0,
+          });
+          send({ type: "install_renderer", payload: { code, css } });
+        },
         setTheme: (isDark: boolean, colorTheme?: string | null) =>
           send({ type: "theme", payload: { isDark, colorTheme } }),
         clear: () => send({ type: "clear" }),
@@ -792,7 +908,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         isReady,
         isIframeReady,
       }),
-      [send, isReady, isIframeReady],
+      [send, isReady, isIframeReady, logFrameDiagnostic],
     );
 
     if (!frameDocument) {

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -35,6 +35,7 @@ export const NTERACT_WIDGET_STATE = "nteract/widgetState" as const;
 // Host → Iframe (Notifications) — additional
 export const NTERACT_THEME = "nteract/theme" as const;
 export const NTERACT_PING = "nteract/ping" as const;
+export const NTERACT_DIAGNOSTIC = "nteract/diagnostic" as const;
 
 // Iframe → Host (Notifications)
 export const NTERACT_READY = "nteract/ready" as const;
@@ -163,4 +164,11 @@ export interface NteractWidgetUpdateParams {
 
 export interface NteractWheelBoundaryParams {
   deltaY?: number;
+}
+
+export interface NteractDiagnosticParams {
+  source?: "isolated-frame" | "isolated-renderer" | "iframe-libraries";
+  phase: string;
+  level?: "debug" | "info" | "warn" | "error";
+  details?: Record<string, unknown>;
 }

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -18,9 +18,14 @@ import * as jsxRuntime from "react/jsx-runtime";
 import "./styles.css";
 
 import type { RenderPayload } from "@/components/isolated/frame-bridge";
+import {
+  logIsolatedDiagnostic,
+  type IsolatedDiagnosticLevel,
+} from "@/components/isolated/diagnostics";
 import { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
 import {
   NTERACT_CLEAR_OUTPUTS,
+  NTERACT_DIAGNOSTIC,
   NTERACT_INSTALL_RENDERER,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_OUTPUT,
@@ -94,8 +99,7 @@ function installRendererPlugin(code: string, css?: string) {
     | undefined;
 
   if (typeof install !== "function") {
-    console.error("[renderer-plugin] Plugin does not export an install() function");
-    return;
+    throw new Error("[renderer-plugin] Plugin does not export an install() function");
   }
 
   install({
@@ -191,6 +195,29 @@ function updateDocumentTheme(isDark: boolean, colorTheme?: string | null) {
 // Global transport for JSON-RPC communication with host
 let rpcTransport: JsonRpcTransport | null = null;
 
+function emitRendererDiagnostic(
+  phase: string,
+  details: Record<string, unknown> = {},
+  level: IsolatedDiagnosticLevel = "debug",
+) {
+  if (rpcTransport) {
+    rpcTransport.notify(NTERACT_DIAGNOSTIC, {
+      source: "isolated-renderer",
+      phase,
+      level,
+      details,
+    });
+    return;
+  }
+
+  logIsolatedDiagnostic({
+    source: "isolated-renderer",
+    phase,
+    level,
+    details,
+  });
+}
+
 /** Get the shared transport instance (available after init()) */
 export function getTransport(): JsonRpcTransport | null {
   return rpcTransport;
@@ -203,14 +230,47 @@ let messageHandler: MessageHandler | null = null;
 const LAYOUT_PULSE_DELAYS_MS = [0, 160, 600];
 let layoutPulseTimers: number[] = [];
 
-function postMeasuredHeight(type: "resize" | "render_complete"): void {
+function renderedRootDetails(expectedOutputCount?: number): Record<string, unknown> {
+  const rootEl = document.getElementById("root");
+  return {
+    expectedOutputCount: expectedOutputCount ?? null,
+    rootChildCount: rootEl?.childElementCount ?? 0,
+    rootHtmlLength: rootEl?.innerHTML.length ?? 0,
+    measuredHeight: measureDocumentHeight(),
+  };
+}
+
+function emitPostPaintRenderDiagnostic(expectedOutputCount?: number): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const details = renderedRootDetails(expectedOutputCount);
+      const expectedCount = expectedOutputCount ?? 0;
+      const rootChildCount = Number(details.rootChildCount);
+      const measuredHeight = Number(details.measuredHeight);
+      if (expectedCount > 0 && (rootChildCount <= 0 || measuredHeight <= 1)) {
+        emitRendererDiagnostic("rendered-empty-after-paint", details, "warn");
+      } else {
+        emitRendererDiagnostic("rendered-after-paint", details);
+      }
+    });
+  });
+}
+
+function postMeasuredHeight(
+  type: "resize" | "render_complete",
+  expectedOutputCount?: number,
+): void {
+  const height = measureDocumentHeight();
   window.parent.postMessage(
     {
       type,
-      payload: { height: measureDocumentHeight() },
+      payload: { height },
     },
     "*",
   );
+  if (type === "render_complete") {
+    emitPostPaintRenderDiagnostic(expectedOutputCount);
+  }
 }
 
 function pulseRendererLayout(): void {
@@ -253,13 +313,29 @@ function setupMessageListener() {
   });
   rpcTransport.onNotification(NTERACT_INSTALL_RENDERER, (params) => {
     const { code, css } = params as { code: string; css?: string };
+    emitRendererDiagnostic("renderer-plugin-install-start", {
+      codeLength: code.length,
+      hasCss: css !== undefined,
+      cssLength: css?.length ?? 0,
+    });
     try {
       installRendererPlugin(code, css);
+      emitRendererDiagnostic("renderer-plugin-install-success", {
+        codeLength: code.length,
+        hasCss: css !== undefined,
+        cssLength: css?.length ?? 0,
+      });
     } catch (err) {
       console.error("[renderer-plugin] install failed:", err);
+      emitRendererDiagnostic(
+        "renderer-plugin-install-failed",
+        { message: err instanceof Error ? err.message : String(err) },
+        "error",
+      );
     }
   });
   rpcTransport.start();
+  emitRendererDiagnostic("renderer-transport-ready");
 
   // Legacy listener for any { type, payload } messages that arrive
   // (e.g., during bootstrap before transport is set up on host side)
@@ -273,10 +349,22 @@ function setupMessageListener() {
     const { type, payload } = data || {};
     // Handle install_renderer directly (doesn't need React message handler)
     if (type === "install_renderer" && payload?.code) {
+      emitRendererDiagnostic("renderer-plugin-install-start", {
+        codeLength: String(payload.code).length,
+        hasCss: payload.css !== undefined,
+        cssLength: typeof payload.css === "string" ? payload.css.length : 0,
+        legacy: true,
+      });
       try {
         installRendererPlugin(payload.code, payload.css);
+        emitRendererDiagnostic("renderer-plugin-install-success", { legacy: true });
       } catch (err) {
         console.error("[renderer-plugin] install failed:", err);
+        emitRendererDiagnostic(
+          "renderer-plugin-install-failed",
+          { legacy: true, message: err instanceof Error ? err.message : String(err) },
+          "error",
+        );
       }
       return;
     }
@@ -326,7 +414,7 @@ function IsolatedRendererApp() {
 
         // Notify parent of render completion after next paint
         requestAnimationFrame(() => {
-          postMeasuredHeight("render_complete");
+          postMeasuredHeight("render_complete", 1);
         });
         scheduleRendererLayoutPulses();
         break;
@@ -346,9 +434,13 @@ function IsolatedRendererApp() {
           payload: p,
         }));
         setState((prev) => ({ ...prev, outputs: entries }));
+        emitRendererDiagnostic("render-batch-received", {
+          outputCount: entries.length,
+          mimes: entries.map((entry) => entry.payload.mimeType),
+        });
 
         requestAnimationFrame(() => {
-          postMeasuredHeight("render_complete");
+          postMeasuredHeight("render_complete", entries.length);
         });
         scheduleRendererLayoutPulses();
         break;
@@ -357,7 +449,7 @@ function IsolatedRendererApp() {
       case "clear":
         setState((prev) => ({ ...prev, outputs: [] }));
         requestAnimationFrame(() => {
-          postMeasuredHeight("render_complete");
+          postMeasuredHeight("render_complete", 0);
         });
         scheduleRendererLayoutPulses();
         break;
@@ -559,6 +651,7 @@ declare global {
 }
 
 export function init() {
+  emitRendererDiagnostic("renderer-init-start");
   // Signal to the inline handler that React is taking over
   // This prevents the inline handler from processing render/theme/clear messages
   window.__REACT_RENDERER_ACTIVE__ = true;
@@ -605,6 +698,7 @@ export function init() {
 
   document.addEventListener("fullscreenchange", scheduleRendererLayoutPulses);
   document.addEventListener("webkitfullscreenchange", scheduleRendererLayoutPulses);
+  emitRendererDiagnostic("renderer-init-complete");
 
   // Note: "renderer_ready" is sent from the React component's useEffect
   // to ensure the message handler is registered before parent sends messages


### PR DESCRIPTION
## Summary

- Add structured isolated iframe diagnostics for bootstrap, bundle injection, plugin install, render batches, renderer readiness, post-paint root/height checks, and anomaly logging.
- Treat an empty renderer CSS string as a valid loaded bundle so embedders can use CSS-less bundles.
- Expand the standalone renderer-test browser harness for markdown, pandas-like HTML, stream+rich batches, delayed bundles, empty CSS bundles, and remounts.
- Expand notebook browser E2E for markdown cells and markdown outputs in addition to the pandas stream+DataFrame regression.

## Verification

- `pnpm --filter notebook-ui exec tsc --noEmit`
- `pnpm --filter renderer-test test:e2e`
- `pnpm --filter notebook-ui test:e2e:browser -- isolated-rich-output.spec.ts`
- `cargo xtask wasm`
- `cargo xtask lint --fix`

Note: the notebook browser E2E runner starts local Vite plus the dev daemon and then terminates Vite after tests; pnpm prints the expected dev-server SIGTERM line after the Playwright tests pass.
