### PR TITLE
test(notebook-cloud): parameterize hosted smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -93,6 +93,13 @@ the configured renderer asset origin with CORS. Override the target with
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
 artifact.
 
+For non-MathNet published notebooks, customize the hosted smoke expectations
+with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
+`NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
+`NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS`. Frame texts can be a JSON string array or
+a `|`-delimited list. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target
+notebook does not include a Sift output.
+
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered
 output manifests for blob refs, uploads the matching local daemon blobs, and

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -10,6 +10,13 @@ const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgb
 const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
 const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
+const expectedSourceText = process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "import polars as pl";
+const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? "[1]:";
+const expectedFrameTexts = parseExpectedTexts(process.env.NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS, [
+  "Loaded 25 rows",
+  "PROBLEM_MARKDOWN",
+]);
+const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const targetOrigin = new URL(targetUrl).origin;
@@ -74,28 +81,37 @@ try {
   await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
   await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
 
-  await page.waitForFunction(
-    () => document.body.innerText.includes("import polars as pl"),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  await page.waitForFunction(
-    () =>
-      Array.from(document.querySelectorAll("[data-slot='execution-count']")).some(
-        (node) => node.textContent?.trim() === "[1]:",
-      ),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  await page.waitForFunction(
-    () =>
-      Array.from(document.querySelectorAll("iframe[sandbox]")).some(
-        (iframe) => iframe.clientHeight >= 240,
-      ),
-    undefined,
-    { timeout: timeoutMs },
-  );
-  const frameTextMatches = await waitForFrameText(page, ["Loaded 25 rows", "PROBLEM_MARKDOWN"]);
+  if (expectedSourceText) {
+    await page.waitForFunction(
+      (text) => document.body.innerText.includes(text),
+      expectedSourceText,
+      {
+        timeout: timeoutMs,
+      },
+    );
+  }
+  if (expectedExecutionCount) {
+    await page.waitForFunction(
+      (count) =>
+        Array.from(document.querySelectorAll("[data-slot='execution-count']")).some(
+          (node) => node.textContent?.trim() === count,
+        ),
+      expectedExecutionCount,
+      { timeout: timeoutMs },
+    );
+  }
+  if (expectedFrameTexts.length > 0) {
+    await page.waitForFunction(
+      () =>
+        Array.from(document.querySelectorAll("iframe[sandbox]")).some(
+          (iframe) => iframe.clientHeight >= 240,
+        ),
+      undefined,
+      { timeout: timeoutMs },
+    );
+  }
+  const frameTextMatches =
+    expectedFrameTexts.length > 0 ? await waitForFrameText(page, expectedFrameTexts) : {};
 
   // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
   await page.waitForTimeout(750);
@@ -112,7 +128,7 @@ try {
     })),
   );
 
-  if (siftWasmRequests.length === 0) {
+  if (requireSiftWasm && siftWasmRequests.length === 0) {
     failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
   }
   for (const request of siftWasmRequests) {
@@ -131,6 +147,7 @@ try {
   }
   if (
     expectedRendererAssetOrigin &&
+    (requireSiftWasm || siftWasmRequests.length > 0) &&
     !siftWasmRequests.some((request) => request.url.startsWith(expectedRendererAssetOrigin))
   ) {
     failures.push({
@@ -152,6 +169,9 @@ try {
       {
         ok: true,
         targetUrl,
+        expectedSourceText,
+        expectedExecutionCount,
+        expectedFrameTexts,
         executionCounts,
         frameTextMatches,
         iframeMetrics,
@@ -170,6 +190,27 @@ try {
   throw error;
 } finally {
   await browser.close();
+}
+
+function parseExpectedTexts(value, fallback) {
+  if (value === undefined) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+  if (trimmed.startsWith("[")) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+      throw new Error("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS JSON must be an array of strings");
+    }
+    return parsed;
+  }
+  return trimmed
+    .split("|")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 function isBenignConsoleError(text) {


### PR DESCRIPTION
## Summary
- let the hosted render smoke target non-MathNet published notebooks by configuring source text, execution count, iframe text expectations, and Sift WASM requirement
- keep the canonical MathNet URL and expectations as defaults
- document the new smoke expectation environment variables

## Test Plan
- node --check apps/notebook-cloud/scripts/hosted-render-smoke.mjs
- NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/nteract-cloud-hosted-smoke-flex-default.png pnpm --dir apps/notebook-cloud smoke:hosted
- NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT="import polars as pl" NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT="[1]:" NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS="[\"Loaded 25 rows\",\"PROBLEM_MARKDOWN\"]" pnpm --dir apps/notebook-cloud smoke:hosted
- pnpm --dir apps/notebook-cloud run typecheck
- cargo xtask lint --fix
- git diff --check