### PR TITLE
refactor(notebook-host): own relay bootstrap coordinator

### DIFF
--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -40,9 +40,11 @@ Configured in `apps/notebook/tsconfig.json`:
 
 ## Shared vs app-specific
 
-Put code in `src/` (shared) when it is a pure UI component with no Tauri/daemon dependencies, could be reused by future apps, or is a generic utility.
+Put pure reusable UI components and generic browser utilities in `src/`.
 
-Put code in `apps/notebook/src/` when it uses the `NotebookHost` interface, interacts with the daemon, or is specific to the notebook editing experience.
+Put host, transport, sync, and lifecycle mechanisms in packages such as `@nteract/notebook-host` or `@nteract/runtimed`. Package code may depend on `NotebookHost` contracts and daemon lifecycle types, but must not import app stores, routes, or React-owned notebook UI policy.
+
+Put code in `apps/notebook/src/` when it owns notebook app policy: stores, routes, layout, UI state, materialization choices, and closures that connect package mechanisms to app-specific state.
 
 ## NotebookHost — platform abstraction
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,4 +1,4 @@
-import { useNotebookHost } from "@nteract/notebook-host";
+import { startRelayBootstrapCoordinator, useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
 import {
@@ -43,7 +43,6 @@ import { emitBroadcast, emitPresence } from "../lib/notebook-frame-bus";
 import { notifyMetadataChanged, setNotebookHandle } from "../lib/notebook-metadata";
 import { type PoolState, resetPoolState, setPoolState } from "../lib/pool-state";
 import { resetRuntimeState, setRuntimeState, useRuntimeState } from "../lib/runtime-state";
-import { startRelayBootstrapCoordinator } from "../lib/relay-bootstrap";
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, {
   encode_heartbeat_presence,

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -11,7 +11,8 @@
     "./tauri": "./src/tauri/index.ts"
   },
   "dependencies": {
-    "runtimed": "workspace:*"
+    "runtimed": "workspace:*",
+    "rxjs": "^7.8.2"
   },
   "peerDependencies": {
     "@tauri-apps/api": "^2.10.0",

--- a/packages/notebook-host/src/index.ts
+++ b/packages/notebook-host/src/index.ts
@@ -41,3 +41,10 @@ export {
 } from "./commands";
 
 export { NotebookHostProvider, type NotebookHostProviderProps, useNotebookHost } from "./react";
+
+export {
+  startRelayBootstrapCoordinator,
+  type RelayBootstrapCoordinator,
+  type RelayBootstrapCoordinatorOptions,
+  type RelayBootstrapTrigger,
+} from "./relay-bootstrap";

--- a/packages/notebook-host/src/relay-bootstrap.ts
+++ b/packages/notebook-host/src/relay-bootstrap.ts
@@ -1,4 +1,4 @@
-import type { DaemonReadyPayload, Unlisten } from "@nteract/notebook-host";
+import type { DaemonReadyPayload, Unlisten } from "./types";
 import { catchError, EMPTY, Observable, from, ignoreElements, switchMap } from "rxjs";
 
 export type RelayBootstrapTrigger = { kind: "ready"; payload: DaemonReadyPayload };
@@ -7,10 +7,7 @@ export interface RelayBootstrapCoordinatorOptions {
   onReady: (cb: (payload: DaemonReadyPayload) => void) => Unlisten;
   requiresReadyGeneration: boolean;
   beforeBootstrap?: (trigger: RelayBootstrapTrigger) => void;
-  bootstrap: (
-    isCancelled: () => boolean,
-    trigger: RelayBootstrapTrigger,
-  ) => Promise<boolean>;
+  bootstrap: (isCancelled: () => boolean, trigger: RelayBootstrapTrigger) => Promise<boolean>;
   notifyRelayReady: (generation?: number) => Promise<void>;
   onBootstrapError?: (error: unknown, trigger: RelayBootstrapTrigger) => void;
   onMissingGeneration?: (payload: DaemonReadyPayload) => void;
@@ -51,6 +48,8 @@ export function startRelayBootstrapCoordinator(
       ) {
         return;
       }
+      // Ungated browser/dev hosts do not have a generation token to dedupe on;
+      // every ready emission is treated as a real host lifecycle event.
       if (generation !== undefined) {
         latestReadyGeneration = generation;
       }

--- a/packages/notebook-host/tests/relay-bootstrap.test.ts
+++ b/packages/notebook-host/tests/relay-bootstrap.test.ts
@@ -1,10 +1,11 @@
-import type { DaemonReadyPayload, Unlisten } from "@nteract/notebook-host";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
   startRelayBootstrapCoordinator,
+  type DaemonReadyPayload,
   type RelayBootstrapCoordinatorOptions,
   type RelayBootstrapTrigger,
-} from "../relay-bootstrap";
+  type Unlisten,
+} from "../src";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -226,6 +227,31 @@ describe("startRelayBootstrapCoordinator", () => {
     expect(onMissingGeneration).not.toHaveBeenCalled();
     expect(notifyRelayReady).toHaveBeenCalledTimes(1);
     expect(notifyRelayReady).toHaveBeenCalledWith(undefined);
+
+    coordinator.stop();
+  });
+
+  it("bootstraps every repeated generationless ready payload for hosts without a ready gate", async () => {
+    const ready = createReadySource();
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      requiresReadyGeneration: false,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1" });
+    await flushMicrotasks();
+    ready.emit({ notebook_id: "nb-1" });
+    await flushMicrotasks();
+
+    expect(bootstrap).toHaveBeenCalledTimes(2);
+    expect(notifyRelayReady).toHaveBeenCalledTimes(2);
+    expect(notifyRelayReady).toHaveBeenNthCalledWith(1, undefined);
+    expect(notifyRelayReady).toHaveBeenNthCalledWith(2, undefined);
 
     coordinator.stop();
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,9 @@ importers:
       runtimed:
         specifier: workspace:*
         version: link:../runtimed
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
 
   packages/runtimed:
     dependencies:


### PR DESCRIPTION
## Summary

- move `startRelayBootstrapCoordinator` from `apps/notebook` into `@nteract/notebook-host`
- keep app-specific bootstrap policy in `useAutomergeNotebook`
- add `rxjs` as a direct notebook-host dependency and export the coordinator from the package root
- move coordinator tests into `packages/notebook-host` and add coverage for repeated generationless ready events on ungated hosts
- update the frontend architecture note to clarify package-owned lifecycle mechanisms vs app-owned UI policy

## Verification

- `pnpm test:run packages/notebook-host/tests/relay-bootstrap.test.ts packages/notebook-host/tests/browser-host.test.ts packages/notebook-host/tests/tauri-host.test.ts packages/runtimed/tests/sync-engine.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/isolated-rich-output.spec.ts:59`

## Notes

- This is intended as a behavior-preserving follow-up to the relay-ready race fix.
- The PR is draft pending full GitHub CI, including Browser E2E and child E2E matrix checks.
