### PR TITLE
feat(notebook-cloud): split renderer asset origin

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -128,7 +128,7 @@ Bindings in `wrangler.toml`:
 - `DB`: D1 catalog for notebooks, revisions, blobs, and room event metadata.
 - `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, generated render caches, and blobs.
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
-- `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. It can point at a dedicated output/plugin origin. If unset, the viewer uses the Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
+- `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 
 Schema lives in `migrations/0001_initial.sql`. The Worker also creates the same tables lazily in local dev so the WebSocket path can run before applying migrations.
 
@@ -150,9 +150,13 @@ The render path is optional. If it is missing, the Worker loads the snapshot pai
 Disposable Cloudflare resources currently wired in `wrangler.toml`:
 
 - Worker: `nteract-notebook-cloud`
+- Renderer asset Worker: `nteract-notebook-cloud-assets`
 - URL: `https://nteract-notebook-cloud.rgbkrk.workers.dev`
+- Renderer assets URL: `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/`
 - D1: `nteract-notebook-cloud-prototype-db`
 - R2: `nteract-notebook-cloud-prototype`
+
+The renderer asset Worker binds only `dist/plugins`, not the full viewer bundle, so the separate origin is limited to renderer sidecars such as Sift's WASM binary.
 
 The remote migration was applied with:
 
@@ -169,6 +173,7 @@ printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
   | pnpm --workspace-root exec wrangler secret put NOTEBOOK_CLOUD_DEV_TOKEN \
       --config apps/notebook-cloud/wrangler.toml
 pnpm --dir apps/notebook-cloud build
+pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.renderer-assets.toml
 pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml
 ```
 

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -130,6 +130,8 @@ Bindings in `wrangler.toml`:
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 
+The dedicated renderer asset Worker serves only public, build-time sidecar files from the plugin asset bundle. It intentionally sends `Access-Control-Allow-Origin: *` so sandboxed `srcdoc` iframes with opaque origins can fetch renderer WASM. Do not serve authenticated, notebook-specific, or user-generated blobs from this origin; those belong behind the notebook host's blob resolver or a future signed output origin. Deploy the renderer asset Worker before the main Worker when `RENDERER_ASSETS_BASE_URL` points at the separate origin.
+
 Schema lives in `migrations/0001_initial.sql`. The Worker also creates the same tables lazily in local dev so the WebSocket path can run before applying migrations.
 
 Accepted WebSocket frame payload caps mirror `notebook-wire` per-frame limits: Automerge sync and runtime-state frames may be up to 64 MiB, `PUT_BLOB` up to 32 MiB, request frames up to 16 MiB, and presence/pool-state/session-control frames up to 1 MiB. The Durable Object keeps only the latest 500 `frame:*` metadata entries in object storage; D1 room events are observability rows, not the replay log.

--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -36,12 +36,27 @@ export default rendererAssetsWorker;
 
 function assetPathnameForRequest(pathname: string): string | null {
   if (pathname.startsWith("/renderer-assets/")) {
-    return `/${pathname.slice("/renderer-assets/".length)}`;
+    return rendererAssetPathname(pathname.slice("/renderer-assets/".length));
   }
   if (pathname.startsWith("/plugins/")) {
-    return `/${pathname.slice("/plugins/".length)}`;
+    return rendererAssetPathname(pathname.slice("/plugins/".length));
   }
   return null;
+}
+
+function rendererAssetPathname(rawName: string): string | null {
+  let name: string;
+  try {
+    name = decodeURIComponent(rawName);
+  } catch {
+    return null;
+  }
+
+  if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+    return null;
+  }
+
+  return `/${name}`;
 }
 
 function json(value: unknown, status = 200): Response {

--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -1,0 +1,67 @@
+import type { Env, ExportedHandler } from "./cloudflare-types.ts";
+
+type RendererAssetsEnv = Pick<Env, "ASSETS">;
+
+const rendererAssetsWorker: ExportedHandler<RendererAssetsEnv> = {
+  async fetch(request: Request, env: RendererAssetsEnv): Promise<Response> {
+    if (request.method === "OPTIONS") {
+      return withRendererAssetCors(new Response(null, { status: 204 }));
+    }
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return json({ error: "method not allowed" }, 405);
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === "/api/health") {
+      return json({ status: "ok", service: "nteract-notebook-cloud-renderer-assets" });
+    }
+
+    const assetPathname = assetPathnameForRequest(url.pathname);
+    if (!assetPathname) {
+      return json({ error: "not found" }, 404);
+    }
+    if (!env.ASSETS) {
+      return json({ error: "renderer assets are not configured" }, 503);
+    }
+
+    const assetUrl = new URL(request.url);
+    assetUrl.pathname = assetPathname;
+    const response = await env.ASSETS.fetch(new Request(assetUrl, request));
+    return withRendererAssetCors(new Response(response.body, response), { immutable: true });
+  },
+};
+
+export default rendererAssetsWorker;
+
+function assetPathnameForRequest(pathname: string): string | null {
+  if (pathname.startsWith("/renderer-assets/")) {
+    return `/${pathname.slice("/renderer-assets/".length)}`;
+  }
+  if (pathname.startsWith("/plugins/")) {
+    return `/${pathname.slice("/plugins/".length)}`;
+  }
+  return null;
+}
+
+function json(value: unknown, status = 200): Response {
+  return withRendererAssetCors(
+    new Response(JSON.stringify(value), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+function withRendererAssetCors(
+  response: Response,
+  options: { immutable?: boolean } = {},
+): Response {
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+  response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  if (options.immutable && response.ok) {
+    response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  }
+  return response;
+}

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -1,0 +1,98 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import rendererAssetsWorker from "../src/renderer-assets-worker.ts";
+import type { Env, ExecutionContext } from "../src/cloudflare-types.ts";
+
+describe("renderer assets Worker", () => {
+  it("serves renderer sidecars from the plugins asset directory", async () => {
+    const seenPaths: string[] = [];
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/renderer-assets/sift_wasm.wasm?v=hash"),
+      fakeEnv({
+        ASSETS: {
+          fetch: async (request: Request) => {
+            seenPaths.push(new URL(request.url).pathname);
+            return new Response("wasm", {
+              headers: { "Content-Type": "application/wasm" },
+            });
+          },
+        },
+      }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenPaths, ["/sift_wasm.wasm"]);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Access-Control-Allow-Methods"), "GET, HEAD, OPTIONS");
+    assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
+    assert.equal(response.headers.get("Content-Type"), "application/wasm");
+    assert.equal(await response.text(), "wasm");
+  });
+
+  it("does not expose the notebook app bundle from the renderer asset origin", async () => {
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/assets/notebook-cloud-viewer.js"),
+      fakeEnv({
+        ASSETS: {
+          fetch: async () => new Response("should not be reached"),
+        },
+      }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.deepEqual(await response.json(), { error: "not found" });
+  });
+
+  it("does not cache health checks as immutable assets", async () => {
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/api/health"),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Cache-Control"), null);
+    assert.deepEqual(await response.json(), {
+      status: "ok",
+      service: "nteract-notebook-cloud-renderer-assets",
+    });
+  });
+
+  it("supports HEAD requests for hosted sidecars", async () => {
+    const response = await rendererAssetsWorker.fetch(
+      new Request("https://assets.test/plugins/sift_wasm.wasm", { method: "HEAD" }),
+      fakeEnv({
+        ASSETS: {
+          fetch: async (request: Request) =>
+            new Response(null, {
+              status: new Request(request).method === "HEAD" ? 200 : 500,
+              headers: { "Content-Type": "application/wasm" },
+            }),
+        },
+      }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Content-Type"), "application/wasm");
+  });
+});
+
+function fakeEnv(overrides: Partial<Env> = {}): Pick<Env, "ASSETS"> {
+  return {
+    ASSETS: undefined,
+    ...overrides,
+  };
+}
+
+function fakeContext(): ExecutionContext {
+  return {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  };
+}

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -46,6 +46,29 @@ describe("renderer assets Worker", () => {
     assert.deepEqual(await response.json(), { error: "not found" });
   });
 
+  it("rejects traversal-shaped renderer asset paths before asset lookup", async () => {
+    const requests = [
+      "https://assets.test/renderer-assets/../assets/notebook-cloud-viewer.js",
+      "https://assets.test/renderer-assets/%2e%2e%2fassets%2fnotebook-cloud-viewer.js",
+      "https://assets.test/plugins/%2e%2e%5csift_wasm.wasm",
+    ];
+
+    for (const request of requests) {
+      const response = await rendererAssetsWorker.fetch(
+        new Request(request),
+        fakeEnv({
+          ASSETS: {
+            fetch: async () => new Response("should not be reached"),
+          },
+        }),
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 404);
+      assert.deepEqual(await response.json(), { error: "not found" });
+    }
+  });
+
   it("does not cache health checks as immutable assets", async () => {
     const response = await rendererAssetsWorker.fetch(
       new Request("https://assets.test/api/health"),

--- a/apps/notebook-cloud/wrangler.renderer-assets.toml
+++ b/apps/notebook-cloud/wrangler.renderer-assets.toml
@@ -1,0 +1,8 @@
+name = "nteract-notebook-cloud-assets"
+main = "./src/renderer-assets-worker.ts"
+compatibility_date = "2024-11-06"
+compatibility_flags = ["nodejs_compat"]
+
+[assets]
+directory = "./dist/plugins"
+binding = "ASSETS"

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -29,3 +29,4 @@ binding = "ASSETS"
 
 [vars]
 DEPLOYMENT_ENV = "prototype"
+RENDERER_ASSETS_BASE_URL = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/"


### PR DESCRIPTION
## Summary

- Add a dedicated `nteract-notebook-cloud-assets` Worker entrypoint for renderer/plugin sidecars.
- Point the prototype main Worker at the separate renderer asset origin via `RENDERER_ASSETS_BASE_URL`.
- Bind the asset Worker to `dist/plugins` only, so the separate origin serves Sift WASM and other sidecars without exposing the notebook app bundle.
- Document the two-Worker deployment path.

## Verification

- `pnpm --dir apps/notebook-cloud test -- renderer-assets-worker`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run build`
- `cargo xtask lint --fix`
- `git diff --check`

## Deployment

- Deployed renderer asset Worker `nteract-notebook-cloud-assets` as version `7f48da69-0b09-4790-b499-ceff4ac0ded8`.
- Deployed main Worker `nteract-notebook-cloud` as version `5124c837-ec24-47c3-9162-9e6df991d559`.
- Verified `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/sift_wasm.wasm` returns CORS and immutable cache headers.
- Verified `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/assets/notebook-cloud-viewer.js` returns 404.
- Verified the canonical hosted MathNet notebook still renders Sift and fetches `sift_wasm.wasm` from the renderer asset origin.
