### PR TITLE
refactor(notebook): extract sync store bridge

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,14 +1,8 @@
 import { startRelayBootstrapCoordinator, useNotebookHost } from "@nteract/notebook-host";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NotebookTransport, SessionStatus, SyncableHandle } from "runtimed";
-import {
-  NotebookHandleHost,
-  SyncEngine,
-  isDisplayCapableJupyterOutput,
-  isInitialLoadFailed,
-  isInitialLoadStreaming,
-} from "runtimed";
-import { concatMap, from, Observable } from "rxjs";
+import { NotebookHandleHost, SyncEngine, isDisplayCapableJupyterOutput } from "runtimed";
+import { Observable } from "rxjs";
 import { needsPlugin, preWarmForMimes } from "@/components/isolated/iframe-libraries";
 import {
   getBlobPort,
@@ -16,7 +10,6 @@ import {
   refreshBlobPort,
   refreshBlobResolver,
 } from "../lib/blob-port";
-import { materializeChangeset } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -33,16 +26,14 @@ import {
 } from "../lib/notebook-cells";
 import {
   applyExecutionViewChangeset,
-  applyOutputChangeset,
   resetRuntimeStoresProjection,
-  seedOutputStoresFromHandle,
 } from "../lib/project-runtime-stores";
 import { updateOutputsByDisplayId } from "../lib/notebook-outputs";
 import { cloneNotebookFile, openNotebookFile, saveNotebook } from "../lib/notebook-file-ops";
-import { emitBroadcast, emitPresence } from "../lib/notebook-frame-bus";
-import { notifyMetadataChanged, setNotebookHandle } from "../lib/notebook-metadata";
-import { type PoolState, resetPoolState, setPoolState } from "../lib/pool-state";
-import { resetRuntimeState, setRuntimeState, useRuntimeState } from "../lib/runtime-state";
+import { setNotebookHandle } from "../lib/notebook-metadata";
+import { resetPoolState } from "../lib/pool-state";
+import { resetRuntimeState, useRuntimeState } from "../lib/runtime-state";
+import { startNotebookSyncStoreBridge } from "../lib/notebook-sync-store-bridge";
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, {
   encode_heartbeat_presence,
@@ -98,8 +89,6 @@ export function useAutomergeNotebook() {
   const handleRef = useRef<NotebookHandle | null>(null);
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
-  const interactiveReadyRef = useRef(false);
-  const latestSessionStatusRef = useRef<SessionStatus | null>(null);
   const prevPathRef = useRef<string | null>(null);
 
   const [handleHost] = useState(
@@ -230,8 +219,6 @@ export function useAutomergeNotebook() {
       const bootstrapped = await handleHost.bootstrap(isCancelled);
       if (!bootstrapped) return false;
 
-      interactiveReadyRef.current = false;
-      latestSessionStatusRef.current = null;
       setCanAcceptCellMutations(false);
       setLoadError(null);
       setIsLoading(true);
@@ -280,116 +267,16 @@ export function useAutomergeNotebook() {
     // Start the engine (subscribes to transport frames).
     engine.start();
 
-    // ── Subscribe to SyncEngine observables ───────────────────────
-
-    const sessionStatusSub = engine.sessionStatus$.subscribe((status) => {
-      latestSessionStatusRef.current = status;
-
-      if (isInitialLoadFailed(status.initial_load)) {
-        logger.warn("[automerge-notebook] Initial load failed:", status.initial_load.reason);
-        setLoadError(status.initial_load.reason);
-        setIsLoading(false);
-        return;
-      }
-
-      setLoadError(null);
-      refreshCanAcceptCellMutations();
-      if (interactiveReadyRef.current) {
-        setIsLoading(isInitialLoadStreaming(status.initial_load));
-      }
+    const storeBridge = startNotebookSyncStoreBridge({
+      engine,
+      getHandle: () => handleHost.current,
+      materializeCells,
+      outputCache: outputCacheRef.current,
+      projectExecutionViewChangeset,
+      refreshCanAcceptCellMutations,
+      setIsLoading,
+      setLoadError,
     });
-
-    // Initial sync completion → full materialization.
-    const initialSyncSub = engine.initialSyncComplete$.subscribe(() => {
-      logger.info("[automerge-notebook] Notebook interactive, materializing");
-      const handle = handleHost.current;
-      if (handle) {
-        materializeCells(handle)
-          .then(() => {
-            interactiveReadyRef.current = true;
-            const cellIdList = [...handle.get_cell_ids()];
-            // Seed the shared execution view from WASM. The projector reads
-            // NotebookDoc pointers and whichever RuntimeStateDoc snapshot has
-            // already arrived, so the browser store does not need a separate
-            // materialization pass.
-            applyExecutionViewChangeset(projectExecutionViewChangeset(handle));
-            // Seed the outputs / executions stores straight from the
-            // notebook doc. `initialSyncComplete$` fires when the
-            // notebook doc is interactive, not when RuntimeStateDoc is
-            // necessarily finished bootstrapping, so this preserves
-            // existing eager output visibility until the authoritative
-            // runtime-state projection lands.
-            seedOutputStoresFromHandle(handle, cellIdList);
-            refreshCanAcceptCellMutations(handle);
-            const status = latestSessionStatusRef.current;
-            setIsLoading(status ? isInitialLoadStreaming(status.initial_load) : false);
-            notifyMetadataChanged();
-            logger.info("[automerge-notebook] Interactive materialization done");
-          })
-          .catch((err: unknown) => {
-            logger.warn("[automerge-notebook] initial materialize failed:", err);
-            setLoadError(err instanceof Error ? err.message : String(err));
-            setIsLoading(false);
-          });
-      } else {
-        setIsLoading(false);
-      }
-    });
-
-    // Steady-state cell changes → incremental materialization.
-    // concatMap serializes async work — if a batch awaits blob resolution,
-    // subsequent batches queue rather than overlapping store writes.
-    const cellChangesSub = engine.cellChanges$
-      .pipe(
-        concatMap((changeset) =>
-          from(
-            materializeChangeset(changeset, {
-              getHandle: () => handleHost.current,
-              materializeCells,
-              outputCache: outputCacheRef.current,
-            })
-              .then(() => {
-                const handle = handleHost.current;
-                if (!handle) return;
-                refreshCanAcceptCellMutations(handle);
-                applyExecutionViewChangeset(projectExecutionViewChangeset(handle));
-              })
-              .catch((err: unknown) =>
-                logger.warn("[automerge-notebook] materialize changeset failed:", err),
-              ),
-          ),
-        ),
-      )
-      .subscribe();
-
-    // Broadcasts → frame bus.
-    const broadcastsSub = engine.broadcasts$.subscribe((payload) => emitBroadcast(payload));
-
-    // Presence → frame bus.
-    const presenceSub = engine.presence$.subscribe((payload) => emitPresence(payload));
-
-    // Runtime state → broad runtime store. The narrow execution and cell
-    // pointer stores are fed separately by SyncEngine.executionViewChanges$.
-    const runtimeStateSub = engine.runtimeState$.subscribe((state) => {
-      setRuntimeState(state);
-    });
-
-    const executionViewSub = engine.executionViewChanges$.subscribe((changeset) => {
-      applyExecutionViewChangeset(changeset);
-    });
-
-    // Per-output changes → outputs store. WASM narrows each manifest
-    // before emitting, so stream appends only touch the affected
-    // output's subscribers and no second state-doc walk is needed.
-    const outputIdChangesSub = engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
-      if (changed.length === 0 && removed_ids.length === 0) return;
-      void applyOutputChangeset(changed, removed_ids).catch((err) =>
-        logger.warn("[automerge-notebook] output store projection failed:", err),
-      );
-    });
-
-    // Pool state → store.
-    const poolStateSub = engine.poolState$.subscribe((state) => setPoolState(state as PoolState));
 
     // ── Bootstrap / daemon lifecycle ─────────────────────────────
 
@@ -400,6 +287,7 @@ export function useAutomergeNotebook() {
         if (trigger.kind !== "ready") return;
 
         logger.info("[automerge-notebook] daemon:ready — bootstrapping relay generation");
+        storeBridge.resetReadiness();
         refreshBlobPort();
         resetNotebookCells();
         resetRuntimeState();
@@ -442,15 +330,7 @@ export function useAutomergeNotebook() {
       // rehearsal unmount under React StrictMode. `engine.stop()` already
       // unsubscribes the frame listener this hook installed.
 
-      initialSyncSub.unsubscribe();
-      sessionStatusSub.unsubscribe();
-      cellChangesSub.unsubscribe();
-      broadcastsSub.unsubscribe();
-      presenceSub.unsubscribe();
-      runtimeStateSub.unsubscribe();
-      executionViewSub.unsubscribe();
-      outputIdChangesSub.unsubscribe();
-      poolStateSub.unsubscribe();
+      storeBridge.stop();
       relayBootstrap.stop();
 
       engineRef.current = null;

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -290,6 +290,7 @@ describe("startNotebookSyncStoreBridge", () => {
     await flushMicrotasks();
 
     expect(refreshCanAcceptCellMutations).toHaveBeenCalledWith(handle);
+    expect(refreshCanAcceptCellMutations).toHaveBeenCalledTimes(2);
     expect(projectExecutionViewChangeset).toHaveBeenCalledTimes(2);
     expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledTimes(2);
 
@@ -344,6 +345,60 @@ describe("startNotebookSyncStoreBridge", () => {
     expect(setIsLoading).not.toHaveBeenCalled();
 
     bridge.stop();
+  });
+
+  it("ignores in-flight materializeCells result if stopped before it resolves", async () => {
+    const materialize = deferred();
+    const materializeCells = vi.fn(() => materialize.promise);
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({ materializeCells });
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+    setIsLoading.mockClear();
+    setLoadError.mockClear();
+
+    bridge.stop();
+    materialize.resolve();
+    await flushMicrotasks();
+
+    expect(mocks.applyExecutionViewChangeset).not.toHaveBeenCalled();
+    expect(mocks.seedOutputStoresFromHandle).not.toHaveBeenCalled();
+    expect(mocks.notifyMetadataChanged).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalled();
+    expect(setLoadError).not.toHaveBeenCalled();
+  });
+
+  it("ignores in-flight materializeChangeset result if stopped before it resolves", async () => {
+    const work = deferred();
+    mocks.materializeChangeset.mockImplementationOnce(() => work.promise);
+    const { bridge, projectExecutionViewChangeset, refreshCanAcceptCellMutations, subjects } =
+      startBridge();
+
+    subjects.cellChanges$.next(null);
+    expect(mocks.materializeChangeset).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+    work.resolve();
+    await flushMicrotasks();
+
+    expect(refreshCanAcceptCellMutations).not.toHaveBeenCalled();
+    expect(projectExecutionViewChangeset).not.toHaveBeenCalled();
+    expect(mocks.applyExecutionViewChangeset).not.toHaveBeenCalled();
+  });
+
+  it("ignores in-flight materializeChangeset errors if stopped before rejection", async () => {
+    const work = deferred();
+    mocks.materializeChangeset.mockImplementationOnce(() => work.promise);
+    const { bridge, subjects } = startBridge();
+
+    subjects.cellChanges$.next(null);
+    expect(mocks.materializeChangeset).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+    work.reject(new Error("late materialize failure"));
+    await flushMicrotasks();
+
+    expect(mocks.logger.warn).not.toHaveBeenCalled();
   });
 
   it("unsubscribes all app-store routes when stopped", async () => {

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -1,0 +1,374 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { Subject } from "rxjs";
+import type {
+  ExecutionViewChangeset,
+  PoolState,
+  RuntimeState,
+  SessionStatus,
+} from "runtimed";
+import type { CellChangeset } from "../cell-changeset";
+import {
+  startNotebookSyncStoreBridge,
+  type NotebookSyncStoreBridgeOptions,
+} from "../notebook-sync-store-bridge";
+import type { NotebookHandle } from "../../wasm/runtimed-wasm/runtimed_wasm.js";
+
+const mocks = vi.hoisted(() => ({
+  applyExecutionViewChangeset: vi.fn(),
+  applyOutputChangeset: vi.fn(async () => {}),
+  emitBroadcast: vi.fn(),
+  emitPresence: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  materializeChangeset: vi.fn(async () => {}),
+  notifyMetadataChanged: vi.fn(),
+  seedOutputStoresFromHandle: vi.fn(),
+  setPoolState: vi.fn(),
+  setRuntimeState: vi.fn(),
+}));
+
+vi.mock("../frame-pipeline", () => ({
+  materializeChangeset: mocks.materializeChangeset,
+}));
+
+vi.mock("../logger", () => ({
+  logger: mocks.logger,
+}));
+
+vi.mock("../notebook-frame-bus", () => ({
+  emitBroadcast: mocks.emitBroadcast,
+  emitPresence: mocks.emitPresence,
+}));
+
+vi.mock("../notebook-metadata", () => ({
+  notifyMetadataChanged: mocks.notifyMetadataChanged,
+}));
+
+vi.mock("../pool-state", () => ({
+  setPoolState: mocks.setPoolState,
+}));
+
+vi.mock("../project-runtime-stores", () => ({
+  applyExecutionViewChangeset: mocks.applyExecutionViewChangeset,
+  applyOutputChangeset: mocks.applyOutputChangeset,
+  seedOutputStoresFromHandle: mocks.seedOutputStoresFromHandle,
+}));
+
+vi.mock("../runtime-state", () => ({
+  setRuntimeState: mocks.setRuntimeState,
+}));
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function readyStatus(): SessionStatus {
+  return {
+    notebook_doc: "interactive",
+    runtime_state: "ready",
+    initial_load: { phase: "ready" },
+  };
+}
+
+function streamingStatus(): SessionStatus {
+  return {
+    notebook_doc: "interactive",
+    runtime_state: "ready",
+    initial_load: { phase: "streaming" },
+  };
+}
+
+function failedStatus(reason = "load failed"): SessionStatus {
+  return {
+    notebook_doc: "interactive",
+    runtime_state: "ready",
+    initial_load: { phase: "failed", reason },
+  };
+}
+
+function createHandle() {
+  return {
+    get_cell_ids: vi.fn(() => ["cell-1"]),
+    get_cell_execution_id: vi.fn(() => "exec-1"),
+    get_cell_outputs: vi.fn(() => [{ output_id: "out-1", output_type: "stream" }]),
+  } as unknown as NotebookHandle;
+}
+
+function createEngineSubjects() {
+  const subjects = {
+    broadcasts$: new Subject<unknown>(),
+    cellChanges$: new Subject<CellChangeset | null>(),
+    executionViewChanges$: new Subject<ExecutionViewChangeset>(),
+    initialSyncComplete$: new Subject<void>(),
+    outputIdChanges$: new Subject<{ changed: Array<[string, unknown]>; removed_ids: string[] }>(),
+    poolState$: new Subject<PoolState>(),
+    presence$: new Subject<unknown>(),
+    runtimeState$: new Subject<RuntimeState>(),
+    sessionStatus$: new Subject<SessionStatus>(),
+  };
+
+  const engine = Object.fromEntries(
+    Object.entries(subjects).map(([key, subject]) => [key, subject.asObservable()]),
+  ) as NotebookSyncStoreBridgeOptions["engine"];
+
+  return { engine, subjects };
+}
+
+function startBridge(
+  overrides: Partial<NotebookSyncStoreBridgeOptions> = {},
+) {
+  const { engine, subjects } = createEngineSubjects();
+  const handle = createHandle();
+  const materializeCells = vi.fn(async () => {});
+  const projection: ExecutionViewChangeset = {
+    execution_upserts: [
+      [
+        "exec-1",
+        {
+          execution_count: 1,
+          output_ids: ["out-1"],
+          status: "done",
+          success: true,
+        },
+      ],
+    ],
+  };
+  const projectExecutionViewChangeset = vi.fn(() => projection);
+  const refreshCanAcceptCellMutations = vi.fn(() => true);
+  const setIsLoading = vi.fn();
+  const setLoadError = vi.fn();
+
+  const options: NotebookSyncStoreBridgeOptions = {
+    engine,
+    getHandle: () => handle,
+    materializeCells,
+    outputCache: new Map(),
+    projectExecutionViewChangeset,
+    refreshCanAcceptCellMutations,
+    setIsLoading,
+    setLoadError,
+    ...overrides,
+  };
+
+  const bridge = startNotebookSyncStoreBridge(options);
+  return {
+    bridge,
+    handle,
+    materializeCells,
+    options,
+    projectExecutionViewChangeset,
+    refreshCanAcceptCellMutations,
+    setIsLoading,
+    setLoadError,
+    subjects,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.applyOutputChangeset.mockResolvedValue(undefined);
+  mocks.materializeChangeset.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("startNotebookSyncStoreBridge", () => {
+  it("sets load error and clears loading when initial load fails", () => {
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge();
+
+    subjects.sessionStatus$.next(failedStatus("trust required"));
+
+    expect(setLoadError).toHaveBeenCalledWith("trust required");
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+
+    bridge.stop();
+  });
+
+  it("materializes and seeds app stores when initial sync becomes interactive", async () => {
+    const {
+      bridge,
+      handle,
+      materializeCells,
+      projectExecutionViewChangeset,
+      refreshCanAcceptCellMutations,
+      setIsLoading,
+      subjects,
+    } = startBridge();
+
+    subjects.sessionStatus$.next(readyStatus());
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(materializeCells).toHaveBeenCalledWith(handle);
+    expect(projectExecutionViewChangeset).toHaveBeenCalledWith(handle);
+    expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledWith(
+      projectExecutionViewChangeset.mock.results[0].value,
+    );
+    expect(mocks.seedOutputStoresFromHandle).toHaveBeenCalledWith(handle, ["cell-1"]);
+    expect(refreshCanAcceptCellMutations).toHaveBeenCalledWith(handle);
+    expect(setIsLoading).toHaveBeenLastCalledWith(false);
+    expect(mocks.notifyMetadataChanged).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
+  it("reports materialization failures and clears loading", async () => {
+    const error = new Error("materialize failed");
+    const materializeCells = vi.fn(async () => {
+      throw error;
+    });
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({ materializeCells });
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(setLoadError).toHaveBeenCalledWith("materialize failed");
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+
+    bridge.stop();
+  });
+
+  it("serializes cell changes and refreshes execution projection after each batch", async () => {
+    const first = deferred();
+    const second = deferred();
+    mocks.materializeChangeset
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise);
+    const {
+      bridge,
+      handle,
+      options,
+      projectExecutionViewChangeset,
+      refreshCanAcceptCellMutations,
+      subjects,
+    } = startBridge();
+
+    const changeset: CellChangeset = {
+      added: [],
+      changed: [{ cell_id: "cell-1", fields: { source: true } }],
+      order_changed: false,
+      removed: [],
+    };
+    subjects.cellChanges$.next(changeset);
+    subjects.cellChanges$.next(null);
+
+    expect(mocks.materializeChangeset).toHaveBeenCalledTimes(1);
+    expect(mocks.materializeChangeset).toHaveBeenCalledWith(changeset, {
+      getHandle: options.getHandle,
+      materializeCells: options.materializeCells,
+      outputCache: options.outputCache,
+    });
+
+    first.resolve();
+    await flushMicrotasks();
+
+    expect(mocks.materializeChangeset).toHaveBeenCalledTimes(2);
+    expect(mocks.materializeChangeset).toHaveBeenLastCalledWith(null, {
+      getHandle: options.getHandle,
+      materializeCells: options.materializeCells,
+      outputCache: options.outputCache,
+    });
+
+    second.resolve();
+    await flushMicrotasks();
+
+    expect(refreshCanAcceptCellMutations).toHaveBeenCalledWith(handle);
+    expect(projectExecutionViewChangeset).toHaveBeenCalledTimes(2);
+    expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledTimes(2);
+
+    bridge.stop();
+  });
+
+  it("routes sync engine streams to app stores and frame buses", async () => {
+    const { bridge, subjects } = startBridge();
+    const runtimeState = { kernel: null } as RuntimeState;
+    const poolState = { uv: {}, conda: {}, pixi: {} } as PoolState;
+    const executionChanges: ExecutionViewChangeset = {
+      cell_pointer_changes: [["cell-1", "exec-1"]],
+    };
+
+    subjects.broadcasts$.next({ type: "broadcast" });
+    subjects.presence$.next({ type: "presence" });
+    subjects.runtimeState$.next(runtimeState);
+    subjects.poolState$.next(poolState);
+    subjects.executionViewChanges$.next(executionChanges);
+    subjects.outputIdChanges$.next({
+      changed: [["out-1", { output_type: "stream" }]],
+      removed_ids: ["out-old"],
+    });
+    await flushMicrotasks();
+
+    expect(mocks.emitBroadcast).toHaveBeenCalledWith({ type: "broadcast" });
+    expect(mocks.emitPresence).toHaveBeenCalledWith({ type: "presence" });
+    expect(mocks.setRuntimeState).toHaveBeenCalledWith(runtimeState);
+    expect(mocks.setPoolState).toHaveBeenCalledWith(poolState);
+    expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledWith(executionChanges);
+    expect(mocks.applyOutputChangeset).toHaveBeenCalledWith(
+      [["out-1", { output_type: "stream" }]],
+      ["out-old"],
+    );
+
+    bridge.stop();
+  });
+
+  it("resetReadiness prevents later session status from changing loading before rematerialization", async () => {
+    const { bridge, setIsLoading, subjects } = startBridge();
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+    setIsLoading.mockClear();
+
+    subjects.sessionStatus$.next(streamingStatus());
+    expect(setIsLoading).toHaveBeenCalledWith(true);
+
+    bridge.resetReadiness();
+    setIsLoading.mockClear();
+    subjects.sessionStatus$.next(streamingStatus());
+    expect(setIsLoading).not.toHaveBeenCalled();
+
+    bridge.stop();
+  });
+
+  it("unsubscribes all app-store routes when stopped", async () => {
+    const { bridge, subjects } = startBridge();
+
+    bridge.stop();
+    vi.clearAllMocks();
+
+    subjects.sessionStatus$.next(failedStatus());
+    subjects.initialSyncComplete$.next();
+    subjects.cellChanges$.next(null);
+    subjects.broadcasts$.next({ type: "broadcast" });
+    subjects.presence$.next({ type: "presence" });
+    subjects.runtimeState$.next({ kernel: null } as RuntimeState);
+    subjects.poolState$.next({ uv: {}, conda: {}, pixi: {} } as PoolState);
+    subjects.executionViewChanges$.next({});
+    subjects.outputIdChanges$.next({ changed: [["out-1", {}]], removed_ids: [] });
+    await flushMicrotasks();
+
+    expect(mocks.materializeChangeset).not.toHaveBeenCalled();
+    expect(mocks.emitBroadcast).not.toHaveBeenCalled();
+    expect(mocks.emitPresence).not.toHaveBeenCalled();
+    expect(mocks.setRuntimeState).not.toHaveBeenCalled();
+    expect(mocks.setPoolState).not.toHaveBeenCalled();
+    expect(mocks.applyExecutionViewChangeset).not.toHaveBeenCalled();
+    expect(mocks.applyOutputChangeset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -1,0 +1,170 @@
+import type { ExecutionViewChangeset, SessionStatus, SyncEngine } from "runtimed";
+import { isInitialLoadFailed, isInitialLoadStreaming } from "runtimed";
+import { concatMap, from, Subscription } from "rxjs";
+import type { JupyterOutput } from "../types";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import { materializeChangeset } from "./frame-pipeline";
+import { logger } from "./logger";
+import { emitBroadcast, emitPresence } from "./notebook-frame-bus";
+import { notifyMetadataChanged } from "./notebook-metadata";
+import {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  seedOutputStoresFromHandle,
+} from "./project-runtime-stores";
+import { type PoolState, setPoolState } from "./pool-state";
+import { setRuntimeState } from "./runtime-state";
+
+type SyncEngineStoreStreams = Pick<
+  SyncEngine,
+  | "sessionStatus$"
+  | "initialSyncComplete$"
+  | "cellChanges$"
+  | "broadcasts$"
+  | "presence$"
+  | "runtimeState$"
+  | "executionViewChanges$"
+  | "outputIdChanges$"
+  | "poolState$"
+>;
+
+export interface NotebookSyncStoreBridgeOptions {
+  engine: SyncEngineStoreStreams;
+  getHandle: () => NotebookHandle | null;
+  materializeCells: (handle: NotebookHandle) => Promise<void>;
+  outputCache: Map<string, JupyterOutput>;
+  projectExecutionViewChangeset: (
+    handle: NotebookHandle,
+  ) => ExecutionViewChangeset | null | undefined;
+  refreshCanAcceptCellMutations: (handle?: NotebookHandle) => boolean;
+  setIsLoading: (isLoading: boolean) => void;
+  setLoadError: (loadError: string | null) => void;
+}
+
+export interface NotebookSyncStoreBridge {
+  resetReadiness(): void;
+  stop(): void;
+}
+
+export function startNotebookSyncStoreBridge(
+  options: NotebookSyncStoreBridgeOptions,
+): NotebookSyncStoreBridge {
+  let interactiveReady = false;
+  let latestSessionStatus: SessionStatus | null = null;
+  const subscription = new Subscription();
+
+  const resetReadiness = () => {
+    interactiveReady = false;
+    latestSessionStatus = null;
+  };
+
+  subscription.add(
+    options.engine.sessionStatus$.subscribe((status) => {
+      latestSessionStatus = status;
+
+      if (isInitialLoadFailed(status.initial_load)) {
+        logger.warn("[automerge-notebook] Initial load failed:", status.initial_load.reason);
+        options.setLoadError(status.initial_load.reason);
+        options.setIsLoading(false);
+        return;
+      }
+
+      options.setLoadError(null);
+      options.refreshCanAcceptCellMutations();
+      if (interactiveReady) {
+        options.setIsLoading(isInitialLoadStreaming(status.initial_load));
+      }
+    }),
+  );
+
+  subscription.add(
+    options.engine.initialSyncComplete$.subscribe(() => {
+      logger.info("[automerge-notebook] Notebook interactive, materializing");
+      const handle = options.getHandle();
+      if (!handle) {
+        options.setIsLoading(false);
+        return;
+      }
+
+      options
+        .materializeCells(handle)
+        .then(() => {
+          interactiveReady = true;
+          const cellIdList = [...handle.get_cell_ids()];
+          applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
+          seedOutputStoresFromHandle(handle, cellIdList);
+          options.refreshCanAcceptCellMutations(handle);
+          options.setIsLoading(
+            latestSessionStatus ? isInitialLoadStreaming(latestSessionStatus.initial_load) : false,
+          );
+          notifyMetadataChanged();
+          logger.info("[automerge-notebook] Interactive materialization done");
+        })
+        .catch((err: unknown) => {
+          logger.warn("[automerge-notebook] initial materialize failed:", err);
+          options.setLoadError(err instanceof Error ? err.message : String(err));
+          options.setIsLoading(false);
+        });
+    }),
+  );
+
+  subscription.add(
+    options.engine.cellChanges$
+      .pipe(
+        concatMap((changeset) =>
+          from(
+            materializeChangeset(changeset, {
+              getHandle: options.getHandle,
+              materializeCells: options.materializeCells,
+              outputCache: options.outputCache,
+            })
+              .then(() => {
+                const handle = options.getHandle();
+                if (!handle) return;
+                options.refreshCanAcceptCellMutations(handle);
+                applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
+              })
+              .catch((err: unknown) =>
+                logger.warn("[automerge-notebook] materialize changeset failed:", err),
+              ),
+          ),
+        ),
+      )
+      .subscribe(),
+  );
+
+  subscription.add(options.engine.broadcasts$.subscribe((payload) => emitBroadcast(payload)));
+  subscription.add(options.engine.presence$.subscribe((payload) => emitPresence(payload)));
+
+  subscription.add(
+    options.engine.runtimeState$.subscribe((state) => {
+      setRuntimeState(state);
+    }),
+  );
+
+  subscription.add(
+    options.engine.executionViewChanges$.subscribe((changeset) => {
+      applyExecutionViewChangeset(changeset);
+    }),
+  );
+
+  subscription.add(
+    options.engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
+      if (changed.length === 0 && removed_ids.length === 0) return;
+      void applyOutputChangeset(changed, removed_ids).catch((err) =>
+        logger.warn("[automerge-notebook] output store projection failed:", err),
+      );
+    }),
+  );
+
+  subscription.add(
+    options.engine.poolState$.subscribe((state) => setPoolState(state as PoolState)),
+  );
+
+  return {
+    resetReadiness,
+    stop() {
+      subscription.unsubscribe();
+    },
+  };
+}

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -12,7 +12,7 @@ import {
   applyOutputChangeset,
   seedOutputStoresFromHandle,
 } from "./project-runtime-stores";
-import { type PoolState, setPoolState } from "./pool-state";
+import { setPoolState } from "./pool-state";
 import { setRuntimeState } from "./runtime-state";
 
 type SyncEngineStoreStreams = Pick<
@@ -51,6 +51,7 @@ export function startNotebookSyncStoreBridge(
 ): NotebookSyncStoreBridge {
   let interactiveReady = false;
   let latestSessionStatus: SessionStatus | null = null;
+  let stopped = false;
   const subscription = new Subscription();
 
   const resetReadiness = () => {
@@ -89,8 +90,14 @@ export function startNotebookSyncStoreBridge(
       options
         .materializeCells(handle)
         .then(() => {
+          if (stopped) return;
           interactiveReady = true;
           const cellIdList = [...handle.get_cell_ids()];
+          // `initialSyncComplete$` fires when the notebook doc is interactive,
+          // not when RuntimeStateDoc has finished bootstrapping. Seeding the
+          // outputs/executions stores from the notebook handle here preserves
+          // eager output visibility until the authoritative runtime-state
+          // projection lands via `executionViewChanges$` / `outputIdChanges$`.
           applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
           seedOutputStoresFromHandle(handle, cellIdList);
           options.refreshCanAcceptCellMutations(handle);
@@ -101,6 +108,7 @@ export function startNotebookSyncStoreBridge(
           logger.info("[automerge-notebook] Interactive materialization done");
         })
         .catch((err: unknown) => {
+          if (stopped) return;
           logger.warn("[automerge-notebook] initial materialize failed:", err);
           options.setLoadError(err instanceof Error ? err.message : String(err));
           options.setIsLoading(false);
@@ -108,6 +116,8 @@ export function startNotebookSyncStoreBridge(
     }),
   );
 
+  // `concatMap` serializes the async work: if a batch awaits blob resolution,
+  // subsequent batches queue rather than overlapping store writes.
   subscription.add(
     options.engine.cellChanges$
       .pipe(
@@ -119,14 +129,16 @@ export function startNotebookSyncStoreBridge(
               outputCache: options.outputCache,
             })
               .then(() => {
+                if (stopped) return;
                 const handle = options.getHandle();
                 if (!handle) return;
                 options.refreshCanAcceptCellMutations(handle);
                 applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
               })
-              .catch((err: unknown) =>
-                logger.warn("[automerge-notebook] materialize changeset failed:", err),
-              ),
+              .catch((err: unknown) => {
+                if (stopped) return;
+                logger.warn("[automerge-notebook] materialize changeset failed:", err);
+              }),
           ),
         ),
       )
@@ -150,20 +162,18 @@ export function startNotebookSyncStoreBridge(
 
   subscription.add(
     options.engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
-      if (changed.length === 0 && removed_ids.length === 0) return;
       void applyOutputChangeset(changed, removed_ids).catch((err) =>
         logger.warn("[automerge-notebook] output store projection failed:", err),
       );
     }),
   );
 
-  subscription.add(
-    options.engine.poolState$.subscribe((state) => setPoolState(state as PoolState)),
-  );
+  subscription.add(options.engine.poolState$.subscribe((state) => setPoolState(state)));
 
   return {
     resetReadiness,
     stop() {
+      stopped = true;
       subscription.unsubscribe();
     },
   };


### PR DESCRIPTION
## Summary

- Extract the app-local `SyncEngine` observable-to-store wiring from `useAutomergeNotebook` into `startNotebookSyncStoreBridge`
- Keep app-owned sinks in `apps/notebook`: React loading/error state, notebook/frame stores, frame buses, runtime/pool stores, and materialization policy
- Add focused bridge tests for initial load failure, interactive materialization, materialization errors, serialized cell changes, app sink routing, readiness reset, and subscription cleanup

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts packages/runtimed/tests/sync-engine.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/isolated-rich-output.spec.ts:59`
