### PR TITLE
feat(isolated): add embed host context bridge

### DIFF
--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -15,6 +15,7 @@ const mockFrameHandle = {
   eval: vi.fn(),
   installRenderer: vi.fn(),
   setTheme: vi.fn(),
+  setHostContext: vi.fn(),
   clear: vi.fn(),
   search: vi.fn(),
   searchNavigate: vi.fn(),

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a71409d0f194a78f694a3afb8cc3afca83dfe9292e5626b4a31c8d7b629a9358
-size 1478464
+oid sha256:1d9b3147cd3eebdcccdbada12c9a280eb1d9e9366a8e1964654cba0b294ec641
+size 1480503

--- a/apps/renderer-test/e2e/render.spec.ts
+++ b/apps/renderer-test/e2e/render.spec.ts
@@ -106,4 +106,41 @@ test.describe("Renderer plugin fixtures", () => {
     const body = page.frameLocator('[data-testid="remount-frame"] iframe').locator("body");
     await expect(body).toContainText("Markdown Plugin", { timeout: 30_000 });
   });
+
+  test("host context reaches the iframe and updates after mount", async ({ page }) => {
+    await page.goto("/?scenario=host-context");
+    await expect(page.getByTestId("host-context-status")).toHaveAttribute("data-ready", "true", {
+      timeout: 30_000,
+    });
+    await expect(page.getByTestId("host-context-status")).toHaveAttribute(
+      "data-dark-mode",
+      "true",
+      {
+        timeout: 30_000,
+      },
+    );
+
+    const frame = page.frameLocator('[data-testid="host-context-frame"] iframe');
+    await expect(frame.locator("#host-context-probe")).toContainText("Host context probe", {
+      timeout: 30_000,
+    });
+
+    const contextDetails = await frame.locator("html").evaluate((html) => {
+      const style = getComputedStyle(html);
+      return {
+        theme: html.getAttribute("data-theme"),
+        probe: style.getPropertyValue("--nteract-host-context-probe").trim(),
+        hostWidth: style.getPropertyValue("--nteract-host-width").trim(),
+        hostMaxHeight: style.getPropertyValue("--nteract-host-max-height").trim(),
+      };
+    });
+
+    expect(contextDetails).toMatchObject({
+      theme: "dark",
+      probe: "#123456",
+      hostMaxHeight: "420px",
+    });
+    expect(contextDetails.hostWidth).toMatch(/^\d+px$/);
+    expect(Number.parseInt(contextDetails.hostWidth, 10)).toBeGreaterThan(0);
+  });
 });

--- a/apps/renderer-test/src/main.tsx
+++ b/apps/renderer-test/src/main.tsx
@@ -2,7 +2,7 @@ import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated/i
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { createRoot } from "react-dom/client";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fixtures, getFixtureOutputs, markdownFixture, type Fixture } from "./fixtures";
 
 type RendererLoader = () => Promise<{ rendererCode: string; rendererCss: string }>;
@@ -186,6 +186,72 @@ function RemountScenarioApp() {
   );
 }
 
+function HostContextScenarioApp() {
+  const frameRef = useRef<IsolatedFrameHandle>(null);
+  const [ready, setReady] = useState(false);
+  const [darkMode, setDarkMode] = useState(false);
+  const [height, setHeight] = useState(0);
+
+  const hostContext = useMemo(
+    () => ({
+      styles: {
+        variables: {
+          "--nteract-host-context-probe": darkMode ? "#123456" : "#654321",
+        },
+        css: {
+          fonts: "",
+        },
+      },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      userAgent: "renderer-test",
+      platform: "web" as const,
+    }),
+    [darkMode],
+  );
+
+  const onReady = useCallback(() => {
+    frameRef.current?.render({
+      mimeType: "text/html",
+      data: '<div id="host-context-probe" style="color: var(--nteract-host-context-probe); font-family: var(--font-sans);">Host context probe</div>',
+      cellId: "host-context",
+      outputIndex: 0,
+    });
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    const timer = window.setTimeout(() => setDarkMode(true), 100);
+    return () => window.clearTimeout(timer);
+  }, [ready]);
+
+  return (
+    <IsolatedRendererProvider loader={defaultRendererLoader}>
+      <div style={{ maxWidth: 900, margin: "0 auto", padding: "24px 16px" }}>
+        <div
+          data-testid="host-context-status"
+          data-ready={ready}
+          data-height={height}
+          data-dark-mode={darkMode}
+        />
+        <div data-testid="host-context-frame">
+          <IsolatedFrame
+            ref={frameRef}
+            id="host-context"
+            darkMode={darkMode}
+            hostContext={hostContext}
+            minHeight={40}
+            maxHeight={420}
+            onReady={onReady}
+            onResize={setHeight}
+          />
+        </div>
+      </div>
+    </IsolatedRendererProvider>
+  );
+}
+
 function App() {
   const scenario = new URLSearchParams(window.location.search).get("scenario");
   if (scenario === "delayed-bundle") {
@@ -196,6 +262,9 @@ function App() {
   }
   if (scenario === "remount") {
     return <RemountScenarioApp />;
+  }
+  if (scenario === "host-context") {
+    return <HostContextScenarioApp />;
   }
   return <FixtureListApp />;
 }

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -13,6 +13,7 @@ const mockFrameHandle = {
   eval: vi.fn(),
   installRenderer: vi.fn(),
   setTheme: vi.fn(),
+  setHostContext: vi.fn(),
   clear: vi.fn(),
   search: vi.fn(),
   searchNavigate: vi.fn(),

--- a/src/components/isolated/__tests__/frame-bridge.test.ts
+++ b/src/components/isolated/__tests__/frame-bridge.test.ts
@@ -66,6 +66,7 @@ describe("isIframeMessage", () => {
     "render",
     "theme",
     "clear",
+    "host_context",
     "ping",
     "eval",
     "bridge_ready",

--- a/src/components/isolated/__tests__/frame-html-jsonrpc.test.ts
+++ b/src/components/isolated/__tests__/frame-html-jsonrpc.test.ts
@@ -41,6 +41,11 @@ describe("bootstrap HTML JSON-RPC support", () => {
     expect(source).toContain("case 'nteract/theme':");
   });
 
+  it("routes MCP Apps host-context changes with React gate", () => {
+    expect(source).toContain("case 'ui/notifications/host-context-changed':");
+    expect(html).toContain("handleHostContext(params)");
+  });
+
   it("routes nteract/clearOutputs with React gate", () => {
     expect(source).toContain("case 'nteract/clearOutputs':");
   });
@@ -73,6 +78,10 @@ describe("bootstrap HTML JSON-RPC support", () => {
     expect(source).toContain("sendRpc('nteract/resize'");
   });
 
+  it("sends MCP Apps size changes as JSON-RPC", () => {
+    expect(source).toContain("sendRpc('ui/notifications/size-changed'");
+  });
+
   it("sends link_click as JSON-RPC", () => {
     expect(source).toContain("sendRpc('nteract/linkClick'");
   });
@@ -90,5 +99,6 @@ describe("bootstrap HTML JSON-RPC support", () => {
     expect(source).toContain("case 'search':");
     expect(source).toContain("case 'eval':");
     expect(source).toContain("case 'render':");
+    expect(source).toContain("case 'host_context':");
   });
 });

--- a/src/components/isolated/__tests__/host-context.test.ts
+++ b/src/components/isolated/__tests__/host-context.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createNteractEmbedHostContext,
+  createNteractThemeVariables,
+  mergeNteractEmbedHostContext,
+} from "../host-context";
+
+describe("nteract embed host context", () => {
+  it("maps classic light theme into MCP Apps-style variables", () => {
+    const context = createNteractEmbedHostContext({
+      isDark: false,
+      colorTheme: "classic",
+      containerDimensions: { width: 640, maxHeight: 400 },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      userAgent: "nteract-test",
+      platform: "desktop",
+      deviceCapabilities: { hover: true, touch: false },
+    });
+
+    expect(context).toMatchObject({
+      theme: "light",
+      displayMode: "inline",
+      availableDisplayModes: ["inline", "fullscreen"],
+      containerDimensions: { width: 640, maxHeight: 400 },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      userAgent: "nteract-test",
+      platform: "desktop",
+      deviceCapabilities: { hover: true, touch: false },
+      nteract: { colorTheme: "classic" },
+    });
+    expect(context.styles?.variables).toMatchObject({
+      "--color-background-primary": "transparent",
+      "--color-text-primary": "#1a1a1a",
+      "--bg-primary": "transparent",
+      "--text-primary": "#1a1a1a",
+      "--font-sans": expect.stringContaining("system-ui"),
+    });
+  });
+
+  it("maps cream dark theme to warm variables and document font", () => {
+    expect(createNteractThemeVariables(true, "cream")).toMatchObject({
+      "--color-text-primary": "#e8e2dc",
+      "--color-border-primary": "#3a3533",
+      "--text-secondary": "#9a918a",
+      "--output-document-font": 'KaTeX_Main, Georgia, "Times New Roman", serif',
+    });
+  });
+
+  it("deep merges host-provided variables and font CSS", () => {
+    const merged = mergeNteractEmbedHostContext(
+      createNteractEmbedHostContext({
+        isDark: true,
+        colorTheme: null,
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        userAgent: "nteract-test",
+        platform: "desktop",
+      }),
+      {
+        styles: {
+          variables: {
+            "--color-text-primary": "#abcdef",
+          },
+          css: {
+            fonts: "@font-face { font-family: Test; src: url(test.woff2); }",
+          },
+        },
+      },
+    );
+
+    expect(merged.theme).toBe("dark");
+    expect(merged.styles?.variables).toMatchObject({
+      "--color-background-primary": "transparent",
+      "--color-text-primary": "#abcdef",
+      "--text-primary": "#e0e0e0",
+    });
+    expect(merged.styles?.css?.fonts).toContain("font-family: Test");
+  });
+});

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -1,13 +1,21 @@
 import { render, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { NTERACT_RENDERER_READY, NTERACT_RESIZE, NTERACT_THEME } from "../rpc-methods";
+import {
+  MCP_UI_HOST_CONTEXT_CHANGED,
+  MCP_UI_RESOURCE_TEARDOWN,
+  NTERACT_RENDERER_READY,
+  NTERACT_RESIZE,
+  NTERACT_THEME,
+} from "../rpc-methods";
+import type { IsolatedFrameHandle } from "../isolated-frame";
 
 const { MockJsonRpcTransport } = vi.hoisted(() => {
   class MockJsonRpcTransport {
     static instances: MockJsonRpcTransport[] = [];
 
     notify = vi.fn();
+    request = vi.fn(() => Promise.resolve({}));
     start = vi.fn();
     stop = vi.fn();
     notificationHandlers = new Map<string, (params: unknown) => void>();
@@ -60,6 +68,22 @@ function dispatchIframeReady(iframeWindow: Window) {
 describe("IsolatedFrame theme updates", () => {
   beforeEach(() => {
     MockJsonRpcTransport.instances = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    );
   });
 
   afterEach(() => {
@@ -90,6 +114,98 @@ describe("IsolatedFrame theme updates", () => {
         isDark: false,
         colorTheme: "cream",
       });
+    });
+
+    await waitFor(() => {
+      expect(transport.notify).toHaveBeenCalledWith(
+        MCP_UI_HOST_CONTEXT_CHANGED,
+        expect.objectContaining({
+          theme: "light",
+          nteract: { colorTheme: "cream" },
+          styles: expect.objectContaining({
+            variables: expect.objectContaining({
+              "--color-text-primary": "#1e1a18",
+              "--output-document-font": 'KaTeX_Main, Georgia, "Times New Roman", serif',
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("merges imperative host-context updates into MCP Apps-compatible notifications", async () => {
+    const frameRef = { current: null as IsolatedFrameHandle | null };
+    const { container } = render(
+      <IsolatedFrame
+        ref={(handle) => {
+          frameRef.current = handle;
+        }}
+        darkMode={false}
+      />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    act(() => {
+      transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+    });
+
+    act(() => {
+      frameRef.current?.setHostContext({
+        styles: {
+          variables: {
+            "--nteract-test-token": "host-context",
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(transport.notify).toHaveBeenCalledWith(
+        MCP_UI_HOST_CONTEXT_CHANGED,
+        expect.objectContaining({
+          styles: expect.objectContaining({
+            variables: expect.objectContaining({
+              "--nteract-test-token": "host-context",
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  it("keeps the JSON-RPC transport alive when frame diagnostics props change", () => {
+    const { container, rerender, unmount } = render(
+      <IsolatedFrame darkMode={false} name="code-Out[*]" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    act(() => {
+      transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+    });
+
+    rerender(<IsolatedFrame darkMode={false} name="code-Out[1]" />);
+
+    expect(transport.stop).not.toHaveBeenCalled();
+    expect(transport.request).not.toHaveBeenCalledWith(MCP_UI_RESOURCE_TEARDOWN, {
+      reason: "unmount",
+    });
+
+    unmount();
+
+    expect(transport.request).toHaveBeenCalledWith(MCP_UI_RESOURCE_TEARDOWN, {
+      reason: "unmount",
     });
   });
 

--- a/src/components/isolated/__tests__/rpc-methods.test.ts
+++ b/src/components/isolated/__tests__/rpc-methods.test.ts
@@ -9,6 +9,10 @@
 
 import { describe, expect, it } from "vite-plus/test";
 import {
+  MCP_NOTIFICATIONS_MESSAGE,
+  MCP_UI_HOST_CONTEXT_CHANGED,
+  MCP_UI_RESOURCE_TEARDOWN,
+  MCP_UI_SIZE_CHANGED,
   NTERACT_BRIDGE_READY,
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_COMM_CLOSE,
@@ -72,6 +76,12 @@ describe("nteract JSON-RPC method constants", () => {
     NTERACT_PONG,
     NTERACT_SEARCH_RESULTS,
   ];
+  const MCP_UI_METHODS = [
+    MCP_UI_HOST_CONTEXT_CHANGED,
+    MCP_UI_SIZE_CHANGED,
+    MCP_UI_RESOURCE_TEARDOWN,
+    MCP_NOTIFICATIONS_MESSAGE,
+  ];
 
   it("all methods have nteract/ namespace prefix", () => {
     for (const method of ALL_METHODS) {
@@ -82,6 +92,16 @@ describe("nteract JSON-RPC method constants", () => {
   it("all method constants are unique", () => {
     const unique = new Set(ALL_METHODS);
     expect(unique.size).toBe(ALL_METHODS.length);
+  });
+
+  it("MCP Apps-compatible method constants keep their standard names", () => {
+    expect(MCP_UI_HOST_CONTEXT_CHANGED).toBe("ui/notifications/host-context-changed");
+    expect(MCP_UI_SIZE_CHANGED).toBe("ui/notifications/size-changed");
+    expect(MCP_UI_RESOURCE_TEARDOWN).toBe("ui/resource-teardown");
+    expect(MCP_NOTIFICATIONS_MESSAGE).toBe("notifications/message");
+
+    const unique = new Set([...ALL_METHODS, ...MCP_UI_METHODS]);
+    expect(unique.size).toBe(ALL_METHODS.length + MCP_UI_METHODS.length);
   });
 
   it("request methods return expected names", () => {

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -1,3 +1,5 @@
+import type { NteractEmbedHostContext } from "./host-context";
+
 export interface EvalMessage {
   type: "eval";
   payload: {
@@ -78,6 +80,15 @@ export interface ThemeMessage {
     /** Optional CSS variables to inject */
     cssVariables?: Record<string, string>;
   };
+}
+
+/**
+ * Sync embed host context with the iframe. This mirrors MCP Apps
+ * HostContext while keeping notebook commands in the nteract namespace.
+ */
+export interface HostContextMessage {
+  type: "host_context";
+  payload: Partial<NteractEmbedHostContext>;
 }
 
 /**
@@ -251,6 +262,7 @@ export type ParentToIframeMessage =
   | RenderBatchMessage
   | WidgetStateMessage
   | ThemeMessage
+  | HostContextMessage
   | PingMessage
   | ClearMessage
   | CommOpenMessage

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -17,6 +17,16 @@
         --accent-color: #3b82f6;
         --error-color: #ef4444;
         --success-color: #22c55e;
+        --color-background-primary: var(--bg-primary);
+        --color-background-secondary: var(--bg-secondary);
+        --color-text-primary: var(--text-primary);
+        --color-text-secondary: var(--text-secondary);
+        --color-border-primary: var(--border-color);
+        --color-ring-primary: var(--accent-color);
+        --color-text-danger: var(--error-color);
+        --color-text-success: var(--success-color);
+        --font-sans: var(--output-ui-font);
+        --font-mono: var(--output-mono-font);
         --output-ui-font:
           system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         --output-mono-font: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
@@ -223,6 +233,7 @@
         // --- State ---
         let isReady = false;
         const root = document.getElementById("root");
+        let hostFontStyle = null;
         const IFRAME_HEIGHT_FUDGE_PX = 2;
 
         function measureDocumentHeight() {
@@ -270,6 +281,10 @@
                 case "nteract/theme":
                   if (window.__REACT_RENDERER_ACTIVE__) return;
                   handleTheme(params);
+                  break;
+                case "ui/notifications/host-context-changed":
+                  if (window.__REACT_RENDERER_ACTIVE__) return;
+                  handleHostContext(params);
                   break;
                 case "nteract/clearOutputs":
                   if (window.__REACT_RENDERER_ACTIVE__) return;
@@ -323,6 +338,11 @@
               case "theme":
                 if (window.__REACT_RENDERER_ACTIVE__) return;
                 handleTheme(payload);
+                break;
+
+              case "host_context":
+                if (window.__REACT_RENDERER_ACTIVE__) return;
+                handleHostContext(payload);
                 break;
 
               case "clear":
@@ -450,7 +470,9 @@
 
           // Notify completion
           requestAnimationFrame(function () {
-            sendRpc("nteract/renderComplete", { height: measureDocumentHeight() });
+            var height = measureDocumentHeight();
+            sendRpc("nteract/renderComplete", { height: height });
+            sendSizeChanged(height);
           });
         }
 
@@ -507,9 +529,73 @@
           }
         }
 
+        function handleHostContext(payload) {
+          var context = payload || {};
+          var theme = context.theme;
+          var colorTheme = context.nteract && context.nteract.colorTheme;
+          if (theme === "light" || theme === "dark" || colorTheme !== undefined) {
+            handleTheme({
+              isDark: theme === "dark" ? true : theme === "light" ? false : undefined,
+              colorTheme: colorTheme === undefined ? undefined : colorTheme,
+            });
+          }
+
+          var variables = context.styles && context.styles.variables;
+          if (variables) {
+            Object.entries(variables).forEach(function ([key, value]) {
+              if (typeof value === "string") {
+                document.documentElement.style.setProperty(key, value);
+              }
+            });
+          }
+
+          var fonts = context.styles && context.styles.css && context.styles.css.fonts;
+          if (typeof fonts === "string" && fonts.length > 0) {
+            if (!hostFontStyle) {
+              hostFontStyle = document.createElement("style");
+              hostFontStyle.setAttribute("data-nteract-host-fonts", "true");
+              document.head.appendChild(hostFontStyle);
+            }
+            hostFontStyle.textContent = fonts;
+          } else if (fonts === "" && hostFontStyle) {
+            hostFontStyle.remove();
+            hostFontStyle = null;
+          }
+
+          var dimensions = context.containerDimensions || {};
+          if (dimensions.width) {
+            document.documentElement.style.setProperty(
+              "--nteract-host-width",
+              dimensions.width + "px",
+            );
+          }
+          if (dimensions.maxWidth) {
+            document.documentElement.style.setProperty(
+              "--nteract-host-max-width",
+              dimensions.maxWidth + "px",
+            );
+          }
+          if (dimensions.height) {
+            document.documentElement.style.setProperty(
+              "--nteract-host-height",
+              dimensions.height + "px",
+            );
+          }
+          if (dimensions.maxHeight) {
+            document.documentElement.style.setProperty(
+              "--nteract-host-max-height",
+              dimensions.maxHeight + "px",
+            );
+          }
+
+          window.dispatchEvent(new Event("resize"));
+        }
+
         function handleClear() {
           root.innerHTML = "";
-          sendRpc("nteract/renderComplete", { height: measureDocumentHeight() });
+          var height = measureDocumentHeight();
+          sendRpc("nteract/renderComplete", { height: height });
+          sendSizeChanged(height);
         }
 
         function handleWidgetState(payload) {
@@ -613,6 +699,15 @@
           window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params || {} }, "*");
         }
 
+        function sendSizeChanged(height) {
+          sendRpc("ui/notifications/size-changed", {
+            width: Math.ceil(
+              document.documentElement.scrollWidth || document.body.scrollWidth || 0,
+            ),
+            height: height,
+          });
+        }
+
         function sendError(err) {
           sendRpc("nteract/error", {
             message: err.message || String(err),
@@ -636,6 +731,7 @@
             if (window.__REACT_RENDERER_ACTIVE__) return;
             var height = measureDocumentHeight();
             sendRpc("nteract/resize", { height: height });
+            sendSizeChanged(height);
           });
         });
         resizeObserver.observe(document.body);

--- a/src/components/isolated/host-context.ts
+++ b/src/components/isolated/host-context.ts
@@ -1,0 +1,286 @@
+export type NteractEmbedTheme = "light" | "dark";
+export type NteractEmbedDisplayMode = "inline" | "fullscreen" | "pip";
+export type NteractEmbedPlatform = "web" | "desktop" | "mobile";
+
+export interface NteractEmbedContainerDimensions {
+  width?: number;
+  maxWidth?: number;
+  height?: number;
+  maxHeight?: number;
+}
+
+export interface NteractEmbedDeviceCapabilities {
+  touch?: boolean;
+  hover?: boolean;
+}
+
+export interface NteractEmbedSafeAreaInsets {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface NteractEmbedHostContext {
+  theme?: NteractEmbedTheme;
+  styles?: {
+    variables?: Record<string, string>;
+    css?: {
+      fonts?: string;
+    };
+  };
+  displayMode?: NteractEmbedDisplayMode;
+  availableDisplayModes?: NteractEmbedDisplayMode[];
+  containerDimensions?: NteractEmbedContainerDimensions;
+  locale?: string;
+  timeZone?: string;
+  userAgent?: string;
+  platform?: NteractEmbedPlatform;
+  deviceCapabilities?: NteractEmbedDeviceCapabilities;
+  safeAreaInsets?: NteractEmbedSafeAreaInsets;
+  nteract?: {
+    colorTheme?: string | null;
+  };
+}
+
+export interface CreateNteractEmbedHostContextOptions {
+  isDark: boolean;
+  colorTheme?: string | null;
+  containerDimensions?: NteractEmbedContainerDimensions;
+  locale?: string;
+  timeZone?: string;
+  userAgent?: string;
+  platform?: NteractEmbedPlatform;
+  deviceCapabilities?: NteractEmbedDeviceCapabilities;
+  safeAreaInsets?: NteractEmbedSafeAreaInsets;
+}
+
+interface ThemePalette {
+  backgroundPrimary: string;
+  backgroundSecondary: string;
+  textPrimary: string;
+  textSecondary: string;
+  borderPrimary: string;
+  accent: string;
+  danger: string;
+  success: string;
+  siftBackground: string;
+  foreground: string;
+  documentFont: string;
+}
+
+const OUTPUT_UI_FONT =
+  'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+const OUTPUT_MONO_FONT = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace';
+const OUTPUT_DOCUMENT_FONT = "var(--output-ui-font)";
+const CREAM_DOCUMENT_FONT = 'KaTeX_Main, Georgia, "Times New Roman", serif';
+
+function themePalette(isDark: boolean, colorTheme?: string | null): ThemePalette {
+  const isCream = colorTheme === "cream";
+  if (isCream) {
+    return {
+      backgroundPrimary: "transparent",
+      backgroundSecondary: isDark ? "#242120" : "#f0ede7",
+      textPrimary: isDark ? "#e8e2dc" : "#1e1a18",
+      textSecondary: isDark ? "#9a918a" : "#6e655f",
+      borderPrimary: isDark ? "#3a3533" : "#d8cec3",
+      accent: isDark ? "#d4896a" : "#955f3b",
+      danger: isDark ? "#e07a64" : "#c4513a",
+      success: isDark ? "#5ec98a" : "#3a8a5c",
+      siftBackground: isDark ? "#1a1816" : "#f5f2ec",
+      foreground: isDark ? "#e8e2dc" : "#1e1a18",
+      documentFont: CREAM_DOCUMENT_FONT,
+    };
+  }
+
+  if (isDark) {
+    return {
+      backgroundPrimary: "transparent",
+      backgroundSecondary: "#1a1a1a",
+      textPrimary: "#e0e0e0",
+      textSecondary: "#a0a0a0",
+      borderPrimary: "#333333",
+      accent: "#60a5fa",
+      danger: "#ef4444",
+      success: "#22c55e",
+      siftBackground: "#0d1117",
+      foreground: "#e0e0e0",
+      documentFont: OUTPUT_DOCUMENT_FONT,
+    };
+  }
+
+  return {
+    backgroundPrimary: "transparent",
+    backgroundSecondary: "#f5f5f5",
+    textPrimary: "#1a1a1a",
+    textSecondary: "#666666",
+    borderPrimary: "#e0e0e0",
+    accent: "#3b82f6",
+    danger: "#ef4444",
+    success: "#22c55e",
+    siftBackground: "#ffffff",
+    foreground: "#1a1a1a",
+    documentFont: OUTPUT_DOCUMENT_FONT,
+  };
+}
+
+function hostLocale(): string | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return navigator.language || navigator.languages?.[0];
+}
+
+function hostTimeZone(): string | undefined {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+function hostUserAgent(): string | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return navigator.userAgent;
+}
+
+function hostPlatform(): NteractEmbedPlatform {
+  if (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0) {
+    return "mobile";
+  }
+  return "desktop";
+}
+
+function hostDeviceCapabilities(): NteractEmbedDeviceCapabilities {
+  if (typeof window === "undefined") return {};
+  return {
+    touch: typeof navigator !== "undefined" ? navigator.maxTouchPoints > 0 : undefined,
+    hover: window.matchMedia?.("(hover: hover)").matches,
+  };
+}
+
+export function createNteractThemeVariables(
+  isDark: boolean,
+  colorTheme?: string | null,
+): Record<string, string> {
+  const palette = themePalette(isDark, colorTheme);
+
+  return {
+    "--color-background-primary": palette.backgroundPrimary,
+    "--color-background-secondary": palette.backgroundSecondary,
+    "--color-text-primary": palette.textPrimary,
+    "--color-text-secondary": palette.textSecondary,
+    "--color-border-primary": palette.borderPrimary,
+    "--color-ring-primary": palette.accent,
+    "--color-text-danger": palette.danger,
+    "--color-text-success": palette.success,
+    "--font-sans": OUTPUT_UI_FONT,
+    "--font-mono": OUTPUT_MONO_FONT,
+    "--font-text-md-size": "1rem",
+    "--font-text-md-line-height": "1.5",
+    "--font-weight-normal": "400",
+    "--font-weight-medium": "500",
+    "--font-weight-semibold": "600",
+    "--font-weight-bold": "700",
+    "--border-radius-sm": "4px",
+    "--border-radius-md": "6px",
+    "--border-radius-lg": "8px",
+    "--border-width-regular": "1px",
+
+    "--bg-primary": palette.backgroundPrimary,
+    "--bg-secondary": palette.backgroundSecondary,
+    "--text-primary": palette.textPrimary,
+    "--text-secondary": palette.textSecondary,
+    "--foreground": palette.foreground,
+    "--border-color": palette.borderPrimary,
+    "--accent-color": palette.accent,
+    "--error-color": palette.danger,
+    "--success-color": palette.success,
+    "--sift-bg": palette.siftBackground,
+    "--output-ui-font": OUTPUT_UI_FONT,
+    "--output-mono-font": OUTPUT_MONO_FONT,
+    "--output-document-font": palette.documentFont,
+  };
+}
+
+export function createNteractEmbedHostContext({
+  isDark,
+  colorTheme,
+  containerDimensions,
+  locale,
+  timeZone,
+  userAgent,
+  platform,
+  deviceCapabilities,
+  safeAreaInsets,
+}: CreateNteractEmbedHostContextOptions): NteractEmbedHostContext {
+  return {
+    theme: isDark ? "dark" : "light",
+    styles: {
+      variables: createNteractThemeVariables(isDark, colorTheme),
+    },
+    displayMode: "inline",
+    availableDisplayModes: ["inline", "fullscreen"],
+    containerDimensions,
+    locale: locale ?? hostLocale(),
+    timeZone: timeZone ?? hostTimeZone(),
+    userAgent: userAgent ?? hostUserAgent(),
+    platform: platform ?? hostPlatform(),
+    deviceCapabilities: deviceCapabilities ?? hostDeviceCapabilities(),
+    safeAreaInsets: safeAreaInsets ?? { top: 0, right: 0, bottom: 0, left: 0 },
+    nteract: {
+      colorTheme: colorTheme ?? null,
+    },
+  };
+}
+
+export function mergeNteractEmbedHostContext(
+  ...contexts: Array<Partial<NteractEmbedHostContext> | null | undefined>
+): NteractEmbedHostContext {
+  const merged: NteractEmbedHostContext = {};
+
+  for (const context of contexts) {
+    if (!context) continue;
+    const previousStyles = merged.styles;
+    const previousDeviceCapabilities = merged.deviceCapabilities;
+    const previousSafeAreaInsets = merged.safeAreaInsets;
+    const previousNteract = merged.nteract;
+    Object.assign(merged, context);
+
+    if (context.styles) {
+      merged.styles = {
+        ...previousStyles,
+        ...context.styles,
+        variables: {
+          ...previousStyles?.variables,
+          ...context.styles.variables,
+        },
+        css: {
+          ...previousStyles?.css,
+          ...context.styles.css,
+        },
+      };
+    }
+
+    if (context.deviceCapabilities) {
+      merged.deviceCapabilities = {
+        ...previousDeviceCapabilities,
+        ...context.deviceCapabilities,
+      };
+    }
+
+    if (context.safeAreaInsets) {
+      merged.safeAreaInsets = {
+        ...previousSafeAreaInsets,
+        ...context.safeAreaInsets,
+      } as NteractEmbedSafeAreaInsets;
+    }
+
+    if (context.nteract) {
+      merged.nteract = {
+        ...previousNteract,
+        ...context.nteract,
+      };
+    }
+  }
+
+  return merged;
+}

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -4,6 +4,7 @@ export type {
   ClearMessage,
   EvalMessage,
   EvalResultMessage,
+  HostContextMessage,
   IframeErrorMessage,
   // Utilities
   IframeMessage,
@@ -27,6 +28,20 @@ export type {
 export { isIframeMessage, isMessageType } from "./frame-bridge";
 // HTML template generator
 export { FRAME_HTML, generateFrameHtml } from "./frame-html";
+export {
+  createNteractEmbedHostContext,
+  createNteractThemeVariables,
+  mergeNteractEmbedHostContext,
+} from "./host-context";
+export type {
+  NteractEmbedContainerDimensions,
+  NteractEmbedDeviceCapabilities,
+  NteractEmbedDisplayMode,
+  NteractEmbedHostContext,
+  NteractEmbedPlatform,
+  NteractEmbedSafeAreaInsets,
+  NteractEmbedTheme,
+} from "./host-context";
 // Security testing component
 export { IsolationTest } from "./IsolationTest";
 export type { IsolatedFrameHandle, IsolatedFrameProps } from "./isolated-frame";

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -519,11 +519,14 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       };
 
       updateContainerDimensions();
-      const observer = new ResizeObserver(updateContainerDimensions);
-      observer.observe(iframe);
+      const observer =
+        typeof ResizeObserver === "undefined"
+          ? null
+          : new ResizeObserver(updateContainerDimensions);
+      observer?.observe(iframe);
       window.addEventListener("resize", updateContainerDimensions);
       return () => {
-        observer.disconnect();
+        observer?.disconnect();
         window.removeEventListener("resize", updateContainerDimensions);
       };
     }, [autoHeight, frameDocument, maxHeight]);

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -1,11 +1,25 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
 import { isIframeMessage } from "./frame-bridge";
 import { logIsolatedDiagnostic, rendererBundleDetails } from "./diagnostics";
 import { generateFrameHtml } from "./frame-html";
+import type { NteractEmbedContainerDimensions, NteractEmbedHostContext } from "./host-context";
+import { createNteractEmbedHostContext, mergeNteractEmbedHostContext } from "./host-context";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
 import { JsonRpcTransport } from "./jsonrpc-transport";
 import {
+  MCP_NOTIFICATIONS_MESSAGE,
+  MCP_UI_HOST_CONTEXT_CHANGED,
+  MCP_UI_RESOURCE_TEARDOWN,
+  MCP_UI_SIZE_CHANGED,
   NTERACT_BRIDGE_READY,
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_COMM_CLOSE,
@@ -67,6 +81,13 @@ export interface IsolatedFrameProps {
    * Passed to the iframe as `data-color-theme` attribute.
    */
   colorTheme?: string;
+
+  /**
+   * Additional host context to expose to the iframe. Shape intentionally
+   * mirrors MCP Apps HostContext so external hosts can embed nteract with
+   * minimal theming and sizing glue.
+   */
+  hostContext?: Partial<NteractEmbedHostContext>;
 
   /**
    * Minimum height of the iframe in pixels.
@@ -196,6 +217,11 @@ export interface IsolatedFrameHandle {
   setTheme: (isDark: boolean, colorTheme?: string | null) => void;
 
   /**
+   * Merge host-context fields into the iframe's current embed context.
+   */
+  setHostContext: (hostContext: Partial<NteractEmbedHostContext>) => void;
+
+  /**
    * Clear all content in the iframe.
    */
   clear: () => void;
@@ -267,6 +293,47 @@ function isTauriRuntime(): boolean {
   return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
 }
 
+function iframeContainerDimensions(
+  iframe: HTMLIFrameElement | null,
+  autoHeight: boolean,
+  maxHeight: number,
+): NteractEmbedContainerDimensions | undefined {
+  const dimensions: NteractEmbedContainerDimensions = {};
+  const width = iframe ? Math.round(iframe.getBoundingClientRect().width) : 0;
+  if (width > 0) {
+    dimensions.width = width;
+  }
+  if (!autoHeight && Number.isFinite(maxHeight)) {
+    dimensions.maxHeight = maxHeight;
+  }
+  return Object.keys(dimensions).length > 0 ? dimensions : undefined;
+}
+
+function sameContainerDimensions(
+  a: NteractEmbedContainerDimensions | undefined,
+  b: NteractEmbedContainerDimensions | undefined,
+): boolean {
+  return (
+    (a?.width ?? null) === (b?.width ?? null) &&
+    (a?.maxWidth ?? null) === (b?.maxWidth ?? null) &&
+    (a?.height ?? null) === (b?.height ?? null) &&
+    (a?.maxHeight ?? null) === (b?.maxHeight ?? null)
+  );
+}
+
+function diagnosticLevelFromMcpLog(level: string | undefined): "debug" | "info" | "warn" | "error" {
+  if (level === "error" || level === "critical" || level === "alert" || level === "emergency") {
+    return "error";
+  }
+  if (level === "warning") {
+    return "warn";
+  }
+  if (level === "notice" || level === "info") {
+    return "info";
+  }
+  return "debug";
+}
+
 /**
  * IsolatedFrame component - Renders untrusted content in a secure iframe.
  *
@@ -307,6 +374,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       initialContent,
       darkMode = true,
       colorTheme,
+      hostContext,
       minHeight = 24,
       maxHeight = 2000,
       autoHeight = false,
@@ -342,7 +410,14 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     // Use ref to track ready state for send callback (avoids stale closure)
     const isReadyRef = useRef(false);
     const [height, setHeight] = useState(minHeight);
+    const displayHeightRef = useRef(minHeight);
     const measuredHeightRef = useRef(minHeight);
+    const [containerDimensions, setContainerDimensions] = useState<
+      NteractEmbedContainerDimensions | undefined
+    >(undefined);
+    const [imperativeHostContext, setImperativeHostContext] = useState<
+      Partial<NteractEmbedHostContext>
+    >({});
     // Track if content has been rendered (for revealOnRender mode)
     const [isContentRendered, setIsContentRendered] = useState(false);
     // Track if the iframe is reloading (DOM move caused browser to tear down)
@@ -390,6 +465,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       },
       [id, name],
     );
+    const logFrameDiagnosticRef = useRef(logFrameDiagnostic);
 
     // Sync refs during render so effects always see the latest callbacks.
     onReadyRef.current = onReady;
@@ -401,6 +477,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
     allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
+    logFrameDiagnosticRef.current = logFrameDiagnostic;
 
     const applyMeasuredHeight = useCallback(
       (contentHeight: number) => {
@@ -408,6 +485,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         const newHeight = autoHeight
           ? Math.max(minHeight, contentHeight)
           : Math.max(minHeight, Math.min(maxHeight, contentHeight));
+        if (displayHeightRef.current === newHeight) {
+          return;
+        }
+        displayHeightRef.current = newHeight;
         setHeight(newHeight);
         onResizeRef.current?.(newHeight);
       },
@@ -428,9 +509,60 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       }
     }, []);
 
-    // Send theme as soon as iframe is ready (before renderer bootstrap).
-    // Once the renderer transport is active, prefer JSON-RPC so live theme
-    // changes follow the same path as other renderer updates.
+    useEffect(() => {
+      const iframe = iframeRef.current;
+      if (!iframe) return;
+
+      const updateContainerDimensions = () => {
+        const next = iframeContainerDimensions(iframe, autoHeight, maxHeight);
+        setContainerDimensions((prev) => (sameContainerDimensions(prev, next) ? prev : next));
+      };
+
+      updateContainerDimensions();
+      const observer = new ResizeObserver(updateContainerDimensions);
+      observer.observe(iframe);
+      window.addEventListener("resize", updateContainerDimensions);
+      return () => {
+        observer.disconnect();
+        window.removeEventListener("resize", updateContainerDimensions);
+      };
+    }, [autoHeight, frameDocument, maxHeight]);
+
+    const resolvedHostContext = useMemo(
+      () =>
+        mergeNteractEmbedHostContext(
+          createNteractEmbedHostContext({
+            isDark: darkMode,
+            colorTheme: colorTheme ?? null,
+            containerDimensions,
+          }),
+          hostContext,
+          imperativeHostContext,
+        ),
+      [colorTheme, containerDimensions, darkMode, hostContext, imperativeHostContext],
+    );
+
+    const postLegacyHostContext = useCallback((context: NteractEmbedHostContext) => {
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: "host_context", payload: context },
+        "*",
+      );
+    }, []);
+
+    const notifyHostContext = useCallback(
+      (context: NteractEmbedHostContext) => {
+        if (rpcRef.current && isReadyRef.current) {
+          rpcRef.current.notify(MCP_UI_HOST_CONTEXT_CHANGED, context);
+        } else {
+          postLegacyHostContext(context);
+        }
+      },
+      [postLegacyHostContext],
+    );
+
+    // Send theme and host context as soon as iframe is ready (before renderer
+    // bootstrap). Once the renderer transport is active, prefer JSON-RPC so
+    // live changes follow the same path as other renderer updates.
     useEffect(() => {
       if (isIframeReady && iframeRef.current?.contentWindow) {
         const payload = { isDark: darkMode, colorTheme: colorTheme ?? null };
@@ -439,8 +571,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         } else {
           iframeRef.current.contentWindow.postMessage({ type: "theme", payload }, "*");
         }
+        notifyHostContext(resolvedHostContext);
       }
-    }, [darkMode, colorTheme, isIframeReady, isReady]);
+    }, [darkMode, colorTheme, isIframeReady, isReady, notifyHostContext, resolvedHostContext]);
 
     // Keep ref in sync with state (ref avoids stale closures in callbacks)
     useEffect(() => {
@@ -587,6 +720,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               // Register handlers for JSON-RPC messages from iframe
               transport.onNotification(NTERACT_RENDERER_READY, () => {
                 logFrameDiagnostic("renderer-ready");
+                isReadyRef.current = true;
                 setIsReady(true);
                 setIsReloading(false);
                 onReadyRef.current?.();
@@ -596,6 +730,17 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
               });
               transport.onNotification(NTERACT_RESIZE, (params) => {
                 const p = params as { height?: number };
+                if (p.height != null) {
+                  applyMeasuredHeight(p.height);
+                }
+              });
+              transport.onNotification(MCP_UI_SIZE_CHANGED, (params) => {
+                const p = params as { height?: number; width?: number };
+                logFrameDiagnostic("size-changed", {
+                  height: p.height ?? null,
+                  width: p.width ?? null,
+                  protocol: "mcp-ui",
+                });
                 if (p.height != null) {
                   applyMeasuredHeight(p.height);
                 }
@@ -689,6 +834,22 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
                   },
                 });
               });
+              transport.onNotification(MCP_NOTIFICATIONS_MESSAGE, (params) => {
+                const p = params as {
+                  level?: string;
+                  logger?: string;
+                  data?: unknown;
+                };
+                logFrameDiagnostic(
+                  "iframe-log-message",
+                  {
+                    logger: p.logger ?? null,
+                    data: p.data ?? null,
+                    protocol: "mcp-ui",
+                  },
+                  diagnosticLevelFromMcpLog(p.level),
+                );
+              });
               transport.start();
               rpcRef.current = transport;
             }
@@ -698,6 +859,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           case "renderer_ready":
             // React renderer bundle is initialized
             logFrameDiagnostic("renderer-ready");
+            isReadyRef.current = true;
             setIsReady(true);
             setIsReloading(false);
             onReadyRef.current?.();
@@ -779,7 +941,28 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     // Clean up JSON-RPC transport on unmount
     useEffect(() => {
       return () => {
-        rpcRef.current?.stop();
+        const transport = rpcRef.current;
+        rpcRef.current = null;
+        if (!transport) return;
+
+        let stopped = false;
+        const stopTransport = () => {
+          if (stopped) return;
+          stopped = true;
+          transport.stop();
+        };
+
+        transport
+          .request(MCP_UI_RESOURCE_TEARDOWN, { reason: "unmount" })
+          .catch((err) => {
+            logFrameDiagnosticRef.current(
+              "resource-teardown-failed",
+              { message: err instanceof Error ? err.message : String(err) },
+              "debug",
+            );
+          })
+          .finally(stopTransport);
+        window.setTimeout(stopTransport, 100);
       };
     }, []);
 
@@ -882,6 +1065,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         },
         setTheme: (isDark: boolean, colorTheme?: string | null) =>
           send({ type: "theme", payload: { isDark, colorTheme } }),
+        setHostContext: (nextHostContext: Partial<NteractEmbedHostContext>) => {
+          setImperativeHostContext((prev) => mergeNteractEmbedHostContext(prev, nextHostContext));
+        },
         clear: () => send({ type: "clear" }),
         search: (query: string, caseSensitive?: boolean) => {
           // Search handler is in bootstrap HTML, so send directly when iframe is loaded

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -7,6 +7,8 @@
  * Standard MCP Apps methods (handled by the SDK):
  * - ui/notifications/host-context-changed → theme sync
  * - ui/notifications/size-changed → resize
+ * - ui/resource-teardown → disposal
+ * - notifications/message → iframe logs
  * - ui/open-link → link clicks
  * - ping → health check
  *
@@ -54,6 +56,13 @@ export const NTERACT_PONG = "nteract/pong" as const;
 export const NTERACT_SEARCH_RESULTS = "nteract/searchResults" as const;
 export const NTERACT_MOUSE_DOWN = "nteract/mouseDown" as const;
 export const NTERACT_WHEEL_BOUNDARY = "nteract/wheelBoundary" as const;
+
+// MCP Apps-compatible methods used by embedders. Notebook rendering commands
+// remain in the nteract/* namespace.
+export const MCP_UI_HOST_CONTEXT_CHANGED = "ui/notifications/host-context-changed" as const;
+export const MCP_UI_SIZE_CHANGED = "ui/notifications/size-changed" as const;
+export const MCP_UI_RESOURCE_TEARDOWN = "ui/resource-teardown" as const;
+export const MCP_NOTIFICATIONS_MESSAGE = "notifications/message" as const;
 
 // ── Host → Iframe: Request Params & Results ─────────────────────────
 
@@ -171,4 +180,19 @@ export interface NteractDiagnosticParams {
   phase: string;
   level?: "debug" | "info" | "warn" | "error";
   details?: Record<string, unknown>;
+}
+
+export interface McpUiSizeChangedParams {
+  width?: number;
+  height?: number;
+}
+
+export interface McpUiResourceTeardownParams {
+  reason?: string;
+}
+
+export interface McpNotificationMessageParams {
+  level?: "debug" | "info" | "notice" | "warning" | "error" | "critical" | "alert" | "emergency";
+  logger?: string;
+  data?: unknown;
 }

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -22,8 +22,12 @@ import {
   logIsolatedDiagnostic,
   type IsolatedDiagnosticLevel,
 } from "@/components/isolated/diagnostics";
+import type { NteractEmbedHostContext } from "@/components/isolated/host-context";
 import { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
 import {
+  MCP_UI_HOST_CONTEXT_CHANGED,
+  MCP_UI_RESOURCE_TEARDOWN,
+  MCP_UI_SIZE_CHANGED,
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_DIAGNOSTIC,
   NTERACT_INSTALL_RENDERER,
@@ -190,6 +194,88 @@ function updateDocumentTheme(isDark: boolean, colorTheme?: string | null) {
   }
 }
 
+let currentHostContext: NteractEmbedHostContext = {};
+let hostFontStyle: HTMLStyleElement | null = null;
+
+function applyHostContext(contextPatch: Partial<NteractEmbedHostContext>) {
+  currentHostContext = {
+    ...currentHostContext,
+    ...contextPatch,
+    styles: {
+      ...currentHostContext.styles,
+      ...contextPatch.styles,
+      variables: {
+        ...currentHostContext.styles?.variables,
+        ...contextPatch.styles?.variables,
+      },
+      css: {
+        ...currentHostContext.styles?.css,
+        ...contextPatch.styles?.css,
+      },
+    },
+    nteract: {
+      ...currentHostContext.nteract,
+      ...contextPatch.nteract,
+    },
+    deviceCapabilities: {
+      ...currentHostContext.deviceCapabilities,
+      ...contextPatch.deviceCapabilities,
+    },
+    safeAreaInsets: {
+      ...currentHostContext.safeAreaInsets,
+      ...contextPatch.safeAreaInsets,
+    } as NteractEmbedHostContext["safeAreaInsets"],
+  };
+
+  const isDark =
+    currentHostContext.theme === "dark"
+      ? true
+      : currentHostContext.theme === "light"
+        ? false
+        : undefined;
+  const colorTheme = currentHostContext.nteract?.colorTheme;
+  if (isDark !== undefined || colorTheme !== undefined) {
+    updateDocumentTheme(isDark ?? document.documentElement.classList.contains("dark"), colorTheme);
+  }
+
+  const root = document.documentElement;
+  const variables = currentHostContext.styles?.variables;
+  if (variables) {
+    for (const [key, value] of Object.entries(variables)) {
+      root.style.setProperty(key, value);
+    }
+  }
+
+  const fonts = currentHostContext.styles?.css?.fonts;
+  if (fonts && fonts.length > 0) {
+    if (!hostFontStyle) {
+      hostFontStyle = document.createElement("style");
+      hostFontStyle.setAttribute("data-nteract-host-fonts", "true");
+      document.head.appendChild(hostFontStyle);
+    }
+    hostFontStyle.textContent = fonts;
+  } else if (fonts === "" && hostFontStyle) {
+    hostFontStyle.remove();
+    hostFontStyle = null;
+  }
+
+  const dimensions = currentHostContext.containerDimensions;
+  if (dimensions?.width) {
+    root.style.setProperty("--nteract-host-width", `${dimensions.width}px`);
+  }
+  if (dimensions?.maxWidth) {
+    root.style.setProperty("--nteract-host-max-width", `${dimensions.maxWidth}px`);
+  }
+  if (dimensions?.height) {
+    root.style.setProperty("--nteract-host-height", `${dimensions.height}px`);
+  }
+  if (dimensions?.maxHeight) {
+    root.style.setProperty("--nteract-host-max-height", `${dimensions.maxHeight}px`);
+  }
+
+  window.dispatchEvent(new Event("resize"));
+}
+
 // --- Message Handling ---
 
 // Global transport for JSON-RPC communication with host
@@ -240,6 +326,19 @@ function renderedRootDetails(expectedOutputCount?: number): Record<string, unkno
   };
 }
 
+function measureDocumentWidth(): number {
+  const doc = document.documentElement;
+  const body = document.body;
+  return Math.ceil(
+    Math.max(
+      body ? body.scrollWidth : 0,
+      body ? body.offsetWidth : 0,
+      doc ? doc.scrollWidth : 0,
+      doc ? doc.offsetWidth : 0,
+    ),
+  );
+}
+
 function emitPostPaintRenderDiagnostic(expectedOutputCount?: number): void {
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
@@ -268,6 +367,10 @@ function postMeasuredHeight(
     },
     "*",
   );
+  rpcTransport?.notify(MCP_UI_SIZE_CHANGED, {
+    width: measureDocumentWidth(),
+    height,
+  });
   if (type === "render_complete") {
     emitPostPaintRenderDiagnostic(expectedOutputCount);
   }
@@ -310,6 +413,21 @@ function setupMessageListener() {
   });
   rpcTransport.onNotification(NTERACT_THEME, (params) => {
     messageHandler?.("theme", params);
+  });
+  rpcTransport.onNotification(MCP_UI_HOST_CONTEXT_CHANGED, (params) => {
+    messageHandler?.("hostContext", params);
+  });
+  rpcTransport.onRequest(MCP_UI_RESOURCE_TEARDOWN, (params) => {
+    const reason =
+      typeof params === "object" && params && "reason" in params
+        ? String((params as { reason?: unknown }).reason ?? "unknown")
+        : "unknown";
+    emitRendererDiagnostic("resource-teardown", { reason, protocol: "mcp-ui" });
+    for (const timer of layoutPulseTimers) {
+      window.clearTimeout(timer);
+    }
+    layoutPulseTimers = [];
+    return {};
   });
   rpcTransport.onNotification(NTERACT_INSTALL_RENDERER, (params) => {
     const { code, css } = params as { code: string; css?: string };
@@ -366,6 +484,10 @@ function setupMessageListener() {
           "error",
         );
       }
+      return;
+    }
+    if (type === "host_context") {
+      messageHandler?.("hostContext", payload);
       return;
     }
     if (messageHandler) {
@@ -461,7 +583,21 @@ function IsolatedRendererApp() {
             ...prev,
             isDark: themePayload.isDark ?? prev.isDark,
           }));
-          updateDocumentTheme(themePayload.isDark ?? state.isDark, themePayload.colorTheme);
+          updateDocumentTheme(
+            themePayload.isDark ?? document.documentElement.classList.contains("dark"),
+            themePayload.colorTheme,
+          );
+        }
+        break;
+      }
+      case "hostContext": {
+        const hostContext = payload as Partial<NteractEmbedHostContext>;
+        applyHostContext(hostContext);
+        if (hostContext.theme === "light" || hostContext.theme === "dark") {
+          setState((prev) => ({
+            ...prev,
+            isDark: hostContext.theme === "dark",
+          }));
         }
         break;
       }


### PR DESCRIPTION
## Summary

- add an MCP Apps-shaped nteract embed host context for theme, style variables, fonts, display mode, container dimensions, locale/timezone/platform/device metadata, and nteract-specific color theme
- propagate host context into isolated output iframes through the legacy bootstrap path and JSON-RPC `ui/notifications/host-context-changed`
- support MCP Apps-style `ui/notifications/size-changed`, `ui/resource-teardown`, and `notifications/message` alongside existing `nteract/*` notebook/rendering methods
- keep transport teardown tied to actual unmounts so preloaded output frames can move from `code-Out[*]` to execution-counted names without losing plugin/render state
- add renderer-test browser coverage for host-context propagation and live theme updates

## Verification

- `cargo xtask wasm`
- `pnpm test:run src/components/isolated/__tests__/host-context.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/frame-html-jsonrpc.test.ts src/components/isolated/__tests__/frame-bridge.test.ts src/components/isolated/__tests__/rpc-methods.test.ts`
- `pnpm test:run src/components/isolated/__tests__/isolated-frame.test.ts`
- `pnpm --filter notebook-ui exec tsc --noEmit`
- `pnpm --filter renderer-test test:e2e`
- `pnpm --filter notebook-ui test:e2e:browser -- isolated-rich-output.spec.ts`
- `cargo xtask lint --fix`

## Notes

This keeps notebook execution and rendering operations under `nteract/*`. The MCP-compatible methods here are only the host/iframe embedding lifecycle surface, matching the plan to make nteract easy to embed elsewhere without pretending notebook output is an MCP tool result.
