### PR TITLE
feat(runtimed): expose frame size limits

### DIFF
--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -13,8 +13,12 @@ export type { PresenceHeartbeatOptions, SyncEngineOptions, SyncEngineLogger } fr
 export type { FrameListener, NotebookRequestOptions, NotebookTransport } from "./transport";
 export {
   FrameType,
+  MAX_CONTROL_FRAME_SIZE,
+  MAX_FRAME_SIZE,
+  frameSizeLimits,
   sendAutomergeSyncFrame,
   sendPresenceFrame,
+  type FrameSizeLimits,
   type FrameTypeValue,
 } from "./transport";
 

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -41,6 +41,54 @@ export const FrameType = {
 
 export type FrameTypeValue = (typeof FrameType)[keyof typeof FrameType];
 
+const KIB = 1024;
+const MIB = 1024 * KIB;
+
+/** Absolute maximum typed-frame payload size, aligned with notebook_wire::MAX_FRAME_SIZE. */
+export const MAX_FRAME_SIZE = 100 * MIB;
+
+/** Maximum control-frame payload size, aligned with notebook_wire::MAX_CONTROL_FRAME_SIZE. */
+export const MAX_CONTROL_FRAME_SIZE = 64 * KIB;
+
+export interface FrameSizeLimits {
+  /** Hard payload cap in bytes. Frames larger than this should be rejected. */
+  cap: number;
+  /** Soft payload threshold in bytes. Frames larger than this should be logged. */
+  warn: number;
+}
+
+/**
+ * Return the payload size limits for a typed notebook frame.
+ *
+ * Keep this table in lockstep with `notebook_wire::frame_size_limits` in
+ * `crates/notebook-wire/src/lib.rs`. Cloud and browser transports use this
+ * shared JS surface instead of copying Rust constants into app-local code.
+ */
+export function frameSizeLimits(frameType: number): FrameSizeLimits {
+  switch (frameType) {
+    case FrameType.AUTOMERGE_SYNC:
+      return { cap: 64 * MIB, warn: 16 * MIB };
+    case FrameType.REQUEST:
+      return { cap: 16 * MIB, warn: 256 * KIB };
+    case FrameType.RESPONSE:
+      return { cap: 64 * MIB, warn: 16 * MIB };
+    case FrameType.BROADCAST:
+      return { cap: 16 * MIB, warn: 4 * MIB };
+    case FrameType.PRESENCE:
+      return { cap: 1 * MIB, warn: 256 * KIB };
+    case FrameType.RUNTIME_STATE_SYNC:
+      return { cap: 64 * MIB, warn: 16 * MIB };
+    case FrameType.POOL_STATE_SYNC:
+      return { cap: 1 * MIB, warn: 256 * KIB };
+    case FrameType.SESSION_CONTROL:
+      return { cap: 1 * MIB, warn: 256 * KIB };
+    case FrameType.PUT_BLOB:
+      return { cap: 32 * MIB, warn: 8 * MIB };
+    default:
+      return { cap: MAX_FRAME_SIZE, warn: Math.floor(MAX_FRAME_SIZE / 2) };
+  }
+}
+
 export function sendAutomergeSyncFrame(
   transport: Pick<NotebookTransport, "sendFrame">,
   payload: Uint8Array,

--- a/packages/runtimed/tests/transport.test.ts
+++ b/packages/runtimed/tests/transport.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import {
   DirectTransport,
   FrameType,
+  MAX_CONTROL_FRAME_SIZE,
+  MAX_FRAME_SIZE,
+  frameSizeLimits,
   sendAutomergeSyncFrame,
   sendPresenceFrame,
   type NotebookTransport,
@@ -36,6 +39,70 @@ describe("FrameType constants", () => {
     expect(FrameType.POOL_STATE_SYNC).toBe(0x06);
     expect(FrameType.SESSION_CONTROL).toBe(0x07);
     expect(FrameType.PUT_BLOB).toBe(0x08);
+  });
+});
+
+describe("frameSizeLimits", () => {
+  const kib = 1024;
+  const mib = 1024 * kib;
+
+  it("matches the notebook wire global limits", () => {
+    expect(MAX_FRAME_SIZE).toBe(100 * mib);
+    expect(MAX_CONTROL_FRAME_SIZE).toBe(64 * kib);
+  });
+
+  it("matches the notebook wire per-frame limits", () => {
+    expect(frameSizeLimits(FrameType.AUTOMERGE_SYNC)).toEqual({
+      cap: 64 * mib,
+      warn: 16 * mib,
+    });
+    expect(frameSizeLimits(FrameType.REQUEST)).toEqual({
+      cap: 16 * mib,
+      warn: 256 * kib,
+    });
+    expect(frameSizeLimits(FrameType.RESPONSE)).toEqual({
+      cap: 64 * mib,
+      warn: 16 * mib,
+    });
+    expect(frameSizeLimits(FrameType.BROADCAST)).toEqual({
+      cap: 16 * mib,
+      warn: 4 * mib,
+    });
+    expect(frameSizeLimits(FrameType.PRESENCE)).toEqual({
+      cap: 1 * mib,
+      warn: 256 * kib,
+    });
+    expect(frameSizeLimits(FrameType.RUNTIME_STATE_SYNC)).toEqual({
+      cap: 64 * mib,
+      warn: 16 * mib,
+    });
+    expect(frameSizeLimits(FrameType.POOL_STATE_SYNC)).toEqual({
+      cap: 1 * mib,
+      warn: 256 * kib,
+    });
+    expect(frameSizeLimits(FrameType.SESSION_CONTROL)).toEqual({
+      cap: 1 * mib,
+      warn: 256 * kib,
+    });
+    expect(frameSizeLimits(FrameType.PUT_BLOB)).toEqual({
+      cap: 32 * mib,
+      warn: 8 * mib,
+    });
+  });
+
+  it("uses the notebook wire fallback for unknown frame types", () => {
+    expect(frameSizeLimits(0xff)).toEqual({
+      cap: MAX_FRAME_SIZE,
+      warn: MAX_FRAME_SIZE / 2,
+    });
+  });
+
+  it("keeps warning thresholds below caps", () => {
+    for (const frameType of Object.values(FrameType)) {
+      const { cap, warn } = frameSizeLimits(frameType);
+
+      expect(warn).toBeLessThan(cap);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- expose `MAX_FRAME_SIZE`, `MAX_CONTROL_FRAME_SIZE`, and `frameSizeLimits()` from the shared `runtimed` JS transport surface
- pin the JS frame-size table against the existing Rust `notebook_wire::frame_size_limits` values
- make cloud/browser transports able to import the same package-owned wire contract instead of copying constants

## Motivation

PR #2804 proved the notebook-cloud Worker needs per-frame typed-frame limits, but carrying a local copy in `apps/notebook-cloud/src/protocol.ts` immediately drifted from the Rust contract during review. This moves the JS-side contract next to the existing `FrameType` exports so future Worker, browser relay, and host transports can share one package-owned table.

This is intentionally narrow: Rust remains the source of truth, and this PR gives the JS package a tested mirror until we have generated cross-language constants.

## Verification

- `pnpm test:run packages/runtimed/tests/transport.test.ts`
- `cargo test -p notebook-wire -p notebook-protocol`
- `cargo xtask lint --fix`
- Bedrock Opus review via `claude-bedrock-reviewer`: clear, no actionable findings.

## Follow-Ups

- Update #2804 to import `frameSizeLimits()` instead of carrying its prototype-local table.
- Continue with the next foundation PR for real presence CBOR encode/decode on a shared JS/Worker surface.
