### PR TITLE
refactor(isolated): share frame adapter config

### DIFF
--- a/src/components/isolated/__tests__/frame-config.test.ts
+++ b/src/components/isolated/__tests__/frame-config.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createIsolatedFrameDocument,
+  ISOLATED_FRAME_ALLOW_ATTR,
+  ISOLATED_FRAME_SANDBOX_ATTRS,
+  isTauriFrameRuntime,
+  NTERACT_FRAME_URL,
+} from "../frame-config";
+import { FRAME_HTML } from "../frame-html";
+
+describe("isolated frame config", () => {
+  it("uses srcDoc in browser-only hosts", () => {
+    expect(createIsolatedFrameDocument({ isTauriRuntime: false })).toEqual({
+      kind: "srcdoc",
+      html: FRAME_HTML,
+    });
+  });
+
+  it("uses the custom nteract-frame URL in Tauri hosts", () => {
+    expect(createIsolatedFrameDocument({ isTauriRuntime: true })).toEqual({
+      kind: "src",
+      url: NTERACT_FRAME_URL,
+    });
+  });
+
+  it("detects Tauri globals without requiring a real browser window", () => {
+    expect(isTauriFrameRuntime(undefined)).toBe(false);
+    expect(isTauriFrameRuntime({ __TAURI__: {} })).toBe(true);
+    expect(isTauriFrameRuntime({ __TAURI_INTERNALS__: {} })).toBe(true);
+  });
+
+  it("keeps the shared sandbox free of same-origin access", () => {
+    const tokens = ISOLATED_FRAME_SANDBOX_ATTRS.split(" ");
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).toContain("allow-downloads");
+    expect(tokens).not.toContain("allow-same-origin");
+    expect(tokens).not.toContain("allow-top-navigation");
+  });
+
+  it("shares the fullscreen allow policy for non-React adapters", () => {
+    expect(ISOLATED_FRAME_ALLOW_ATTR).toBe("fullscreen *");
+  });
+});

--- a/src/components/isolated/__tests__/frame-config.test.ts
+++ b/src/components/isolated/__tests__/frame-config.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../frame-config";
 import { FRAME_HTML } from "../frame-html";
 
+const EXPECTED_SANDBOX_ATTRS = "allow-scripts allow-downloads allow-forms allow-pointer-lock";
+
 describe("isolated frame config", () => {
   it("uses srcDoc in browser-only hosts", () => {
     expect(createIsolatedFrameDocument({ isTauriRuntime: false })).toEqual({
@@ -30,6 +32,8 @@ describe("isolated frame config", () => {
   });
 
   it("keeps the shared sandbox free of same-origin access", () => {
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).toBe(EXPECTED_SANDBOX_ATTRS);
+
     const tokens = ISOLATED_FRAME_SANDBOX_ATTRS.split(" ");
     expect(tokens).toContain("allow-scripts");
     expect(tokens).toContain("allow-downloads");
@@ -37,7 +41,10 @@ describe("isolated frame config", () => {
     expect(tokens).not.toContain("allow-top-navigation");
   });
 
-  it("shares the fullscreen allow policy for non-React adapters", () => {
-    expect(ISOLATED_FRAME_ALLOW_ATTR).toBe("fullscreen *");
+  it("allows fullscreen in the shared iframe allow policy", () => {
+    const directives = ISOLATED_FRAME_ALLOW_ATTR.split(/\s+/);
+
+    expect(directives).toContain("fullscreen");
+    expect(directives).toContain("*");
   });
 });

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -40,6 +40,7 @@ vi.mock("../jsonrpc-transport", () => ({
 }));
 
 vi.mock("../frame-html", () => ({
+  FRAME_HTML: "<!DOCTYPE html><html><body></body></html>",
   generateFrameHtml: vi.fn(() => "<!DOCTYPE html><html><body></body></html>"),
 }));
 

--- a/src/components/isolated/__tests__/isolated-frame.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame.test.ts
@@ -19,19 +19,8 @@ vi.mock("../isolated-renderer-context", () => ({
   }),
 }));
 
+import { ISOLATED_FRAME_SANDBOX_ATTRS } from "../frame-config";
 import { IsolatedFrame } from "../isolated-frame";
-
-/**
- * The sandbox attributes string from isolated-frame.tsx.
- * We duplicate it here to test against - if the source changes,
- * this test will catch discrepancies.
- */
-const EXPECTED_SANDBOX_ATTRS = [
-  "allow-scripts",
-  "allow-downloads",
-  "allow-forms",
-  "allow-pointer-lock",
-].join(" ");
 
 describe("iframe sandbox security", () => {
   /**
@@ -45,7 +34,7 @@ describe("iframe sandbox security", () => {
    * This would completely break the security model.
    */
   it("sandbox does NOT include allow-same-origin", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-same-origin");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).not.toContain("allow-same-origin");
   });
 
   it("rendered iframe sandbox does NOT include allow-same-origin", () => {
@@ -58,39 +47,39 @@ describe("iframe sandbox security", () => {
   });
 
   it("sandbox includes allow-scripts (required for widgets)", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).toContain("allow-scripts");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).toContain("allow-scripts");
   });
 
   it("sandbox does NOT include allow-popups", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-popups");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).not.toContain("allow-popups");
   });
 
   it("sandbox does NOT include allow-modals", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-modals");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).not.toContain("allow-modals");
   });
 
   /**
    * Verify we're not accidentally including dangerous permissions.
    */
   it("sandbox does NOT include allow-top-navigation", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-top-navigation");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).not.toContain("allow-top-navigation");
   });
 
   it("sandbox does NOT include allow-top-navigation-by-user-activation", () => {
-    expect(EXPECTED_SANDBOX_ATTRS).not.toContain("allow-top-navigation-by-user-activation");
+    expect(ISOLATED_FRAME_SANDBOX_ATTRS).not.toContain("allow-top-navigation-by-user-activation");
   });
 });
 
 describe("sandbox attribute format", () => {
   it("is a space-separated string", () => {
-    const parts = EXPECTED_SANDBOX_ATTRS.split(" ");
+    const parts = ISOLATED_FRAME_SANDBOX_ATTRS.split(" ");
     expect(parts.length).toBeGreaterThan(0);
     // No empty parts (no double spaces)
     expect(parts.every((p) => p.length > 0)).toBe(true);
   });
 
   it("all parts start with 'allow-'", () => {
-    const parts = EXPECTED_SANDBOX_ATTRS.split(" ");
+    const parts = ISOLATED_FRAME_SANDBOX_ATTRS.split(" ");
     expect(parts.every((p) => p.startsWith("allow-"))).toBe(true);
   });
 });

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -1,4 +1,4 @@
-import { generateFrameHtml } from "./frame-html";
+import { FRAME_HTML } from "./frame-html";
 
 /**
  * Physical frame resource used by the Tauri app.
@@ -48,5 +48,5 @@ export function createIsolatedFrameDocument(options?: {
   if (options?.isTauriRuntime ?? isTauriFrameRuntime()) {
     return { kind: "src", url: NTERACT_FRAME_URL };
   }
-  return { kind: "srcdoc", html: generateFrameHtml() };
+  return { kind: "srcdoc", html: FRAME_HTML };
 }

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -1,0 +1,52 @@
+import { generateFrameHtml } from "./frame-html";
+
+/**
+ * Physical frame resource used by the Tauri app.
+ *
+ * Browser-only development uses srcDoc so local Vite can serve the parent app
+ * without also registering the custom scheme.
+ */
+export const NTERACT_FRAME_URL = "nteract-frame://localhost/";
+
+/**
+ * Sandbox attributes for the isolated iframe.
+ *
+ * CRITICAL: Do NOT include 'allow-same-origin' - this would give the iframe
+ * access to the parent's origin and Tauri APIs.
+ */
+export const ISOLATED_FRAME_SANDBOX_ATTRS = [
+  "allow-scripts", // Required for rendering interactive content
+  "allow-downloads", // Allow file downloads (e.g., from widgets)
+  "allow-forms", // Allow form submissions
+  "allow-pointer-lock", // For interactive visualizations
+  // Fullscreen for sift maximize, maps, 3D, etc. is enabled via the
+  // separate `allowFullScreen` iframe attribute (not a sandbox flag).
+].join(" ");
+
+export const ISOLATED_FRAME_ALLOW_ATTR = "fullscreen *";
+
+export type IsolatedFrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
+
+export interface TauriFrameGlobal {
+  __TAURI__?: unknown;
+  __TAURI_INTERNALS__?: unknown;
+}
+
+export function isTauriFrameRuntime(
+  globalWindow: TauriFrameGlobal | undefined = typeof window === "undefined"
+    ? undefined
+    : (window as Window & TauriFrameGlobal),
+): boolean {
+  return Boolean(
+    globalWindow && ("__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow),
+  );
+}
+
+export function createIsolatedFrameDocument(options?: {
+  isTauriRuntime?: boolean;
+}): IsolatedFrameDocument {
+  if (options?.isTauriRuntime ?? isTauriFrameRuntime()) {
+    return { kind: "src", url: NTERACT_FRAME_URL };
+  }
+  return { kind: "srcdoc", html: generateFrameHtml() };
+}

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -26,6 +26,14 @@ export type {
   WidgetUpdateMessage,
 } from "./frame-bridge";
 export { isIframeMessage, isMessageType } from "./frame-bridge";
+export {
+  createIsolatedFrameDocument,
+  ISOLATED_FRAME_ALLOW_ATTR,
+  ISOLATED_FRAME_SANDBOX_ATTRS,
+  isTauriFrameRuntime,
+  NTERACT_FRAME_URL,
+} from "./frame-config";
+export type { IsolatedFrameDocument } from "./frame-config";
 // HTML template generator
 export { FRAME_HTML, generateFrameHtml } from "./frame-html";
 export {

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -158,6 +158,13 @@ export class IsolatedFrameRuntime {
     return this.iframeReady;
   }
 
+  /**
+   * Marks this runtime as live for an adapter mount.
+   *
+   * React dev StrictMode can run effect cleanup and setup again without
+   * discarding refs. Adapters should call activate() during mount/setup before
+   * letting frame messages reach the runtime, then dispose() during cleanup.
+   */
   activate(): void {
     this.disposed = false;
   }
@@ -212,7 +219,11 @@ export class IsolatedFrameRuntime {
     if (this.disposed) {
       return;
     }
-    const channel = this.transport && this.ready ? "rpc" : "legacy";
+    // Host context waits for the React renderer because the bootstrap document
+    // handles only the simple theme/style subset. The renderer owns the richer
+    // MCP Apps-shaped context application.
+    const transport = this.rendererTransport();
+    const channel = transport ? "rpc" : "legacy";
     const key = stableHostContextKey(context);
     const lastDelivery = this.lastHostContextDelivery;
     if (lastDelivery?.channel === channel && lastDelivery.key === key) {
@@ -220,8 +231,8 @@ export class IsolatedFrameRuntime {
     }
     this.lastHostContextDelivery = { channel, key };
 
-    if (this.transport && this.ready) {
-      this.transport.notify(MCP_UI_HOST_CONTEXT_CHANGED, context);
+    if (transport) {
+      transport.notify(MCP_UI_HOST_CONTEXT_CHANGED, context);
     } else {
       this.postLegacy({ type: "host_context", payload: context });
     }
@@ -324,6 +335,10 @@ export class IsolatedFrameRuntime {
     return true;
   }
 
+  /**
+   * Gracefully tears down the active iframe resource and stops message
+   * delivery. Safe to call more than once.
+   */
   dispose(): void {
     if (this.disposed) {
       return;
@@ -355,6 +370,10 @@ export class IsolatedFrameRuntime {
       })
       .finally(stopTransport);
     window.setTimeout(stopTransport, 100);
+  }
+
+  private rendererTransport(): JsonRpcTransport | null {
+    return this.ready ? this.transport : null;
   }
 
   private deliver(message: ParentToIframeMessage): void {
@@ -604,6 +623,8 @@ export class IsolatedFrameRuntime {
     if (
       this.disposed ||
       this.rendererReadyChannels.has(channel) ||
+      // RPC ready is tied to a specific transport generation. A delayed
+      // notification from an old iframe must not mark the current iframe ready.
       (channel === "rpc" && transport !== this.transport)
     ) {
       return;
@@ -620,6 +641,9 @@ export class IsolatedFrameRuntime {
     }
 
     const initialContent = this.getInitialContent();
+    // Initial content is sent on the first ready channel, then sent again if
+    // JSON-RPC arrives after legacy ready so the React renderer takes over from
+    // the bootstrap renderer with the same content.
     if (initialContent && (!wasReady || channel === "rpc")) {
       if (channel === "rpc" && transport) {
         transport.notify(NTERACT_RENDER_OUTPUT, initialContent);
@@ -628,6 +652,8 @@ export class IsolatedFrameRuntime {
       }
     }
     if (!wasReady) {
+      // Pending messages are flushed only for the first ready channel. After
+      // that, send() delivers directly through the active channel.
       this.flushPending();
     }
   }

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -9,7 +9,12 @@ import {
 } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
 import { logIsolatedDiagnostic } from "./diagnostics";
-import { generateFrameHtml } from "./frame-html";
+import {
+  createIsolatedFrameDocument,
+  ISOLATED_FRAME_ALLOW_ATTR,
+  ISOLATED_FRAME_SANDBOX_ATTRS,
+  type IsolatedFrameDocument,
+} from "./frame-config";
 import type { NteractEmbedContainerDimensions, NteractEmbedHostContextPatch } from "./host-context";
 import { createNteractEmbedHostContext, mergeNteractEmbedHostContext } from "./host-context";
 import { IsolatedFrameRuntime } from "./isolated-frame-runtime";
@@ -213,31 +218,6 @@ export interface IsolatedFrameHandle {
   isIframeReady: boolean;
 }
 
-/**
- * Sandbox attributes for the isolated iframe.
- *
- * CRITICAL: Do NOT include 'allow-same-origin' - this would give the iframe
- * access to the parent's origin and Tauri APIs.
- */
-const SANDBOX_ATTRS = [
-  "allow-scripts", // Required for rendering interactive content
-  "allow-downloads", // Allow file downloads (e.g., from widgets)
-  "allow-forms", // Allow form submissions
-  "allow-pointer-lock", // For interactive visualizations
-  // Fullscreen for sift maximize, maps, 3D, etc. is enabled via the
-  // separate `allowFullScreen` iframe attribute (not a sandbox flag).
-].join(" ");
-
-type FrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
-
-function isTauriRuntime(): boolean {
-  const globalWindow = window as Window & {
-    __TAURI__?: unknown;
-    __TAURI_INTERNALS__?: unknown;
-  };
-  return "__TAURI_INTERNALS__" in globalWindow || "__TAURI__" in globalWindow;
-}
-
 function iframeContainerDimensions(
   iframe: HTMLIFrameElement | null,
   autoHeight: boolean,
@@ -336,7 +316,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const runtimeRef = useRef<IsolatedFrameRuntime | null>(null);
     const initialContentRef = useRef(initialContent);
     const applyMeasuredHeightRef = useRef<(contentHeight: number) => void>(() => {});
-    const [frameDocument, setFrameDocument] = useState<FrameDocument | null>(null);
+    const [frameDocument, setFrameDocument] = useState<IsolatedFrameDocument | null>(null);
     // Track iframe ready (bootstrap HTML loaded)
     const [isIframeReady, setIsIframeReady] = useState(false);
     // Track renderer ready (React bundle initialized)
@@ -485,14 +465,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       applyMeasuredHeight(measuredHeightRef.current);
     }, [applyMeasuredHeight]);
 
-    // Create frame document on mount. Tauri loads from a custom scheme so the
-    // iframe receives its own CSP; browser-only dev keeps srcDoc.
+    // Create frame document on mount. The shared config keeps React, future
+    // non-React adapters, and tests on the same source/sandbox contract.
     useEffect(() => {
-      if (isTauriRuntime()) {
-        setFrameDocument({ kind: "src", url: "nteract-frame://localhost/" });
-      } else {
-        setFrameDocument({ kind: "srcdoc", html: generateFrameHtml() });
-      }
+      setFrameDocument(createIsolatedFrameDocument());
     }, []);
 
     useEffect(() => {
@@ -644,9 +620,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         name={name}
         src={frameDocument.kind === "src" ? frameDocument.url : undefined}
         srcDoc={frameDocument.kind === "srcdoc" ? frameDocument.html : undefined}
-        sandbox={SANDBOX_ATTRS}
+        sandbox={ISOLATED_FRAME_SANDBOX_ATTRS}
         allowFullScreen
-        allow="fullscreen *"
+        allow={ISOLATED_FRAME_ALLOW_ATTR}
         className={className}
         data-slot="isolated-frame"
         style={{


### PR DESCRIPTION
## Summary

Follow-up Phase 3 runtime extraction work after #2792:

- move isolated iframe source/sandbox setup into a shared framework-neutral config module
- export the frame document/sandbox contract for non-React adapters
- keep the React component as the thin adapter that applies the shared config
- document runtime lifecycle and channel-routing invariants for future adapters
- add focused coverage for browser vs Tauri frame source selection and sandbox invariants

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-config.test.ts src/components/isolated/__tests__/isolated-frame.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
- `pnpm --filter notebook-ui exec tsc --noEmit`
- `cargo xtask lint --fix`
