### PR TITLE
test(notebook-cloud): add hosted render smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -20,6 +20,7 @@ With Wrangler running:
 
 ```bash
 pnpm --dir apps/notebook-cloud smoke
+pnpm --dir apps/notebook-cloud smoke:hosted
 pnpm --dir apps/notebook-cloud publish:demo
 pnpm --dir apps/notebook-cloud publish:fixture
 pnpm --dir apps/notebook-cloud publish:live
@@ -76,6 +77,21 @@ http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming
 
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
 `NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair.
+
+`smoke:hosted` runs a headless Chromium check against the deployed canonical
+MathNet notebook by default:
+
+```text
+https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet
+```
+
+It verifies that the hosted viewer renders the live-published code cell with a
+runtime-derived execution count, that sandboxed output iframes expose the
+MathNet stdout and Sift table content, and that Sift's WASM sidecar loads from
+the configured renderer asset origin with CORS. Override the target with
+`NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
+`NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
+artifact.
 
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -85,11 +85,21 @@ MathNet notebook by default:
 https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet
 ```
 
+Install the Chromium browser once before running the hosted smoke from a fresh
+checkout:
+
+```bash
+pnpm --dir apps/notebook-cloud smoke:hosted:install
+```
+
 It verifies that the hosted viewer renders the live-published code cell with a
-runtime-derived execution count, that sandboxed output iframes expose the
-MathNet stdout and Sift table content, and that Sift's WASM sidecar loads from
-the configured renderer asset origin with CORS. Override the target with
-`NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
+runtime-derived execution count, that sandboxed output iframes expose expected
+notebook content, and that Sift's WASM sidecar loads from the configured
+renderer asset origin with CORS. Override the target with
+`NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Override the content
+contract with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
+`NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
+`NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS` (`|` separated). Set
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
 artifact.
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
+    "smoke:hosted:install": "playwright install chromium",
     "publish:demo": "node scripts/publish-demo.mjs",
     "publish:fixture": "node scripts/publish-fixture.mjs",
     "publish:live": "node --import tsx scripts/publish-live.mjs",

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -11,6 +11,7 @@
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts",
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
+    "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",
     "publish:fixture": "node scripts/publish-fixture.mjs",
     "publish:live": "node --import tsx scripts/publish-live.mjs",
@@ -22,6 +23,7 @@
     "runtimed": "workspace:*"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@runtimed/node": "workspace:*",
     "@tailwindcss/vite": "^4.1.8",
     "@types/node": "^20.10.0",
@@ -29,8 +31,8 @@
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.1.8",
-    "tw-animate-css": "^1.4.0",
     "tsx": "^4.21.0",
+    "tw-animate-css": "^1.4.0",
     "typescript": "~5.8.3",
     "vite": "catalog:",
     "vite-plus": "catalog:"

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -10,6 +10,14 @@ const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgb
 const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
 const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
+const expectedSourceText = process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "import polars as pl";
+const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
+const expectedFrameTexts = (
+  process.env.NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS ?? "Loaded 25 rows|PROBLEM_MARKDOWN"
+)
+  .split("|")
+  .map((text) => text.trim())
+  .filter(Boolean);
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const targetOrigin = new URL(targetUrl).origin;
@@ -17,159 +25,180 @@ const rendererAssetOrigin = expectedRendererAssetOrigin
   ? new URL(expectedRendererAssetOrigin).origin
   : null;
 
-const browser = await chromium.launch({ headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1" });
-const page = await browser.newPage({
-  viewport: { width: 1440, height: 1200 },
-  deviceScaleFactor: 1,
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
 });
 
-const failures = [];
-const warnings = [];
-const siftWasmRequests = [];
-const rendererCompletions = [];
-let screenshotSaved = false;
-
-page.on("console", (message) => {
-  const text = message.text();
-  if (message.type() === "error" && !isBenignConsoleError(text)) {
-    failures.push({ kind: "console-error", text });
-    return;
-  }
-  if (message.type() === "warning") {
-    warnings.push(text);
-  }
-  if (text.includes("render-complete") || text.includes("rendered-after-paint")) {
-    rendererCompletions.push(text);
-  }
-});
-
-page.on("pageerror", (error) => {
-  failures.push({ kind: "page-error", text: error.message });
-});
-
-page.on("requestfailed", (request) => {
-  if (!isRelevantRequestUrl(request.url())) {
-    return;
-  }
-  failures.push({
-    kind: "request-failed",
-    url: request.url(),
-    error: request.failure()?.errorText ?? "unknown",
+async function main() {
+  const browser = await chromium.launch({
+    headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1",
+    timeout: timeoutMs,
   });
-});
+  const page = await browser.newPage({
+    viewport: { width: 1440, height: 1200 },
+    deviceScaleFactor: 1,
+  });
 
-page.on("response", (response) => {
-  const url = response.url();
-  if (url.includes("sift_wasm.wasm")) {
-    siftWasmRequests.push({
-      url,
-      status: response.status(),
-      cors: response.headers()["access-control-allow-origin"] ?? null,
-      contentType: response.headers()["content-type"] ?? null,
+  const failures = [];
+  const warnings = [];
+  const siftWasmRequests = [];
+  const rendererCompletions = [];
+  let screenshotSaved = false;
+
+  page.on("console", (message) => {
+    const text = message.text();
+    if (message.type() === "error" && !isBenignConsoleError(text)) {
+      warnings.push(`console-error: ${text}`);
+      return;
+    }
+    if (message.type() === "warning") {
+      warnings.push(text);
+    }
+    if (text.includes("render-complete") || text.includes("rendered-after-paint")) {
+      rendererCompletions.push(text);
+    }
+  });
+
+  page.on("pageerror", (error) => {
+    failures.push({ kind: "page-error", text: error.message });
+  });
+
+  page.on("requestfailed", (request) => {
+    if (!isRelevantRequestUrl(request.url())) {
+      return;
+    }
+    failures.push({
+      kind: "request-failed",
+      url: request.url(),
+      error: request.failure()?.errorText ?? "unknown",
     });
-  }
-});
+  });
 
-try {
-  await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
-
-  await page.waitForFunction(
-    () => document.body.innerText.includes("import polars as pl"),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  await page.waitForFunction(
-    () =>
-      Array.from(document.querySelectorAll("[data-slot='execution-count']")).some(
-        (node) => node.textContent?.trim() === "[1]:",
-      ),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  await page.waitForFunction(
-    () =>
-      Array.from(document.querySelectorAll("iframe[sandbox]")).some(
-        (iframe) => iframe.clientHeight >= 240,
-      ),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  const frameTextMatches = await waitForFrameText(page, ["Loaded 25 rows", "PROBLEM_MARKDOWN"]);
-
-  // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
-  await page.waitForTimeout(750);
-
-  const executionCounts = await page
-    .locator("[data-slot='execution-count']")
-    .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim() ?? ""));
-  const iframeMetrics = await page.evaluate(() =>
-    Array.from(document.querySelectorAll("iframe[sandbox]")).map((iframe) => ({
-      width: iframe.clientWidth,
-      height: iframe.clientHeight,
-      sandbox: iframe.getAttribute("sandbox"),
-      allow: iframe.getAttribute("allow"),
-    })),
-  );
-
-  if (siftWasmRequests.length === 0) {
-    failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
-  }
-  for (const request of siftWasmRequests) {
-    if (request.status >= 400) {
-      failures.push({ kind: "sift-wasm", text: `Sift WASM returned ${request.status}` });
-    }
-    if (request.cors !== "*") {
-      failures.push({ kind: "sift-wasm", text: "Sift WASM response did not include CORS *" });
-    }
-    if (!request.contentType?.includes("application/wasm")) {
-      failures.push({
-        kind: "sift-wasm",
-        text: `Sift WASM content type was ${request.contentType ?? "missing"}`,
+  page.on("response", (response) => {
+    const url = response.url();
+    if (url.includes("sift_wasm.wasm")) {
+      siftWasmRequests.push({
+        url,
+        status: response.status(),
+        cors: response.headers()["access-control-allow-origin"] ?? null,
+        contentType: response.headers()["content-type"] ?? null,
       });
     }
-  }
-  if (
-    expectedRendererAssetOrigin &&
-    !siftWasmRequests.some((request) => request.url.startsWith(expectedRendererAssetOrigin))
-  ) {
-    failures.push({
-      kind: "sift-wasm-origin",
-      text: `Sift WASM did not load from ${expectedRendererAssetOrigin}`,
-      requests: siftWasmRequests.map((request) => request.url),
-    });
-  }
-  if (screenshotPath) {
-    await saveScreenshot(page);
-  }
+  });
 
-  if (failures.length > 0) {
-    throw new SmokeFailure(failures);
-  }
+  try {
+    await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+    await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
 
-  console.log(
-    JSON.stringify(
+    await page.waitForFunction(
+      (text) => document.body.innerText.includes(text),
+      expectedSourceText,
       {
-        ok: true,
-        targetUrl,
-        executionCounts,
-        frameTextMatches,
-        iframeMetrics,
-        siftWasmRequests,
-        rendererCompletions: rendererCompletions.length,
-        warnings,
+        timeout: timeoutMs,
       },
-      null,
-      2,
-    ),
-  );
-} catch (error) {
-  if (screenshotPath && !screenshotSaved) {
-    await saveScreenshot(page).catch(() => {});
+    );
+    await page.waitForFunction(
+      (expected) => {
+        const counts = Array.from(document.querySelectorAll("[data-slot='execution-count']")).map(
+          (node) => node.textContent?.trim() ?? "",
+        );
+        if (expected) {
+          return counts.includes(expected);
+        }
+        return counts.some((count) => /^\[\d+\]:$/.test(count));
+      },
+      expectedExecutionCount,
+      { timeout: timeoutMs },
+    );
+    await page.waitForFunction(
+      () =>
+        Array.from(document.querySelectorAll("iframe[sandbox]")).some(
+          (iframe) => iframe.clientHeight >= 240,
+        ),
+      undefined,
+      { timeout: timeoutMs },
+    );
+    const frameTextMatches = await waitForFrameText(page, expectedFrameTexts);
+
+    // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
+    await page.waitForTimeout(750);
+
+    const executionCounts = await page
+      .locator("[data-slot='execution-count']")
+      .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim() ?? ""));
+    const iframeMetrics = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("iframe[sandbox]")).map((iframe) => ({
+        width: iframe.clientWidth,
+        height: iframe.clientHeight,
+        sandbox: iframe.getAttribute("sandbox"),
+        allow: iframe.getAttribute("allow"),
+      })),
+    );
+
+    if (siftWasmRequests.length === 0) {
+      failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
+    }
+    for (const request of siftWasmRequests) {
+      if (request.status >= 400) {
+        failures.push({ kind: "sift-wasm", text: `Sift WASM returned ${request.status}` });
+      }
+      if (request.cors !== "*") {
+        failures.push({ kind: "sift-wasm", text: "Sift WASM response did not include CORS *" });
+      }
+      if (!request.contentType?.includes("application/wasm")) {
+        failures.push({
+          kind: "sift-wasm",
+          text: `Sift WASM content type was ${request.contentType ?? "missing"}`,
+        });
+      }
+    }
+    if (
+      expectedRendererAssetOrigin &&
+      !siftWasmRequests.some((request) => request.url.startsWith(expectedRendererAssetOrigin))
+    ) {
+      failures.push({
+        kind: "sift-wasm-origin",
+        text: `Sift WASM did not load from ${expectedRendererAssetOrigin}`,
+        requests: siftWasmRequests.map((request) => request.url),
+      });
+    }
+    if (screenshotPath) {
+      await saveScreenshot(page);
+      screenshotSaved = true;
+    }
+
+    if (failures.length > 0) {
+      throw new SmokeFailure(failures);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          targetUrl,
+          expectedSourceText,
+          expectedExecutionCount,
+          expectedFrameTexts,
+          executionCounts,
+          frameTextMatches,
+          iframeMetrics,
+          siftWasmRequests,
+          rendererCompletions: rendererCompletions.length,
+          warnings,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    if (screenshotPath && !screenshotSaved) {
+      await saveScreenshot(page).catch(() => {});
+    }
+    throw error;
+  } finally {
+    await browser.close();
   }
-  throw error;
-} finally {
-  await browser.close();
 }
 
 function isBenignConsoleError(text) {
@@ -193,7 +222,7 @@ async function waitForFrameText(page, expectedTexts) {
   const matches = new Map(expectedTexts.map((text) => [text, false]));
 
   while (Date.now() < deadline) {
-    for (const frame of page.frames()) {
+    for (const frame of page.frames().filter((frame) => frame !== page.mainFrame())) {
       const text = await frame
         .locator("body")
         .innerText({ timeout: 1_000 })

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -1,0 +1,231 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { chromium } from "@playwright/test";
+
+const DEFAULT_URL =
+  "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet";
+const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
+
+const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
+const expectedRendererAssetOrigin =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
+const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
+const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
+const targetOrigin = new URL(targetUrl).origin;
+const rendererAssetOrigin = expectedRendererAssetOrigin
+  ? new URL(expectedRendererAssetOrigin).origin
+  : null;
+
+const browser = await chromium.launch({ headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1" });
+const page = await browser.newPage({
+  viewport: { width: 1440, height: 1200 },
+  deviceScaleFactor: 1,
+});
+
+const failures = [];
+const warnings = [];
+const siftWasmRequests = [];
+const rendererCompletions = [];
+let screenshotSaved = false;
+
+page.on("console", (message) => {
+  const text = message.text();
+  if (message.type() === "error" && !isBenignConsoleError(text)) {
+    failures.push({ kind: "console-error", text });
+    return;
+  }
+  if (message.type() === "warning") {
+    warnings.push(text);
+  }
+  if (text.includes("render-complete") || text.includes("rendered-after-paint")) {
+    rendererCompletions.push(text);
+  }
+});
+
+page.on("pageerror", (error) => {
+  failures.push({ kind: "page-error", text: error.message });
+});
+
+page.on("requestfailed", (request) => {
+  if (!isRelevantRequestUrl(request.url())) {
+    return;
+  }
+  failures.push({
+    kind: "request-failed",
+    url: request.url(),
+    error: request.failure()?.errorText ?? "unknown",
+  });
+});
+
+page.on("response", (response) => {
+  const url = response.url();
+  if (url.includes("sift_wasm.wasm")) {
+    siftWasmRequests.push({
+      url,
+      status: response.status(),
+      cors: response.headers()["access-control-allow-origin"] ?? null,
+      contentType: response.headers()["content-type"] ?? null,
+    });
+  }
+});
+
+try {
+  await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
+
+  await page.waitForFunction(
+    () => document.body.innerText.includes("import polars as pl"),
+    undefined,
+    { timeout: timeoutMs },
+  );
+  await page.waitForFunction(
+    () =>
+      Array.from(document.querySelectorAll("[data-slot='execution-count']")).some(
+        (node) => node.textContent?.trim() === "[1]:",
+      ),
+    undefined,
+    { timeout: timeoutMs },
+  );
+  await page.waitForFunction(
+    () =>
+      Array.from(document.querySelectorAll("iframe[sandbox]")).some(
+        (iframe) => iframe.clientHeight >= 240,
+      ),
+    undefined,
+    { timeout: timeoutMs },
+  );
+  const frameTextMatches = await waitForFrameText(page, ["Loaded 25 rows", "PROBLEM_MARKDOWN"]);
+
+  // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
+  await page.waitForTimeout(750);
+
+  const executionCounts = await page
+    .locator("[data-slot='execution-count']")
+    .evaluateAll((nodes) => nodes.map((node) => node.textContent?.trim() ?? ""));
+  const iframeMetrics = await page.evaluate(() =>
+    Array.from(document.querySelectorAll("iframe[sandbox]")).map((iframe) => ({
+      width: iframe.clientWidth,
+      height: iframe.clientHeight,
+      sandbox: iframe.getAttribute("sandbox"),
+      allow: iframe.getAttribute("allow"),
+    })),
+  );
+
+  if (siftWasmRequests.length === 0) {
+    failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
+  }
+  for (const request of siftWasmRequests) {
+    if (request.status >= 400) {
+      failures.push({ kind: "sift-wasm", text: `Sift WASM returned ${request.status}` });
+    }
+    if (request.cors !== "*") {
+      failures.push({ kind: "sift-wasm", text: "Sift WASM response did not include CORS *" });
+    }
+    if (!request.contentType?.includes("application/wasm")) {
+      failures.push({
+        kind: "sift-wasm",
+        text: `Sift WASM content type was ${request.contentType ?? "missing"}`,
+      });
+    }
+  }
+  if (
+    expectedRendererAssetOrigin &&
+    !siftWasmRequests.some((request) => request.url.startsWith(expectedRendererAssetOrigin))
+  ) {
+    failures.push({
+      kind: "sift-wasm-origin",
+      text: `Sift WASM did not load from ${expectedRendererAssetOrigin}`,
+      requests: siftWasmRequests.map((request) => request.url),
+    });
+  }
+  if (screenshotPath) {
+    await saveScreenshot(page);
+  }
+
+  if (failures.length > 0) {
+    throw new SmokeFailure(failures);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        targetUrl,
+        executionCounts,
+        frameTextMatches,
+        iframeMetrics,
+        siftWasmRequests,
+        rendererCompletions: rendererCompletions.length,
+        warnings,
+      },
+      null,
+      2,
+    ),
+  );
+} catch (error) {
+  if (screenshotPath && !screenshotSaved) {
+    await saveScreenshot(page).catch(() => {});
+  }
+  throw error;
+} finally {
+  await browser.close();
+}
+
+function isBenignConsoleError(text) {
+  return (
+    text.includes("A listener indicated an asynchronous response by returning true") ||
+    text.includes("message channel closed before a response was received")
+  );
+}
+
+function isRelevantRequestUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.origin === targetOrigin || url.origin === rendererAssetOrigin;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForFrameText(page, expectedTexts) {
+  const deadline = Date.now() + timeoutMs;
+  const matches = new Map(expectedTexts.map((text) => [text, false]));
+
+  while (Date.now() < deadline) {
+    for (const frame of page.frames()) {
+      const text = await frame
+        .locator("body")
+        .innerText({ timeout: 1_000 })
+        .catch(() => "");
+      for (const expectedText of expectedTexts) {
+        if (text.includes(expectedText)) {
+          matches.set(expectedText, true);
+        }
+      }
+    }
+
+    if (Array.from(matches.values()).every(Boolean)) {
+      return Object.fromEntries(matches);
+    }
+    await page.waitForTimeout(250);
+  }
+
+  const missing = Array.from(matches.entries())
+    .filter(([, found]) => !found)
+    .map(([text]) => text);
+  throw new Error(`Timed out waiting for hosted renderer iframe text: ${missing.join(", ")}`);
+}
+
+async function saveScreenshot(page) {
+  await mkdir(path.dirname(screenshotPath), { recursive: true });
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  screenshotSaved = true;
+}
+
+class SmokeFailure extends Error {
+  constructor(failures) {
+    super(`Hosted render smoke failed:\n${JSON.stringify(failures, null, 2)}`);
+    this.name = "SmokeFailure";
+  }
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -49,7 +49,7 @@ async function main() {
   page.on("console", (message) => {
     const text = message.text();
     if (message.type() === "error" && !isBenignConsoleError(text)) {
-      warnings.push(`console-error: ${text}`);
+      failures.push({ kind: "console-error", text });
       return;
     }
     if (message.type() === "warning") {
@@ -193,7 +193,11 @@ async function main() {
     );
   } catch (error) {
     if (screenshotPath && !screenshotSaved) {
-      await saveScreenshot(page).catch(() => {});
+      await saveScreenshot(page)
+        .then(() => {
+          screenshotSaved = true;
+        })
+        .catch(() => {});
     }
     throw error;
   } finally {
@@ -249,7 +253,6 @@ async function waitForFrameText(page, expectedTexts) {
 async function saveScreenshot(page) {
   await mkdir(path.dirname(screenshotPath), { recursive: true });
   await page.screenshot({ path: screenshotPath, fullPage: true });
-  screenshotSaved = true;
 }
 
 class SmokeFailure extends Error {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtimed
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@runtimed/node':
         specifier: workspace:*
         version: link:../../packages/runtimed-node


### PR DESCRIPTION
## Summary

- add an opt-in `pnpm --dir apps/notebook-cloud smoke:hosted` Chromium smoke check for the canonical hosted MathNet notebook
- verify the live-published viewer path renders a runtime-derived execution count, sandboxed iframe output text, Sift table content, and Sift WASM from the renderer asset origin with CORS
- document the command and its target/env overrides

## Test Plan

- `pnpm --dir apps/notebook-cloud run typecheck`
- `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/nteract-cloud-hosted-smoke.png pnpm --dir apps/notebook-cloud smoke:hosted`
- `pnpm --dir apps/notebook-cloud test`
- `node --check apps/notebook-cloud/scripts/hosted-render-smoke.mjs`
- `cargo xtask lint --fix`
