### PR TITLE
fix(notebook-cloud): validate snapshot publishes

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -4,7 +4,7 @@ This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It 
 
 The current Durable Object does not host kernels and does not parse Automerge sync messages. It enforces connection scope, rewrites canonical CBOR presence through the shared `runtimed-wasm` helper, stores bounded frame metadata, and broadcasts accepted binary typed frames to other peers in the same room.
 
-`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
+`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
 ## Local dev
 
@@ -159,7 +159,10 @@ n/{id}/blobs/{sha256}
 n/{id}/renders/{notebookHeadsHash}.json
 ```
 
-The render path is optional. If it is missing, the Worker loads the snapshot pair through `runtimed-wasm` and returns a materialized render response.
+The render path is derived. Snapshot-pair publishes pre-materialize it to prove
+the pair and all referenced blobs are complete before recording a revision. If
+the render object is later missing, the Worker can load the snapshot pair
+through `runtimed-wasm` and regenerate the materialized render response.
 
 ## Prototype deployment
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -43,6 +43,17 @@ interface MissingRenderBlob {
   media_type: string | null;
 }
 
+type RenderMaterializationResult =
+  | {
+      ok: true;
+      body: string;
+    }
+  | {
+      ok: false;
+      status: number;
+      body: Record<string, unknown>;
+    };
+
 const worker: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
@@ -258,6 +269,8 @@ async function routeSnapshot(
   const body = await request.arrayBuffer();
   const runtimeHeadsHash = normalizedRuntimeHeadsHash(request.headers.get("x-runtime-heads-hash"));
   const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
+  const renderCacheKey = renderKey(notebookId, headsHash);
+  let renderCacheWritten = false;
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -268,6 +281,37 @@ async function routeSnapshot(
       notebook_heads_hash: headsHash,
     },
   });
+
+  if (runtimeHeadsHash && runtimeKey) {
+    const runtimeObject = await env.NOTEBOOK_SNAPSHOTS.get(runtimeKey);
+    if (!runtimeObject) {
+      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+      return json(
+        {
+          error: "snapshot publish missing runtime-state snapshot",
+          runtime_heads_hash: runtimeHeadsHash,
+        },
+        424,
+      );
+    }
+
+    const materialized = await materializeSnapshotRenderCache({
+      request,
+      env,
+      notebookId,
+      notebookHeadsHash: headsHash,
+      runtimeHeadsHash,
+      notebookBytes: new Uint8Array(body),
+      runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
+      immutable: true,
+    });
+    if (!materialized.ok) {
+      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+      return json(materialized.body, materialized.status);
+    }
+    renderCacheWritten = true;
+  }
+
   let revisionId: string;
   try {
     revisionId = await recordRevision(env, {
@@ -280,6 +324,9 @@ async function routeSnapshot(
     });
   } catch (error) {
     await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    if (renderCacheWritten) {
+      await env.NOTEBOOK_SNAPSHOTS.delete(renderCacheKey).catch(() => undefined);
+    }
     throw error;
   }
 
@@ -504,69 +551,22 @@ async function materializeSnapshotRender(
     return json({ error: "runtime snapshot not found" }, 404);
   }
 
-  let render: Awaited<ReturnType<typeof materializeSnapshotPairRender>>;
-  try {
-    render = await materializeSnapshotPairRender({
-      notebookId,
-      notebookHeadsHash: revision.notebook_heads_hash,
-      runtimeHeadsHash: revision.runtime_heads_hash,
-      notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
-      runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
-      blobResolver: createNotebookCloudBlobResolver({
-        baseUrl: request.url,
-        blobBasePath: notebookCloudBlobBasePath(notebookId),
-      }),
-    });
-  } catch (error) {
-    console.warn("Unable to materialize notebook render", {
-      notebookId,
-      notebookHeadsHash: revision.notebook_heads_hash,
-      runtimeHeadsHash: revision.runtime_heads_hash,
-      error,
-    });
-    return json(
-      {
-        error: "render materialization failed",
-        details: errorMessage(error),
-      },
-      422,
-    );
-  }
-
-  const missingBlobs = await findMissingRenderBlobs(env, notebookId, render.cells);
-  if (missingBlobs.length > 0) {
-    console.warn("Unable to materialize notebook render: missing blobs", {
-      notebookId,
-      notebookHeadsHash: revision.notebook_heads_hash,
-      runtimeHeadsHash: revision.runtime_heads_hash,
-      missingBlobs,
-    });
-    return json(
-      {
-        error: "render materialization missing blobs",
-        missing_blobs: missingBlobs,
-      },
-      424,
-    );
-  }
-
-  const body = JSON.stringify(render);
-  await env.NOTEBOOK_SNAPSHOTS.put(renderKey(notebookId, revision.notebook_heads_hash), body, {
-    httpMetadata: {
-      contentType: "application/json; charset=utf-8",
-      cacheControl: immutable
-        ? "public, max-age=31536000, immutable"
-        : "public, max-age=30, stale-while-revalidate=300",
-    },
-    customMetadata: {
-      notebook_id: notebookId,
-      notebook_heads_hash: revision.notebook_heads_hash,
-      runtime_heads_hash: revision.runtime_heads_hash ?? "",
-      artifact: "materialized-render",
-    },
+  const materialized = await materializeSnapshotRenderCache({
+    request,
+    env,
+    notebookId,
+    notebookHeadsHash: revision.notebook_heads_hash,
+    runtimeHeadsHash: revision.runtime_heads_hash,
+    notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
+    runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
+    immutable,
   });
+  if (!materialized.ok) {
+    return json(materialized.body, materialized.status);
+  }
+
   return withCors(
-    new Response(body, {
+    new Response(materialized.body, {
       headers: {
         "Cache-Control": immutable
           ? "public, max-age=31536000, immutable"
@@ -575,6 +575,91 @@ async function materializeSnapshotRender(
       },
     }),
   );
+}
+
+async function materializeSnapshotRenderCache(options: {
+  request: Request;
+  env: Env;
+  notebookId: string;
+  notebookHeadsHash: string;
+  runtimeHeadsHash: string | null;
+  notebookBytes: Uint8Array;
+  runtimeStateBytes: Uint8Array;
+  immutable: boolean;
+}): Promise<RenderMaterializationResult> {
+  const bucket = options.env.NOTEBOOK_SNAPSHOTS;
+  if (!bucket) {
+    return {
+      ok: false,
+      status: 503,
+      body: { error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" },
+    };
+  }
+
+  let render: Awaited<ReturnType<typeof materializeSnapshotPairRender>>;
+  try {
+    render = await materializeSnapshotPairRender({
+      notebookId: options.notebookId,
+      notebookHeadsHash: options.notebookHeadsHash,
+      runtimeHeadsHash: options.runtimeHeadsHash,
+      notebookBytes: options.notebookBytes,
+      runtimeStateBytes: options.runtimeStateBytes,
+      blobResolver: createNotebookCloudBlobResolver({
+        baseUrl: options.request.url,
+        blobBasePath: notebookCloudBlobBasePath(options.notebookId),
+      }),
+    });
+  } catch (error) {
+    console.warn("Unable to materialize notebook render", {
+      notebookId: options.notebookId,
+      notebookHeadsHash: options.notebookHeadsHash,
+      runtimeHeadsHash: options.runtimeHeadsHash,
+      error,
+    });
+    return {
+      ok: false,
+      status: 422,
+      body: {
+        error: "render materialization failed",
+        details: errorMessage(error),
+      },
+    };
+  }
+
+  const missingBlobs = await findMissingRenderBlobs(options.env, options.notebookId, render.cells);
+  if (missingBlobs.length > 0) {
+    console.warn("Unable to materialize notebook render: missing blobs", {
+      notebookId: options.notebookId,
+      notebookHeadsHash: options.notebookHeadsHash,
+      runtimeHeadsHash: options.runtimeHeadsHash,
+      missingBlobs,
+    });
+    return {
+      ok: false,
+      status: 424,
+      body: {
+        error: "render materialization missing blobs",
+        missing_blobs: missingBlobs,
+      },
+    };
+  }
+
+  const body = JSON.stringify(render);
+  await bucket.put(renderKey(options.notebookId, options.notebookHeadsHash), body, {
+    httpMetadata: {
+      contentType: "application/json; charset=utf-8",
+      cacheControl: options.immutable
+        ? "public, max-age=31536000, immutable"
+        : "public, max-age=30, stale-while-revalidate=300",
+    },
+    customMetadata: {
+      notebook_id: options.notebookId,
+      notebook_heads_hash: options.notebookHeadsHash,
+      runtime_heads_hash: options.runtimeHeadsHash ?? "",
+      artifact: "materialized-render",
+    },
+  });
+  return { ok: true, body };
 }
 
 async function findMissingRenderBlobs(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -16,7 +16,7 @@ import type {
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
 import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
-import { renderKey } from "../src/storage.ts";
+import { renderKey, snapshotKey } from "../src/storage.ts";
 
 const wasmBytes = await readFile(
   new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
@@ -155,6 +155,11 @@ describe("Worker artifact routes", () => {
       },
     );
     assert.equal(notebookPut.status, 201);
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("route-demo", "heads-fixture")),
+      true,
+      "snapshot publish should pre-materialize a render cache for complete snapshot pairs",
+    );
 
     const response = await worker.fetch(
       new Request("http://localhost/api/n/route-demo/render"),
@@ -184,7 +189,37 @@ describe("Worker artifact routes", () => {
     );
   });
 
-  it("returns a structured error when persisted snapshots cannot be materialized", async () => {
+  it("rejects snapshot publish when the referenced runtime snapshot is missing", async () => {
+    const env = fakeEnv();
+    const notebookBytes = await readFile(
+      new URL(
+        "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+        import.meta.url,
+      ),
+    );
+
+    const response = await ownerPut(
+      env,
+      "/api/n/missing-runtime-demo/snapshots/heads-fixture",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-missing",
+      },
+    );
+
+    assert.equal(response.status, 424);
+    const body = (await response.json()) as { error: string; runtime_heads_hash: string };
+    assert.equal(body.error, "snapshot publish missing runtime-state snapshot");
+    assert.equal(body.runtime_heads_hash, "runtime-missing");
+    assert.equal(env.DB.revisions.length, 0);
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(snapshotKey("missing-runtime-demo", "heads-fixture")),
+      false,
+      "rejected snapshot publish should not leave an orphan notebook snapshot",
+    );
+  });
+
+  it("rejects snapshot publish when the persisted pair cannot be materialized", async () => {
     const env = fakeEnv();
     const corruptBytes = new TextEncoder().encode("not an automerge document");
 
@@ -195,16 +230,6 @@ describe("Worker artifact routes", () => {
     );
     assert.equal(runtimePut.status, 201);
 
-    const notebookPut = await ownerPut(
-      env,
-      "/api/n/corrupt-demo/snapshots/heads-corrupt",
-      corruptBytes,
-      {
-        "X-Runtime-Heads-Hash": "runtime-corrupt",
-      },
-    );
-    assert.equal(notebookPut.status, 201);
-
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
     console.warn = (...args: unknown[]) => {
@@ -212,11 +237,9 @@ describe("Worker artifact routes", () => {
     };
     let response: Response;
     try {
-      response = await worker.fetch(
-        new Request("http://localhost/api/n/corrupt-demo/render"),
-        env,
-        fakeContext(),
-      );
+      response = await ownerPut(env, "/api/n/corrupt-demo/snapshots/heads-corrupt", corruptBytes, {
+        "X-Runtime-Heads-Hash": "runtime-corrupt",
+      });
     } finally {
       console.warn = originalWarn;
     }
@@ -226,16 +249,22 @@ describe("Worker artifact routes", () => {
     const body = (await response.json()) as { error: string; details: string };
     assert.equal(body.error, "render materialization failed");
     assert.match(body.details, /load|document|decode|automerge/i);
+    assert.equal(env.DB.revisions.length, 0);
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(snapshotKey("corrupt-demo", "heads-corrupt")),
+      false,
+      "rejected snapshot publish should not leave a corrupt notebook snapshot",
+    );
     assert.equal(
       env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("corrupt-demo", "heads-corrupt")),
       false,
-      "failed materialization should not cache a render object",
+      "failed publish materialization should not cache a render object",
     );
     assert.equal(warnings.length, 1);
     assert.equal(warnings[0][0], "Unable to materialize notebook render");
   });
 
-  it("fails materialization when snapshot blob refs are missing from R2", async () => {
+  it("rejects snapshot publish when materialized blob refs are missing from R2", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes, manifestBytes] = await Promise.all([
       readFile(
@@ -269,16 +298,6 @@ describe("Worker artifact routes", () => {
     );
     assert.equal(runtimePut.status, 201);
 
-    const notebookPut = await ownerPut(
-      env,
-      "/api/n/missing-blob-demo/snapshots/heads-fixture",
-      notebookBytes,
-      {
-        "X-Runtime-Heads-Hash": "runtime-fixture",
-      },
-    );
-    assert.equal(notebookPut.status, 201);
-
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
     console.warn = (...args: unknown[]) => {
@@ -286,10 +305,13 @@ describe("Worker artifact routes", () => {
     };
     let response: Response;
     try {
-      response = await worker.fetch(
-        new Request("http://localhost/api/n/missing-blob-demo/render"),
+      response = await ownerPut(
         env,
-        fakeContext(),
+        "/api/n/missing-blob-demo/snapshots/heads-fixture",
+        notebookBytes,
+        {
+          "X-Runtime-Heads-Hash": "runtime-fixture",
+        },
       );
     } finally {
       console.warn = originalWarn;
@@ -305,6 +327,12 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(
       body.missing_blobs.map((blob) => blob.hash),
       [missingHash],
+    );
+    assert.equal(env.DB.revisions.length, 0);
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(snapshotKey("missing-blob-demo", "heads-fixture")),
+      false,
+      "rejected snapshot publish should not leave an orphan notebook snapshot",
     );
     assert.equal(
       env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("missing-blob-demo", "heads-fixture")),

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -44,6 +44,11 @@ The revision row records:
 Render caches may exist, but they are derived caches. They are not the source of
 truth and can be regenerated from the snapshot pair.
 
+The publish API may materialize that cache before recording the catalog row.
+This is a validation step, not a change in durability: if the `NotebookDoc` /
+`RuntimeStateDoc` pair cannot load, or if any rendered output manifest points at
+a missing blob object, the host rejects the publish and leaves no revision row.
+
 ## Decision 2: R2 layout is deterministic
 
 For a notebook `n/:id`:
@@ -55,8 +60,9 @@ n/{id}/blobs/{sha256}
 n/{id}/renders/{notebookHeadsHash}.json
 ```
 
-The render path is optional. The first three paths are the durable publish
-artifact set.
+The render path is derived. The first three paths are the durable publish
+artifact set, but hosts can precompute the render path at publish time to prove
+the snapshot pair and blob set are complete.
 
 ## Decision 3: Materialization uses runtimed-wasm
 


### PR DESCRIPTION
## Summary
- pre-materialize snapshot-pair render caches during snapshot publish before recording catalog revisions
- reject missing runtime snapshots, corrupt snapshot pairs, and missing output blobs without leaving revision rows or orphan notebook snapshots
- update notebook-cloud docs and the hosted artifacts ADR to reflect the publish-time validation contract

## Test Plan
- pnpm --dir apps/notebook-cloud run typecheck
- pnpm --dir apps/notebook-cloud test
- cargo xtask lint --fix
- git diff --check