### PR TITLE
feat(settings): default nteract launcher

### DIFF
--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -66,8 +66,8 @@ pub async fn check_uv_available() -> bool {
 /// The `dx` PyPI package is no longer installed — its behavior (DataFrame
 /// formatters, buffer hooks, nteract renderers) is provided by the vendored
 /// `nteract_kernel_launcher` package that the daemon injects via PYTHONPATH.
-/// The `bootstrap_dx` feature flag now gates launcher-vs-vanilla, not a
-/// PyPI install.
+/// `disable_nteract_launcher` is the escape hatch back to vanilla IPython;
+/// it does not change this base package set.
 pub const UV_BASE_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -14,21 +14,19 @@ use serde::{Deserialize, Serialize};
 
 // ── Data structs referenced by protocol enums ───────────────────────────────
 
-/// Optional runtime behaviors toggled by the user.
+/// Optional runtime behaviors captured for a kernel launch.
 ///
-/// Single source of truth for feature-flag state across the daemon,
-/// settings UI, and kernel launch pipeline. Each flag defaults to `false`,
-/// so adding a new flag is one extra field here, no new arguments threaded
-/// through call sites.
+/// The daemon derives these from settings before launch and stores the
+/// materialized values in `LaunchedEnvConfig` so restart and drift checks know
+/// which runtime behavior produced the active kernel.
 ///
 /// Serialized flat via `#[serde(flatten)]` in parent structs, so the
 /// on-wire JSON and Automerge keys stay at the top level (`bootstrap_dx`)
 /// for backward compatibility.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FeatureFlags {
-    /// Install `nteract-kernel-launcher` and `dx` into UV kernels, launch
-    /// via `nteract_kernel_launcher`, and register dx display formatters
-    /// before the first user cell.
+    /// Launch via `nteract_kernel_launcher` so rich display formatters are
+    /// registered before the first user cell.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub bootstrap_dx: bool,
 }

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -109,10 +109,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("install_default_data_packages")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.install_default_data_packages),
-        bootstrap_dx: json
-            .get("bootstrap_dx")
+        disable_nteract_launcher: json
+            .get("disable_nteract_launcher")
             .and_then(|v| v.as_bool())
-            .unwrap_or(defaults.bootstrap_dx),
+            .unwrap_or(defaults.disable_nteract_launcher),
         redact_env_values_in_outputs: json
             .get("redact_env_values_in_outputs")
             .and_then(|v| v.as_bool())
@@ -178,6 +178,7 @@ mod tests {
         assert!(settings.uv.default_packages.is_empty());
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
+        assert!(!settings.disable_nteract_launcher);
         assert!(settings.redact_env_values_in_outputs);
     }
 
@@ -199,7 +200,7 @@ mod tests {
             conda_pool_size: 5,
             pixi_pool_size: 6,
             install_default_data_packages: true,
-            bootstrap_dx: false,
+            disable_nteract_launcher: false,
             ..SyncedSettings::default()
         };
 
@@ -391,7 +392,7 @@ mod tests {
             conda_pool_size: defaults.conda_pool_size,
             pixi_pool_size: defaults.pixi_pool_size,
             install_default_data_packages: defaults.install_default_data_packages,
-            bootstrap_dx: defaults.bootstrap_dx,
+            disable_nteract_launcher: defaults.disable_nteract_launcher,
             ..defaults
         };
         // Valid fields are preserved

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -14,6 +14,7 @@
 //!   default_runtime: "python"
 //!   default_python_env: "uv"
 //!   install_default_data_packages: true
+//!   disable_nteract_launcher: false
 //!   uv/                           ← nested Map
 //!     default_packages: List[…]   ← List of Str
 //!   conda/                        ← nested Map
@@ -288,16 +289,15 @@ pub struct SyncedSettings {
     #[serde(default = "default_install_default_data_packages")]
     pub install_default_data_packages: bool,
 
-    /// Enable the nteract data-experience kernel bootstrap.
-    /// When true, the daemon launches kernels via `nteract_kernel_launcher`
-    /// so the vendored launcher can register rich display formatters before
-    /// the first user cell. Default: false.
+    /// Disable the nteract kernel launcher and fall back to the legacy
+    /// `ipykernel_launcher` entry point.
     ///
-    /// Mirrors `FeatureFlags::bootstrap_dx`. Flattened on the wire so the
-    /// settings JSON and Automerge document keep a flat layout even as new
-    /// feature flags are added.
+    /// The nteract launcher is now the default path so Python kernels can
+    /// register rich DataFrame and exception formatters before the first user
+    /// cell. This opt-out flag is an escape hatch for environments that need
+    /// vanilla IPython launch behavior.
     #[serde(default)]
-    pub bootstrap_dx: bool,
+    pub disable_nteract_launcher: bool,
 
     /// Redact eligible environment variable values from text outputs for newly
     /// launched or restarted kernels.
@@ -351,7 +351,7 @@ impl SyncedSettings {
     /// Snapshot the user's feature-flag settings.
     pub fn feature_flags(&self) -> notebook_protocol::protocol::FeatureFlags {
         notebook_protocol::protocol::FeatureFlags {
-            bootstrap_dx: self.bootstrap_dx,
+            bootstrap_dx: !self.disable_nteract_launcher,
         }
     }
 }
@@ -373,7 +373,7 @@ impl Default for SyncedSettings {
             conda_pool_size: pool_sizes.conda_pool_size,
             pixi_pool_size: pool_sizes.pixi_pool_size,
             install_default_data_packages: true,
-            bootstrap_dx: false,
+            disable_nteract_launcher: false,
             redact_env_values_in_outputs: true,
             import_shell_environment: true,
             install_id: String::new(),
@@ -571,8 +571,12 @@ impl SettingsDoc {
         // Store onboarding_completed as boolean
         let _ = doc.put(automerge::ROOT, "onboarding_completed", false);
 
-        // nteract kernel-launcher bootstrap (opt-in)
-        let _ = doc.put(automerge::ROOT, "bootstrap_dx", defaults.bootstrap_dx);
+        // nteract kernel launcher is default-on; this is the legacy escape hatch.
+        let _ = doc.put(
+            automerge::ROOT,
+            "disable_nteract_launcher",
+            defaults.disable_nteract_launcher,
+        );
         let _ = doc.put(
             automerge::ROOT,
             "redact_env_values_in_outputs",
@@ -705,9 +709,12 @@ impl SettingsDoc {
             settings.put_bool("onboarding_completed", completed);
         }
 
-        // bootstrap_dx: boolean
-        if let Some(enabled) = json.get("bootstrap_dx").and_then(|v| v.as_bool()) {
-            settings.put_bool("bootstrap_dx", enabled);
+        // disable_nteract_launcher: boolean
+        if let Some(disabled) = json
+            .get("disable_nteract_launcher")
+            .and_then(|v| v.as_bool())
+        {
+            settings.put_bool("disable_nteract_launcher", disabled);
         }
         if let Some(enabled) = json
             .get("redact_env_values_in_outputs")
@@ -1167,9 +1174,9 @@ impl SettingsDoc {
             install_default_data_packages: self
                 .get_bool("install_default_data_packages")
                 .unwrap_or(defaults.install_default_data_packages),
-            bootstrap_dx: self
-                .get_bool("bootstrap_dx")
-                .unwrap_or(defaults.bootstrap_dx),
+            disable_nteract_launcher: self
+                .get_bool("disable_nteract_launcher")
+                .unwrap_or(defaults.disable_nteract_launcher),
             redact_env_values_in_outputs: self
                 .get_bool("redact_env_values_in_outputs")
                 .unwrap_or(defaults.redact_env_values_in_outputs),
@@ -1365,15 +1372,18 @@ impl SettingsDoc {
             }
         }
 
-        // bootstrap_dx: boolean
-        if let Some(enabled) = json.get("bootstrap_dx").and_then(|v| v.as_bool()) {
-            let current = self.get_bool("bootstrap_dx");
-            if current != Some(enabled) {
+        // disable_nteract_launcher: boolean
+        if let Some(disabled) = json
+            .get("disable_nteract_launcher")
+            .and_then(|v| v.as_bool())
+        {
+            let current = self.get_bool("disable_nteract_launcher");
+            if current != Some(disabled) {
                 info!(
-                    "[settings] apply_json_changes: bootstrap_dx changed {:?} -> {}",
-                    current, enabled
+                    "[settings] apply_json_changes: disable_nteract_launcher changed {:?} -> {}",
+                    current, disabled
                 );
-                self.put_bool("bootstrap_dx", enabled);
+                self.put_bool("disable_nteract_launcher", disabled);
                 changed = true;
             }
         }
@@ -1583,6 +1593,8 @@ mod tests {
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.pixi.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
+        assert!(!settings.disable_nteract_launcher);
+        assert!(settings.feature_flags().bootstrap_dx);
         assert!(settings.redact_env_values_in_outputs);
     }
 
@@ -1644,6 +1656,31 @@ mod tests {
 
         assert_eq!(doc.get_bool("install_default_data_packages"), Some(false));
         assert!(!doc.get_all().install_default_data_packages);
+    }
+
+    #[test]
+    fn test_disable_nteract_launcher_can_be_enabled_from_json() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "disable_nteract_launcher": true
+        })));
+
+        let settings = doc.get_all();
+        assert_eq!(doc.get_bool("disable_nteract_launcher"), Some(true));
+        assert!(settings.disable_nteract_launcher);
+        assert!(!settings.feature_flags().bootstrap_dx);
+    }
+
+    #[test]
+    fn test_legacy_bootstrap_dx_false_does_not_disable_launcher() {
+        let doc = SettingsDoc::from_json_value(&serde_json::json!({
+            "bootstrap_dx": false
+        }));
+
+        let settings = doc.get_all();
+        assert!(!settings.disable_nteract_launcher);
+        assert!(settings.feature_flags().bootstrap_dx);
     }
 
     #[test]
@@ -2025,6 +2062,7 @@ mod tests {
         assert!(schema_str.contains("default_runtime"));
         assert!(schema_str.contains("default_python_env"));
         assert!(schema_str.contains("install_default_data_packages"));
+        assert!(schema_str.contains("disable_nteract_launcher"));
         assert!(schema_str.contains("redact_env_values_in_outputs"));
         // Should have known values as examples for editor autocomplete
         assert!(schema_str.contains("python"));

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -596,7 +596,8 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         pixi_pool_size: get_u64("pixi_pool_size").unwrap_or(pool_sizes.pixi_pool_size),
         install_default_data_packages: get_bool("install_default_data_packages")
             .unwrap_or(defaults.install_default_data_packages),
-        bootstrap_dx: get_bool("bootstrap_dx").unwrap_or(defaults.bootstrap_dx),
+        disable_nteract_launcher: get_bool("disable_nteract_launcher")
+            .unwrap_or(defaults.disable_nteract_launcher),
         redact_env_values_in_outputs: get_bool("redact_env_values_in_outputs")
             .unwrap_or(defaults.redact_env_values_in_outputs),
         import_shell_environment: get_bool("import_shell_environment")
@@ -802,6 +803,17 @@ mod tests {
         assert_eq!(settings.theme, ThemeMode::Dark);
         assert_eq!(settings.default_runtime, Runtime::Deno);
         assert_eq!(settings.default_python_env, PythonEnvType::Conda);
+    }
+
+    #[test]
+    fn test_get_all_reads_disable_nteract_launcher() {
+        let mut doc = AutoCommit::new();
+        doc.put(automerge::ROOT, "disable_nteract_launcher", true)
+            .unwrap();
+
+        let settings = get_all_from_doc(&doc);
+        assert!(settings.disable_nteract_launcher);
+        assert!(!settings.feature_flags().bootstrap_dx);
     }
 
     #[test]

--- a/e2e/specs/dx-bootstrap-repr-llm.spec.js
+++ b/e2e/specs/dx-bootstrap-repr-llm.spec.js
@@ -1,7 +1,7 @@
 /**
  * DX bootstrap LLM formatter E2E test.
  *
- * This spec must run with the `bootstrap_dx` setting enabled before the daemon
+ * This spec must run with `disable_nteract_launcher` off before the daemon
  * starts. That makes the Python kernel launch through nteract_kernel_launcher,
  * which installs the `text/llm+plain` display formatter.
  */

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -31,7 +31,7 @@ const FIXTURE_SPECS = [
   "cell-visibility.spec.js", // Requires fixture notebook with pre-existing outputs
   "conda-inline.spec.js",
   "deno.spec.js",
-  "dx-bootstrap-repr-llm.spec.js", // Requires bootstrap_dx before daemon startup
+  "dx-bootstrap-repr-llm.spec.js", // Requires nteract launcher before daemon startup
   "prewarmed-uv.spec.js",
   "trust-dialog-dismiss.spec.js",
   "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
@@ -8,9 +8,9 @@ Subclasses ``IPKernelApp``/``IPythonKernel``/``ZMQInteractiveShell``/
 - An auto-loaded bootstrap extension that registers DataFrame formatters
   and publisher hooks for the nteract data-experience integration.
 
-The daemon invokes this module in place of ``ipykernel_launcher`` when the
-``bootstrap_dx`` feature flag (user-facing: "Enhanced Data Experience") is
-on. See ``docs/superpowers/specs/2026-04-24-launcher-hosted-display-bootstrap.md``.
+The daemon invokes this module in place of ``ipykernel_launcher`` by default.
+Users can opt back into the legacy entry point with the
+``disable_nteract_launcher`` feature flag.
 """
 
 from nteract_kernel_launcher._progressive import display_arrow_stream

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -71,16 +71,15 @@ export type SyncedSettings = {
    */
   install_default_data_packages: boolean;
   /**
-   * Enable the nteract data-experience kernel bootstrap.
-   * When true, the daemon launches kernels via `nteract_kernel_launcher`
-   * so the vendored launcher can register rich display formatters before
-   * the first user cell. Default: false.
+   * Disable the nteract kernel launcher and fall back to the legacy
+   * `ipykernel_launcher` entry point.
    *
-   * Mirrors `FeatureFlags::bootstrap_dx`. Flattened on the wire so the
-   * settings JSON and Automerge document keep a flat layout even as new
-   * feature flags are added.
+   * The nteract launcher is now the default path so Python kernels can
+   * register rich DataFrame and exception formatters before the first user
+   * cell. This opt-out flag is an escape hatch for environments that need
+   * vanilla IPython launch behavior.
    */
-  bootstrap_dx: boolean;
+  disable_nteract_launcher: boolean;
   /**
    * Redact eligible environment variable values from text outputs for newly
    * launched or restarted kernels.

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -110,21 +110,20 @@ export function isKnownPythonEnv(value: string): value is "uv" | "conda" | "pixi
 /**
  * Feature flags exposed to the settings UI.
  *
- * Mirrors the `FeatureFlags` struct on the Rust side. The TS source of truth
- * is intentionally flat (each flag is a top-level boolean on `SyncedSettings`)
- * so that adding a new flag is one field here, one struct field in Rust, and
- * one entry in the settings UI — no schema migration.
+ * Mirrors feature-flag settings exposed by `SyncedSettings`. The TS source of
+ * truth is intentionally flat (each flag is a top-level boolean on
+ * `SyncedSettings`) so that adding a new flag is one field here, one struct
+ * field in Rust, and one entry in the settings UI — no schema migration.
  *
  * Adding a flag:
- *  1. Add `flag_id: boolean` to `FeatureFlags` in Rust + the matching field
- *     on `SyncedSettings`.
+ *  1. Add `flag_id: boolean` to `SyncedSettings`.
  *  2. Add `flag_id: { label, description }` below.
  *  3. Done — the settings UI renders a toggle automatically.
  */
 export const FEATURE_FLAG_METADATA = {
-  bootstrap_dx: {
-    label: "Rich DataFrames and Exceptions",
-    description: "Enable the nteract kernel launcher into Python runtimes.",
+  disable_nteract_launcher: {
+    label: "Use Legacy IPython Launcher",
+    description: "Launch Python kernels with ipykernel_launcher instead of the nteract launcher.",
   },
 } as const satisfies Record<string, { label: string; description: string }>;
 
@@ -132,7 +131,7 @@ export type FeatureFlagId = keyof typeof FEATURE_FLAG_METADATA;
 export type FeatureFlagValues = Record<FeatureFlagId, boolean>;
 
 const FEATURE_FLAG_DEFAULTS: FeatureFlagValues = {
-  bootstrap_dx: false,
+  disable_nteract_launcher: false,
 };
 
 export const FEATURE_FLAGS: ReadonlyArray<{


### PR DESCRIPTION
## Summary

- Make the nteract kernel launcher the default by deriving launch-time `bootstrap_dx` from a new opt-out setting.
- Add `disable_nteract_launcher` as the Settings feature flag for the legacy `ipykernel_launcher` escape hatch.
- Update synced settings readers, generated TS bindings, comments, and E2E launcher notes.

## Verification

- `cargo test -p runtimed-client --features ts-bindings`
- `cargo test -p runtimed-settings-sync -p runtimed-client`
- `cargo test -p notebook settings`
- `cargo xtask lint --fix`
- `cargo xtask wasm runtimed`
- `cargo xtask renderer-plugins`
- `pnpm --dir apps/notebook build`
