### PR TITLE
test(notebook-cloud): verify live catalog provenance

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -98,18 +98,23 @@ runtime-derived execution count, that sandboxed output iframes expose expected
 notebook content, and that Sift's WASM sidecar loads from the configured
 renderer asset origin with CORS. It also checks the backing `/api/n/:id/render`
 document reports `source: "snapshot-pair"` so the smoke proves the page is using
-a materialized NotebookDoc + RuntimeStateDoc snapshot pair. Override the target
-with `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
-`NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
-artifact.
+a materialized NotebookDoc + RuntimeStateDoc snapshot pair, and checks the
+catalog owner/latest revision actor match the live publish path. Override the
+target with `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
+`NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a
+visual artifact.
 
 For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
 `NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
 `NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS`. Frame texts can be a JSON string array or
 a `|`-delimited list. Set `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip the
-render API source check. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the
-target notebook does not include a Sift output.
+render API source check. Set
+`NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL=` and
+`NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL=` to skip the live-publish
+catalog provenance checks, or set them to the expected owner/actor for another
+published notebook. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target
+notebook does not include a Sift output.
 
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
@@ -1,0 +1,46 @@
+export function summarizeCatalog(json) {
+  const ownerPrincipal =
+    typeof json?.notebook?.owner_principal === "string" ? json.notebook.owner_principal : null;
+  const latestRevisionId =
+    typeof json?.notebook?.latest_revision_id === "string"
+      ? json.notebook.latest_revision_id
+      : null;
+  const revisions = Array.isArray(json?.revisions) ? json.revisions : [];
+  const latestRevision = latestRevisionId
+    ? (revisions.find((revision) => revision?.id === latestRevisionId) ?? null)
+    : null;
+  const latestRevisionActorLabel =
+    typeof latestRevision?.actor_label === "string" ? latestRevision.actor_label : null;
+
+  return {
+    ownerPrincipal,
+    latestRevisionId,
+    latestRevisionActorLabel,
+    revisionCount: revisions.length,
+  };
+}
+
+export function catalogExpectationFailures(
+  summary,
+  { expectedCatalogOwnerPrincipal, expectedLatestRevisionActorLabel },
+) {
+  const failures = [];
+  if (expectedCatalogOwnerPrincipal && summary.ownerPrincipal !== expectedCatalogOwnerPrincipal) {
+    failures.push({
+      text: `expected catalog owner ${expectedCatalogOwnerPrincipal}, got ${
+        summary.ownerPrincipal ?? "missing"
+      }`,
+    });
+  }
+  if (
+    expectedLatestRevisionActorLabel &&
+    summary.latestRevisionActorLabel !== expectedLatestRevisionActorLabel
+  ) {
+    failures.push({
+      text: `expected latest revision actor ${expectedLatestRevisionActorLabel}, got ${
+        summary.latestRevisionActorLabel ?? "missing"
+      }`,
+    });
+  }
+  return failures;
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -6,3 +6,12 @@ export function renderApiUrlForViewer(viewerUrl) {
   }
   return new URL(`/api/n/${match[1]}/render`, parsed.origin).href;
 }
+
+export function catalogApiUrlForViewer(viewerUrl) {
+  const parsed = new URL(viewerUrl);
+  const match = parsed.pathname.match(/^\/n\/([^/]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+  return new URL(`/api/n/${match[1]}`, parsed.origin).href;
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -3,17 +3,20 @@ import path from "node:path";
 
 import { chromium } from "@playwright/test";
 
+import { catalogExpectationFailures, summarizeCatalog } from "./hosted-render-smoke-catalog.mjs";
 import {
   consoleMessageLevel,
   isolatedDiagnosticFailure,
   isFatalIsolatedDiagnostic,
   parseIsolatedDiagnosticText,
 } from "./hosted-render-smoke-diagnostics.mjs";
-import { renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
+import { catalogApiUrlForViewer, renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL =
   "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
+const DEFAULT_CATALOG_OWNER_PRINCIPAL = "user:dev:live-publish";
+const DEFAULT_LATEST_REVISION_ACTOR_LABEL = "user:dev:live-publish/agent:publish-live";
 
 const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
 const expectedRendererAssetOrigin =
@@ -25,6 +28,11 @@ const expectedFrameTexts = parseExpectedTexts(process.env.NOTEBOOK_CLOUD_EXPECTE
   "PROBLEM_MARKDOWN",
 ]);
 const expectedRenderSource = process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE ?? "snapshot-pair";
+const expectedCatalogOwnerPrincipal =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL ?? DEFAULT_CATALOG_OWNER_PRINCIPAL;
+const expectedLatestRevisionActorLabel =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL ??
+  DEFAULT_LATEST_REVISION_ACTOR_LABEL;
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
@@ -40,6 +48,7 @@ const rendererCompletions = [];
 const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
 let renderApiCheck = null;
+let catalogApiCheck = null;
 let screenshotSaved = false;
 
 main().catch((error) => {
@@ -108,6 +117,12 @@ async function main() {
   try {
     if (expectedRenderSource) {
       renderApiCheck = await checkHostedRenderApi(targetUrl, expectedRenderSource);
+    }
+    if (expectedCatalogOwnerPrincipal || expectedLatestRevisionActorLabel) {
+      catalogApiCheck = await checkHostedCatalogApi(targetUrl, {
+        expectedCatalogOwnerPrincipal,
+        expectedLatestRevisionActorLabel,
+      });
     }
 
     await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
@@ -210,7 +225,10 @@ async function main() {
           expectedExecutionCount,
           expectedFrameTexts,
           expectedRenderSource,
+          expectedCatalogOwnerPrincipal,
+          expectedLatestRevisionActorLabel,
           renderApiCheck,
+          catalogApiCheck,
           executionCounts,
           frameTextMatches,
           iframeMetrics,
@@ -310,6 +328,48 @@ async function checkHostedRenderApi(viewerUrl, expectedSource) {
     status: response.status,
     source,
     cellCount,
+  };
+}
+
+async function checkHostedCatalogApi(
+  viewerUrl,
+  { expectedCatalogOwnerPrincipal, expectedLatestRevisionActorLabel },
+) {
+  const catalogUrl = catalogApiUrlForViewer(viewerUrl);
+  if (!catalogUrl) {
+    failures.push({
+      kind: "catalog-api",
+      text: `Could not derive /api/n/:id URL from ${viewerUrl}`,
+    });
+    return null;
+  }
+
+  const response = await fetch(catalogUrl);
+  if (!response.ok) {
+    failures.push({
+      kind: "catalog-api",
+      text: `${catalogUrl} returned ${response.status}`,
+    });
+    return { url: catalogUrl, status: response.status };
+  }
+
+  const json = await response.json();
+  const summary = summarizeCatalog(json);
+  for (const failure of catalogExpectationFailures(summary, {
+    expectedCatalogOwnerPrincipal,
+    expectedLatestRevisionActorLabel,
+  })) {
+    failures.push({
+      ...failure,
+      kind: "catalog-api",
+      url: catalogUrl,
+    });
+  }
+
+  return {
+    url: catalogUrl,
+    status: response.status,
+    ...summary,
   };
 }
 

--- a/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  catalogExpectationFailures,
+  summarizeCatalog,
+} from "../scripts/hosted-render-smoke-catalog.mjs";
+
+describe("hosted render smoke catalog checks", () => {
+  it("uses notebook.latest_revision_id to select the revision actor", () => {
+    const summary = summarizeCatalog({
+      notebook: {
+        owner_principal: "user:dev:live-publish",
+        latest_revision_id: "revision-2",
+      },
+      revisions: [
+        { id: "revision-1", actor_label: "user:dev:fixture/agent:publish-fixture" },
+        { id: "revision-2", actor_label: "user:dev:live-publish/agent:publish-live" },
+      ],
+    });
+
+    assert.deepEqual(summary, {
+      ownerPrincipal: "user:dev:live-publish",
+      latestRevisionId: "revision-2",
+      latestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
+      revisionCount: 2,
+    });
+  });
+
+  it("does not fall back to the first revision when latest_revision_id is absent", () => {
+    const summary = summarizeCatalog({
+      notebook: { owner_principal: "user:dev:live-publish" },
+      revisions: [{ id: "revision-1", actor_label: "user:dev:live-publish/agent:publish-live" }],
+    });
+
+    assert.equal(summary.latestRevisionId, null);
+    assert.equal(summary.latestRevisionActorLabel, null);
+  });
+
+  it("reports catalog expectation mismatches", () => {
+    assert.deepEqual(
+      catalogExpectationFailures(
+        {
+          ownerPrincipal: "user:dev:fixture",
+          latestRevisionId: "revision-1",
+          latestRevisionActorLabel: null,
+          revisionCount: 1,
+        },
+        {
+          expectedCatalogOwnerPrincipal: "user:dev:live-publish",
+          expectedLatestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
+        },
+      ),
+      [
+        {
+          text: "expected catalog owner user:dev:live-publish, got user:dev:fixture",
+        },
+        {
+          text: "expected latest revision actor user:dev:live-publish/agent:publish-live, got missing",
+        },
+      ],
+    );
+  });
+});

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { renderApiUrlForViewer } from "../scripts/hosted-render-smoke-routes.mjs";
+import {
+  catalogApiUrlForViewer,
+  renderApiUrlForViewer,
+} from "../scripts/hosted-render-smoke-routes.mjs";
 
 describe("hosted render smoke routes", () => {
   it("derives the render API URL from a hosted notebook viewer URL", () => {
@@ -13,8 +16,23 @@ describe("hosted render smoke routes", () => {
     );
   });
 
+  it("derives the catalog API URL from a hosted notebook viewer URL", () => {
+    assert.equal(
+      catalogApiUrlForViewer(
+        "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
+      ),
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet",
+    );
+    assert.equal(
+      catalogApiUrlForViewer("https://example.com/n/foo/"),
+      "https://example.com/api/n/foo",
+    );
+  });
+
   it("returns null for non-viewer URLs", () => {
     assert.equal(renderApiUrlForViewer("https://example.com/"), null);
     assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync"), null);
+    assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
+    assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });
 });


### PR DESCRIPTION
## Summary
- make hosted smoke derive `/api/n/:id` from the viewer URL and verify catalog provenance for the canonical live-published notebook
- default the catalog checks to the live publish owner and actor label, with env overrides/empty values for non-canonical notebooks
- document the catalog provenance check next to the existing snapshot-pair render and Sift WASM smoke checks

## Test Plan
- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs`
- `NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=60000 pnpm --dir apps/notebook-cloud smoke:hosted`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `cargo xtask lint --fix`
- `git diff --check`
