### PR TITLE
fix(isolated): tighten host context cleanup

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d9b3147cd3eebdcccdbada12c9a280eb1d9e9366a8e1964654cba0b294ec641
-size 1480503
+oid sha256:380e21d0527f5750a7b30f24b8a4549b9337a4cab78fe14e948989414e7e8e3f
+size 1480822

--- a/src/components/isolated/__tests__/host-context.test.ts
+++ b/src/components/isolated/__tests__/host-context.test.ts
@@ -78,4 +78,27 @@ describe("nteract embed host context", () => {
     });
     expect(merged.styles?.css?.fonts).toContain("font-family: Test");
   });
+
+  it("fills partial safe-area patches with prior values and zero defaults", () => {
+    const merged = mergeNteractEmbedHostContext(
+      {
+        safeAreaInsets: {
+          top: 12,
+          bottom: 4,
+        },
+      },
+      {
+        safeAreaInsets: {
+          left: 8,
+        },
+      },
+    );
+
+    expect(merged.safeAreaInsets).toEqual({
+      top: 12,
+      right: 0,
+      bottom: 4,
+      left: 8,
+    });
+  });
 });

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -179,6 +179,50 @@ describe("IsolatedFrame theme updates", () => {
     });
   });
 
+  it("does not resend an unchanged host context when parent prop identity changes", async () => {
+    const makeHostContext = (color: string) => ({
+      styles: {
+        variables: {
+          "--nteract-test-token": color,
+        },
+      },
+    });
+    const { container, rerender } = render(
+      <IsolatedFrame darkMode={false} hostContext={makeHostContext("same")} />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const iframeWindow = iframe.contentWindow as Window;
+
+    dispatchIframeReady(iframeWindow);
+
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    act(() => {
+      transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+    });
+
+    await waitFor(() => {
+      expect(
+        transport.notify.mock.calls.filter(([method]) => method === MCP_UI_HOST_CONTEXT_CHANGED),
+      ).toHaveLength(1);
+    });
+
+    rerender(<IsolatedFrame darkMode={false} hostContext={makeHostContext("same")} />);
+
+    expect(
+      transport.notify.mock.calls.filter(([method]) => method === MCP_UI_HOST_CONTEXT_CHANGED),
+    ).toHaveLength(1);
+
+    rerender(<IsolatedFrame darkMode={false} hostContext={makeHostContext("changed")} />);
+
+    await waitFor(() => {
+      expect(
+        transport.notify.mock.calls.filter(([method]) => method === MCP_UI_HOST_CONTEXT_CHANGED),
+      ).toHaveLength(2);
+    });
+  });
+
   it("keeps the JSON-RPC transport alive when frame diagnostics props change", () => {
     const { container, rerender, unmount } = render(
       <IsolatedFrame darkMode={false} name="code-Out[*]" />,

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -1,4 +1,4 @@
-import type { NteractEmbedHostContext } from "./host-context";
+import type { NteractEmbedHostContextPatch } from "./host-context";
 
 export interface EvalMessage {
   type: "eval";
@@ -88,7 +88,7 @@ export interface ThemeMessage {
  */
 export interface HostContextMessage {
   type: "host_context";
-  payload: Partial<NteractEmbedHostContext>;
+  payload: NteractEmbedHostContextPatch;
 }
 
 /**

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -550,6 +550,8 @@
           }
 
           var fonts = context.styles && context.styles.css && context.styles.css.fonts;
+          // Keep font-style handling in sync with src/isolated-renderer/index.tsx
+          // for the React renderer path.
           if (typeof fonts === "string" && fonts.length > 0) {
             if (!hostFontStyle) {
               hostFontStyle = document.createElement("style");
@@ -588,6 +590,9 @@
             );
           }
 
+          // Renderer bundles may size themselves from host-context CSS variables.
+          // Parent-side height and width guards are load-bearing: this resize
+          // must not create an unbounded host-context <-> size-changed loop.
           window.dispatchEvent(new Event("resize"));
         }
 

--- a/src/components/isolated/host-context.ts
+++ b/src/components/isolated/host-context.ts
@@ -43,6 +43,13 @@ export interface NteractEmbedHostContext {
   };
 }
 
+export type NteractEmbedHostContextPatch = Omit<
+  Partial<NteractEmbedHostContext>,
+  "safeAreaInsets"
+> & {
+  safeAreaInsets?: Partial<NteractEmbedSafeAreaInsets>;
+};
+
 export interface CreateNteractEmbedHostContextOptions {
   isDark: boolean;
   colorTheme?: string | null;
@@ -52,7 +59,7 @@ export interface CreateNteractEmbedHostContextOptions {
   userAgent?: string;
   platform?: NteractEmbedPlatform;
   deviceCapabilities?: NteractEmbedDeviceCapabilities;
-  safeAreaInsets?: NteractEmbedSafeAreaInsets;
+  safeAreaInsets?: Partial<NteractEmbedSafeAreaInsets>;
 }
 
 interface ThemePalette {
@@ -74,6 +81,12 @@ const OUTPUT_UI_FONT =
 const OUTPUT_MONO_FONT = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace';
 const OUTPUT_DOCUMENT_FONT = "var(--output-ui-font)";
 const CREAM_DOCUMENT_FONT = 'KaTeX_Main, Georgia, "Times New Roman", serif';
+const DEFAULT_SAFE_AREA_INSETS: NteractEmbedSafeAreaInsets = {
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+};
 
 function themePalette(isDark: boolean, colorTheme?: string | null): ThemePalette {
   const isCream = colorTheme === "cream";
@@ -157,6 +170,18 @@ function hostDeviceCapabilities(): NteractEmbedDeviceCapabilities {
   };
 }
 
+function mergeSafeAreaInsets(
+  previous: NteractEmbedSafeAreaInsets | undefined,
+  next: Partial<NteractEmbedSafeAreaInsets> | undefined,
+): NteractEmbedSafeAreaInsets {
+  return {
+    top: next?.top ?? previous?.top ?? DEFAULT_SAFE_AREA_INSETS.top,
+    right: next?.right ?? previous?.right ?? DEFAULT_SAFE_AREA_INSETS.right,
+    bottom: next?.bottom ?? previous?.bottom ?? DEFAULT_SAFE_AREA_INSETS.bottom,
+    left: next?.left ?? previous?.left ?? DEFAULT_SAFE_AREA_INSETS.left,
+  };
+}
+
 export function createNteractThemeVariables(
   isDark: boolean,
   colorTheme?: string | null,
@@ -225,7 +250,7 @@ export function createNteractEmbedHostContext({
     userAgent: userAgent ?? hostUserAgent(),
     platform: platform ?? hostPlatform(),
     deviceCapabilities: deviceCapabilities ?? hostDeviceCapabilities(),
-    safeAreaInsets: safeAreaInsets ?? { top: 0, right: 0, bottom: 0, left: 0 },
+    safeAreaInsets: mergeSafeAreaInsets(undefined, safeAreaInsets),
     nteract: {
       colorTheme: colorTheme ?? null,
     },
@@ -233,7 +258,7 @@ export function createNteractEmbedHostContext({
 }
 
 export function mergeNteractEmbedHostContext(
-  ...contexts: Array<Partial<NteractEmbedHostContext> | null | undefined>
+  ...contexts: Array<NteractEmbedHostContextPatch | null | undefined>
 ): NteractEmbedHostContext {
   const merged: NteractEmbedHostContext = {};
 
@@ -268,10 +293,7 @@ export function mergeNteractEmbedHostContext(
     }
 
     if (context.safeAreaInsets) {
-      merged.safeAreaInsets = {
-        ...previousSafeAreaInsets,
-        ...context.safeAreaInsets,
-      } as NteractEmbedSafeAreaInsets;
+      merged.safeAreaInsets = mergeSafeAreaInsets(previousSafeAreaInsets, context.safeAreaInsets);
     }
 
     if (context.nteract) {

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -38,6 +38,7 @@ export type {
   NteractEmbedDeviceCapabilities,
   NteractEmbedDisplayMode,
   NteractEmbedHostContext,
+  NteractEmbedHostContextPatch,
   NteractEmbedPlatform,
   NteractEmbedSafeAreaInsets,
   NteractEmbedTheme,

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -11,7 +11,11 @@ import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from
 import { isIframeMessage } from "./frame-bridge";
 import { logIsolatedDiagnostic, rendererBundleDetails } from "./diagnostics";
 import { generateFrameHtml } from "./frame-html";
-import type { NteractEmbedContainerDimensions, NteractEmbedHostContext } from "./host-context";
+import type {
+  NteractEmbedContainerDimensions,
+  NteractEmbedHostContext,
+  NteractEmbedHostContextPatch,
+} from "./host-context";
 import { createNteractEmbedHostContext, mergeNteractEmbedHostContext } from "./host-context";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
 import { JsonRpcTransport } from "./jsonrpc-transport";
@@ -87,7 +91,7 @@ export interface IsolatedFrameProps {
    * mirrors MCP Apps HostContext so external hosts can embed nteract with
    * minimal theming and sizing glue.
    */
-  hostContext?: Partial<NteractEmbedHostContext>;
+  hostContext?: NteractEmbedHostContextPatch;
 
   /**
    * Minimum height of the iframe in pixels.
@@ -219,7 +223,7 @@ export interface IsolatedFrameHandle {
   /**
    * Merge host-context fields into the iframe's current embed context.
    */
-  setHostContext: (hostContext: Partial<NteractEmbedHostContext>) => void;
+  setHostContext: (hostContext: NteractEmbedHostContextPatch) => void;
 
   /**
    * Clear all content in the iframe.
@@ -334,6 +338,21 @@ function diagnosticLevelFromMcpLog(level: string | undefined): "debug" | "info" 
   return "debug";
 }
 
+function stableHostContextKey(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableHostContextKey).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries
+      .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableHostContextKey(entryValue)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 /**
  * IsolatedFrame component - Renders untrusted content in a secure iframe.
  *
@@ -415,9 +434,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const [containerDimensions, setContainerDimensions] = useState<
       NteractEmbedContainerDimensions | undefined
     >(undefined);
-    const [imperativeHostContext, setImperativeHostContext] = useState<
-      Partial<NteractEmbedHostContext>
-    >({});
+    const [imperativeHostContext, setImperativeHostContext] =
+      useState<NteractEmbedHostContextPatch>({});
+    const lastHostContextDeliveryRef = useRef<{
+      channel: "legacy" | "rpc";
+      key: string;
+    } | null>(null);
     // Track if content has been rendered (for revealOnRender mode)
     const [isContentRendered, setIsContentRendered] = useState(false);
     // Track if the iframe is reloading (DOM move caused browser to tear down)
@@ -554,6 +576,14 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
 
     const notifyHostContext = useCallback(
       (context: NteractEmbedHostContext) => {
+        const channel = rpcRef.current && isReadyRef.current ? "rpc" : "legacy";
+        const key = stableHostContextKey(context);
+        const lastDelivery = lastHostContextDeliveryRef.current;
+        if (lastDelivery?.channel === channel && lastDelivery.key === key) {
+          return;
+        }
+        lastHostContextDeliveryRef.current = { channel, key };
+
         if (rpcRef.current && isReadyRef.current) {
           rpcRef.current.notify(MCP_UI_HOST_CONTEXT_CHANGED, context);
         } else {
@@ -673,6 +703,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             const isReload = hasReceivedReadyRef.current;
             hasReceivedReadyRef.current = true;
             frameGenerationRef.current += 1;
+            lastHostContextDeliveryRef.current = null;
             logFrameDiagnostic("bootstrap-ready", {
               isReload,
               ...rendererBundleDetails(rendererCode, rendererCss),
@@ -1068,7 +1099,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         },
         setTheme: (isDark: boolean, colorTheme?: string | null) =>
           send({ type: "theme", payload: { isDark, colorTheme } }),
-        setHostContext: (nextHostContext: Partial<NteractEmbedHostContext>) => {
+        setHostContext: (nextHostContext: NteractEmbedHostContextPatch) => {
           setImperativeHostContext((prev) => mergeNteractEmbedHostContext(prev, nextHostContext));
         },
         clear: () => send({ type: "clear" }),

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -22,7 +22,11 @@ import {
   logIsolatedDiagnostic,
   type IsolatedDiagnosticLevel,
 } from "@/components/isolated/diagnostics";
-import type { NteractEmbedHostContext } from "@/components/isolated/host-context";
+import type {
+  NteractEmbedHostContext,
+  NteractEmbedHostContextPatch,
+} from "@/components/isolated/host-context";
+import { mergeNteractEmbedHostContext } from "@/components/isolated/host-context";
 import { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
 import {
   MCP_UI_HOST_CONTEXT_CHANGED,
@@ -197,35 +201,8 @@ function updateDocumentTheme(isDark: boolean, colorTheme?: string | null) {
 let currentHostContext: NteractEmbedHostContext = {};
 let hostFontStyle: HTMLStyleElement | null = null;
 
-function applyHostContext(contextPatch: Partial<NteractEmbedHostContext>) {
-  currentHostContext = {
-    ...currentHostContext,
-    ...contextPatch,
-    styles: {
-      ...currentHostContext.styles,
-      ...contextPatch.styles,
-      variables: {
-        ...currentHostContext.styles?.variables,
-        ...contextPatch.styles?.variables,
-      },
-      css: {
-        ...currentHostContext.styles?.css,
-        ...contextPatch.styles?.css,
-      },
-    },
-    nteract: {
-      ...currentHostContext.nteract,
-      ...contextPatch.nteract,
-    },
-    deviceCapabilities: {
-      ...currentHostContext.deviceCapabilities,
-      ...contextPatch.deviceCapabilities,
-    },
-    safeAreaInsets: {
-      ...currentHostContext.safeAreaInsets,
-      ...contextPatch.safeAreaInsets,
-    } as NteractEmbedHostContext["safeAreaInsets"],
-  };
+function applyHostContext(contextPatch: NteractEmbedHostContextPatch) {
+  currentHostContext = mergeNteractEmbedHostContext(currentHostContext, contextPatch);
 
   const isDark =
     currentHostContext.theme === "dark"
@@ -247,6 +224,8 @@ function applyHostContext(contextPatch: Partial<NteractEmbedHostContext>) {
   }
 
   const fonts = currentHostContext.styles?.css?.fonts;
+  // Keep font-style handling in sync with the bootstrap implementation in
+  // src/components/isolated/frame.html for pre-React renderer delivery.
   if (fonts && fonts.length > 0) {
     if (!hostFontStyle) {
       hostFontStyle = document.createElement("style");
@@ -273,6 +252,9 @@ function applyHostContext(contextPatch: Partial<NteractEmbedHostContext>) {
     root.style.setProperty("--nteract-host-max-height", `${dimensions.maxHeight}px`);
   }
 
+  // Renderer plugins may size themselves from host-context CSS variables.
+  // Parent-side height and width guards are load-bearing: this resize must not
+  // create an unbounded host-context <-> size-changed feedback loop.
   window.dispatchEvent(new Event("resize"));
 }
 
@@ -591,7 +573,7 @@ function IsolatedRendererApp() {
         break;
       }
       case "hostContext": {
-        const hostContext = payload as Partial<NteractEmbedHostContext>;
+        const hostContext = payload as NteractEmbedHostContextPatch;
         applyHostContext(hostContext);
         if (hostContext.theme === "light" || hostContext.theme === "dark") {
           setState((prev) => ({


### PR DESCRIPTION
## Summary

- reuse the shared host-context merge helper inside the isolated renderer instead of a second ad hoc merge path
- make `safeAreaInsets` patches explicit and fill missing sides from prior values or zero defaults
- suppress duplicate host-context notifications when a parent passes a fresh but equivalent `hostContext` prop object
- document the synthetic iframe resize invariant and keep bootstrap/React font-style handling called out as paired paths

## Verification

- `pnpm test:run src/components/isolated/__tests__/host-context.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/frame-html-jsonrpc.test.ts`
- `pnpm --filter notebook-ui exec tsc --noEmit`
- `cargo xtask wasm`
- `pnpm --filter renderer-test test:e2e`
- `pnpm --filter notebook-ui test:e2e:browser -- isolated-rich-output.spec.ts`
- `cargo xtask lint --fix`
