### PR TITLE
feat(notebook-cloud): materialize hosted snapshot pairs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ node_modules/
 **/node_modules/
 dist/
 **/dist/
+.wrangler/
 *.tsbuildinfo
 
 # Generated isolated-renderer bundle (built from src/isolated-renderer)

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -1,0 +1,189 @@
+# nteract notebook cloud prototype
+
+This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates a dev or anonymous viewer connection, stamps a trusted `<principal>/<operator>` actor label, routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id, and relays typed-frame-v4-shaped WebSocket frames.
+
+The current Durable Object does not host kernels and does not parse Automerge sync messages. It enforces connection scope, rewrites canonical CBOR presence through the shared `runtimed-wasm` helper, stores bounded frame metadata, and broadcasts accepted binary typed frames to other peers in the same room.
+
+`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface.
+
+## Local dev
+
+```bash
+pnpm --dir apps/notebook-cloud typecheck
+pnpm --dir apps/notebook-cloud test
+pnpm --dir apps/notebook-cloud wasm
+pnpm --dir apps/notebook-cloud dev
+```
+
+With Wrangler running:
+
+```bash
+pnpm --dir apps/notebook-cloud smoke
+pnpm --dir apps/notebook-cloud publish:demo
+```
+
+The smoke script proves:
+
+- WebSocket upgrade on `/n/:notebookId/sync`.
+- Durable Object room routing by notebook id.
+- Dev identity stamping from `X-User` / `X-Operator` headers or `user` / `operator` query params.
+- Presence CBOR rewrite to the server peer id and authenticated principal.
+- Explicit rejection for malformed/non-CBOR presence payloads.
+- Same-room typed-frame relay.
+- Viewer-scope rejection for notebook writes.
+- Viewer-scope rejection for blob, request, and pool-state writes.
+- Explicit anonymous viewer identity (`anonymous:<session>/browser:<session>`).
+- Local-only anonymous presence: accepted to the sender, not broadcast or persisted.
+- D1 room-event readback.
+
+If the volatile frontend WASM package exists at `apps/notebook/src/wasm/runtimed-wasm`,
+the deeper roundtrip smoke sends real `runtimed-wasm` Automerge sync payloads through
+the Durable Object and verifies that a second `NotebookHandle` converges:
+
+```bash
+pnpm --dir apps/notebook-cloud wasm:roundtrip
+```
+
+Rebuild the volatile package with:
+
+```bash
+cargo xtask wasm runtimed --skip-renderer-plugins
+```
+
+The browser harness is available at:
+
+```text
+http://127.0.0.1:8787/n/demo/debug
+```
+
+The notebook viewer is available at:
+
+```text
+http://127.0.0.1:8787/n/nteract-cloud-demo
+```
+
+`/` redirects to that demo notebook id.
+
+## Dev auth
+
+The edge Worker maps dev credentials into the same identity shape as `crates/nteract-identity`:
+
+```text
+X-User: alice@example.com
+X-Operator: desktop:local
+X-Scope: editor
+```
+
+becomes:
+
+```text
+user:dev:alice%40example.com/desktop:local
+```
+
+For browser-only testing, the same values can be supplied as query params:
+
+```text
+/n/demo/sync?user=alice&operator=desktop:browser&scope=viewer
+```
+
+`X-Principal` or `principal` may be used to provide a full principal directly. The Worker stamps internal `x-nteract-*` headers before forwarding to the Durable Object, modeling the ADR boundary where the room host trusts an upstream-authenticated identity.
+
+Dev credentials are accepted without an extra token only from Wrangler local development (`localhost`, `127.0.0.1`, `::1`, or `DEPLOYMENT_ENV=development`). Deployed prototype environments require the `NOTEBOOK_CLOUD_DEV_TOKEN` Worker secret to match either the `X-Notebook-Cloud-Dev-Token` header or `dev_token` query parameter. If no scope is supplied, dev auth defaults to `viewer`. Write and publish paths must ask for `editor`, `runtime_peer`, or `owner` explicitly.
+
+Requests with no dev credential become anonymous public viewers. The Worker derives:
+
+```text
+anonymous:<session>/browser:<session>
+```
+
+from the `viewer_session` query parameter, `X-Viewer-Session` header, or a generated UUID. This is intentionally not `system`: `system` is reserved for seed/import authorship, while anonymous viewers are real room connections with read-only `viewer` scope. Anonymous viewers cannot write `NotebookDoc`, `RuntimeStateDoc`, blob, pool, or request frames. Anonymous presence is local-only so public page views do not appear as collaborators to editors.
+
+Snapshot and blob reads are public in this prototype so `/n/:id` can act like a publish viewer without a product auth flow. Production hosts should move those reads behind viewer-or-better auth, signed URLs, or a dedicated output origin before accepting private notebooks.
+
+## Storage shape
+
+Bindings in `wrangler.toml`:
+
+- `NOTEBOOK_ROOMS`: Durable Object namespace, one object per notebook id.
+- `DB`: D1 catalog for notebooks, revisions, blobs, and room event metadata.
+- `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, generated render caches, and blobs.
+
+Schema lives in `migrations/0001_initial.sql`. The Worker also creates the same tables lazily in local dev so the WebSocket path can run before applying migrations.
+
+Accepted WebSocket frame payload caps mirror `notebook-wire` per-frame limits: Automerge sync and runtime-state frames may be up to 64 MiB, `PUT_BLOB` up to 32 MiB, request frames up to 16 MiB, and presence/pool-state/session-control frames up to 1 MiB. The Durable Object keeps only the latest 500 `frame:*` metadata entries in object storage; D1 room events are observability rows, not the replay log.
+
+Published revision artifacts follow `docs/architecture/hosted-notebook-artifacts.md`:
+
+```text
+n/{id}/snapshots/{notebookHeadsHash}.am
+n/{id}/snapshots/runtime-state/{runtimeHeadsHash}.am
+n/{id}/blobs/{sha256}
+n/{id}/renders/{notebookHeadsHash}.json
+```
+
+The render path is optional. If it is missing, the Worker loads the snapshot pair through `runtimed-wasm` and returns a materialized render response.
+
+## Prototype deployment
+
+Disposable Cloudflare resources currently wired in `wrangler.toml`:
+
+- Worker: `nteract-notebook-cloud`
+- URL: `https://nteract-notebook-cloud.rgbkrk.workers.dev`
+- D1: `nteract-notebook-cloud-prototype-db`
+- R2: `nteract-notebook-cloud-prototype`
+
+The remote migration was applied with:
+
+```bash
+pnpm --workspace-root exec wrangler d1 migrations apply nteract-notebook-cloud-prototype-db \
+  --config apps/notebook-cloud/wrangler.toml \
+  --remote
+```
+
+Deploy with:
+
+```bash
+printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
+  | pnpm --workspace-root exec wrangler secret put NOTEBOOK_CLOUD_DEV_TOKEN \
+      --config apps/notebook-cloud/wrangler.toml
+pnpm --dir apps/notebook-cloud wasm
+pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml
+```
+
+Snapshot and blob stubs:
+
+```bash
+curl -X PUT "http://127.0.0.1:8787/api/n/demo/runtime-snapshots/runtime123" \
+  -H "X-User: alice" \
+  -H "X-Operator: desktop:curl" \
+  -H "X-Scope: owner" \
+  --data-binary @runtime-state.am
+
+curl -X PUT "http://127.0.0.1:8787/api/n/demo/snapshots/heads123" \
+  -H "X-User: alice" \
+  -H "X-Operator: desktop:curl" \
+  -H "X-Scope: owner" \
+  -H "X-Runtime-Heads-Hash: runtime123" \
+  --data-binary @notebook.am
+
+curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
+  -H "X-User: alice" \
+  -H "X-Operator: desktop:curl" \
+  -H "X-Scope: owner" \
+  --data-binary @output.bin
+```
+
+Catalog and event readback:
+
+```bash
+curl "http://127.0.0.1:8787/api/n/demo"
+curl "http://127.0.0.1:8787/api/n/demo/events?limit=20"
+curl "http://127.0.0.1:8787/api/n/demo/render"
+```
+
+## Next integration steps
+
+1. Move the Durable Object from byte relay to a real `runtimed-wasm` room peer.
+2. Connect the HTML viewer to the shared isolated output renderer bundle.
+3. Publish a full Sift/Arrow fixture and verify blob-backed output rendering.
+4. Swap dev auth for OIDC/JupyterHub providers using the `nteract-identity` model.

--- a/apps/notebook-cloud/migrations/0001_initial.sql
+++ b/apps/notebook-cloud/migrations/0001_initial.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS notebooks (
+  id TEXT PRIMARY KEY,
+  owner_principal TEXT NOT NULL,
+  title TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  latest_revision_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS notebook_revisions (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  notebook_heads_hash TEXT NOT NULL,
+  runtime_heads_hash TEXT,
+  snapshot_key TEXT NOT NULL,
+  runtime_snapshot_key TEXT,
+  actor_label TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE TABLE IF NOT EXISTS notebook_blobs (
+  notebook_id TEXT NOT NULL,
+  hash TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  content_type TEXT,
+  r2_key TEXT NOT NULL,
+  uploaded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  PRIMARY KEY (notebook_id, hash),
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE TABLE IF NOT EXISTS room_events (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  peer_id TEXT NOT NULL,
+  actor_label TEXT NOT NULL,
+  connection_scope TEXT NOT NULL,
+  frame_type INTEGER NOT NULL,
+  byte_length INTEGER NOT NULL,
+  received_at TEXT NOT NULL,
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "notebook-cloud",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "wasm": "cargo xtask wasm runtimed --skip-renderer-plugins",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "pnpm run wasm && node --import tsx --test test/*.test.ts",
+    "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
+    "smoke": "node --import tsx scripts/smoke.mjs",
+    "publish:demo": "node scripts/publish-demo.mjs",
+    "wasm:roundtrip": "node --import tsx scripts/wasm-roundtrip.mjs"
+  },
+  "dependencies": {
+    "runtimed": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsx": "^4.21.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? "nteract-cloud-demo";
+const actorLabel = "user:dev:demo/agent:publish-demo";
+const wasmJsUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBytesUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+await assertWasmBuildExists();
+
+const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
+const wasmBytes = await readFile(wasmBytesUrl);
+initSync({ module: wasmBytes });
+
+const handle = NotebookHandle.create_bootstrap(actorLabel);
+handle.add_cell_after("intro", "markdown", null);
+handle.update_source(
+  "intro",
+  [
+    "# nteract cloud notebook",
+    "",
+    "This public viewer is rendering a persisted NotebookDoc snapshot.",
+    "",
+    "- The NotebookDoc and RuntimeStateDoc .am snapshots are stored in R2.",
+    "- The read-only render is materialized by runtimed-wasm from those snapshots.",
+  ].join("\n"),
+);
+handle.add_cell_after("hello", "code", "intro");
+handle.update_source("hello", 'print("hello from nteract cloud")');
+handle.add_cell_after("next", "markdown", "hello");
+handle.update_source(
+  "next",
+  "## Prototype status\n\nAnonymous visitors connect as viewer-scoped room peers, while the published notebook history stays intact.",
+);
+
+const snapshotBytes = new Uint8Array(handle.save());
+const runtimeSnapshotBytes = new Uint8Array(handle.save_state_doc());
+const heads = handle.get_heads_hex();
+const runtimeHeads = handle.get_runtime_state_heads_hex();
+const headsHash = headsDigest(heads);
+const runtimeHeadsHash = headsDigest(runtimeHeads);
+const cells = JSON.parse(handle.get_cells_json());
+
+await putBytes(
+  `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
+  runtimeSnapshotBytes,
+  "application/octet-stream",
+);
+await putBytes(
+  `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
+  snapshotBytes,
+  "application/octet-stream",
+  {
+    "X-Runtime-Heads-Hash": runtimeHeadsHash,
+  },
+);
+
+const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
+assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+assert(
+  rendered.cells.some((cell) => cell.id === "hello" && cell.source.includes("nteract cloud")),
+  "latest snapshot render did not include the demo code cell",
+);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      baseUrl,
+      notebookId,
+      viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      headsHash,
+      runtimeHeadsHash,
+      cells: cells.length,
+      checks: [
+        "runtimed_wasm_snapshot_pair",
+        "r2_runtime_snapshot_publish",
+        "r2_snapshot_publish",
+        "latest_snapshot_materialization",
+      ],
+    },
+    null,
+    2,
+  ),
+);
+
+function headsDigest(heads) {
+  const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
+  return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+async function assertWasmBuildExists() {
+  try {
+    await access(fileURLToPath(wasmJsUrl));
+    await access(fileURLToPath(wasmBytesUrl));
+  } catch {
+    throw new Error(
+      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
+    );
+  }
+}
+
+async function putBytes(pathname, body, contentType, extraHeaders = {}) {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    method: "PUT",
+    headers: publishHeaders(contentType, extraHeaders),
+    body,
+  });
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+function publishHeaders(contentType, extraHeaders) {
+  return {
+    "Content-Type": contentType,
+    "X-User": "demo",
+    "X-Operator": "agent:publish-demo",
+    "X-Scope": "owner",
+    ...devAuthHeaders(),
+    ...extraHeaders,
+  };
+}
+
+function devAuthHeaders() {
+  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
+}
+
+async function fetchJson(pathname) {
+  const response = await fetch(new URL(pathname, baseUrl));
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+async function assertOk(response, pathname) {
+  if (response.ok) {
+    return;
+  }
+  throw new Error(`${pathname} returned ${response.status}: ${await response.text()}`);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -1,0 +1,574 @@
+import { readFile } from "node:fs/promises";
+import { FrameType } from "runtimed";
+
+const wasmJsPath = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+const wasm = await import(wasmJsPath.href);
+await wasm.default({ module_or_path: await readFile(wasmBinPath) });
+
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const roomId = `smoke-${Date.now()}`;
+const otherRoomId = `${roomId}-other`;
+
+if (typeof WebSocket === "undefined") {
+  throw new Error("This smoke script requires Node.js with a global WebSocket implementation");
+}
+
+const health = await fetch(new URL("/api/health", baseUrl));
+assert(health.ok, `health check failed: ${health.status}`);
+
+const alice = await connect(roomId, "alice", "desktop:alice", "owner");
+const bob = await connect(roomId, "bob", "desktop:bob", "editor");
+const other = await connect(otherRoomId, "other", "desktop:other", "owner");
+const viewer = await connect(roomId, "viewer", "desktop:viewer", "viewer");
+const anonymous = await connectAnonymous(roomId, "anon-smoke");
+
+assert(
+  alice.ready.actor_label === "user:dev:alice/desktop:alice",
+  "alice actor label was not stamped",
+);
+assert(bob.ready.actor_label === "user:dev:bob/desktop:bob", "bob actor label was not stamped");
+assert(other.ready.notebook_id === otherRoomId, "other room routed to the wrong notebook id");
+assert(
+  anonymous.ready.actor_label === "anonymous:anon-smoke/browser:anon-smoke",
+  `anonymous viewer actor label was not explicit: ${anonymous.ready.actor_label}`,
+);
+assert(anonymous.ready.connection_scope === "viewer", "anonymous viewer was not viewer-scoped");
+
+sendPresenceFrame(alice.socket, {
+  type: "update",
+  peer_id: "client-forged-peer",
+  peer_label: "Alice",
+  actor_label: "user:dev:mallory/desktop:alice",
+  channel: "cursor",
+  data: { cell_id: "cell-1", line: 0, column: 0 },
+});
+
+const rewrittenPresence = await bob.nextFrame((frame) => frame.type === FrameType.PRESENCE);
+assert(
+  rewrittenPresence.json.actor_label === "user:dev:alice/desktop:alice",
+  `presence principal was not rewritten: ${JSON.stringify(rewrittenPresence.json)}`,
+);
+assert(
+  rewrittenPresence.json.peer_id === alice.ready.peer_id,
+  `presence peer id was not rewritten: ${JSON.stringify(rewrittenPresence.json)}`,
+);
+
+sendBinaryFrame(
+  alice.socket,
+  FrameType.PRESENCE,
+  new TextEncoder().encode(JSON.stringify({ actor_label: "browser:json" })),
+);
+const rejectedMalformedPresence = await alice.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.PRESENCE,
+);
+assert(
+  rejectedMalformedPresence.json.reason.includes("CBOR decode error"),
+  `malformed presence was not rejected explicitly: ${JSON.stringify(rejectedMalformedPresence.json)}`,
+);
+const leakedMalformedPresence = await bob
+  .nextFrame((frame) => frame.type === FrameType.PRESENCE, 250)
+  .catch(() => undefined);
+assert(leakedMalformedPresence === undefined, "malformed presence was rebroadcast");
+
+sendPresenceFrame(alice.socket, {
+  type: "update",
+  peer_id: "client-peer",
+  peer_label: "Alice",
+  actor_label: "/bad",
+  channel: "focus",
+  data: { cell_id: "cell-1" },
+});
+const invalidActorPresence = await bob.nextFrame((frame) => frame.type === FrameType.PRESENCE);
+assert(
+  invalidActorPresence.json.actor_label === "user:dev:alice/desktop:alice",
+  `invalid actor presence was not stamped safely: ${JSON.stringify(invalidActorPresence.json)}`,
+);
+
+sendBinaryFrame(alice.socket, FrameType.AUTOMERGE_SYNC, new Uint8Array([1, 2, 3, 4]));
+const relayedSync = await bob.nextFrame((frame) => frame.type === FrameType.AUTOMERGE_SYNC);
+assert(relayedSync.payload.byteLength === 4, "same-room sync frame was not relayed");
+
+const accepted = await alice.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_accepted" &&
+    frame.json.frame_type === FrameType.AUTOMERGE_SYNC,
+);
+assert(accepted.json.frame_type === FrameType.AUTOMERGE_SYNC, "owner sync frame was not accepted");
+
+sendBinaryFrame(viewer.socket, FrameType.AUTOMERGE_SYNC, new Uint8Array([9]));
+const rejected = await viewer.nextFrame(
+  (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_frame_rejected",
+);
+assert(rejected.json.reason.includes("viewer cannot write"), "viewer write was not rejected");
+
+sendBinaryFrame(viewer.socket, FrameType.PUT_BLOB, new Uint8Array([9]));
+const rejectedBlob = await viewer.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.PUT_BLOB,
+);
+assert(
+  rejectedBlob.json.reason.includes("viewer cannot write"),
+  "viewer blob write was not rejected",
+);
+
+sendBinaryFrame(viewer.socket, FrameType.RUNTIME_STATE_SYNC, new Uint8Array([9]));
+const rejectedRuntime = await viewer.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.RUNTIME_STATE_SYNC,
+);
+assert(
+  rejectedRuntime.json.reason.includes("viewer cannot write"),
+  "viewer runtime-state write was not rejected",
+);
+
+sendBinaryFrame(viewer.socket, FrameType.POOL_STATE_SYNC, new Uint8Array([9]));
+const rejectedPool = await viewer.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.POOL_STATE_SYNC,
+);
+assert(
+  rejectedPool.json.reason.includes("viewer cannot write"),
+  "viewer pool write was not rejected",
+);
+
+sendJsonFrame(viewer.socket, FrameType.REQUEST, { id: "viewer-request", type: "noop" });
+const rejectedRequest = await viewer.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.REQUEST,
+);
+assert(
+  rejectedRequest.json.reason.includes("viewer cannot write"),
+  "viewer request frame was not rejected",
+);
+
+sendBinaryFrame(anonymous.socket, FrameType.AUTOMERGE_SYNC, new Uint8Array([9]));
+const rejectedAnonymousSync = await anonymous.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_rejected" &&
+    frame.json.frame_type === FrameType.AUTOMERGE_SYNC,
+);
+assert(
+  rejectedAnonymousSync.json.reason.includes("viewer cannot write"),
+  "anonymous viewer sync write was not rejected",
+);
+
+sendPresenceFrame(anonymous.socket, {
+  type: "update",
+  peer_id: "anonymous-client",
+  peer_label: "anonymous smoke",
+  actor_label: "browser:anon-smoke",
+  channel: "focus",
+  data: { cell_id: "cell-1" },
+});
+const anonymousPresenceAccepted = await anonymous.nextFrame(
+  (frame) =>
+    frame.type === FrameType.SESSION_CONTROL &&
+    frame.json.type === "cloud_frame_accepted" &&
+    frame.json.frame_type === FrameType.PRESENCE,
+);
+assert(
+  anonymousPresenceAccepted.json.frame_type === FrameType.PRESENCE,
+  "anonymous presence was not locally accepted",
+);
+const leakedAnonymousPresence = await bob
+  .nextFrame(
+    (frame) =>
+      frame.type === FrameType.PRESENCE &&
+      typeof frame.json?.actor_label === "string" &&
+      frame.json.actor_label.startsWith("anonymous:"),
+    250,
+  )
+  .catch(() => undefined);
+assert(leakedAnonymousPresence === undefined, "anonymous presence was broadcast to room peers");
+
+const events = await waitForEvents(
+  roomId,
+  (event) => event.frame_type === FrameType.AUTOMERGE_SYNC,
+);
+assert(
+  events.events.some((event) => event.frame_type === FrameType.AUTOMERGE_SYNC),
+  "D1 event readback did not include the accepted sync frame",
+);
+
+const snapshotHeads = `heads-${roomId}`;
+const runtimeHeads = `runtime-${roomId}`;
+const runtimePath = `/api/n/${encodeURIComponent(roomId)}/runtime-snapshots/${encodeURIComponent(runtimeHeads)}`;
+const snapshotPath = `/api/n/${encodeURIComponent(roomId)}/snapshots/${encodeURIComponent(snapshotHeads)}`;
+const snapshotBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+const runtimeBytes = new Uint8Array([0xca, 0xfe, 0xba, 0xbe]);
+const invalidAuthResponse = await fetch(new URL(snapshotPath, baseUrl), {
+  method: "PUT",
+  headers: {
+    "Content-Type": "application/octet-stream",
+    "X-Scope": "admin",
+    ...devAuthHeaders(),
+  },
+  body: snapshotBytes,
+});
+assert(
+  invalidAuthResponse.status === 400,
+  `invalid auth should return 400, got ${invalidAuthResponse.status}`,
+);
+const runtimePut = await putBytes(runtimePath, runtimeBytes, "application/octet-stream");
+assert(runtimePut.ok === true, `runtime snapshot PUT failed: ${JSON.stringify(runtimePut)}`);
+assertBytesEqual(
+  await fetchBytes(runtimePath),
+  runtimeBytes,
+  "runtime snapshot GET did not round-trip",
+);
+const snapshotPut = await putBytes(snapshotPath, snapshotBytes, "application/octet-stream", {
+  "X-Runtime-Heads-Hash": runtimeHeads,
+});
+assert(snapshotPut.ok === true, `snapshot PUT failed: ${JSON.stringify(snapshotPut)}`);
+assertBytesEqual(await fetchBytes(snapshotPath), snapshotBytes, "snapshot GET did not round-trip");
+
+const blobHash = `sha256-${roomId}`;
+const blobPath = `/api/n/${encodeURIComponent(roomId)}/blobs/${encodeURIComponent(blobHash)}`;
+const blobBytes = new TextEncoder().encode(`blob:${roomId}`);
+const blobPut = await putBytes(blobPath, blobBytes, "text/plain");
+assert(blobPut.ok === true, `blob PUT failed: ${JSON.stringify(blobPut)}`);
+const blobHead = await fetchHead(blobPath);
+assert(
+  blobHead.headers.get("content-length") === blobBytes.byteLength.toString(),
+  "blob HEAD did not return the stored content length",
+);
+assertBytesEqual(await fetchBytes(blobPath), blobBytes, "blob GET did not round-trip");
+
+const catalog = await fetchJson(`/api/n/${encodeURIComponent(roomId)}`);
+assert(
+  catalog.revisions.some(
+    (revision) =>
+      revision.notebook_heads_hash === snapshotHeads &&
+      revision.runtime_heads_hash === runtimeHeads &&
+      typeof revision.runtime_snapshot_key === "string",
+  ),
+  "D1 catalog did not include the stored snapshot revision",
+);
+assert(
+  catalog.blobs.some((blob) => blob.hash === blobHash && blob.size === blobBytes.byteLength),
+  "D1 catalog did not include the stored blob",
+);
+
+const leaked = await other
+  .nextFrame((frame) => frame.type === FrameType.AUTOMERGE_SYNC, 250)
+  .catch(() => undefined);
+assert(leaked === undefined, "frame leaked across Durable Object room ids");
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      baseUrl,
+      roomId,
+      checks: [
+        "websocket_upgrade",
+        "durable_object_room_routing",
+        "identity_stamping",
+        "presence_principal_rewrite",
+        "malformed_presence_rejection",
+        "invalid_presence_actor_safe_fallback",
+        "typed_frame_relay",
+        "scope_rejection",
+        "viewer_blob_rejection",
+        "viewer_runtime_state_rejection",
+        "viewer_pool_rejection",
+        "viewer_request_rejection",
+        "anonymous_viewer_identity",
+        "anonymous_viewer_write_rejection",
+        "anonymous_presence_local_only",
+        "d1_room_event_readback",
+        "invalid_auth_structured_rejection",
+        "r2_runtime_snapshot_roundtrip",
+        "r2_snapshot_roundtrip",
+        "r2_blob_roundtrip",
+        "d1_catalog_readback",
+      ],
+    },
+    null,
+    2,
+  ),
+);
+
+await Promise.all([alice, bob, other, viewer, anonymous].map(closeClient));
+process.exit(0);
+
+async function connect(notebookId, user, operator, scope) {
+  const url = new URL(`/n/${encodeURIComponent(notebookId)}/sync`, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("user", user);
+  url.searchParams.set("operator", operator);
+  url.searchParams.set("scope", scope);
+  if (devAuthToken) {
+    url.searchParams.set("dev_token", devAuthToken);
+  }
+  const safeUrl = redactDevToken(url);
+
+  const socket = new WebSocket(url);
+  socket.binaryType = "arraybuffer";
+  const queue = [];
+  const waiters = [];
+  socket.addEventListener("message", async (event) => {
+    const frame = await decodeFrame(event.data);
+    const index = waiters.findIndex((waiter) => waiter.predicate(frame));
+    if (index === -1) {
+      queue.push(frame);
+      return;
+    }
+
+    const [waiter] = waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+    waiter.resolve(frame);
+  });
+
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", () => reject(new Error(`failed to connect ${safeUrl}`)), {
+      once: true,
+    });
+  });
+
+  const client = {
+    socket,
+    nextFrame(predicate, timeoutMs = 5_000) {
+      const queued = queue.findIndex(predicate);
+      if (queued !== -1) {
+        const [frame] = queue.splice(queued, 1);
+        return Promise.resolve(frame);
+      }
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = waiters.findIndex((waiter) => waiter.timer === timer);
+          if (index !== -1) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`timed out waiting for frame from ${safeUrl}`));
+        }, timeoutMs);
+        waiters.push({ predicate, resolve, timer });
+      });
+    },
+  };
+  const ready = await client.nextFrame(
+    (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_room_ready",
+  );
+  return { ...client, ready: ready.json };
+}
+
+async function connectAnonymous(notebookId, sessionId) {
+  const url = new URL(`/n/${encodeURIComponent(notebookId)}/sync`, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("viewer_session", sessionId);
+
+  const socket = new WebSocket(url);
+  socket.binaryType = "arraybuffer";
+  const queue = [];
+  const waiters = [];
+  socket.addEventListener("message", async (event) => {
+    const frame = await decodeFrame(event.data);
+    const index = waiters.findIndex((waiter) => waiter.predicate(frame));
+    if (index === -1) {
+      queue.push(frame);
+      return;
+    }
+
+    const [waiter] = waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+    waiter.resolve(frame);
+  });
+
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", () => reject(new Error(`failed to connect ${url.href}`)), {
+      once: true,
+    });
+  });
+
+  const client = {
+    socket,
+    nextFrame(predicate, timeoutMs = 5_000) {
+      const queued = queue.findIndex(predicate);
+      if (queued !== -1) {
+        const [frame] = queue.splice(queued, 1);
+        return Promise.resolve(frame);
+      }
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = waiters.findIndex((waiter) => waiter.timer === timer);
+          if (index !== -1) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`timed out waiting for frame from ${url.href}`));
+        }, timeoutMs);
+        waiters.push({ predicate, resolve, timer });
+      });
+    },
+  };
+  const ready = await client.nextFrame(
+    (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_room_ready",
+  );
+  return { ...client, ready: ready.json };
+}
+
+async function closeClient(client) {
+  if (client.socket.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 250);
+    client.socket.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+    client.socket.close();
+  });
+}
+
+async function fetchJson(pathname) {
+  const url = new URL(pathname, baseUrl);
+  const response = await fetch(url);
+  assert(response.ok, `${url.href} returned ${response.status}`);
+  return response.json();
+}
+
+async function putBytes(pathname, body, contentType, extraHeaders = {}) {
+  const url = new URL(pathname, baseUrl);
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      "Content-Type": contentType,
+      "X-User": "alice",
+      "X-Operator": "desktop:smoke",
+      "X-Scope": "owner",
+      ...devAuthHeaders(),
+      ...extraHeaders,
+    },
+    body,
+  });
+  assert(response.ok, `${url.href} returned ${response.status}`);
+  return response.json();
+}
+
+async function fetchBytes(pathname) {
+  const url = new URL(pathname, baseUrl);
+  const response = await fetch(url);
+  assert(response.ok, `${url.href} returned ${response.status}`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+async function fetchHead(pathname) {
+  const url = new URL(pathname, baseUrl);
+  const response = await fetch(url, { method: "HEAD" });
+  assert(response.ok, `${url.href} returned ${response.status}`);
+  return response;
+}
+
+async function waitForEvents(notebookId, predicate, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  const pathname = `/api/n/${encodeURIComponent(notebookId)}/events?limit=20`;
+  let lastEvents;
+  while (Date.now() < deadline) {
+    lastEvents = await fetchJson(pathname);
+    if (lastEvents.events.some(predicate)) {
+      return lastEvents;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return lastEvents ?? { events: [] };
+}
+
+function assertBytesEqual(actual, expected, message) {
+  assert(actual.byteLength === expected.byteLength, message);
+  for (let index = 0; index < expected.byteLength; index += 1) {
+    assert(actual[index] === expected[index], message);
+  }
+}
+
+function sendJsonFrame(socket, type, payload) {
+  sendBinaryFrame(socket, type, new TextEncoder().encode(JSON.stringify(payload)));
+}
+
+function sendPresenceFrame(socket, message) {
+  sendBinaryFrame(socket, FrameType.PRESENCE, wasm.encode_presence_frame(message));
+}
+
+function sendBinaryFrame(socket, type, payload) {
+  const frame = new Uint8Array(payload.byteLength + 1);
+  frame[0] = type;
+  frame.set(payload, 1);
+  socket.send(frame);
+}
+
+async function decodeFrame(data) {
+  let buffer;
+  if (data instanceof ArrayBuffer) {
+    buffer = data;
+  } else if (ArrayBuffer.isView(data)) {
+    buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  } else if (typeof Blob !== "undefined" && data instanceof Blob) {
+    buffer = await data.arrayBuffer();
+  } else {
+    throw new Error(`unsupported WebSocket message ${Object.prototype.toString.call(data)}`);
+  }
+
+  const bytes = new Uint8Array(buffer);
+  const type = bytes[0];
+  const payload = bytes.slice(1);
+  let json;
+  if (type === FrameType.SESSION_CONTROL) {
+    try {
+      json = JSON.parse(new TextDecoder().decode(payload));
+    } catch {
+      json = undefined;
+    }
+  } else if (type === FrameType.PRESENCE) {
+    try {
+      json = wasm.decode_presence_frame(payload);
+    } catch {
+      json = undefined;
+    }
+  }
+  return { type, payload, json };
+}
+
+function devAuthHeaders() {
+  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
+}
+
+function redactDevToken(url) {
+  const copy = new URL(url.href);
+  copy.searchParams.delete("dev_token");
+  return copy.href;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -221,6 +221,7 @@ const invalidAuthResponse = await fetch(new URL(snapshotPath, baseUrl), {
   method: "PUT",
   headers: {
     "Content-Type": "application/octet-stream",
+    "X-User": "alice",
     "X-Scope": "admin",
     ...devAuthHeaders(),
   },

--- a/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
+++ b/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
@@ -1,0 +1,232 @@
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { FrameType } from "runtimed";
+
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const roomId = `wasm-${Date.now()}`;
+const wasmJsUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBytesUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+if (typeof WebSocket === "undefined") {
+  throw new Error("This smoke script requires Node.js with a global WebSocket implementation");
+}
+
+await assertWasmBuildExists();
+
+const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
+const wasmBytes = await readFile(wasmBytesUrl);
+initSync({ module: wasmBytes });
+
+const aliceActor = "user:dev:alice/desktop:wasm";
+const bobActor = "user:dev:bob/desktop:wasm";
+const aliceHandle = NotebookHandle.create_bootstrap(aliceActor);
+const bobHandle = NotebookHandle.create_bootstrap(bobActor);
+const alice = await connect(roomId, "alice", "desktop:wasm", "owner");
+const bob = await connect(roomId, "bob", "desktop:wasm", "editor");
+
+aliceHandle.add_cell_after("cell-wasm-1", "code", null);
+aliceHandle.update_source("cell-wasm-1", "print('cloud wasm')");
+
+let nextPayload = aliceHandle.flush_local_changes();
+let sender = alice;
+let receiver = bob;
+let receiverHandle = bobHandle;
+let hops = 0;
+
+while (nextPayload && hops < 10) {
+  sendBinaryFrame(sender.socket, FrameType.AUTOMERGE_SYNC, nextPayload);
+
+  const received = await receiver.nextFrame((frame) => frame.type === FrameType.AUTOMERGE_SYNC);
+  const events = receiverHandle.receive_frame(received.bytes);
+  const reply = events.find((event) => Array.isArray(event.reply))?.reply;
+
+  nextPayload = reply ? new Uint8Array(reply) : undefined;
+  [sender, receiver] = [receiver, sender];
+  receiverHandle = receiverHandle === bobHandle ? aliceHandle : bobHandle;
+  hops += 1;
+}
+
+assert(
+  bobHandle.cell_count() === 1,
+  `expected Bob handle to receive one cell, got ${bobHandle.cell_count()}`,
+);
+assert(
+  bobHandle.get_cell_source("cell-wasm-1") === "print('cloud wasm')",
+  `unexpected Bob cell source: ${bobHandle.get_cell_source("cell-wasm-1")}`,
+);
+assert(
+  bobHandle.contributing_actors().includes(aliceActor),
+  `Bob handle did not record Alice actor: ${bobHandle.contributing_actors().join(", ")}`,
+);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      baseUrl,
+      roomId,
+      checks: [
+        "runtimed_wasm_init",
+        "real_automerge_sync_payload",
+        "durable_object_typed_frame_relay",
+        "wasm_handle_convergence",
+        "actor_attribution_preserved",
+      ],
+      hops,
+      bob: {
+        cell_count: bobHandle.cell_count(),
+        source: bobHandle.get_cell_source("cell-wasm-1"),
+        actors: bobHandle.contributing_actors(),
+      },
+    },
+    null,
+    2,
+  ),
+);
+
+await Promise.all([alice, bob].map(closeClient));
+process.exit(0);
+
+async function assertWasmBuildExists() {
+  try {
+    await access(fileURLToPath(wasmJsUrl));
+    await access(fileURLToPath(wasmBytesUrl));
+  } catch {
+    throw new Error(
+      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
+    );
+  }
+}
+
+async function connect(notebookId, user, operator, scope) {
+  const url = new URL(`/n/${encodeURIComponent(notebookId)}/sync`, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("user", user);
+  url.searchParams.set("operator", operator);
+  url.searchParams.set("scope", scope);
+  if (devAuthToken) {
+    url.searchParams.set("dev_token", devAuthToken);
+  }
+  const safeUrl = redactDevToken(url);
+
+  const socket = new WebSocket(url);
+  socket.binaryType = "arraybuffer";
+  const queue = [];
+  const waiters = [];
+  socket.addEventListener("message", async (event) => {
+    const frame = await decodeFrame(event.data);
+    const index = waiters.findIndex((waiter) => waiter.predicate(frame));
+    if (index === -1) {
+      queue.push(frame);
+      return;
+    }
+
+    const [waiter] = waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+    waiter.resolve(frame);
+  });
+
+  await new Promise((resolve, reject) => {
+    socket.addEventListener("open", resolve, { once: true });
+    socket.addEventListener("error", () => reject(new Error(`failed to connect ${safeUrl}`)), {
+      once: true,
+    });
+  });
+
+  const client = {
+    socket,
+    nextFrame(predicate, timeoutMs = 5_000) {
+      const queued = queue.findIndex(predicate);
+      if (queued !== -1) {
+        const [frame] = queue.splice(queued, 1);
+        return Promise.resolve(frame);
+      }
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = waiters.findIndex((waiter) => waiter.timer === timer);
+          if (index !== -1) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`timed out waiting for frame from ${safeUrl}`));
+        }, timeoutMs);
+        waiters.push({ predicate, resolve, timer });
+      });
+    },
+  };
+  await client.nextFrame(
+    (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_room_ready",
+  );
+  return client;
+}
+
+function sendBinaryFrame(socket, type, payload) {
+  const frame = new Uint8Array(payload.byteLength + 1);
+  frame[0] = type;
+  frame.set(payload, 1);
+  socket.send(frame);
+}
+
+async function decodeFrame(data) {
+  let buffer;
+  if (data instanceof ArrayBuffer) {
+    buffer = data;
+  } else if (ArrayBuffer.isView(data)) {
+    buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  } else if (typeof Blob !== "undefined" && data instanceof Blob) {
+    buffer = await data.arrayBuffer();
+  } else {
+    throw new Error(`unsupported WebSocket message ${Object.prototype.toString.call(data)}`);
+  }
+
+  const bytes = new Uint8Array(buffer);
+  const type = bytes[0];
+  const payload = bytes.slice(1);
+  let json;
+  if (type === FrameType.SESSION_CONTROL) {
+    try {
+      json = JSON.parse(new TextDecoder().decode(payload));
+    } catch {
+      json = undefined;
+    }
+  }
+  return { type, payload, bytes, json };
+}
+
+async function closeClient(client) {
+  if (client.socket.readyState === WebSocket.CLOSED) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 250);
+    client.socket.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+    client.socket.close();
+  });
+}
+
+function redactDevToken(url) {
+  const copy = new URL(url.href);
+  copy.searchParams.delete("dev_token");
+  return copy.href;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -1,0 +1,18 @@
+import { createBlobResolver, type BlobRef, type BlobResolver } from "runtimed";
+
+export function createNotebookCloudBlobResolver(input: {
+  baseUrl: string | URL;
+  notebookId: string;
+  fetchImpl?: typeof fetch;
+}): BlobResolver {
+  const baseUrl = new URL(input.baseUrl);
+  return createBlobResolver({
+    fetchImpl: input.fetchImpl,
+    url(ref: BlobRef) {
+      return new URL(
+        `/api/n/${encodeURIComponent(input.notebookId)}/blobs/${encodeURIComponent(ref.blob)}`,
+        baseUrl,
+      ).href;
+    },
+  });
+}

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -77,6 +77,7 @@ export interface R2Bucket {
     value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
     options?: R2PutOptions,
   ): Promise<R2Object>;
+  delete(key: string): Promise<void>;
 }
 
 export interface R2Object {

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -1,0 +1,126 @@
+export interface Env {
+  NOTEBOOK_ROOMS: DurableObjectNamespace;
+  DB?: D1Database;
+  NOTEBOOK_SNAPSHOTS?: R2Bucket;
+  DEPLOYMENT_ENV?: string;
+  NOTEBOOK_CLOUD_DEV_TOKEN?: string;
+}
+
+export interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+}
+
+export interface ExportedHandler<E> {
+  fetch(request: Request, env: E, ctx: ExecutionContext): Response | Promise<Response>;
+}
+
+export interface DurableObjectId {
+  toString(): string;
+}
+
+export interface DurableObjectNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub;
+}
+
+export interface DurableObjectStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+export interface DurableObjectState {
+  id: DurableObjectId;
+  storage: DurableObjectStorage;
+  waitUntil(promise: Promise<unknown>): void;
+  acceptWebSocket?(socket: CloudflareWebSocket, tags?: string[]): void;
+  getWebSockets?(tag?: string): CloudflareWebSocket[];
+}
+
+export interface DurableObjectStorage {
+  get<T>(key: string): Promise<T | undefined>;
+  put<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<boolean>;
+  list<T>(options?: {
+    prefix?: string;
+    limit?: number;
+    reverse?: boolean;
+  }): Promise<Map<string, T>>;
+}
+
+export interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+  exec(query: string): Promise<D1Result>;
+  batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]>;
+}
+
+export interface D1PreparedStatement {
+  bind(...values: D1Value[]): D1PreparedStatement;
+  first<T = unknown>(columnName?: string): Promise<T | null>;
+  run<T = unknown>(): Promise<D1Result<T>>;
+  all<T = unknown>(): Promise<D1Result<T>>;
+}
+
+export type D1Value = string | number | boolean | null | ArrayBuffer;
+
+export interface D1Result<T = unknown> {
+  results?: T[];
+  success: boolean;
+  error?: string;
+  meta: Record<string, unknown>;
+}
+
+export interface R2Bucket {
+  get(key: string): Promise<R2ObjectBody | null>;
+  head(key: string): Promise<R2Object | null>;
+  put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+    options?: R2PutOptions,
+  ): Promise<R2Object>;
+}
+
+export interface R2Object {
+  key: string;
+  version: string;
+  size: number;
+  etag: string;
+  httpEtag: string;
+  uploaded: Date;
+  httpMetadata?: R2HTTPMetadata;
+  customMetadata?: Record<string, string>;
+  writeHttpMetadata(headers: Headers): void;
+}
+
+export interface R2ObjectBody extends R2Object {
+  body: ReadableStream;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+}
+
+export interface R2PutOptions {
+  httpMetadata?: R2HTTPMetadata;
+  customMetadata?: Record<string, string>;
+}
+
+export interface R2HTTPMetadata {
+  contentType?: string;
+  cacheControl?: string;
+}
+
+export type CloudflareWebSocket = WebSocket & {
+  accept(): void;
+  send(message: string | ArrayBuffer | ArrayBufferView): void;
+  serializeAttachment?(value: unknown): void;
+  deserializeAttachment?(): unknown;
+};
+
+export interface WebSocketPair {
+  0: CloudflareWebSocket;
+  1: CloudflareWebSocket;
+}
+
+declare global {
+  const WebSocketPair: {
+    new (): WebSocketPair;
+  };
+}

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -247,7 +247,6 @@ function hasDevCredential(request: Request): boolean {
     ["x-principal", "principal"],
     ["x-user", "user"],
     ["x-operator", "operator"],
-    ["x-scope", "scope"],
   ].some(
     ([headerName, queryName]) => request.headers.has(headerName) || url.searchParams.has(queryName),
   );

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -1,0 +1,299 @@
+export type ConnectionScope = "viewer" | "editor" | "runtime_peer" | "owner";
+
+export interface ActorLabel {
+  value: string;
+  principal: string;
+  operator: string;
+}
+
+export interface AuthenticatedConnection {
+  principal: string;
+  operator: string;
+  actorLabel: string;
+  scope: ConnectionScope;
+}
+
+export interface IdentityEnvironment {
+  DEPLOYMENT_ENV?: string;
+  NOTEBOOK_CLOUD_DEV_TOKEN?: string;
+}
+
+const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
+
+export const TRUSTED_PRINCIPAL_HEADER = "x-nteract-principal";
+export const TRUSTED_OPERATOR_HEADER = "x-nteract-operator";
+export const TRUSTED_SCOPE_HEADER = "x-nteract-scope";
+export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";
+export const DEV_AUTH_TOKEN_QUERY = "dev_token";
+
+export class AuthError extends Error {
+  constructor(
+    message: string,
+    readonly status = 400,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+export function authenticateRequest(
+  request: Request,
+  env: IdentityEnvironment = {},
+): AuthenticatedConnection {
+  if (!hasDevCredential(request)) {
+    return authenticateAnonymousViewer(request);
+  }
+
+  if (!allowsDevCredential(request, env)) {
+    throw new AuthError("dev credentials require a local request or NOTEBOOK_CLOUD_DEV_TOKEN", 401);
+  }
+
+  return authenticateDevRequest(request);
+}
+
+export function authenticateDevRequest(request: Request): AuthenticatedConnection {
+  const url = new URL(request.url);
+  const principalHeader = headerOrQuery(request, url, "x-principal", "principal");
+  const user = headerOrQuery(request, url, "x-user", "user") ?? "dev-anonymous";
+  const operator = headerOrQuery(request, url, "x-operator", "operator") ?? defaultOperator();
+  const scope = parseScope(headerOrQuery(request, url, "x-scope", "scope") ?? "viewer");
+  const principal = principalHeader ?? principalForDevUser(user);
+
+  validatePrincipal(principal);
+  validateOperator(operator);
+
+  return {
+    principal,
+    operator,
+    actorLabel: `${principal}/${operator}`,
+    scope,
+  };
+}
+
+export function authenticateAnonymousViewer(request: Request): AuthenticatedConnection {
+  const url = new URL(request.url);
+  const session =
+    headerOrQuery(request, url, "x-viewer-session", "viewer_session") ??
+    headerOrQuery(request, url, "x-session", "session") ??
+    crypto.randomUUID();
+  const encodedSession = encodePrincipalComponent(session.trim() || crypto.randomUUID());
+  const principal = `${ANONYMOUS_PRINCIPAL_PREFIX}${encodedSession}`;
+  const operator = `browser:${encodedSession}`;
+
+  validatePrincipal(principal);
+  validateOperator(operator);
+
+  return {
+    principal,
+    operator,
+    actorLabel: `${principal}/${operator}`,
+    scope: "viewer",
+  };
+}
+
+export function isAnonymousViewer(identity: AuthenticatedConnection): boolean {
+  return identity.scope === "viewer" && identity.principal.startsWith(ANONYMOUS_PRINCIPAL_PREFIX);
+}
+
+export function stampTrustedIdentity(request: Request, identity: AuthenticatedConnection): Request {
+  const headers = new Headers(request.headers);
+  headers.set(TRUSTED_PRINCIPAL_HEADER, identity.principal);
+  headers.set(TRUSTED_OPERATOR_HEADER, identity.operator);
+  headers.set(TRUSTED_SCOPE_HEADER, identity.scope);
+  return new Request(request, { headers });
+}
+
+export function readTrustedIdentity(request: Request): AuthenticatedConnection {
+  const principal = request.headers.get(TRUSTED_PRINCIPAL_HEADER);
+  const operator = request.headers.get(TRUSTED_OPERATOR_HEADER);
+  const scope = request.headers.get(TRUSTED_SCOPE_HEADER);
+
+  if (!principal || !operator || !scope) {
+    throw new Error("missing trusted identity headers");
+  }
+
+  validatePrincipal(principal);
+  validateOperator(operator);
+
+  const parsedScope = parseScope(scope);
+  return {
+    principal,
+    operator,
+    actorLabel: `${principal}/${operator}`,
+    scope: parsedScope,
+  };
+}
+
+export function principalForDevUser(user: string): string {
+  const normalized = user.trim();
+  if (normalized === "") {
+    throw new Error("dev user cannot be empty");
+  }
+
+  return `user:dev:${encodePrincipalComponent(normalized)}`;
+}
+
+export function encodePrincipalComponent(value: string): string {
+  return encodeURIComponent(value);
+}
+
+export function parseScope(value: string): ConnectionScope {
+  switch (value) {
+    case "viewer":
+    case "editor":
+    case "runtime_peer":
+    case "owner":
+      return value;
+    default:
+      throw new Error(`unknown connection scope: ${value}`);
+  }
+}
+
+export function allowsNotebookWrite(scope: ConnectionScope): boolean {
+  return scope === "editor" || scope === "owner";
+}
+
+export function allowsRuntimeStateWrite(scope: ConnectionScope): boolean {
+  return scope === "editor" || scope === "runtime_peer" || scope === "owner";
+}
+
+export function allowsPublish(scope: ConnectionScope): boolean {
+  return scope === "owner";
+}
+
+export function parseActorLabel(value: string): ActorLabel {
+  const delimiter = value.indexOf("/");
+  if (delimiter === -1) {
+    throw new Error("actor label must be '<principal>/<operator>'");
+  }
+
+  const principal = value.slice(0, delimiter);
+  const operator = value.slice(delimiter + 1);
+  validatePrincipal(principal);
+  validateOperator(operator);
+
+  return {
+    value,
+    principal,
+    operator,
+  };
+}
+
+export function rewriteActorLabelPrincipal(
+  presented: string | undefined,
+  authenticated: AuthenticatedConnection,
+): string {
+  const operator = presented ? operatorFromActorLabelOrOperator(presented) : authenticated.operator;
+  return `${authenticated.principal}/${operator}`;
+}
+
+export function operatorFromActorLabelOrOperator(value: string): string {
+  const delimiter = value.indexOf("/");
+  if (delimiter === -1) {
+    validateOperator(value);
+    return value;
+  }
+
+  return parseActorLabel(value).operator;
+}
+
+export function validatePrincipal(value: string): void {
+  if (value.length === 0) {
+    throw new Error("principal cannot be empty");
+  }
+  if (value.includes("/")) {
+    throw new Error("principal cannot contain '/'");
+  }
+  if (value === "system") {
+    return;
+  }
+
+  const delimiter = value.indexOf(":");
+  if (delimiter === -1) {
+    throw new Error("principal must be 'system' or '<scheme>:<id>'");
+  }
+  if (delimiter === 0) {
+    throw new Error("principal scheme cannot be empty");
+  }
+  if (delimiter === value.length - 1) {
+    throw new Error("principal id cannot be empty");
+  }
+}
+
+export function validateOperator(value: string): void {
+  if (value.length === 0) {
+    throw new Error("operator cannot be empty");
+  }
+  if (value.includes("/")) {
+    throw new Error("operator cannot contain '/'");
+  }
+  if (value.startsWith(":")) {
+    throw new Error("operator kind cannot be empty");
+  }
+}
+
+function headerOrQuery(
+  request: Request,
+  url: URL,
+  headerName: string,
+  queryName: string,
+): string | undefined {
+  return request.headers.get(headerName) ?? url.searchParams.get(queryName) ?? undefined;
+}
+
+function hasDevCredential(request: Request): boolean {
+  const url = new URL(request.url);
+  return [
+    ["x-principal", "principal"],
+    ["x-user", "user"],
+    ["x-operator", "operator"],
+    ["x-scope", "scope"],
+  ].some(
+    ([headerName, queryName]) => request.headers.has(headerName) || url.searchParams.has(queryName),
+  );
+}
+
+function allowsDevCredential(request: Request, env: IdentityEnvironment): boolean {
+  return isLocalDevRequest(request, env) || hasValidDevToken(request, env);
+}
+
+function isLocalDevRequest(request: Request, env: IdentityEnvironment): boolean {
+  if (env.DEPLOYMENT_ENV === "development") {
+    return true;
+  }
+
+  const hostname = new URL(request.url).hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function hasValidDevToken(request: Request, env: IdentityEnvironment): boolean {
+  const expected = env.NOTEBOOK_CLOUD_DEV_TOKEN?.trim();
+  if (!expected) {
+    return false;
+  }
+
+  const url = new URL(request.url);
+  const presented = headerOrQuery(request, url, DEV_AUTH_TOKEN_HEADER, DEV_AUTH_TOKEN_QUERY);
+  return timingSafeStringEqual(presented, expected);
+}
+
+function defaultOperator(): string {
+  return `desktop:${crypto.randomUUID()}`;
+}
+
+function timingSafeStringEqual(presented: string | undefined, expected: string): boolean {
+  if (presented === undefined) {
+    return false;
+  }
+
+  const encoder = new TextEncoder();
+  const presentedBytes = encoder.encode(presented);
+  const expectedBytes = encoder.encode(expected);
+  let diff = presentedBytes.length ^ expectedBytes.length;
+
+  for (let index = 0; index < expectedBytes.length; index += 1) {
+    diff |= (presentedBytes[index] ?? 0) ^ expectedBytes[index];
+  }
+
+  return diff === 0;
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,0 +1,983 @@
+import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
+import { NotebookRoom } from "./notebook-room.ts";
+import {
+  AuthError,
+  allowsPublish,
+  authenticateRequest,
+  DEV_AUTH_TOKEN_HEADER,
+  stampTrustedIdentity,
+  type AuthenticatedConnection,
+} from "./identity.ts";
+import {
+  blobKey,
+  ensureCatalogSchema,
+  ensureNotebook,
+  getNotebookCatalog,
+  listRoomEvents,
+  recordBlob,
+  recordRevision,
+  renderKey,
+  runtimeSnapshotKey,
+  snapshotKey,
+  type RevisionRow,
+} from "./storage.ts";
+import { materializeSnapshotPairRender } from "./snapshot-render.ts";
+import { createNotebookCloudBlobResolver } from "./blob-resolver.ts";
+
+export { NotebookRoom };
+
+const DEMO_NOTEBOOK_ID = "nteract-cloud-demo";
+
+const worker: ExportedHandler<Env> = {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "OPTIONS") {
+      return withCors(new Response(null, { status: 204 }));
+    }
+
+    if (url.pathname === "/api/health" && request.method === "GET") {
+      await safeEnsureCatalogSchema(env, ctx);
+      return json({
+        status: "ok",
+        service: "nteract-notebook-cloud",
+        deployment_env: env.DEPLOYMENT_ENV ?? "development",
+      });
+    }
+
+    if (url.pathname === "/" && request.method === "GET") {
+      return withCors(
+        new Response(null, {
+          status: 302,
+          headers: {
+            Location: new URL(`/n/${encodeURIComponent(DEMO_NOTEBOOK_ID)}`, request.url).href,
+          },
+        }),
+      );
+    }
+
+    const syncMatch = url.pathname.match(/^\/n\/([^/]+)\/sync\/?$/);
+    if (syncMatch) {
+      return routeRoomSync(request, env);
+    }
+
+    const debugMatch = url.pathname.match(/^\/n\/([^/]+)\/debug\/?$/);
+    if (debugMatch && request.method === "GET") {
+      return debugViewer(decodeURIComponent(debugMatch[1]));
+    }
+
+    const pinnedViewerMatch = url.pathname.match(/^\/n\/([^/]+)\/r\/([^/]+)\/?$/);
+    if (pinnedViewerMatch && request.method === "GET") {
+      return viewer(
+        decodeURIComponent(pinnedViewerMatch[1]),
+        decodeURIComponent(pinnedViewerMatch[2]),
+      );
+    }
+
+    const viewerMatch = url.pathname.match(/^\/n\/([^/]+)\/?$/);
+    if (viewerMatch && request.method === "GET") {
+      return viewer(decodeURIComponent(viewerMatch[1]));
+    }
+
+    const catalogMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/?$/);
+    if (catalogMatch && request.method === "GET") {
+      return routeCatalog(env, decodeURIComponent(catalogMatch[1]));
+    }
+
+    const eventsMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/events$/);
+    if (eventsMatch && request.method === "GET") {
+      return routeRoomEvents(request, env, decodeURIComponent(eventsMatch[1]));
+    }
+
+    const latestRenderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/render$/);
+    if (latestRenderMatch && request.method === "GET") {
+      return routeLatestRender(request, env, decodeURIComponent(latestRenderMatch[1]));
+    }
+
+    const renderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/renders\/([^/]+)$/);
+    if (renderMatch) {
+      return routeRender(
+        request,
+        env,
+        decodeURIComponent(renderMatch[1]),
+        decodeURIComponent(renderMatch[2]),
+      );
+    }
+
+    const runtimeSnapshotMatch = url.pathname.match(
+      /^\/api\/n\/([^/]+)\/runtime-snapshots\/([^/]+)$/,
+    );
+    if (runtimeSnapshotMatch) {
+      return routeRuntimeSnapshot(
+        request,
+        env,
+        decodeURIComponent(runtimeSnapshotMatch[1]),
+        decodeURIComponent(runtimeSnapshotMatch[2]),
+      );
+    }
+
+    const snapshotMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/snapshots\/([^/]+)$/);
+    if (snapshotMatch) {
+      return routeSnapshot(
+        request,
+        env,
+        decodeURIComponent(snapshotMatch[1]),
+        decodeURIComponent(snapshotMatch[2]),
+      );
+    }
+
+    const blobMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/blobs\/([^/]+)$/);
+    if (blobMatch) {
+      return routeBlob(
+        request,
+        env,
+        decodeURIComponent(blobMatch[1]),
+        decodeURIComponent(blobMatch[2]),
+      );
+    }
+
+    return json({ error: "not found" }, 404);
+  },
+};
+
+export default worker;
+
+async function routeRoomSync(request: Request, env: Env): Promise<Response> {
+  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return json({ error: "expected WebSocket upgrade" }, 426);
+  }
+
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  const url = new URL(request.url);
+  const notebookId = decodeURIComponent(url.pathname.match(/^\/n\/([^/]+)\/sync\/?$/)?.[1] ?? "");
+  if (!notebookId) {
+    return json({ error: "notebook id is required" }, 400);
+  }
+
+  const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  return room.fetch(stampTrustedIdentity(request, identity));
+}
+
+async function routeSnapshot(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  headsHash: string,
+): Promise<Response> {
+  const key = snapshotKey(notebookId, headsHash);
+
+  if (request.method === "GET") {
+    // Prototype publish reads are intentionally public. Production hosts should
+    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+    if (!object) {
+      return json({ error: "snapshot not found" }, 404);
+    }
+
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+      ETag: object.httpEtag,
+    });
+    return withCors(new Response(object.body, { headers }));
+  }
+
+  if (request.method !== "PUT") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot publish snapshots` }, 403);
+  }
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+
+  await ensureNotebook(env, notebookId, identity);
+  const body = await request.arrayBuffer();
+  const runtimeHeadsHash = normalizedRuntimeHeadsHash(request.headers.get("x-runtime-heads-hash"));
+  const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
+  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+    httpMetadata: {
+      contentType: request.headers.get("content-type") ?? "application/octet-stream",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
+    customMetadata: {
+      notebook_id: notebookId,
+      notebook_heads_hash: headsHash,
+    },
+  });
+  const revisionId = await recordRevision(env, {
+    notebookId,
+    notebookHeadsHash: headsHash,
+    runtimeHeadsHash,
+    snapshotKey: key,
+    runtimeSnapshotKey: runtimeKey,
+    actorLabel: identity.actorLabel,
+  });
+
+  return json({ ok: true, revision_id: revisionId, key }, 201);
+}
+
+async function routeRuntimeSnapshot(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  headsHash: string,
+): Promise<Response> {
+  const key = runtimeSnapshotKey(notebookId, headsHash);
+
+  if (request.method === "GET") {
+    const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+    if (!object) {
+      return json({ error: "runtime snapshot not found" }, 404);
+    }
+
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+      ETag: object.httpEtag,
+    });
+    return withCors(new Response(object.body, { headers }));
+  }
+
+  if (request.method !== "PUT") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot publish runtime snapshots` }, 403);
+  }
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+
+  await ensureNotebook(env, notebookId, identity);
+  const body = await request.arrayBuffer();
+  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+    httpMetadata: {
+      contentType: request.headers.get("content-type") ?? "application/octet-stream",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
+    customMetadata: {
+      notebook_id: notebookId,
+      runtime_heads_hash: headsHash,
+      artifact: "runtime-state-snapshot",
+    },
+  });
+
+  return json({ ok: true, key, size: body.byteLength }, 201);
+}
+
+async function routeCatalog(env: Env, notebookId: string): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const catalog = await getNotebookCatalog(env, notebookId);
+  if (!catalog) {
+    return json({ error: "notebook not found" }, 404);
+  }
+
+  return json(catalog);
+}
+
+async function routeRoomEvents(request: Request, env: Env, notebookId: string): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const url = new URL(request.url);
+  const limit = parseLimit(url.searchParams.get("limit"));
+  return json({
+    notebook_id: notebookId,
+    events: await listRoomEvents(env, notebookId, limit),
+  });
+}
+
+async function routeLatestRender(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const catalog = await getNotebookCatalog(env, notebookId);
+  if (!catalog) {
+    return json({ error: "notebook not found" }, 404);
+  }
+
+  const revision =
+    catalog.revisions.find((candidate) => candidate.id === catalog.notebook.latest_revision_id) ??
+    catalog.revisions[0];
+  if (!revision) {
+    return json({ error: "notebook has no published revisions" }, 404);
+  }
+
+  return getRenderObjectOrMaterialize(request, env, notebookId, revision, false);
+}
+
+async function routeRender(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  headsHash: string,
+): Promise<Response> {
+  if (request.method === "GET") {
+    if (!env.DB) {
+      return getRenderObject(env, notebookId, headsHash, true);
+    }
+    const catalog = await getNotebookCatalog(env, notebookId);
+    const revision = catalog?.revisions.find(
+      (candidate) => candidate.notebook_heads_hash === headsHash,
+    );
+    return revision
+      ? getRenderObjectOrMaterialize(request, env, notebookId, revision, true)
+      : getRenderObject(env, notebookId, headsHash, true);
+  }
+
+  if (request.method !== "PUT") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot publish render caches` }, 403);
+  }
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+
+  await ensureNotebook(env, notebookId, identity);
+  const key = renderKey(notebookId, headsHash);
+  const body = await request.text();
+  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+    httpMetadata: {
+      contentType: request.headers.get("content-type") ?? "application/json; charset=utf-8",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
+    customMetadata: {
+      notebook_id: notebookId,
+      notebook_heads_hash: headsHash,
+      artifact: "render-cache",
+    },
+  });
+
+  return json({ ok: true, key, size: body.length }, 201);
+}
+
+async function getRenderObjectOrMaterialize(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  revision: RevisionRow,
+  immutable: boolean,
+): Promise<Response> {
+  const cached = await getRenderObject(env, notebookId, revision.notebook_heads_hash, immutable);
+  if (cached.status !== 404) {
+    return cached;
+  }
+
+  return materializeSnapshotRender(request, env, notebookId, revision, immutable);
+}
+
+async function getRenderObject(
+  env: Env,
+  notebookId: string,
+  headsHash: string,
+  immutable: boolean,
+): Promise<Response> {
+  const key = renderKey(notebookId, headsHash);
+  const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+  if (!object) {
+    return json({ error: "render cache not found" }, 404);
+  }
+
+  const headers = new Headers({
+    "Cache-Control": immutable
+      ? "public, max-age=31536000, immutable"
+      : "public, max-age=30, stale-while-revalidate=300",
+    "Content-Type": object.httpMetadata?.contentType ?? "application/json; charset=utf-8",
+    ETag: object.httpEtag,
+  });
+  return withCors(new Response(object.body, { headers }));
+}
+
+async function materializeSnapshotRender(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  revision: RevisionRow,
+  immutable: boolean,
+): Promise<Response> {
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+  if (!revision.runtime_snapshot_key) {
+    return json({ error: "revision has no runtime-state snapshot" }, 404);
+  }
+
+  const [notebookObject, runtimeObject] = await Promise.all([
+    env.NOTEBOOK_SNAPSHOTS.get(revision.snapshot_key),
+    env.NOTEBOOK_SNAPSHOTS.get(revision.runtime_snapshot_key),
+  ]);
+  if (!notebookObject) {
+    return json({ error: "notebook snapshot not found" }, 404);
+  }
+  if (!runtimeObject) {
+    return json({ error: "runtime snapshot not found" }, 404);
+  }
+
+  const render = await materializeSnapshotPairRender({
+    notebookId,
+    notebookHeadsHash: revision.notebook_heads_hash,
+    runtimeHeadsHash: revision.runtime_heads_hash,
+    notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
+    runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
+    blobResolver: createNotebookCloudBlobResolver({
+      baseUrl: request.url,
+      notebookId,
+    }),
+  });
+  return withCors(
+    new Response(JSON.stringify(render), {
+      headers: {
+        "Cache-Control": immutable
+          ? "public, max-age=31536000, immutable"
+          : "public, max-age=30, stale-while-revalidate=300",
+        "Content-Type": "application/json; charset=utf-8",
+      },
+    }),
+  );
+}
+
+async function routeBlob(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  hash: string,
+): Promise<Response> {
+  const key = blobKey(notebookId, hash);
+
+  if (request.method === "HEAD") {
+    // Prototype publish reads are intentionally public. Production hosts should
+    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const object = await env.NOTEBOOK_SNAPSHOTS?.head(key);
+    if (!object) {
+      return json({ error: "blob not found" }, 404);
+    }
+
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Length": object.size.toString(),
+      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+      ETag: object.httpEtag,
+    });
+    return withCors(new Response(null, { headers }));
+  }
+
+  if (request.method === "GET") {
+    // Prototype publish reads are intentionally public. Production hosts should
+    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+    if (!object) {
+      return json({ error: "blob not found" }, 404);
+    }
+
+    const headers = new Headers({
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Length": object.size.toString(),
+      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+      ETag: object.httpEtag,
+    });
+    return withCors(new Response(object.body, { headers }));
+  }
+
+  if (request.method !== "PUT") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot upload blobs` }, 403);
+  }
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+
+  await ensureNotebook(env, notebookId, identity);
+  const body = await request.arrayBuffer();
+  const contentType = request.headers.get("content-type");
+  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+    httpMetadata: {
+      contentType: contentType ?? "application/octet-stream",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
+    customMetadata: {
+      notebook_id: notebookId,
+      hash,
+    },
+  });
+  await recordBlob(env, {
+    notebookId,
+    hash,
+    size: body.byteLength,
+    contentType,
+    r2Key: key,
+  });
+
+  return json({ ok: true, key, size: body.byteLength }, 201);
+}
+
+async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise<void> {
+  ctx.waitUntil(
+    ensureCatalogSchema(env).catch((error: unknown) => {
+      console.warn("Unable to ensure D1 schema", error);
+    }),
+  );
+}
+
+function authenticateRequestOrResponse(
+  request: Request,
+  env: Env,
+): AuthenticatedConnection | Response {
+  try {
+    return authenticateRequest(request, env);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return json({ error: error.message }, error.status);
+    }
+    return json({ error: String(error) }, 400);
+  }
+}
+
+function json(value: unknown, status = 200): Response {
+  return withCors(
+    new Response(JSON.stringify(value), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function withCors(response: Response): Response {
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, OPTIONS");
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    `Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
+  );
+  return response;
+}
+
+function parseLimit(value: string | null): number {
+  if (!value) {
+    return 25;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 25;
+  }
+
+  return Math.min(parsed, 100);
+}
+
+function normalizedRuntimeHeadsHash(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "none" ? trimmed : null;
+}
+
+function viewer(notebookId: string, headsHash?: string): Response {
+  const escaped = escapeHtml(notebookId);
+  const title = headsHash ? `${escaped} @ ${escapeHtml(headsHash)}` : escaped;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>nteract cloud notebook ${title}</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: Canvas;
+      color: CanvasText;
+    }
+    body { margin: 0; }
+    main { width: min(960px, calc(100vw - 32px)); margin: 0 auto; padding: 32px 0 48px; }
+    header { display: flex; gap: 16px; justify-content: space-between; align-items: flex-start; margin-bottom: 28px; }
+    h1 { font-size: 24px; line-height: 1.2; margin: 0 0 8px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 8px 16px; color: color-mix(in srgb, CanvasText 62%, transparent); font-size: 13px; }
+    .meta code { color: CanvasText; }
+    .links { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+    a.button {
+      color: CanvasText;
+      border: 1px solid color-mix(in srgb, CanvasText 22%, transparent);
+      border-radius: 6px;
+      padding: 7px 10px;
+      text-decoration: none;
+      font-size: 13px;
+    }
+    .state {
+      border: 1px solid color-mix(in srgb, CanvasText 16%, transparent);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-bottom: 18px;
+      color: color-mix(in srgb, CanvasText 72%, transparent);
+      background: color-mix(in srgb, Canvas 94%, CanvasText 6%);
+    }
+    .state[data-kind="error"] {
+      border-color: color-mix(in srgb, #b42318 50%, transparent);
+      color: #b42318;
+      background: color-mix(in srgb, #b42318 8%, Canvas);
+    }
+    .notebook { display: grid; gap: 14px; }
+    .cell {
+      border-left: 3px solid color-mix(in srgb, CanvasText 20%, transparent);
+      padding: 8px 0 8px 16px;
+    }
+    .cell[data-type="code"] { border-left-color: #4f46e5; }
+    .cell[data-type="markdown"] { border-left-color: #0f766e; }
+    .cell-label {
+      font-size: 12px;
+      color: color-mix(in srgb, CanvasText 56%, transparent);
+      margin-bottom: 6px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .markdown { line-height: 1.55; }
+    .markdown h2, .markdown h3, .markdown p, .markdown ul { margin: 0 0 10px; }
+    .markdown h2 { font-size: 21px; }
+    .markdown h3 { font-size: 17px; }
+    pre {
+      margin: 0;
+      border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
+      border-radius: 8px;
+      padding: 12px;
+      overflow: auto;
+      background: color-mix(in srgb, Canvas 90%, CanvasText 10%);
+    }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
+    .outputs { margin-top: 8px; }
+    @media (max-width: 640px) {
+      main { width: min(100vw - 24px, 960px); padding-top: 20px; }
+      header { display: block; }
+      .links { justify-content: flex-start; margin-top: 12px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>nteract cloud notebook</h1>
+        <div class="meta">
+          <span>Notebook <code>${escaped}</code></span>
+          <span id="revision"></span>
+          <span id="connection">anonymous viewer connecting</span>
+        </div>
+      </div>
+      <nav class="links" aria-label="Notebook links">
+        <a class="button" href="/n/${encodeURIComponent(notebookId)}/debug">Debug</a>
+        <a class="button" href="/api/n/${encodeURIComponent(notebookId)}">Catalog JSON</a>
+      </nav>
+    </header>
+    <div id="state" class="state">Loading notebook snapshot...</div>
+    <section id="notebook" class="notebook" aria-label="Notebook cells"></section>
+  </main>
+  <script type="module">
+    const notebookId = ${scriptJsonForHtml(notebookId)};
+    const pinnedHeadsHash = ${scriptJsonForHtml(headsHash ?? null)};
+    const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
+    const state = document.querySelector("#state");
+    const notebook = document.querySelector("#notebook");
+    const revision = document.querySelector("#revision");
+    const connection = document.querySelector("#connection");
+    const renderEndpoint = pinnedHeadsHash
+      ? "/api/n/" + encodeURIComponent(notebookId) + "/renders/" + encodeURIComponent(pinnedHeadsHash)
+      : "/api/n/" + encodeURIComponent(notebookId) + "/render";
+
+    connectAnonymousViewer();
+    loadNotebook();
+
+    async function loadNotebook() {
+      try {
+        const response = await fetch(renderEndpoint, { headers: { Accept: "application/json" } });
+        if (!response.ok) {
+          showState(response.status === 404
+            ? "No published snapshot is available for this notebook yet."
+            : "Unable to load notebook render: " + response.status,
+            response.status === 404 ? "empty" : "error");
+          return;
+        }
+        const render = await response.json();
+        renderNotebook(render);
+      } catch (error) {
+        showState("Unable to load notebook: " + String(error), "error");
+      }
+    }
+
+    function renderNotebook(render) {
+      const cells = Array.isArray(render.cells) ? render.cells : [];
+      revision.textContent = render.heads_hash ? "Revision " + render.heads_hash : "";
+      notebook.replaceChildren();
+      if (cells.length === 0) {
+        showState("This published notebook has no cells.", "empty");
+        return;
+      }
+      const source = render.source === "snapshot-pair" ? "snapshot pair" : "render cache";
+      showState("Rendered " + cells.length + " cells from a persisted " + source + ".", "ready");
+      for (const cell of cells) {
+        notebook.append(renderCell(cell));
+      }
+    }
+
+    function renderCell(cell) {
+      const type = typeof cell.cell_type === "string" ? cell.cell_type : "code";
+      const id = typeof cell.id === "string" ? cell.id : "cell";
+      const source = typeof cell.source === "string" ? cell.source : "";
+      const section = document.createElement("article");
+      section.className = "cell";
+      section.dataset.type = type;
+
+      const label = document.createElement("div");
+      label.className = "cell-label";
+      label.textContent = type + " - " + id;
+      section.append(label);
+
+      if (type === "markdown") {
+        const markdown = document.createElement("div");
+        markdown.className = "markdown";
+        renderMarkdown(markdown, source);
+        section.append(markdown);
+      } else {
+        const pre = document.createElement("pre");
+        const code = document.createElement("code");
+        code.textContent = source;
+        pre.append(code);
+        section.append(pre);
+      }
+
+      if (Array.isArray(cell.outputs) && cell.outputs.length > 0) {
+        const outputs = document.createElement("pre");
+        outputs.className = "outputs";
+        outputs.textContent = JSON.stringify(cell.outputs, null, 2);
+        section.append(outputs);
+      }
+
+      return section;
+    }
+
+    function renderMarkdown(container, source) {
+      const lines = source.split(/\\r?\\n/);
+      let list;
+      for (const line of lines) {
+        if (line.startsWith("## ")) {
+          list = undefined;
+          appendText(container, "h3", line.slice(3));
+        } else if (line.startsWith("# ")) {
+          list = undefined;
+          appendText(container, "h2", line.slice(2));
+        } else if (line.startsWith("- ")) {
+          if (!list) {
+            list = document.createElement("ul");
+            container.append(list);
+          }
+          appendText(list, "li", line.slice(2));
+        } else if (line.trim() === "") {
+          list = undefined;
+        } else {
+          list = undefined;
+          appendText(container, "p", line);
+        }
+      }
+    }
+
+    function appendText(parent, tagName, text) {
+      const element = document.createElement(tagName);
+      element.textContent = text;
+      parent.append(element);
+    }
+
+    function connectAnonymousViewer() {
+      const url = new URL("/n/" + encodeURIComponent(notebookId) + "/sync", location.href);
+      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+      url.searchParams.set("viewer_session", sessionId);
+      const socket = new WebSocket(url);
+      socket.binaryType = "arraybuffer";
+      socket.addEventListener("open", () => {
+        connection.textContent = "anonymous viewer connected";
+      });
+      socket.addEventListener("close", () => {
+        connection.textContent = "anonymous viewer disconnected";
+      });
+      socket.addEventListener("message", async (event) => {
+        const bytes = new Uint8Array(event.data);
+        if (bytes[0] !== 0x07) {
+          return;
+        }
+        const message = JSON.parse(new TextDecoder().decode(bytes.slice(1)));
+        if (message.type === "cloud_room_ready") {
+          connection.textContent = message.actor_label + " (" + message.connection_scope + ")";
+        }
+      });
+    }
+
+    function showState(message, kind) {
+      state.textContent = message;
+      state.dataset.kind = kind;
+    }
+  </script>
+</body>
+</html>`;
+
+  return withCors(
+    new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    }),
+  );
+}
+
+function debugViewer(notebookId: string): Response {
+  const escaped = escapeHtml(notebookId);
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>nteract cloud room ${escaped}</title>
+  <style>
+    :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: Canvas; color: CanvasText; }
+    main { max-width: 1120px; margin: 0 auto; padding: 24px; }
+    h1 { font-size: 20px; margin: 0 0 16px; }
+    dl { display: grid; grid-template-columns: max-content 1fr; gap: 8px 16px; margin: 0 0 20px; }
+    dt { color: color-mix(in srgb, CanvasText 65%, transparent); }
+    dd { margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .actions { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+    button { font: inherit; padding: 8px 12px; }
+    section { margin-top: 18px; }
+    h2 { font-size: 14px; margin: 0 0 8px; }
+    .grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+    pre { border: 1px solid color-mix(in srgb, CanvasText 18%, transparent); padding: 12px; min-height: 220px; overflow: auto; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>nteract cloud room</h1>
+    <dl>
+      <dt>Notebook</dt><dd>${escaped}</dd>
+      <dt>WebSocket</dt><dd id="url"></dd>
+      <dt>Status</dt><dd id="status">connecting</dd>
+    </dl>
+    <div class="actions">
+      <button id="presence" type="button">Send presence frame</button>
+      <button id="refresh" type="button">Refresh catalog</button>
+    </div>
+    <div class="grid">
+      <section>
+        <h2>Frames</h2>
+        <pre id="log"></pre>
+      </section>
+      <section>
+        <h2>Catalog</h2>
+        <pre id="catalog"></pre>
+      </section>
+      <section>
+        <h2>Events</h2>
+        <pre id="events"></pre>
+      </section>
+    </div>
+  </main>
+  <script type="module">
+    const notebookId = ${scriptJsonForHtml(notebookId)};
+    const frameType = { presence: 0x04, sessionControl: 0x07 };
+    const log = document.querySelector("#log");
+    const catalog = document.querySelector("#catalog");
+    const events = document.querySelector("#events");
+    const status = document.querySelector("#status");
+    const urlCell = document.querySelector("#url");
+    const base = new URL(location.href);
+    base.protocol = base.protocol === "https:" ? "wss:" : "ws:";
+    base.pathname = "/n/" + encodeURIComponent(notebookId) + "/sync";
+    base.search = "?viewer_session=debug-browser";
+    urlCell.textContent = base.href;
+    const socket = new WebSocket(base);
+    socket.binaryType = "arraybuffer";
+    socket.addEventListener("open", () => { status.textContent = "open"; });
+    socket.addEventListener("close", () => { status.textContent = "closed"; });
+    socket.addEventListener("message", async (event) => {
+      const bytes = new Uint8Array(event.data);
+      const payload = new TextDecoder().decode(bytes.slice(1));
+      log.textContent += "[" + bytes[0] + "] " + payload + "\\n";
+      if (bytes[0] === frameType.sessionControl) refreshCatalog();
+    });
+    document.querySelector("#presence").addEventListener("click", () => {
+      const payload = new TextEncoder().encode(JSON.stringify({ peer_label: "browser viewer", actor_label: "desktop:browser" }));
+      const frame = new Uint8Array(payload.byteLength + 1);
+      frame[0] = frameType.presence;
+      frame.set(payload, 1);
+      socket.send(frame);
+    });
+    document.querySelector("#refresh").addEventListener("click", refreshCatalog);
+    async function refreshCatalog() {
+      const [catalogResponse, eventsResponse] = await Promise.all([
+        fetch("/api/n/" + encodeURIComponent(notebookId)),
+        fetch("/api/n/" + encodeURIComponent(notebookId) + "/events?limit=10"),
+      ]);
+      catalog.textContent = catalogResponse.ok
+        ? JSON.stringify(await catalogResponse.json(), null, 2)
+        : "No catalog row yet";
+      events.textContent = eventsResponse.ok
+        ? JSON.stringify(await eventsResponse.json(), null, 2)
+        : "No room events yet";
+    }
+    refreshCatalog();
+  </script>
+</body>
+</html>`;
+
+  return withCors(
+    new Response(html, {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    }),
+  );
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#x27;");
+}
+
+export function scriptJsonForHtml(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -215,14 +215,20 @@ async function routeSnapshot(
       notebook_heads_hash: headsHash,
     },
   });
-  const revisionId = await recordRevision(env, {
-    notebookId,
-    notebookHeadsHash: headsHash,
-    runtimeHeadsHash,
-    snapshotKey: key,
-    runtimeSnapshotKey: runtimeKey,
-    actorLabel: identity.actorLabel,
-  });
+  let revisionId: string;
+  try {
+    revisionId = await recordRevision(env, {
+      notebookId,
+      notebookHeadsHash: headsHash,
+      runtimeHeadsHash,
+      snapshotKey: key,
+      runtimeSnapshotKey: runtimeKey,
+      actorLabel: identity.actorLabel,
+    });
+  } catch (error) {
+    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    throw error;
+  }
 
   return json({ ok: true, revision_id: revisionId, key }, 201);
 }
@@ -456,8 +462,23 @@ async function materializeSnapshotRender(
       notebookId,
     }),
   });
+  const body = JSON.stringify(render);
+  await env.NOTEBOOK_SNAPSHOTS.put(renderKey(notebookId, revision.notebook_heads_hash), body, {
+    httpMetadata: {
+      contentType: "application/json; charset=utf-8",
+      cacheControl: immutable
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=30, stale-while-revalidate=300",
+    },
+    customMetadata: {
+      notebook_id: notebookId,
+      notebook_heads_hash: revision.notebook_heads_hash,
+      runtime_heads_hash: revision.runtime_heads_hash ?? "",
+      artifact: "materialized-render",
+    },
+  });
   return withCors(
-    new Response(JSON.stringify(render), {
+    new Response(body, {
       headers: {
         "Cache-Control": immutable
           ? "public, max-age=31536000, immutable"

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -48,7 +48,6 @@ const MAX_STORED_FRAMES = 500;
 
 export class NotebookRoom {
   private readonly peers = new Map<string, Peer>();
-  private readonly removedPeerIds = new Set<string>();
   private readonly pendingRemovals = new Map<string, { notebookId: string; peer: Peer }>();
   private nextFrameSequence = 0;
   private frameSequenceReady: Promise<void> | undefined;
@@ -95,7 +94,6 @@ export class NotebookRoom {
       connectedAt: new Date().toISOString(),
     };
 
-    this.removedPeerIds.delete(peer.id);
     this.acceptPeerSocket(notebookId, peer);
     this.peers.set(peer.id, peer);
 
@@ -202,10 +200,6 @@ export class NotebookRoom {
     if (!attachment) {
       return undefined;
     }
-    if (this.removedPeerIds.has(attachment.peerId)) {
-      return undefined;
-    }
-
     return this.peers.get(attachment.peerId);
   }
 
@@ -507,7 +501,6 @@ export class NotebookRoom {
       return;
     }
 
-    this.removedPeerIds.add(peer.id);
     try {
       peer.socket.close();
     } catch {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1,0 +1,587 @@
+import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
+import {
+  allowsNotebookWrite,
+  allowsRuntimeStateWrite,
+  isAnonymousViewer,
+  readTrustedIdentity,
+  type AuthenticatedConnection,
+} from "./identity.ts";
+import {
+  encodeJsonFrame,
+  encodeTypedFrame,
+  FrameType,
+  frameSizeLimits,
+  frameTypeName,
+  isClientWritableFrame,
+  splitTypedFrame,
+  type SessionControlMessage,
+  type TypedFrame,
+} from "./protocol.ts";
+import { rewritePresenceIngress } from "./runtimed-wasm.ts";
+import { ensureNotebook, recordRoomEvent } from "./storage.ts";
+
+interface Peer {
+  id: string;
+  socket: CloudflareWebSocket;
+  identity: AuthenticatedConnection;
+  connectedAt: string;
+}
+
+interface StoredRoomFrame {
+  sequence: number;
+  peerId: string;
+  actorLabel: string;
+  connectionScope: string;
+  frameType: number;
+  byteLength: number;
+  receivedAt: string;
+}
+
+interface PeerAttachment {
+  notebookId: string;
+  peerId: string;
+  identity: AuthenticatedConnection;
+  connectedAt: string;
+}
+
+const MAX_STORED_FRAMES = 500;
+
+export class NotebookRoom {
+  private readonly peers = new Map<string, Peer>();
+  private readonly removedPeerIds = new Set<string>();
+  private readonly pendingRemovals = new Map<string, { notebookId: string; peer: Peer }>();
+  private nextFrameSequence = 0;
+  private frameSequenceReady: Promise<void> | undefined;
+  private framePersistQueue: Promise<void> = Promise.resolve();
+  private broadcastDepth = 0;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    this.restoreHibernatedPeers();
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const notebookId = notebookIdFromPath(url.pathname);
+
+    if (!notebookId) {
+      return json({ error: "notebook id is required" }, 400);
+    }
+
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return json({ error: "expected WebSocket upgrade" }, 426);
+    }
+
+    let identity: AuthenticatedConnection;
+    try {
+      identity = readTrustedIdentity(request);
+    } catch (error) {
+      return json({ error: String(error) }, 401);
+    }
+
+    if (!isAnonymousViewer(identity)) {
+      await ensureNotebook(this.env, notebookId, identity);
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    const peer: Peer = {
+      id: crypto.randomUUID(),
+      socket: server,
+      identity,
+      connectedAt: new Date().toISOString(),
+    };
+
+    this.removedPeerIds.delete(peer.id);
+    this.acceptPeerSocket(notebookId, peer);
+    this.peers.set(peer.id, peer);
+
+    this.sendControl(notebookId, peer, {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: notebookId,
+      peer_id: peer.id,
+      actor_label: identity.actorLabel,
+      connection_scope: identity.scope,
+      room_peer_count: this.peers.size,
+      timestamp: peer.connectedAt,
+    });
+
+    this.broadcastControl(
+      notebookId,
+      {
+        type: "cloud_peer_joined",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        actor_label: identity.actorLabel,
+        room_peer_count: this.peers.size,
+        timestamp: peer.connectedAt,
+      },
+      peer.id,
+    );
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    } as ResponseInit & { webSocket: CloudflareWebSocket });
+  }
+
+  async webSocketMessage(
+    socket: CloudflareWebSocket,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    const peer = this.peerForSocket(socket);
+    if (!peer) {
+      return;
+    }
+
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return;
+    }
+
+    await this.handleMessage(attachment.notebookId, peer, message);
+  }
+
+  webSocketClose(socket: CloudflareWebSocket): void {
+    this.removeAttachedPeer(socket);
+  }
+
+  webSocketError(socket: CloudflareWebSocket): void {
+    this.removeAttachedPeer(socket);
+  }
+
+  private restoreHibernatedPeers(): void {
+    const sockets = this.state.getWebSockets?.() ?? [];
+    for (const socket of sockets) {
+      const attachment = socketAttachment(socket);
+      if (!attachment) {
+        continue;
+      }
+
+      this.peers.set(attachment.peerId, {
+        id: attachment.peerId,
+        socket,
+        identity: attachment.identity,
+        connectedAt: attachment.connectedAt,
+      });
+    }
+  }
+
+  private acceptPeerSocket(notebookId: string, peer: Peer): void {
+    const attachment: PeerAttachment = {
+      notebookId,
+      peerId: peer.id,
+      identity: peer.identity,
+      connectedAt: peer.connectedAt,
+    };
+
+    if (this.state.acceptWebSocket && peer.socket.serializeAttachment) {
+      this.state.acceptWebSocket(peer.socket);
+      peer.socket.serializeAttachment(attachment);
+      return;
+    }
+
+    peer.socket.accept();
+    peer.socket.addEventListener("message", (event) => {
+      this.state.waitUntil(this.handleMessage(notebookId, peer, event.data));
+    });
+    peer.socket.addEventListener("close", () => {
+      this.removePeer(notebookId, peer);
+    });
+    peer.socket.addEventListener("error", () => {
+      this.removePeer(notebookId, peer);
+    });
+  }
+
+  private peerForSocket(socket: CloudflareWebSocket): Peer | undefined {
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return undefined;
+    }
+    if (this.removedPeerIds.has(attachment.peerId)) {
+      return undefined;
+    }
+
+    return this.peers.get(attachment.peerId);
+  }
+
+  private removeAttachedPeer(socket: CloudflareWebSocket): void {
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return;
+    }
+
+    const peer = this.peers.get(attachment.peerId);
+    if (!peer) {
+      return;
+    }
+
+    this.removePeer(attachment.notebookId, peer);
+  }
+
+  private async handleMessage(
+    notebookId: string,
+    peer: Peer,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    if (typeof message === "string") {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        undefined,
+        "typed-frame WebSocket messages must be binary",
+      );
+      return;
+    }
+
+    let frame: TypedFrame;
+    try {
+      frame = splitTypedFrame(message);
+    } catch (error) {
+      this.rejectFrame(notebookId, peer, undefined, String(error));
+      return;
+    }
+
+    const sizeLimits = frameSizeLimits(frame.type);
+    if (frame.payload.byteLength > sizeLimits.cap) {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        frame.type,
+        `${frameTypeName(frame.type)} frame payload exceeds ${sizeLimits.cap} byte limit`,
+      );
+      return;
+    }
+
+    if (!isClientWritableFrame(frame.type)) {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        frame.type,
+        `${frameTypeName(frame.type)} is server-originated`,
+      );
+      return;
+    }
+
+    if (!this.scopeAllowsFrame(peer.identity, frame)) {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        frame.type,
+        `${peer.identity.scope} cannot write ${frameTypeName(frame.type)} frames`,
+      );
+      return;
+    }
+
+    let normalizedFrame = frame;
+    if (frame.type === FrameType.PRESENCE) {
+      try {
+        normalizedFrame = await rewritePresenceFrame(frame, peer);
+      } catch (error) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          frame.type,
+          `unsupported presence payload: ${String(error)}`,
+        );
+        return;
+      }
+    }
+
+    const receivedAt = new Date().toISOString();
+    if (!shouldBroadcastFrame(normalizedFrame, peer.identity)) {
+      // Anonymous public viewers are read-only observers. Their presence is
+      // acknowledged locally but not broadcast or persisted as room activity.
+      this.sendControl(notebookId, peer, {
+        type: "cloud_frame_accepted",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        frame_type: normalizedFrame.type,
+        byte_length: normalizedFrame.payload.byteLength,
+        timestamp: receivedAt,
+      });
+      return;
+    }
+
+    try {
+      await this.persistFrame(notebookId, peer, normalizedFrame, receivedAt);
+    } catch (error) {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        normalizedFrame.type,
+        `failed to persist ${frameTypeName(normalizedFrame.type)} frame: ${String(error)}`,
+      );
+      return;
+    }
+
+    this.broadcastFrame(
+      notebookId,
+      encodeTypedFrame(normalizedFrame.type, normalizedFrame.payload),
+      peer.id,
+    );
+    this.sendControl(notebookId, peer, {
+      type: "cloud_frame_accepted",
+      notebook_id: notebookId,
+      peer_id: peer.id,
+      frame_type: normalizedFrame.type,
+      byte_length: normalizedFrame.payload.byteLength,
+      timestamp: receivedAt,
+    });
+  }
+
+  private scopeAllowsFrame(identity: AuthenticatedConnection, frame: TypedFrame): boolean {
+    switch (frame.type) {
+      case FrameType.AUTOMERGE_SYNC:
+        return allowsNotebookWrite(identity.scope);
+      case FrameType.RUNTIME_STATE_SYNC:
+      case FrameType.PUT_BLOB:
+        return allowsRuntimeStateWrite(identity.scope);
+      case FrameType.POOL_STATE_SYNC:
+        return identity.scope === "owner";
+      case FrameType.REQUEST:
+        return identity.scope !== "viewer";
+      case FrameType.PRESENCE:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private async persistFrame(
+    notebookId: string,
+    peer: Peer,
+    frame: TypedFrame,
+    receivedAt: string,
+  ): Promise<void> {
+    const operation = this.framePersistQueue
+      .catch(() => undefined)
+      .then(async () => {
+        await this.prepareFrameSequence();
+        const sequence = this.nextFrameSequence + 1;
+        const stored: StoredRoomFrame = {
+          sequence,
+          peerId: peer.id,
+          actorLabel: peer.identity.actorLabel,
+          connectionScope: peer.identity.scope,
+          frameType: frame.type,
+          byteLength: frame.payload.byteLength,
+          receivedAt,
+        };
+
+        await this.state.storage.put(frameStorageKey(sequence), stored);
+        await this.state.storage.put("frame_sequence", sequence);
+        this.nextFrameSequence = sequence;
+        this.state.waitUntil(
+          this.evictStoredFrame(sequence - MAX_STORED_FRAMES).catch(() => undefined),
+        );
+        // D1 event rows are observability only; relay delivery must not depend on D1.
+        this.state.waitUntil(
+          recordRoomEvent(this.env, {
+            notebookId,
+            peerId: peer.id,
+            actorLabel: peer.identity.actorLabel,
+            connectionScope: peer.identity.scope,
+            frameType: frame.type,
+            byteLength: frame.payload.byteLength,
+            receivedAt,
+          }).catch(() => undefined),
+        );
+      });
+
+    this.framePersistQueue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    await operation;
+  }
+
+  private async prepareFrameSequence(): Promise<void> {
+    this.frameSequenceReady ??= this.state.storage
+      .get<number>("frame_sequence")
+      .then((sequence) => {
+        this.nextFrameSequence = sequence ?? 0;
+      });
+
+    await this.frameSequenceReady;
+  }
+
+  private async evictStoredFrame(sequence: number): Promise<void> {
+    if (sequence < 1) {
+      return;
+    }
+
+    await this.state.storage.delete(frameStorageKey(sequence));
+  }
+
+  private rejectFrame(
+    notebookId: string,
+    peer: Peer,
+    frameType: number | undefined,
+    reason: string,
+  ): void {
+    this.sendControl(notebookId, peer, {
+      type: "cloud_frame_rejected",
+      notebook_id: notebookId,
+      peer_id: peer.id,
+      frame_type: frameType,
+      reason,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private sendControl(notebookId: string, peer: Peer, message: SessionControlMessage): void {
+    this.sendFrameToPeer(notebookId, peer, encodeJsonFrame(FrameType.SESSION_CONTROL, message));
+  }
+
+  private broadcastControl(
+    notebookId: string,
+    message: SessionControlMessage,
+    excludePeerId?: string,
+  ): void {
+    const frame = encodeJsonFrame(FrameType.SESSION_CONTROL, message);
+    this.broadcastFrame(notebookId, frame, excludePeerId);
+  }
+
+  private broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void {
+    const peers = Array.from(this.peers.values()).filter((peer) => peer.id !== excludePeerId);
+    this.broadcastDepth += 1;
+    try {
+      for (const peer of peers) {
+        if (!this.trySendFrame(peer, frame)) {
+          this.queuePeerRemoval(notebookId, peer);
+        }
+      }
+    } finally {
+      this.broadcastDepth -= 1;
+      if (this.broadcastDepth === 0) {
+        this.flushPendingRemovals();
+      }
+    }
+  }
+
+  private sendFrameToPeer(notebookId: string, peer: Peer, frame: Uint8Array): void {
+    if (!this.trySendFrame(peer, frame)) {
+      this.removePeer(notebookId, peer);
+    }
+  }
+
+  private trySendFrame(peer: Peer, frame: Uint8Array): boolean {
+    try {
+      peer.socket.send(frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private queuePeerRemoval(notebookId: string, peer: Peer): void {
+    if (!this.peers.has(peer.id)) {
+      return;
+    }
+
+    this.pendingRemovals.set(peer.id, { notebookId, peer });
+  }
+
+  private flushPendingRemovals(): void {
+    while (this.pendingRemovals.size > 0) {
+      const removals = Array.from(this.pendingRemovals.values());
+      this.pendingRemovals.clear();
+      for (const { notebookId, peer } of removals) {
+        this.removePeer(notebookId, peer);
+      }
+    }
+  }
+
+  private removePeer(notebookId: string, peer: Peer): void {
+    if (this.broadcastDepth > 0) {
+      this.queuePeerRemoval(notebookId, peer);
+      return;
+    }
+
+    if (!this.peers.delete(peer.id)) {
+      return;
+    }
+
+    this.removedPeerIds.add(peer.id);
+    try {
+      peer.socket.close();
+    } catch {
+      // Socket is already gone; the peer has still been removed from room state.
+    }
+
+    this.broadcastControl(notebookId, {
+      type: "cloud_peer_left",
+      notebook_id: notebookId,
+      peer_id: peer.id,
+      actor_label: peer.identity.actorLabel,
+      room_peer_count: this.peers.size,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+
+export function shouldBroadcastFrame(
+  frame: TypedFrame,
+  identity: AuthenticatedConnection,
+): boolean {
+  return !(frame.type === FrameType.PRESENCE && isAnonymousViewer(identity));
+}
+
+export function rewritePresenceFrame(
+  frame: TypedFrame,
+  peer: { id: string; identity: AuthenticatedConnection },
+): Promise<TypedFrame> {
+  return rewritePresenceIngress(
+    frame.payload,
+    peer.id,
+    peer.identity.principal,
+    peer.identity.principal,
+    peer.identity.operator,
+  ).then((payload) => ({
+    type: frame.type,
+    payload,
+  }));
+}
+
+function notebookIdFromPath(pathname: string): string | undefined {
+  const match = pathname.match(/^\/n\/([^/]+)\/sync\/?$/);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}
+
+function json(value: unknown, status: number): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function frameStorageKey(sequence: number): string {
+  return `frame:${sequence.toString().padStart(12, "0")}`;
+}
+
+function socketAttachment(socket: CloudflareWebSocket): PeerAttachment | undefined {
+  const value = socket.deserializeAttachment?.();
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const candidate = value as Partial<PeerAttachment>;
+  if (
+    typeof candidate.notebookId !== "string" ||
+    typeof candidate.peerId !== "string" ||
+    typeof candidate.connectedAt !== "string" ||
+    !candidate.identity
+  ) {
+    return undefined;
+  }
+
+  return candidate as PeerAttachment;
+}

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -1,0 +1,133 @@
+import {
+  FrameType,
+  MAX_FRAME_SIZE,
+  frameSizeLimits,
+  type FrameSizeLimits,
+  type FrameTypeValue,
+} from "runtimed";
+
+export { FrameType, MAX_FRAME_SIZE, frameSizeLimits };
+export type { FrameSizeLimits, FrameTypeValue };
+
+export const NOTEBOOK_PROTOCOL = "v4";
+
+export interface TypedFrame {
+  type: FrameTypeValue;
+  payload: Uint8Array;
+}
+
+export type SessionControlMessage =
+  | {
+      type: "cloud_room_ready";
+      protocol: typeof NOTEBOOK_PROTOCOL;
+      notebook_id: string;
+      peer_id: string;
+      actor_label: string;
+      connection_scope: string;
+      room_peer_count: number;
+      timestamp: string;
+    }
+  | {
+      type: "cloud_frame_accepted";
+      notebook_id: string;
+      peer_id: string;
+      frame_type: number;
+      byte_length: number;
+      timestamp: string;
+    }
+  | {
+      type: "cloud_frame_rejected";
+      notebook_id: string;
+      peer_id: string;
+      frame_type?: number;
+      reason: string;
+      timestamp: string;
+    }
+  | {
+      type: "cloud_peer_joined" | "cloud_peer_left";
+      notebook_id: string;
+      peer_id: string;
+      actor_label: string;
+      room_peer_count: number;
+      timestamp: string;
+    };
+
+export function encodeTypedFrame(type: FrameTypeValue, payload: Uint8Array): Uint8Array {
+  const frame = new Uint8Array(payload.byteLength + 1);
+  frame[0] = type;
+  frame.set(payload, 1);
+  return frame;
+}
+
+export function encodeJsonFrame(type: FrameTypeValue, value: unknown): Uint8Array {
+  return encodeTypedFrame(type, new TextEncoder().encode(JSON.stringify(value)));
+}
+
+export function decodeJsonPayload<T>(payload: Uint8Array): T {
+  return JSON.parse(new TextDecoder().decode(payload)) as T;
+}
+
+export function splitTypedFrame(message: ArrayBuffer | ArrayBufferView): TypedFrame {
+  const bytes = toUint8Array(message);
+  if (bytes.byteLength === 0) {
+    throw new Error("typed frame cannot be empty");
+  }
+
+  const type = bytes[0] as FrameTypeValue;
+  if (!isKnownFrameType(type)) {
+    throw new Error(`unknown frame type ${type}`);
+  }
+
+  return {
+    type,
+    payload: bytes.slice(1),
+  };
+}
+
+export function frameTypeName(type: number): string {
+  switch (type) {
+    case FrameType.AUTOMERGE_SYNC:
+      return "automerge_sync";
+    case FrameType.REQUEST:
+      return "request";
+    case FrameType.RESPONSE:
+      return "response";
+    case FrameType.BROADCAST:
+      return "broadcast";
+    case FrameType.PRESENCE:
+      return "presence";
+    case FrameType.RUNTIME_STATE_SYNC:
+      return "runtime_state_sync";
+    case FrameType.POOL_STATE_SYNC:
+      return "pool_state_sync";
+    case FrameType.SESSION_CONTROL:
+      return "session_control";
+    case FrameType.PUT_BLOB:
+      return "put_blob";
+    default:
+      return `unknown_${type}`;
+  }
+}
+
+export function isKnownFrameType(type: number): type is FrameTypeValue {
+  return Object.values(FrameType).includes(type as FrameTypeValue);
+}
+
+export function isClientWritableFrame(type: FrameTypeValue): boolean {
+  return (
+    type === FrameType.AUTOMERGE_SYNC ||
+    type === FrameType.REQUEST ||
+    type === FrameType.PRESENCE ||
+    type === FrameType.RUNTIME_STATE_SYNC ||
+    type === FrameType.POOL_STATE_SYNC ||
+    type === FrameType.PUT_BLOB
+  );
+}
+
+export function toUint8Array(message: ArrayBuffer | ArrayBufferView): Uint8Array {
+  if (message instanceof ArrayBuffer) {
+    return new Uint8Array(message);
+  }
+
+  return new Uint8Array(message.buffer, message.byteOffset, message.byteLength);
+}

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -1,0 +1,25 @@
+declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
+  export default function init(moduleOrPath?: unknown): Promise<unknown>;
+  export function decode_presence_frame(payload: Uint8Array): unknown;
+  export function encode_presence_frame(message: unknown): Uint8Array;
+  export function rewrite_presence_ingress(
+    payload: Uint8Array,
+    peerId: string,
+    peerLabel: string,
+    principal: string,
+    fallbackOperator: string,
+  ): Uint8Array;
+
+  export class NotebookHandle {
+    static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): NotebookHandle;
+    get_cells_json(): string;
+    get_heads_hex(): string;
+    get_runtime_state_heads_hex(): string;
+    free(): void;
+  }
+}
+
+declare module "*.wasm" {
+  const module: WebAssembly.Module;
+  export default module;
+}

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -1,0 +1,56 @@
+import initWasm, {
+  decode_presence_frame,
+  encode_presence_frame,
+  rewrite_presence_ingress,
+  NotebookHandle,
+} from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+
+let initialized: Promise<void> | undefined;
+
+type RuntimedWasmInitInput = Parameters<typeof initWasm>[0];
+type RuntimedWasmModuleOrPath = Exclude<
+  Extract<RuntimedWasmInitInput, { module_or_path: unknown }>["module_or_path"],
+  Promise<unknown>
+>;
+
+export function initializeRuntimedWasm(moduleOrPath?: RuntimedWasmModuleOrPath): Promise<void> {
+  initialized ??= (async () => {
+    const resolvedModuleOrPath = moduleOrPath ?? (await loadBundledWasmModule());
+    await initWasm({ module_or_path: resolvedModuleOrPath } as RuntimedWasmInitInput);
+  })();
+  return initialized;
+}
+
+async function loadBundledWasmModule(): Promise<WebAssembly.Module> {
+  const module = await import("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm");
+  return module.default;
+}
+
+export async function decodePresenceFrame(payload: Uint8Array): Promise<unknown> {
+  await initializeRuntimedWasm();
+  return decode_presence_frame(payload);
+}
+
+export async function encodePresenceFrame(message: unknown): Promise<Uint8Array> {
+  await initializeRuntimedWasm();
+  return encode_presence_frame(message);
+}
+
+export async function rewritePresenceIngress(
+  payload: Uint8Array,
+  peerId: string,
+  peerLabel: string,
+  principal: string,
+  fallbackOperator: string,
+): Promise<Uint8Array> {
+  await initializeRuntimedWasm();
+  return rewrite_presence_ingress(payload, peerId, peerLabel, principal, fallbackOperator);
+}
+
+export async function loadSnapshotPair(
+  notebookBytes: Uint8Array,
+  runtimeStateBytes: Uint8Array,
+): Promise<NotebookHandle> {
+  await initializeRuntimedWasm();
+  return NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
+}

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -17,7 +17,10 @@ export function initializeRuntimedWasm(moduleOrPath?: RuntimedWasmModuleOrPath):
   initialized ??= (async () => {
     const resolvedModuleOrPath = moduleOrPath ?? (await loadBundledWasmModule());
     await initWasm({ module_or_path: resolvedModuleOrPath } as RuntimedWasmInitInput);
-  })();
+  })().catch((error: unknown) => {
+    initialized = undefined;
+    throw error;
+  });
   return initialized;
 }
 

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -1,0 +1,73 @@
+import type { BlobResolver } from "runtimed";
+import { loadSnapshotPair } from "./runtimed-wasm.ts";
+
+export interface SnapshotRender {
+  schema_version: 1;
+  generated_from: "runtimed-wasm:load_snapshot";
+  generated_at: string;
+  notebook_id: string;
+  heads_hash: string;
+  runtime_heads_hash: string | null;
+  source: "snapshot-pair";
+  cells: unknown;
+  blob_urls: Record<string, string>;
+}
+
+export async function materializeSnapshotPairRender(input: {
+  notebookId: string;
+  notebookHeadsHash: string;
+  runtimeHeadsHash: string | null;
+  notebookBytes: Uint8Array;
+  runtimeStateBytes: Uint8Array;
+  blobResolver?: BlobResolver;
+  generatedAt?: string;
+}): Promise<SnapshotRender> {
+  const handle = await loadSnapshotPair(input.notebookBytes, input.runtimeStateBytes);
+  try {
+    const cells = JSON.parse(handle.get_cells_json()) as unknown;
+    return {
+      schema_version: 1,
+      generated_from: "runtimed-wasm:load_snapshot",
+      generated_at: input.generatedAt ?? new Date().toISOString(),
+      notebook_id: input.notebookId,
+      heads_hash: input.notebookHeadsHash,
+      runtime_heads_hash: input.runtimeHeadsHash,
+      source: "snapshot-pair",
+      cells,
+      blob_urls: input.blobResolver ? collectBlobUrls(cells, input.blobResolver) : {},
+    };
+  } finally {
+    handle.free();
+  }
+}
+
+function collectBlobUrls(value: unknown, resolver: BlobResolver): Record<string, string> {
+  const urls: Record<string, string> = {};
+  visitBlobRefs(value, resolver, urls);
+  return urls;
+}
+
+function visitBlobRefs(value: unknown, resolver: BlobResolver, urls: Record<string, string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitBlobRefs(item, resolver, urls);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.blob === "string") {
+    urls[record.blob] = resolver.url({
+      blob: record.blob,
+      size: typeof record.size === "number" ? record.size : undefined,
+      media_type: typeof record.media_type === "string" ? record.media_type : undefined,
+    });
+  }
+
+  for (const item of Object.values(record)) {
+    visitBlobRefs(item, resolver, urls);
+  }
+}

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1,0 +1,358 @@
+import type { AuthenticatedConnection } from "./identity.ts";
+import type { Env } from "./cloudflare-types.ts";
+
+export interface NotebookCatalog {
+  notebook: NotebookRow;
+  revisions: RevisionRow[];
+  blobs: BlobRow[];
+}
+
+export interface NotebookRow {
+  id: string;
+  owner_principal: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+}
+
+export interface RevisionRow {
+  id: string;
+  notebook_id: string;
+  notebook_heads_hash: string;
+  runtime_heads_hash: string | null;
+  snapshot_key: string;
+  runtime_snapshot_key: string | null;
+  actor_label: string;
+  created_at: string;
+}
+
+export interface BlobRow {
+  notebook_id: string;
+  hash: string;
+  size: number;
+  content_type: string | null;
+  r2_key: string;
+  uploaded_at: string;
+}
+
+export interface RoomEventRow {
+  id: string;
+  notebook_id: string;
+  peer_id: string;
+  actor_label: string;
+  connection_scope: string;
+  frame_type: number;
+  byte_length: number;
+  received_at: string;
+}
+
+const SCHEMA_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS notebooks (
+    id TEXT PRIMARY KEY,
+    owner_principal TEXT NOT NULL,
+    title TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    latest_revision_id TEXT
+  )`,
+  `CREATE TABLE IF NOT EXISTS notebook_revisions (
+    id TEXT PRIMARY KEY,
+    notebook_id TEXT NOT NULL,
+    notebook_heads_hash TEXT NOT NULL,
+    runtime_heads_hash TEXT,
+    snapshot_key TEXT NOT NULL,
+    runtime_snapshot_key TEXT,
+    actor_label TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS notebook_blobs (
+    notebook_id TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    content_type TEXT,
+    r2_key TEXT NOT NULL,
+    uploaded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (notebook_id, hash),
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS room_events (
+    id TEXT PRIMARY KEY,
+    notebook_id TEXT NOT NULL,
+    peer_id TEXT NOT NULL,
+    actor_label TEXT NOT NULL,
+    connection_scope TEXT NOT NULL,
+    frame_type INTEGER NOT NULL,
+    byte_length INTEGER NOT NULL,
+    received_at TEXT NOT NULL,
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+];
+
+// Prototype-local schema memo. The Worker binds every room to the same D1
+// database; production multi-binding hosts should scope this per binding.
+let schemaReady: Promise<void> | undefined;
+
+export function snapshotKey(notebookId: string, headsHash: string): string {
+  return `n/${encodePathComponent(notebookId)}/snapshots/${encodePathComponent(headsHash)}.am`;
+}
+
+export function runtimeSnapshotKey(notebookId: string, headsHash: string): string {
+  return `n/${encodePathComponent(notebookId)}/snapshots/runtime-state/${encodePathComponent(headsHash)}.am`;
+}
+
+export function blobKey(notebookId: string, hash: string): string {
+  return `n/${encodePathComponent(notebookId)}/blobs/${encodePathComponent(hash)}`;
+}
+
+export function renderKey(notebookId: string, headsHash: string): string {
+  return `n/${encodePathComponent(notebookId)}/renders/${encodePathComponent(headsHash)}.json`;
+}
+
+export async function ensureCatalogSchema(env: Env): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  schemaReady ??= Promise.all(
+    SCHEMA_STATEMENTS.map((statement) => env.DB!.prepare(statement).run()),
+  )
+    .then(() => undefined)
+    .catch((error: unknown) => {
+      schemaReady = undefined;
+      throw error;
+    });
+
+  await schemaReady;
+}
+
+export async function ensureNotebook(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `INSERT INTO notebooks (id, owner_principal, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at`,
+  )
+    .bind(notebookId, identity.principal, new Date().toISOString())
+    .run();
+}
+
+export async function recordRoomEvent(
+  env: Env,
+  event: {
+    notebookId: string;
+    peerId: string;
+    actorLabel: string;
+    connectionScope: string;
+    frameType: number;
+    byteLength: number;
+    receivedAt: string;
+  },
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `INSERT INTO room_events (
+       id,
+       notebook_id,
+       peer_id,
+       actor_label,
+       connection_scope,
+       frame_type,
+       byte_length,
+       received_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      crypto.randomUUID(),
+      event.notebookId,
+      event.peerId,
+      event.actorLabel,
+      event.connectionScope,
+      event.frameType,
+      event.byteLength,
+      event.receivedAt,
+    )
+    .run();
+}
+
+export async function recordRevision(
+  env: Env,
+  revision: {
+    notebookId: string;
+    notebookHeadsHash: string;
+    runtimeHeadsHash: string | null;
+    snapshotKey: string;
+    runtimeSnapshotKey: string | null;
+    actorLabel: string;
+  },
+): Promise<string> {
+  if (!env.DB) {
+    return crypto.randomUUID();
+  }
+
+  await ensureCatalogSchema(env);
+  const revisionId = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO notebook_revisions (
+       id,
+       notebook_id,
+       notebook_heads_hash,
+       runtime_heads_hash,
+       snapshot_key,
+       runtime_snapshot_key,
+       actor_label
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      revisionId,
+      revision.notebookId,
+      revision.notebookHeadsHash,
+      revision.runtimeHeadsHash,
+      revision.snapshotKey,
+      revision.runtimeSnapshotKey,
+      revision.actorLabel,
+    ),
+    env.DB.prepare(
+      `UPDATE notebooks
+       SET latest_revision_id = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind(revisionId, createdAt, revision.notebookId),
+  ]);
+  return revisionId;
+}
+
+export async function recordBlob(
+  env: Env,
+  blob: {
+    notebookId: string;
+    hash: string;
+    size: number;
+    contentType: string | null;
+    r2Key: string;
+  },
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `INSERT INTO notebook_blobs (
+       notebook_id,
+       hash,
+       size,
+       content_type,
+       r2_key
+     ) VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(notebook_id, hash) DO UPDATE SET
+       size = excluded.size,
+       content_type = excluded.content_type,
+       r2_key = excluded.r2_key,
+       uploaded_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+  )
+    .bind(blob.notebookId, blob.hash, blob.size, blob.contentType, blob.r2Key)
+    .run();
+}
+
+export async function getNotebookCatalog(
+  env: Env,
+  notebookId: string,
+): Promise<NotebookCatalog | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const notebook = await env.DB.prepare(
+    `SELECT id, owner_principal, title, created_at, updated_at, latest_revision_id
+       FROM notebooks
+       WHERE id = ?`,
+  )
+    .bind(notebookId)
+    .first<NotebookRow>();
+
+  if (!notebook) {
+    return null;
+  }
+
+  const revisions = await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            notebook_heads_hash,
+            runtime_heads_hash,
+            snapshot_key,
+            runtime_snapshot_key,
+            actor_label,
+            created_at
+       FROM notebook_revisions
+       WHERE notebook_id = ?
+       ORDER BY created_at DESC
+       LIMIT 50`,
+  )
+    .bind(notebookId)
+    .all<RevisionRow>();
+
+  const blobs = await env.DB.prepare(
+    `SELECT notebook_id, hash, size, content_type, r2_key, uploaded_at
+       FROM notebook_blobs
+       WHERE notebook_id = ?
+       ORDER BY uploaded_at DESC
+       LIMIT 50`,
+  )
+    .bind(notebookId)
+    .all<BlobRow>();
+
+  return {
+    notebook,
+    revisions: revisions.results ?? [],
+    blobs: blobs.results ?? [],
+  };
+}
+
+export async function listRoomEvents(
+  env: Env,
+  notebookId: string,
+  limit: number,
+): Promise<RoomEventRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const result = await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            peer_id,
+            actor_label,
+            connection_scope,
+            frame_type,
+            byte_length,
+            received_at
+       FROM room_events
+       WHERE notebook_id = ?
+       ORDER BY received_at DESC
+       LIMIT ?`,
+  )
+    .bind(notebookId, limit)
+    .all<RoomEventRow>();
+
+  return result.results ?? [];
+}
+
+function encodePathComponent(value: string): string {
+  return encodeURIComponent(value).replaceAll("%2F", "%252F");
+}

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { escapeHtml, scriptJsonForHtml } from "../src/index.ts";
+
+describe("HTML script serialization", () => {
+  it("escapes text and attribute metacharacters", () => {
+    assert.equal(escapeHtml(`<&>"'`), "&lt;&amp;&gt;&quot;&#x27;");
+  });
+
+  it("escapes script-breaking characters", () => {
+    const serialized = scriptJsonForHtml("</script><img src=x onerror=alert(1)>");
+
+    assert.equal(serialized.includes("</script>"), false);
+    assert.equal(serialized.includes("<img"), false);
+    assert.equal(serialized, '"\\u003c/script\\u003e\\u003cimg src=x onerror=alert(1)\\u003e"');
+  });
+});

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -1,0 +1,197 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AuthError,
+  authenticateAnonymousViewer,
+  authenticateDevRequest,
+  authenticateRequest,
+  isAnonymousViewer,
+  parseActorLabel,
+  parseScope,
+  principalForDevUser,
+  readTrustedIdentity,
+  rewriteActorLabelPrincipal,
+  stampTrustedIdentity,
+  validateOperator,
+  validatePrincipal,
+} from "../src/identity.ts";
+
+const localEnv = { DEPLOYMENT_ENV: "development" };
+
+describe("dev identity", () => {
+  it("uses explicit anonymous viewer auth when no dev credential is presented", () => {
+    const identity = authenticateRequest(
+      new Request("https://cloud.test/n/demo/sync?viewer_session=session/a"),
+    );
+
+    assert.deepEqual(identity, {
+      principal: "anonymous:session%2Fa",
+      operator: "browser:session%2Fa",
+      actorLabel: "anonymous:session%2Fa/browser:session%2Fa",
+      scope: "viewer",
+    });
+    assert.equal(isAnonymousViewer(identity), true);
+  });
+
+  it("keeps dev auth explicit instead of treating anonymous viewers as system actors", () => {
+    const anonymous = authenticateAnonymousViewer(
+      new Request("https://cloud.test/n/demo/sync?viewer_session=anon-1"),
+    );
+    const dev = authenticateRequest(
+      new Request("https://cloud.test/n/demo/sync?user=anonymous&operator=desktop:a"),
+      localEnv,
+    );
+
+    assert.equal(anonymous.principal, "anonymous:anon-1");
+    assert.equal(dev.principal, "user:dev:anonymous");
+    assert.equal(anonymous.principal.startsWith("system"), false);
+  });
+
+  it("maps X-User and X-Operator into a layered actor label", () => {
+    const request = new Request("https://cloud.test/n/demo/sync", {
+      headers: {
+        "X-User": "kyle@example.com",
+        "X-Operator": "desktop:test-session",
+        "X-Scope": "editor",
+      },
+    });
+
+    const identity = authenticateDevRequest(request);
+
+    assert.deepEqual(identity, {
+      principal: "user:dev:kyle%40example.com",
+      operator: "desktop:test-session",
+      actorLabel: "user:dev:kyle%40example.com/desktop:test-session",
+      scope: "editor",
+    });
+  });
+
+  it("supports browser query params for the local viewer harness", () => {
+    const request = new Request(
+      "https://cloud.test/n/demo/sync?user=alice&operator=agent:codex:s1&scope=owner",
+    );
+
+    const identity = authenticateDevRequest(request);
+
+    assert.equal(identity.actorLabel, "user:dev:alice/agent:codex:s1");
+    assert.equal(identity.scope, "owner");
+  });
+
+  it("rejects remote dev credentials unless the prototype admin token matches", () => {
+    const request = new Request(
+      "https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner",
+    );
+
+    assert.throws(
+      () => authenticateRequest(request, { DEPLOYMENT_ENV: "prototype" }),
+      (error) => error instanceof AuthError && error.status === 401,
+    );
+
+    const authenticated = authenticateRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner&dev_token=secret",
+      ),
+      { DEPLOYMENT_ENV: "prototype", NOTEBOOK_CLOUD_DEV_TOKEN: "secret" },
+    );
+    assert.equal(authenticated.actorLabel, "user:dev:alice/desktop:a");
+    assert.equal(authenticated.scope, "owner");
+  });
+
+  it("accepts remote dev token from headers and rejects same-prefix guesses", () => {
+    const rejected = new Request("https://cloud.test/n/demo/sync?user=alice", {
+      headers: {
+        "X-Notebook-Cloud-Dev-Token": "secret-guess",
+      },
+    });
+    assert.throws(
+      () =>
+        authenticateRequest(rejected, {
+          DEPLOYMENT_ENV: "prototype",
+          NOTEBOOK_CLOUD_DEV_TOKEN: "secret-token",
+        }),
+      (error) => error instanceof AuthError && error.status === 401,
+    );
+
+    const accepted = new Request("https://cloud.test/n/demo/sync?user=alice", {
+      headers: {
+        "X-Notebook-Cloud-Dev-Token": "secret-token",
+      },
+    });
+    assert.equal(
+      authenticateRequest(accepted, {
+        DEPLOYMENT_ENV: "prototype",
+        NOTEBOOK_CLOUD_DEV_TOKEN: "secret-token",
+      }).principal,
+      "user:dev:alice",
+    );
+  });
+
+  it("allows dev credentials from loopback during wrangler local development", () => {
+    const identity = authenticateRequest(
+      new Request("http://127.0.0.1:8787/n/demo/sync?user=alice&operator=desktop:a"),
+      { DEPLOYMENT_ENV: "prototype" },
+    );
+
+    assert.equal(identity.actorLabel, "user:dev:alice/desktop:a");
+  });
+
+  it("defaults missing dev scope to viewer", () => {
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=anonymous&operator=desktop:a"),
+    );
+
+    assert.equal(identity.scope, "viewer");
+  });
+
+  it("stamps and reads trusted upstream identity headers", () => {
+    const request = new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a");
+    const identity = authenticateDevRequest(request);
+    const stamped = stampTrustedIdentity(request, identity);
+
+    assert.deepEqual(readTrustedIdentity(stamped), identity);
+  });
+
+  it("rewrites presence actor principal while preserving the operator suffix", () => {
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a"),
+    );
+
+    assert.equal(
+      rewriteActorLabelPrincipal("user:dev:mallory/agent:codex:s2", identity),
+      "user:dev:alice/agent:codex:s2",
+    );
+    assert.equal(rewriteActorLabelPrincipal("desktop:b", identity), "user:dev:alice/desktop:b");
+  });
+
+  it("validates the same principal and operator shape as nteract-identity", () => {
+    for (const value of ["system", "system:anonymous", "local:kylekelley", "user:anaconda:550e"]) {
+      assert.doesNotThrow(() => validatePrincipal(value));
+    }
+    for (const value of ["", "local", "local:", ":alice", "local/foo"]) {
+      assert.throws(() => validatePrincipal(value));
+    }
+    for (const value of ["desktop:7f3a", "agent:codex:s2", "runtime:py-3.12-s4"]) {
+      assert.doesNotThrow(() => validateOperator(value));
+    }
+    for (const value of ["", ":claude:s1", "agent/claude:s1"]) {
+      assert.throws(() => validateOperator(value));
+    }
+  });
+
+  it("parses actor labels and scopes explicitly", () => {
+    assert.deepEqual(parseActorLabel("user:dev:alice/desktop:a"), {
+      value: "user:dev:alice/desktop:a",
+      principal: "user:dev:alice",
+      operator: "desktop:a",
+    });
+    assert.equal(parseScope("runtime_peer"), "runtime_peer");
+    assert.throws(() => parseScope("admin"), /unknown connection scope/);
+  });
+
+  it("percent-encodes dev principal components", () => {
+    assert.equal(
+      principalForDevUser("alice/bob@example.com"),
+      "user:dev:alice%2Fbob%40example.com",
+    );
+  });
+});

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -47,6 +47,16 @@ describe("dev identity", () => {
     assert.equal(anonymous.principal.startsWith("system"), false);
   });
 
+  it("does not treat a bare scope parameter as dev authentication", () => {
+    const identity = authenticateRequest(
+      new Request("https://cloud.test/n/demo/sync?scope=viewer&viewer_session=anon-scope"),
+      { DEPLOYMENT_ENV: "prototype" },
+    );
+
+    assert.equal(identity.actorLabel, "anonymous:anon-scope/browser:anon-scope");
+    assert.equal(identity.scope, "viewer");
+  });
+
   it("maps X-User and X-Operator into a layered actor label", () => {
     const request = new Request("https://cloud.test/n/demo/sync", {
       headers: {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1,0 +1,253 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import type { CloudflareWebSocket, DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import { authenticateAnonymousViewer, authenticateDevRequest } from "../src/identity.ts";
+import { NotebookRoom, rewritePresenceFrame, shouldBroadcastFrame } from "../src/notebook-room.ts";
+import {
+  FrameType,
+  decodeJsonPayload,
+  encodeTypedFrame,
+  splitTypedFrame,
+} from "../src/protocol.ts";
+import {
+  decodePresenceFrame,
+  encodePresenceFrame,
+  initializeRuntimedWasm,
+} from "../src/runtimed-wasm.ts";
+
+const wasmBytes = await readFile(
+  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
+);
+
+before(async () => {
+  await initializeRuntimedWasm(wasmBytes);
+});
+
+describe("NotebookRoom presence rewrite", () => {
+  it("rewrites canonical CBOR presence to the server peer and authenticated principal", async () => {
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const payload = await encodePresenceFrame({
+      type: "update",
+      peer_id: "client-forged-peer",
+      peer_label: "Mallory",
+      actor_label: "user:dev:mallory/agent:codex:s1",
+      channel: "cursor",
+      data: { cell_id: "cell-1", line: 2, column: 4 },
+    });
+    const frame = splitTypedFrame(encodeTypedFrame(FrameType.PRESENCE, payload));
+
+    const rewritten = await rewritePresenceFrame(frame, { id: "server-peer", identity });
+    const body = (await decodePresenceFrame(rewritten.payload)) as Record<string, unknown>;
+
+    assert.equal(rewritten.type, FrameType.PRESENCE);
+    assert.equal(body.peer_id, "server-peer");
+    assert.equal(body.peer_label, "user:dev:alice");
+    assert.equal(body.actor_label, "user:dev:alice/agent:codex:s1");
+  });
+
+  it("falls back to the authenticated operator for invalid presented actor labels", async () => {
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const payload = await encodePresenceFrame({
+      type: "update",
+      peer_id: "client-peer",
+      peer_label: "Mallory",
+      actor_label: "/bad",
+      channel: "focus",
+      data: { cell_id: "cell-1" },
+    });
+    const frame = splitTypedFrame(encodeTypedFrame(FrameType.PRESENCE, payload));
+
+    const rewritten = await rewritePresenceFrame(frame, { id: "server-peer", identity });
+    const body = (await decodePresenceFrame(rewritten.payload)) as Record<string, unknown>;
+
+    assert.equal(rewritten.type, FrameType.PRESENCE);
+    assert.equal(body.actor_label, "user:dev:alice/desktop:a");
+    assert.equal(body.peer_label, "user:dev:alice");
+  });
+
+  it("rejects non-CBOR presence payloads", async () => {
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const frame = splitTypedFrame(
+      encodeTypedFrame(
+        FrameType.PRESENCE,
+        new TextEncoder().encode(JSON.stringify({ actor_label: identity.actorLabel })),
+      ),
+    );
+
+    await assert.rejects(
+      () => rewritePresenceFrame(frame, { id: "server-peer", identity }),
+      /CBOR decode error/,
+    );
+  });
+
+  it("keeps anonymous viewer presence local to the connection", async () => {
+    const anonymous = authenticateAnonymousViewer(
+      new Request("https://cloud.test/n/demo/sync?viewer_session=anon-a"),
+    );
+    const editor = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const frame = splitTypedFrame(
+      encodeTypedFrame(
+        FrameType.PRESENCE,
+        await encodePresenceFrame({
+          type: "heartbeat",
+          peer_id: "anonymous-client",
+        }),
+      ),
+    );
+
+    assert.equal(shouldBroadcastFrame(frame, anonymous), false);
+    assert.equal(shouldBroadcastFrame(frame, editor), true);
+  });
+});
+
+describe("NotebookRoom peer lifecycle", () => {
+  it("does not silently resurrect a removed hibernated peer", () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    socket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "peer-a",
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    });
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+
+    harness.removePeer("demo", peer);
+
+    assert.equal(socket.closed, true);
+    assert.equal(harness.peerForSocket(socket.asCloudflareWebSocket()), undefined);
+  });
+
+  it("broadcasts the original frame before peer-left cleanup for failed peers", () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const staleIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=stale&operator=desktop:a&scope=editor"),
+    );
+    const healthyIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=healthy&operator=desktop:b&scope=editor"),
+    );
+    const staleSocket = new FakeSocket({ throwOnSend: true });
+    const healthySocket = new FakeSocket();
+    const stalePeer = {
+      id: "stale",
+      socket: staleSocket.asCloudflareWebSocket(),
+      identity: staleIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const healthyPeer = {
+      id: "healthy",
+      socket: healthySocket.asCloudflareWebSocket(),
+      identity: healthyIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(stalePeer.id, stalePeer);
+    harness.peers.set(healthyPeer.id, healthyPeer);
+
+    harness.broadcastFrame("demo", new Uint8Array([FrameType.AUTOMERGE_SYNC, 42]));
+
+    assert.equal(healthySocket.sent.length, 2);
+    assert.deepEqual([...healthySocket.sent[0]], [FrameType.AUTOMERGE_SYNC, 42]);
+    assert.equal(healthySocket.sent[1][0], FrameType.SESSION_CONTROL);
+    assert.equal(
+      decodeJsonPayload<Record<string, unknown>>(healthySocket.sent[1].slice(1)).type,
+      "cloud_peer_left",
+    );
+    assert.equal(staleSocket.closed, true);
+  });
+});
+
+type PeerForTest = {
+  id: string;
+  socket: CloudflareWebSocket;
+  identity: ReturnType<typeof authenticateDevRequest>;
+  connectedAt: string;
+};
+
+interface RoomHarness {
+  peers: Map<string, PeerForTest>;
+  removePeer(notebookId: string, peer: PeerForTest): void;
+  peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
+  broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;
+}
+
+function roomHarness(room: NotebookRoom): RoomHarness {
+  return room as unknown as RoomHarness;
+}
+
+function fakeState(): DurableObjectState {
+  const values = new Map<string, unknown>();
+  return {
+    id: { toString: () => "room-id" },
+    storage: {
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => values.delete(key),
+      list: async <T>() => new Map(values as Map<string, T>),
+    },
+    waitUntil: () => undefined,
+  };
+}
+
+class FakeSocket {
+  readonly sent: Uint8Array[] = [];
+  closed = false;
+  private attachment: unknown;
+
+  constructor(private readonly options: { throwOnSend?: boolean } = {}) {}
+
+  accept(): void {}
+
+  addEventListener(): void {}
+
+  send(message: string | ArrayBuffer | ArrayBufferView): void {
+    if (this.options.throwOnSend) {
+      throw new Error("send failed");
+    }
+
+    if (typeof message === "string") {
+      this.sent.push(new TextEncoder().encode(message));
+    } else if (message instanceof ArrayBuffer) {
+      this.sent.push(new Uint8Array(message));
+    } else {
+      this.sent.push(new Uint8Array(message.buffer, message.byteOffset, message.byteLength));
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  serializeAttachment(value: unknown): void {
+    this.attachment = value;
+  }
+
+  deserializeAttachment(): unknown {
+    return this.attachment;
+  }
+
+  asCloudflareWebSocket(): CloudflareWebSocket {
+    return this as unknown as CloudflareWebSocket;
+  }
+}

--- a/apps/notebook-cloud/test/protocol.test.ts
+++ b/apps/notebook-cloud/test/protocol.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FrameType,
+  decodeJsonPayload,
+  encodeJsonFrame,
+  encodeTypedFrame,
+  frameSizeLimits,
+  frameTypeName,
+  isClientWritableFrame,
+  splitTypedFrame,
+} from "../src/protocol.ts";
+
+describe("typed-frame protocol helpers", () => {
+  it("encodes and splits v4-shaped typed frames", () => {
+    const payload = new Uint8Array([1, 2, 3]);
+    const frame = encodeTypedFrame(FrameType.AUTOMERGE_SYNC, payload);
+
+    assert.deepEqual([...frame], [FrameType.AUTOMERGE_SYNC, 1, 2, 3]);
+    assert.deepEqual(splitTypedFrame(frame), {
+      type: FrameType.AUTOMERGE_SYNC,
+      payload,
+    });
+  });
+
+  it("uses session-control JSON for room status", () => {
+    const frame = encodeJsonFrame(FrameType.SESSION_CONTROL, {
+      type: "cloud_frame_accepted",
+      notebook_id: "demo",
+      peer_id: "peer",
+      frame_type: FrameType.PRESENCE,
+      byte_length: 4,
+      timestamp: "2026-05-22T00:00:00.000Z",
+    });
+
+    const split = splitTypedFrame(frame);
+
+    assert.equal(split.type, FrameType.SESSION_CONTROL);
+    assert.deepEqual(
+      {
+        ...(decodeJsonPayload(split.payload) as Record<string, unknown>),
+        timestamp: undefined,
+      },
+      {
+        type: "cloud_frame_accepted",
+        notebook_id: "demo",
+        peer_id: "peer",
+        frame_type: FrameType.PRESENCE,
+        byte_length: 4,
+        timestamp: undefined,
+      },
+    );
+  });
+
+  it("names and gates client writable frames", () => {
+    assert.equal(frameTypeName(FrameType.RUNTIME_STATE_SYNC), "runtime_state_sync");
+    assert.equal(isClientWritableFrame(FrameType.AUTOMERGE_SYNC), true);
+    assert.equal(isClientWritableFrame(FrameType.SESSION_CONTROL), false);
+  });
+
+  it("mirrors notebook-wire per-frame payload size limits", () => {
+    assert.equal(frameSizeLimits(FrameType.AUTOMERGE_SYNC).cap, 64 * 1024 * 1024);
+    assert.equal(frameSizeLimits(FrameType.RUNTIME_STATE_SYNC).cap, 64 * 1024 * 1024);
+    assert.equal(frameSizeLimits(FrameType.PUT_BLOB).cap, 32 * 1024 * 1024);
+    assert.equal(frameSizeLimits(FrameType.REQUEST).cap, 16 * 1024 * 1024);
+    assert.equal(frameSizeLimits(FrameType.PRESENCE).cap, 1024 * 1024);
+  });
+
+  it("rejects empty and unknown typed frames", () => {
+    assert.throws(() => splitTypedFrame(new Uint8Array()), /typed frame cannot be empty/);
+    assert.throws(() => splitTypedFrame(new Uint8Array([255])), /unknown frame type 255/);
+  });
+});

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -1,0 +1,96 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
+import { materializeSnapshotPairRender } from "../src/snapshot-render.ts";
+import { createNotebookCloudBlobResolver } from "../src/blob-resolver.ts";
+
+const wasmBytes = await readFile(
+  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
+);
+
+before(async () => {
+  await initializeRuntimedWasm(wasmBytes);
+});
+
+describe("snapshot pair render materialization", () => {
+  it("loads NotebookDoc + RuntimeStateDoc bytes and preserves output manifests", async () => {
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+
+    const render = await materializeSnapshotPairRender({
+      notebookId: "fixture-output-streaming",
+      notebookHeadsHash: "heads-fixture",
+      runtimeHeadsHash: "runtime-fixture",
+      notebookBytes,
+      runtimeStateBytes,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    });
+    const cells = render.cells as Array<Record<string, unknown>>;
+    const outputs = cells[0].outputs as Array<Record<string, unknown>>;
+
+    assert.equal(render.generated_from, "runtimed-wasm:load_snapshot");
+    assert.equal(render.source, "snapshot-pair");
+    assert.equal(cells.length, 1);
+    assert.equal(cells[0].id, "cell-1");
+    assert.deepEqual(
+      outputs.map((output) => output.output_id),
+      [
+        "c8b09c2d-a456-5186-b875-441a5fadf374",
+        "58af4526-9a90-5bca-98de-d8d0e36718b2",
+        "cad63e3f-42e3-542b-b28b-5d3acde7906d",
+      ],
+    );
+  });
+
+  it("derives hosted blob URLs through the shared BlobResolver surface", async () => {
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+
+    const render = await materializeSnapshotPairRender({
+      notebookId: "fixture-display-data",
+      notebookHeadsHash: "heads-fixture",
+      runtimeHeadsHash: "runtime-fixture",
+      notebookBytes,
+      runtimeStateBytes,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+      blobResolver: createNotebookCloudBlobResolver({
+        baseUrl: "https://cloud.test/n/fixture-display-data",
+        notebookId: "fixture-display-data",
+      }),
+    });
+    const blobUrls = Object.values(render.blob_urls);
+
+    assert.ok(blobUrls.length > 0, "fixture should contain at least one blob ref");
+    assert.ok(
+      blobUrls.every((url) =>
+        url.startsWith("https://cloud.test/api/n/fixture-display-data/blobs/"),
+      ),
+      `unexpected blob URL set: ${JSON.stringify(render.blob_urls)}`,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1,0 +1,346 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import worker from "../src/index.ts";
+import type {
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  DurableObjectNamespace,
+  Env,
+  ExecutionContext,
+  R2Bucket,
+  R2HTTPMetadata,
+  R2Object,
+  R2ObjectBody,
+  R2PutOptions,
+} from "../src/cloudflare-types.ts";
+import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
+import { renderKey } from "../src/storage.ts";
+
+const wasmBytes = await readFile(
+  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
+);
+
+before(async () => {
+  await initializeRuntimedWasm(wasmBytes);
+});
+
+describe("Worker artifact routes", () => {
+  it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
+    const env = fakeEnv();
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/route-demo/runtime-snapshots/runtime-fixture",
+      runtimeStateBytes,
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const notebookPut = await ownerPut(
+      env,
+      "/api/n/route-demo/snapshots/heads-fixture",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-fixture",
+      },
+    );
+    assert.equal(notebookPut.status, 201);
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/render"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(response.status, 200);
+    const render = (await response.json()) as {
+      source: string;
+      cells: Array<{ id: string; outputs: Array<{ output_id: string }> }>;
+    };
+
+    assert.equal(render.source, "snapshot-pair");
+    assert.equal(render.cells[0].id, "cell-1");
+    assert.deepEqual(
+      render.cells[0].outputs.map((output) => output.output_id),
+      [
+        "c8b09c2d-a456-5186-b875-441a5fadf374",
+        "58af4526-9a90-5bca-98de-d8d0e36718b2",
+        "cad63e3f-42e3-542b-b28b-5d3acde7906d",
+      ],
+    );
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("route-demo", "heads-fixture")),
+      true,
+      "materialized render should be cached back into R2",
+    );
+  });
+});
+
+async function ownerPut(
+  env: FakeEnv,
+  pathname: string,
+  body: Uint8Array,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(pathname, "http://localhost"), {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "owner",
+        ...headers,
+      },
+      body,
+    }),
+    env,
+    fakeContext(),
+  );
+}
+
+interface FakeEnv extends Env {
+  DB: FakeD1;
+  NOTEBOOK_SNAPSHOTS: FakeR2Bucket;
+}
+
+function fakeEnv(): FakeEnv {
+  return {
+    DEPLOYMENT_ENV: "development",
+    DB: new FakeD1(),
+    NOTEBOOK_SNAPSHOTS: new FakeR2Bucket(),
+    NOTEBOOK_ROOMS: {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async () => new Response("not implemented", { status: 501 }),
+      }),
+    } satisfies DurableObjectNamespace,
+  };
+}
+
+function fakeContext(): ExecutionContext {
+  return {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  };
+}
+
+interface NotebookRow {
+  id: string;
+  owner_principal: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+}
+
+interface RevisionRow {
+  id: string;
+  notebook_id: string;
+  notebook_heads_hash: string;
+  runtime_heads_hash: string | null;
+  snapshot_key: string;
+  runtime_snapshot_key: string | null;
+  actor_label: string;
+  created_at: string;
+}
+
+class FakeD1 implements D1Database {
+  readonly notebooks = new Map<string, NotebookRow>();
+  readonly revisions: RevisionRow[] = [];
+
+  prepare(query: string): D1PreparedStatement {
+    return new FakeD1Statement(this, query);
+  }
+
+  async exec(): Promise<D1Result> {
+    return okResult();
+  }
+
+  async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    const results: D1Result<T>[] = [];
+    for (const statement of statements) {
+      results.push(await statement.run<T>());
+    }
+    return results;
+  }
+}
+
+class FakeD1Statement implements D1PreparedStatement {
+  private values: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeD1,
+    private readonly query: string,
+  ) {}
+
+  bind(...values: unknown[]): D1PreparedStatement {
+    this.values = values;
+    return this;
+  }
+
+  async run<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("INSERT INTO notebooks")) {
+      const [id, ownerPrincipal, updatedAt] = this.values as [string, string, string];
+      const existing = this.db.notebooks.get(id);
+      this.db.notebooks.set(id, {
+        id,
+        owner_principal: existing?.owner_principal ?? ownerPrincipal,
+        title: existing?.title ?? null,
+        created_at: existing?.created_at ?? updatedAt,
+        updated_at: updatedAt,
+        latest_revision_id: existing?.latest_revision_id ?? null,
+      });
+    } else if (this.query.includes("INSERT INTO notebook_revisions")) {
+      const [
+        id,
+        notebookId,
+        notebookHeadsHash,
+        runtimeHeadsHash,
+        snapshotKey,
+        runtimeSnapshotKey,
+        actorLabel,
+      ] = this.values as [string, string, string, string | null, string, string | null, string];
+      this.db.revisions.push({
+        id,
+        notebook_id: notebookId,
+        notebook_heads_hash: notebookHeadsHash,
+        runtime_heads_hash: runtimeHeadsHash,
+        snapshot_key: snapshotKey,
+        runtime_snapshot_key: runtimeSnapshotKey,
+        actor_label: actorLabel,
+        created_at: new Date().toISOString(),
+      });
+    } else if (this.query.includes("UPDATE notebooks")) {
+      const [revisionId, updatedAt, notebookId] = this.values as [string, string, string];
+      const existing = this.db.notebooks.get(notebookId);
+      if (existing) {
+        existing.latest_revision_id = revisionId;
+        existing.updated_at = updatedAt;
+      }
+    }
+    return okResult();
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM notebooks")) {
+      return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;
+    }
+    return null;
+  }
+
+  async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("FROM notebook_revisions")) {
+      const notebookId = this.values[0] as string;
+      return okResult(
+        this.db.revisions.filter((revision) => revision.notebook_id === notebookId) as T[],
+      );
+    }
+    return okResult([]);
+  }
+}
+
+function okResult<T = unknown>(results?: T[]): D1Result<T> {
+  return {
+    results,
+    success: true,
+    meta: {},
+  };
+}
+
+class FakeR2Bucket implements R2Bucket {
+  readonly objects = new Map<string, FakeR2Object>();
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    return this.objects.get(key) ?? null;
+  }
+
+  async head(key: string): Promise<R2Object | null> {
+    return this.objects.get(key) ?? null;
+  }
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+    options?: R2PutOptions,
+  ): Promise<R2Object> {
+    const object = new FakeR2Object(key, await toBytes(value), options?.httpMetadata);
+    this.objects.set(key, object);
+    return object;
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+}
+
+class FakeR2Object implements R2ObjectBody {
+  readonly version = "fake-version";
+  readonly etag = "fake-etag";
+  readonly httpEtag = '"fake-etag"';
+  readonly uploaded = new Date("2026-05-22T00:00:00.000Z");
+  readonly customMetadata = {};
+
+  constructor(
+    readonly key: string,
+    private readonly bytes: Uint8Array,
+    readonly httpMetadata?: R2HTTPMetadata,
+  ) {}
+
+  get size(): number {
+    return this.bytes.byteLength;
+  }
+
+  get body(): ReadableStream {
+    return new Response(this.bytes).body!;
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    return this.bytes.buffer.slice(
+      this.bytes.byteOffset,
+      this.bytes.byteOffset + this.bytes.byteLength,
+    );
+  }
+
+  async text(): Promise<string> {
+    return new TextDecoder().decode(this.bytes);
+  }
+
+  writeHttpMetadata(headers: Headers): void {
+    if (this.httpMetadata?.contentType) {
+      headers.set("Content-Type", this.httpMetadata.contentType);
+    }
+  }
+}
+
+async function toBytes(
+  value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+): Promise<Uint8Array> {
+  if (value === null) {
+    return new Uint8Array();
+  }
+  if (typeof value === "string") {
+    return new TextEncoder().encode(value);
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return new Uint8Array(await new Response(value).arrayBuffer());
+}

--- a/apps/notebook-cloud/tsconfig.json
+++ b/apps/notebook-cloud/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -1,0 +1,27 @@
+name = "nteract-notebook-cloud"
+main = "./src/index.ts"
+compatibility_date = "2024-11-06"
+compatibility_flags = ["nodejs_compat"]
+
+[dev]
+port = 8787
+
+[[durable_objects.bindings]]
+name = "NOTEBOOK_ROOMS"
+class_name = "NotebookRoom"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["NotebookRoom"]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "nteract-notebook-cloud-prototype-db"
+database_id = "59decd97-a3d4-4442-abe7-50b465cb347e"
+
+[[r2_buckets]]
+binding = "NOTEBOOK_SNAPSHOTS"
+bucket_name = "nteract-notebook-cloud-prototype"
+
+[vars]
+DEPLOYMENT_ENV = "prototype"

--- a/docs/architecture/deployment-topology.md
+++ b/docs/architecture/deployment-topology.md
@@ -45,7 +45,7 @@ Sections to fill in:
 
 - *Who can do what* (lives in `identity-and-trust.md`).
 - Wire protocol (lives in `crates/notebook-wire/AGENTS.md`).
-- Storage shape for snapshots and blobs (separate forthcoming ADR alongside the hosted-room prototype).
+- Storage shape for snapshots and blobs (see `hosted-notebook-artifacts.md`).
 - Specific ACL semantics (separate forthcoming ADR).
 
 ## Status

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -1,0 +1,128 @@
+# Hosted Notebook Artifacts
+
+**Status:** Draft, 2026-05-22.
+
+## Context
+
+Hosted notebook rooms need to serve two related workflows:
+
+1. A live room that relays typed-frame v4 sync and presence.
+2. A published viewer at `/n/:notebookId` that can load without the publisher's local daemon.
+
+The tempting shortcut is a publish bundle JSON that contains projected cells,
+executions, blobs, and output render data. That would create a second durable
+notebook format next to `NotebookDoc`, `RuntimeStateDoc`, and `.ipynb`.
+
+The shared runtime work now gives us a cleaner path:
+
+- `NotebookDoc` persists cells, metadata, ordering, and execution pointers.
+- `RuntimeStateDoc` persists executions and output manifests by execution id.
+- `runtimed-wasm` can load a persisted `NotebookDoc` + `RuntimeStateDoc` pair
+  with `NotebookHandle.load_snapshot()`.
+- JS hosts have a shared `BlobResolver` surface, so blob references can stay as
+  `{ "blob": "<sha256>" }` until the host maps them to a URL.
+- The Worker can use shared typed-frame size limits and shared CBOR presence
+  helpers instead of local protocol copies.
+
+## Decision 1: Durable publish artifacts are snapshot pairs
+
+A published revision is durable when these artifacts exist:
+
+- Notebook snapshot: saved `NotebookDoc` bytes.
+- Runtime snapshot: saved `RuntimeStateDoc` bytes.
+- Blob objects: content-addressed output bytes referenced by output manifests.
+- Catalog row: D1 metadata tying the above artifacts to a notebook id and heads.
+
+The revision row records:
+
+- `notebook_heads_hash`
+- `runtime_heads_hash`
+- `snapshot_key`
+- `runtime_snapshot_key`
+- `actor_label`
+
+Render caches may exist, but they are derived caches. They are not the source of
+truth and can be regenerated from the snapshot pair.
+
+## Decision 2: R2 layout is deterministic
+
+For a notebook `n/:id`:
+
+```text
+n/{id}/snapshots/{notebookHeadsHash}.am
+n/{id}/snapshots/runtime-state/{runtimeHeadsHash}.am
+n/{id}/blobs/{sha256}
+n/{id}/renders/{notebookHeadsHash}.json
+```
+
+The render path is optional. The first three paths are the durable publish
+artifact set.
+
+## Decision 3: Materialization uses runtimed-wasm
+
+Hosted viewers and room hosts materialize published revisions by calling:
+
+```ts
+NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes)
+```
+
+Then they read cells through the same WASM handle APIs that the desktop viewer
+uses. This keeps execution-id lookup and output manifest projection in the Rust
+runtime document code rather than duplicating projection in a Worker-local JSON
+format.
+
+In the current prototype the Worker materializes a JSON render response on
+request. The next viewer step is to move this materialized model into the real
+isolated output renderer path instead of the temporary JSON/pre text renderer.
+
+## Decision 4: Blob refs stay host-neutral
+
+Runtime output manifests keep blob references as structured refs such as:
+
+```json
+{ "blob": "sha256-...", "size": 1234 }
+```
+
+WASM does not rewrite these into daemon-local HTTP URLs. The host provides a
+`BlobResolver`:
+
+- Desktop resolver: maps refs to the local daemon blob HTTP port.
+- Cloud resolver: maps refs to `/api/n/:id/blobs/:hash` or a future signed blob
+  origin.
+
+This keeps the storage and rendering model independent of where the blob bytes
+live.
+
+## Decision 5: Presence stays typed-frame v4 CBOR
+
+Cloud rooms relay frame type `0x04` as canonical nteract presence CBOR. The
+Worker decodes and rewrites ingress presence with shared `runtimed-wasm`
+helpers:
+
+- overwrite the peer id with the server-assigned peer id,
+- rewrite actor labels to the authenticated principal while preserving the
+  operator suffix,
+- reject malformed/non-CBOR presence instead of rebroadcasting a local shim.
+
+Anonymous public viewers can connect with viewer scope and send local presence,
+but the prototype keeps anonymous presence connection-local until the product
+decision for public viewer presence is settled.
+
+## Non-Goals
+
+- This ADR does not define ACL semantics; that belongs with identity and room
+  authorization.
+- This ADR does not require hosted rooms to run kernels. Runtime snapshots can
+  be imported from a local daemon or future remote runtime peer.
+- This ADR does not define the final blob origin. `/api/n/:id/blobs/:hash` is a
+  prototype origin; a separate output-blob origin with signed URLs remains open.
+
+## Open Questions
+
+1. Whether `/n/:id` should materialize in the Worker, in the browser, or both.
+2. How the isolated output renderer bundle should be packaged for the cloud
+   viewer.
+3. How to publish large Arrow/Sift outputs efficiently without routing all
+   artifact bytes through a single Worker request.
+4. Whether public anonymous viewer presence should be visible to editors or
+   remain connection-local.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      runtimed:
+        specifier: workspace:*
+        version: link:packages/runtimed
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,9 +192,6 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
-      runtimed:
-        specifier: workspace:*
-        version: link:packages/runtimed
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -486,6 +483,22 @@ importers:
       ws:
         specifier: ^8.20.0
         version: 8.20.0
+
+  apps/notebook-cloud:
+    dependencies:
+      runtimed:
+        specifier: workspace:*
+        version: link:../../packages/runtimed
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.37
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   apps/renderer-test:
     dependencies:
@@ -20182,7 +20195,7 @@ snapshots:
       deepmerge-ts: 5.1.0
       got: 12.6.1
       ky: 0.33.3
-      ws: 8.19.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer


### PR DESCRIPTION
## Summary

This takes the notebook-cloud Worker spike out of PR #2804 and rebases the first hosted-viewer slice onto the merged foundations:

- adds `apps/notebook-cloud` as a Wrangler/Durable Object prototype for `/n/:id/sync`, `/n/:id`, and artifact APIs
- uses shared `runtimed` typed-frame size limits instead of Worker-local constants
- rewrites real presence frame `0x04` CBOR with the shared `runtimed-wasm` ingress helper
- persists published revisions as `NotebookDoc` + `RuntimeStateDoc` snapshot pairs in R2, with D1 catalog rows pointing at both
- materializes `/api/n/:id/render` from `NotebookHandle.load_snapshot()` when no render cache exists
- maps output blob refs through the shared `BlobResolver` surface for cloud URLs
- adds `docs/architecture/hosted-notebook-artifacts.md` to pin the storage/materialization contract

## Current limitations

- The DO is still a typed-frame relay, not yet a full `runtimed-wasm` room peer.
- The HTML viewer still uses a temporary built-in renderer for cells/outputs; the next slice should wire the shared isolated output renderer bundle.
- Anonymous viewer presence is accepted locally but not broadcast to other peers.
- Dev auth is gated for deployed prototypes, but this is not the final OIDC/JupyterHub auth path.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud exec wrangler deploy --config wrangler.toml --dry-run`
- `pnpm --dir apps/notebook-cloud smoke` against local Wrangler
- `pnpm --dir apps/notebook-cloud publish:demo` against local Wrangler
- `pnpm --dir apps/notebook-cloud wasm:roundtrip` against local Wrangler
- `cargo xtask lint --fix`
- Bedrock Claude Opus 4.6 review of the code slice found six issues; follow-up commit `f8ac77a8` addressed them and the follow-up review found no new actionable bugs.

Keeping this draft until CI and external review clear.
