### PR TITLE
fix(notebook-cloud): derive counts from runtime outputs

### DIFF
--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -140,6 +140,57 @@ describe("cloud viewer render resolution", () => {
     assert.equal(markdownCell.language, null);
     assert.equal(codeCellWithDefaultLanguage.language, "python");
   });
+
+  it("falls back to RuntimeStateDoc output execution counts", async () => {
+    const cell = await resolveCell(
+      {
+        id: "runtime-count",
+        cell_type: "code",
+        source: "df",
+        execution_count: "null",
+        outputs: [
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "loaded\n",
+          },
+          {
+            output_type: "execute_result",
+            execution_count: 7,
+            data: { "text/plain": "shape: (25, 8)" },
+            metadata: {},
+          },
+        ],
+      },
+      rejectingBlobResolver(),
+      0,
+    );
+
+    assert.equal(cell.executionCount, 7);
+  });
+
+  it("keeps an explicit cell execution count over output fallbacks", async () => {
+    const cell = await resolveCell(
+      {
+        id: "cell-count",
+        cell_type: "code",
+        source: "df",
+        execution_count: 3,
+        outputs: [
+          {
+            output_type: "execute_result",
+            execution_count: 7,
+            data: { "text/plain": "shape: (25, 8)" },
+            metadata: {},
+          },
+        ],
+      },
+      rejectingBlobResolver(),
+      0,
+    );
+
+    assert.equal(cell.executionCount, 3);
+  });
 });
 
 function rejectingBlobResolver(): BlobResolver {

--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -169,6 +169,63 @@ describe("cloud viewer render resolution", () => {
     assert.equal(cell.executionCount, 7);
   });
 
+  it("uses the first finite execute_result count as the output fallback", async () => {
+    const cell = await resolveCell(
+      {
+        id: "multiple-results",
+        cell_type: "code",
+        source: "a\nb",
+        execution_count: "null",
+        outputs: [
+          {
+            output_type: "execute_result",
+            execution_count: 7,
+            data: { "text/plain": "a" },
+            metadata: {},
+          },
+          {
+            output_type: "execute_result",
+            execution_count: 8,
+            data: { "text/plain": "b" },
+            metadata: {},
+          },
+        ],
+      },
+      rejectingBlobResolver(),
+      0,
+    );
+
+    assert.equal(cell.executionCount, 7);
+  });
+
+  it("does not derive execution counts from non-result outputs", async () => {
+    const cell = await resolveCell(
+      {
+        id: "no-result-count",
+        cell_type: "code",
+        source: "display(df)",
+        execution_count: "null",
+        outputs: [
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "loaded\n",
+          },
+          {
+            output_type: "display_data",
+            execution_count: 99,
+            data: { "text/plain": "display only" },
+            metadata: {},
+          },
+        ],
+      },
+      rejectingBlobResolver(),
+      0,
+    );
+
+    assert.equal(cell.executionCount, null);
+  });
+
   it("keeps an explicit cell execution count over output fallbacks", async () => {
     const cell = await resolveCell(
       {

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -114,17 +114,16 @@ function normalizeExecutionCount(value: unknown): number | null {
 }
 
 function executionCountFromOutputs(outputs: JupyterOutput[]): number | null {
-  let count: number | null = null;
   for (const output of outputs) {
     if (
-      (output.output_type === "execute_result" || output.output_type === "display_data") &&
+      output.output_type === "execute_result" &&
       typeof output.execution_count === "number" &&
       Number.isFinite(output.execution_count)
     ) {
-      count = output.execution_count;
+      return output.execution_count;
     }
   }
-  return count;
+  return null;
 }
 
 function normalizeMetadata(value: unknown): Record<string, unknown> {

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -33,13 +33,18 @@ export async function resolveCell(
 ): Promise<ResolvedCell> {
   const cellType = normalizeCellType(cell.cell_type);
   const metadata = normalizeMetadata(cell.metadata);
+  const outputs = Array.isArray(cell.outputs)
+    ? await resolveOutputs(cell.outputs, blobResolver)
+    : [];
+  const executionCount =
+    normalizeExecutionCount(cell.execution_count) ?? executionCountFromOutputs(outputs);
   return {
     id: typeof cell.id === "string" ? cell.id : `cell-${index + 1}`,
     cellType,
     source: typeof cell.source === "string" ? cell.source : "",
     language: cellType === "code" ? (normalizeCellLanguage(metadata) ?? defaultLanguage) : null,
-    executionCount: normalizeExecutionCount(cell.execution_count),
-    outputs: Array.isArray(cell.outputs) ? await resolveOutputs(cell.outputs, blobResolver) : [],
+    executionCount,
+    outputs,
     metadata,
   };
 }
@@ -106,6 +111,20 @@ function normalizeExecutionCount(value: unknown): number | null {
   if (typeof value !== "string" || value === "null") return null;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function executionCountFromOutputs(outputs: JupyterOutput[]): number | null {
+  let count: number | null = null;
+  for (const output of outputs) {
+    if (
+      (output.output_type === "execute_result" || output.output_type === "display_data") &&
+      typeof output.execution_count === "number" &&
+      Number.isFinite(output.execution_count)
+    ) {
+      count = output.execution_count;
+    }
+  }
+  return count;
 }
 
 function normalizeMetadata(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Derive cloud viewer execution counts from resolved RuntimeStateDoc outputs when the NotebookDoc cell field is null.
- Keep explicit cell-level execution counts as the highest-priority source.
- Add render-resolution tests for RuntimeStateDoc output fallback and explicit cell-count precedence.

## Verification

- `pnpm --dir apps/notebook-cloud test -- render-resolution`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run build`
- `cargo xtask lint --fix`
- `git diff --check`

## Deployment

- Deployed to `https://nteract-notebook-cloud.rgbkrk.workers.dev` as Worker version `3ae1a7ac-c4aa-4575-9a59-39abc479e30b`.
- Verified the canonical hosted live MathNet notebook at `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet`.
- Visual/DOM check confirms the notebook renders `In [1]:`, stdout, and the Sift Arrow table from the persisted snapshot pair.
