### PR TITLE
test(notebook-cloud): verify hosted render source

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -96,11 +96,10 @@ pnpm --dir apps/notebook-cloud smoke:hosted:install
 It verifies that the hosted viewer renders the live-published code cell with a
 runtime-derived execution count, that sandboxed output iframes expose expected
 notebook content, and that Sift's WASM sidecar loads from the configured
-renderer asset origin with CORS. Override the target with
-`NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Override the content
-contract with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
-`NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
-`NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS` (`|` separated). Set
+renderer asset origin with CORS. It also checks the backing `/api/n/:id/render`
+document reports `source: "snapshot-pair"` so the smoke proves the page is using
+a materialized NotebookDoc + RuntimeStateDoc snapshot pair. Override the target
+with `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
 artifact.
 
@@ -108,8 +107,9 @@ For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
 `NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
 `NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS`. Frame texts can be a JSON string array or
-a `|`-delimited list. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target
-notebook does not include a Sift output.
+a `|`-delimited list. Set `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip the
+render API source check. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the
+target notebook does not include a Sift output.
 
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -1,0 +1,8 @@
+export function renderApiUrlForViewer(viewerUrl) {
+  const parsed = new URL(viewerUrl);
+  const match = parsed.pathname.match(/^\/n\/([^/]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+  return new URL(`/api/n/${match[1]}/render`, parsed.origin).href;
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -9,6 +9,7 @@ import {
   isFatalIsolatedDiagnostic,
   parseIsolatedDiagnosticText,
 } from "./hosted-render-smoke-diagnostics.mjs";
+import { renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL =
   "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet";
@@ -23,6 +24,7 @@ const expectedFrameTexts = parseExpectedTexts(process.env.NOTEBOOK_CLOUD_EXPECTE
   "Loaded 25 rows",
   "PROBLEM_MARKDOWN",
 ]);
+const expectedRenderSource = process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE ?? "snapshot-pair";
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
@@ -37,6 +39,7 @@ const siftWasmRequests = [];
 const rendererCompletions = [];
 const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
+let renderApiCheck = null;
 let screenshotSaved = false;
 
 main().catch((error) => {
@@ -103,6 +106,10 @@ async function main() {
   });
 
   try {
+    if (expectedRenderSource) {
+      renderApiCheck = await checkHostedRenderApi(targetUrl, expectedRenderSource);
+    }
+
     await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
     await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
 
@@ -202,6 +209,8 @@ async function main() {
           expectedSourceText,
           expectedExecutionCount,
           expectedFrameTexts,
+          expectedRenderSource,
+          renderApiCheck,
           executionCounts,
           frameTextMatches,
           iframeMetrics,
@@ -265,6 +274,43 @@ function isRelevantRequestUrl(value) {
   } catch {
     return false;
   }
+}
+
+async function checkHostedRenderApi(viewerUrl, expectedSource) {
+  const renderUrl = renderApiUrlForViewer(viewerUrl);
+  if (!renderUrl) {
+    failures.push({
+      kind: "render-api",
+      text: `Could not derive /api/n/:id/render URL from ${viewerUrl}`,
+    });
+    return null;
+  }
+
+  const response = await fetch(renderUrl);
+  if (!response.ok) {
+    failures.push({
+      kind: "render-api",
+      text: `${renderUrl} returned ${response.status}`,
+    });
+    return { url: renderUrl, status: response.status };
+  }
+
+  const json = await response.json();
+  const source = typeof json.source === "string" ? json.source : null;
+  const cellCount = Array.isArray(json.cells) ? json.cells.length : null;
+  if (source !== expectedSource) {
+    failures.push({
+      kind: "render-api",
+      text: `expected render source ${expectedSource}, got ${source ?? "missing"}`,
+      url: renderUrl,
+    });
+  }
+  return {
+    url: renderUrl,
+    status: response.status,
+    source,
+    cellCount,
+  };
 }
 
 function captureIsolatedDiagnostic(message, parsedDiagnostic) {

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { renderApiUrlForViewer } from "../scripts/hosted-render-smoke-routes.mjs";
+
+describe("hosted render smoke routes", () => {
+  it("derives the render API URL from a hosted notebook viewer URL", () => {
+    assert.equal(
+      renderApiUrlForViewer(
+        "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
+      ),
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet/render",
+    );
+  });
+
+  it("returns null for non-viewer URLs", () => {
+    assert.equal(renderApiUrlForViewer("https://example.com/"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync"), null);
+  });
+});


### PR DESCRIPTION
## Summary

Make the hosted notebook-cloud smoke verify the backing render API is serving a materialized snapshot pair, not just that the browser page eventually shows iframe text.

## What Changed

- Derive `/api/n/:id/render` from the hosted `/n/:id` viewer URL.
- Default `smoke:hosted` to assert the render API reports `source: "snapshot-pair"`.
- Include the render API check in the smoke JSON output.
- Add focused route-helper tests for the viewer-to-render API URL derivation.
- Document `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` as the escape hatch for non-standard smoke targets.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs test/hosted-smoke-diagnostics.test.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=60000 pnpm --dir apps/notebook-cloud smoke:hosted`
- `git diff --check`
- `cargo xtask lint --fix`
