### PR TITLE
feat(notebook-cloud): render published outputs through shared iframe

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -4,7 +4,7 @@ This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It 
 
 The current Durable Object does not host kernels and does not parse Automerge sync messages. It enforces connection scope, rewrites canonical CBOR presence through the shared `runtimed-wasm` helper, stores bounded frame metadata, and broadcasts accepted binary typed frames to other peers in the same room.
 
-`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface.
+`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses `createNteractOutputEmbed()` so published markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the shared isolated output renderer path.
 
 ## Local dev
 
@@ -12,6 +12,7 @@ The current Durable Object does not host kernels and does not parse Automerge sy
 pnpm --dir apps/notebook-cloud typecheck
 pnpm --dir apps/notebook-cloud test
 pnpm --dir apps/notebook-cloud wasm
+pnpm --dir apps/notebook-cloud build:viewer
 pnpm --dir apps/notebook-cloud dev
 ```
 
@@ -20,6 +21,7 @@ With Wrangler running:
 ```bash
 pnpm --dir apps/notebook-cloud smoke
 pnpm --dir apps/notebook-cloud publish:demo
+pnpm --dir apps/notebook-cloud publish:fixture
 ```
 
 The smoke script proves:
@@ -64,6 +66,16 @@ http://127.0.0.1:8787/n/nteract-cloud-demo
 
 `/` redirects to that demo notebook id.
 
+`publish:fixture` defaults to `packages/runtimed/tests/fixtures/output_streaming`
+and publishes a notebook revision with real `RuntimeStateDoc` output manifests:
+
+```text
+http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming
+```
+
+Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
+`NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair.
+
 ## Dev auth
 
 The edge Worker maps dev credentials into the same identity shape as `crates/nteract-identity`:
@@ -107,6 +119,7 @@ Bindings in `wrangler.toml`:
 - `NOTEBOOK_ROOMS`: Durable Object namespace, one object per notebook id.
 - `DB`: D1 catalog for notebooks, revisions, blobs, and room event metadata.
 - `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, generated render caches, and blobs.
+- `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 
 Schema lives in `migrations/0001_initial.sql`. The Worker also creates the same tables lazily in local dev so the WebSocket path can run before applying migrations.
 
@@ -146,7 +159,7 @@ Deploy with:
 printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
   | pnpm --workspace-root exec wrangler secret put NOTEBOOK_CLOUD_DEV_TOKEN \
       --config apps/notebook-cloud/wrangler.toml
-pnpm --dir apps/notebook-cloud wasm
+pnpm --dir apps/notebook-cloud build
 pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml
 ```
 
@@ -184,6 +197,5 @@ curl "http://127.0.0.1:8787/api/n/demo/render"
 ## Next integration steps
 
 1. Move the Durable Object from byte relay to a real `runtimed-wasm` room peer.
-2. Connect the HTML viewer to the shared isolated output renderer bundle.
-3. Publish a full Sift/Arrow fixture and verify blob-backed output rendering.
-4. Swap dev auth for OIDC/JupyterHub providers using the `nteract-identity` model.
+2. Publish a full Sift/Arrow fixture and verify blob-backed table rendering.
+3. Swap dev auth for OIDC/JupyterHub providers using the `nteract-identity` model.

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -4,11 +4,15 @@
   "type": "module",
   "scripts": {
     "wasm": "cargo xtask wasm runtimed --skip-renderer-plugins",
+    "renderer-plugins": "cargo xtask renderer-plugins",
+    "build:viewer": "vp build -c vite.config.ts && node scripts/copy-viewer-assets.mjs",
+    "build": "pnpm run wasm && pnpm run renderer-plugins && pnpm run build:viewer",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts",
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",
+    "publish:fixture": "node scripts/publish-fixture.mjs",
     "wasm:roundtrip": "node --import tsx scripts/wasm-roundtrip.mjs"
   },
   "dependencies": {
@@ -17,6 +21,8 @@
   "devDependencies": {
     "@types/node": "^20.10.0",
     "tsx": "^4.21.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
   }
 }

--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -1,0 +1,22 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { access } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
+const outputUrl = new URL("../dist/plugins/sift_wasm.wasm", import.meta.url);
+
+await assertExists(siftWasmUrl);
+await mkdir(new URL("../dist/plugins/", import.meta.url), { recursive: true });
+await copyFile(siftWasmUrl, outputUrl);
+
+console.log(`copied ${fileURLToPath(siftWasmUrl)} -> ${fileURLToPath(outputUrl)}`);
+
+async function assertExists(url) {
+  try {
+    await access(fileURLToPath(url));
+  } catch {
+    throw new Error(
+      "Missing crates/sift-wasm/pkg/sift_wasm_bg.wasm. Run `cargo xtask renderer-plugins` first.",
+    );
+  }
+}

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
+const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? `nteract-cloud-fixture-${fixtureName}`;
+const fixtureRoot = new URL(
+  `../../../packages/runtimed/tests/fixtures/${fixtureName}/`,
+  import.meta.url,
+);
+const wasmJsUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBytesUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+await assertExists(wasmJsUrl);
+await assertExists(wasmBytesUrl);
+await assertExists(new URL("doc.bin", fixtureRoot));
+await assertExists(new URL("state_doc.bin", fixtureRoot));
+
+const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
+const wasmBytes = await readFile(wasmBytesUrl);
+initSync({ module: wasmBytes });
+
+const [snapshotBytes, runtimeSnapshotBytes] = await Promise.all([
+  readFile(new URL("doc.bin", fixtureRoot)),
+  readFile(new URL("state_doc.bin", fixtureRoot)),
+]);
+const handle = NotebookHandle.load_snapshot(snapshotBytes, runtimeSnapshotBytes);
+const headsHash = headsDigest(handle.get_heads_hex());
+const runtimeHeadsHash = headsDigest(handle.get_runtime_state_heads_hex());
+const cells = JSON.parse(handle.get_cells_json());
+handle.free();
+
+await putBytes(
+  `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
+  runtimeSnapshotBytes,
+  "application/octet-stream",
+);
+await putBytes(
+  `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
+  snapshotBytes,
+  "application/octet-stream",
+  {
+    "X-Runtime-Heads-Hash": runtimeHeadsHash,
+  },
+);
+
+const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
+assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      baseUrl,
+      fixtureName,
+      notebookId,
+      viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      headsHash,
+      runtimeHeadsHash,
+      cells: cells.length,
+      outputs: cells.reduce(
+        (count, cell) => count + (Array.isArray(cell.outputs) ? cell.outputs.length : 0),
+        0,
+      ),
+      checks: [
+        "fixture_snapshot_pair_publish",
+        "runtime_state_output_manifests",
+        "latest_snapshot_materialization",
+      ],
+    },
+    null,
+    2,
+  ),
+);
+
+function headsDigest(heads) {
+  const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
+  return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+async function putBytes(pathname, body, contentType, extraHeaders = {}) {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    method: "PUT",
+    headers: publishHeaders(contentType, extraHeaders),
+    body,
+  });
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+function publishHeaders(contentType, extraHeaders) {
+  return {
+    "Content-Type": contentType,
+    "X-User": "fixture",
+    "X-Operator": "agent:publish-fixture",
+    "X-Scope": "owner",
+    ...devAuthHeaders(),
+    ...extraHeaders,
+  };
+}
+
+function devAuthHeaders() {
+  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
+}
+
+async function fetchJson(pathname) {
+  const response = await fetch(new URL(pathname, baseUrl));
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+async function assertOk(response, pathname) {
+  if (response.ok) return;
+  throw new Error(`${pathname} returned ${response.status}: ${await response.text()}`);
+}
+
+async function assertExists(url) {
+  try {
+    await access(fileURLToPath(url));
+  } catch {
+    throw new Error(`Missing ${fileURLToPath(url)}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -2,8 +2,13 @@ export interface Env {
   NOTEBOOK_ROOMS: DurableObjectNamespace;
   DB?: D1Database;
   NOTEBOOK_SNAPSHOTS?: R2Bucket;
+  ASSETS?: WorkerAssets;
   DEPLOYMENT_ENV?: string;
   NOTEBOOK_CLOUD_DEV_TOKEN?: string;
+}
+
+export interface WorkerAssets {
+  fetch(request: Request): Promise<Response>;
 }
 
 export interface ExecutionContext {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -36,6 +36,11 @@ const worker: ExportedHandler<Env> = {
       return withCors(new Response(null, { status: 204 }));
     }
 
+    const assetResponse = await routeAsset(request, env);
+    if (assetResponse) {
+      return assetResponse;
+    }
+
     if (url.pathname === "/api/health" && request.method === "GET") {
       await safeEnsureCatalogSchema(env, ctx);
       return json({
@@ -141,6 +146,19 @@ const worker: ExportedHandler<Env> = {
 };
 
 export default worker;
+
+async function routeAsset(request: Request, env: Env): Promise<Response | null> {
+  const pathname = new URL(request.url).pathname;
+  if (!pathname.startsWith("/assets/") && !pathname.startsWith("/plugins/")) {
+    return null;
+  }
+  if (!env.ASSETS) {
+    return json({ error: "viewer assets are not configured" }, 503);
+  }
+
+  const response = await env.ASSETS.fetch(request);
+  return withCors(new Response(response.body, response));
+}
 
 async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
@@ -632,6 +650,16 @@ function normalizedRuntimeHeadsHash(value: string | null): string | null {
 function viewer(notebookId: string, headsHash?: string): Response {
   const escaped = escapeHtml(notebookId);
   const title = headsHash ? `${escaped} @ ${escapeHtml(headsHash)}` : escaped;
+  const renderEndpoint = headsHash
+    ? `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`
+    : `/api/n/${encodeURIComponent(notebookId)}/render`;
+  const config = {
+    notebookId,
+    headsHash: headsHash ?? null,
+    renderEndpoint,
+    syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
+    blobBasePath: `/api/n/${encodeURIComponent(notebookId)}/blobs/`,
+  };
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -646,7 +674,7 @@ function viewer(notebookId: string, headsHash?: string): Response {
       color: CanvasText;
     }
     body { margin: 0; }
-    main { width: min(960px, calc(100vw - 32px)); margin: 0 auto; padding: 32px 0 48px; }
+    main { width: min(1040px, calc(100vw - 32px)); margin: 0 auto; padding: 32px 0 48px; }
     header { display: flex; gap: 16px; justify-content: space-between; align-items: flex-start; margin-bottom: 28px; }
     h1 { font-size: 24px; line-height: 1.2; margin: 0 0 8px; }
     .meta { display: flex; flex-wrap: wrap; gap: 8px 16px; color: color-mix(in srgb, CanvasText 62%, transparent); font-size: 13px; }
@@ -680,16 +708,16 @@ function viewer(notebookId: string, headsHash?: string): Response {
     }
     .cell[data-type="code"] { border-left-color: #4f46e5; }
     .cell[data-type="markdown"] { border-left-color: #0f766e; }
+    .cell[data-rendering="pending"] { opacity: 0.72; }
     .cell-label {
       font-size: 12px;
       color: color-mix(in srgb, CanvasText 56%, transparent);
       margin-bottom: 6px;
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     }
-    .markdown { line-height: 1.55; }
-    .markdown h2, .markdown h3, .markdown p, .markdown ul { margin: 0 0 10px; }
-    .markdown h2 { font-size: 21px; }
-    .markdown h3 { font-size: 17px; }
+    .source {
+      margin-bottom: 10px;
+    }
     pre {
       margin: 0;
       border: 1px solid color-mix(in srgb, CanvasText 14%, transparent);
@@ -699,7 +727,21 @@ function viewer(notebookId: string, headsHash?: string): Response {
       background: color-mix(in srgb, Canvas 90%, CanvasText 10%);
     }
     code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 13px; }
-    .outputs { margin-top: 8px; }
+    .outputs {
+      display: grid;
+      gap: 10px;
+      margin-top: 10px;
+    }
+    .output-embed, .markdown-embed {
+      min-height: 1px;
+    }
+    .render-error {
+      color: #b42318;
+      border: 1px solid color-mix(in srgb, #b42318 42%, transparent);
+      border-radius: 6px;
+      padding: 10px 12px;
+      background: color-mix(in srgb, #b42318 7%, Canvas);
+    }
     @media (max-width: 640px) {
       main { width: min(100vw - 24px, 960px); padding-top: 20px; }
       header { display: block; }
@@ -726,149 +768,8 @@ function viewer(notebookId: string, headsHash?: string): Response {
     <div id="state" class="state">Loading notebook snapshot...</div>
     <section id="notebook" class="notebook" aria-label="Notebook cells"></section>
   </main>
-  <script type="module">
-    const notebookId = ${scriptJsonForHtml(notebookId)};
-    const pinnedHeadsHash = ${scriptJsonForHtml(headsHash ?? null)};
-    const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
-    const state = document.querySelector("#state");
-    const notebook = document.querySelector("#notebook");
-    const revision = document.querySelector("#revision");
-    const connection = document.querySelector("#connection");
-    const renderEndpoint = pinnedHeadsHash
-      ? "/api/n/" + encodeURIComponent(notebookId) + "/renders/" + encodeURIComponent(pinnedHeadsHash)
-      : "/api/n/" + encodeURIComponent(notebookId) + "/render";
-
-    connectAnonymousViewer();
-    loadNotebook();
-
-    async function loadNotebook() {
-      try {
-        const response = await fetch(renderEndpoint, { headers: { Accept: "application/json" } });
-        if (!response.ok) {
-          showState(response.status === 404
-            ? "No published snapshot is available for this notebook yet."
-            : "Unable to load notebook render: " + response.status,
-            response.status === 404 ? "empty" : "error");
-          return;
-        }
-        const render = await response.json();
-        renderNotebook(render);
-      } catch (error) {
-        showState("Unable to load notebook: " + String(error), "error");
-      }
-    }
-
-    function renderNotebook(render) {
-      const cells = Array.isArray(render.cells) ? render.cells : [];
-      revision.textContent = render.heads_hash ? "Revision " + render.heads_hash : "";
-      notebook.replaceChildren();
-      if (cells.length === 0) {
-        showState("This published notebook has no cells.", "empty");
-        return;
-      }
-      const source = render.source === "snapshot-pair" ? "snapshot pair" : "render cache";
-      showState("Rendered " + cells.length + " cells from a persisted " + source + ".", "ready");
-      for (const cell of cells) {
-        notebook.append(renderCell(cell));
-      }
-    }
-
-    function renderCell(cell) {
-      const type = typeof cell.cell_type === "string" ? cell.cell_type : "code";
-      const id = typeof cell.id === "string" ? cell.id : "cell";
-      const source = typeof cell.source === "string" ? cell.source : "";
-      const section = document.createElement("article");
-      section.className = "cell";
-      section.dataset.type = type;
-
-      const label = document.createElement("div");
-      label.className = "cell-label";
-      label.textContent = type + " - " + id;
-      section.append(label);
-
-      if (type === "markdown") {
-        const markdown = document.createElement("div");
-        markdown.className = "markdown";
-        renderMarkdown(markdown, source);
-        section.append(markdown);
-      } else {
-        const pre = document.createElement("pre");
-        const code = document.createElement("code");
-        code.textContent = source;
-        pre.append(code);
-        section.append(pre);
-      }
-
-      if (Array.isArray(cell.outputs) && cell.outputs.length > 0) {
-        const outputs = document.createElement("pre");
-        outputs.className = "outputs";
-        outputs.textContent = JSON.stringify(cell.outputs, null, 2);
-        section.append(outputs);
-      }
-
-      return section;
-    }
-
-    function renderMarkdown(container, source) {
-      const lines = source.split(/\\r?\\n/);
-      let list;
-      for (const line of lines) {
-        if (line.startsWith("## ")) {
-          list = undefined;
-          appendText(container, "h3", line.slice(3));
-        } else if (line.startsWith("# ")) {
-          list = undefined;
-          appendText(container, "h2", line.slice(2));
-        } else if (line.startsWith("- ")) {
-          if (!list) {
-            list = document.createElement("ul");
-            container.append(list);
-          }
-          appendText(list, "li", line.slice(2));
-        } else if (line.trim() === "") {
-          list = undefined;
-        } else {
-          list = undefined;
-          appendText(container, "p", line);
-        }
-      }
-    }
-
-    function appendText(parent, tagName, text) {
-      const element = document.createElement(tagName);
-      element.textContent = text;
-      parent.append(element);
-    }
-
-    function connectAnonymousViewer() {
-      const url = new URL("/n/" + encodeURIComponent(notebookId) + "/sync", location.href);
-      url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
-      url.searchParams.set("viewer_session", sessionId);
-      const socket = new WebSocket(url);
-      socket.binaryType = "arraybuffer";
-      socket.addEventListener("open", () => {
-        connection.textContent = "anonymous viewer connected";
-      });
-      socket.addEventListener("close", () => {
-        connection.textContent = "anonymous viewer disconnected";
-      });
-      socket.addEventListener("message", async (event) => {
-        const bytes = new Uint8Array(event.data);
-        if (bytes[0] !== 0x07) {
-          return;
-        }
-        const message = JSON.parse(new TextDecoder().decode(bytes.slice(1)));
-        if (message.type === "cloud_room_ready") {
-          connection.textContent = message.actor_label + " (" + message.connection_scope + ")";
-        }
-      });
-    }
-
-    function showState(message, kind) {
-      state.textContent = message;
-      state.dataset.kind = kind;
-    }
-  </script>
+  <script id="nteract-cloud-viewer-config" type="application/json">${scriptJsonForHtml(config)}</script>
+  <script type="module" src="/assets/notebook-cloud-viewer.js"></script>
 </body>
 </html>`;
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { escapeHtml, scriptJsonForHtml } from "../src/index.ts";
+import worker, { escapeHtml, scriptJsonForHtml } from "../src/index.ts";
+import type { DurableObjectNamespace, Env, ExecutionContext } from "../src/cloudflare-types.ts";
 
 describe("HTML script serialization", () => {
   it("escapes text and attribute metacharacters", () => {
@@ -14,4 +15,47 @@ describe("HTML script serialization", () => {
     assert.equal(serialized.includes("<img"), false);
     assert.equal(serialized, '"\\u003c/script\\u003e\\u003cimg src=x onerror=alert(1)\\u003e"');
   });
+
+  it("escapes script-breaking characters inside objects", () => {
+    const serialized = scriptJsonForHtml({
+      notebookId: "</script><img src=x onerror=alert(1)>",
+    });
+
+    assert.equal(serialized.includes("</script>"), false);
+    assert.equal(serialized.includes("<img"), false);
+    assert.match(serialized, /"notebookId":"\\u003c\/script\\u003e/);
+  });
+
+  it("serves the notebook viewer as a shell backed by the shared viewer bundle", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/r/heads-123"),
+      fakeEnv(),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /id="nteract-cloud-viewer-config"/);
+    assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.match(html, /"renderEndpoint":"\/api\/n\/demo\/renders\/heads-123"/);
+    assert.doesNotMatch(html, /function renderNotebook/);
+  });
 });
+
+function fakeEnv(): Env {
+  return {
+    NOTEBOOK_ROOMS: {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async () => new Response("not implemented", { status: 501 }),
+      }),
+    } satisfies DurableObjectNamespace,
+  };
+}
+
+function fakeContext(): ExecutionContext {
+  return {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  };
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -27,6 +27,27 @@ before(async () => {
 });
 
 describe("Worker artifact routes", () => {
+  it("serves viewer bundle assets through the Worker assets binding", async () => {
+    const env = fakeEnv({
+      ASSETS: {
+        fetch: async () =>
+          new Response("console.log('viewer')", {
+            headers: { "Content-Type": "application/javascript" },
+          }),
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/assets/notebook-cloud-viewer.js"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(await response.text(), "console.log('viewer')");
+  });
+
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes] = await Promise.all([
@@ -118,8 +139,8 @@ interface FakeEnv extends Env {
   NOTEBOOK_SNAPSHOTS: FakeR2Bucket;
 }
 
-function fakeEnv(): FakeEnv {
-  return {
+function fakeEnv(overrides: Partial<Env> = {}): FakeEnv {
+  const env: FakeEnv = {
     DEPLOYMENT_ENV: "development",
     DB: new FakeD1(),
     NOTEBOOK_SNAPSHOTS: new FakeR2Bucket(),
@@ -130,6 +151,8 @@ function fakeEnv(): FakeEnv {
       }),
     } satisfies DurableObjectNamespace,
   };
+  Object.assign(env, overrides);
+  return env;
 }
 
 function fakeContext(): ExecutionContext {

--- a/apps/notebook-cloud/tsconfig.json
+++ b/apps/notebook-cloud/tsconfig.json
@@ -12,7 +12,11 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": "../..",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "viewer"]
 }

--- a/apps/notebook-cloud/viewer/index.ts
+++ b/apps/notebook-cloud/viewer/index.ts
@@ -1,0 +1,256 @@
+import { createNteractOutputEmbed } from "@/components/isolated/output-embed";
+import type { NteractEmbeddableOutput } from "@/components/isolated/embeddable-output";
+import type { NteractOutputEmbedHandle } from "@/components/isolated/output-embed";
+import { createBlobResolver } from "runtimed";
+
+interface CloudViewerConfig {
+  notebookId: string;
+  headsHash: string | null;
+  renderEndpoint: string;
+  syncEndpoint: string;
+  blobBasePath: string;
+}
+
+interface SnapshotRender {
+  heads_hash?: string;
+  source?: string;
+  cells?: unknown;
+}
+
+interface RenderCell {
+  id?: unknown;
+  cell_type?: unknown;
+  source?: unknown;
+  execution_count?: unknown;
+  outputs?: unknown;
+}
+
+const rendererBundle = () => import("virtual:isolated-renderer");
+const handles = new Set<NteractOutputEmbedHandle>();
+
+function requireElement<T extends Element = HTMLElement>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`Missing cloud viewer element ${selector}`);
+  }
+  return element;
+}
+
+function loadConfig(): CloudViewerConfig {
+  const element = requireElement<HTMLScriptElement>("#nteract-cloud-viewer-config");
+  const parsed = JSON.parse(element.textContent ?? "{}") as Partial<CloudViewerConfig>;
+  if (
+    !parsed.notebookId ||
+    !parsed.renderEndpoint ||
+    !parsed.syncEndpoint ||
+    !parsed.blobBasePath
+  ) {
+    throw new Error("Cloud viewer config is incomplete");
+  }
+  return {
+    notebookId: parsed.notebookId,
+    headsHash: parsed.headsHash ?? null,
+    renderEndpoint: parsed.renderEndpoint,
+    syncEndpoint: parsed.syncEndpoint,
+    blobBasePath: parsed.blobBasePath,
+  };
+}
+
+const config = loadConfig();
+const state = requireElement("#state");
+const notebook = requireElement("#notebook");
+const revision = requireElement("#revision");
+const connection = requireElement("#connection");
+
+const blobResolver = createBlobResolver({
+  url(ref) {
+    return new URL(`${config.blobBasePath}${encodeURIComponent(ref.blob)}`, location.href).href;
+  },
+});
+
+connectAnonymousViewer();
+void loadNotebook();
+
+window.addEventListener("beforeunload", () => {
+  for (const handle of handles) {
+    handle.dispose();
+  }
+  handles.clear();
+});
+
+async function loadNotebook(): Promise<void> {
+  try {
+    const response = await fetch(config.renderEndpoint, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) {
+      showState(
+        response.status === 404
+          ? "No published snapshot is available for this notebook yet."
+          : `Unable to load notebook render: ${response.status}`,
+        response.status === 404 ? "empty" : "error",
+      );
+      return;
+    }
+    renderNotebook((await response.json()) as SnapshotRender);
+  } catch (error) {
+    showState(`Unable to load notebook: ${String(error)}`, "error");
+  }
+}
+
+function renderNotebook(render: SnapshotRender): void {
+  const cells = Array.isArray(render.cells) ? (render.cells as RenderCell[]) : [];
+  revision.textContent = render.heads_hash ? `Revision ${render.heads_hash}` : "";
+  for (const handle of handles) {
+    handle.dispose();
+  }
+  handles.clear();
+  notebook.replaceChildren();
+
+  if (cells.length === 0) {
+    showState("This published notebook has no cells.", "empty");
+    return;
+  }
+
+  const source = render.source === "snapshot-pair" ? "snapshot pair" : "render cache";
+  showState(`Rendering ${cells.length} cells from a persisted ${source}.`, "ready");
+  for (const cell of cells) {
+    notebook.append(renderCell(cell));
+  }
+}
+
+function renderCell(cell: RenderCell): HTMLElement {
+  const type = typeof cell.cell_type === "string" ? cell.cell_type : "code";
+  const id = typeof cell.id === "string" ? cell.id : "cell";
+  const source = typeof cell.source === "string" ? cell.source : "";
+  const section = document.createElement("article");
+  section.className = "cell";
+  section.dataset.type = type;
+  section.dataset.rendering = "pending";
+
+  const label = document.createElement("div");
+  label.className = "cell-label";
+  label.textContent = labelText(type, id, cell.execution_count);
+  section.append(label);
+
+  if (type === "markdown") {
+    const markdown = document.createElement("div");
+    markdown.className = "markdown-embed";
+    section.append(markdown);
+    mountOutputEmbed(markdown, markdownOutput(source), section);
+  } else {
+    const pre = document.createElement("pre");
+    pre.className = "source";
+    const code = document.createElement("code");
+    code.textContent = source;
+    pre.append(code);
+    section.append(pre);
+  }
+
+  const outputs = Array.isArray(cell.outputs) ? cell.outputs : [];
+  if (outputs.length > 0) {
+    const outputContainer = document.createElement("div");
+    outputContainer.className = "outputs";
+    section.append(outputContainer);
+    mountOutputEmbed(outputContainer, outputs, section);
+  } else if (type !== "markdown") {
+    section.dataset.rendering = "complete";
+  }
+
+  return section;
+}
+
+function labelText(type: string, id: string, executionCount: unknown): string {
+  const count =
+    typeof executionCount === "number" ||
+    (typeof executionCount === "string" && executionCount !== "null")
+      ? ` [${executionCount}]`
+      : "";
+  return `${type}${count} - ${id}`;
+}
+
+function markdownOutput(source: string): unknown {
+  return {
+    output_type: "display_data",
+    data: {
+      "text/markdown": source,
+    },
+    metadata: {},
+  };
+}
+
+function mountOutputEmbed(target: HTMLElement, output: unknown, section: HTMLElement): void {
+  const embeddableOutput = output as NteractEmbeddableOutput | readonly NteractEmbeddableOutput[];
+  const handle = createNteractOutputEmbed({
+    target,
+    output: embeddableOutput,
+    rendererBundle,
+    blobResolver,
+    maxHeight: 760,
+    hostContext: hostContext(),
+    onDiagnostic(phase, details, level) {
+      if (phase === "render-complete") {
+        section.dataset.rendering = "complete";
+      }
+      if (level === "error") {
+        showRenderError(target, `${phase}: ${JSON.stringify(details ?? {})}`);
+      }
+    },
+    onError(error) {
+      showRenderError(target, error.message);
+      section.dataset.rendering = "error";
+    },
+  });
+  handles.add(handle);
+}
+
+function hostContext() {
+  const language = navigator.language || "en-US";
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return {
+    theme: matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+    locale: language,
+    timeZone,
+    userAgent: navigator.userAgent,
+    platform: "web",
+  } as const;
+}
+
+function showRenderError(target: HTMLElement, message: string): void {
+  if (target.querySelector(".render-error")) return;
+  const error = document.createElement("div");
+  error.className = "render-error";
+  error.textContent = message;
+  target.append(error);
+}
+
+function connectAnonymousViewer(): void {
+  const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
+  const url = new URL(config.syncEndpoint, location.href);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("viewer_session", sessionId);
+
+  const socket = new WebSocket(url);
+  socket.binaryType = "arraybuffer";
+  socket.addEventListener("open", () => {
+    connection.textContent = "anonymous viewer connected";
+  });
+  socket.addEventListener("close", () => {
+    connection.textContent = "anonymous viewer disconnected";
+  });
+  socket.addEventListener("message", async (event) => {
+    const bytes = new Uint8Array(event.data);
+    if (bytes[0] !== 0x07) {
+      return;
+    }
+    const message = JSON.parse(new TextDecoder().decode(bytes.slice(1))) as Record<string, unknown>;
+    if (message.type === "cloud_room_ready") {
+      connection.textContent = `${message.actor_label} (${message.connection_scope})`;
+    }
+  });
+}
+
+function showState(message: string, kind: string): void {
+  state.textContent = message;
+  state.setAttribute("data-kind", kind);
+}

--- a/apps/notebook-cloud/viewer/vite-env.d.ts
+++ b/apps/notebook-cloud/viewer/vite-env.d.ts
@@ -1,0 +1,34 @@
+declare module "virtual:isolated-renderer" {
+  export const rendererCode: string;
+  export const rendererCss: string;
+}
+
+declare module "*.html?raw" {
+  const source: string;
+  export default source;
+}
+
+declare module "virtual:renderer-plugin/markdown" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/vega" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/plotly" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/leaflet" {
+  export const code: string;
+  export const css: string;
+}
+
+declare module "virtual:renderer-plugin/sift" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/notebook-cloud/vite.config.ts
+++ b/apps/notebook-cloud/vite.config.ts
@@ -1,0 +1,45 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite-plus";
+import { isolatedRendererPlugin } from "../notebook/vite-plugin-isolated-renderer";
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(appDir, "../..");
+
+export default defineConfig({
+  plugins: [isolatedRendererPlugin()],
+  resolve: {
+    alias: {
+      "@/": path.join(repoRoot, "src") + "/",
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: false,
+    lib: {
+      entry: path.join(appDir, "viewer/index.ts"),
+      formats: ["es"],
+      fileName: () => "assets/notebook-cloud-viewer.js",
+    },
+    rolldownOptions: {
+      output: {
+        entryFileNames: "assets/notebook-cloud-viewer.js",
+        chunkFileNames: "assets/[name]-[hash].js",
+        assetFileNames: "assets/[name]-[hash].[ext]",
+      },
+      onwarn(warning, warn) {
+        if (
+          warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+          warning.message?.includes('"use client"')
+        ) {
+          return;
+        }
+        warn(warning);
+      },
+    },
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+});

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -23,5 +23,9 @@ database_id = "59decd97-a3d4-4442-abe7-50b465cb347e"
 binding = "NOTEBOOK_SNAPSHOTS"
 bucket_name = "nteract-notebook-cloud-prototype"
 
+[assets]
+directory = "./dist"
+binding = "ASSETS"
+
 [vars]
 DEPLOYMENT_ENV = "prototype"

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -72,8 +72,10 @@ runtime document code rather than duplicating projection in a Worker-local JSON
 format.
 
 In the current prototype the Worker materializes a JSON render response on
-request. The next viewer step is to move this materialized model into the real
-isolated output renderer path instead of the temporary JSON/pre text renderer.
+request. The browser viewer consumes that response with the framework-agnostic
+`createNteractOutputEmbed()` surface, so markdown cells, rich display data,
+stdout/stderr, Plotly/Vega/Leaflet, and Sift-style table outputs go through the
+same isolated renderer path as desktop instead of a Worker-local DOM renderer.
 
 ## Decision 4: Blob refs stay host-neutral
 
@@ -93,7 +95,29 @@ WASM does not rewrite these into daemon-local HTTP URLs. The host provides a
 This keeps the storage and rendering model independent of where the blob bytes
 live.
 
-## Decision 5: Presence stays typed-frame v4 CBOR
+## Decision 5: The cloud viewer is a static bundle, not a forked app
+
+The Worker still owns notebook identity, artifact routes, and room WebSockets.
+The viewer UI is a static browser bundle served from Worker assets:
+
+```text
+/assets/notebook-cloud-viewer.js
+/assets/* dynamic renderer chunks
+/plugins/sift_wasm.wasm
+```
+
+The bundle imports the shared isolated output embed API and the existing
+renderer plugin virtual modules. It receives notebook-specific configuration
+from the Worker HTML shell as JSON:
+
+- render endpoint (`/api/n/:id/render` or pinned `/renders/:headsHash`);
+- sync endpoint for anonymous viewer-scope presence;
+- blob base path (`/api/n/:id/blobs/`).
+
+This keeps the cloud app from copying desktop renderer code while still leaving
+room host and artifact serving inside the Worker.
+
+## Decision 6: Presence stays typed-frame v4 CBOR
 
 Cloud rooms relay frame type `0x04` as canonical nteract presence CBOR. The
 Worker decodes and rewrites ingress presence with shared `runtimed-wasm`
@@ -119,10 +143,9 @@ decision for public viewer presence is settled.
 
 ## Open Questions
 
-1. Whether `/n/:id` should materialize in the Worker, in the browser, or both.
-2. How the isolated output renderer bundle should be packaged for the cloud
-   viewer.
-3. How to publish large Arrow/Sift outputs efficiently without routing all
+1. Whether `/n/:id` should eventually stream materialized cells into the browser
+   instead of returning one render JSON response.
+2. How to publish large Arrow/Sift outputs efficiently without routing all
    artifact bytes through a single Worker request.
-4. Whether public anonymous viewer presence should be visible to editors or
+3. Whether public anonymous viewer presence should be visible to editors or
    remain connection-local.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,12 @@ importers:
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
+      vite:
+        specifier: 'catalog:'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
 
   apps/renderer-test:
     dependencies:
@@ -14730,6 +14736,47 @@ snapshots:
       - utf-8-validate
       - yaml
 
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.1.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      ws: 8.20.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 20.19.37
+      jsdom: 29.0.2
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - yaml
+
   '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -19956,6 +20003,51 @@ snapshots:
       '@oxc-project/types': 0.123.0
       '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      oxfmt: 0.43.0
+      oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
+      oxlint-tsgolint: 0.20.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.16
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.16
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.16
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.16
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.16
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.16
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.16
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.16
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - utf-8-validate
+      - vite
+      - yaml
+
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
+    dependencies:
+      '@oxc-project/types': 0.123.0
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.17.19)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0


### PR DESCRIPTION
## Summary

This is stacked on #2809 (`quod/notebook-cloud-shared-viewer`). It turns the notebook-cloud viewer from an inline debug renderer into a real static bundle that reuses the shared isolated output renderer path.

- builds `/assets/notebook-cloud-viewer.js` with Vite and the existing `isolatedRendererPlugin`
- serves viewer assets and plugin wasm through the Worker static assets binding
- renders markdown and code-cell outputs through `createNteractOutputEmbed()` with the shared renderer bundle
- maps cloud blob refs through the shared `createBlobResolver()` surface to `/api/n/:id/blobs/:hash`
- adds a fixture publish script that loads existing `doc.bin` + `state_doc.bin` snapshots with `NotebookHandle.load_snapshot()` and proves RuntimeStateDoc output manifests materialize into the viewer
- documents the current hosted-artifact reality in the ADR: snapshot pairs are durable, the browser viewer is a static bundle, and render-cache JSON is a compatibility/cache layer rather than the durable source of truth

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --dir apps/notebook-cloud exec wrangler deploy --config wrangler.toml --dry-run`
- local Wrangler smoke:
  - `pnpm --dir apps/notebook-cloud publish:demo`
  - `pnpm --dir apps/notebook-cloud publish:fixture`
  - Playwright loaded `/n/nteract-cloud-demo` and `/n/nteract-cloud-fixture-output_streaming`; both reached `data-rendering="complete"` with no console errors
  - fixture iframe text rendered `0\n\n1\n\n2\n`

## Notes

This does not yet ship the full Polars/Sift notebook fixture. The Sift renderer chunk and `sift_wasm.wasm` are included in the viewer asset build, but the end-to-end fixture here is the existing `output_streaming` RuntimeStateDoc fixture so the PR stays focused and reviewable.
