### PR TITLE
feat(notebook-cloud): publish live snapshot pairs

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -22,6 +22,7 @@ With Wrangler running:
 pnpm --dir apps/notebook-cloud smoke
 pnpm --dir apps/notebook-cloud publish:demo
 pnpm --dir apps/notebook-cloud publish:fixture
+pnpm --dir apps/notebook-cloud publish:live
 ```
 
 The smoke script proves:
@@ -75,6 +76,13 @@ http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming
 
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
 `NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair.
+
+`publish:live` exports a real synced notebook session through `@runtimed/node`,
+uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered
+output manifests for blob refs, uploads the matching local daemon blobs, and
+materializes the hosted render. By default it creates and executes a small
+`ShadenA/MathNet` Polars notebook. Set `NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID=<id>`
+to publish an already-open live notebook room instead.
 
 ## Dev auth
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -13,6 +13,7 @@
     "smoke": "node --import tsx scripts/smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",
     "publish:fixture": "node scripts/publish-fixture.mjs",
+    "publish:live": "node --import tsx scripts/publish-live.mjs",
     "wasm:roundtrip": "node --import tsx scripts/wasm-roundtrip.mjs"
   },
   "dependencies": {
@@ -21,6 +22,7 @@
     "runtimed": "workspace:*"
   },
   "devDependencies": {
+    "@runtimed/node": "workspace:*",
     "@tailwindcss/vite": "^4.1.8",
     "@types/node": "^20.10.0",
     "@types/react": "^19.1.6",

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -1,0 +1,265 @@
+import { createHash } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { collectBlobRefs } from "../src/blob-refs.ts";
+
+const require = createRequire(import.meta.url);
+const rt = loadRuntimedNode();
+
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const sourceNotebookId = process.env.NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID;
+const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
+const notebookId =
+  process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ??
+  (sourceNotebookId ? `live-${sourceNotebookId}` : `nteract-cloud-live-${preset}`);
+const wasmJsUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBytesUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+await assertWasmBuildExists();
+
+const session = sourceNotebookId
+  ? await rt.openNotebook(sourceNotebookId, {
+      description: "notebook-cloud live publish",
+    })
+  : await createPresetNotebook();
+
+try {
+  const snapshot = await session.exportSnapshotPair();
+  const cells = await cellsFromSnapshotPair(snapshot.notebookBytes, snapshot.runtimeStateBytes);
+  const blobRefs = collectBlobRefs(cells);
+  const headsHash = headsDigest(snapshot.notebookHeads);
+  const runtimeHeadsHash = headsDigest(snapshot.runtimeStateHeads);
+
+  for (const ref of Object.values(blobRefs)) {
+    await uploadLiveBlob(ref, snapshot);
+  }
+
+  await putBytes(
+    `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
+    snapshot.runtimeStateBytes,
+    "application/octet-stream",
+  );
+  await putBytes(
+    `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
+    snapshot.notebookBytes,
+    "application/octet-stream",
+    {
+      "X-Runtime-Heads-Hash": runtimeHeadsHash,
+    },
+  );
+
+  const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
+  assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        baseUrl,
+        preset: sourceNotebookId ? "source-notebook" : preset,
+        sourceNotebookId: sourceNotebookId ?? session.notebookId,
+        notebookId,
+        viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+        headsHash,
+        runtimeHeadsHash,
+        cells: Array.isArray(cells) ? cells.length : null,
+        blobs: Object.keys(blobRefs).length,
+        checks: [
+          "live_session_snapshot_pair",
+          "runtime_state_output_manifests",
+          "local_blob_uploads",
+          "latest_snapshot_materialization",
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  if (!sourceNotebookId) {
+    await session.shutdownNotebook().catch(() => {});
+  }
+  await session.close().catch(() => {});
+}
+
+async function createPresetNotebook() {
+  if (preset !== "mathnet") {
+    throw new Error(`Unknown NOTEBOOK_CLOUD_LIVE_PRESET ${preset}`);
+  }
+
+  const session = await rt.createNotebook({
+    runtime: "python",
+    description: "notebook-cloud live publish",
+    dependencies: ["polars", "pyarrow", "datasets", "pillow"],
+    packageManager: "uv",
+    environmentMode: "notebook",
+  });
+
+  await session.createCell(
+    [
+      "# MathNet via notebook-cloud",
+      "",
+      "This notebook was executed through a live local runtimed session, exported as a NotebookDoc + RuntimeStateDoc snapshot pair, and published to the Cloudflare notebook-cloud worker.",
+    ].join("\n"),
+    { cellType: "markdown" },
+  );
+  await session.approveTrust();
+  await session.syncEnvironment();
+  await session.runCell(
+    [
+      "import polars as pl",
+      "from datasets import load_dataset",
+      "",
+      "def summarize_value(value):",
+      "    if value is None or isinstance(value, (str, int, float, bool)):",
+      "        return value",
+      "    if hasattr(value, 'size') and hasattr(value, 'mode'):",
+      '        return f"Image({value.size[0]}x{value.size[1]}, {value.mode})"',
+      "    if isinstance(value, list):",
+      '        return f"list[{len(value)}]"',
+      "    text = str(value)",
+      "    return text if len(text) <= 240 else text[:237] + '...'",
+      "",
+      "dataset = load_dataset('ShadenA/MathNet', 'all', split='train[:25]')",
+      "rows = [{key: summarize_value(value) for key, value in example.items()} for example in dataset]",
+      "df = pl.DataFrame(rows)",
+      "print(f'Loaded {df.height} rows and {df.width} columns from ShadenA/MathNet')",
+      "df",
+    ].join("\n"),
+    { timeoutMs: 10 * 60 * 1000 },
+  );
+  return session;
+}
+
+async function cellsFromSnapshotPair(notebookBytes, runtimeStateBytes) {
+  const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
+  const wasmBytes = await readFile(wasmBytesUrl);
+  initSync({ module: wasmBytes });
+  const handle = NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
+  try {
+    return JSON.parse(handle.get_cells_json());
+  } finally {
+    handle.free();
+  }
+}
+
+async function uploadLiveBlob(ref, snapshot) {
+  const bytes = await readLocalBlob(ref.blob, snapshot);
+  await putBytes(
+    `/api/n/${encodeURIComponent(notebookId)}/blobs/${encodeURIComponent(ref.blob)}`,
+    bytes,
+    ref.media_type ?? "application/octet-stream",
+  );
+}
+
+async function readLocalBlob(hash, snapshot) {
+  if (snapshot.blobStorePath) {
+    for (const candidate of localBlobPathCandidates(snapshot.blobStorePath, hash)) {
+      try {
+        return await readFile(candidate);
+      } catch {
+        // Try the next candidate or fall through to the daemon blob URL.
+      }
+    }
+  }
+
+  if (snapshot.blobBaseUrl) {
+    const response = await fetch(`${snapshot.blobBaseUrl.replace(/\/$/, "")}/blob/${hash}`);
+    if (response.ok) {
+      return new Uint8Array(await response.arrayBuffer());
+    }
+  }
+
+  throw new Error(`Unable to resolve local blob ${hash}`);
+}
+
+function localBlobPathCandidates(root, hash) {
+  const hashes = [hash];
+  if (hash.startsWith("sha256:")) {
+    hashes.push(hash.slice("sha256:".length));
+  }
+  return hashes
+    .filter((candidate) => candidate.length >= 2)
+    .map((candidate) => path.join(root, candidate.slice(0, 2), candidate.slice(2)));
+}
+
+function headsDigest(heads) {
+  const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
+  return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+async function putBytes(pathname, body, contentType, extraHeaders = {}) {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    method: "PUT",
+    headers: publishHeaders(contentType, extraHeaders),
+    body,
+  });
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+function publishHeaders(contentType, extraHeaders) {
+  return {
+    "Content-Type": contentType,
+    "X-User": "live-publish",
+    "X-Operator": "agent:publish-live",
+    "X-Scope": "owner",
+    ...devAuthHeaders(),
+    ...extraHeaders,
+  };
+}
+
+function devAuthHeaders() {
+  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
+}
+
+async function fetchJson(pathname) {
+  const response = await fetch(new URL(pathname, baseUrl));
+  await assertOk(response, pathname);
+  return response.json();
+}
+
+async function assertOk(response, pathname) {
+  if (response.ok) return;
+  throw new Error(`${pathname} returned ${response.status}: ${await response.text()}`);
+}
+
+async function assertWasmBuildExists() {
+  try {
+    await access(fileURLToPath(wasmJsUrl));
+    await access(fileURLToPath(wasmBytesUrl));
+  } catch {
+    throw new Error(
+      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
+    );
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function loadRuntimedNode() {
+  try {
+    return require("@runtimed/node");
+  } catch (error) {
+    if (error?.code !== "MODULE_NOT_FOUND") {
+      throw error;
+    }
+    return require(
+      fileURLToPath(new URL("../../../packages/runtimed-node/src/index.cjs", import.meta.url)),
+    );
+  }
+}

--- a/apps/notebook-cloud/src/blob-refs.ts
+++ b/apps/notebook-cloud/src/blob-refs.ts
@@ -1,0 +1,81 @@
+import type { BlobRef, BlobResolver } from "runtimed";
+
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+export function collectBlobRefs(value: unknown): Record<string, BlobRef> {
+  const refs: Record<string, BlobRef> = {};
+  visitBlobRefs(value, refs);
+  return refs;
+}
+
+export function collectBlobUrls(value: unknown, resolver: BlobResolver): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(collectBlobRefs(value)).map(([hash, ref]) => [hash, resolver.url(ref)]),
+  );
+}
+
+function visitBlobRefs(value: unknown, refs: Record<string, BlobRef>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitBlobRefs(item, refs);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") {
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.blob === "string") {
+    addBlobRef(record, refs);
+  }
+
+  const arrowManifestRef = record[ARROW_STREAM_MANIFEST_MIME];
+  if (isInlineContentRef(arrowManifestRef)) {
+    visitArrowStreamManifest(arrowManifestRef.inline, refs);
+  }
+
+  for (const item of Object.values(record)) {
+    visitBlobRefs(item, refs);
+  }
+}
+
+function addBlobRef(record: Record<string, unknown>, refs: Record<string, BlobRef>): void {
+  if (typeof record.blob !== "string") return;
+  refs[record.blob] = {
+    blob: record.blob,
+    size: typeof record.size === "number" ? record.size : undefined,
+    media_type: typeof record.media_type === "string" ? record.media_type : undefined,
+  };
+}
+
+function isInlineContentRef(value: unknown): value is { inline: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).inline === "string"
+  );
+}
+
+function visitArrowStreamManifest(content: string, refs: Record<string, BlobRef>): void {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(content);
+  } catch {
+    return;
+  }
+  if (typeof manifest !== "object" || manifest === null) return;
+  const chunks = (manifest as Record<string, unknown>).chunks;
+  if (!Array.isArray(chunks)) return;
+
+  for (const chunk of chunks) {
+    if (typeof chunk !== "object" || chunk === null) continue;
+    const record = chunk as Record<string, unknown>;
+    if (typeof record.hash !== "string") continue;
+    refs[record.hash] = {
+      blob: record.hash,
+      size: typeof record.size === "number" ? record.size : undefined,
+      media_type: typeof record.media_type === "string" ? record.media_type : undefined,
+    };
+  }
+}

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -1,7 +1,6 @@
 import type { BlobResolver } from "runtimed";
+import { collectBlobUrls } from "./blob-refs.ts";
 import { loadSnapshotPair } from "./runtimed-wasm.ts";
-
-const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
 export interface SnapshotRender {
   schema_version: 1;
@@ -52,85 +51,5 @@ function parseJsonOrNull(value: string | undefined): unknown {
     return JSON.parse(value) as unknown;
   } catch {
     return null;
-  }
-}
-
-function collectBlobUrls(value: unknown, resolver: BlobResolver): Record<string, string> {
-  const urls: Record<string, string> = {};
-  visitBlobRefs(value, resolver, urls);
-  return urls;
-}
-
-function visitBlobRefs(value: unknown, resolver: BlobResolver, urls: Record<string, string>): void {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      visitBlobRefs(item, resolver, urls);
-    }
-    return;
-  }
-  if (value === null || typeof value !== "object") {
-    return;
-  }
-
-  const record = value as Record<string, unknown>;
-  if (typeof record.blob === "string") {
-    addBlobUrl(record, resolver, urls);
-  }
-
-  const arrowManifestRef = record[ARROW_STREAM_MANIFEST_MIME];
-  if (isInlineContentRef(arrowManifestRef)) {
-    visitArrowStreamManifest(arrowManifestRef.inline, resolver, urls);
-  }
-
-  for (const item of Object.values(record)) {
-    visitBlobRefs(item, resolver, urls);
-  }
-}
-
-function addBlobUrl(
-  record: Record<string, unknown>,
-  resolver: BlobResolver,
-  urls: Record<string, string>,
-): void {
-  if (typeof record.blob !== "string") return;
-  urls[record.blob] = resolver.url({
-    blob: record.blob,
-    size: typeof record.size === "number" ? record.size : undefined,
-    media_type: typeof record.media_type === "string" ? record.media_type : undefined,
-  });
-}
-
-function isInlineContentRef(value: unknown): value is { inline: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as Record<string, unknown>).inline === "string"
-  );
-}
-
-function visitArrowStreamManifest(
-  content: string,
-  resolver: BlobResolver,
-  urls: Record<string, string>,
-): void {
-  let manifest: unknown;
-  try {
-    manifest = JSON.parse(content);
-  } catch {
-    return;
-  }
-  if (typeof manifest !== "object" || manifest === null) return;
-  const chunks = (manifest as Record<string, unknown>).chunks;
-  if (!Array.isArray(chunks)) return;
-
-  for (const chunk of chunks) {
-    if (typeof chunk !== "object" || chunk === null) continue;
-    const record = chunk as Record<string, unknown>;
-    if (typeof record.hash !== "string") continue;
-    urls[record.hash] = resolver.url({
-      blob: record.hash,
-      size: typeof record.size === "number" ? record.size : undefined,
-      media_type: typeof record.media_type === "string" ? record.media_type : undefined,
-    });
   }
 }

--- a/apps/notebook-cloud/test/mime-policy.test.ts
+++ b/apps/notebook-cloud/test/mime-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { jupyterOutputToRenderPayload } from "@/components/isolated/output-payloads";
+import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
+import { CLOUD_VIEWER_PRIORITY } from "../viewer/mime-policy.ts";
+
+const WIDGET_VIEW_MIME = "application/vnd.jupyter.widget-view+json";
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+describe("cloud viewer MIME policy", () => {
+  it("prefers text fallbacks over unhydrated widget views", () => {
+    const data = {
+      [WIDGET_VIEW_MIME]: { version_major: 2, version_minor: 0, model_id: "progress" },
+      "text/plain": "Resolving data files: 100%",
+    };
+
+    assert.equal(selectMimeType(data, DEFAULT_PRIORITY), WIDGET_VIEW_MIME);
+    assert.equal(selectMimeType(data, CLOUD_VIEWER_PRIORITY), "text/plain");
+
+    const payload = jupyterOutputToRenderPayload(
+      {
+        output_type: "display_data",
+        data,
+        metadata: {},
+      },
+      0,
+      { priority: CLOUD_VIEWER_PRIORITY },
+    );
+
+    assert.equal(payload?.mimeType, "text/plain");
+    assert.equal(payload?.data, "Resolving data files: 100%");
+  });
+
+  it("keeps Arrow stream manifests ahead of table text and HTML fallbacks", () => {
+    const data = {
+      "text/html": "<table><tr><td>fallback</td></tr></table>",
+      "text/plain": "plain fallback",
+      [ARROW_STREAM_MANIFEST_MIME]: { chunks: [{ url: "https://cloud.test/blob.arrow" }] },
+    };
+
+    assert.equal(selectMimeType(data, CLOUD_VIEWER_PRIORITY), ARROW_STREAM_MANIFEST_MIME);
+  });
+});

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -9,6 +9,7 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
+import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import { cloudSourceLanguage } from "./source-language";
 import { installDocumentThemeSync } from "./theme";
@@ -244,6 +245,7 @@ function ReadonlyNotebookCell({
         executionCount={cell.executionCount}
         outputs={cell.outputs}
         isolated="auto"
+        priority={CLOUD_VIEWER_PRIORITY}
         hostContext={outputHostContext}
       />
     ) : null;
@@ -278,6 +280,7 @@ function renderCellSource(
           },
         ]}
         isolated="auto"
+        priority={CLOUD_VIEWER_PRIORITY}
         hostContext={outputHostContext}
       />
     );
@@ -351,7 +354,7 @@ createRoot(requireElement("#root")).render(
     fallback={(error) => <ViewerStartupError message={`Cloud viewer crashed: ${error.message}`} />}
   >
     <IsolatedRendererProvider loader={rendererBundle}>
-      <MediaProvider>
+      <MediaProvider priority={CLOUD_VIEWER_PRIORITY}>
         <App />
       </MediaProvider>
     </IsolatedRendererProvider>

--- a/apps/notebook-cloud/viewer/mime-policy.ts
+++ b/apps/notebook-cloud/viewer/mime-policy.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_PRIORITY } from "@/components/outputs/mime-priority";
+
+const WIDGET_VIEW_MIME = "application/vnd.jupyter.widget-view+json";
+
+/**
+ * The published cloud viewer does not hydrate RuntimeStateDoc widget models
+ * yet. Prefer a widget output's text/plain fallback when it exists, while
+ * keeping every other shared nteract MIME priority unchanged.
+ */
+export const CLOUD_VIEWER_PRIORITY = DEFAULT_PRIORITY.filter(
+  (mimeType) => mimeType !== WIDGET_VIEW_MIME,
+);

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -96,6 +96,19 @@ pub struct DocHandle {
     notebook_id: String,
 }
 
+/// Serialized notebook snapshot pair suitable for hosted publish flows.
+///
+/// `notebook_bytes` are the saved `NotebookDoc`; `runtime_state_bytes` are the
+/// saved `RuntimeStateDoc` whose execution/output manifests are resolved by
+/// `execution_id` from the notebook cells.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotPairBytes {
+    pub notebook_bytes: Vec<u8>,
+    pub runtime_state_bytes: Vec<u8>,
+    pub notebook_heads: Vec<String>,
+    pub runtime_state_heads: Vec<String>,
+}
+
 impl std::fmt::Debug for DocHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DocHandle")
@@ -691,6 +704,36 @@ impl DocHandle {
             .into_iter()
             .map(|head| head.to_string())
             .collect())
+    }
+
+    /// Save the current local `NotebookDoc` and `RuntimeStateDoc` replicas.
+    ///
+    /// Callers that need a daemon-fresh publish artifact should call
+    /// [`confirm_sync`](Self::confirm_sync) and
+    /// [`confirm_state_sync`](Self::confirm_state_sync) before saving.
+    pub fn save_snapshot_pair(&self) -> Result<SnapshotPairBytes, SyncError> {
+        let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        let notebook_heads = state
+            .doc
+            .get_heads()
+            .into_iter()
+            .map(|head| head.to_string())
+            .collect();
+        let runtime_state_heads = state
+            .state_doc
+            .get_heads()
+            .into_iter()
+            .map(|head| hex::encode(head.as_ref()))
+            .collect();
+        let notebook_bytes = state.doc.save();
+        let runtime_state_bytes = state.state_doc.doc_mut().save();
+
+        Ok(SnapshotPairBytes {
+            notebook_bytes,
+            runtime_state_bytes,
+            notebook_heads,
+            runtime_state_heads,
+        })
     }
 
     /// Confirm that the daemon has merged our current local heads.

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -72,7 +72,7 @@ pub use execution_wait::{
     DEFAULT_OUTPUT_SYNC_GRACE,
 };
 pub use execution_watch::{ExecutionProgressState, ExecutionTerminalReason, ExecutionWatcher};
-pub use handle::DocHandle;
+pub use handle::{DocHandle, SnapshotPairBytes};
 pub use notebook_protocol::protocol::PutBlobResult;
 pub use relay::RelayHandle;
 pub use shared::SharedDocState;

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -832,6 +832,47 @@ mod tests {
     }
 
     #[test]
+    fn test_save_snapshot_pair_exports_notebook_and_runtime_state_docs() {
+        let (handle, shared, _changed_rx, _cmd_rx) = test_handle_with_shared();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+        handle.update_source("cell-1", "print('live')").unwrap();
+        set_execution(
+            &shared,
+            "exec-1",
+            "cell-1",
+            "done",
+            &[stream_output("out-1", "live\n")],
+            Some(1),
+        );
+
+        let snapshot = handle.save_snapshot_pair().unwrap();
+        assert!(!snapshot.notebook_bytes.is_empty());
+        assert!(!snapshot.runtime_state_bytes.is_empty());
+        assert!(!snapshot.notebook_heads.is_empty());
+        assert!(!snapshot.runtime_state_heads.is_empty());
+
+        let notebook_doc =
+            automerge::AutoCommit::load(&snapshot.notebook_bytes).expect("notebook doc loads");
+        let cells = notebook_doc::get_cells_from_doc(&notebook_doc);
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].source, "print('live')");
+
+        let runtime_doc = runtime_doc::RuntimeStateDoc::from_doc(
+            automerge::AutoCommit::load(&snapshot.runtime_state_bytes)
+                .expect("runtime state doc loads"),
+        );
+        let runtime_state = runtime_doc.read_state();
+        let execution = runtime_state
+            .executions
+            .get("exec-1")
+            .expect("execution exported");
+        assert_eq!(execution.status, "done");
+        assert_eq!(execution.execution_count, Some(1));
+        assert_eq!(execution.outputs.len(), 1);
+    }
+
+    #[test]
     fn get_cell_execution_count_falls_back_to_notebook_doc() {
         let (handle, _shared, _rx, _cmd_rx) = test_handle_with_shared();
 

--- a/crates/runtimed-node/src/lib.rs
+++ b/crates/runtimed-node/src/lib.rs
@@ -37,7 +37,7 @@ pub use session::{
     ListActiveNotebooksOptions, MoveCellOptions, OpenNotebookOptions, PackageManager,
     PixiDependencyStatus, QueueCellOptions, QueuedExecution, RunCellOptions, RuntimeStatus,
     Session, SetCellOptions, ShowNotebookOptions, ShowNotebookResult, ShutdownNotebookOptions,
-    UvDependencyStatus, WaitExecutionOptions,
+    SnapshotPair, UvDependencyStatus, WaitExecutionOptions,
 };
 
 /// Return the default daemon socket path.

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -362,6 +362,18 @@ pub struct CellResult {
     pub outputs: Vec<JsOutput>,
 }
 
+/// Serialized notebook + runtime-state snapshots for hosted publishing.
+#[napi(object)]
+pub struct SnapshotPair {
+    pub notebook_id: String,
+    pub notebook_bytes: Buffer,
+    pub runtime_state_bytes: Buffer,
+    pub notebook_heads: Vec<String>,
+    pub runtime_state_heads: Vec<String>,
+    pub blob_base_url: Option<String>,
+    pub blob_store_path: Option<String>,
+}
+
 // ── Internal state ─────────────────────────────────────────────────────
 
 struct SessionState {
@@ -750,6 +762,40 @@ impl Session {
                 "Unexpected response: {other:?}"
             ))),
         }
+    }
+
+    /// Export the live synced notebook and runtime-state documents.
+    ///
+    /// This waits for both document channels to converge with the daemon
+    /// before serializing, so hosted publish clients can upload a coherent
+    /// `NotebookDoc` + `RuntimeStateDoc` snapshot pair.
+    #[napi]
+    pub async fn export_snapshot_pair(&self) -> Result<SnapshotPair> {
+        let (handle, blob_base_url, blob_store_path) = {
+            let st = self.state.lock().await;
+            (
+                st.handle
+                    .as_ref()
+                    .ok_or_else(|| Error::from_reason("Not connected"))?
+                    .clone(),
+                st.blob_base_url.clone(),
+                st.blob_store_path
+                    .as_ref()
+                    .map(|path| path.to_string_lossy().to_string()),
+            )
+        };
+        handle.confirm_sync().await.map_err(to_napi_err)?;
+        handle.confirm_state_sync().await.map_err(to_napi_err)?;
+        let snapshot = handle.save_snapshot_pair().map_err(to_napi_err)?;
+        Ok(SnapshotPair {
+            notebook_id: self.notebook_id.clone(),
+            notebook_bytes: snapshot.notebook_bytes.into(),
+            runtime_state_bytes: snapshot.runtime_state_bytes.into(),
+            notebook_heads: snapshot.notebook_heads,
+            runtime_state_heads: snapshot.runtime_state_heads,
+            blob_base_url,
+            blob_store_path,
+        })
     }
 
     /// Close the session and release the underlying connection.

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -148,6 +148,16 @@ export interface CellResult {
   outputs: JsOutput[];
 }
 
+export interface SnapshotPair {
+  notebookId: string;
+  notebookBytes: Uint8Array;
+  runtimeStateBytes: Uint8Array;
+  notebookHeads: string[];
+  runtimeStateHeads: string[];
+  blobBaseUrl?: string | null;
+  blobStorePath?: string | null;
+}
+
 export interface EventSubscription {
   dispose(): void;
 }
@@ -222,6 +232,7 @@ export class Session {
   waitForExecution(executionId: string, options?: WaitExecutionOptions): Promise<CellResult>;
   runCell(source: string, options?: RunCellOptions): Promise<CellResult>;
   saveNotebook(path?: string): Promise<void>;
+  exportSnapshotPair(): Promise<SnapshotPair>;
   listCells(): Promise<CellSnapshot[]>;
   getCell(cellId: string): Promise<CellSnapshot | null>;
   createCell(source: string, options?: CreateCellOptions): Promise<string>;

--- a/packages/runtimed-node/src/session.cjs
+++ b/packages/runtimed-node/src/session.cjs
@@ -107,6 +107,10 @@ class Session {
     return this._native.saveNotebook(path);
   }
 
+  exportSnapshotPair() {
+    return this._native.exportSnapshotPair();
+  }
+
   listCells() {
     return this._native.listCells();
   }

--- a/packages/runtimed-node/tests/session.test.ts
+++ b/packages/runtimed-node/tests/session.test.ts
@@ -16,6 +16,7 @@ const { Session } = require("../src/session.cjs") as {
     };
     getExecutionView: () => unknown;
     runCell: (source: string, options?: Record<string, unknown>) => Promise<unknown>;
+    exportSnapshotPair: () => Promise<unknown>;
     close: () => Promise<void>;
   };
 };
@@ -293,5 +294,26 @@ describe("@runtimed/node Session wrapper", () => {
       executionId: "exec-1",
       status: "done",
     });
+  });
+
+  it("passes snapshot pair export through to the native session", async () => {
+    const snapshot = {
+      notebookId: "nb-1",
+      notebookBytes: new Uint8Array([1, 2, 3]),
+      runtimeStateBytes: new Uint8Array([4, 5, 6]),
+      notebookHeads: ["a"],
+      runtimeStateHeads: ["b"],
+      blobBaseUrl: "http://127.0.0.1:1234",
+      blobStorePath: "/tmp/runtimed-blobs",
+    };
+    const native = {
+      notebookId: "nb-1",
+      exportSnapshotPair: vi.fn(async () => snapshot),
+      close: vi.fn(async () => {}),
+    };
+    const session = new Session(native);
+
+    await expect(session.exportSnapshotPair()).resolves.toBe(snapshot);
+    expect(native.exportSnapshotPair).toHaveBeenCalledTimes(1);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtimed
     devDependencies:
+      '@runtimed/node':
+        specifier: workspace:*
+        version: link:../../packages/runtimed-node
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.17.19)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))


### PR DESCRIPTION
## Summary

- add a coherent NotebookDoc + RuntimeStateDoc snapshot export to `notebook-sync` and `@runtimed/node`
- add a `notebook-cloud publish:live` script that executes/publishes a real live MathNet/Polars notebook and uploads referenced blobs
- share blob-ref walking between render materialization and live publishing
- add a cloud viewer MIME policy that prefers text fallbacks over unhydrated widget views, while preserving Sift/Arrow priority

## Verification

- `cargo test -p notebook-sync`
- `cargo check -p runtimed-node`
- `pnpm test:run packages/runtimed-node/tests/session.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `node --check apps/notebook-cloud/scripts/publish-live.mjs`
- `git diff --check`
- `cargo xtask lint --fix`

## Hosted Smoke

- Deployed Worker version `aad8f5f4-ec15-41b2-af97-c050d59fe72a`
- Published live notebook: `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet`
- Headless Chrome verified markdown, shared read-only CodeMirror source, stdout/progress text fallback, and Sift table rendering from persisted snapshot-pair data.

## Stack

- Stacked on #2824 (`quod/notebook-cloud-readonly-codemirror`)
