### PR TITLE
test(notebook-cloud): guard renderer artifact API

### DIFF
--- a/apps/notebook-cloud/test/renderer-artifacts.test.ts
+++ b/apps/notebook-cloud/test/renderer-artifacts.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+const REPO_ROOT = new URL("../../../", import.meta.url);
+const REGISTRY_SOURCE = new URL("src/lib/renderer-registry.ts", REPO_ROOT);
+const ISOLATED_RENDERER_ARTIFACT = new URL(
+  "apps/notebook/src/renderer-plugins/isolated-renderer.js",
+  REPO_ROOT,
+);
+
+describe("renderer plugin artifacts", () => {
+  it("keeps the checked-in isolated renderer artifact compatible with the install context", async () => {
+    const [registrySource, artifactSource] = await Promise.all([
+      readFile(REGISTRY_SOURCE, "utf8"),
+      readFile(ISOLATED_RENDERER_ARTIFACT, "utf8"),
+    ]);
+
+    assert.ok(
+      !artifactSource.startsWith("version https://git-lfs.github.com/spec/"),
+      "isolated renderer artifact must be checked out through Git LFS",
+    );
+
+    const fields = rendererInstallContextFields(registrySource);
+    assert.notEqual(fields.length, 0, "RendererInstallContext fields were not found");
+
+    for (const field of fields) {
+      assert.ok(
+        artifactSource.includes(field),
+        `isolated renderer artifact is missing RendererInstallContext.${field}; run cargo xtask renderer-plugins`,
+      );
+    }
+  });
+});
+
+function rendererInstallContextFields(source: string): string[] {
+  const interfaceBody = source.match(
+    /export interface RendererInstallContext\s*{(?<body>[\s\S]*?)^}/m,
+  )?.groups?.body;
+  if (!interfaceBody) return [];
+
+  return Array.from(interfaceBody.matchAll(/^\s{2}(\w+):/gm), (match) => match[1]);
+}

--- a/apps/notebook-cloud/test/renderer-artifacts.test.ts
+++ b/apps/notebook-cloud/test/renderer-artifacts.test.ts
@@ -26,7 +26,7 @@ describe("renderer plugin artifacts", () => {
 
     for (const field of fields) {
       assert.ok(
-        artifactSource.includes(field),
+        hasIdentifierOccurrence(artifactSource, field),
         `isolated renderer artifact is missing RendererInstallContext.${field}; run cargo xtask renderer-plugins`,
       );
     }
@@ -40,4 +40,9 @@ function rendererInstallContextFields(source: string): string[] {
   if (!interfaceBody) return [];
 
   return Array.from(interfaceBody.matchAll(/^\s{2}(\w+):/gm), (match) => match[1]);
+}
+
+function hasIdentifierOccurrence(source: string, identifier: string): boolean {
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[^A-Za-z0-9_$])${escaped}([^A-Za-z0-9_$]|$)`).test(source);
 }


### PR DESCRIPTION
## Summary

- add a notebook-cloud test that checks the checked-out isolated renderer LFS artifact contains every `RendererInstallContext` field from `src/lib/renderer-registry.ts`
- fail fast when a source/plugin API change lands without regenerating the stable isolated renderer artifacts
- specifically guards the stale artifact mismatch that broke hosted Sift rendering before #2833 refreshed the bundle

## Stack

- stacked on #2833 (`quod/notebook-cloud-shared-readonly-cell`)

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/renderer-artifacts.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `git diff --check`
- `cargo xtask lint --fix`
