### PR TITLE
feat(wasm): expose presence cbor helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7596,6 +7596,7 @@ dependencies = [
  "getrandom 0.4.2",
  "notebook-doc",
  "notebook-wire",
+ "nteract-identity",
  "runtime-doc",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 automerge = { workspace = true }
 notebook-doc = { path = "../notebook-doc" }
 notebook-wire = { path = "../notebook-wire" }
+nteract-identity = { path = "../nteract-identity", default-features = false }
 runtime-doc = { path = "../runtime-doc" }
 wasm-bindgen = "0.2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2185,6 +2185,8 @@ pub fn encode_presence_frame(message: JsValue) -> Result<Vec<u8>, JsError> {
 /// overwrites the peer id, rewrites update actor labels to the authenticated
 /// principal while preserving the presented operator suffix, and re-encodes
 /// canonical CBOR. Malformed or missing actor labels use `fallback_operator`.
+/// The operator suffix is self-declared attribution metadata only; authorization
+/// must use the authenticated principal and connection scope.
 #[wasm_bindgen]
 pub fn rewrite_presence_ingress(
     payload: &[u8],
@@ -2206,13 +2208,22 @@ pub fn rewrite_presence_ingress(
 
     let rewritten = match message {
         presence::PresenceMessage::Update {
-            actor_label, data, ..
+            peer_id: _,
+            peer_label: _,
+            actor_label,
+            data,
         } => {
-            if matches!(data, presence::ChannelData::KernelState(_)) {
-                return Err(JsError::new(
-                    "client presence updates cannot publish kernel state",
-                ));
-            }
+            let data = match data {
+                client_data @ (presence::ChannelData::Cursor(_)
+                | presence::ChannelData::Selection(_)
+                | presence::ChannelData::Focus(_)
+                | presence::ChannelData::Custom(_)) => client_data,
+                presence::ChannelData::KernelState(_) => {
+                    return Err(JsError::new(
+                        "client presence updates cannot publish kernel state",
+                    ));
+                }
+            };
             let operator = actor_label
                 .as_deref()
                 .and_then(|label| Operator::from_actor_label_or_operator(label).ok())

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -16,6 +16,7 @@ use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
 use notebook_doc::{CellSnapshot, NotebookDoc};
 use notebook_wire::{frame_types, SessionControlMessage, SessionSyncStatusWire};
+use nteract_identity::{ActorLabel, Operator, Principal};
 use runtime_doc::{
     diff_output_ids, output_ids_for_execution, ExecutionState, ExecutionViewChangeset,
     ExecutionViewProjector, RuntimeState, RuntimeStateDoc,
@@ -2152,6 +2153,98 @@ pub fn encode_clear_channel_presence(peer_id: &str, channel: &str) -> Result<Vec
         other => return Err(JsError::new(&format!("unknown presence channel: {other}"))),
     };
     presence::encode_clear_channel(peer_id, ch).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Decode a presence frame payload from CBOR into a JS object.
+///
+/// This is intentionally standalone from `NotebookHandle.receive_frame()` so
+/// Worker and test harness code can inspect real presence bytes without owning
+/// a notebook document replica.
+#[wasm_bindgen]
+pub fn decode_presence_frame(payload: &[u8]) -> Result<JsValue, JsError> {
+    let message = presence::decode_message(payload).map_err(|e| JsError::new(&e.to_string()))?;
+    serialize_to_js(&message).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Encode a JS presence message object into the canonical CBOR frame payload.
+///
+/// The object shape is the same as `decode_presence_frame()` returns:
+/// `{ type: "update", peer_id, channel, data, ... }`, `{ type: "heartbeat",
+/// peer_id }`, etc.
+#[wasm_bindgen]
+pub fn encode_presence_frame(message: JsValue) -> Result<Vec<u8>, JsError> {
+    let message: presence::PresenceMessage =
+        serde_wasm_bindgen::from_value(message).map_err(|e| JsError::new(&e.to_string()))?;
+    presence::encode_message(&message).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Rewrite client-authored presence for trusted server ingress.
+///
+/// Room hosts should authenticate the connection first, then use this helper
+/// before relaying a client presence payload. It decodes canonical CBOR,
+/// overwrites the peer id, rewrites update actor labels to the authenticated
+/// principal while preserving the presented operator suffix, and re-encodes
+/// canonical CBOR. Malformed or missing actor labels use `fallback_operator`.
+#[wasm_bindgen]
+pub fn rewrite_presence_ingress(
+    payload: &[u8],
+    peer_id: &str,
+    peer_label: &str,
+    principal: &str,
+    fallback_operator: &str,
+) -> Result<Vec<u8>, JsError> {
+    let principal =
+        Principal::new(principal.to_string()).map_err(|e| JsError::new(&e.to_string()))?;
+    let fallback_operator =
+        Operator::new(fallback_operator.to_string()).map_err(|e| JsError::new(&e.to_string()))?;
+    let message = presence::decode_message(payload).map_err(|e| JsError::new(&e.to_string()))?;
+    let peer_label = if peer_label.is_empty() {
+        None
+    } else {
+        Some(peer_label.to_string())
+    };
+
+    let rewritten = match message {
+        presence::PresenceMessage::Update {
+            actor_label, data, ..
+        } => {
+            if matches!(data, presence::ChannelData::KernelState(_)) {
+                return Err(JsError::new(
+                    "client presence updates cannot publish kernel state",
+                ));
+            }
+            let operator = actor_label
+                .as_deref()
+                .and_then(|label| Operator::from_actor_label_or_operator(label).ok())
+                .unwrap_or(fallback_operator);
+            let actor_label = ActorLabel::new(principal, operator);
+            presence::PresenceMessage::Update {
+                peer_id: peer_id.to_string(),
+                peer_label,
+                actor_label: Some(actor_label.as_str().to_string()),
+                data,
+            }
+        }
+        presence::PresenceMessage::Heartbeat { .. } => presence::PresenceMessage::Heartbeat {
+            peer_id: peer_id.to_string(),
+        },
+        presence::PresenceMessage::ClearChannel { channel, .. } => {
+            presence::PresenceMessage::ClearChannel {
+                peer_id: peer_id.to_string(),
+                channel,
+            }
+        }
+        presence::PresenceMessage::Left { .. } => presence::PresenceMessage::Left {
+            peer_id: peer_id.to_string(),
+        },
+        presence::PresenceMessage::Snapshot { .. } => {
+            return Err(JsError::new(
+                "client presence ingress cannot publish snapshots",
+            ));
+        }
+    };
+
+    presence::encode_message(&rewritten).map_err(|e| JsError::new(&e.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2185,6 +2185,7 @@ pub fn encode_presence_frame(message: JsValue) -> Result<Vec<u8>, JsError> {
 /// overwrites the peer id, rewrites update actor labels to the authenticated
 /// principal while preserving the presented operator suffix, and re-encodes
 /// canonical CBOR. Malformed or missing actor labels use `fallback_operator`.
+/// Pass an empty `peer_label` to omit display text from rewritten updates.
 /// The operator suffix is self-declared attribution metadata only; authorization
 /// must use the authenticated principal and connection scope.
 #[wasm_bindgen]

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -130,6 +130,32 @@ Deno.test("Presence: ingress rewrite falls back for malformed actor labels", () 
   });
 });
 
+Deno.test("Presence: ingress rewrite preserves custom channel bytes", () => {
+  const payload = mod.encode_presence_frame({
+    type: "update",
+    peer_id: "client-peer",
+    actor_label: "user:dev:mallory/desktop:custom",
+    channel: "custom",
+    data: [1, 3, 5, 8],
+  });
+
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "",
+    "user:dev:alice",
+    "desktop:browser",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "update",
+    peer_id: "server-peer",
+    actor_label: "user:dev:alice/desktop:custom",
+    channel: "custom",
+    data: [1, 3, 5, 8],
+  });
+});
+
 Deno.test("Presence: ingress rewrite restamps heartbeat peer id", () => {
   const payload = mod.encode_heartbeat_presence("client-peer");
   const rewritten = mod.rewrite_presence_ingress(

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -146,6 +146,46 @@ Deno.test("Presence: ingress rewrite restamps heartbeat peer id", () => {
   });
 });
 
+Deno.test("Presence: ingress rewrite restamps clear-channel peer id", () => {
+  const payload = mod.encode_presence_frame({
+    type: "clear_channel",
+    peer_id: "client-forged-peer",
+    channel: "cursor",
+  });
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "",
+    "user:dev:alice",
+    "desktop:browser",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "clear_channel",
+    peer_id: "server-peer",
+    channel: "cursor",
+  });
+});
+
+Deno.test("Presence: ingress rewrite restamps left peer id", () => {
+  const payload = mod.encode_presence_frame({
+    type: "left",
+    peer_id: "client-forged-peer",
+  });
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "",
+    "user:dev:alice",
+    "desktop:browser",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "left",
+    peer_id: "server-peer",
+  });
+});
+
 Deno.test("Presence: ingress rewrite rejects client snapshots", () => {
   const payload = mod.encode_presence_frame({
     type: "snapshot",

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -7,7 +7,7 @@
 
 import {
   assertEquals,
-  assertRejects,
+  assertThrows,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
 // @ts-nocheck - wasm-bindgen output is browser-shaped, but Deno can run it.
@@ -153,8 +153,8 @@ Deno.test("Presence: ingress rewrite rejects client snapshots", () => {
     peers: [],
   });
 
-  assertRejects(
-    async () =>
+  assertThrows(
+    () =>
       mod.rewrite_presence_ingress(
         payload,
         "server-peer",
@@ -164,5 +164,30 @@ Deno.test("Presence: ingress rewrite rejects client snapshots", () => {
       ),
     Error,
     "snapshots",
+  );
+});
+
+Deno.test("Presence: ingress rewrite rejects client kernel-state updates", () => {
+  const payload = mod.encode_presence_frame({
+    type: "update",
+    peer_id: "client-peer",
+    channel: "kernel_state",
+    data: {
+      status: "idle",
+      env_source: "python",
+    },
+  });
+
+  assertThrows(
+    () =>
+      mod.rewrite_presence_ingress(
+        payload,
+        "server-peer",
+        "",
+        "user:dev:alice",
+        "desktop:browser",
+      ),
+    Error,
+    "kernel state",
   );
 });

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -1,0 +1,168 @@
+/**
+ * Presence CBOR smoke tests for runtimed-wasm.
+ *
+ * Run with:
+ *   deno test --allow-read crates/runtimed-wasm/tests/presence_test.ts
+ */
+
+import {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// @ts-nocheck - wasm-bindgen output is browser-shaped, but Deno can run it.
+
+const wasmJsPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+const mod = await import(wasmJsPath.href);
+const wasmBytes = await Deno.readFile(wasmBinPath);
+await mod.default(wasmBytes);
+
+Deno.test("Presence: standalone decoder reads real cursor CBOR", () => {
+  const payload = mod.encode_cursor_presence(
+    "client-peer",
+    "Alice",
+    "user:dev:alice/desktop:browser",
+    "cell-1",
+    2,
+    4,
+  );
+
+  const decoded = mod.decode_presence_frame(payload);
+
+  assertEquals(decoded, {
+    type: "update",
+    peer_id: "client-peer",
+    peer_label: "Alice",
+    actor_label: "user:dev:alice/desktop:browser",
+    channel: "cursor",
+    data: {
+      cell_id: "cell-1",
+      line: 2,
+      column: 4,
+    },
+  });
+});
+
+Deno.test("Presence: generic JS object encoder round-trips through CBOR", () => {
+  const message = {
+    type: "update",
+    peer_id: "client-peer",
+    peer_label: "Alice",
+    actor_label: "user:dev:alice/desktop:browser",
+    channel: "selection",
+    data: {
+      cell_id: "cell-1",
+      anchor_line: 1,
+      anchor_col: 2,
+      head_line: 3,
+      head_col: 4,
+    },
+  };
+
+  const encoded = mod.encode_presence_frame(message);
+
+  assertEquals(mod.decode_presence_frame(encoded), message);
+});
+
+Deno.test("Presence: ingress rewrite stamps trusted peer and principal", () => {
+  const payload = mod.encode_cursor_presence(
+    "client-forged-peer",
+    "Mallory",
+    "user:dev:mallory/agent:codex:s1",
+    "cell-2",
+    5,
+    7,
+  );
+
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "Alice",
+    "user:dev:alice",
+    "desktop:browser",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "update",
+    peer_id: "server-peer",
+    peer_label: "Alice",
+    actor_label: "user:dev:alice/agent:codex:s1",
+    channel: "cursor",
+    data: {
+      cell_id: "cell-2",
+      line: 5,
+      column: 7,
+    },
+  });
+});
+
+Deno.test("Presence: ingress rewrite falls back for malformed actor labels", () => {
+  const payload = mod.encode_presence_frame({
+    type: "update",
+    peer_id: "client-peer",
+    actor_label: "bad/principal/extra",
+    channel: "focus",
+    data: { cell_id: "cell-3" },
+  });
+
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "",
+    "user:dev:alice",
+    "desktop:fallback",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "update",
+    peer_id: "server-peer",
+    actor_label: "user:dev:alice/desktop:fallback",
+    channel: "focus",
+    data: { cell_id: "cell-3" },
+  });
+});
+
+Deno.test("Presence: ingress rewrite restamps heartbeat peer id", () => {
+  const payload = mod.encode_heartbeat_presence("client-peer");
+  const rewritten = mod.rewrite_presence_ingress(
+    payload,
+    "server-peer",
+    "",
+    "user:dev:alice",
+    "desktop:browser",
+  );
+
+  assertEquals(mod.decode_presence_frame(rewritten), {
+    type: "heartbeat",
+    peer_id: "server-peer",
+  });
+});
+
+Deno.test("Presence: ingress rewrite rejects client snapshots", () => {
+  const payload = mod.encode_presence_frame({
+    type: "snapshot",
+    peer_id: "client-peer",
+    peers: [],
+  });
+
+  assertRejects(
+    async () =>
+      mod.rewrite_presence_ingress(
+        payload,
+        "server-peer",
+        "",
+        "user:dev:alice",
+        "desktop:browser",
+      ),
+    Error,
+    "snapshots",
+  );
+});


### PR DESCRIPTION
## Summary

- expose standalone `runtimed-wasm` helpers for canonical presence CBOR decode and encode
- add `rewrite_presence_ingress()` for trusted room hosts to stamp server peer identity and authenticated actor principal before relay
- harden ingress rewriting with an exhaustive client-writable presence allowlist and Deno coverage for every ingress message variant

## Motivation

PR #2804 proved the cloud room needs to inspect and rewrite presence, but its prototype shim only understood JSON presence. Real nteract clients send `notebook_doc::presence` CBOR on frame `0x04`.

This PR makes the existing Rust presence codec available to JS/Worker callers without requiring a `NotebookHandle` replica. A Worker Durable Object can now decode real presence bytes, reject server-owned snapshots/kernel-state updates, rewrite client-authored actor labels to the authenticated principal, and re-encode the same canonical CBOR format other clients already decode.

## API Notes

- `decode_presence_frame(payload)` returns the same JS message shape produced by `NotebookHandle.receive_frame()` presence events.
- `encode_presence_frame(message)` accepts that JS message shape and emits canonical CBOR.
- `rewrite_presence_ingress(payload, peer_id, peer_label, principal, fallback_operator)` is for authenticated server ingress. It overwrites peer id, applies a server-provided peer label, preserves a valid presented operator suffix, falls back for malformed actor labels, rejects client snapshots, and rejects client kernel-state presence.
- The preserved operator suffix is self-declared attribution metadata only. Authorization must use the authenticated principal and connection scope.

Generated wasm-bindgen artifacts remain ignored in this repo. CI rebuilds them before the Deno WASM suite; local verification rebuilt them before running tests.

## Verification

- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `deno test --allow-read crates/runtimed-wasm/tests/presence_test.ts`
- `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/`
- `cargo clippy -p runtimed-wasm --target wasm32-unknown-unknown -- -D warnings`
- `cargo xtask lint --fix`
- Bedrock Opus 4.6 review via `claude-bedrock-reviewer`: final rebased pass reported no actionable findings.

## Follow-Ups

- Update #2804 to call these helpers instead of rejecting non-JSON presence.
- Continue with the blob URL resolver strategy PR so local daemon URLs and cloud/R2 URLs share one output-resolution contract.
