### PR TITLE
test(notebook-cloud): pin live smoke snapshot heads

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -113,8 +113,11 @@ render API source check. Set
 `NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL=` and
 `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL=` to skip the live-publish
 catalog provenance checks, or set them to the expected owner/actor for another
-published notebook. Set `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target
-notebook does not include a Sift output.
+published notebook. `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH`
+and `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH` can pin the
+catalog check to a specific exported snapshot pair. Set
+`NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target notebook does not include a
+Sift output.
 
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered
@@ -124,8 +127,10 @@ materializes the hosted render. By default it creates and executes a small
 to publish an already-open live notebook room instead.
 
 `smoke:hosted:live` composes the two live checks: it runs `publish:live`, reads
-the returned viewer URL, then runs `smoke:hosted` against that exact notebook.
-Use `NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev` and
+the returned viewer URL and exported notebook/runtime heads, then runs
+`smoke:hosted` against that exact notebook while asserting the catalog latest
+revision still points at those heads. Use
+`NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev` and
 `NOTEBOOK_CLOUD_DEV_TOKEN=...` to target the deployed prototype, or leave the
 defaults to target local Wrangler.
 

--- a/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
@@ -1,0 +1,63 @@
+export function smokeEnvForPublishResult(env, publishResult) {
+  assertPublishResultHasViewerUrl(publishResult);
+
+  const smokeEnv = {
+    ...env,
+    NOTEBOOK_CLOUD_HOSTED_URL: publishResult.viewerUrl,
+  };
+  setRequiredDefaultEnv(
+    smokeEnv,
+    "NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH",
+    publishResult.headsHash,
+    "headsHash",
+  );
+  setRequiredDefaultEnv(
+    smokeEnv,
+    "NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH",
+    publishResult.runtimeHeadsHash,
+    "runtimeHeadsHash",
+  );
+
+  if (!hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN")) {
+    const origin = new URL(publishResult.viewerUrl).origin;
+    if (isLoopbackOrigin(origin)) {
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN = origin;
+    }
+  }
+
+  return smokeEnv;
+}
+
+export function assertPublishResultMatchesSource(env, publishResult) {
+  const expectedSourceNotebookId = env.NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID;
+  if (expectedSourceNotebookId && publishResult.sourceNotebookId !== expectedSourceNotebookId) {
+    throw new Error(
+      `publish-live exported source notebook ${publishResult.sourceNotebookId ?? "missing"}, expected ${expectedSourceNotebookId}`,
+    );
+  }
+}
+
+function assertPublishResultHasViewerUrl(publishResult) {
+  if (!publishResult.viewerUrl) {
+    throw new Error("publish-live output did not include viewerUrl");
+  }
+}
+
+function setRequiredDefaultEnv(env, name, value, fieldName) {
+  if (hasOwn(env, name)) {
+    return;
+  }
+  if (!value) {
+    throw new Error(`publish-live did not provide ${fieldName}; cannot pin catalog assertion`);
+  }
+  env[name] = value;
+}
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function isLoopbackOrigin(origin) {
+  const hostname = new URL(origin).hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}

--- a/apps/notebook-cloud/scripts/hosted-live-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-smoke.mjs
@@ -2,25 +2,18 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  assertPublishResultMatchesSource,
+  smokeEnvForPublishResult,
+} from "./hosted-live-smoke-env.mjs";
+
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const publish = await runNode(["--import", "tsx", "scripts/publish-live.mjs"], process.env);
 const publishResult = parseJson(publish.stdout, "publish-live");
-if (!publishResult.viewerUrl) {
-  throw new Error("publish-live output did not include viewerUrl");
-}
+assertPublishResultMatchesSource(process.env, publishResult);
 
-const smokeEnv = {
-  ...process.env,
-  NOTEBOOK_CLOUD_HOSTED_URL: publishResult.viewerUrl,
-};
-if (!smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN) {
-  const origin = new URL(publishResult.viewerUrl).origin;
-  if (isLoopbackOrigin(origin)) {
-    smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN = origin;
-  }
-}
-
+const smokeEnv = smokeEnvForPublishResult(process.env, publishResult);
 const smoke = await runNode(["scripts/hosted-render-smoke.mjs", publishResult.viewerUrl], smokeEnv);
 const smokeResult = parseJson(smoke.stdout, "hosted-render-smoke");
 
@@ -77,9 +70,4 @@ function parseJson(stdout, label) {
   } catch (error) {
     throw new Error(`${label} did not print JSON: ${error.message}\n${stdout}`);
   }
-}
-
-function isLoopbackOrigin(origin) {
-  const hostname = new URL(origin).hostname;
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
@@ -11,18 +11,33 @@ export function summarizeCatalog(json) {
     : null;
   const latestRevisionActorLabel =
     typeof latestRevision?.actor_label === "string" ? latestRevision.actor_label : null;
+  const latestRevisionNotebookHeadsHash =
+    typeof latestRevision?.notebook_heads_hash === "string"
+      ? latestRevision.notebook_heads_hash
+      : null;
+  const latestRevisionRuntimeHeadsHash =
+    typeof latestRevision?.runtime_heads_hash === "string"
+      ? latestRevision.runtime_heads_hash
+      : null;
 
   return {
     ownerPrincipal,
     latestRevisionId,
     latestRevisionActorLabel,
+    latestRevisionNotebookHeadsHash,
+    latestRevisionRuntimeHeadsHash,
     revisionCount: revisions.length,
   };
 }
 
 export function catalogExpectationFailures(
   summary,
-  { expectedCatalogOwnerPrincipal, expectedLatestRevisionActorLabel },
+  {
+    expectedCatalogOwnerPrincipal,
+    expectedLatestRevisionActorLabel,
+    expectedLatestRevisionNotebookHeadsHash,
+    expectedLatestRevisionRuntimeHeadsHash,
+  },
 ) {
   const failures = [];
   if (expectedCatalogOwnerPrincipal && summary.ownerPrincipal !== expectedCatalogOwnerPrincipal) {
@@ -39,6 +54,26 @@ export function catalogExpectationFailures(
     failures.push({
       text: `expected latest revision actor ${expectedLatestRevisionActorLabel}, got ${
         summary.latestRevisionActorLabel ?? "missing"
+      }`,
+    });
+  }
+  if (
+    expectedLatestRevisionNotebookHeadsHash &&
+    summary.latestRevisionNotebookHeadsHash !== expectedLatestRevisionNotebookHeadsHash
+  ) {
+    failures.push({
+      text: `expected latest notebook heads ${expectedLatestRevisionNotebookHeadsHash}, got ${
+        summary.latestRevisionNotebookHeadsHash ?? "missing"
+      }`,
+    });
+  }
+  if (
+    expectedLatestRevisionRuntimeHeadsHash &&
+    summary.latestRevisionRuntimeHeadsHash !== expectedLatestRevisionRuntimeHeadsHash
+  ) {
+    failures.push({
+      text: `expected latest runtime heads ${expectedLatestRevisionRuntimeHeadsHash}, got ${
+        summary.latestRevisionRuntimeHeadsHash ?? "missing"
       }`,
     });
   }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -33,6 +33,10 @@ const expectedCatalogOwnerPrincipal =
 const expectedLatestRevisionActorLabel =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL ??
   DEFAULT_LATEST_REVISION_ACTOR_LABEL;
+const expectedLatestRevisionNotebookHeadsHash =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH ?? "";
+const expectedLatestRevisionRuntimeHeadsHash =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH ?? "";
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
@@ -118,10 +122,17 @@ async function main() {
     if (expectedRenderSource) {
       renderApiCheck = await checkHostedRenderApi(targetUrl, expectedRenderSource);
     }
-    if (expectedCatalogOwnerPrincipal || expectedLatestRevisionActorLabel) {
+    if (
+      expectedCatalogOwnerPrincipal ||
+      expectedLatestRevisionActorLabel ||
+      expectedLatestRevisionNotebookHeadsHash ||
+      expectedLatestRevisionRuntimeHeadsHash
+    ) {
       catalogApiCheck = await checkHostedCatalogApi(targetUrl, {
         expectedCatalogOwnerPrincipal,
         expectedLatestRevisionActorLabel,
+        expectedLatestRevisionNotebookHeadsHash,
+        expectedLatestRevisionRuntimeHeadsHash,
       });
     }
 
@@ -227,6 +238,8 @@ async function main() {
           expectedRenderSource,
           expectedCatalogOwnerPrincipal,
           expectedLatestRevisionActorLabel,
+          expectedLatestRevisionNotebookHeadsHash,
+          expectedLatestRevisionRuntimeHeadsHash,
           renderApiCheck,
           catalogApiCheck,
           executionCounts,
@@ -333,7 +346,12 @@ async function checkHostedRenderApi(viewerUrl, expectedSource) {
 
 async function checkHostedCatalogApi(
   viewerUrl,
-  { expectedCatalogOwnerPrincipal, expectedLatestRevisionActorLabel },
+  {
+    expectedCatalogOwnerPrincipal,
+    expectedLatestRevisionActorLabel,
+    expectedLatestRevisionNotebookHeadsHash,
+    expectedLatestRevisionRuntimeHeadsHash,
+  },
 ) {
   const catalogUrl = catalogApiUrlForViewer(viewerUrl);
   if (!catalogUrl) {
@@ -358,6 +376,8 @@ async function checkHostedCatalogApi(
   for (const failure of catalogExpectationFailures(summary, {
     expectedCatalogOwnerPrincipal,
     expectedLatestRevisionActorLabel,
+    expectedLatestRevisionNotebookHeadsHash,
+    expectedLatestRevisionRuntimeHeadsHash,
   })) {
     failures.push({
       ...failure,

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -66,6 +66,7 @@ try {
       {
         ok: true,
         baseUrl,
+        sourceMode: sourceNotebookId ? "existing-notebook-room" : "generated-live-preset",
         preset: sourceNotebookId ? "source-notebook" : preset,
         sourceNotebookId: sourceNotebookId ?? session.notebookId,
         notebookId,

--- a/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  assertPublishResultMatchesSource,
+  smokeEnvForPublishResult,
+} from "../scripts/hosted-live-smoke-env.mjs";
+
+describe("hosted live smoke environment", () => {
+  it("threads live-published snapshot heads into the hosted smoke expectations", () => {
+    const smokeEnv = smokeEnvForPublishResult(
+      {},
+      {
+        viewerUrl: "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source",
+        headsHash: "heads-notebook",
+        runtimeHeadsHash: "heads-runtime",
+      },
+    );
+
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_HOSTED_URL,
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source",
+    );
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH,
+      "heads-notebook",
+    );
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH,
+      "heads-runtime",
+    );
+  });
+
+  it("does not override explicit hosted smoke expectation env values", () => {
+    const smokeEnv = smokeEnvForPublishResult(
+      {
+        NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH: "",
+        NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH: "override-runtime",
+        NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN: "https://assets.example.test",
+      },
+      {
+        viewerUrl: "http://127.0.0.1:8787/n/live-source",
+        headsHash: "heads-notebook",
+        runtimeHeadsHash: "heads-runtime",
+      },
+    );
+
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH, "");
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH,
+      "override-runtime",
+    );
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN,
+      "https://assets.example.test",
+    );
+  });
+
+  it("uses the viewer origin as the renderer asset origin for loopback live smoke", () => {
+    const smokeEnv = smokeEnvForPublishResult(
+      {},
+      {
+        viewerUrl: "http://127.0.0.1:8787/n/live-source",
+        headsHash: "heads-notebook",
+        runtimeHeadsHash: "heads-runtime",
+      },
+    );
+
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN, "http://127.0.0.1:8787");
+  });
+
+  it("rejects publish results without exported snapshot heads unless expectations are explicit", () => {
+    assert.throws(
+      () =>
+        smokeEnvForPublishResult(
+          {},
+          {
+            viewerUrl: "http://127.0.0.1:8787/n/live-source",
+          },
+        ),
+      /did not provide headsHash/,
+    );
+    assert.doesNotThrow(() =>
+      smokeEnvForPublishResult(
+        {
+          NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH: "",
+          NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH: "",
+        },
+        {
+          viewerUrl: "http://127.0.0.1:8787/n/live-source",
+        },
+      ),
+    );
+  });
+
+  it("rejects a publish result from the wrong source notebook", () => {
+    assert.throws(
+      () =>
+        assertPublishResultMatchesSource(
+          { NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID: "expected-notebook" },
+          { sourceNotebookId: "other-notebook" },
+        ),
+      /expected expected-notebook/,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
@@ -15,7 +15,12 @@ describe("hosted render smoke catalog checks", () => {
       },
       revisions: [
         { id: "revision-1", actor_label: "user:dev:fixture/agent:publish-fixture" },
-        { id: "revision-2", actor_label: "user:dev:live-publish/agent:publish-live" },
+        {
+          id: "revision-2",
+          actor_label: "user:dev:live-publish/agent:publish-live",
+          notebook_heads_hash: "heads-notebook",
+          runtime_heads_hash: "heads-runtime",
+        },
       ],
     });
 
@@ -23,6 +28,8 @@ describe("hosted render smoke catalog checks", () => {
       ownerPrincipal: "user:dev:live-publish",
       latestRevisionId: "revision-2",
       latestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
+      latestRevisionNotebookHeadsHash: "heads-notebook",
+      latestRevisionRuntimeHeadsHash: "heads-runtime",
       revisionCount: 2,
     });
   });
@@ -35,6 +42,8 @@ describe("hosted render smoke catalog checks", () => {
 
     assert.equal(summary.latestRevisionId, null);
     assert.equal(summary.latestRevisionActorLabel, null);
+    assert.equal(summary.latestRevisionNotebookHeadsHash, null);
+    assert.equal(summary.latestRevisionRuntimeHeadsHash, null);
   });
 
   it("reports catalog expectation mismatches", () => {
@@ -49,6 +58,8 @@ describe("hosted render smoke catalog checks", () => {
         {
           expectedCatalogOwnerPrincipal: "user:dev:live-publish",
           expectedLatestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
+          expectedLatestRevisionNotebookHeadsHash: "heads-notebook",
+          expectedLatestRevisionRuntimeHeadsHash: "heads-runtime",
         },
       ),
       [
@@ -57,6 +68,12 @@ describe("hosted render smoke catalog checks", () => {
         },
         {
           text: "expected latest revision actor user:dev:live-publish/agent:publish-live, got missing",
+        },
+        {
+          text: "expected latest notebook heads heads-notebook, got missing",
+        },
+        {
+          text: "expected latest runtime heads heads-runtime, got missing",
         },
       ],
     );


### PR DESCRIPTION
## Summary

- thread live-published notebook/runtime heads from `publish:live` into `smoke:hosted`
- make the catalog smoke assert the latest revision still points at the exact exported snapshot pair
- document and test the source-notebook/live-publish smoke contract

## Verification

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-catalog.test.mjs test/hosted-live-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=60000 pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`
- `git diff --check`
