### PR TITLE
refactor(isolated): retain renderer bundle in runtime

### DIFF
--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { IsolatedFrameRuntime } from "../isolated-frame-runtime";
+import type { IsolatedFrameRendererBundle } from "../isolated-frame-runtime";
 import {
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
@@ -45,7 +46,10 @@ function frameMessage(source: Window, data: unknown): MessageEvent {
   });
 }
 
-function createRuntime(initialContent?: RenderPayload) {
+function createRuntime(
+  initialContent?: RenderPayload,
+  rendererBundle?: IsolatedFrameRendererBundle,
+) {
   const frameWindow = {
     postMessage: vi.fn(),
   } as unknown as Window;
@@ -66,6 +70,7 @@ function createRuntime(initialContent?: RenderPayload) {
   const runtime = new IsolatedFrameRuntime({
     getFrameWindow: () => frameWindow,
     getInitialContent: () => initialContent,
+    rendererBundle,
     callbacks,
   });
 
@@ -88,7 +93,7 @@ describe("IsolatedFrameRuntime", () => {
     runtime.render(payload);
     expect(frameWindow.postMessage).not.toHaveBeenCalled();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
     expect(transport).toBeDefined();
     expect(transport.notify).not.toHaveBeenCalledWith(NTERACT_RENDER_OUTPUT, payload);
@@ -125,7 +130,7 @@ describe("IsolatedFrameRuntime", () => {
       "*",
     );
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
     transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
 
@@ -137,7 +142,7 @@ describe("IsolatedFrameRuntime", () => {
   it("sends theme over JSON-RPC once the bootstrap transport is available", () => {
     const { frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
 
     runtime.setTheme(true, "dark-theme");
@@ -155,12 +160,12 @@ describe("IsolatedFrameRuntime", () => {
   it("recreates transport and reports reloads on a second bootstrap ready", () => {
     const { callbacks, frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const firstTransport = MockJsonRpcTransport.instances[0];
     firstTransport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
     expect(runtime.isReady).toBe(true);
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
 
     expect(firstTransport.stop).toHaveBeenCalled();
     expect(MockJsonRpcTransport.instances).toHaveLength(2);
@@ -179,9 +184,9 @@ describe("IsolatedFrameRuntime", () => {
     };
     const { frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     runtime.render(stalePayload);
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const reloadedTransport = MockJsonRpcTransport.instances[1];
 
     reloadedTransport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
@@ -192,7 +197,7 @@ describe("IsolatedFrameRuntime", () => {
   it("ignores duplicate renderer-ready notifications for the current generation", () => {
     const { callbacks, frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
 
     transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
@@ -208,11 +213,10 @@ describe("IsolatedFrameRuntime", () => {
     };
     const { callbacks, frameWindow, runtime } = createRuntime(initialContent);
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
     runtime.handleWindowMessage(
       frameMessage(frameWindow, { type: "renderer_ready", payload: null }),
-      {},
     );
 
     expect(callbacks.onRendererReady).toHaveBeenCalledTimes(1);
@@ -230,9 +234,9 @@ describe("IsolatedFrameRuntime", () => {
   it("ignores stale renderer-ready notifications from a previous reload generation", () => {
     const { callbacks, frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const firstTransport = MockJsonRpcTransport.instances[0];
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const secondTransport = MockJsonRpcTransport.instances[1];
 
     firstTransport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
@@ -249,20 +253,14 @@ describe("IsolatedFrameRuntime", () => {
   it("injects renderer CSS and JS once per bootstrap generation", () => {
     const { callbacks, frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    runtime.setRendererBundle({
+      rendererCode: "window.__renderer = true;",
+      rendererCss: "body { color: red; }",
+    });
 
-    expect(
-      runtime.injectRendererBundle({
-        rendererCode: "window.__renderer = true;",
-        rendererCss: "body { color: red; }",
-      }),
-    ).toBe(true);
-    expect(
-      runtime.injectRendererBundle({
-        rendererCode: "window.__renderer = true;",
-        rendererCss: "body { color: red; }",
-      }),
-    ).toBe(false);
+    expect(runtime.injectRendererBundle()).toBe(true);
+    expect(runtime.injectRendererBundle()).toBe(false);
 
     expect(frameWindow.postMessage).toHaveBeenCalledTimes(2);
     expect(callbacks.onDiagnostic).toHaveBeenCalledWith(
@@ -275,10 +273,97 @@ describe("IsolatedFrameRuntime", () => {
     );
   });
 
+  it("uses the retained renderer bundle for bootstrap diagnostics and injection", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime(undefined, {
+      rendererCode: "window.__storedRenderer = true;",
+      rendererCss: "body { color: blue; }",
+    });
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+
+    expect(callbacks.onDiagnostic).toHaveBeenCalledWith(
+      "bootstrap-ready",
+      expect.objectContaining({ hasRendererCode: true, hasRendererCss: true }),
+    );
+    expect(runtime.waitingForRendererBundle()).toBe(false);
+    expect(runtime.injectRendererBundle()).toBe(true);
+    expect(frameWindow.postMessage).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: "eval",
+        payload: { code: expect.stringContaining("body { color: blue; }") },
+      },
+      "*",
+    );
+    expect(frameWindow.postMessage).toHaveBeenNthCalledWith(
+      2,
+      {
+        type: "eval",
+        payload: { code: expect.stringContaining("window.__storedRenderer = true;") },
+      },
+      "*",
+    );
+  });
+
+  it("replaces the retained renderer bundle rather than merging it", () => {
+    const { frameWindow, runtime } = createRuntime();
+
+    runtime.setRendererBundle({
+      rendererCode: "window.__oldRenderer = true;",
+      rendererCss: "body { color: orange; }",
+    });
+    runtime.setRendererBundle({
+      rendererCode: "window.__newRenderer = true;",
+      rendererCss: "body { color: green; }",
+    });
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+
+    expect(runtime.injectRendererBundle()).toBe(true);
+    expect(frameWindow.postMessage).toHaveBeenNthCalledWith(
+      1,
+      {
+        type: "eval",
+        payload: { code: expect.stringContaining("body { color: green; }") },
+      },
+      "*",
+    );
+    expect(frameWindow.postMessage).toHaveBeenNthCalledWith(
+      2,
+      {
+        type: "eval",
+        payload: { code: expect.stringContaining("window.__newRenderer = true;") },
+      },
+      "*",
+    );
+    expect(frameWindow.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ code: expect.stringContaining("__oldRenderer") }),
+      }),
+      "*",
+    );
+  });
+
+  it("reports pending renderer bundles from retained state", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime();
+
+    runtime.setRendererBundle({ rendererCode: "window.__renderer = true;" });
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    runtime.reportRendererBundlePending({ providerLoading: true });
+
+    expect(callbacks.onDiagnostic).toHaveBeenCalledWith(
+      "renderer-bundle-pending",
+      expect.objectContaining({
+        providerLoading: true,
+        hasRendererCode: true,
+        hasRendererCss: false,
+      }),
+    );
+  });
+
   it("requests resource teardown before stopping the active transport", () => {
     const { frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     const transport = MockJsonRpcTransport.instances[0];
 
     runtime.dispose();
@@ -291,9 +376,9 @@ describe("IsolatedFrameRuntime", () => {
   it("does not recreate transport from queued messages after dispose", () => {
     const { callbacks, frameWindow, runtime } = createRuntime();
 
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
     runtime.dispose();
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
 
     expect(MockJsonRpcTransport.instances).toHaveLength(1);
     expect(callbacks.onBootstrapReady).toHaveBeenCalledTimes(1);
@@ -310,7 +395,7 @@ describe("IsolatedFrameRuntime", () => {
 
     runtime.dispose();
     runtime.activate();
-    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }), {});
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
 
     expect(MockJsonRpcTransport.instances).toHaveLength(1);
     expect(callbacks.onBootstrapReady).toHaveBeenCalledWith({

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -83,6 +83,7 @@ export interface IsolatedFrameRuntimeCallbacks {
 export interface IsolatedFrameRuntimeOptions {
   getFrameWindow: () => Window | null | undefined;
   getInitialContent?: () => RenderPayload | undefined;
+  rendererBundle?: IsolatedFrameRendererBundle;
   callbacks: IsolatedFrameRuntimeCallbacks;
 }
 
@@ -141,6 +142,7 @@ export class IsolatedFrameRuntime {
   private lastHostContextDelivery: { channel: "legacy" | "rpc"; key: string } | null = null;
   private disposed = false;
   private rendererReadyChannels = new Set<"legacy" | "rpc">();
+  private rendererBundle: IsolatedFrameRendererBundle;
 
   generation = 0;
 
@@ -148,6 +150,7 @@ export class IsolatedFrameRuntime {
     this.getFrameWindow = options.getFrameWindow;
     this.getInitialContent = options.getInitialContent ?? (() => undefined);
     this.callbacks = options.callbacks;
+    this.rendererBundle = options.rendererBundle ?? {};
   }
 
   get isReady(): boolean {
@@ -206,6 +209,10 @@ export class IsolatedFrameRuntime {
     this.send({ type: "install_renderer", payload: { code, css } });
   }
 
+  setRendererBundle(bundle: IsolatedFrameRendererBundle): void {
+    this.rendererBundle = bundle;
+  }
+
   setTheme(isDark: boolean, colorTheme?: string | null): void {
     if (this.disposed) {
       return;
@@ -254,7 +261,7 @@ export class IsolatedFrameRuntime {
     this.deliver({ type: "search_navigate", payload: { matchIndex } });
   }
 
-  handleWindowMessage(event: MessageEvent, bundle: IsolatedFrameRendererBundle): boolean {
+  handleWindowMessage(event: MessageEvent): boolean {
     if (this.disposed) {
       return false;
     }
@@ -271,34 +278,39 @@ export class IsolatedFrameRuntime {
     }
 
     this.callbacks.onMessage(data);
-    this.handleLegacyMessage(data, bundle);
+    this.handleLegacyMessage(data);
     return true;
   }
 
-  waitingForRendererBundle(bundle: IsolatedFrameRendererBundle): boolean {
+  waitingForRendererBundle(): boolean {
     return (
       this.iframeReady &&
       !this.ready &&
       !this.bootstrapping &&
-      (bundle.rendererCode === undefined || bundle.rendererCss === undefined)
+      (this.rendererBundle.rendererCode === undefined ||
+        this.rendererBundle.rendererCss === undefined)
     );
   }
 
-  reportRendererBundlePending(
-    bundle: IsolatedFrameRendererBundle,
-    provider: { providerLoading: boolean; providerError?: Error | null },
-  ): void {
-    if (!this.waitingForRendererBundle(bundle)) {
+  reportRendererBundlePending(provider: {
+    providerLoading: boolean;
+    providerError?: Error | null;
+  }): void {
+    if (!this.waitingForRendererBundle()) {
       return;
     }
     this.callbacks.onDiagnostic("renderer-bundle-pending", {
       providerLoading: provider.providerLoading,
       providerError: provider.providerError?.message ?? null,
-      ...rendererBundleDetails(bundle.rendererCode, bundle.rendererCss),
+      ...rendererBundleDetails(this.rendererBundle.rendererCode, this.rendererBundle.rendererCss),
     });
   }
 
-  injectRendererBundle(bundle: Required<IsolatedFrameRendererBundle>): boolean {
+  injectRendererBundle(): boolean {
+    const completeBundle = this.completeRendererBundle();
+    if (!completeBundle) {
+      return false;
+    }
     const frameWindow = this.getFrameWindow();
     if (this.disposed || !this.iframeReady || this.ready || this.bootstrapping || !frameWindow) {
       return false;
@@ -307,7 +319,7 @@ export class IsolatedFrameRuntime {
     this.bootstrapping = true;
     this.callbacks.onDiagnostic(
       "renderer-bundle-injecting",
-      rendererBundleDetails(bundle.rendererCode, bundle.rendererCss),
+      rendererBundleDetails(completeBundle.rendererCode, completeBundle.rendererCss),
     );
 
     const cssCode = `
@@ -315,7 +327,7 @@ export class IsolatedFrameRuntime {
           if (window.__ISOLATED_CSS_LOADED__) return;
           window.__ISOLATED_CSS_LOADED__ = true;
           var style = document.createElement('style');
-          style.textContent = ${JSON.stringify(bundle.rendererCss)};
+          style.textContent = ${JSON.stringify(completeBundle.rendererCss)};
           document.head.appendChild(style);
         })();
       `;
@@ -325,12 +337,12 @@ export class IsolatedFrameRuntime {
       "(function() {" +
       "if (window.__ISOLATED_RENDERER_LOADED__) return;" +
       "window.__ISOLATED_RENDERER_LOADED__ = true;" +
-      bundle.rendererCode +
+      completeBundle.rendererCode +
       "})();";
     frameWindow.postMessage({ type: "eval", payload: { code: jsWrapper } }, "*");
     this.callbacks.onDiagnostic(
       "renderer-bundle-injected",
-      rendererBundleDetails(bundle.rendererCode, bundle.rendererCss),
+      rendererBundleDetails(completeBundle.rendererCode, completeBundle.rendererCss),
     );
     return true;
   }
@@ -376,6 +388,14 @@ export class IsolatedFrameRuntime {
     return this.ready ? this.transport : null;
   }
 
+  private completeRendererBundle(): Required<IsolatedFrameRendererBundle> | null {
+    const { rendererCode, rendererCss } = this.rendererBundle;
+    if (rendererCode === undefined || rendererCss === undefined) {
+      return null;
+    }
+    return { rendererCode, rendererCss };
+  }
+
   private deliver(message: ParentToIframeMessage): void {
     if (this.disposed) {
       return;
@@ -402,13 +422,10 @@ export class IsolatedFrameRuntime {
     pending.forEach((message) => this.deliver(message));
   }
 
-  private handleLegacyMessage(
-    data: IframeToParentMessage,
-    bundle: IsolatedFrameRendererBundle,
-  ): void {
+  private handleLegacyMessage(data: IframeToParentMessage): void {
     switch (data.type) {
       case "ready":
-        this.handleBootstrapReady(bundle);
+        this.handleBootstrapReady();
         break;
 
       case "renderer_ready":
@@ -466,7 +483,7 @@ export class IsolatedFrameRuntime {
     }
   }
 
-  private handleBootstrapReady(bundle: IsolatedFrameRendererBundle): void {
+  private handleBootstrapReady(): void {
     if (this.disposed) {
       return;
     }
@@ -478,7 +495,7 @@ export class IsolatedFrameRuntime {
     this.rendererReadyChannels.clear();
     this.callbacks.onDiagnostic("bootstrap-ready", {
       isReload,
-      ...rendererBundleDetails(bundle.rendererCode, bundle.rendererCss),
+      ...rendererBundleDetails(this.rendererBundle.rendererCode, this.rendererBundle.rendererCss),
     });
 
     if (isReload) {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -404,6 +404,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       runtimeRef.current = new IsolatedFrameRuntime({
         getFrameWindow: () => iframeRef.current?.contentWindow,
         getInitialContent: () => initialContentRef.current,
+        // Seed the runtime before passive effects so an early iframe bootstrap
+        // message can report the current bundle state.
+        rendererBundle: { rendererCode, rendererCss },
         callbacks: {
           onBootstrapReady: ({ isReload }) => {
             if (isReload) {
@@ -537,15 +540,19 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       runtimeRef.current?.send(message);
     }, []);
 
+    useEffect(() => {
+      runtimeRef.current?.setRendererBundle({ rendererCode, rendererCss });
+    }, [rendererCode, rendererCss]);
+
     // Handle messages from iframe
     useEffect(() => {
       const handleMessage = (event: MessageEvent) => {
-        runtimeRef.current?.handleWindowMessage(event, { rendererCode, rendererCss });
+        runtimeRef.current?.handleWindowMessage(event);
       };
 
       window.addEventListener("message", handleMessage);
       return () => window.removeEventListener("message", handleMessage);
-    }, [rendererCode, rendererCss]);
+    }, []);
 
     // Clean up JSON-RPC transport on unmount
     useEffect(() => {
@@ -558,26 +565,22 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     useEffect(() => {
       if (!isIframeReady) return;
       const runtime = runtimeRef.current;
-      if (!runtime?.waitingForRendererBundle({ rendererCode, rendererCss })) return;
+      if (!runtime?.waitingForRendererBundle()) return;
       const timer = window.setTimeout(() => {
-        runtime.reportRendererBundlePending(
-          { rendererCode, rendererCss },
-          {
-            providerLoading,
-            providerError,
-          },
-        );
+        runtime.reportRendererBundlePending({
+          providerLoading,
+          providerError,
+        });
       }, 1500);
 
       return () => window.clearTimeout(timer);
     }, [isIframeReady, isReady, rendererCode, rendererCss, providerLoading, providerError]);
 
-    // Inject renderer when iframe is ready AND bundle props are available
+    // Inject renderer when iframe is ready. The runtime returns false until
+    // both bundle parts are available.
     useEffect(() => {
       if (!isIframeReady) return;
-      if (rendererCode !== undefined && rendererCss !== undefined) {
-        runtimeRef.current?.injectRendererBundle({ rendererCode, rendererCss });
-      }
+      runtimeRef.current?.injectRendererBundle();
     }, [isIframeReady, isReady, rendererCode, rendererCss]);
 
     // Expose imperative API


### PR DESCRIPTION
## Summary

- move renderer bundle state into `IsolatedFrameRuntime`
- make the React adapter update the runtime bundle once instead of threading `{ rendererCode, rendererCss }` through iframe message handling, pending diagnostics, and bundle injection calls
- add runtime coverage for stored bundle diagnostics, delayed injection, and pending bundle reporting

## Verification

- `pnpm test:run src/components/isolated/__tests__/isolated-frame-runtime.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit`
- `pnpm test:run src/components/isolated/__tests__/isolated-frame.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/frame-config.test.ts src/components/isolated/__tests__/frame-html.test.ts`
- `pnpm test:run src/components/isolated/__tests__`
- `cargo xtask lint --fix`
