### PR TITLE
test(notebook-cloud): surface hosted renderer diagnostics

### DIFF
--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -8,7 +8,7 @@
     "build:viewer": "vp build -c vite.config.ts && node scripts/copy-viewer-assets.mjs",
     "build": "pnpm run wasm && pnpm run renderer-plugins && pnpm run build:viewer",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "pnpm run wasm && node --import tsx --test test/*.test.ts",
+    "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-diagnostics.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-diagnostics.mjs
@@ -1,0 +1,45 @@
+const FATAL_ISOLATED_DIAGNOSTIC_PHASES = new Set([
+  "renderer-plugin-install-failed",
+  "rendered-empty-after-paint",
+]);
+
+export function parseIsolatedDiagnosticText(text) {
+  const match = text.match(/^\[(isolated-frame|isolated-renderer|iframe-libraries)\]\s+(\S+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    source: match[1],
+    phase: match[2],
+  };
+}
+
+export function consoleMessageLevel(type) {
+  if (type === "error") {
+    return "error";
+  }
+  if (type === "warning") {
+    return "warn";
+  }
+  if (type === "info") {
+    return "info";
+  }
+  return "debug";
+}
+
+export function isFatalIsolatedDiagnostic(diagnostic) {
+  return diagnostic.level === "error" || FATAL_ISOLATED_DIAGNOSTIC_PHASES.has(diagnostic.phase);
+}
+
+export function isolatedDiagnosticFailure(diagnostic) {
+  const message =
+    typeof diagnostic.details?.message === "string" ? diagnostic.details.message : diagnostic.text;
+  return {
+    kind: "isolated-diagnostic",
+    source: diagnostic.source,
+    phase: diagnostic.phase,
+    level: diagnostic.level,
+    text: message,
+    details: diagnostic.details ?? null,
+  };
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -3,6 +3,13 @@ import path from "node:path";
 
 import { chromium } from "@playwright/test";
 
+import {
+  consoleMessageLevel,
+  isolatedDiagnosticFailure,
+  isFatalIsolatedDiagnostic,
+  parseIsolatedDiagnosticText,
+} from "./hosted-render-smoke-diagnostics.mjs";
+
 const DEFAULT_URL =
   "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -24,6 +31,14 @@ const rendererAssetOrigin = expectedRendererAssetOrigin
   ? new URL(expectedRendererAssetOrigin).origin
   : null;
 
+const failures = [];
+const warnings = [];
+const siftWasmRequests = [];
+const rendererCompletions = [];
+const fatalIsolatedDiagnostics = [];
+const diagnosticTasks = [];
+let screenshotSaved = false;
+
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
@@ -39,14 +54,15 @@ async function main() {
     deviceScaleFactor: 1,
   });
 
-  const failures = [];
-  const warnings = [];
-  const siftWasmRequests = [];
-  const rendererCompletions = [];
-  let screenshotSaved = false;
-
   page.on("console", (message) => {
     const text = message.text();
+    const parsedDiagnostic = parseIsolatedDiagnosticText(text);
+    if (parsedDiagnostic) {
+      captureIsolatedDiagnostic(message, parsedDiagnostic);
+      if (message.type() === "error") {
+        return;
+      }
+    }
     if (message.type() === "error" && !isBenignConsoleError(text)) {
       failures.push({ kind: "console-error", text });
       return;
@@ -127,6 +143,7 @@ async function main() {
 
     // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
     await page.waitForTimeout(750);
+    await flushDiagnosticTasks();
 
     const executionCounts = await page
       .locator("[data-slot='execution-count']")
@@ -143,6 +160,7 @@ async function main() {
     if (requireSiftWasm && siftWasmRequests.length === 0) {
       failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
     }
+    failures.push(...fatalIsolatedDiagnostics.map(isolatedDiagnosticFailure));
     for (const request of siftWasmRequests) {
       if (request.status >= 400) {
         failures.push({ kind: "sift-wasm", text: `Sift WASM returned ${request.status}` });
@@ -170,7 +188,6 @@ async function main() {
     }
     if (screenshotPath) {
       await saveScreenshot(page);
-      screenshotSaved = true;
     }
 
     if (failures.length > 0) {
@@ -197,12 +214,15 @@ async function main() {
       ),
     );
   } catch (error) {
+    await flushDiagnosticTasks();
     if (screenshotPath && !screenshotSaved) {
-      await saveScreenshot(page)
-        .then(() => {
-          screenshotSaved = true;
-        })
-        .catch(() => {});
+      await saveScreenshot(page).catch(() => {});
+    }
+    if (!(error instanceof SmokeFailure) && fatalIsolatedDiagnostics.length > 0) {
+      throw new SmokeFailure([
+        ...fatalIsolatedDiagnostics.map(isolatedDiagnosticFailure),
+        { kind: "smoke-error", text: error instanceof Error ? error.message : String(error) },
+      ]);
     }
     throw error;
   } finally {
@@ -247,11 +267,57 @@ function isRelevantRequestUrl(value) {
   }
 }
 
+function captureIsolatedDiagnostic(message, parsedDiagnostic) {
+  const diagnostic = {
+    ...parsedDiagnostic,
+    level: consoleMessageLevel(message.type()),
+    text: message.text(),
+    details: null,
+  };
+  if (isFatalIsolatedDiagnostic(diagnostic)) {
+    fatalIsolatedDiagnostics.push(diagnostic);
+  }
+
+  diagnosticTasks.push(
+    readConsoleMessageDetails(message).then((details) => {
+      diagnostic.details = details;
+    }),
+  );
+}
+
+async function readConsoleMessageDetails(message) {
+  const detailsArg = message.args()[1];
+  if (!detailsArg) {
+    return null;
+  }
+  try {
+    const value = await detailsArg.jsonValue();
+    if (isPlainRecord(value)) {
+      return value;
+    }
+    return { value };
+  } catch (error) {
+    return { unavailable: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function flushDiagnosticTasks() {
+  await Promise.allSettled(diagnosticTasks);
+}
+
+function isPlainRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 async function waitForFrameText(page, expectedTexts) {
   const deadline = Date.now() + timeoutMs;
   const matches = new Map(expectedTexts.map((text) => [text, false]));
 
   while (Date.now() < deadline) {
+    if (fatalIsolatedDiagnostics.length > 0) {
+      await flushDiagnosticTasks();
+      throw new SmokeFailure(fatalIsolatedDiagnostics.map(isolatedDiagnosticFailure));
+    }
     for (const frame of page.frames().filter((frame) => frame !== page.mainFrame())) {
       const text = await frame
         .locator("body")
@@ -279,6 +345,7 @@ async function waitForFrameText(page, expectedTexts) {
 async function saveScreenshot(page) {
   await mkdir(path.dirname(screenshotPath), { recursive: true });
   await page.screenshot({ path: screenshotPath, fullPage: true });
+  screenshotSaved = true;
 }
 
 class SmokeFailure extends Error {

--- a/apps/notebook-cloud/test/hosted-smoke-diagnostics.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-diagnostics.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  consoleMessageLevel,
+  isolatedDiagnosticFailure,
+  isFatalIsolatedDiagnostic,
+  parseIsolatedDiagnosticText,
+} from "../scripts/hosted-render-smoke-diagnostics.mjs";
+
+describe("hosted render smoke diagnostics", () => {
+  it("parses isolated renderer diagnostic console messages", () => {
+    assert.deepEqual(
+      parseIsolatedDiagnosticText("[isolated-renderer] renderer-plugin-install-failed Object"),
+      {
+        source: "isolated-renderer",
+        phase: "renderer-plugin-install-failed",
+      },
+    );
+    assert.equal(parseIsolatedDiagnosticText("[sift-renderer] render Object"), null);
+  });
+
+  it("treats renderer install failures as fatal smoke diagnostics", () => {
+    const diagnostic = {
+      source: "isolated-renderer",
+      phase: "renderer-plugin-install-failed",
+      level: "debug",
+      text: "[isolated-renderer] renderer-plugin-install-failed Object",
+      details: { message: "subscribeHostContext is not a function" },
+    };
+
+    assert.equal(isFatalIsolatedDiagnostic(diagnostic), true);
+    assert.deepEqual(isolatedDiagnosticFailure(diagnostic), {
+      kind: "isolated-diagnostic",
+      source: "isolated-renderer",
+      phase: "renderer-plugin-install-failed",
+      level: "debug",
+      text: "subscribeHostContext is not a function",
+      details: { message: "subscribeHostContext is not a function" },
+    });
+  });
+
+  it("maps Playwright console message types to diagnostic levels", () => {
+    assert.equal(consoleMessageLevel("error"), "error");
+    assert.equal(consoleMessageLevel("warning"), "warn");
+    assert.equal(consoleMessageLevel("info"), "info");
+    assert.equal(consoleMessageLevel("log"), "debug");
+  });
+});


### PR DESCRIPTION
## Summary

Tighten the hosted notebook-cloud smoke so renderer/plugin failures surface as structured smoke failures instead of hiding behind iframe text timeouts.

## What Changed

- Parse isolated iframe diagnostic console lines from `hosted-render-smoke.mjs`.
- Treat fatal isolated diagnostics, especially `renderer-plugin-install-failed`, as smoke failures with the diagnostic detail payload.
- Add a focused unit test for diagnostic parsing/failure shaping.
- Include `.test.mjs` files in the notebook-cloud test script so Node-only smoke helper tests can run without forcing declarations for runtime `.mjs` scripts.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-diagnostics.test.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=60000 pnpm --dir apps/notebook-cloud smoke:hosted`
- `git diff --check`
- `cargo xtask lint --fix`
