### PR TITLE
test(notebook-cloud): compose live publish smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -21,6 +21,7 @@ With Wrangler running:
 ```bash
 pnpm --dir apps/notebook-cloud smoke
 pnpm --dir apps/notebook-cloud smoke:hosted
+pnpm --dir apps/notebook-cloud smoke:hosted:live
 pnpm --dir apps/notebook-cloud publish:demo
 pnpm --dir apps/notebook-cloud publish:fixture
 pnpm --dir apps/notebook-cloud publish:live
@@ -106,6 +107,12 @@ output manifests for blob refs, uploads the matching local daemon blobs, and
 materializes the hosted render. By default it creates and executes a small
 `ShadenA/MathNet` Polars notebook. Set `NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID=<id>`
 to publish an already-open live notebook room instead.
+
+`smoke:hosted:live` composes the two live checks: it runs `publish:live`, reads
+the returned viewer URL, then runs `smoke:hosted` against that exact notebook.
+Use `NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev` and
+`NOTEBOOK_CLOUD_DEV_TOKEN=...` to target the deployed prototype, or leave the
+defaults to target local Wrangler.
 
 ## Dev auth
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
+    "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",
     "publish:fixture": "node scripts/publish-fixture.mjs",
     "publish:live": "node --import tsx scripts/publish-live.mjs",

--- a/apps/notebook-cloud/scripts/hosted-live-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-smoke.mjs
@@ -1,0 +1,85 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const publish = await runNode(["--import", "tsx", "scripts/publish-live.mjs"], process.env);
+const publishResult = parseJson(publish.stdout, "publish-live");
+if (!publishResult.viewerUrl) {
+  throw new Error("publish-live output did not include viewerUrl");
+}
+
+const smokeEnv = {
+  ...process.env,
+  NOTEBOOK_CLOUD_HOSTED_URL: publishResult.viewerUrl,
+};
+if (!smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN) {
+  const origin = new URL(publishResult.viewerUrl).origin;
+  if (isLoopbackOrigin(origin)) {
+    smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN = origin;
+  }
+}
+
+const smoke = await runNode(["scripts/hosted-render-smoke.mjs", publishResult.viewerUrl], smokeEnv);
+const smokeResult = parseJson(smoke.stdout, "hosted-render-smoke");
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      publish: publishResult,
+      smoke: smokeResult,
+    },
+    null,
+    2,
+  ),
+);
+
+function runNode(args, env) {
+  console.error(`$ node ${args.join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: appDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      process.stderr.write(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `node ${args.join(" ")} exited with ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+function parseJson(stdout, label) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} did not print JSON: ${error.message}\n${stdout}`);
+  }
+}
+
+function isLoopbackOrigin(origin) {
+  const hostname = new URL(origin).hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}


### PR DESCRIPTION
## Summary
- add `smoke:hosted:live` to publish a real live notebook and immediately run the hosted smoke against the returned viewer URL
- default the renderer asset origin to the target origin for local Wrangler runs
- document the one-command live publish + hosted render smoke flow

## Test Plan
- node --check apps/notebook-cloud/scripts/hosted-live-smoke.mjs
- node --check apps/notebook-cloud/scripts/hosted-render-smoke.mjs
- pnpm --dir apps/notebook-cloud run typecheck
- cargo xtask lint --fix
- git diff --check

Note: I did not run the full deployed `smoke:hosted:live` command because this shell does not have `NOTEBOOK_CLOUD_DEV_TOKEN`; local Wrangler runs do not need that token.