### PR TITLE
fix(notebook-cloud): reject renders with missing blobs

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -36,6 +36,7 @@ const DEMO_NOTEBOOK_ID = "nteract-cloud-demo";
 // Worker-owned route by default so sandboxed srcdoc iframes can fetch sidecar
 // assets with explicit CORS, and let hosts replace it with a dedicated origin.
 const DEFAULT_RENDERER_ASSETS_BASE_PATH = "/renderer-assets/";
+const RENDER_BLOB_HEAD_CONCURRENCY = 16;
 
 interface MissingRenderBlob {
   hash: string;
@@ -533,7 +534,11 @@ async function materializeSnapshotRender(
     );
   }
 
-  const missingBlobs = await findMissingRenderBlobs(env, notebookId, render.cells);
+  const missingBlobs = await findMissingRenderBlobs(
+    env.NOTEBOOK_SNAPSHOTS,
+    notebookId,
+    render.cells,
+  );
   if (missingBlobs.length > 0) {
     console.warn("Unable to materialize notebook render: missing blobs", {
       notebookId,
@@ -578,28 +583,30 @@ async function materializeSnapshotRender(
 }
 
 async function findMissingRenderBlobs(
-  env: Env,
+  bucket: NonNullable<Env["NOTEBOOK_SNAPSHOTS"]>,
   notebookId: string,
   cells: unknown,
 ): Promise<MissingRenderBlob[]> {
-  const bucket = env.NOTEBOOK_SNAPSHOTS;
-  if (!bucket) {
-    return [];
-  }
-
   const refs = Object.values(collectBlobRefs(cells));
-  const missing = await Promise.all(
-    refs.map(async (ref) => {
-      const object = await bucket.head(blobKey(notebookId, ref.blob));
-      return object
-        ? null
-        : {
-            hash: ref.blob,
-            size: ref.size ?? null,
-            media_type: ref.media_type ?? null,
-          };
-    }),
-  );
+  const missing: Array<MissingRenderBlob | null> = [];
+
+  for (let index = 0; index < refs.length; index += RENDER_BLOB_HEAD_CONCURRENCY) {
+    const batch = refs.slice(index, index + RENDER_BLOB_HEAD_CONCURRENCY);
+    missing.push(
+      ...(await Promise.all(
+        batch.map(async (ref) => {
+          const object = await bucket.head(blobKey(notebookId, ref.blob));
+          return object
+            ? null
+            : {
+                hash: ref.blob,
+                size: ref.size ?? null,
+                media_type: ref.media_type ?? null,
+              };
+        }),
+      )),
+    );
+  }
 
   return missing
     .filter((entry): entry is MissingRenderBlob => entry !== null)

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -27,6 +27,7 @@ import {
   notebookCloudBlobBasePath,
   withTrailingSlash,
 } from "./blob-resolver.ts";
+import { collectBlobRefs } from "./blob-refs.ts";
 
 export { NotebookRoom };
 
@@ -35,6 +36,12 @@ const DEMO_NOTEBOOK_ID = "nteract-cloud-demo";
 // Worker-owned route by default so sandboxed srcdoc iframes can fetch sidecar
 // assets with explicit CORS, and let hosts replace it with a dedicated origin.
 const DEFAULT_RENDERER_ASSETS_BASE_PATH = "/renderer-assets/";
+
+interface MissingRenderBlob {
+  hash: string;
+  size: number | null;
+  media_type: string | null;
+}
 
 const worker: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -525,6 +532,24 @@ async function materializeSnapshotRender(
       422,
     );
   }
+
+  const missingBlobs = await findMissingRenderBlobs(env, notebookId, render.cells);
+  if (missingBlobs.length > 0) {
+    console.warn("Unable to materialize notebook render: missing blobs", {
+      notebookId,
+      notebookHeadsHash: revision.notebook_heads_hash,
+      runtimeHeadsHash: revision.runtime_heads_hash,
+      missingBlobs,
+    });
+    return json(
+      {
+        error: "render materialization missing blobs",
+        missing_blobs: missingBlobs,
+      },
+      424,
+    );
+  }
+
   const body = JSON.stringify(render);
   await env.NOTEBOOK_SNAPSHOTS.put(renderKey(notebookId, revision.notebook_heads_hash), body, {
     httpMetadata: {
@@ -550,6 +575,35 @@ async function materializeSnapshotRender(
       },
     }),
   );
+}
+
+async function findMissingRenderBlobs(
+  env: Env,
+  notebookId: string,
+  cells: unknown,
+): Promise<MissingRenderBlob[]> {
+  const bucket = env.NOTEBOOK_SNAPSHOTS;
+  if (!bucket) {
+    return [];
+  }
+
+  const refs = Object.values(collectBlobRefs(cells));
+  const missing = await Promise.all(
+    refs.map(async (ref) => {
+      const object = await bucket.head(blobKey(notebookId, ref.blob));
+      return object
+        ? null
+        : {
+            hash: ref.blob,
+            size: ref.size ?? null,
+            media_type: ref.media_type ?? null,
+          };
+    }),
+  );
+
+  return missing
+    .filter((entry): entry is MissingRenderBlob => entry !== null)
+    .sort((left, right) => left.hash.localeCompare(right.hash));
 }
 
 async function routeBlob(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -302,9 +302,9 @@ describe("Worker artifact routes", () => {
       missing_blobs: Array<{ hash: string }>;
     };
     assert.equal(body.error, "render materialization missing blobs");
-    assert.deepEqual(
-      body.missing_blobs.map((blob) => blob.hash),
-      [missingHash],
+    assert.ok(
+      body.missing_blobs.some((blob) => blob.hash === missingHash),
+      "response should include the missing fixture blob hash",
     );
     assert.equal(
       env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("missing-blob-demo", "heads-fixture")),

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -234,6 +234,86 @@ describe("Worker artifact routes", () => {
     assert.equal(warnings.length, 1);
     assert.equal(warnings[0][0], "Unable to materialize notebook render");
   });
+
+  it("fails materialization when snapshot blob refs are missing from R2", async () => {
+    const env = fakeEnv();
+    const [notebookBytes, runtimeStateBytes, manifestBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/sift_arrow_output/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/sift_arrow_output/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/sift_arrow_output/manifest.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ]);
+    const manifest = JSON.parse(manifestBytes) as { blobs: Array<{ hash: string }> };
+    const missingHash = manifest.blobs[0]?.hash;
+    assert.equal(typeof missingHash, "string");
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/missing-blob-demo/runtime-snapshots/runtime-fixture",
+      runtimeStateBytes,
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const notebookPut = await ownerPut(
+      env,
+      "/api/n/missing-blob-demo/snapshots/heads-fixture",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-fixture",
+      },
+    );
+    assert.equal(notebookPut.status, 201);
+
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    let response: Response;
+    try {
+      response = await worker.fetch(
+        new Request("http://localhost/api/n/missing-blob-demo/render"),
+        env,
+        fakeContext(),
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(response.status, 424);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    const body = (await response.json()) as {
+      error: string;
+      missing_blobs: Array<{ hash: string }>;
+    };
+    assert.equal(body.error, "render materialization missing blobs");
+    assert.deepEqual(
+      body.missing_blobs.map((blob) => blob.hash),
+      [missingHash],
+    );
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("missing-blob-demo", "heads-fixture")),
+      false,
+      "failed blob validation should not cache a render object",
+    );
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0][0], "Unable to materialize notebook render: missing blobs");
+  });
 });
 
 async function ownerPut(

--- a/apps/notebook/e2e/noisy-output-interrupt.spec.ts
+++ b/apps/notebook/e2e/noisy-output-interrupt.spec.ts
@@ -13,6 +13,8 @@ import { McpPeer } from "./mcp-peer";
 test.describe("noisy output interrupt", () => {
   let mcp: McpPeer | null = null;
 
+  test.setTimeout(180_000);
+
   test.afterEach(async () => {
     await mcp?.close();
     mcp = null;
@@ -45,7 +47,9 @@ test.describe("noisy output interrupt", () => {
     );
 
     await executeCell(cell);
-    await waitForOutputContaining(cell, "noisy-e2e-line-25", 60_000);
+    // Long stream output is intentionally collapsed to a head/tail preview.
+    // Wait for a visible head line before interrupting the flood.
+    await waitForOutputContaining(cell, "noisy-e2e-line-6", 60_000);
 
     await page.getByTestId("interrupt-kernel-button").click();
     await waitForKernelStatus(page, "idle", 60_000);

--- a/apps/notebook/e2e/noisy-output-interrupt.spec.ts
+++ b/apps/notebook/e2e/noisy-output-interrupt.spec.ts
@@ -47,9 +47,10 @@ test.describe("noisy output interrupt", () => {
     );
 
     await executeCell(cell);
-    // Long stream output is intentionally collapsed to a head/tail preview.
-    // Wait for a visible head line before interrupting the flood.
-    await waitForOutputContaining(cell, "noisy-e2e-line-6", 60_000);
+    // Long stream output is intentionally collapsed after the flood is underway.
+    // Wait for the collapsed-output sentinel so this keeps exercising the noisy path.
+    const floodOutput = await waitForOutputContaining(cell, "lines hidden", 60_000);
+    await expect(floodOutput.getByRole("button", { name: "Show full log" })).toBeVisible();
 
     await page.getByTestId("interrupt-kernel-button").click();
     await waitForKernelStatus(page, "idle", 60_000);


### PR DESCRIPTION
## Summary

- make notebook-cloud render materialization verify every rendered blob ref exists in R2 before caching render JSON
- return a structured `424` with `missing_blobs` when a persisted snapshot pair references unavailable blob content
- add route coverage with the real `sift_arrow_output` fixture so missing Sift/Arrow blobs become a hard failure instead of a broken viewer URL

## Test Plan

- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud test -- worker-routes`
- `cargo xtask lint --fix`
