### PR TITLE
feat(runtimed): share blob resolvers

### DIFF
--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   ARROW_STREAM_MANIFEST_MIME,
+  createBlobResolver,
   type ContentRef,
   isOutputManifest,
   type OutputManifest,
@@ -411,6 +412,26 @@ describe("resolveContentRef", () => {
     expect(mockFetch).toHaveBeenCalledWith(
       "http://127.0.0.1:5555/blob/hash123",
     );
+  });
+
+  it("uses resolver URLs and fetch policy without a daemon port", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("cloud", { status: 200 }));
+    const resolver = createBlobResolver({
+      url: (ref) => `/api/n/notebook-1/blobs/${encodeURIComponent(ref.blob)}`,
+      fetchImpl,
+      requestInit: { credentials: "include" },
+    });
+
+    const result = await resolveContentRef(
+      { blob: "sha256:abc", size: 5 },
+      resolver,
+      "text/plain",
+    );
+
+    expect(result).toBe("cloud");
+    expect(fetchImpl).toHaveBeenCalledWith("/api/n/notebook-1/blobs/sha256%3Aabc", {
+      credentials: "include",
+    });
   });
 });
 

--- a/apps/notebook/src/lib/__tests__/markdown-assets.test.ts
+++ b/apps/notebook/src/lib/__tests__/markdown-assets.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { createBlobResolver } from "../manifest-resolution";
 import { rewriteMarkdownAssetRefs } from "../markdown-assets";
 
 describe("rewriteMarkdownAssetRefs", () => {
@@ -90,6 +91,18 @@ describe("rewriteMarkdownAssetRefs", () => {
     expect(result).toBe(
       '![one](http://127.0.0.1:4321/blob/abc123)\n<img src="http://127.0.0.1:4321/blob/abc123" />',
     );
+  });
+
+  it("rewrites refs through a host blob resolver without a daemon port", () => {
+    const result = rewriteMarkdownAssetRefs(
+      "![plot](images/foo.png)",
+      { "images/foo.png": "sha256:abc" },
+      createBlobResolver({
+        url: (ref) => `/api/n/notebook-1/blobs/${encodeURIComponent(ref.blob)}`,
+      }),
+    );
+
+    expect(result).toBe("![plot](/api/n/notebook-1/blobs/sha256%3Aabc)");
   });
 
   it("rewrites angle-bracketed markdown destinations with spaces", () => {

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -1,6 +1,9 @@
 export {
   ARROW_STREAM_MANIFEST_MIME,
+  createBlobResolver,
+  createHttpBlobResolver,
   isOutputManifest,
+  normalizeBlobResolver,
   resolveContentRef,
   resolveDataBundle,
   resolveManifest,

--- a/apps/notebook/src/lib/markdown-assets.ts
+++ b/apps/notebook/src/lib/markdown-assets.ts
@@ -1,8 +1,8 @@
+import { normalizeBlobResolver } from "../../../../packages/runtimed/src/blob-resolver";
 import type { BlobResolverInput } from "./manifest-resolution";
 
 function blobUrl(blobResolver: BlobResolverInput, hash: string): string {
-  if (typeof blobResolver === "number") return `http://127.0.0.1:${blobResolver}/blob/${hash}`;
-  return blobResolver.url({ blob: hash });
+  return normalizeBlobResolver(blobResolver).url({ blob: hash });
 }
 
 /**

--- a/apps/notebook/src/lib/markdown-assets.ts
+++ b/apps/notebook/src/lib/markdown-assets.ts
@@ -1,4 +1,4 @@
-import { normalizeBlobResolver } from "../../../../packages/runtimed/src/blob-resolver";
+import { normalizeBlobResolver } from "runtimed";
 import type { BlobResolverInput } from "./manifest-resolution";
 
 function blobUrl(blobResolver: BlobResolverInput, hash: string): string {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "runtimed": "workspace:*",
     "tailwind-merge": "^3.4.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -8,6 +8,7 @@
 
 import {
   FrameType,
+  createHttpBlobResolver,
   type FrameListener,
   type FrameTypeValue,
   type NotebookRequest,
@@ -22,7 +23,6 @@ import type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
-  HostBlobRef,
   HostBlobResolver,
   HostBlobs,
   HostUpdaterState,
@@ -78,17 +78,6 @@ function requestTimeoutMs(request: NotebookRequest): number {
     default:
       return 30_000;
   }
-}
-
-function createHttpBlobResolver(port: number, fetchImpl: typeof fetch): HostBlobResolver {
-  const url = (ref: HostBlobRef) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
-  return {
-    port,
-    url,
-    fetch(ref) {
-      return fetchImpl(url(ref));
-    },
-  };
 }
 
 function addToken(url: string, token: string): string {

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -24,7 +24,7 @@ import {
 } from "@tauri-apps/plugin-log";
 import { open as pluginOpenShell } from "@tauri-apps/plugin-shell";
 import { check as pluginCheckUpdate } from "@tauri-apps/plugin-updater";
-import type { NotebookResponse, NotebookTransport } from "runtimed";
+import { createHttpBlobResolver, type NotebookResponse, type NotebookTransport } from "runtimed";
 import { createCommandRegistry } from "../commands";
 import { wireTauriMenuBridge } from "./menu-bridge";
 import { TauriTransport } from "./transport";
@@ -35,7 +35,6 @@ import type {
   DaemonReadyPayload,
   DaemonUnavailablePayload,
   GitInfo,
-  HostBlobRef,
   HostBlobResolver,
   HostBlobs,
   HostDaemon,
@@ -86,17 +85,6 @@ function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten
       unlisten();
       unlisten = null;
     }
-  };
-}
-
-function createHttpBlobResolver(port: number, fetchImpl: typeof fetch = fetch): HostBlobResolver {
-  const url = (ref: HostBlobRef) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
-  return {
-    port,
-    url,
-    fetch(ref) {
-      return fetchImpl(url(ref));
-    },
   };
 }
 

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -29,7 +29,7 @@
  *   point — not pre-optional now, to keep the contract honest.
  */
 
-import type { NotebookTransport } from "runtimed";
+import type { BlobRef, BlobResolver, NotebookTransport } from "runtimed";
 import type { CommandRegistry } from "./commands";
 
 // ── Shared types ─────────────────────────────────────────────────────────
@@ -121,27 +121,8 @@ export interface HostDaemon {
   getReadyInfo(): Promise<DaemonReadyPayload | null>;
 }
 
-export interface HostBlobRef {
-  blob: string;
-  size?: number;
-  media_type?: string;
-}
-
-export interface HostBlobResolver {
-  /**
-   * Local blob port when this resolver is backed by the daemon HTTP server.
-   *
-   * Kept for WASM compatibility while frontend render paths move to `url()`
-   * and `fetch()`.
-   */
-  readonly port?: number;
-
-  /** Return a browser-consumable URL for renderers that stream/fetch directly. */
-  url(ref: HostBlobRef): string;
-
-  /** Fetch blob bytes/text through the host, including any auth/proxy policy. */
-  fetch(ref: HostBlobRef): Promise<Response>;
-}
+export type HostBlobRef = BlobRef;
+export type HostBlobResolver = BlobResolver;
 
 /** Blob store — host-owned access to daemon blob content. */
 export interface HostBlobs {

--- a/packages/runtimed/src/blob-resolver.ts
+++ b/packages/runtimed/src/blob-resolver.ts
@@ -1,0 +1,70 @@
+export interface BlobRef {
+  blob: string;
+  size?: number;
+  media_type?: string;
+}
+
+export interface BlobResolver {
+  /**
+   * Local daemon blob port when the resolver is backed by the daemon HTTP
+   * server. Cloud/native resolvers should omit this and rely on `url()` and
+   * `fetch()` instead.
+   */
+  readonly port?: number;
+
+  /** Return a browser-consumable URL for renderers that stream/fetch directly. */
+  url(ref: BlobRef): string;
+
+  /** Fetch blob bytes/text through the host, including any auth/proxy policy. */
+  fetch(ref: BlobRef): Promise<Response>;
+}
+
+export type BlobResolverInput = BlobResolver | number;
+
+export interface BlobResolverOptions {
+  url(ref: BlobRef): string;
+  fetchImpl?: typeof fetch;
+  requestInit?: RequestInit | ((ref: BlobRef) => RequestInit);
+}
+
+function requestInitFor(
+  requestInit: BlobResolverOptions["requestInit"],
+  ref: BlobRef,
+): RequestInit | undefined {
+  return typeof requestInit === "function" ? requestInit(ref) : requestInit;
+}
+
+/**
+ * Create a host-agnostic blob resolver.
+ *
+ * This is the cloud/native path: callers own URL construction and fetch
+ * policy, and no daemon `port` is exposed to downstream consumers.
+ */
+export function createBlobResolver(options: BlobResolverOptions): BlobResolver {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  return {
+    url: options.url,
+    fetch(ref) {
+      return fetchImpl(options.url(ref), requestInitFor(options.requestInit, ref));
+    },
+  };
+}
+
+/** Create a resolver for the local daemon HTTP blob server. */
+export function createHttpBlobResolver(
+  port: number,
+  fetchImpl: typeof fetch = fetch,
+): BlobResolver {
+  const url = (ref: BlobRef) => `http://127.0.0.1:${port}/blob/${encodeURIComponent(ref.blob)}`;
+  return {
+    port,
+    url,
+    fetch(ref) {
+      return fetchImpl(url(ref));
+    },
+  };
+}
+
+export function normalizeBlobResolver(input: BlobResolverInput): BlobResolver {
+  return typeof input === "number" ? createHttpBlobResolver(input) : input;
+}

--- a/packages/runtimed/src/blob-resolver.ts
+++ b/packages/runtimed/src/blob-resolver.ts
@@ -55,7 +55,7 @@ export function createHttpBlobResolver(
   port: number,
   fetchImpl: typeof fetch = fetch,
 ): BlobResolver {
-  const url = (ref: BlobRef) => `http://127.0.0.1:${port}/blob/${encodeURIComponent(ref.blob)}`;
+  const url = (ref: BlobRef) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
   return {
     port,
     url,

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -200,6 +200,15 @@ export type {
 
 // Blob upload
 export { BlobUploadError, PUT_BLOB_TIMEOUT_MS, putBlob, type PutBlobResult } from "./blob-upload";
+export {
+  createBlobResolver,
+  createHttpBlobResolver,
+  normalizeBlobResolver,
+  type BlobRef,
+  type BlobResolver,
+  type BlobResolverInput,
+  type BlobResolverOptions,
+} from "./blob-resolver";
 
 // MIME priority
 export { DEFAULT_MIME_PRIORITY } from "./mime-priority";

--- a/packages/runtimed/tests/blob-resolver.test.ts
+++ b/packages/runtimed/tests/blob-resolver.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { createBlobResolver, createHttpBlobResolver, normalizeBlobResolver } from "../src";
+
+describe("blob resolver helpers", () => {
+  it("creates daemon HTTP blob URLs from a local port", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("ok"));
+    const resolver = createHttpBlobResolver(8765, fetchImpl);
+    const ref = { blob: "sha256:abc/def", size: 12 };
+
+    expect(resolver.port).toBe(8765);
+    expect(resolver.url(ref)).toBe("http://127.0.0.1:8765/blob/sha256%3Aabc%2Fdef");
+
+    const response = await resolver.fetch(ref);
+
+    expect(await response.text()).toBe("ok");
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:8765/blob/sha256%3Aabc%2Fdef");
+  });
+
+  it("creates host-agnostic resolvers without exposing a daemon port", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("cloud"));
+    const resolver = createBlobResolver({
+      url: (ref) => `/api/n/notebook-1/blobs/${encodeURIComponent(ref.blob)}`,
+      fetchImpl,
+      requestInit: (ref) => ({
+        headers: { "X-Blob-Size": String(ref.size ?? 0) },
+      }),
+    });
+    const ref = { blob: "sha256:abc", size: 42 };
+
+    expect(resolver.port).toBeUndefined();
+    expect(resolver.url(ref)).toBe("/api/n/notebook-1/blobs/sha256%3Aabc");
+
+    const response = await resolver.fetch(ref);
+
+    expect(await response.text()).toBe("cloud");
+    expect(fetchImpl).toHaveBeenCalledWith("/api/n/notebook-1/blobs/sha256%3Aabc", {
+      headers: { "X-Blob-Size": "42" },
+    });
+  });
+
+  it("normalizes legacy numeric ports to daemon HTTP resolvers", () => {
+    const resolver = normalizeBlobResolver(4321);
+
+    expect(resolver.port).toBe(4321);
+    expect(resolver.url({ blob: "hash" })).toBe("http://127.0.0.1:4321/blob/hash");
+  });
+
+  it("passes resolver objects through unchanged", () => {
+    const resolver = createBlobResolver({
+      url: (ref) => `https://outputs.example/${ref.blob}`,
+    });
+
+    expect(normalizeBlobResolver(resolver)).toBe(resolver);
+  });
+});

--- a/packages/runtimed/tests/blob-resolver.test.ts
+++ b/packages/runtimed/tests/blob-resolver.test.ts
@@ -6,15 +6,15 @@ describe("blob resolver helpers", () => {
   it("creates daemon HTTP blob URLs from a local port", async () => {
     const fetchImpl = vi.fn().mockResolvedValue(new Response("ok"));
     const resolver = createHttpBlobResolver(8765, fetchImpl);
-    const ref = { blob: "sha256:abc/def", size: 12 };
+    const ref = { blob: "sha256:abc", size: 12 };
 
     expect(resolver.port).toBe(8765);
-    expect(resolver.url(ref)).toBe("http://127.0.0.1:8765/blob/sha256%3Aabc%2Fdef");
+    expect(resolver.url(ref)).toBe("http://127.0.0.1:8765/blob/sha256:abc");
 
     const response = await resolver.fetch(ref);
 
     expect(await response.text()).toBe("ok");
-    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:8765/blob/sha256%3Aabc%2Fdef");
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:8765/blob/sha256:abc");
   });
 
   it("creates host-agnostic resolvers without exposing a daemon port", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      runtimed:
+        specifier: workspace:*
+        version: link:packages/runtimed
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -69,7 +69,14 @@ export type {
   NteractOutputEmbedOptions,
   NteractOutputRendererBundleProvider,
 } from "./output-embed";
-export { isOutputManifest, resolveManifest, resolveManifestSync } from "./output-manifest";
+export {
+  createBlobResolver,
+  createHttpBlobResolver,
+  isOutputManifest,
+  normalizeBlobResolver,
+  resolveManifest,
+  resolveManifestSync,
+} from "./output-manifest";
 export type {
   BlobResolverInput,
   ContentRef,

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -3,15 +3,11 @@ import {
   type BlobRef as OutputBlobRef,
   type BlobResolver as OutputBlobResolver,
   type BlobResolverInput,
-} from "../../../packages/runtimed/src/blob-resolver";
+} from "runtimed";
 
 export const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
-export {
-  createBlobResolver,
-  createHttpBlobResolver,
-  normalizeBlobResolver,
-} from "../../../packages/runtimed/src/blob-resolver";
+export { createBlobResolver, createHttpBlobResolver, normalizeBlobResolver } from "runtimed";
 export type { BlobResolverInput, OutputBlobRef, OutputBlobResolver };
 
 export type ContentRef =

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -1,18 +1,18 @@
+import {
+  normalizeBlobResolver,
+  type BlobRef as OutputBlobRef,
+  type BlobResolver as OutputBlobResolver,
+  type BlobResolverInput,
+} from "../../../packages/runtimed/src/blob-resolver";
+
 export const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
-export interface OutputBlobRef {
-  blob: string;
-  size?: number;
-  media_type?: string;
-}
-
-export interface OutputBlobResolver {
-  readonly port?: number;
-  url(ref: OutputBlobRef): string;
-  fetch(ref: OutputBlobRef): Promise<Response>;
-}
-
-export type BlobResolverInput = OutputBlobResolver | number;
+export {
+  createBlobResolver,
+  createHttpBlobResolver,
+  normalizeBlobResolver,
+} from "../../../packages/runtimed/src/blob-resolver";
+export type { BlobResolverInput, OutputBlobRef, OutputBlobResolver };
 
 export type ContentRef =
   | { inline: string }
@@ -80,19 +80,6 @@ export type ResolvedJupyterOutput =
       traceback: string[];
       rich?: unknown;
     };
-
-function normalizeBlobResolver(input: BlobResolverInput): OutputBlobResolver {
-  if (typeof input !== "number") return input;
-  const port = input;
-  const url = (ref: { blob: string }) => `http://127.0.0.1:${port}/blob/${ref.blob}`;
-  return {
-    port,
-    url,
-    fetch(ref: OutputBlobRef) {
-      return fetch(url(ref));
-    },
-  };
-}
 
 function looksLikeBinaryMime(mime: string): boolean {
   if (mime.startsWith("image/") && !mime.endsWith("+xml")) return true;


### PR DESCRIPTION
## Summary

Adds a shared blob resolver strategy in `packages/runtimed` and threads it through the existing notebook host and isolated output manifest paths.

This keeps the current local daemon `blob_port` compatibility path, but gives cloud/native hosts a first-class `url(ref)` and `fetch(ref)` contract that does not expose or require a local port.

## Motivation

The notebook-cloud spike in #2804 needs to render persisted notebook outputs from R2-backed blob URLs. The desktop app currently resolves blobs through the daemon HTTP port, and several render paths had grown local helper copies that assumed `http://127.0.0.1:<port>/blob/<hash>`.

This PR moves that policy boundary into a reusable resolver:

- local desktop/Tauri/browser hosts use `createHttpBlobResolver(port)`;
- cloud/native hosts can use `createBlobResolver({ url, fetchImpl, requestInit })`;
- output manifests and markdown assets resolve blobs through the same interface.

## Changes

- Add `BlobRef`, `BlobResolver`, `BlobResolverInput`, `createBlobResolver`, `createHttpBlobResolver`, and `normalizeBlobResolver` to `packages/runtimed`.
- Re-export the resolver helpers from `packages/runtimed/src/index.ts`.
- Replace duplicated notebook-host HTTP blob resolver helpers with the shared helper.
- Make isolated output manifest resolution and markdown asset rewriting normalize through the shared resolver.
- Re-export resolver helpers from the isolated output/manifest surface used by app code.

## Migration Notes

Existing numeric `blob_port` callers continue to work through `normalizeBlobResolver(number)`.

New hosts should pass a `BlobResolver` directly instead of teaching render code about transport details. For notebook-cloud this means R2/API URLs can stay outside WASM and outside renderer internals.

## Verification

- `pnpm test:run packages/runtimed/tests/blob-resolver.test.ts apps/notebook/src/lib/__tests__/manifest-resolution.test.ts apps/notebook/src/lib/__tests__/markdown-assets.test.ts packages/notebook-host/tests/relay-bootstrap.test.ts`
- `pnpm exec tsc -b --pretty false packages/runtimed/tsconfig.json apps/notebook/tsconfig.json`
- `cargo xtask lint --fix`
- `git diff --check`

## Relationship To #2804

This is the third foundation PR split out from the notebook-cloud spike. #2804 can replace prototype blob URL assumptions with this shared resolver before trying to materialize real persisted outputs.
