### PR TITLE
feat(identity): add nteract identity crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7437,6 +7437,7 @@ dependencies = [
  "notebook-wire",
  "notify",
  "notify-debouncer-mini",
+ "nteract-identity",
  "nteract-telemetry",
  "petname",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +731,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "better_scoped_tls"
@@ -1345,6 +1357,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -1524,6 +1542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1643,33 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "darling"
@@ -1755,6 +1812,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1827,7 +1896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
 
@@ -2039,10 +2108,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "elsa"
@@ -2217,6 +2345,22 @@ checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -2654,6 +2798,7 @@ dependencies = [
  "serde",
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2884,6 +3029,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3066,6 +3222,24 @@ source = "git+https://github.com/nteract/automerge?rev=345f172285641cd52a1f92275
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3729,6 +3903,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "jupyter-protocol"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,6 +4093,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128"
@@ -4642,6 +4843,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nteract-identity"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "jsonwebtoken",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "nteract-mcp"
 version = "0.2.9"
 dependencies = [
@@ -4715,6 +4927,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -5183,6 +5411,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5309,6 +5561,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -5591,6 +5862,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5692,6 +5984,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -6791,6 +7092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,6 +7260,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -7555,6 +7886,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8004,6 +8349,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8028,6 +8383,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "simple_spawn_blocking"
@@ -8160,6 +8527,22 @@ dependencies = [
  "gobject-sys 0.18.0",
  "libc",
  "system-deps 6.2.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -11233,6 +11616,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zeromq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/runtime-doc",
     "crates/notebook-protocol",
     "crates/notebook-sync",
+    "crates/nteract-identity",
     "crates/nteract-telemetry",
     "crates/xtask",
     "crates/runtimed",

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -90,7 +90,7 @@ export function useAutomergeNotebook() {
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
   const prevPathRef = useRef<string | null>(null);
-  const actorLabelRef = useRef(`local:browser/desktop:${sessionIdRef.current}`);
+  const actorLabelRef = useRef(`desktop:${sessionIdRef.current}`);
   const [localActor, setLocalActor] = useState(actorLabelRef.current);
 
   const [handleHost] = useState(

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -90,11 +90,13 @@ export function useAutomergeNotebook() {
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
   const prevPathRef = useRef<string | null>(null);
+  const actorLabelRef = useRef(`local:browser/desktop:${sessionIdRef.current}`);
+  const [localActor, setLocalActor] = useState(actorLabelRef.current);
 
   const [handleHost] = useState(
     () =>
       new NotebookHandleHost<NotebookHandle>({
-        actorLabel: () => `human:${sessionIdRef.current}`,
+        actorLabel: () => actorLabelRef.current,
         createHandle: (actorLabel) => NotebookHandle.create_empty_with_actor(actorLabel),
         getBlobPort,
         publishHandle: setNotebookHandle,
@@ -287,6 +289,10 @@ export function useAutomergeNotebook() {
         if (trigger.kind !== "ready") return;
 
         logger.info("[automerge-notebook] daemon:ready — bootstrapping relay generation");
+        if (trigger.payload.actor_label) {
+          actorLabelRef.current = trigger.payload.actor_label;
+          setLocalActor(trigger.payload.actor_label);
+        }
         storeBridge.resetReadiness();
         refreshBlobPort();
         resetNotebookCells();
@@ -552,7 +558,6 @@ export function useAutomergeNotebook() {
 
   const getHandle = useCallback(() => handleHost.current, [handleHost]);
   const triggerSync = useCallback(() => engineRef.current?.scheduleFlush(), []);
-  const localActor = `human:${sessionIdRef.current}`;
 
   /** Accessor for the SyncEngine (for subscribing to commChanges$ etc.). */
   const getEngine = useCallback(() => engineRef.current, []);

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -31,7 +31,7 @@ interface CrdtBridgeContextValue {
   getHandle: () => NotebookHandle | null;
   /** Signal that the CRDT was mutated and needs syncing to daemon. */
   onSyncNeeded: () => void;
-  /** Local actor label (e.g. "human:abcd1234") for filtering self-echo attributions. */
+  /** Local actor label (e.g. "local:kyle/desktop:abcd1234") for filtering self-echo attributions. */
   localActor: string;
 }
 

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -164,6 +164,7 @@ mod tests {
             protocol: None,
             working_dir: None,
             initial_metadata: None,
+            operator: None,
         })
         .unwrap();
         assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
@@ -174,6 +175,7 @@ mod tests {
             protocol: Some(PROTOCOL_V4.into()),
             working_dir: None,
             initial_metadata: None,
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -187,6 +189,7 @@ mod tests {
             protocol: Some(PROTOCOL_V4.into()),
             working_dir: Some("/home/user/project".into()),
             initial_metadata: None,
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -194,9 +197,24 @@ mod tests {
             r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v4","working_dir":"/home/user/project"}"#
         );
 
+        // NotebookSync with authenticated operator hint
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "abc".into(),
+            protocol: Some(PROTOCOL_V4.into()),
+            working_dir: None,
+            initial_metadata: None,
+            operator: Some("agent:codex:s1".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v4","operator":"agent:codex:s1"}"#
+        );
+
         // OpenNotebook
         let json = serde_json::to_string(&Handshake::OpenNotebook {
             path: "/home/user/notebook.ipynb".into(),
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -213,6 +231,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            operator: None,
         })
         .unwrap();
         assert_eq!(json, r#"{"channel":"create_notebook","runtime":"python"}"#);
@@ -226,6 +245,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -242,6 +262,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -257,6 +278,7 @@ mod tests {
             package_manager: None,
             environment_mode: Some(CreateNotebookEnvironmentMode::Notebook),
             dependencies: vec![],
+            operator: None,
         })
         .unwrap();
         assert_eq!(
@@ -276,6 +298,8 @@ mod tests {
                 protocol_version,
                 daemon_version,
                 put_blob: None,
+                actor_label: None,
+                connection_scope: None,
             }
         }
 
@@ -348,10 +372,27 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));
 
+        // With identity metadata
+        let info = NotebookConnectionInfo {
+            capabilities: capabilities(None, None)
+                .with_identity("local:kyle/desktop:7f3a", "owner"),
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: false,
+            notebook_path: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""actor_label":"local:kyle/desktop:7f3a""#));
+        assert!(json.contains(r#""connection_scope":"owner""#));
+
         // Backward compat: deserialize without notebook_path
         let old_json = r#"{"protocol":"v2","notebook_id":"abc","cell_count":1,"needs_trust_approval":false,"ephemeral":false}"#;
         let info: NotebookConnectionInfo = serde_json::from_str(old_json).unwrap();
         assert!(info.notebook_path.is_none());
+        assert!(info.capabilities.actor_label.is_none());
+        assert!(info.capabilities.connection_scope.is_none());
     }
 
     #[test]

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -31,6 +31,11 @@ pub enum Handshake {
         /// so the daemon can read kernelspec before auto-launching a kernel.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         initial_metadata: Option<String>,
+        /// Self-declared operator suffix for the authenticated actor label.
+        /// The room host owns the principal prefix and returns the assembled
+        /// `<principal>/<operator>` label in `ProtocolCapabilities`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operator: Option<String>,
     },
     /// Open an existing notebook file. Daemon loads from disk, derives notebook_id.
     ///
@@ -39,6 +44,9 @@ pub enum Handshake {
     OpenNotebook {
         /// Path to the .ipynb file.
         path: String,
+        /// Self-declared operator suffix for the authenticated actor label.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operator: Option<String>,
     },
 
     /// Runtime agent handshake. Sent by the coordinator to a spawned runtime
@@ -87,6 +95,9 @@ pub enum Handshake {
         /// Dependencies to seed into notebook metadata before auto-launch.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         dependencies: Vec<String>,
+        /// Self-declared operator suffix for the authenticated actor label.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operator: Option<String>,
     },
 }
 
@@ -118,6 +129,14 @@ pub struct ProtocolCapabilities {
     /// Blob upload support advertised by the daemon.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub put_blob: Option<PutBlobCapability>,
+    /// Authenticated actor label that the client should use for Automerge
+    /// changes on this connection, formatted as `<principal>/<operator>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_label: Option<String>,
+    /// Server-enforced connection scope. This is informational for clients;
+    /// room hosts still enforce scope server-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_scope: Option<String>,
 }
 
 impl ProtocolCapabilities {
@@ -135,7 +154,20 @@ impl ProtocolCapabilities {
                 multipart: true,
                 ephemeral_supported: true,
             }),
+            actor_label: None,
+            connection_scope: None,
         }
+    }
+
+    /// Attach authenticated identity metadata to this capability response.
+    pub fn with_identity(
+        mut self,
+        actor_label: impl Into<String>,
+        connection_scope: impl Into<String>,
+    ) -> Self {
+        self.actor_label = Some(actor_label.into());
+        self.connection_scope = Some(connection_scope.into());
+        self
     }
 }
 

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -187,6 +187,7 @@ pub async fn connect_with_options(
         protocol: Some(PROTOCOL_V4.to_string()),
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         initial_metadata: initial_metadata.clone(),
+        operator: operator_from_actor_label(actor_label),
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -203,7 +204,7 @@ pub async fn connect_with_options(
     // owns the entire bootstrap from the first post-handshake frame onward.
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
-        actor_label,
+        caps.actor_label.as_deref().unwrap_or(actor_label),
     );
     let doc = bootstrap.into_inner();
     let peer_state = sync::State::new();
@@ -235,6 +236,7 @@ pub async fn connect_open(
     // Send open handshake
     let handshake = Handshake::OpenNotebook {
         path: path.to_string_lossy().to_string(),
+        operator: operator_from_actor_label(actor_label),
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -254,7 +256,10 @@ pub async fn connect_open(
 
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
-        actor_label,
+        info.capabilities
+            .actor_label
+            .as_deref()
+            .unwrap_or(actor_label),
     );
     let doc = bootstrap.into_inner();
     let peer_state = sync::State::new();
@@ -351,6 +356,7 @@ async fn connect_create_inner(
         package_manager,
         environment_mode,
         dependencies,
+        operator: operator_from_actor_label(actor_label),
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -370,7 +376,10 @@ async fn connect_create_inner(
 
     let bootstrap = notebook_doc::NotebookDoc::bootstrap(
         notebook_doc::TextEncoding::UnicodeCodePoint,
-        actor_label,
+        info.capabilities
+            .actor_label
+            .as_deref()
+            .unwrap_or(actor_label),
     );
     let doc = bootstrap.into_inner();
     let peer_state = sync::State::new();
@@ -481,6 +490,16 @@ pub async fn connect_open_relay(
     path: PathBuf,
     frame_tx: mpsc::UnboundedSender<Vec<u8>>,
 ) -> Result<RelayOpenResult, SyncError> {
+    connect_open_relay_with_operator(socket_path, path, frame_tx, None).await
+}
+
+/// Open a notebook as a relay with a self-declared operator label.
+pub async fn connect_open_relay_with_operator(
+    socket_path: PathBuf,
+    path: PathBuf,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    operator: Option<String>,
+) -> Result<RelayOpenResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -492,6 +511,7 @@ pub async fn connect_open_relay(
     // Send open handshake
     let handshake = Handshake::OpenNotebook {
         path: path.to_string_lossy().to_string(),
+        operator,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -534,6 +554,35 @@ pub async fn connect_create_relay(
     dependencies: Vec<String>,
     environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
 ) -> Result<RelayCreateResult, SyncError> {
+    connect_create_relay_with_operator(
+        socket_path,
+        runtime,
+        working_dir,
+        notebook_id,
+        frame_tx,
+        ephemeral,
+        package_manager,
+        dependencies,
+        environment_mode,
+        None,
+    )
+    .await
+}
+
+/// Create a notebook as a relay with a self-declared operator label.
+#[allow(clippy::too_many_arguments)]
+pub async fn connect_create_relay_with_operator(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    ephemeral: bool,
+    package_manager: Option<notebook_protocol::connection::PackageManager>,
+    dependencies: Vec<String>,
+    environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
+    operator: Option<String>,
+) -> Result<RelayCreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -553,6 +602,7 @@ pub async fn connect_create_relay(
         package_manager,
         environment_mode,
         dependencies,
+        operator,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -588,6 +638,16 @@ pub async fn connect_relay(
     notebook_id: String,
     frame_tx: mpsc::UnboundedSender<Vec<u8>>,
 ) -> Result<RelayConnectResult, SyncError> {
+    connect_relay_with_operator(socket_path, notebook_id, frame_tx, None).await
+}
+
+/// Connect to a notebook room by ID as a relay with a self-declared operator label.
+pub async fn connect_relay_with_operator(
+    socket_path: PathBuf,
+    notebook_id: String,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    operator: Option<String>,
+) -> Result<RelayConnectResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -602,6 +662,7 @@ pub async fn connect_relay(
         protocol: Some(PROTOCOL_V4.to_string()),
         initial_metadata: None,
         working_dir: None,
+        operator,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -622,13 +683,27 @@ pub async fn connect_relay(
 
     let handle = spawn_relay(notebook_id, frame_tx, reader, writer);
 
-    Ok(RelayConnectResult { handle })
+    Ok(RelayConnectResult {
+        handle,
+        capabilities: caps,
+    })
 }
 
 /// Result of connecting to a notebook room by ID as a relay.
 pub struct RelayConnectResult {
     /// Handle for forwarding frames and sending requests.
     pub handle: RelayHandle,
+
+    /// Protocol capabilities returned by the daemon.
+    pub capabilities: ProtocolCapabilities,
+}
+
+fn operator_from_actor_label(actor_label: &str) -> Option<String> {
+    match actor_label.split_once('/') {
+        Some((_, operator)) if !operator.is_empty() => Some(operator.to_string()),
+        None if !actor_label.is_empty() => Some(actor_label.to_string()),
+        _ => None,
+    }
 }
 
 /// Spawn a relay task and return the handle.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -348,6 +348,10 @@ struct DaemonReadyPayload {
     /// Only set for Create (where we know the exact runtime); None for Open
     /// (where the actual runtime is determined from the file's metadata).
     runtime: Option<String>,
+    /// Authenticated actor label the frontend should use for Automerge writes.
+    actor_label: Option<String>,
+    /// Server-enforced scope for this connection.
+    connection_scope: Option<String>,
 }
 
 /// How to connect a new window to the daemon.
@@ -452,6 +456,11 @@ where
     )
 }
 
+fn desktop_operator_label() -> String {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    format!("desktop:{}", &suffix[..8])
+}
+
 /// Connect to the daemon by opening an existing notebook file.
 ///
 /// The daemon loads the file, derives notebook_id, creates the room, and populates
@@ -494,9 +503,15 @@ async fn initialize_notebook_sync_open(
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
     let caller_path = path.to_string_lossy().to_string();
-    let result = notebook_sync::connect::connect_open_relay(socket_path, path, frame_tx)
-        .await
-        .map_err(|e| format!("sync connect (open): {}", e))?;
+    let operator = desktop_operator_label();
+    let result = notebook_sync::connect::connect_open_relay_with_operator(
+        socket_path,
+        path,
+        frame_tx,
+        Some(operator),
+    )
+    .await
+    .map_err(|e| format!("sync connect (open): {}", e))?;
 
     let handle = result.handle;
     let info = result.info;
@@ -519,6 +534,8 @@ async fn initialize_notebook_sync_open(
         ephemeral: info.ephemeral,
         notebook_path: info.notebook_path.or(Some(caller_path)),
         runtime: None,
+        actor_label: info.capabilities.actor_label.clone(),
+        connection_scope: info.capabilities.connection_scope.clone(),
     };
 
     setup_sync_receivers(
@@ -560,7 +577,8 @@ async fn initialize_notebook_sync_create(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
-    let result = notebook_sync::connect::connect_create_relay(
+    let operator = desktop_operator_label();
+    let result = notebook_sync::connect::connect_create_relay_with_operator(
         socket_path,
         &runtime,
         working_dir,
@@ -570,6 +588,7 @@ async fn initialize_notebook_sync_create(
         None,
         vec![],
         None,
+        Some(operator),
     )
     .await
     .map_err(|e| format!("sync connect (create): {}", e))?;
@@ -595,6 +614,8 @@ async fn initialize_notebook_sync_create(
         ephemeral: info.ephemeral,
         notebook_path: info.notebook_path.clone(),
         runtime: Some(runtime),
+        actor_label: info.capabilities.actor_label.clone(),
+        connection_scope: info.capabilities.connection_scope.clone(),
     };
 
     setup_sync_receivers(
@@ -636,11 +657,18 @@ async fn initialize_notebook_sync_attach(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
-    let result = notebook_sync::connect::connect_relay(socket_path, notebook_id.clone(), frame_tx)
-        .await
-        .map_err(|e| format!("sync connect (attach): {}", e))?;
+    let operator = desktop_operator_label();
+    let result = notebook_sync::connect::connect_relay_with_operator(
+        socket_path,
+        notebook_id.clone(),
+        frame_tx,
+        Some(operator),
+    )
+    .await
+    .map_err(|e| format!("sync connect (attach): {}", e))?;
 
     let handle = result.handle;
+    let capabilities = result.capabilities;
 
     // Update notebook_id to match the room we just attached to.
     if let Ok(mut id) = notebook_id_arc.lock() {
@@ -658,6 +686,8 @@ async fn initialize_notebook_sync_attach(
         ephemeral: true,
         notebook_path: None,
         runtime: Some(runtime),
+        actor_label: capabilities.actor_label.clone(),
+        connection_scope: capabilities.connection_scope.clone(),
     };
 
     setup_sync_receivers(

--- a/crates/nteract-identity/Cargo.toml
+++ b/crates/nteract-identity/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "nteract-identity"
+version = "0.1.0"
+edition.workspace = true
+description = "Identity and authorization primitives for nteract notebook rooms"
+repository.workspace = true
+license.workspace = true
+
+[features]
+default = ["local"]
+local = []
+oidc = ["dep:jsonwebtoken"]
+jupyterhub = []
+
+[lints]
+workspace = true
+
+[dependencies]
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto"], optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto", "use_pem"] }
+serde_json = { workspace = true }

--- a/crates/nteract-identity/src/jupyterhub.rs
+++ b/crates/nteract-identity/src/jupyterhub.rs
@@ -4,7 +4,8 @@ use crate::{AuthError, AuthenticatedUser, Credential, Result};
 ///
 /// The provider enum and feature gate land with the core crate so downstream
 /// code can compile against the intended dispatch shape before Hub API
-/// validation dependencies are introduced.
+/// validation dependencies are introduced. Until that path lands, this
+/// provider intentionally returns [`AuthError::ProviderUnavailable`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct JupyterHubProvider;
 

--- a/crates/nteract-identity/src/jupyterhub.rs
+++ b/crates/nteract-identity/src/jupyterhub.rs
@@ -1,0 +1,20 @@
+use crate::{AuthError, AuthenticatedUser, Credential, Result};
+
+/// JupyterHub identity provider placeholder.
+///
+/// The provider enum and feature gate land with the core crate so downstream
+/// code can compile against the intended dispatch shape before Hub API
+/// validation dependencies are introduced.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JupyterHubProvider;
+
+impl JupyterHubProvider {
+    /// JupyterHub authentication is implemented in the provider follow-up.
+    #[allow(clippy::manual_async_fn)]
+    pub fn authenticate(
+        &self,
+        _presented: Credential,
+    ) -> impl std::future::Future<Output = Result<AuthenticatedUser>> + Send + '_ {
+        async move { Err(AuthError::ProviderUnavailable("jupyterhub")) }
+    }
+}

--- a/crates/nteract-identity/src/lib.rs
+++ b/crates/nteract-identity/src/lib.rs
@@ -183,6 +183,22 @@ impl Operator {
             None => self.as_str(),
         }
     }
+
+    /// Extracts an operator from either a full actor label or a legacy
+    /// operator-only label.
+    ///
+    /// Current room hosts emit `<principal>/<operator>`, but existing local
+    /// clients may still present values such as `human:session`. Treating a
+    /// valid operator-only value as the suffix keeps those clients attributed
+    /// under the authenticated principal instead of falling back to an
+    /// anonymous connection operator.
+    pub fn from_actor_label_or_operator(value: &str) -> Result<Self> {
+        match ActorLabel::parse(value.to_owned()) {
+            Ok(label) => label.operator_value(),
+            Err(AuthError::ActorLabelMissingDelimiter) => Self::new(value.to_owned()),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 impl fmt::Display for Operator {
@@ -521,13 +537,9 @@ impl AuthenticatedConnection {
         presented: Option<&str>,
         fallback_operator: Operator,
     ) -> ActorLabel {
-        let operator = match presented.and_then(|label| ActorLabel::parse(label).ok()) {
-            Some(label) => match label.operator_value() {
-                Ok(operator) => operator,
-                Err(_) => fallback_operator,
-            },
-            None => fallback_operator,
-        };
+        let operator = presented
+            .and_then(|label| Operator::from_actor_label_or_operator(label).ok())
+            .unwrap_or(fallback_operator);
 
         ActorLabel::new(self.principal.clone(), operator)
     }
@@ -681,15 +693,26 @@ mod tests {
         let connection =
             AuthenticatedConnection::new(principal("user:anaconda:550e"), ConnectionScope::Editor);
 
-        let rewritten = connection.rewrite_presence_actor_label(
-            Some("not-a-layered-label"),
-            operator("unknown:connection-1"),
-        );
+        let rewritten = connection
+            .rewrite_presence_actor_label(Some("bad/operator"), operator("unknown:connection-1"));
 
         assert_eq!(
             rewritten.as_str(),
             "user:anaconda:550e/unknown:connection-1"
         );
+    }
+
+    #[test]
+    fn connection_rewrite_preserves_legacy_operator_only_label() {
+        let connection =
+            AuthenticatedConnection::new(principal("local:kylekelley"), ConnectionScope::Owner);
+
+        let rewritten = connection.rewrite_presence_actor_label(
+            Some("human:session-abc"),
+            operator("unknown:connection-1"),
+        );
+
+        assert_eq!(rewritten.as_str(), "local:kylekelley/human:session-abc");
     }
 
     #[test]

--- a/crates/nteract-identity/src/lib.rs
+++ b/crates/nteract-identity/src/lib.rs
@@ -1,7 +1,9 @@
 //! Identity primitives for nteract notebook rooms.
 //!
 //! The crate keeps the security-critical parsing rules close to the provider
-//! dispatch types that room hosts will use at connection time.
+//! dispatch types that room hosts will use at connection time. The
+//! JupyterHub provider surface is feature-gated and currently returns
+//! [`AuthError::ProviderUnavailable`] until the Hub API validation path lands.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -71,6 +73,8 @@ pub enum AuthError {
 ///
 /// Principals are room-local identity names, not process-local identity names.
 /// They must either be the seed principal `system` or follow `<scheme>:<id>`.
+/// The literal `system` principal is reserved; `system:*` values are ordinary
+/// scheme principals and do not receive the seed-author exemption.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Principal(String);
 

--- a/crates/nteract-identity/src/lib.rs
+++ b/crates/nteract-identity/src/lib.rs
@@ -1,0 +1,801 @@
+//! Identity primitives for nteract notebook rooms.
+//!
+//! The crate keeps the security-critical parsing rules close to the provider
+//! dispatch types that room hosts will use at connection time.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+#[cfg(feature = "jupyterhub")]
+mod jupyterhub;
+mod local;
+#[cfg(feature = "oidc")]
+mod oidc;
+
+#[cfg(feature = "jupyterhub")]
+pub use jupyterhub::JupyterHubProvider;
+pub use local::{LocalPeerCredential, LocalProvider};
+#[cfg(feature = "oidc")]
+pub use oidc::{OidcProvider, OidcProviderConfig};
+
+/// Result alias for identity and authentication operations.
+pub type Result<T> = std::result::Result<T, AuthError>;
+
+/// Errors raised while parsing labels or authenticating a connection.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AuthError {
+    #[error("principal cannot be empty")]
+    EmptyPrincipal,
+    #[error("principal cannot contain '/'")]
+    PrincipalContainsSlash,
+    #[error("principal must be 'system' or '<scheme>:<id>'")]
+    PrincipalMissingScheme,
+    #[error("principal scheme cannot be empty")]
+    PrincipalEmptyScheme,
+    #[error("principal id cannot be empty")]
+    PrincipalEmptyId,
+    #[error("operator cannot be empty")]
+    EmptyOperator,
+    #[error("operator kind cannot be empty")]
+    EmptyOperatorKind,
+    #[error("operator cannot contain '/'")]
+    OperatorContainsSlash,
+    #[error("actor label must be '<principal>/<operator>'")]
+    ActorLabelMissingDelimiter,
+    #[error("local username cannot be empty")]
+    EmptyLocalUsername,
+    #[error("local username cannot contain '/'")]
+    LocalUsernameContainsSlash,
+    #[error("invalid credential: {0}")]
+    InvalidCredential(&'static str),
+    #[error("identity provider is unavailable: {0}")]
+    ProviderUnavailable(&'static str),
+    #[error("unknown connection scope: {0}")]
+    UnknownConnectionScope(String),
+    #[error("invalid OIDC configuration: {0}")]
+    InvalidOidcConfig(&'static str),
+    #[error("invalid OIDC JWKS: {0}")]
+    InvalidOidcJwks(String),
+    #[error("OIDC token rejected: {0}")]
+    OidcTokenRejected(String),
+    #[error("OIDC signing key not found for kid {kid:?}")]
+    OidcKeyNotFound { kid: Option<String> },
+    #[error("OIDC algorithm is not allowed: {algorithm}")]
+    OidcAlgorithmNotAllowed { algorithm: String },
+    #[error("operator kind '{kind}' is not allowed for this connection")]
+    OperatorKindNotAllowed { kind: String },
+}
+
+/// Authenticated entity for a room.
+///
+/// Principals are room-local identity names, not process-local identity names.
+/// They must either be the seed principal `system` or follow `<scheme>:<id>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Principal(String);
+
+impl Principal {
+    /// Principal reserved for system seed changes.
+    pub const SYSTEM: &'static str = "system";
+
+    /// Creates a validated principal.
+    pub fn new(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(AuthError::EmptyPrincipal);
+        }
+        if value.contains('/') {
+            return Err(AuthError::PrincipalContainsSlash);
+        }
+        if value == Self::SYSTEM {
+            return Ok(Self(value));
+        }
+
+        let Some((scheme, id)) = value.split_once(':') else {
+            return Err(AuthError::PrincipalMissingScheme);
+        };
+        if scheme.is_empty() {
+            return Err(AuthError::PrincipalEmptyScheme);
+        }
+        if id.is_empty() {
+            return Err(AuthError::PrincipalEmptyId);
+        }
+
+        Ok(Self(value))
+    }
+
+    /// Returns the underlying principal string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Principal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Principal {
+    type Err = AuthError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl TryFrom<String> for Principal {
+    type Error = AuthError;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl Serialize for Principal {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Principal {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Self-declared operator acting on behalf of a principal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Operator(String);
+
+impl Operator {
+    /// Creates a validated operator suffix.
+    pub fn new(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        if value.is_empty() {
+            return Err(AuthError::EmptyOperator);
+        }
+        if value.contains('/') {
+            return Err(AuthError::OperatorContainsSlash);
+        }
+        if value.starts_with(':') {
+            return Err(AuthError::EmptyOperatorKind);
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the underlying operator string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns the operator kind before the first colon.
+    pub fn kind(&self) -> &str {
+        match self.0.split_once(':') {
+            Some((kind, _)) => kind,
+            None => self.as_str(),
+        }
+    }
+}
+
+impl fmt::Display for Operator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Operator {
+    type Err = AuthError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Self::new(value.to_owned())
+    }
+}
+
+impl TryFrom<String> for Operator {
+    type Error = AuthError;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::new(value)
+    }
+}
+
+impl Serialize for Operator {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Operator {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Full Automerge actor label, formatted as `<principal>/<operator>`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ActorLabel {
+    value: String,
+    delimiter_index: usize,
+}
+
+impl ActorLabel {
+    /// Creates a label from already-validated parts.
+    pub fn new(principal: Principal, operator: Operator) -> Self {
+        let delimiter_index = principal.as_str().len();
+        let value = format!("{principal}/{operator}");
+        Self {
+            value,
+            delimiter_index,
+        }
+    }
+
+    /// Parses and validates an actor label.
+    pub fn parse(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        let Some(delimiter_index) = value.find('/') else {
+            return Err(AuthError::ActorLabelMissingDelimiter);
+        };
+
+        Principal::new(value[..delimiter_index].to_owned())?;
+        Operator::new(value[delimiter_index + 1..].to_owned())?;
+
+        Ok(Self {
+            value,
+            delimiter_index,
+        })
+    }
+
+    /// Returns the full actor label string.
+    pub fn as_str(&self) -> &str {
+        &self.value
+    }
+
+    /// Returns the principal prefix.
+    pub fn principal(&self) -> &str {
+        &self.value[..self.delimiter_index]
+    }
+
+    /// Returns the operator suffix.
+    pub fn operator(&self) -> &str {
+        &self.value[self.delimiter_index + 1..]
+    }
+
+    /// Returns a parsed copy of the principal prefix.
+    pub fn principal_value(&self) -> Result<Principal> {
+        Principal::new(self.principal().to_owned())
+    }
+
+    /// Returns a parsed copy of the operator suffix.
+    pub fn operator_value(&self) -> Result<Operator> {
+        Operator::new(self.operator().to_owned())
+    }
+
+    /// Returns the same operator under a different authenticated principal.
+    pub fn with_principal(&self, principal: Principal) -> Result<Self> {
+        let operator = self.operator_value()?;
+        Ok(Self::new(principal, operator))
+    }
+}
+
+impl fmt::Display for ActorLabel {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ActorLabel {
+    type Err = AuthError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Self::parse(value.to_owned())
+    }
+}
+
+impl TryFrom<String> for ActorLabel {
+    type Error = AuthError;
+
+    fn try_from(value: String) -> Result<Self> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for ActorLabel {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ActorLabel {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Server-side connection scope assigned by an identity provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionScope {
+    Viewer,
+    Editor,
+    RuntimePeer,
+    Owner,
+}
+
+impl ConnectionScope {
+    /// Stable lowercase scope name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Viewer => "viewer",
+            Self::Editor => "editor",
+            Self::RuntimePeer => "runtime_peer",
+            Self::Owner => "owner",
+        }
+    }
+
+    /// Whether this scope can send NotebookDoc frames.
+    pub const fn allows_notebook_write(self) -> bool {
+        matches!(self, Self::Editor | Self::Owner)
+    }
+
+    /// Whether this scope can send RuntimeStateDoc frames.
+    pub const fn allows_runtime_state_write(self) -> bool {
+        matches!(self, Self::Editor | Self::RuntimePeer | Self::Owner)
+    }
+
+    /// Whether this scope can publish revisions.
+    pub const fn allows_publish(self) -> bool {
+        matches!(self, Self::Owner)
+    }
+
+    /// Whether this scope can manage ACLs.
+    pub const fn allows_acl_mutation(self) -> bool {
+        matches!(self, Self::Owner)
+    }
+}
+
+impl fmt::Display for ConnectionScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ConnectionScope {
+    type Err = AuthError;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "viewer" => Ok(Self::Viewer),
+            "editor" => Ok(Self::Editor),
+            "runtime_peer" => Ok(Self::RuntimePeer),
+            "owner" => Ok(Self::Owner),
+            _ => Err(AuthError::UnknownConnectionScope(value.to_owned())),
+        }
+    }
+}
+
+/// Normalized credential presented to a server-side provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum Credential {
+    BearerToken(String),
+    Cookie(String),
+    OneTimeTicket(String),
+    LocalPeer(LocalPeerCredential),
+}
+
+/// Authenticated room user returned by an identity provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedUser {
+    principal: Principal,
+    scope: ConnectionScope,
+    allowed_operator_kinds: Vec<String>,
+}
+
+impl AuthenticatedUser {
+    /// Creates an authenticated user with no operator-kind restriction.
+    pub fn new(principal: Principal, scope: ConnectionScope) -> Self {
+        Self {
+            principal,
+            scope,
+            allowed_operator_kinds: Vec::new(),
+        }
+    }
+
+    /// Creates an authenticated user with explicit operator-kind restrictions.
+    pub fn with_allowed_operator_kinds(
+        principal: Principal,
+        scope: ConnectionScope,
+        allowed_operator_kinds: Vec<String>,
+    ) -> Self {
+        Self {
+            principal,
+            scope,
+            allowed_operator_kinds,
+        }
+    }
+
+    /// Authenticated principal in the room's identity space.
+    pub fn principal(&self) -> &Principal {
+        &self.principal
+    }
+
+    /// Server-enforced connection scope.
+    pub const fn scope(&self) -> ConnectionScope {
+        self.scope
+    }
+
+    /// Allowed operator kinds. Empty means unrestricted.
+    pub fn allowed_operator_kinds(&self) -> &[String] {
+        &self.allowed_operator_kinds
+    }
+}
+
+/// In-memory identity state attached to an authenticated connection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedConnection {
+    principal: Principal,
+    scope: ConnectionScope,
+    allowed_operator_kinds: Vec<String>,
+}
+
+impl AuthenticatedConnection {
+    /// Creates a connection identity from an authenticated provider result.
+    pub fn new(principal: Principal, scope: ConnectionScope) -> Self {
+        Self::from_user(AuthenticatedUser::new(principal, scope))
+    }
+
+    /// Creates a connection identity from an authenticated provider result.
+    pub fn from_user(user: AuthenticatedUser) -> Self {
+        Self {
+            principal: user.principal,
+            scope: user.scope,
+            allowed_operator_kinds: user.allowed_operator_kinds,
+        }
+    }
+
+    /// Authenticated principal in the room's identity space.
+    pub fn principal(&self) -> &Principal {
+        &self.principal
+    }
+
+    /// Server-enforced connection scope.
+    pub const fn scope(&self) -> ConnectionScope {
+        self.scope
+    }
+
+    /// Allowed operator kinds. Empty means unrestricted.
+    pub fn allowed_operator_kinds(&self) -> &[String] {
+        &self.allowed_operator_kinds
+    }
+
+    /// Whether the supplied operator is allowed for this connection.
+    pub fn permits_operator(&self, operator: &Operator) -> bool {
+        self.allowed_operator_kinds.is_empty()
+            || self
+                .allowed_operator_kinds
+                .iter()
+                .any(|allowed| allowed == operator.kind())
+    }
+
+    /// Constructs an actor label under this connection's authenticated principal.
+    pub fn actor_label_for(&self, operator: Operator) -> Result<ActorLabel> {
+        if !self.permits_operator(&operator) {
+            return Err(AuthError::OperatorKindNotAllowed {
+                kind: operator.kind().to_owned(),
+            });
+        }
+        Ok(ActorLabel::new(self.principal.clone(), operator))
+    }
+
+    /// Rewrites a presented presence actor label to this connection's principal.
+    ///
+    /// The operator suffix is preserved when the presented label is valid. If
+    /// the label is absent or malformed, the caller-provided fallback operator
+    /// is used instead. Presence ingress is deliberately non-rejecting; use
+    /// [`Self::actor_label_for`] when constructing a handshake actor label that
+    /// must honor operator-kind restrictions.
+    pub fn rewrite_presence_actor_label(
+        &self,
+        presented: Option<&str>,
+        fallback_operator: Operator,
+    ) -> ActorLabel {
+        let operator = match presented.and_then(|label| ActorLabel::parse(label).ok()) {
+            Some(label) => match label.operator_value() {
+                Ok(operator) => operator,
+                Err(_) => fallback_operator,
+            },
+            None => fallback_operator,
+        };
+
+        ActorLabel::new(self.principal.clone(), operator)
+    }
+}
+
+/// Closed provider dispatch for server-side authentication.
+#[derive(Debug, Clone)]
+pub enum IdentityProvider {
+    Local(LocalProvider),
+    #[cfg(feature = "oidc")]
+    Oidc(OidcProvider),
+    #[cfg(feature = "jupyterhub")]
+    JupyterHub(JupyterHubProvider),
+}
+
+impl IdentityProvider {
+    /// Creates a local peer-credential provider.
+    pub fn local() -> Self {
+        Self::Local(LocalProvider::default())
+    }
+
+    /// Authenticates a normalized credential using the selected provider.
+    #[allow(clippy::manual_async_fn)]
+    pub fn authenticate(
+        &self,
+        presented: Credential,
+    ) -> impl std::future::Future<Output = Result<AuthenticatedUser>> + Send + '_ {
+        async move {
+            match self {
+                Self::Local(provider) => provider.authenticate(presented).await,
+                #[cfg(feature = "oidc")]
+                Self::Oidc(provider) => provider.authenticate(presented).await,
+                #[cfg(feature = "jupyterhub")]
+                Self::JupyterHub(provider) => provider.authenticate(presented).await,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+
+    fn principal(value: &str) -> Principal {
+        match Principal::new(value.to_owned()) {
+            Ok(principal) => principal,
+            Err(error) => panic!("principal should parse: {error}"),
+        }
+    }
+
+    fn operator(value: &str) -> Operator {
+        match Operator::new(value.to_owned()) {
+            Ok(operator) => operator,
+            Err(error) => panic!("operator should parse: {error}"),
+        }
+    }
+
+    fn actor_label(value: &str) -> ActorLabel {
+        match ActorLabel::parse(value.to_owned()) {
+            Ok(label) => label,
+            Err(error) => panic!("actor label should parse: {error}"),
+        }
+    }
+
+    fn auth_user(result: Result<AuthenticatedUser>) -> AuthenticatedUser {
+        match result {
+            Ok(user) => user,
+            Err(error) => panic!("authentication should pass: {error}"),
+        }
+    }
+
+    fn actor_result(result: Result<ActorLabel>) -> ActorLabel {
+        match result {
+            Ok(label) => label,
+            Err(error) => panic!("actor label should be constructed: {error}"),
+        }
+    }
+
+    #[test]
+    fn validates_principal_shape() {
+        for value in [
+            "system",
+            "system:anonymous",
+            "local:kylekelley",
+            "user:anaconda:550e8400-e29b-41d4-a716-446655440000",
+            "hub:hub.example.com:alice",
+        ] {
+            assert!(Principal::new(value.to_owned()).is_ok(), "{value}");
+        }
+
+        for value in ["", "local", "local:", ":alice", "local/foo"] {
+            assert!(Principal::new(value.to_owned()).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn validates_operator_shape() {
+        for value in ["desktop:7f3a", "agent:codex:s2", "runtime:py-3.12-s4"] {
+            assert!(Operator::new(value.to_owned()).is_ok(), "{value}");
+        }
+
+        for value in ["", ":claude:s1", "agent/claude:s1"] {
+            assert!(Operator::new(value.to_owned()).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn parses_actor_label_layers() {
+        let label = actor_label("user:anaconda:550e/agent:codex:s2");
+        assert_eq!(label.as_str(), "user:anaconda:550e/agent:codex:s2");
+        assert_eq!(label.principal(), "user:anaconda:550e");
+        assert_eq!(label.operator(), "agent:codex:s2");
+    }
+
+    #[test]
+    fn rejects_malformed_actor_labels() {
+        for value in [
+            "local:kylekelley",
+            "local:kylekelley/",
+            "/desktop:7f3a",
+            "local:kylekelley/agent/codex:s2",
+        ] {
+            assert!(ActorLabel::parse(value.to_owned()).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn rewrites_actor_label_principal() {
+        let label = actor_label("local:kylekelley/agent:claude:s1");
+        let rewritten = actor_result(label.with_principal(principal("user:anaconda:550e")));
+
+        assert_eq!(rewritten.as_str(), "user:anaconda:550e/agent:claude:s1");
+    }
+
+    #[test]
+    fn connection_rewrite_preserves_presented_operator() {
+        let connection =
+            AuthenticatedConnection::new(principal("user:anaconda:550e"), ConnectionScope::Editor);
+
+        let rewritten = connection.rewrite_presence_actor_label(
+            Some("local:kylekelley/agent:claude:s1"),
+            operator("unknown:connection-1"),
+        );
+
+        assert_eq!(rewritten.as_str(), "user:anaconda:550e/agent:claude:s1");
+    }
+
+    #[test]
+    fn connection_rewrite_uses_fallback_for_malformed_label() {
+        let connection =
+            AuthenticatedConnection::new(principal("user:anaconda:550e"), ConnectionScope::Editor);
+
+        let rewritten = connection.rewrite_presence_actor_label(
+            Some("not-a-layered-label"),
+            operator("unknown:connection-1"),
+        );
+
+        assert_eq!(
+            rewritten.as_str(),
+            "user:anaconda:550e/unknown:connection-1"
+        );
+    }
+
+    #[test]
+    fn operator_kind_restrictions_are_enforced() {
+        let user = AuthenticatedUser::with_allowed_operator_kinds(
+            principal("user:anaconda:550e"),
+            ConnectionScope::Editor,
+            vec!["agent".to_owned()],
+        );
+        let connection = AuthenticatedConnection::from_user(user);
+
+        assert!(connection
+            .actor_label_for(operator("agent:codex:s2"))
+            .is_ok());
+        assert_eq!(
+            connection.actor_label_for(operator("desktop:7f3a")),
+            Err(AuthError::OperatorKindNotAllowed {
+                kind: "desktop".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn scopes_expose_frame_permissions() {
+        assert!(!ConnectionScope::Viewer.allows_notebook_write());
+        assert!(!ConnectionScope::Viewer.allows_runtime_state_write());
+
+        assert!(ConnectionScope::Editor.allows_notebook_write());
+        assert!(ConnectionScope::Editor.allows_runtime_state_write());
+        assert!(!ConnectionScope::Editor.allows_publish());
+
+        assert!(!ConnectionScope::RuntimePeer.allows_notebook_write());
+        assert!(ConnectionScope::RuntimePeer.allows_runtime_state_write());
+
+        assert!(ConnectionScope::Owner.allows_notebook_write());
+        assert!(ConnectionScope::Owner.allows_runtime_state_write());
+        assert!(ConnectionScope::Owner.allows_publish());
+        assert!(ConnectionScope::Owner.allows_acl_mutation());
+    }
+
+    #[test]
+    fn scope_strings_are_stable() {
+        assert_eq!(ConnectionScope::Viewer.to_string(), "viewer");
+        assert_eq!(
+            ConnectionScope::from_str("runtime_peer"),
+            Ok(ConnectionScope::RuntimePeer)
+        );
+        assert!(ConnectionScope::from_str("runtime-peer").is_err());
+    }
+
+    #[test]
+    fn serde_revalidates_string_newtypes() {
+        let parsed = match serde_json::from_str::<ActorLabel>("\"local:kyle/desktop:7f3a\"") {
+            Ok(label) => label,
+            Err(error) => panic!("valid actor label should deserialize: {error}"),
+        };
+        assert_eq!(parsed.principal(), "local:kyle");
+        assert_eq!(parsed.operator(), "desktop:7f3a");
+
+        let invalid = serde_json::from_str::<ActorLabel>("\"local:kyle\"");
+        assert!(invalid.is_err());
+    }
+
+    #[test]
+    fn local_provider_maps_peer_credentials_to_owner() {
+        let provider = IdentityProvider::local();
+        let credential = Credential::LocalPeer(match LocalPeerCredential::new("kylekelley") {
+            Ok(credential) => credential,
+            Err(error) => panic!("local peer credential should parse: {error}"),
+        });
+        let user = auth_user(block_on(provider.authenticate(credential)));
+
+        assert_eq!(user.principal().as_str(), "local:kylekelley");
+        assert_eq!(user.scope(), ConnectionScope::Owner);
+        assert!(user.allowed_operator_kinds().is_empty());
+    }
+
+    #[test]
+    fn local_provider_rejects_remote_credentials() {
+        let provider = IdentityProvider::local();
+        let result = block_on(provider.authenticate(Credential::BearerToken("token".to_owned())));
+
+        assert_eq!(
+            result,
+            Err(AuthError::InvalidCredential(
+                "local provider requires local peer credentials"
+            ))
+        );
+    }
+
+    #[test]
+    fn local_peer_credentials_reject_bad_usernames() {
+        assert_eq!(
+            LocalPeerCredential::new(""),
+            Err(AuthError::EmptyLocalUsername)
+        );
+        assert_eq!(
+            LocalPeerCredential::new("bad/user"),
+            Err(AuthError::LocalUsernameContainsSlash)
+        );
+    }
+
+    #[test]
+    fn local_peer_credential_deserialization_revalidates_username() {
+        let invalid = serde_json::from_str::<LocalPeerCredential>(r#"{"username":"bad/user"}"#);
+
+        assert!(invalid.is_err());
+    }
+}

--- a/crates/nteract-identity/src/local.rs
+++ b/crates/nteract-identity/src/local.rs
@@ -1,0 +1,103 @@
+use crate::{AuthError, AuthenticatedUser, ConnectionScope, Credential, Principal, Result};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Peer credentials extracted by a trusted local listener.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LocalPeerCredential {
+    username: String,
+}
+
+impl LocalPeerCredential {
+    /// Creates a local peer credential for an OS user.
+    pub fn new(username: impl Into<String>) -> Result<Self> {
+        let username = username.into();
+        if username.is_empty() {
+            return Err(AuthError::EmptyLocalUsername);
+        }
+        if username.contains('/') {
+            return Err(AuthError::LocalUsernameContainsSlash);
+        }
+
+        Ok(Self { username })
+    }
+
+    /// Returns the OS username supplied by the listener.
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    /// Maps the peer credential into the local identity space.
+    pub fn principal(&self) -> Result<Principal> {
+        Principal::new(format!("local:{}", self.username))
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalPeerCredential {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireLocalPeerCredential {
+            username: String,
+        }
+
+        let wire = WireLocalPeerCredential::deserialize(deserializer)?;
+        Self::new(wire.username).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Local identity provider backed by listener-verified peer credentials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalProvider {
+    default_scope: ConnectionScope,
+    allowed_operator_kinds: Vec<String>,
+}
+
+impl Default for LocalProvider {
+    fn default() -> Self {
+        Self {
+            default_scope: ConnectionScope::Owner,
+            allowed_operator_kinds: Vec::new(),
+        }
+    }
+}
+
+impl LocalProvider {
+    /// Creates a local provider with a custom default scope.
+    pub fn new(default_scope: ConnectionScope) -> Self {
+        Self {
+            default_scope,
+            allowed_operator_kinds: Vec::new(),
+        }
+    }
+
+    /// Restricts the operator kinds accepted for local connections.
+    pub fn with_allowed_operator_kinds(mut self, allowed_operator_kinds: Vec<String>) -> Self {
+        self.allowed_operator_kinds = allowed_operator_kinds;
+        self
+    }
+
+    /// Authenticates local peer credentials.
+    #[allow(clippy::manual_async_fn)]
+    pub fn authenticate(
+        &self,
+        presented: Credential,
+    ) -> impl std::future::Future<Output = Result<AuthenticatedUser>> + Send + '_ {
+        let default_scope = self.default_scope;
+        let allowed_operator_kinds = self.allowed_operator_kinds.clone();
+
+        async move {
+            match presented {
+                Credential::LocalPeer(peer) => Ok(AuthenticatedUser::with_allowed_operator_kinds(
+                    peer.principal()?,
+                    default_scope,
+                    allowed_operator_kinds,
+                )),
+                _ => Err(AuthError::InvalidCredential(
+                    "local provider requires local peer credentials",
+                )),
+            }
+        }
+    }
+}

--- a/crates/nteract-identity/src/oidc.rs
+++ b/crates/nteract-identity/src/oidc.rs
@@ -176,7 +176,12 @@ impl OidcProviderConfig {
                 "principal namespace cannot be empty",
             ));
         }
-        Principal::new(format!("{principal_namespace}:subject"))?;
+        let namespace = Principal::new(principal_namespace.clone())?;
+        if namespace.as_str() == Principal::SYSTEM {
+            return Err(AuthError::InvalidOidcConfig(
+                "principal namespace cannot be system",
+            ));
+        }
 
         Ok(Self {
             issuer,
@@ -642,6 +647,16 @@ iK6jkmv5/uDc/iFj+DniQQ==
                 "OIDC bearer validation requires asymmetric algorithms"
             ))
         );
+    }
+
+    #[test]
+    fn rejects_invalid_principal_namespaces() {
+        for namespace in ["user:", "system", "bad/namespace"] {
+            assert!(
+                OidcProviderConfig::new(ISSUER, AUDIENCE, namespace).is_err(),
+                "{namespace}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nteract-identity/src/oidc.rs
+++ b/crates/nteract-identity/src/oidc.rs
@@ -13,6 +13,10 @@ pub struct OidcProvider {
 
 impl OidcProvider {
     /// Creates an OIDC provider from a JWKS JSON document.
+    ///
+    /// Tokens without a `kid` header are accepted only when exactly one JWKS
+    /// key matches the token algorithm. A no-`kid` token with multiple
+    /// matching candidate keys is rejected as ambiguous.
     pub fn from_jwks_json(config: OidcProviderConfig, jwks_json: &str) -> Result<Self> {
         let jwks = serde_json::from_str::<JwkSet>(jwks_json)
             .map_err(|error| AuthError::InvalidOidcJwks(error.to_string()))?;

--- a/crates/nteract-identity/src/oidc.rs
+++ b/crates/nteract-identity/src/oidc.rs
@@ -1,0 +1,657 @@
+use crate::{AuthError, AuthenticatedUser, ConnectionScope, Credential, Principal, Result};
+use jsonwebtoken::jwk::{Jwk, JwkSet, KeyOperations, PublicKeyUse};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+/// OIDC bearer-token provider backed by a caller-managed JWKS cache.
+#[derive(Debug, Clone)]
+pub struct OidcProvider {
+    config: OidcProviderConfig,
+    jwks: JwkSet,
+}
+
+impl OidcProvider {
+    /// Creates an OIDC provider from a JWKS JSON document.
+    pub fn from_jwks_json(config: OidcProviderConfig, jwks_json: &str) -> Result<Self> {
+        let jwks = serde_json::from_str::<JwkSet>(jwks_json)
+            .map_err(|error| AuthError::InvalidOidcJwks(error.to_string()))?;
+        if jwks.keys.is_empty() {
+            return Err(AuthError::InvalidOidcJwks(
+                "JWKS must contain at least one key".to_owned(),
+            ));
+        }
+
+        Ok(Self { config, jwks })
+    }
+
+    /// Returns the provider configuration.
+    pub fn config(&self) -> &OidcProviderConfig {
+        &self.config
+    }
+
+    /// Authenticates a bearer JWT.
+    #[allow(clippy::manual_async_fn)]
+    pub fn authenticate(
+        &self,
+        presented: Credential,
+    ) -> impl std::future::Future<Output = Result<AuthenticatedUser>> + Send + '_ {
+        async move {
+            match presented {
+                Credential::BearerToken(token) => self.authenticate_bearer(&token),
+                _ => Err(AuthError::InvalidCredential(
+                    "OIDC provider requires a bearer token",
+                )),
+            }
+        }
+    }
+
+    fn authenticate_bearer(&self, token: &str) -> Result<AuthenticatedUser> {
+        let header = decode_header(token)
+            .map_err(|error| AuthError::OidcTokenRejected(error.to_string()))?;
+        if !self.config.allowed_algorithms.contains(&header.alg) {
+            return Err(AuthError::OidcAlgorithmNotAllowed {
+                algorithm: format!("{:?}", header.alg),
+            });
+        }
+
+        let jwk = self.select_jwk(header.kid.as_deref(), header.alg)?;
+        let decoding_key = DecodingKey::from_jwk(jwk)
+            .map_err(|error| AuthError::OidcTokenRejected(error.to_string()))?;
+        let claims = decode::<OidcClaims>(token, &decoding_key, &self.validation(header.alg))
+            .map_err(|error| AuthError::OidcTokenRejected(error.to_string()))?
+            .claims;
+
+        let principal = self.config.principal_for_subject(&claims.sub)?;
+        let scope = self.config.scope_for_claims(&claims.extra);
+
+        Ok(AuthenticatedUser::with_allowed_operator_kinds(
+            principal,
+            scope,
+            self.config.allowed_operator_kinds.clone(),
+        ))
+    }
+
+    fn select_jwk(&self, kid: Option<&str>, algorithm: Algorithm) -> Result<&Jwk> {
+        if let Some(kid) = kid {
+            let jwk = self
+                .jwks
+                .find(kid)
+                .ok_or_else(|| AuthError::OidcKeyNotFound {
+                    kid: Some(kid.to_owned()),
+                })?;
+            self.validate_jwk_algorithm(jwk, algorithm)?;
+            return Ok(jwk);
+        }
+
+        let mut candidates = self
+            .jwks
+            .keys
+            .iter()
+            .filter(|jwk| self.validate_jwk_algorithm(jwk, algorithm).is_ok());
+
+        let Some(jwk) = candidates.next() else {
+            return Err(AuthError::OidcKeyNotFound { kid: None });
+        };
+        if candidates.next().is_some() {
+            return Err(AuthError::OidcKeyNotFound { kid: None });
+        }
+
+        Ok(jwk)
+    }
+
+    fn validate_jwk_algorithm(&self, jwk: &Jwk, algorithm: Algorithm) -> Result<()> {
+        if matches!(jwk.common.public_key_use, Some(PublicKeyUse::Encryption)) {
+            return Err(AuthError::OidcTokenRejected(
+                "JWK is not marked for signature verification".to_owned(),
+            ));
+        }
+        if let Some(key_operations) = &jwk.common.key_operations {
+            let has_verify = key_operations
+                .iter()
+                .any(|operation| matches!(operation, KeyOperations::Verify));
+            if !has_verify {
+                return Err(AuthError::OidcTokenRejected(
+                    "JWK is not allowed to verify signatures".to_owned(),
+                ));
+            }
+        }
+        if let Some(key_algorithm) = jwk.common.key_algorithm {
+            let key_algorithm = format!("{key_algorithm}");
+            if key_algorithm != format!("{algorithm:?}") {
+                return Err(AuthError::OidcAlgorithmNotAllowed {
+                    algorithm: format!("{algorithm:?}"),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn validation(&self, algorithm: Algorithm) -> Validation {
+        let mut validation = Validation::new(algorithm);
+        validation.set_issuer(&[self.config.issuer.as_str()]);
+        validation.set_audience(&[self.config.audience.as_str()]);
+        validation.set_required_spec_claims(&["exp", "iss", "aud", "sub"]);
+        validation.leeway = self.config.leeway_seconds;
+        validation
+    }
+}
+
+/// OIDC provider configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OidcProviderConfig {
+    issuer: String,
+    audience: String,
+    principal_namespace: String,
+    default_scope: ConnectionScope,
+    allowed_algorithms: Vec<Algorithm>,
+    leeway_seconds: u64,
+    scope_claim_names: Vec<String>,
+    scope_mappings: Vec<OidcScopeMapping>,
+    allowed_operator_kinds: Vec<String>,
+}
+
+impl OidcProviderConfig {
+    /// Creates a config for a single issuer/audience pair.
+    ///
+    /// `principal_namespace` is prepended to the token subject with a colon,
+    /// for example `user:anaconda` + `550e` becomes `user:anaconda:550e`.
+    pub fn new(
+        issuer: impl Into<String>,
+        audience: impl Into<String>,
+        principal_namespace: impl Into<String>,
+    ) -> Result<Self> {
+        let issuer = issuer.into();
+        let audience = audience.into();
+        let principal_namespace = principal_namespace.into();
+
+        if issuer.is_empty() {
+            return Err(AuthError::InvalidOidcConfig("issuer cannot be empty"));
+        }
+        if audience.is_empty() {
+            return Err(AuthError::InvalidOidcConfig("audience cannot be empty"));
+        }
+        if principal_namespace.is_empty() {
+            return Err(AuthError::InvalidOidcConfig(
+                "principal namespace cannot be empty",
+            ));
+        }
+        Principal::new(format!("{principal_namespace}:subject"))?;
+
+        Ok(Self {
+            issuer,
+            audience,
+            principal_namespace,
+            default_scope: ConnectionScope::Viewer,
+            allowed_algorithms: vec![Algorithm::RS256],
+            leeway_seconds: 60,
+            scope_claim_names: vec!["scope".to_owned(), "scp".to_owned()],
+            scope_mappings: Vec::new(),
+            allowed_operator_kinds: Vec::new(),
+        })
+    }
+
+    /// Expected issuer claim.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// Expected audience claim.
+    pub fn audience(&self) -> &str {
+        &self.audience
+    }
+
+    /// Principal namespace used for authenticated subjects.
+    pub fn principal_namespace(&self) -> &str {
+        &self.principal_namespace
+    }
+
+    /// Scope assigned when no configured mapping matches token claims.
+    pub const fn default_scope(&self) -> ConnectionScope {
+        self.default_scope
+    }
+
+    /// Allows a different default scope.
+    pub fn with_default_scope(mut self, default_scope: ConnectionScope) -> Self {
+        self.default_scope = default_scope;
+        self
+    }
+
+    /// Allows a custom algorithm allow-list.
+    pub fn with_allowed_algorithms(mut self, allowed_algorithms: Vec<Algorithm>) -> Result<Self> {
+        if allowed_algorithms.is_empty() {
+            return Err(AuthError::InvalidOidcConfig(
+                "allowed algorithms cannot be empty",
+            ));
+        }
+        if allowed_algorithms
+            .iter()
+            .any(|algorithm| !is_asymmetric_algorithm(*algorithm))
+        {
+            return Err(AuthError::InvalidOidcConfig(
+                "OIDC bearer validation requires asymmetric algorithms",
+            ));
+        }
+        self.allowed_algorithms = allowed_algorithms;
+        Ok(self)
+    }
+
+    /// Allows a custom expiration/not-before clock-skew allowance in seconds.
+    pub const fn with_leeway_seconds(mut self, leeway_seconds: u64) -> Self {
+        self.leeway_seconds = leeway_seconds;
+        self
+    }
+
+    /// Replaces the claim names used to read provider scopes.
+    pub fn with_scope_claim_names(mut self, scope_claim_names: Vec<String>) -> Result<Self> {
+        if scope_claim_names.is_empty() {
+            return Err(AuthError::InvalidOidcConfig(
+                "scope claim names cannot be empty",
+            ));
+        }
+        if scope_claim_names.iter().any(|claim| claim.is_empty()) {
+            return Err(AuthError::InvalidOidcConfig(
+                "scope claim names cannot contain empty values",
+            ));
+        }
+        self.scope_claim_names = scope_claim_names;
+        Ok(self)
+    }
+
+    /// Adds a provider-scope to connection-scope mapping.
+    ///
+    /// Mappings are evaluated in insertion order. This avoids pretending the
+    /// room scopes form a total order when `editor` and `runtime_peer` are
+    /// intentionally different capabilities.
+    pub fn map_scope(mut self, claim_value: impl Into<String>, scope: ConnectionScope) -> Self {
+        self.scope_mappings.push(OidcScopeMapping {
+            claim_value: claim_value.into(),
+            scope,
+        });
+        self
+    }
+
+    /// Restricts operator kinds accepted for authenticated connections.
+    pub fn with_allowed_operator_kinds(mut self, allowed_operator_kinds: Vec<String>) -> Self {
+        self.allowed_operator_kinds = allowed_operator_kinds;
+        self
+    }
+
+    fn principal_for_subject(&self, subject: &str) -> Result<Principal> {
+        if subject.is_empty() {
+            return Err(AuthError::OidcTokenRejected(
+                "subject cannot be empty".to_owned(),
+            ));
+        }
+        Principal::new(format!(
+            "{}:{}",
+            self.principal_namespace,
+            encode_principal_component(subject)
+        ))
+    }
+
+    fn scope_for_claims(&self, extra: &Map<String, Value>) -> ConnectionScope {
+        let values = self.claim_values(extra);
+        for mapping in &self.scope_mappings {
+            if values.iter().any(|value| value == &mapping.claim_value) {
+                return mapping.scope;
+            }
+        }
+        self.default_scope
+    }
+
+    fn claim_values(&self, extra: &Map<String, Value>) -> Vec<String> {
+        let mut values = Vec::new();
+        for claim_name in &self.scope_claim_names {
+            if let Some(value) = extra.get(claim_name) {
+                collect_scope_claim_values(value, &mut values);
+            }
+        }
+        values
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OidcScopeMapping {
+    claim_value: String,
+    scope: ConnectionScope,
+}
+
+#[derive(Debug, Deserialize)]
+struct OidcClaims {
+    sub: String,
+    #[serde(flatten)]
+    extra: Map<String, Value>,
+}
+
+fn collect_scope_claim_values(value: &Value, values: &mut Vec<String>) {
+    match value {
+        Value::String(scope) => {
+            values.extend(scope.split_whitespace().map(ToOwned::to_owned));
+        }
+        Value::Array(scopes) => {
+            for scope in scopes {
+                if let Value::String(scope) = scope {
+                    values.push(scope.to_owned());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn encode_principal_component(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if is_principal_component_byte(byte) {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+            encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded
+}
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+const fn is_principal_component_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b':' | b'@'
+    )
+}
+
+const fn is_asymmetric_algorithm(algorithm: Algorithm) -> bool {
+    matches!(
+        algorithm,
+        Algorithm::RS256
+            | Algorithm::RS384
+            | Algorithm::RS512
+            | Algorithm::PS256
+            | Algorithm::PS384
+            | Algorithm::PS512
+            | Algorithm::ES256
+            | Algorithm::ES384
+            | Algorithm::EdDSA
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde_json::json;
+
+    const ISSUER: &str = "https://issuer.example.com";
+    const AUDIENCE: &str = "nteract-web";
+    const PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDLElP+KJGndkuQ
+G22TX+Ep3YPUiiLmrQbsilIhXHXvtl4kBGkAqMnj8eFLR/4cR3MqcyJ3u6ms/xDq
+rgsKgDObUim7cUnRLmJ9l519SFcATX7CQ09VeXluvekf8CornpBRZzRD2hsVCtmO
+YRyvQ03s0Ic/jvEW31Colhtglh1ATUJIHl75dfvgru2rP26RckQayF1JfdqYdfXQ
+XF9jWQtrVIfaUzW2phi4YzzQT1zz8z0LzsY9FbBYMplPSfuoRv6/wsh7DLUZDBO3
+qjxq9iDnexhz8ttQjkw//4/vhM8oQqjH95soFD2KbUNuU3Y6Zuye9tbsFTJPEc5t
+kmaidZgLAgMBAAECggEAAxopaKa5AZG9Ohsufi5cSQtGbMmcGoxbyzhFD0Jo1iZ3
+OLNNNq0ywbCGbGPR/h+Z+Eo1pWubU3ZlYphnDcbYmE+rLd8KAs/jwZ8T0P/5EvBG
+y/PtndTTEJMxIQObuU/c94liky4dSiHWIfvaItPzOEy/4YOEVlZHVqlNthjaTeBO
+oZtWyxEVsH0XHCAdIginv9sILy5/UCTjFdTkCUVaAc9pkP752iI0kztsynmGNtEn
+3xa9VvQ8o4RlyiARB2zC2uBBo3cliHVtz3Gl4bQpIUAO8wUpnpy9KDzFeT3CEJoo
+jUFrYiI4joPUzmhQaZ7XC6XQOmIszr3TQfrviQWKNQKBgQDsJ2jgTgyIVLbEJGKS
+l+4fgeLrILUWoz3rxz8O30KH7ivRnhr9hPDszbx9VowTHG9E+Je8xGBi5qirUc79
+GJjDmvin08a/bMHNZvIj2Fk6R+A+necy7FFtzfUHMWLXs/L0QE2/KSK+z2lm9Vq3
+Wza70wbkdSDRjtV9tOz1ohvCjQKBgQDcIzA27T5iptTveFDW0qk7hbtfcD/A2nJo
+i/Rkt7nLFiyqBxDAoCf4iVtaSToOY6F0U37dZhCmRwpXYEK+QSYKe5JhgJbjvzjG
+iiKDMhMexdOmohEeoDxqnmGL7409jWX0WXleTg5tBtv5j72ukPbUELbqMHLGB7Z/
+kH6HNzjq9wKBgDLWGQGQS6pdciqvGnksM5qcv1iWZeVFpuLGtZBiB1RztQMe4fiJ
+UcPoVhc1Nlo22M0kJqYAMC+aL90Rc1mQnfIdvkGCmVpD80RgUOfefvbI2kEghNC1
+hqH4oDK4Mur0Vey2mwX3uP8Sb0I2txyZiiLMvsMXY8U41kSFWi1WhFtRAoGAQVh4
+sXVPNX2Ma+FtLbeu4Kpb6oKpihfOKlaRH2yiTDSy4W3jfSqNcutjILPn9emBPcSj
+PhlUC+e+nB1I8qzoG+h+lU7Ue5qBwf2zLPqqTlIu96HYLx0lkgidsCpV5NWaVCRT
+MLk+8wI8PiJ7DdyeSGkFwxLKnxofBFLiHEU6MhUCgYAfLmbG0JtayVRo0oU0NJqC
+WoI9aFRX2MxbVecKHip8yRVx+Ja7ycbGZ3BfOGyRsRT52dAnqG1Qq6F8BUCPsJGz
+Yg2nk7XSKd0ChUB6lyP6WzNYxDyboMZ8RoDeyY/JvvC147djuRHZMIEygCLYkImt
+iK6jkmv5/uDc/iFj+DniQQ==
+-----END PRIVATE KEY-----"#;
+    const JWK_N: &str = "yxJT_iiRp3ZLkBttk1_hKd2D1Ioi5q0G7IpSIVx177ZeJARpAKjJ4_HhS0f-HEdzKnMid7uprP8Q6q4LCoAzm1Ipu3FJ0S5ifZedfUhXAE1-wkNPVXl5br3pH_AqK56QUWc0Q9obFQrZjmEcr0NN7NCHP47xFt9QqJYbYJYdQE1CSB5e-XX74K7tqz9ukXJEGshdSX3amHX10FxfY1kLa1SH2lM1tqYYuGM80E9c8_M9C87GPRWwWDKZT0n7qEb-v8LIewy1GQwTt6o8avYg53sYc_LbUI5MP_-P74TPKEKox_ebKBQ9im1DblN2OmbsnvbW7BUyTxHObZJmonWYCw";
+
+    fn jwks_json() -> String {
+        jwks_json_with_extra("")
+    }
+
+    fn jwks_json_with_extra(extra: &str) -> String {
+        format!(
+            r#"{{"keys":[{{"kty":"RSA","kid":"test-key","alg":"RS256"{extra},"n":"{JWK_N}","e":"AQAB"}}]}}"#
+        )
+    }
+
+    fn config() -> OidcProviderConfig {
+        match OidcProviderConfig::new(ISSUER, AUDIENCE, "user:anaconda") {
+            Ok(config) => config
+                .map_scope("notebook:owner", ConnectionScope::Owner)
+                .map_scope("notebook:edit", ConnectionScope::Editor)
+                .map_scope("notebook:runtime", ConnectionScope::RuntimePeer)
+                .map_scope("notebook:read", ConnectionScope::Viewer)
+                .with_allowed_operator_kinds(vec!["desktop".to_owned(), "agent".to_owned()]),
+            Err(error) => panic!("OIDC config should construct: {error}"),
+        }
+    }
+
+    fn provider(config: OidcProviderConfig) -> OidcProvider {
+        match OidcProvider::from_jwks_json(config, &jwks_json()) {
+            Ok(provider) => provider,
+            Err(error) => panic!("OIDC provider should construct: {error}"),
+        }
+    }
+
+    fn token(mut claims: Value, kid: Option<&str>) -> String {
+        let Some(claims_object) = claims.as_object_mut() else {
+            panic!("claims fixture should be an object");
+        };
+        claims_object.insert(
+            "exp".to_owned(),
+            Value::from(jsonwebtoken::get_current_timestamp() + 3600),
+        );
+
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = kid.map(ToOwned::to_owned);
+        let key = match EncodingKey::from_rsa_pem(PRIVATE_KEY.as_bytes()) {
+            Ok(key) => key,
+            Err(error) => panic!("fixture private key should parse: {error}"),
+        };
+
+        match encode(&header, &claims, &key) {
+            Ok(token) => token,
+            Err(error) => panic!("fixture token should encode: {error}"),
+        }
+    }
+
+    fn valid_claims() -> Value {
+        json!({
+            "sub": "550e8400-e29b-41d4-a716-446655440000",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "scope": "notebook:edit notebook:owner"
+        })
+    }
+
+    fn authenticate(provider: &OidcProvider, token: String) -> Result<AuthenticatedUser> {
+        block_on(provider.authenticate(Credential::BearerToken(token)))
+    }
+
+    #[test]
+    fn accepts_valid_rs256_bearer_token() {
+        let provider = provider(config());
+        let user = match authenticate(&provider, token(valid_claims(), Some("test-key"))) {
+            Ok(user) => user,
+            Err(error) => panic!("valid OIDC token should authenticate: {error}"),
+        };
+
+        assert_eq!(
+            user.principal().as_str(),
+            "user:anaconda:550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(user.scope(), ConnectionScope::Owner);
+        assert_eq!(
+            user.allowed_operator_kinds(),
+            &["desktop".to_owned(), "agent".to_owned()]
+        );
+    }
+
+    #[test]
+    fn uses_configured_scope_claim_arrays() {
+        let provider = provider(config());
+        let claims = json!({
+            "sub": "runtime-peer",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "scp": ["notebook:runtime"]
+        });
+        let user = match authenticate(&provider, token(claims, Some("test-key"))) {
+            Ok(user) => user,
+            Err(error) => panic!("valid OIDC token should authenticate: {error}"),
+        };
+
+        assert_eq!(user.scope(), ConnectionScope::RuntimePeer);
+    }
+
+    #[test]
+    fn falls_back_to_default_scope_without_mapping() {
+        let provider = provider(config().with_default_scope(ConnectionScope::Viewer));
+        let claims = json!({
+            "sub": "viewer",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "scope": "profile email"
+        });
+        let user = match authenticate(&provider, token(claims, Some("test-key"))) {
+            Ok(user) => user,
+            Err(error) => panic!("valid OIDC token should authenticate: {error}"),
+        };
+
+        assert_eq!(user.scope(), ConnectionScope::Viewer);
+    }
+
+    #[test]
+    fn percent_encodes_subject_slashes_for_principal() {
+        let provider = provider(config());
+        let claims = json!({
+            "sub": "team/alice%admin/é",
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "scope": "notebook:edit"
+        });
+        let user = match authenticate(&provider, token(claims, Some("test-key"))) {
+            Ok(user) => user,
+            Err(error) => panic!("valid OIDC token should authenticate: {error}"),
+        };
+
+        assert_eq!(
+            user.principal().as_str(),
+            "user:anaconda:team%2Falice%25admin%2F%C3%A9"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_audience() {
+        let provider = provider(config());
+        let claims = json!({
+            "sub": "alice",
+            "iss": ISSUER,
+            "aud": "other-audience",
+            "scope": "notebook:edit"
+        });
+        let result = authenticate(&provider, token(claims, Some("test-key")));
+
+        assert!(matches!(result, Err(AuthError::OidcTokenRejected(_))));
+    }
+
+    #[test]
+    fn rejects_unknown_key_id() {
+        let provider = provider(config());
+        let result = authenticate(&provider, token(valid_claims(), Some("missing-key")));
+
+        assert_eq!(
+            result,
+            Err(AuthError::OidcKeyNotFound {
+                kid: Some("missing-key".to_owned())
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_encryption_jwks() {
+        let provider = match OidcProvider::from_jwks_json(
+            config(),
+            &jwks_json_with_extra(r#","use":"enc""#),
+        ) {
+            Ok(provider) => provider,
+            Err(error) => panic!("OIDC provider should construct: {error}"),
+        };
+        let result = authenticate(&provider, token(valid_claims(), Some("test-key")));
+
+        assert_eq!(
+            result,
+            Err(AuthError::OidcTokenRejected(
+                "JWK is not marked for signature verification".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_jwks_without_verify_operation() {
+        let provider = match OidcProvider::from_jwks_json(
+            config(),
+            &jwks_json_with_extra(r#","key_ops":["sign"]"#),
+        ) {
+            Ok(provider) => provider,
+            Err(error) => panic!("OIDC provider should construct: {error}"),
+        };
+        let result = authenticate(&provider, token(valid_claims(), Some("test-key")));
+
+        assert_eq!(
+            result,
+            Err(AuthError::OidcTokenRejected(
+                "JWK is not allowed to verify signatures".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_non_bearer_credentials() {
+        let provider = provider(config());
+        let result = block_on(provider.authenticate(Credential::Cookie("cookie".to_owned())));
+
+        assert_eq!(
+            result,
+            Err(AuthError::InvalidCredential(
+                "OIDC provider requires a bearer token"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_symmetric_algorithm_configuration() {
+        let result = config().with_allowed_algorithms(vec![Algorithm::HS256]);
+
+        assert_eq!(
+            result,
+            Err(AuthError::InvalidOidcConfig(
+                "OIDC bearer validation requires asymmetric algorithms"
+            ))
+        );
+    }
+
+    #[test]
+    fn rejects_empty_jwks() {
+        let result = OidcProvider::from_jwks_json(config(), r#"{"keys":[]}"#);
+
+        assert!(matches!(
+            result,
+            Err(AuthError::InvalidOidcJwks(message))
+                if message == "JWKS must contain at least one key"
+        ));
+    }
+}

--- a/crates/runtime-doc/src/error.rs
+++ b/crates/runtime-doc/src/error.rs
@@ -14,6 +14,8 @@ pub enum RuntimeStateError {
     AutomergeRecovery(Box<automerge_recovery::AutomergeOperationError>),
     #[error("RuntimeStateDoc mutex poisoned")]
     LockPoisoned,
+    #[error("unauthorized actor: {0}")]
+    UnauthorizedActor(String),
 }
 
 impl From<automerge_recovery::AutomergeOperationError> for RuntimeStateError {

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -25,6 +25,7 @@ runtimed-settings-sync = { path = "../runtimed-settings-sync" }
 nteract-telemetry = { path = "../nteract-telemetry" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
+nteract-identity = { path = "../nteract-identity" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2501,6 +2501,7 @@ impl Daemon {
                 protocol,
                 working_dir,
                 initial_metadata,
+                operator,
             } => {
                 info!(
                     "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
@@ -2579,6 +2580,8 @@ impl Daemon {
                 let default_python_env = settings.default_python_env;
                 // Convert working_dir String to PathBuf
                 let working_dir_path = working_dir.map(std::path::PathBuf::from);
+                let connection_identity =
+                    crate::notebook_sync_server::RoomConnectionIdentity::local(operator).await?;
                 crate::notebook_sync_server::handle_notebook_sync_connection(
                     reader,
                     writer,
@@ -2593,12 +2596,13 @@ impl Daemon {
                     false, // Send ProtocolCapabilities for direct NotebookSync handshake
                     None,  // No streaming load for direct NotebookSync handshake
                     false, // Not a newly-created notebook at path
+                    connection_identity,
                     client_protocol_version,
                 )
                 .await
             }
-            Handshake::OpenNotebook { path } => {
-                self.handle_open_notebook(stream, path, client_protocol_version)
+            Handshake::OpenNotebook { path, operator } => {
+                self.handle_open_notebook(stream, path, operator, client_protocol_version)
                     .await
             }
             Handshake::CreateNotebook {
@@ -2609,6 +2613,7 @@ impl Daemon {
                 package_manager,
                 environment_mode,
                 dependencies,
+                operator,
             } => {
                 self.handle_create_notebook(
                     stream,
@@ -2619,6 +2624,7 @@ impl Daemon {
                     package_manager,
                     environment_mode,
                     dependencies,
+                    operator,
                     client_protocol_version,
                 )
                 .await
@@ -2671,6 +2677,7 @@ impl Daemon {
         self: Arc<Self>,
         stream: S,
         path: String,
+        operator: Option<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
@@ -2681,6 +2688,8 @@ impl Daemon {
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
+        let connection_identity =
+            crate::notebook_sync_server::RoomConnectionIdentity::local(operator.clone()).await?;
 
         // Diagnostic: flag suspicious path shapes. UUID-shaped paths (no slash,
         // no extension, parses as a UUID) almost certainly indicate a bug
@@ -2775,6 +2784,7 @@ impl Daemon {
                         None,
                         None,
                         vec![],
+                        operator,
                         client_protocol_version,
                     )
                     .await;
@@ -2953,7 +2963,11 @@ impl Daemon {
         // used for logging and file-watcher wiring below.
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
-            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
+            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
+                .with_identity(
+                    connection_identity.actor_label().as_str(),
+                    connection_identity.scope().as_str(),
+                ),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
@@ -2983,6 +2997,7 @@ impl Daemon {
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             needs_load,
             created_new_at_path, // Enable auto-launch for notebooks created at non-existent paths
+            connection_identity,
             client_protocol_version,
         )
         .await
@@ -3003,6 +3018,7 @@ impl Daemon {
         package_manager: Option<notebook_protocol::connection::PackageManager>,
         environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
         dependencies: Vec<String>,
+        operator: Option<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
     where
@@ -3019,6 +3035,8 @@ impl Daemon {
             notebook_id_hint,
             environment_mode.unwrap_or_default().as_str()
         );
+        let connection_identity =
+            crate::notebook_sync_server::RoomConnectionIdentity::local(operator).await?;
 
         // Get settings for default Python env preference
         let settings = self.settings.read().await.get_all();
@@ -3157,7 +3175,11 @@ impl Daemon {
             .await
             .map(|p| p.to_string_lossy().to_string());
         let response = NotebookConnectionInfo {
-            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
+            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
+                .with_identity(
+                    connection_identity.actor_label().as_str(),
+                    connection_identity.scope().as_str(),
+                ),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
@@ -3189,6 +3211,7 @@ impl Daemon {
             true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
             None,  // No streaming load - doc was just created with empty cell
             false, // UUID-based new notebook, handled by is_new_notebook check
+            connection_identity,
             client_protocol_version,
         )
         .await

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -9,7 +9,7 @@ pub(crate) struct RoomConnectionIdentity {
     auth: AuthenticatedConnection,
     actor_label: ActorLabel,
     fallback_operator: Operator,
-    allow_legacy_operator_actor_labels: bool,
+    legacy_operator_actor_policy: LegacyOperatorActorPolicy,
 }
 
 impl RoomConnectionIdentity {
@@ -31,7 +31,7 @@ impl RoomConnectionIdentity {
             auth,
             actor_label,
             fallback_operator: operator,
-            allow_legacy_operator_actor_labels: true,
+            legacy_operator_actor_policy: LegacyOperatorActorPolicy::AllowLocalSameUid,
         })
     }
 
@@ -62,6 +62,7 @@ impl RoomConnectionIdentity {
     ) -> anyhow::Result<()> {
         for label in labels {
             match ActorLabel::parse(label.to_string()) {
+                // Reserved for future system/schema:* seed and import writes.
                 Ok(actor) if actor.principal() == nteract_identity::Principal::SYSTEM => {}
                 Ok(actor) if actor.principal() == self.auth.principal().as_str() => {}
                 Ok(actor) => anyhow::bail!(
@@ -70,13 +71,42 @@ impl RoomConnectionIdentity {
                     self.auth.principal()
                 ),
                 Err(nteract_identity::AuthError::ActorLabelMissingDelimiter)
-                    if self.allow_legacy_operator_actor_labels
+                    if self
+                        .legacy_operator_actor_policy
+                        .allows_operator_only(&self.auth)
                         && Operator::new(label.to_string()).is_ok() => {}
                 Err(error) => anyhow::bail!("actor label {label:?} is invalid: {error}"),
             }
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyOperatorActorPolicy {
+    // Used by future non-local constructors. Local is the only constructor
+    // today, but remote providers must start from this strict policy.
+    #[allow(dead_code)]
+    Reject,
+    /// Local rooms historically accepted operator-only labels from same-UID
+    /// clients. Keep that compatibility local-only; remote auth providers must
+    /// send fully layered actor labels.
+    AllowLocalSameUid,
+}
+
+impl LegacyOperatorActorPolicy {
+    fn allows_operator_only(self, auth: &AuthenticatedConnection) -> bool {
+        match self {
+            Self::Reject => false,
+            Self::AllowLocalSameUid => {
+                debug_assert!(
+                    auth.principal().as_str().starts_with("local:"),
+                    "legacy operator-only labels are only allowed for local same-UID rooms"
+                );
+                auth.principal().as_str().starts_with("local:")
+            }
+        }
     }
 }
 
@@ -166,6 +196,27 @@ mod tests {
         identity
             .validate_actor_labels(["human:legacy-session"])
             .expect("local same-UID rooms keep legacy operator labels working");
+    }
+
+    #[test]
+    fn non_local_identity_rejects_legacy_operator_only_actor() {
+        let principal =
+            nteract_identity::Principal::new("user:anaconda:550e".to_string()).expect("principal");
+        let operator = Operator::new("desktop:window-1".to_string()).expect("operator");
+        let auth = AuthenticatedConnection::new(principal, ConnectionScope::Editor);
+        let actor_label = auth.actor_label_for(operator.clone()).expect("actor label");
+        let identity = RoomConnectionIdentity {
+            auth,
+            actor_label,
+            fallback_operator: operator,
+            legacy_operator_actor_policy: LegacyOperatorActorPolicy::Reject,
+        };
+
+        let error = identity
+            .validate_actor_labels(["human:legacy-session"])
+            .expect_err("remote rooms must reject legacy operator-only actors");
+
+        assert!(error.to_string().contains("actor label"));
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -113,7 +113,10 @@ impl LegacyOperatorActorPolicy {
 fn fallback_operator(kind: &str) -> Operator {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let value = format!("{kind}:{}", &suffix[..8]);
-    Operator::new(value).expect("generated fallback operator is valid")
+    match Operator::new(value) {
+        Ok(operator) => operator,
+        Err(error) => panic!("generated fallback operator is invalid: {error}"),
+    }
 }
 
 fn local_username() -> String {

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -1,0 +1,177 @@
+use nteract_identity::{
+    ActorLabel, AuthenticatedConnection, ConnectionScope, Credential, IdentityProvider,
+    LocalPeerCredential, Operator,
+};
+
+/// Identity state attached to one room connection.
+#[derive(Debug, Clone)]
+pub(crate) struct RoomConnectionIdentity {
+    auth: AuthenticatedConnection,
+    actor_label: ActorLabel,
+    fallback_operator: Operator,
+    allow_legacy_operator_actor_labels: bool,
+}
+
+impl RoomConnectionIdentity {
+    /// Authenticate a local same-UID daemon connection.
+    pub(crate) async fn local(presented_operator: Option<String>) -> anyhow::Result<Self> {
+        let username = local_username();
+        let provider = IdentityProvider::local();
+        let credential = Credential::LocalPeer(LocalPeerCredential::new(username)?);
+        let user = provider.authenticate(credential).await?;
+        let auth = AuthenticatedConnection::from_user(user);
+        let fallback_operator = fallback_operator("desktop");
+        let operator = presented_operator
+            .as_deref()
+            .and_then(|value| Operator::from_actor_label_or_operator(value).ok())
+            .unwrap_or_else(|| fallback_operator.clone());
+        let actor_label = auth.actor_label_for(operator.clone())?;
+
+        Ok(Self {
+            auth,
+            actor_label,
+            fallback_operator: operator,
+            allow_legacy_operator_actor_labels: true,
+        })
+    }
+
+    pub(crate) fn actor_label(&self) -> &ActorLabel {
+        &self.actor_label
+    }
+
+    pub(crate) fn scope(&self) -> ConnectionScope {
+        self.auth.scope()
+    }
+
+    pub(crate) fn rewrite_presence_actor_label(&self, presented: Option<&str>) -> ActorLabel {
+        self.auth
+            .rewrite_presence_actor_label(presented, self.fallback_operator.clone())
+    }
+
+    pub(crate) fn allows_notebook_write(&self) -> bool {
+        self.scope().allows_notebook_write()
+    }
+
+    pub(crate) fn allows_runtime_state_write(&self) -> bool {
+        self.scope().allows_runtime_state_write()
+    }
+
+    pub(crate) fn validate_actor_labels<'a>(
+        &self,
+        labels: impl IntoIterator<Item = &'a str>,
+    ) -> anyhow::Result<()> {
+        for label in labels {
+            match ActorLabel::parse(label.to_string()) {
+                Ok(actor) if actor.principal() == nteract_identity::Principal::SYSTEM => {}
+                Ok(actor) if actor.principal() == self.auth.principal().as_str() => {}
+                Ok(actor) => anyhow::bail!(
+                    "actor principal {} is not authorized for authenticated principal {}",
+                    actor.principal(),
+                    self.auth.principal()
+                ),
+                Err(nteract_identity::AuthError::ActorLabelMissingDelimiter)
+                    if self.allow_legacy_operator_actor_labels
+                        && Operator::new(label.to_string()).is_ok() => {}
+                Err(error) => anyhow::bail!("actor label {label:?} is invalid: {error}"),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn fallback_operator(kind: &str) -> Operator {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let value = format!("{kind}:{}", &suffix[..8]);
+    Operator::new(value).expect("generated fallback operator is valid")
+}
+
+fn local_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .ok()
+        .and_then(|username| sanitize_local_username(&username))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn sanitize_local_username(username: &str) -> Option<String> {
+    let trimmed = username.trim();
+    if trimmed.is_empty() || trimmed.contains('/') {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_identity_preserves_presented_operator() {
+        let identity = RoomConnectionIdentity::local(Some("agent:codex:s1".to_string()))
+            .await
+            .expect("local identity");
+
+        assert!(identity.actor_label().as_str().contains("/agent:codex:s1"));
+        assert_eq!(identity.scope(), ConnectionScope::Owner);
+        assert!(identity.allows_notebook_write());
+        assert!(identity.allows_runtime_state_write());
+    }
+
+    #[tokio::test]
+    async fn local_identity_accepts_legacy_actor_as_operator() {
+        let identity = RoomConnectionIdentity::local(Some("human:session-abc".to_string()))
+            .await
+            .expect("local identity");
+
+        assert!(identity
+            .actor_label()
+            .as_str()
+            .contains("/human:session-abc"));
+    }
+
+    #[tokio::test]
+    async fn local_identity_rewrites_presence_principal() {
+        let identity = RoomConnectionIdentity::local(Some("desktop:window-1".to_string()))
+            .await
+            .expect("local identity");
+
+        let rewritten =
+            identity.rewrite_presence_actor_label(Some("user:anaconda:other/agent:claude:s1"));
+
+        assert!(rewritten.as_str().ends_with("/agent:claude:s1"));
+        assert_eq!(rewritten.principal(), identity.actor_label().principal());
+    }
+
+    #[tokio::test]
+    async fn local_identity_rejects_layered_actor_from_another_principal() {
+        let identity = RoomConnectionIdentity::local(Some("desktop:window-1".to_string()))
+            .await
+            .expect("local identity");
+
+        let error = identity
+            .validate_actor_labels(["user:anaconda:evil/desktop:window-1"])
+            .expect_err("wrong principal should be rejected");
+
+        assert!(error.to_string().contains("not authorized"));
+    }
+
+    #[tokio::test]
+    async fn local_identity_allows_legacy_operator_only_actor() {
+        let identity = RoomConnectionIdentity::local(Some("desktop:window-1".to_string()))
+            .await
+            .expect("local identity");
+
+        identity
+            .validate_actor_labels(["human:legacy-session"])
+            .expect("local same-UID rooms keep legacy operator labels working");
+    }
+
+    #[test]
+    fn sanitize_local_username_rejects_empty_and_slashes() {
+        assert_eq!(sanitize_local_username(""), None);
+        assert_eq!(sanitize_local_username("bad/user"), None);
+        assert_eq!(sanitize_local_username(" kyle "), Some("kyle".to_string()));
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -50,6 +50,7 @@ use runtime_doc::RuntimeStateDoc;
 mod attachments;
 mod blob_upload;
 mod catalog;
+mod identity;
 mod load;
 mod metadata;
 mod nbformat_convert;
@@ -74,6 +75,7 @@ mod tests;
 
 pub(crate) use attachments::*;
 pub(crate) use catalog::*;
+pub(crate) use identity::*;
 pub(crate) use load::*;
 pub(crate) use metadata::*;
 pub(crate) use nbformat_convert::*;

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -35,6 +35,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     // True if this is a newly-created notebook at a non-existent path.
     // Used to enable auto-launch for notebooks created via `runt notebook newfile.ipynb`.
     created_new_at_path: bool,
+    connection_identity: RoomConnectionIdentity,
     // Protocol version from the client preamble. v4 is required at connection
     // setup, so SessionControl frames are always supported.
     client_protocol_version: u8,
@@ -239,7 +240,11 @@ where
 
     // Send capabilities response unless already sent via NotebookConnectionInfo.
     if !skip_capabilities {
-        let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()));
+        let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
+            .with_identity(
+                connection_identity.actor_label().as_str(),
+                connection_identity.scope().as_str(),
+            );
         connection::send_json_frame(&mut writer, &caps).await?;
     }
 
@@ -256,6 +261,7 @@ where
         daemon.clone(),
         needs_load.as_deref(),
         &peer_id,
+        &connection_identity,
         client_protocol_version,
     )
     .await;

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -38,6 +38,7 @@ pub(crate) async fn run_sync_loop_v2<R, W>(
     daemon: std::sync::Arc<crate::daemon::Daemon>,
     needs_load: Option<&Path>,
     peer_id: &str,
+    connection_identity: &RoomConnectionIdentity,
     client_protocol_version: u8,
 ) -> anyhow::Result<()>
 where
@@ -241,10 +242,20 @@ where
                 }
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
+                                if !connection_identity.allows_notebook_write() {
+                                    warn!(
+                                        "[notebook-sync] Rejecting NotebookDoc frame for {} from peer {} with scope {}",
+                                        notebook_id,
+                                        peer_id,
+                                        connection_identity.scope()
+                                    );
+                                    continue;
+                                }
                                 let NotebookDocFrameOutcome::Applied(notebook_doc_effects) =
                                     handle_notebook_doc_frame(
                                     room,
                                     &mut peer_state,
+                                    connection_identity,
                                     &peer_writer,
                                     &frame.payload,
                                 )
@@ -281,11 +292,26 @@ where
                             }
 
                             NotebookFrameType::Presence => {
-                                handle_presence_frame(room, peer_id, &peer_writer, &frame.payload)
-                                    .await?;
+                                handle_presence_frame(
+                                    room,
+                                    peer_id,
+                                    connection_identity,
+                                    &peer_writer,
+                                    &frame.payload,
+                                )
+                                .await?;
                             }
 
                             NotebookFrameType::RuntimeStateSync => {
+                                if !connection_identity.allows_runtime_state_write() {
+                                    warn!(
+                                        "[notebook-sync] Rejecting RuntimeStateDoc frame for {} from peer {} with scope {}",
+                                        notebook_id,
+                                        peer_id,
+                                        connection_identity.scope()
+                                    );
+                                    continue;
+                                }
                                 if !handle_runtime_state_frame(
                                     room,
                                     &mut state_peer_state,
@@ -293,6 +319,7 @@ where
                                     &frame.payload,
                                     &execution_store,
                                     &mut persisted_execution_records,
+                                    connection_identity,
                                 )
                                 .await?
                                 {

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -6,13 +6,14 @@ use notebook_protocol::connection::NotebookFrameType;
 use super::peer_writer::PeerWriter;
 use super::{
     check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
-    NotebookRoom,
+    NotebookRoom, RoomConnectionIdentity,
 };
-use notebook_doc::diff::diff_metadata_touched;
+use notebook_doc::diff::{diff_metadata_touched, extract_change_actors};
 
 pub(super) async fn handle_notebook_doc_frame(
     room: &NotebookRoom,
     peer_state: &mut sync::State,
+    connection_identity: &RoomConnectionIdentity,
     writer: &PeerWriter,
     payload: &[u8],
 ) -> anyhow::Result<NotebookDocFrameOutcome> {
@@ -23,6 +24,27 @@ pub(super) async fn handle_notebook_doc_frame(
     // release the lock before performing async I/O.
     let (persist_bytes, reply_encoded, metadata_changed) = {
         let mut doc = room.doc.write().await;
+
+        if !message.changes.is_empty() {
+            let heads_before = doc.get_heads();
+            let mut preview = notebook_doc::NotebookDoc::wrap(doc.doc().clone());
+            let mut preview_peer_state = peer_state.clone();
+            match preview.receive_sync_message_recovering(
+                &mut preview_peer_state,
+                message.clone(),
+                "doc-auth-preview",
+            ) {
+                Ok(()) => {
+                    let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+                    connection_identity
+                        .validate_actor_labels(actors.iter().map(std::string::String::as_str))?;
+                }
+                Err(e) => {
+                    warn!("[notebook-sync] doc auth preview failed: {}", e);
+                    return Err(anyhow::anyhow!("doc auth preview failed: {e}"));
+                }
+            }
+        }
 
         let heads_before = doc.get_heads();
 

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -26,6 +26,8 @@ pub(super) async fn handle_notebook_doc_frame(
         let mut doc = room.doc.write().await;
 
         if !message.changes.is_empty() {
+            // v1: clone-preview validator. Replace with sync_message_new_changes
+            // once nteract/automerge ships Patch 1.
             let heads_before = doc.get_heads();
             let mut preview = notebook_doc::NotebookDoc::wrap(doc.doc().clone());
             let mut preview_peer_state = peer_state.clone();

--- a/crates/runtimed/src/notebook_sync_server/peer_presence.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_presence.rs
@@ -8,7 +8,7 @@ use tracing::{debug, warn};
 use notebook_protocol::connection::{self, NotebookFrameType};
 
 use super::peer_writer::PeerWriter;
-use super::NotebookRoom;
+use super::{NotebookRoom, RoomConnectionIdentity};
 
 /// Sanitize a peer label from the wire.
 ///
@@ -128,6 +128,7 @@ where
 pub(super) async fn handle_presence_frame(
     room: &Arc<NotebookRoom>,
     peer_id: &str,
+    connection_identity: &RoomConnectionIdentity,
     peer_writer: &PeerWriter,
     payload: &[u8],
 ) -> anyhow::Result<()> {
@@ -160,14 +161,16 @@ pub(super) async fn handle_presence_frame(
             }
 
             let data_for_relay = data.clone();
-            let actor_label_for_relay = actor_label.clone();
+            let rewritten_actor_label =
+                connection_identity.rewrite_presence_actor_label(actor_label.as_deref());
+            let actor_label_for_relay = Some(rewritten_actor_label.as_str().to_string());
             let label = sanitize_peer_label(peer_label.as_deref(), peer_id);
             let sanitized_label = Some(label.clone());
 
             let is_new = room.broadcasts.presence.write().await.update_peer(
                 peer_id,
                 &label,
-                actor_label.as_deref(),
+                actor_label_for_relay.as_deref(),
                 data,
                 now_ms,
             );

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -80,6 +80,8 @@ pub(super) async fn handle_runtime_state_frame(
     let reply_encoded = room.state.with_doc(|state_doc| {
         let before = runtime_file_save_fingerprint(state_doc);
         if !message.changes.is_empty() {
+            // v1: clone-preview validator. Replace with sync_message_new_changes
+            // once nteract/automerge ships Patch 1.
             let heads_before = state_doc.get_heads();
             let mut preview = runtime_doc::RuntimeStateDoc::from_doc(state_doc.doc().clone());
             let mut preview_peer_state = state_peer_state.clone();

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -4,10 +4,11 @@ use automerge::sync;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
+use notebook_doc::diff::extract_change_actors;
 use notebook_protocol::connection::NotebookFrameType;
 
 use super::peer_writer::PeerWriter;
-use super::NotebookRoom;
+use super::{NotebookRoom, RoomConnectionIdentity};
 
 type PersistedExecutionRecords = HashMap<String, runtimed_client::execution_store::ExecutionRecord>;
 
@@ -70,6 +71,7 @@ pub(super) async fn handle_runtime_state_frame(
     payload: &[u8],
     store: &runtimed_client::execution_store::ExecutionStore,
     persisted_records: &mut PersistedExecutionRecords,
+    connection_identity: &RoomConnectionIdentity,
 ) -> anyhow::Result<bool> {
     let message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
@@ -77,6 +79,30 @@ pub(super) async fn handle_runtime_state_frame(
 
     let reply_encoded = room.state.with_doc(|state_doc| {
         let before = runtime_file_save_fingerprint(state_doc);
+        if !message.changes.is_empty() {
+            let heads_before = state_doc.get_heads();
+            let mut preview = runtime_doc::RuntimeStateDoc::from_doc(state_doc.doc().clone());
+            let mut preview_peer_state = state_peer_state.clone();
+            match preview.receive_sync_message_with_changes_recovering(
+                &mut preview_peer_state,
+                message.clone(),
+                "state-auth-preview",
+            ) {
+                Ok(true) => {
+                    let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+                    connection_identity
+                        .validate_actor_labels(actors.iter().map(std::string::String::as_str))
+                        .map_err(|error| {
+                            runtime_doc::RuntimeStateError::UnauthorizedActor(error.to_string())
+                        })?;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    warn!("[notebook-sync] state auth preview failed: {}", e);
+                    return Err(e.into());
+                }
+            }
+        }
         let had_changes = match state_doc.receive_sync_message_with_changes_recovering(
             state_peer_state,
             message,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -761,6 +761,74 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
 }
 
 #[tokio::test]
+async fn test_local_identity_rejects_foreign_automerge_actor() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new_for_test(config).unwrap();
+    let daemon_for_inspect = daemon.clone();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let owner = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "desktop:owner",
+        true,
+        None,
+        vec![],
+    )
+    .await
+    .expect("owner should connect");
+    assert_session_ready(&owner.handle, "owner client").await;
+
+    let forged = connect::connect(
+        socket_path.clone(),
+        owner.info.notebook_id.clone(),
+        "desktop:forge",
+    )
+    .await
+    .expect("forged client should connect before actor switch")
+    .handle;
+    assert_session_ready(&forged, "forged client").await;
+
+    forged
+        .set_actor("user:anaconda:evil/desktop:forge")
+        .expect("test client can switch actor locally");
+    forged
+        .add_cell_after("forged-cell", "code", None)
+        .expect("local forged mutation should apply before sync rejection");
+
+    let confirm = tokio::time::timeout(Duration::from_secs(5), forged.confirm_sync()).await;
+    match confirm {
+        Ok(Err(_)) => {}
+        Ok(Ok(())) => panic!("forged actor sync unexpectedly confirmed"),
+        Err(_) => panic!("forged actor sync did not fail before timeout"),
+    }
+
+    let room_uuid = uuid::Uuid::parse_str(&owner.info.notebook_id)
+        .expect("created test notebook id should be a UUID");
+    let room = daemon_for_inspect
+        .test_get_room(room_uuid)
+        .await
+        .expect("room should still exist after rejecting forged actor");
+    let cell = room.doc.read().await.get_cell("forged-cell");
+    assert!(
+        cell.is_none(),
+        "daemon room must not apply a cell authored by a foreign principal"
+    );
+
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
 async fn test_notebook_sync_via_unified_socket() {
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use notebook_doc::presence::PresenceMessage;
 use notebook_protocol::connection::LaunchSpec;
 use notebook_sync::connect;
 use notebook_wire::frame_types;
@@ -203,6 +204,37 @@ async fn wait_for_cell_count(
         sleep(Duration::from_millis(20)).await;
     }
     false
+}
+
+async fn wait_for_presence_update_actor_label(
+    frame_rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
+    peer_label: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        let remaining = timeout.saturating_sub(start.elapsed());
+        let frame =
+            tokio::time::timeout(remaining.min(Duration::from_millis(250)), frame_rx.recv())
+                .await
+                .ok()
+                .flatten()?;
+        if frame.first().copied() != Some(frame_types::PRESENCE) {
+            continue;
+        }
+        let Ok(PresenceMessage::Update {
+            peer_label: Some(label),
+            actor_label,
+            ..
+        }) = notebook_doc::presence::decode_message(&frame[1..])
+        else {
+            continue;
+        };
+        if label == peer_label {
+            return actor_label;
+        }
+    }
+    None
 }
 
 #[cfg(unix)]
@@ -628,6 +660,103 @@ async fn test_blob_server_health() {
 
     // Shutdown
     client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_local_identity_handshake_and_presence_rewrite() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new_for_test(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client).await);
+
+    let result = connect::connect_create(
+        socket_path.clone(),
+        "python",
+        None,
+        "agent:codex:s1",
+        true,
+        None,
+        vec![],
+    )
+    .await
+    .expect("client should connect");
+    assert_session_ready(&result.handle, "identity client").await;
+
+    let actor_label = result
+        .info
+        .capabilities
+        .actor_label
+        .as_deref()
+        .expect("daemon should return authenticated actor label");
+    assert!(actor_label.starts_with("local:"), "{actor_label}");
+    assert!(actor_label.ends_with("/agent:codex:s1"), "{actor_label}");
+    assert_eq!(
+        result.info.capabilities.connection_scope.as_deref(),
+        Some("owner")
+    );
+    assert_eq!(
+        notebook_sync::presence::actor_label(&result.handle).as_deref(),
+        Some(actor_label)
+    );
+
+    let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    let relay = connect::connect_relay_with_operator(
+        socket_path.clone(),
+        result.info.notebook_id.clone(),
+        frame_tx,
+        Some("desktop:observer".to_string()),
+    )
+    .await
+    .expect("relay should connect");
+    assert!(relay
+        .capabilities
+        .actor_label
+        .as_deref()
+        .is_some_and(|label| label.ends_with("/desktop:observer")));
+    assert_eq!(
+        relay.capabilities.connection_scope.as_deref(),
+        Some("owner")
+    );
+
+    let forged = notebook_doc::presence::encode_custom_update_labeled(
+        "client-peer",
+        Some("Forged Presence"),
+        Some("user:anaconda:evil/agent:claude:s1"),
+        &[],
+    )
+    .expect("presence should encode");
+    result
+        .handle
+        .send_presence(forged)
+        .await
+        .expect("presence should send");
+
+    let relayed_actor = wait_for_presence_update_actor_label(
+        &mut frame_rx,
+        "Forged Presence",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("observer should receive rewritten presence");
+    assert!(relayed_actor.starts_with("local:"), "{relayed_actor}");
+    assert!(
+        relayed_actor.ends_with("/agent:claude:s1"),
+        "{relayed_actor}"
+    );
+    assert!(
+        !relayed_actor.starts_with("user:anaconda:"),
+        "{relayed_actor}"
+    );
+
+    pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 

--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -73,7 +73,7 @@ Three properties fall out:
 3. If the principal is in the ACL, the connection inherits the ACL-stated scope. If not, the connection is rejected (or downgraded to anonymous `viewer` if the ACL has a public-read entry).
 4. The connection's `AuthenticatedConnection` carries that principal and scope for the life of the socket.
 
-What this changes from the older framing: rooms are no longer implicitly scoped to one IdP's principal space. They authenticate principals from whatever IdPs the host validates against, and the per-room ACL is the source of truth for who can do what. Per-frame actor-label enforcement (ensuring the actor inside each accepted frame's changes matches the connection's principal) is deferred to the Automerge fork patch tracked in `docs/architecture/automerge-fork-patches.md`; until that lands, intra-room actor labels are best-effort (see Limitations).
+What this changes from the older framing: rooms are no longer implicitly scoped to one IdP's principal space. They authenticate principals from whatever IdPs the host validates against, and the per-room ACL is the source of truth for who can do what. v1 enforces per-frame actor labels with a clone-preview validator before applying inbound `NotebookDoc` and `RuntimeStateDoc` sync frames. The Automerge fork patch tracked in `docs/architecture/automerge-fork-patches.md` remains the intended lower-cost replacement for that validator.
 
 ### ACL mechanics (deferred)
 
@@ -88,7 +88,7 @@ Authentication is connection-scoped. The IdP (Identity Provider) is consulted at
 3. Room-host looks the validated principal up in the room's ACL. If present, the connection inherits the ACL scope; if absent, the connection is rejected (or downgraded to `viewer` if the ACL has a public-read entry).
 4. Validation yields an `AuthenticatedConnection { principal, scope, allowed_operator_kinds }` in server memory, scoped to this socket.
 5. Handshake response includes the assembled actor label so the client knows what to author as.
-6. Every subsequent frame is checked against `AuthenticatedConnection.scope` for **scope-level legality** at the frame layer (frame type and emptiness of `Message.changes`). Actor labels *inside* accepted frames are not cryptographically validated in v1. See Limitations.
+6. Every subsequent frame is checked against `AuthenticatedConnection.scope` for **scope-level legality** at the frame layer (frame type and emptiness of `Message.changes`). Inbound frames that carry changes are also applied to a cloned document first so the room-host can extract new change actors and reject principal forgery before mutating the real room document.
 
 If the credential expires while connected, the connection stays open. Revocation is future work: a server-pushed `SESSION_CONTROL` close frame ends affected connections when an out-of-band signal (admin revoke, plan downgrade, sign-out) arrives. v1 assumes that anyone who authenticated continues to have access for the connection's lifetime.
 
@@ -98,18 +98,18 @@ If the credential expires while connected, the connection stays open. Revocation
 
 Bearer-token replay is a separate, well-known property of bearer auth: if a user's JWT is stolen, the thief can open a new socket and obtain their own `AuthenticatedConnection`. The mitigation is at the credential layer, not the connection layer (e.g., DPoP / proof-of-possession tokens, short token lifetimes, mTLS for system-to-system). v1 inherits the bearer-token threat model; tightening it is future work.
 
-### Per-frame scope checks
+### Per-frame sync checks
 
-The room-host enforces scope at frame ingress by inspecting frame type and emptiness. It does **not** parse Automerge change bytes or extract actor IDs in v1.
+The room-host enforces scope at frame ingress by inspecting frame type and emptiness:
 
 - **viewer** scope: any inbound `0x00` or `0x05` frame with non-empty `Message.changes` is rejected. Empty negotiation frames (heads/have/need with `ChunkList::empty()`) pass.
 - **runtime_peer** scope: any inbound `0x00` (NotebookDoc) frame with non-empty changes is rejected. `RuntimeStateDoc` writes are allowed.
 - **editor** scope: both `0x00` and `0x05` with non-empty changes are allowed. The widget-comm-state subtree convention from Decision 5 (`doc.comms/*/state/*`) is enforced client-side via the approved comm writer.
 - **owner** scope: same frame-level rules as `editor`, plus ACL-mutation requests are honored.
 
-This is a one-byte-type-check plus a `ChunkList::is_empty()` check per frame. No Automerge parsing. No upstream hook required.
+For non-empty `NotebookDoc` and `RuntimeStateDoc` sync messages, the room-host also performs a v1 clone-preview validator: clone the current Automerge doc and sync state, apply the incoming message to the clone, extract the actors in the newly applied changes, and reject the frame if any new change's principal differs from the connection's authenticated principal. The real room document is mutated only after this preview succeeds.
 
-What this does **not** enforce is the actor label *inside* an accepted frame. An authenticated editor connection can author a change whose actor claims a different operator (or even a different principal that is also in the ACL). The trust gate at the room boundary catches scope violations and unauthenticated access; it does not catch intra-room attribution forgery. The Limitations section below names this explicitly and tracks it as deferred hardening.
+This closes live principal forgery for v1, but it is intentionally a stopgap. It deep-clones the document and applies each non-empty inbound message twice, which is most expensive on the high-churn `RuntimeStateDoc` path. `docs/architecture/automerge-fork-patches.md` Patch 1 (`sync_message_new_changes`) is the planned v2 replacement: inspect the new changes from a sync message without cloning or applying to a throwaway document.
 
 ### Schema-seed actors get principal-prefixed labels
 
@@ -287,13 +287,13 @@ Concretely: quill publishes a local untitled notebook to Anaconda.
 
 Attribution after publish reflects what the destination can actually vouch for: "this snapshot was published by `user:anaconda:550e...` on `<timestamp>`." Per-edit history of the source notebook is not preserved. Side effects:
 
-- **Import-time forgery is closed.** A hosted deployment never accepts a *published* doc that contains historical Automerge attribution from outside its own scope; the import path strips source-space history and re-authors as a fresh publisher actor. Live in-room actor spoofing by an authenticated peer is a separate concern and is deferred (see Limitations).
+- **Import-time forgery is closed.** A hosted deployment never accepts a *published* doc that contains historical Automerge attribution from outside its own scope; the import path strips source-space history and re-authors as a fresh publisher actor. Live in-room principal forgery is also rejected by the v1 clone-preview validator; the remaining caveat is its performance cost until the Automerge fork patch lands.
 - **History is lost on publish.** Anyone who needs the pre-publish authorship trail keeps the source notebook around (it still lives in the source space). Re-publishing produces a new snapshot in the destination; old snapshots are immutable revisions.
 - **Future cryptographic verification.** When Automerge gains signed-change support (keyhive direction; see `https://www.inkandswitch.com/keyhive/notebook/`), historical authorship from a source space could be carried across publish if every historical change is signed by its claimed author. Until then, this ADR closes the door on cross-space attribution.
 
 ## Limitations
 
-v1 enforces the trust gate at room ingress: bearer auth and ACL membership at connect, scope-based frame rejection per frame. It does **not** validate the Automerge actor labels *inside* accepted frames. An authenticated peer in a room can author changes claiming any operator suffix, or any principal that is also in the room's ACL. Within-room attribution is best-effort.
+v1 enforces the trust gate at room ingress: bearer auth and ACL membership at connect, scope-based frame rejection per frame, and actor-principal validation for newly received Automerge changes. The v1 validator is intentionally conservative: it clone-previews non-empty sync messages before applying them to the real `NotebookDoc` or `RuntimeStateDoc`.
 
 The threat surface this leaves:
 
@@ -303,10 +303,11 @@ The threat surface this leaves:
 | Unauthorized write at all | Bearer auth + ACL at connect | closed |
 | Scope escalation (viewer authoring, runtime_peer editing NotebookDoc) | Scope-based frame rejection | closed |
 | Import-time cross-IdP forgery (publishing a doc with historical foreign actor labels) | Publish-as-fresh-doc (Decision 6) | closed |
+| **Live actor-principal spoofing** (an authenticated peer authors a new change under a different principal) | Clone-preview actor validation before apply | closed in v1 |
 | Bearer-token replay (stolen JWT opens a new socket) | DPoP / mTLS / short token lifetimes | deferred |
-| **Intra-room actor spoofing** (an authenticated peer authors a change with any operator suffix, any principal in the room's ACL, or even a foreign principal not in the ACL) | None in v1 | **deferred** |
+| Clone-preview validator cost on large/high-churn docs | `sync_message_new_changes` Automerge fork patch | deferred performance hardening |
 
-The intra-room spoofing case is deferred for v1, not punted indefinitely. It covers both intra-IdP spoofing (claiming a different operator suffix or a different principal also in the room's ACL) and cross-IdP spoofing (claiming a principal not in the ACL at all, e.g., a `local:*` actor authored by an authenticated Anaconda peer). Both fall out of the same root cause: v1 does not parse Automerge `Change`s pre-apply to inspect their actor labels. Building that validator means parsing `automerge::sync::Message.changes` (`ChunkList(Vec<Vec<u8>>)` of raw chunks; V1 = one `Change` per chunk; V2 = potentially a whole-doc save), which is what the companion `automerge-fork-patches.md` ADR proposes adding to our Automerge fork. Until that patch ships, the remaining attack surface is bounded to peers who already have legitimate edit access to the room.
+The v1 clone-preview validator closes principal forgery without new Automerge APIs by using the existing post-apply actor extraction primitive against a cloned document. The deferred work is performance, not correctness: parsing `automerge::sync::Message.changes` (`ChunkList(Vec<Vec<u8>>)` of raw chunks; V1 = one `Change` per chunk; V2 = potentially a whole-doc save) without cloning is what the companion `automerge-fork-patches.md` ADR proposes adding to our Automerge fork.
 
 The upstream `filters` work (`origin/filters` branch on `automerge/automerge`, post-peer-review, `rust/automerge/src/filter.rs`) gives us a complementary subduction primitive once it lands in main: `Filter::Allow / AllowUpTo { heads } / Deny` per-actor or per-author. Filters do not reject changes pre-storage (rejected changes still ingest and sync) but they hide them from rendering, which is the right primitive for runtime revocation and post-hoc audit hiding. When filters lands, pairing them with a pre-apply validator becomes the natural next step. Keyhive ([inkandswitch/keyhive notebook](https://www.inkandswitch.com/keyhive/notebook/)) is orthogonal: change-level capability tokens with signed changes; composable later if needed.
 
@@ -329,7 +330,7 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 9. **ACL mechanics.** Editing semantics, owner transfer, group/org principals, anonymous public-read entries, persistence layout. Drafted in a separate ACL ADR (to be written).
 10. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. Until then, publish produces a fresh document in the destination space (see Decision 6).
 11. **Bearer-token replay mitigation.** DPoP / proof-of-possession tokens, mTLS for system-to-system, short token lifetimes. v1 inherits the bearer-token threat model; tightening it is future work.
-12. **Pre-apply actor-label validator.** Parsing `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/architecture/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.
+12. **Lower-cost actor-label validator.** Replace the v1 clone-preview validator with parsing of `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/architecture/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.
 
 ## Worked examples
 
@@ -338,7 +339,7 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 - Unix socket connect. Listener reads `SO_PEERCRED`, finds OS user `quill`. `IdentityProvider::Local(...)` returns principal `local:quill`, scope `owner`.
 - Desktop UI opens the notebook via the daemon. Daemon stands up a WASM peer with actor `local:quill/desktop:7f3a`.
 - Claude (via MCP) joins the same room from the same machine. Claude's MCP process connects on the same Unix socket; its principal is also `local:quill`. It picks operator `agent:claude:s1`. Actor label `local:quill/agent:claude:s1`.
-- Both connections write changes. The room-host enforces scope at frame ingress (both are `owner` scope so both can write NotebookDoc and RuntimeStateDoc). Actor labels are not validated per change in v1 (see Limitations).
+- Both connections write changes. The room-host enforces scope at frame ingress (both are `owner` scope so both can write NotebookDoc and RuntimeStateDoc) and validates that each newly received change is authored by `local:quill` or a permitted system seed actor.
 - Presence shows two operators under one principal. UI can render "quill (Desktop)" and "quill (Claude)" by reading the operator suffix.
 
 ### quill editing an Anaconda-hosted notebook
@@ -346,7 +347,7 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 - quill's client opens an authenticated connection to the Anaconda-hosted room. The transport (browser-direct WebSocket, local-daemon proxy, native client, etc.) is a deployment-topology concern, separate from identity.
 - Anaconda's room-host validates the credential. Returns principal `user:anaconda:550e...`. Looks the principal up in the room's ACL, finds scope `editor`.
 - The client stands up a WASM peer in the hosted room with actor `user:anaconda:550e.../desktop:7f3a`.
-- Edits flow over the established connection. Scope-level frame checks pass (editor may send `0x00` and `0x05` with changes). Actor labels are not validated per change in v1 (see Limitations).
+- Edits flow over the established connection. Scope-level frame checks pass (editor may send `0x00` and `0x05` with changes), and clone-preview actor validation rejects any newly received change whose principal is not `user:anaconda:550e...` or a permitted system seed actor.
 - The same process may simultaneously have an untitled local notebook open in a separate connection. That connection authenticates as `local:quill` against the local daemon. Two rooms, two ACLs, two separately authenticated connections.
 
 ### Claude editing the Anaconda-hosted notebook on quill's behalf
@@ -371,7 +372,7 @@ This section records the audit against Automerge and automerge-repo so the trust
 
 **Actor IDs are self-attested in Automerge.** An Automerge `Change` carries an `actor_id` set by the author at write time. Automerge does not cryptographically bind the actor to anything; it uses the actor only for change ordering and conflict resolution. Two clients must not use the same actor concurrently or `(actor_id, seq)` collisions break CRDT correctness. The `<principal>/<operator>` format includes a `<session-uuid>` in the operator suffix, so uniqueness is preserved when a single user runs multiple operators in parallel. Compatible.
 
-**No actor-label validation per change in v1.** `automerge::sync::Message.changes` is `ChunkList(Vec<Vec<u8>>)`, raw chunk bytes that are not pre-parsed `Change`s. Pre-apply actor-label enforcement would require parsing each chunk (V1: one `Change` per chunk via `Change::try_from`; V2: whole-doc chunks need `load_incremental` into a throwaway peer), filtering by known hashes, then walking actor IDs. We deliberately defer this work (see Limitations) and rely on connect-time auth + scope-based frame checks. The shape is compatible with the underlying Automerge sync surface for when we do add it; a pre-apply hook or a public `parse_change_chunks` would be the natural upstream contribution.
+**Actor-label validation is v1 clone-preview, v2 parse-only.** `automerge::sync::Message.changes` is `ChunkList(Vec<Vec<u8>>)`, raw chunk bytes that are not pre-parsed `Change`s. v1 applies non-empty inbound sync messages to a cloned `NotebookDoc` or `RuntimeStateDoc`, extracts actors from the new heads on that clone, validates principals, then applies the same message to the real document only after validation passes. This is correct but costs a clone and duplicate apply per non-empty inbound frame. The planned Automerge fork patch (`sync_message_new_changes`) replaces the clone-preview with a parse-only pre-apply hook.
 
 **Hash-pinned history is immutable.** Each `Change` references its parents by hash. A peer cannot rewrite history without changing every downstream hash, which then fails the room's existing heads check. The validator only needs to guard *new* changes; historical changes are protected by hash chaining. Compatible.
 
@@ -388,7 +389,7 @@ This section records the audit against Automerge and automerge-repo so the trust
 - `crates/notebook-wire/AGENTS.md` - frame types and v4 wire details.
 - `crates/notebook-protocol/src/connection/handshake.rs` - handshake shape.
 - `crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs` - where the per-frame validator hooks in.
-- `crates/notebook-doc/src/diff.rs:439` - `extract_change_actors`, the post-apply attribution primitive feeding `TextAttribution`. The pre-apply enforcement equivalent is deferred (see Limitations).
+- `crates/notebook-doc/src/diff.rs:439` - `extract_change_actors`, the post-apply attribution primitive used by both `TextAttribution` and the v1 clone-preview actor validator.
 - `automerge::sync::Message` (rust/automerge/src/sync.rs:516-588) - the `ChunkList` wire shape backing per-frame validation.
 - `crates/notebook-doc/src/presence.rs` - presence frame shape.
 - intheloop `backend/auth.ts`, `backend/sync.ts` - bearer-JWT validation + connection-time auth model.

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -82,6 +82,10 @@ export interface DaemonReadyPayload {
   /** On-disk path if the notebook is file-backed. Derives the titlebar filename. */
   notebook_path?: string | null;
   runtime?: string;
+  /** Authenticated actor label to use for Automerge writes on this connection. */
+  actor_label?: string;
+  /** Server-enforced connection scope for this room connection. */
+  connection_scope?: string;
 }
 
 export interface DaemonProgressPayload {

--- a/packages/notebook-host/tests/relay-bootstrap.test.ts
+++ b/packages/notebook-host/tests/relay-bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookHandleHost, type HostedNotebookHandle, type NotebookHandleSlot } from "runtimed";
 import {
   startRelayBootstrapCoordinator,
   type DaemonReadyPayload,
@@ -36,6 +37,14 @@ function createReadySource() {
     emit(payload: DaemonReadyPayload) {
       callbacks.forEach((cb) => cb(payload));
     },
+  };
+}
+
+function createHostedHandle(): HostedNotebookHandle {
+  return {
+    free: vi.fn(),
+    set_blob_port: vi.fn(),
+    set_mime_priority: vi.fn(),
   };
 }
 
@@ -90,6 +99,46 @@ describe("startRelayBootstrapCoordinator", () => {
       payload: { notebook_id: "nb-1", relay_generation: 7 },
     });
     expect(notifyRelayReady).toHaveBeenCalledWith(7);
+
+    coordinator.stop();
+  });
+
+  it("applies the daemon actor label before creating the notebook handle", async () => {
+    const ready = createReadySource();
+    const authoritativeActor = "local:quill/desktop:daemon";
+    let actorLabel = "desktop:fallback";
+    const handle = createHostedHandle();
+    const slot: NotebookHandleSlot = { current: null };
+    const createHandle = vi.fn((_actor: string) => handle);
+    const handleHost = new NotebookHandleHost({
+      actorLabel: () => actorLabel,
+      createHandle,
+      getBlobPort: vi.fn(() => null),
+      publishHandle: vi.fn(),
+      slot,
+    });
+    const notifyRelayReady = vi.fn(async () => {});
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      beforeBootstrap: (trigger) => {
+        actorLabel = trigger.payload.actor_label ?? actorLabel;
+      },
+      bootstrap: (isCancelled) => handleHost.bootstrap(isCancelled),
+      notifyRelayReady,
+    });
+
+    ready.emit({
+      notebook_id: "nb-1",
+      relay_generation: 8,
+      actor_label: authoritativeActor,
+    });
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(createHandle).toHaveBeenCalledWith(authoritativeActor);
+    expect(createHandle).not.toHaveBeenCalledWith("desktop:fallback");
+    expect(notifyRelayReady).toHaveBeenCalledWith(8);
 
     coordinator.stop();
   });


### PR DESCRIPTION
## Summary

- Adds `crates/nteract-identity` as the shared identity foundation for notebook rooms.
- Implements validated `Principal`, `Operator`, and `<principal>/<operator>` `ActorLabel` parsing with serde revalidation.
- Adds `ConnectionScope`, `Credential`, `AuthenticatedUser`, `AuthenticatedConnection`, and closed `IdentityProvider` dispatch.
- Implements `LocalProvider` over listener-verified peer credentials.
- Implements `OidcProvider` over caller-managed JWKS JSON using `jsonwebtoken` for JWT/JWK verification, issuer/audience checks, asymmetric algorithm enforcement, JWK key-use checks, subject-to-principal encoding, principal-namespace validation, operator-kind limits, and configurable scope mapping.
- Extends notebook handshakes and protocol capabilities so the daemon can return the authenticated actor label and connection scope.
- Wires local identity into the daemon room connection path, including presence principal rewrite, scope checks, and per-frame actor-principal validation for `NotebookDoc` and `RuntimeStateDoc` changes.
- Updates the desktop relay path and notebook frontend so the browser-side WASM handle authors with the daemon-returned actor label.
- Documents the shipped clone-preview validator as the v1 actor-forgery closure, with `sync_message_new_changes` left as the future lower-cost replacement.
- Adds focused coverage for local handshake identity, presence rewrite behavior, daemon rejection of a forged Automerge actor, and relay bootstrap actor assignment before handle creation.

## Plan From Here

1. Add the upstream JWKS fetch/cache layer at the listener or host boundary; keep network policy out of `nteract-identity`.
2. Implement the JupyterHub provider behind the existing feature gate once the room-host call site can exercise it against a fake Hub API.
3. Move the same identity enforcement into the extracted room-host crate when that split lands.
4. Add hosted-room tests for viewer/runtime-peer scopes once non-local providers are wired into an actual listener.

## Verification

- `cargo test -p nteract-identity`
- `cargo test -p nteract-identity --no-default-features`
- `cargo test -p nteract-identity --all-features`
- `cargo test -p notebook-protocol -p notebook-sync`
- `cargo test -p runtimed notebook_sync_server::identity --lib`
- `cargo test -p runtimed --test integration test_local_identity -- --nocapture`
- `cargo test -p runtime-doc`
- `cargo check -p runtimed -p notebook`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm test:run packages/notebook-host/tests/relay-bootstrap.test.ts`
- `cargo clippy -p nteract-identity --all-targets -- -D warnings`
- `cargo clippy -p nteract-identity --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p nteract-identity --all-features --all-targets -- -D warnings`
- `git diff --check`
- `cargo xtask lint --fix`
