### PR TITLE
feat(renderer): configure plugin asset base

### DIFF
--- a/apps/notebook-cloud/viewer/index.ts
+++ b/apps/notebook-cloud/viewer/index.ts
@@ -213,6 +213,9 @@ function hostContext() {
     timeZone,
     userAgent: navigator.userAgent,
     platform: "web",
+    nteract: {
+      rendererAssetsBaseUrl: new URL("/api/plugins/", location.href).href,
+    },
   } as const;
 }
 

--- a/src/components/isolated/host-context.ts
+++ b/src/components/isolated/host-context.ts
@@ -40,6 +40,11 @@ export interface NteractEmbedHostContext {
   safeAreaInsets?: NteractEmbedSafeAreaInsets;
   nteract?: {
     colorTheme?: string | null;
+    /**
+     * Absolute or host-relative base URL for renderer sidecar assets loaded
+     * from inside isolated output iframes, e.g. Sift's WASM binary.
+     */
+    rendererAssetsBaseUrl?: string;
   };
 }
 

--- a/src/isolated-renderer/__tests__/sift-assets.test.ts
+++ b/src/isolated-renderer/__tests__/sift-assets.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveSiftWasmUrl } from "../sift-assets";
+
+describe("Sift renderer assets", () => {
+  it("uses an explicit renderer asset base when the host provides one", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+      }),
+    ).toBe("https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev");
+  });
+
+  it("supports host-relative renderer asset bases for Worker/CDN routes", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "/api/plugins/",
+      }),
+    ).toBe("https://notebooks.example/api/plugins/sift_wasm.wasm?v=dev");
+  });
+
+  it("falls back to the daemon-style plugin route on the blob URL origin", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "http://127.0.0.1:49152/api/n/demo/blobs/sha256-abc",
+      }),
+    ).toBe("http://127.0.0.1:49152/plugins/sift_wasm.wasm?v=dev");
+  });
+});

--- a/src/isolated-renderer/__tests__/sift-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/sift-renderer.test.tsx
@@ -1,0 +1,66 @@
+import { render } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import type {
+  RendererHostContext,
+  RendererInstallContext,
+  RendererProps,
+} from "@/lib/renderer-registry";
+import { install } from "../sift-renderer";
+
+const siftMocks = vi.hoisted(() => ({
+  setWasmUrl: vi.fn(),
+}));
+
+vi.mock("@nteract/sift", () => ({
+  setWasmUrl: siftMocks.setWasmUrl,
+  SiftFocusStatus: () => null,
+  SiftTable: () => <div data-testid="sift-table" />,
+}));
+
+describe("Sift renderer plugin", () => {
+  it("reconfigures WASM when a renderer asset base arrives after first render", () => {
+    let hostContext: RendererHostContext | undefined;
+    const hostContextListeners = new Set<
+      Parameters<RendererInstallContext["subscribeHostContext"]>[0]
+    >();
+    let Renderer: ComponentType<RendererProps> | undefined;
+
+    install({
+      register: (_mimeTypes, component) => {
+        Renderer = component;
+      },
+      registerPattern: vi.fn(),
+      getHostContext: () => hostContext,
+      subscribeHostContext: (listener) => {
+        hostContextListeners.add(listener);
+        return () => hostContextListeners.delete(listener);
+      },
+    });
+
+    expect(Renderer).toBeDefined();
+    render(
+      <Renderer
+        data="https://notebooks.example/api/n/demo/blobs/sha256-abc"
+        mimeType="application/vnd.apache.parquet"
+      />,
+    );
+
+    expect(siftMocks.setWasmUrl).toHaveBeenLastCalledWith(
+      "https://notebooks.example/plugins/sift_wasm.wasm?v=dev",
+    );
+
+    hostContext = {
+      nteract: {
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+      },
+    };
+    for (const listener of hostContextListeners) {
+      listener(hostContext);
+    }
+
+    expect(siftMocks.setWasmUrl).toHaveBeenLastCalledWith(
+      "https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev",
+    );
+  });
+});

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -70,13 +70,14 @@ import "@/components/widgets/controls";
 // The registry lives in @/lib/renderer-registry so that both OutputRenderer
 // and MediaRouter (used by output widgets) can look up installed renderers.
 
-import type { ComponentType } from "react";
 import {
-  type RendererProps,
+  type RendererInstallContext,
   getRenderer,
   registerRenderer,
   registerRendererPattern,
 } from "@/lib/renderer-registry";
+
+const rendererPluginHostContextListeners = new Set<(context: NteractEmbedHostContext) => void>();
 
 /**
  * Load and install a renderer plugin.
@@ -96,15 +97,7 @@ function installRendererPlugin(code: string, css?: string) {
   // eslint-disable-next-line no-new-func -- CJS loader pattern
   new Function("module", "exports", "require", code)(mod, mod.exports, customRequire);
 
-  const install = mod.exports.install as
-    | ((ctx: {
-        register: (mimeTypes: string[], component: ComponentType<RendererProps>) => void;
-        registerPattern: (
-          test: (mime: string) => boolean,
-          component: ComponentType<RendererProps>,
-        ) => void;
-      }) => void)
-    | undefined;
+  const install = mod.exports.install as ((ctx: RendererInstallContext) => void) | undefined;
 
   if (typeof install !== "function") {
     throw new Error("[renderer-plugin] Plugin does not export an install() function");
@@ -113,6 +106,11 @@ function installRendererPlugin(code: string, css?: string) {
   install({
     register: registerRenderer,
     registerPattern: registerRendererPattern,
+    getHostContext: () => currentHostContext,
+    subscribeHostContext: (listener) => {
+      rendererPluginHostContextListeners.add(listener);
+      return () => rendererPluginHostContextListeners.delete(listener);
+    },
   });
 
   if (css) {
@@ -256,6 +254,9 @@ function applyHostContext(contextPatch: NteractEmbedHostContextPatch) {
   // Parent-side height and width guards are load-bearing: this resize must not
   // create an unbounded host-context <-> size-changed feedback loop.
   window.dispatchEvent(new Event("resize"));
+  for (const listener of rendererPluginHostContextListeners) {
+    listener(currentHostContext);
+  }
 }
 
 // --- Message Handling ---

--- a/src/isolated-renderer/sift-assets.ts
+++ b/src/isolated-renderer/sift-assets.ts
@@ -1,0 +1,27 @@
+declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
+
+const SIFT_WASM_CACHE_KEY =
+  typeof __SIFT_WASM_CACHE_KEY__ === "string" ? __SIFT_WASM_CACHE_KEY__ : "dev";
+
+export interface ResolveSiftWasmUrlOptions {
+  tableUrl: string;
+  rendererAssetsBaseUrl?: string;
+}
+
+function withTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+export function resolveSiftWasmUrl({
+  tableUrl,
+  rendererAssetsBaseUrl,
+}: ResolveSiftWasmUrlOptions): string {
+  const parsedTableUrl = new URL(tableUrl);
+  const assetsBase = rendererAssetsBaseUrl?.trim();
+  const wasmUrl = assetsBase
+    ? new URL("sift_wasm.wasm", withTrailingSlash(new URL(assetsBase, parsedTableUrl.origin).href))
+    : new URL("/plugins/sift_wasm.wasm", parsedTableUrl.origin);
+
+  wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
+  return wasmUrl.toString();
+}

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -19,19 +19,13 @@ import {
 } from "@nteract/sift";
 import "@nteract/sift/style.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
+import type { NteractEmbedHostContext } from "@/components/isolated/host-context";
+import type { RendererInstallContext, RendererProps } from "@/lib/renderer-registry";
+import { resolveSiftWasmUrl } from "./sift-assets";
 
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
 // --- Types ---
-
-interface RendererProps {
-  data: unknown;
-  metadata?: Record<string, unknown>;
-  mimeType: string;
-  interactionActive?: boolean;
-}
 
 interface RendererArrowStreamManifestChunk {
   url?: unknown;
@@ -45,21 +39,25 @@ interface RendererArrowStreamManifest {
 // --- WASM configuration ---
 
 let wasmConfigured = false;
-
-const SIFT_WASM_CACHE_KEY =
-  typeof __SIFT_WASM_CACHE_KEY__ === "string" ? __SIFT_WASM_CACHE_KEY__ : "dev";
+let configuredWasmUrl: string | undefined;
+let lastTableUrl: string | undefined;
+let getHostContext: (() => NteractEmbedHostContext | undefined) | undefined;
+let unsubscribeHostContext: (() => void) | undefined;
 
 /**
- * Extract the blob server origin from a blob URL and configure WASM
- * to load from the same server's /plugins/ route.
+ * Configure Sift's WASM sidecar from the host's renderer asset base.
+ * The daemon fallback remains the blob URL origin's /plugins/ route.
  */
 function configureWasm(blobUrl: string): void {
-  if (wasmConfigured) return;
+  lastTableUrl = blobUrl;
   try {
-    const parsed = new URL(blobUrl);
-    const wasmUrl = new URL("/plugins/sift_wasm.wasm", parsed.origin);
-    wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
-    setWasmUrl(wasmUrl.toString());
+    const nextUrl = resolveSiftWasmUrl({
+      tableUrl: blobUrl,
+      rendererAssetsBaseUrl: getHostContext?.()?.nteract?.rendererAssetsBaseUrl,
+    });
+    if (wasmConfigured && configuredWasmUrl === nextUrl) return;
+    setWasmUrl(nextUrl);
+    configuredWasmUrl = nextUrl;
     wasmConfigured = true;
   } catch (err) {
     console.warn("[sift-renderer] configureWasm failed, using defaults:", err);
@@ -202,9 +200,13 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
 
 // --- Plugin install ---
 
-export function install(ctx: {
-  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
-}) {
+export function install(ctx: RendererInstallContext) {
+  getHostContext = ctx.getHostContext;
+  unsubscribeHostContext?.();
+  unsubscribeHostContext = ctx.subscribeHostContext((context) => {
+    if (!lastTableUrl || !context.nteract?.rendererAssetsBaseUrl) return;
+    configureWasm(lastTableUrl);
+  });
   ctx.register(
     [
       "application/vnd.apache.parquet",

--- a/src/lib/renderer-registry.ts
+++ b/src/lib/renderer-registry.ts
@@ -18,6 +18,19 @@ export interface RendererProps {
   interactionActive?: boolean;
 }
 
+export interface RendererHostContext {
+  nteract?: {
+    rendererAssetsBaseUrl?: string;
+  };
+}
+
+export interface RendererInstallContext {
+  register: (mimeTypes: string[], component: ComponentType<RendererProps>) => void;
+  registerPattern: (test: (mime: string) => boolean, component: ComponentType<RendererProps>) => void;
+  getHostContext: () => RendererHostContext | undefined;
+  subscribeHostContext: (listener: (context: RendererHostContext) => void) => () => void;
+}
+
 const exactMatches = new Map<string, ComponentType<RendererProps>>();
 const patternMatchers: Array<{
   test: (mime: string) => boolean;


### PR DESCRIPTION
## Summary

- add an explicit `nteract.rendererAssetsBaseUrl` host-context field for isolated renderer sidecar assets
- configure the Sift renderer WASM URL from that host context, with a daemon-style `/plugins/` fallback
- point the notebook-cloud viewer at its Worker/CDN plugin route without encoding notebook URL shapes into Sift

## Verification

- `pnpm test:run src/isolated-renderer/__tests__/sift-assets.test.ts src/components/isolated/__tests__/host-context.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
