### PR TITLE
fix(notebook): acknowledge relay generation after bootstrap

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,4 +1,4 @@
-import { useNotebookHost, type DaemonReadyPayload } from "@nteract/notebook-host";
+import { useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
 import {
@@ -8,7 +8,7 @@ import {
   isInitialLoadFailed,
   isInitialLoadStreaming,
 } from "runtimed";
-import { concatMap, from, Observable, switchMap } from "rxjs";
+import { concatMap, from, Observable } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
 import {
   getBlobPort,
@@ -43,6 +43,7 @@ import { emitBroadcast, emitPresence } from "../lib/notebook-frame-bus";
 import { notifyMetadataChanged, setNotebookHandle } from "../lib/notebook-metadata";
 import { type PoolState, resetPoolState, setPoolState } from "../lib/pool-state";
 import { resetRuntimeState, setRuntimeState, useRuntimeState } from "../lib/runtime-state";
+import { startRelayBootstrapCoordinator } from "../lib/relay-bootstrap";
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, {
   encode_heartbeat_presence,
@@ -251,14 +252,7 @@ export function useAutomergeNotebook() {
 
   const notifyRelayReady = useCallback(
     (relayGeneration?: number) => {
-      if (relayGeneration === undefined) {
-        logger.debug(
-          "[automerge-notebook] Signaling relay ready without a relay generation; active gates will reject it",
-        );
-      }
-      return host.relay
-        .notifySyncReady(relayGeneration)
-        .catch((e: unknown) => logger.warn("[automerge-notebook] Failed to signal sync ready:", e));
+      return host.relay.notifySyncReady(relayGeneration);
     },
     [host.relay],
   );
@@ -398,65 +392,43 @@ export function useAutomergeNotebook() {
     // Pool state → store.
     const poolStateSub = engine.poolState$.subscribe((state) => setPoolState(state as PoolState));
 
-    // ── Bootstrap ─────────────────────────────────────────────────
+    // ── Bootstrap / daemon lifecycle ─────────────────────────────
 
-    setIsLoading(true);
-    void host.daemon
-      .getReadyInfo()
-      .catch(() => null)
-      .then((readyInfo) =>
-        bootstrap(() => cancelled).then((bootstrapped) => ({ bootstrapped, readyInfo })),
-      )
-      .then((bootstrapped) => {
-        if (!bootstrapped.bootstrapped || cancelled) return;
-        // Signal the Rust relay only after the WASM handle exists and the
-        // bootstrap reset has run. Otherwise buffered daemon frames can mark
-        // the session interactive, then resetForBootstrap() emits pending
-        // afterward with no later status frame to recover.
-        return notifyRelayReady(bootstrapped.readyInfo?.relay_generation);
-      })
-      .catch((error) => {
+    const relayBootstrap = startRelayBootstrapCoordinator({
+      onReady: host.daemonEvents.onReady,
+      requiresReadyGeneration: host.relay.requiresReadyGeneration,
+      beforeBootstrap: (trigger) => {
+        if (trigger.kind !== "ready") return;
+
+        logger.info("[automerge-notebook] daemon:ready — bootstrapping relay generation");
+        refreshBlobPort();
+        resetNotebookCells();
+        resetRuntimeState();
+        resetRuntimeStoresProjection();
+        resetPoolState();
+        setCanAcceptCellMutations(false);
+        outputCacheRef.current.clear();
+        setIsLoading(true);
+        setLoadError(null);
+      },
+      bootstrap: (isCancelled) => bootstrap(() => cancelled || isCancelled()),
+      notifyRelayReady,
+      onMissingGeneration: () => {
+        logger.debug(
+          "[automerge-notebook] daemon:ready payload had no relay generation; relay ack skipped",
+        );
+      },
+      onBootstrapError: (error) => {
         logger.error("[automerge-notebook] Bootstrap failed", error);
         if (!cancelled) {
           setLoadError(error instanceof Error ? error.message : String(error));
           setIsLoading(false);
         }
-      });
-
-    // ── Daemon lifecycle ─────────────────────────────────────────
-
-    const lifecycleSub = new Observable<DaemonReadyPayload>((subscriber) =>
-      host.daemonEvents.onReadyLive((payload) => subscriber.next(payload)),
-    )
-      .pipe(
-        switchMap((readyPayload) => {
-          logger.info("[automerge-notebook] daemon:ready — re-bootstrapping");
-          refreshBlobPort();
-          resetNotebookCells();
-          resetRuntimeState();
-          resetRuntimeStoresProjection();
-          resetPoolState();
-          setCanAcceptCellMutations(false);
-          outputCacheRef.current.clear();
-          setIsLoading(true);
-          setLoadError(null);
-          return from(
-            bootstrap(() => cancelled)
-              .then((bootstrapped) => {
-                if (!bootstrapped || cancelled) return;
-                return notifyRelayReady(readyPayload.relay_generation);
-              })
-              .catch((err: unknown) => {
-                logger.error("[automerge-notebook] lifecycle bootstrap failed:", err);
-                if (!cancelled) {
-                  setLoadError(err instanceof Error ? err.message : String(err));
-                  setIsLoading(false);
-                }
-              }),
-          );
-        }),
-      )
-      .subscribe();
+      },
+      onNotifyError: (error) => {
+        logger.warn("[automerge-notebook] Failed to signal sync ready:", error);
+      },
+    });
 
     return () => {
       cancelled = true;
@@ -480,7 +452,7 @@ export function useAutomergeNotebook() {
       executionViewSub.unsubscribe();
       outputIdChangesSub.unsubscribe();
       poolStateSub.unsubscribe();
-      lifecycleSub.unsubscribe();
+      relayBootstrap.stop();
 
       engineRef.current = null;
       transportRef.current = null;

--- a/apps/notebook/src/lib/__tests__/relay-bootstrap.test.ts
+++ b/apps/notebook/src/lib/__tests__/relay-bootstrap.test.ts
@@ -1,0 +1,322 @@
+import type { DaemonReadyPayload, Unlisten } from "@nteract/notebook-host";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  startRelayBootstrapCoordinator,
+  type RelayBootstrapCoordinatorOptions,
+  type RelayBootstrapTrigger,
+} from "../relay-bootstrap";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createReadySource() {
+  const callbacks: Array<(payload: DaemonReadyPayload) => void> = [];
+  const unlisten = vi.fn();
+  const onReady = vi.fn((cb: (payload: DaemonReadyPayload) => void): Unlisten => {
+    callbacks.push(cb);
+    return unlisten;
+  });
+  return {
+    callbacks,
+    onReady,
+    unlisten,
+    emit(payload: DaemonReadyPayload) {
+      callbacks.forEach((cb) => cb(payload));
+    },
+  };
+}
+
+function startCoordinator(
+  options: Omit<RelayBootstrapCoordinatorOptions, "requiresReadyGeneration"> &
+    Partial<Pick<RelayBootstrapCoordinatorOptions, "requiresReadyGeneration">>,
+) {
+  return startRelayBootstrapCoordinator({
+    requiresReadyGeneration: true,
+    ...options,
+  });
+}
+
+describe("startRelayBootstrapCoordinator", () => {
+  it("waits for daemon ready before bootstrapping", () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    expect(ready.onReady).toHaveBeenCalledTimes(1);
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+
+    coordinator.stop();
+    expect(ready.unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("bootstraps a synchronously replayed ready payload", async () => {
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: (cb) => {
+        cb({ notebook_id: "nb-1", relay_generation: 7 });
+        return vi.fn();
+      },
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    await flushMicrotasks();
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(bootstrap.mock.calls[0][1]).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 7 },
+    });
+    expect(notifyRelayReady).toHaveBeenCalledWith(7);
+
+    coordinator.stop();
+  });
+
+  it("acks only the latest ready generation when a newer one supersedes an in-flight bootstrap", async () => {
+    const ready = createReadySource();
+    const bootstraps: Array<{
+      isCancelled: () => boolean;
+      trigger: RelayBootstrapTrigger;
+      resolve: (value: boolean) => void;
+    }> = [];
+    const bootstrap = vi.fn((isCancelled: () => boolean, trigger: RelayBootstrapTrigger) => {
+      const pending = deferred<boolean>();
+      bootstraps.push({ isCancelled, trigger, resolve: pending.resolve });
+      return pending.promise;
+    });
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 1 });
+    ready.emit({ notebook_id: "nb-1", relay_generation: 2 });
+
+    expect(bootstraps).toHaveLength(2);
+    expect(bootstraps[0].trigger).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 1 },
+    });
+    expect(bootstraps[0].isCancelled()).toBe(true);
+    expect(bootstraps[1].trigger).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 2 },
+    });
+
+    bootstraps[0].resolve(true);
+    bootstraps[1].resolve(true);
+    await flushMicrotasks();
+
+    expect(notifyRelayReady).toHaveBeenCalledTimes(1);
+    expect(notifyRelayReady).toHaveBeenCalledWith(2);
+
+    coordinator.stop();
+  });
+
+  it("deduplicates repeated ready payloads for the same relay generation", () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 5 });
+    ready.emit({ notebook_id: "nb-1", relay_generation: 5 });
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(bootstrap.mock.calls[0][1]).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 5 },
+    });
+
+    coordinator.stop();
+  });
+
+  it("ignores stale ready payloads after a newer generation has arrived", () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 2 });
+    ready.emit({ notebook_id: "nb-1", relay_generation: 1 });
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(bootstrap.mock.calls[0][1]).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 2 },
+    });
+
+    coordinator.stop();
+  });
+
+  it("does not acknowledge an active relay when ready has no generation", async () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+    const onMissingGeneration = vi.fn();
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+      onMissingGeneration,
+    });
+
+    ready.emit({ notebook_id: "nb-1" });
+    await flushMicrotasks();
+
+    expect(onMissingGeneration).toHaveBeenCalledWith({ notebook_id: "nb-1" });
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+
+    coordinator.stop();
+  });
+
+  it("acknowledges a ready payload without a generation when the host does not require one", async () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+    const onMissingGeneration = vi.fn();
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      requiresReadyGeneration: false,
+      bootstrap,
+      notifyRelayReady,
+      onMissingGeneration,
+    });
+
+    ready.emit({ notebook_id: "nb-1" });
+    await flushMicrotasks();
+
+    expect(onMissingGeneration).not.toHaveBeenCalled();
+    expect(notifyRelayReady).toHaveBeenCalledTimes(1);
+    expect(notifyRelayReady).toHaveBeenCalledWith(undefined);
+
+    coordinator.stop();
+  });
+
+  it("reports before-bootstrap errors and does not acknowledge", async () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+    const onBootstrapError = vi.fn();
+    const error = new Error("reset failed");
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      beforeBootstrap: () => {
+        throw error;
+      },
+      bootstrap,
+      notifyRelayReady,
+      onBootstrapError,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 6 });
+    await flushMicrotasks();
+
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+    expect(onBootstrapError).toHaveBeenCalledWith(error, {
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 6 },
+    });
+
+    coordinator.stop();
+  });
+
+  it("does not acknowledge when bootstrap fails", async () => {
+    const ready = createReadySource();
+    const notifyRelayReady = vi.fn(async () => {});
+    const onBootstrapError = vi.fn();
+    const error = new Error("bootstrap failed");
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap: vi.fn(async () => {
+        throw error;
+      }),
+      notifyRelayReady,
+      onBootstrapError,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 3 });
+    await flushMicrotasks();
+
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+    expect(onBootstrapError).toHaveBeenCalledWith(error, {
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 3 },
+    });
+
+    coordinator.stop();
+  });
+
+  it("does not acknowledge an in-flight generation after stop", async () => {
+    const ready = createReadySource();
+    const bootstraps: Array<{
+      trigger: RelayBootstrapTrigger;
+      resolve: (value: boolean) => void;
+    }> = [];
+    const bootstrap = vi.fn((_isCancelled: () => boolean, trigger: RelayBootstrapTrigger) => {
+      const pending = deferred<boolean>();
+      bootstraps.push({ trigger, resolve: pending.resolve });
+      return pending.promise;
+    });
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 4 });
+    expect(bootstraps.at(-1)?.trigger).toEqual({
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 4 },
+    });
+
+    coordinator.stop();
+    bootstraps.at(-1)?.resolve(true);
+    await flushMicrotasks();
+
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+    expect(ready.unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/notebook/src/lib/relay-bootstrap.ts
+++ b/apps/notebook/src/lib/relay-bootstrap.ts
@@ -1,0 +1,107 @@
+import type { DaemonReadyPayload, Unlisten } from "@nteract/notebook-host";
+import { catchError, EMPTY, Observable, from, ignoreElements, switchMap } from "rxjs";
+
+export type RelayBootstrapTrigger = { kind: "ready"; payload: DaemonReadyPayload };
+
+export interface RelayBootstrapCoordinatorOptions {
+  onReady: (cb: (payload: DaemonReadyPayload) => void) => Unlisten;
+  requiresReadyGeneration: boolean;
+  beforeBootstrap?: (trigger: RelayBootstrapTrigger) => void;
+  bootstrap: (
+    isCancelled: () => boolean,
+    trigger: RelayBootstrapTrigger,
+  ) => Promise<boolean>;
+  notifyRelayReady: (generation?: number) => Promise<void>;
+  onBootstrapError?: (error: unknown, trigger: RelayBootstrapTrigger) => void;
+  onMissingGeneration?: (payload: DaemonReadyPayload) => void;
+  onNotifyError?: (error: unknown, generation?: number) => void;
+}
+
+export interface RelayBootstrapCoordinator {
+  stop(): void;
+}
+
+/**
+ * Own the frontend side of the relay bootstrap handshake.
+ *
+ * The host's `onReady` surface is sticky: it subscribes to future daemon-ready
+ * events and backfills the cached payload for late-mounted webviews. This
+ * coordinator turns that into one ordered bootstrap pipeline, so cache backfill,
+ * live ready, reconnect, cancellation, and generation acknowledgement all share
+ * the same path.
+ */
+export function startRelayBootstrapCoordinator(
+  options: RelayBootstrapCoordinatorOptions,
+): RelayBootstrapCoordinator {
+  let stopped = false;
+  let cycle = 0;
+  let latestReadyGeneration: number | null = null;
+
+  const trigger$ = new Observable<RelayBootstrapTrigger>((subscriber) => {
+    const unlisten = options.onReady((payload) => {
+      const generation = payload.relay_generation;
+      if (generation === undefined && options.requiresReadyGeneration) {
+        options.onMissingGeneration?.(payload);
+        return;
+      }
+      if (
+        generation !== undefined &&
+        latestReadyGeneration !== null &&
+        generation <= latestReadyGeneration
+      ) {
+        return;
+      }
+      if (generation !== undefined) {
+        latestReadyGeneration = generation;
+      }
+      subscriber.next({ kind: "ready", payload });
+    });
+
+    return () => unlisten();
+  });
+
+  const subscription = trigger$
+    .pipe(
+      switchMap((trigger) => {
+        const currentCycle = ++cycle;
+        const isCancelled = () => stopped || currentCycle !== cycle;
+
+        try {
+          options.beforeBootstrap?.(trigger);
+        } catch (error) {
+          options.onBootstrapError?.(error, trigger);
+          return EMPTY;
+        }
+
+        return from(options.bootstrap(isCancelled, trigger)).pipe(
+          switchMap((bootstrapped) => {
+            if (!bootstrapped || isCancelled()) return EMPTY;
+
+            const generation = trigger.payload.relay_generation;
+            return from(options.notifyRelayReady(generation)).pipe(
+              catchError((error: unknown) => {
+                options.onNotifyError?.(error, generation);
+                return EMPTY;
+              }),
+              ignoreElements(),
+            );
+          }),
+          catchError((error: unknown) => {
+            if (!isCancelled()) {
+              options.onBootstrapError?.(error, trigger);
+            }
+            return EMPTY;
+          }),
+        );
+      }),
+    )
+    .subscribe();
+
+  return {
+    stop() {
+      stopped = true;
+      cycle += 1;
+      subscription.unsubscribe();
+    },
+  };
+}

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -476,6 +476,7 @@ export async function createBrowserHost(
       },
     },
     relay: {
+      requiresReadyGeneration: false,
       async notifySyncReady() {
         transport.releaseFrames();
       },

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -213,6 +213,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   };
 
   const relay: HostRelay = {
+    requiresReadyGeneration: true,
     async notifySyncReady(generation?: number) {
       await invoke("notify_sync_ready", { generation });
     },

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -195,6 +195,16 @@ export interface HostDaemonEvents {
  */
 export interface HostRelay {
   /**
+   * Whether `notifySyncReady` must carry the daemon's current relay generation.
+   *
+   * Tauri buffers frames behind a generation-specific gate so a stale webview
+   * cannot release frames for a newer daemon session. The browser dev relay has
+   * only a per-WebSocket local queue; its ready payload has no generation and
+   * the ack simply releases frames after the frontend bootstrap path is wired.
+   */
+  readonly requiresReadyGeneration: boolean;
+
+  /**
    * Signal that the JS frame listener is attached and the Tauri-side
    * relay may replay any buffered frames. Matches the existing
    * `notify_sync_ready` Tauri command. No-op in hosts where the main


### PR DESCRIPTION
## Summary

- Replace the split startup/lifecycle bootstrap paths with a single relay bootstrap coordinator.
- Feed the coordinator from sticky `host.daemonEvents.onReady`, so cached ready backfill and live `daemon:ready` events share the same cancellation-aware path.
- Acknowledge a relay generation only after that generation's WASM bootstrap succeeds, and ignore duplicate/stale generations.
- Make `HostRelay` declare whether ready acknowledgements require a generation, preserving Tauri's generation gate while still releasing the browser dev relay's local frame queue.
- Remove the fallback initial bootstrap path; readiness now comes only from the sticky daemon-ready stream.
- Add focused coverage for cached/live ready replay, cancellation, superseded generations, missing generations, browser-dev generationless ready payloads, bootstrap errors, before-bootstrap errors, and cleanup.

## Verification

- `cargo xtask lint --fix`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook build`
- `pnpm test:run apps/notebook/src/lib/__tests__/relay-bootstrap.test.ts packages/notebook-host/tests/browser-host.test.ts packages/notebook-host/tests/tauri-host.test.ts packages/runtimed/tests/sync-engine.test.ts`
- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/isolated-rich-output.spec.ts:59`

## Notes

The original nightly symptom was a file-backed notebook whose daemon room had the correct cell count while the frontend stayed on an empty/one-cell bootstrap state. The affected window did not log `Frontend sync ready`, consistent with Rust buffering initial sync frames behind an unacknowledged relay generation.

This keeps Rust as the owner of generation validity while moving the frontend sequencing into one tested RxJS coordinator instead of patching the startup promise chain.
