### PR TITLE
feat(wasm): load notebook snapshot pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7594,6 +7594,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
+ "hex",
  "notebook-doc",
  "notebook-wire",
  "runtime-doc",

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -26,6 +26,7 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 console_error_panic_hook = "0.1"
+hex = "0.4"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -550,11 +550,14 @@ impl NotebookHandle {
     /// Load a RuntimeStateDoc from saved bytes.
     ///
     /// Used by test fixtures to provide pre-populated state doc data
-    /// (outputs, executions) alongside the notebook doc.
+    /// (outputs, executions) alongside the notebook doc. Replacing the state
+    /// doc also resets RuntimeStateDoc sync state so later room-host sync starts
+    /// from the loaded snapshot, not the previous empty/bootstrap doc.
     pub fn load_state_doc(&mut self, bytes: &[u8]) -> Result<(), JsError> {
         let doc = automerge::AutoCommit::load(bytes)
             .map_err(|e| JsError::new(&format!("load_state_doc failed: {}", e)))?;
         self.state_doc = RuntimeStateDoc::from_doc(doc);
+        self.state_sync_state = sync::State::new();
         self.prev_output_by_id.clear();
         self.execution_view_projector.reset();
         Ok(())
@@ -1080,7 +1083,7 @@ impl NotebookHandle {
         self.state_doc
             .get_heads()
             .into_iter()
-            .map(|head| head.to_string())
+            .map(|head| hex::encode(head.as_ref()))
             .collect()
     }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -533,6 +533,20 @@ impl NotebookHandle {
         })
     }
 
+    /// Load a persisted NotebookDoc + RuntimeStateDoc snapshot pair.
+    ///
+    /// Hosted viewers and room hosts should use this when materializing a
+    /// published notebook revision: NotebookDoc owns cells and execution_id
+    /// pointers, while RuntimeStateDoc owns execution/output manifests.
+    pub fn load_snapshot(
+        notebook_bytes: &[u8],
+        runtime_state_bytes: &[u8],
+    ) -> Result<NotebookHandle, JsError> {
+        let mut handle = Self::load(notebook_bytes)?;
+        handle.load_state_doc(runtime_state_bytes)?;
+        Ok(handle)
+    }
+
     /// Load a RuntimeStateDoc from saved bytes.
     ///
     /// Used by test fixtures to provide pre-populated state doc data
@@ -1061,6 +1075,15 @@ impl NotebookHandle {
         self.doc.get_heads_hex()
     }
 
+    /// Return the current RuntimeStateDoc heads as hex strings.
+    pub fn get_runtime_state_heads_hex(&mut self) -> Vec<String> {
+        self.state_doc
+            .get_heads()
+            .into_iter()
+            .map(|head| head.to_string())
+            .collect()
+    }
+
     /// Return a stable fingerprint of dependency metadata covered by trust approval.
     pub fn get_dependency_fingerprint(&self) -> Option<String> {
         self.doc.get_dependency_fingerprint()
@@ -1444,6 +1467,11 @@ impl NotebookHandle {
     /// Export the full document as bytes (for debugging or persistence).
     pub fn save(&mut self) -> Vec<u8> {
         self.doc.save()
+    }
+
+    /// Export the full RuntimeStateDoc as bytes.
+    pub fn save_state_doc(&mut self) -> Vec<u8> {
+        self.state_doc.doc_mut().save()
     }
 
     /// Set a single property in a comm's state map.

--- a/crates/runtimed-wasm/tests/snapshot_test.ts
+++ b/crates/runtimed-wasm/tests/snapshot_test.ts
@@ -8,6 +8,7 @@ import {
   assert,
   assertEquals,
   assertExists,
+  assertThrows,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -97,5 +98,44 @@ Deno.test("save_state_doc preserves runtime outputs for snapshot round trips", a
     }
   } finally {
     original.free();
+  }
+});
+
+Deno.test("load_snapshot reports invalid notebook and runtime-state bytes", async () => {
+  const docBytes = await readFixtureBytes("multi_cell_execution", "doc.bin");
+  const stateBytes = await readFixtureBytes("multi_cell_execution", "state_doc.bin");
+  const malformedBytes = new Uint8Array([0xff, 0x00, 0xff, 0x00]);
+
+  assertThrows(
+    () => NotebookHandle.load_snapshot(malformedBytes, stateBytes),
+    Error,
+    "load failed",
+  );
+  assertThrows(
+    () => NotebookHandle.load_snapshot(docBytes, malformedBytes),
+    Error,
+    "load_state_doc failed",
+  );
+});
+
+Deno.test("load_state_doc resets runtime-state sync tracking", async () => {
+  const docBytes = await readFixtureBytes("multi_cell_execution", "doc.bin");
+  const stateBytes = await readFixtureBytes("multi_cell_execution", "state_doc.bin");
+
+  const handle = NotebookHandle.load(docBytes);
+  try {
+    assertExists(
+      handle.flush_runtime_state_sync(),
+      "bootstrap RuntimeStateDoc should produce an initial sync message",
+    );
+
+    handle.load_state_doc(stateBytes);
+
+    assertExists(
+      handle.flush_runtime_state_sync(),
+      "loaded RuntimeStateDoc should flush after sync-state reset",
+    );
+  } finally {
+    handle.free();
   }
 });

--- a/crates/runtimed-wasm/tests/snapshot_test.ts
+++ b/crates/runtimed-wasm/tests/snapshot_test.ts
@@ -1,0 +1,101 @@
+/**
+ * Snapshot materialization tests for persisted NotebookDoc + RuntimeStateDoc
+ * pairs. This is the path hosted viewers use when loading published revisions
+ * from object storage instead of joining a live local daemon room.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// deno-lint-ignore no-explicit-any
+let init: any, NotebookHandle: any;
+
+const wasmJsPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+const fixturesDir = new URL("../../../packages/runtimed/tests/fixtures/", import.meta.url);
+
+const mod = await import(wasmJsPath.href);
+init = mod.default;
+NotebookHandle = mod.NotebookHandle;
+
+const wasmBytes = await Deno.readFile(wasmBinPath);
+await init(wasmBytes);
+
+async function readFixtureBytes(scenario: string, name: string): Promise<Uint8Array> {
+  return await Deno.readFile(new URL(`${scenario}/${name}`, fixturesDir));
+}
+
+function loadCellsJson(handle: any): Array<Record<string, any>> {
+  return JSON.parse(handle.get_cells_json());
+}
+
+Deno.test("load_snapshot materializes NotebookDoc cells with RuntimeStateDoc outputs", async () => {
+  const docBytes = await readFixtureBytes("multi_cell_execution", "doc.bin");
+  const stateBytes = await readFixtureBytes("multi_cell_execution", "state_doc.bin");
+
+  const handle = NotebookHandle.load_snapshot(docBytes, stateBytes);
+  try {
+    const cells = loadCellsJson(handle);
+
+    assertEquals(cells.length, 3);
+    assertEquals(cells[0].id, "cell-1");
+    assertEquals(cells[0].execution_id, "exec-001");
+    assertEquals(cells[0].outputs, []);
+
+    assertEquals(cells[1].id, "cell-2");
+    assertEquals(cells[1].execution_id, "exec-002");
+    assertEquals(cells[1].outputs.length, 1);
+    assertEquals(cells[1].outputs[0].output_id, "8f359d50-e5a4-5243-a71a-120209c0adb1");
+
+    const changeset = handle.project_execution_view_changeset();
+    assertExists(changeset.execution_upserts);
+    assert(
+      changeset.execution_upserts.some(
+        ([executionId]: [string, unknown]) => executionId === "exec-002",
+      ),
+      "projector should expose fixture execution snapshots",
+    );
+  } finally {
+    handle.free();
+  }
+});
+
+Deno.test("save_state_doc preserves runtime outputs for snapshot round trips", async () => {
+  const docBytes = await readFixtureBytes("output_streaming", "doc.bin");
+  const stateBytes = await readFixtureBytes("output_streaming", "state_doc.bin");
+
+  const original = NotebookHandle.load_snapshot(docBytes, stateBytes);
+  try {
+    const originalNotebookHeads = original.get_heads_hex();
+    const originalRuntimeHeads = original.get_runtime_state_heads_hex();
+    const savedDoc = original.save();
+    const savedStateDoc = original.save_state_doc();
+
+    const roundTrip = NotebookHandle.load_snapshot(savedDoc, savedStateDoc);
+    try {
+      assertEquals(roundTrip.get_heads_hex(), originalNotebookHeads);
+      assertEquals(roundTrip.get_runtime_state_heads_hex(), originalRuntimeHeads);
+
+      const cell = loadCellsJson(roundTrip)[0];
+      assertEquals(cell.id, "cell-1");
+      assertEquals(cell.outputs.map((output: Record<string, unknown>) => output.output_id), [
+        "c8b09c2d-a456-5186-b875-441a5fadf374",
+        "58af4526-9a90-5bca-98de-d8d0e36718b2",
+        "cad63e3f-42e3-542b-b28b-5d3acde7906d",
+      ]);
+    } finally {
+      roundTrip.free();
+    }
+  } finally {
+    original.free();
+  }
+});


### PR DESCRIPTION
## Summary

Adds `runtimed-wasm` helpers for materializing persisted notebook snapshot pairs:

- `NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes)`
- `NotebookHandle.save_state_doc()`
- `NotebookHandle.get_runtime_state_heads_hex()`

## Motivation

The notebook-cloud spike in #2804 proves the Cloudflare boundary, but its viewer still relies on render-cache JSON generated at publish time. The durable published artifact should be the real Automerge bytes:

- `NotebookDoc` snapshot for cells and cell `execution_id` pointers
- `RuntimeStateDoc` snapshot for executions and output manifests
- blob refs resolved by the host/viewer through the resolver surface from #2807

This PR exposes the missing WASM persistence hooks so a hosted viewer or Durable Object can load the snapshot pair directly and project outputs with the same Rust/WASM codepath as the desktop frontend.

## Changes

- Add `NotebookHandle.load_snapshot()` as a one-call loader for persisted `NotebookDoc` + `RuntimeStateDoc` bytes.
- Add `NotebookHandle.save_state_doc()` so publish/export paths can persist RuntimeStateDoc bytes alongside NotebookDoc bytes.
- Add `NotebookHandle.get_runtime_state_heads_hex()` so publish paths can pin RuntimeStateDoc revisions by heads just like NotebookDoc revisions.
- Reset RuntimeStateDoc sync state when replacing the state doc, so room-host sync starts from the loaded snapshot.
- Add fixture-backed Deno tests proving snapshot materialization preserves execution/output data, RuntimeStateDoc save/load round trips, malformed bytes reject cleanly, and RuntimeStateDoc sync tracking resets after load.

## Migration Notes

Existing callers can keep using `NotebookHandle.load()` plus `load_state_doc()`.

Hosted publish/viewer code should prefer `load_snapshot()` when both persisted docs are available, because it makes the intended dual-doc artifact explicit.

## Verification

- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `deno test --allow-read crates/runtimed-wasm/tests/snapshot_test.ts`
- `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/`
- `cargo clippy -p runtimed-wasm --target wasm32-unknown-unknown -- -D warnings`
- `cargo test -p runtimed-wasm`
- `cargo xtask lint --fix`
- `git diff --check`
- Bedrock Opus 4.6 review via `claude-bedrock-reviewer`: final rebased pass reported no actionable findings.

## Relationship To #2804

This is the fourth foundation PR split out from the notebook-cloud spike. It gives #2804 a real snapshot materialization primitive so the next cloud viewer iteration can reduce or remove render-cache JSON as the durable source of truth.
