### PR TITLE
feat(notebook-cloud): share read-only notebook cells

### DIFF
--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,9 +1,6 @@
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { CellContainer } from "@/components/cell/CellContainer";
-import { ExecutionCount } from "@/components/cell/ExecutionCount";
-import { OutputArea } from "@/components/cell/OutputArea";
-import { ReadOnlyCodeMirror } from "@/components/editor/readonly-codemirror";
+import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -234,68 +231,18 @@ function ReadonlyNotebookCell({
   cell: ResolvedCell;
   outputHostContext: NteractEmbedHostContextPatch;
 }) {
-  const codeContent = useMemo(
-    () => renderCellSource(cell, outputHostContext),
-    [cell, outputHostContext],
-  );
-  const outputContent =
-    cell.outputs.length > 0 ? (
-      <OutputArea
-        cellId={cell.id}
-        executionCount={cell.executionCount}
-        outputs={cell.outputs}
-        isolated="auto"
-        priority={CLOUD_VIEWER_PRIORITY}
-        hostContext={outputHostContext}
-      />
-    ) : null;
-
   return (
-    <CellContainer
+    <ReadOnlyNotebookCell
       id={cell.id}
       cellType={cell.cellType}
-      codeContent={codeContent}
-      outputContent={outputContent}
-      gutterContent={
-        cell.cellType === "code" ? <ExecutionCount count={cell.executionCount} /> : null
-      }
+      source={cell.source}
+      language={cloudSourceLanguage(cell.language)}
+      outputs={cell.outputs}
+      executionCount={cell.executionCount}
+      priority={CLOUD_VIEWER_PRIORITY}
+      hostContext={outputHostContext}
       className="cloud-cell"
-    />
-  );
-}
-
-function renderCellSource(
-  cell: ResolvedCell,
-  outputHostContext: NteractEmbedHostContextPatch,
-): ReactNode {
-  if (cell.cellType === "markdown") {
-    return (
-      <OutputArea
-        cellId={cell.id}
-        outputs={[
-          {
-            output_type: "display_data",
-            data: { "text/markdown": cell.source },
-            metadata: {},
-          },
-        ]}
-        isolated="auto"
-        priority={CLOUD_VIEWER_PRIORITY}
-        hostContext={outputHostContext}
-      />
-    );
-  }
-
-  return <ReadonlySource source={cell.source} language={cell.language} />;
-}
-
-function ReadonlySource({ source, language }: { source: string; language: string | null }) {
-  return (
-    <ReadOnlyCodeMirror
-      value={source}
-      language={cloudSourceLanguage(language)}
-      lineWrapping
-      className="cloud-source-block"
+      sourceClassName="cloud-source-block"
     />
   );
 }

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d32bbeff7e196dcba073ea3e9e0725998427fb83c174a523c31299a8ac8d52c8
-size 1600869
+oid sha256:932b280861a2c306e760c7da3ab4a1e3e98d236d2884cae6e779df93e3fba353
+size 1601199

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a23aeaa250f68127f24fe64e5986dde7c6983e8d53267f8efc8217b461309be3
-size 1480825
+oid sha256:74cce54927eac44b8a70b54ed305a5d0911f0c4a1b38ac864725f59923dc6219
+size 1480937

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -1,0 +1,126 @@
+import { type ReactNode, useMemo } from "react";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { ReadOnlyCodeMirror } from "@/components/editor/readonly-codemirror";
+import type { SupportedLanguage } from "@/components/editor/languages";
+import { CellContainer } from "./CellContainer";
+import { ExecutionCount } from "./ExecutionCount";
+import { OutputArea } from "./OutputArea";
+import type { JupyterOutput } from "./jupyter-output";
+
+export interface ReadOnlyNotebookCellProps {
+  id: string;
+  cellType: string;
+  source: string;
+  language?: SupportedLanguage | null;
+  outputs?: readonly JupyterOutput[];
+  executionCount?: number | null;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  className?: string;
+  sourceClassName?: string;
+  outputClassName?: string;
+  lineWrapping?: boolean;
+}
+
+export function ReadOnlyNotebookCell({
+  id,
+  cellType,
+  source,
+  language = "plain",
+  outputs = [],
+  executionCount = null,
+  priority,
+  hostContext,
+  className,
+  sourceClassName,
+  outputClassName,
+  lineWrapping = true,
+}: ReadOnlyNotebookCellProps) {
+  const codeContent = useMemo(
+    () =>
+      renderReadOnlyCellSource({
+        cellId: id,
+        cellType,
+        hostContext,
+        language,
+        lineWrapping,
+        priority,
+        source,
+        sourceClassName,
+      }),
+    [cellType, hostContext, id, language, lineWrapping, priority, source, sourceClassName],
+  );
+
+  const outputContent =
+    outputs.length > 0 ? (
+      <OutputArea
+        cellId={id}
+        executionCount={executionCount}
+        outputs={[...outputs]}
+        isolated="auto"
+        priority={priority}
+        hostContext={hostContext}
+        className={outputClassName}
+      />
+    ) : null;
+
+  return (
+    <CellContainer
+      id={id}
+      cellType={cellType}
+      codeContent={codeContent}
+      outputContent={outputContent}
+      gutterContent={cellType === "code" ? <ExecutionCount count={executionCount} /> : null}
+      className={className}
+    />
+  );
+}
+
+function renderReadOnlyCellSource({
+  cellId,
+  cellType,
+  hostContext,
+  language,
+  lineWrapping,
+  priority,
+  source,
+  sourceClassName,
+}: {
+  cellId: string;
+  cellType: string;
+  hostContext?: NteractEmbedHostContextPatch;
+  language?: SupportedLanguage | null;
+  lineWrapping: boolean;
+  priority?: readonly string[];
+  source: string;
+  sourceClassName?: string;
+}): ReactNode {
+  if (cellType === "markdown") {
+    return (
+      <OutputArea
+        cellId={cellId}
+        outputs={[markdownSourceOutput(source)]}
+        isolated="auto"
+        priority={priority}
+        hostContext={hostContext}
+      />
+    );
+  }
+
+  return (
+    <ReadOnlyCodeMirror
+      value={source}
+      language={language ?? "plain"}
+      lineWrapping={lineWrapping}
+      className={sourceClassName}
+    />
+  );
+}
+
+function markdownSourceOutput(source: string): JupyterOutput {
+  return {
+    output_type: "display_data",
+    data: { "text/markdown": source },
+    metadata: {},
+  };
+}

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { ReadOnlyNotebookCell } from "../ReadOnlyNotebookCell";
+import type { JupyterOutput } from "../jupyter-output";
+
+vi.mock("../OutputArea", () => ({
+  OutputArea: ({
+    cellId,
+    className,
+    executionCount,
+    hostContext,
+    outputs,
+    priority,
+  }: {
+    cellId?: string;
+    className?: string;
+    executionCount?: number | null;
+    hostContext?: unknown;
+    outputs: JupyterOutput[];
+    priority?: readonly string[];
+  }) => (
+    <div
+      data-cell-id={cellId}
+      data-class-name={className ?? ""}
+      data-execution-count={executionCount ?? ""}
+      data-host-context={JSON.stringify(hostContext ?? null)}
+      data-mimes={outputs
+        .flatMap((output) =>
+          output.output_type === "display_data" || output.output_type === "execute_result"
+            ? Object.keys(output.data)
+            : [output.output_type],
+        )
+        .join(",")}
+      data-priority={priority?.join(",") ?? ""}
+      data-testid="output-area"
+    />
+  ),
+}));
+
+vi.mock("@/components/editor/readonly-codemirror", () => ({
+  ReadOnlyCodeMirror: ({
+    className,
+    language,
+    lineWrapping,
+    value,
+  }: {
+    className?: string;
+    language?: string;
+    lineWrapping?: boolean;
+    value: string;
+  }) => (
+    <pre
+      className={className}
+      data-language={language}
+      data-line-wrapping={String(lineWrapping)}
+      data-testid="readonly-codemirror"
+    >
+      {value}
+    </pre>
+  ),
+}));
+
+describe("ReadOnlyNotebookCell", () => {
+  it("renders code through shared cell chrome with execution count and outputs", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="cell-code"
+        cellType="code"
+        source="print('hello')"
+        language="ipython"
+        executionCount={7}
+        outputs={[
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "hello\n",
+          },
+        ]}
+        priority={["text/plain"]}
+        hostContext={{
+          nteract: {
+            rendererAssetsBaseUrl: "https://assets.example.test/renderer-assets/",
+          },
+        }}
+        className="cloud-cell"
+        sourceClassName="cloud-source"
+        outputClassName="cloud-output"
+      />,
+    );
+
+    const container = document.querySelector('[data-slot="cell-container"]');
+    expect(container).toHaveAttribute("data-cell-id", "cell-code");
+    expect(container).toHaveAttribute("data-cell-type", "code");
+    expect(container).toHaveClass("cloud-cell");
+
+    expect(screen.getByTestId("readonly-codemirror")).toHaveTextContent("print('hello')");
+    expect(screen.getByTestId("readonly-codemirror")).toHaveAttribute("data-language", "ipython");
+    expect(screen.getByTestId("readonly-codemirror")).toHaveAttribute("data-line-wrapping", "true");
+    expect(screen.getByTestId("readonly-codemirror")).toHaveClass("cloud-source");
+
+    expect(screen.getByText("[7]:")).toHaveAttribute("data-slot", "execution-count");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "cell-code");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-execution-count", "7");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-mimes", "stream");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-priority", "text/plain");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-class-name", "cloud-output");
+    expect(screen.getByTestId("output-area").getAttribute("data-host-context")).toContain(
+      "https://assets.example.test/renderer-assets/",
+    );
+  });
+
+  it("renders markdown source as a notebook output without code execution chrome", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="cell-markdown"
+        cellType="markdown"
+        source="## Title"
+        outputs={[]}
+        priority={["text/markdown", "text/plain"]}
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="execution-count"]')).toBeNull();
+    expect(screen.queryByTestId("readonly-codemirror")).toBeNull();
+
+    const outputArea = screen.getByTestId("output-area");
+    expect(outputArea).toHaveAttribute("data-cell-id", "cell-markdown");
+    expect(outputArea).toHaveAttribute("data-mimes", "text/markdown");
+    expect(outputArea).toHaveAttribute("data-priority", "text/markdown,text/plain");
+  });
+
+  it("omits the output row for code cells with no outputs", () => {
+    render(<ReadOnlyNotebookCell id="empty-code" cellType="code" source="x = 1" outputs={[]} />);
+
+    expect(screen.getByTestId("readonly-codemirror")).toHaveTextContent("x = 1");
+    expect(screen.queryByTestId("output-area")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared `ReadOnlyNotebookCell` component that composes `CellContainer`, `ExecutionCount`, `ReadOnlyCodeMirror`, and `OutputArea`
- route notebook-cloud viewer cells through that shared component instead of maintaining a local read-only cell renderer
- refresh the LFS-tracked isolated renderer artifacts so the deployed renderer/plugin API includes `subscribeHostContext` for Sift
- cover code, markdown, and empty-output behavior with focused component tests

## Stack

- stacked on #2832 (`quod/notebook-cloud-live-smoke-command`)

## Verification

- `pnpm test:run src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
- `git diff --check`
- `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/nteract-cloud-hosted-smoke-after-renderer-refresh.png pnpm --dir apps/notebook-cloud smoke:hosted`

## Deployment

- deployed `nteract-notebook-cloud` version `bf56334b-22b5-4e1e-8bcf-90a063bb7482`
- canonical hosted notebook: https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet
