### PR TITLE
test(notebook-cloud): add source room hosted smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -134,6 +134,12 @@ revision still points at those heads. Use
 `NOTEBOOK_CLOUD_DEV_TOKEN=...` to target the deployed prototype, or leave the
 defaults to target local Wrangler.
 
+`smoke:hosted:source-room` covers the already-open room path. It creates and
+executes the same live MathNet notebook first, then calls `smoke:hosted:live`
+with `NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID=<created-room-id>` so `publish:live`
+must reopen and export that existing room instead of creating its own preset
+session.
+
 ## Dev auth
 
 The edge Worker maps dev credentials into the same identity shape as `crates/nteract-identity`:

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -14,6 +14,7 @@
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
+    "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",
     "publish:fixture": "node scripts/publish-fixture.mjs",
     "publish:live": "node --import tsx scripts/publish-live.mjs",

--- a/apps/notebook-cloud/scripts/hosted-source-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-source-room-smoke.mjs
@@ -1,0 +1,118 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
+import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
+const childTimeoutMs = Number(process.env.NOTEBOOK_CLOUD_SOURCE_ROOM_SMOKE_TIMEOUT_MS ?? 900_000);
+const rt = loadRuntimedNode();
+const sourceSession = await createLiveNotebookFixture(rt, { preset });
+
+try {
+  const env = {
+    ...process.env,
+    NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID: sourceSession.notebookId,
+  };
+  const live = await runNode(["scripts/hosted-live-smoke.mjs"], env, { timeoutMs: childTimeoutMs });
+  const liveResult = parseJson(live.stdout, "hosted-live-smoke");
+
+  assert(
+    liveResult.publish?.sourceMode === "existing-notebook-room",
+    "publish-live did not use the existing notebook room source path",
+  );
+  assert(
+    liveResult.publish?.sourceNotebookId === sourceSession.notebookId,
+    `publish-live exported ${liveResult.publish?.sourceNotebookId ?? "missing"}, expected ${sourceSession.notebookId}`,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        preset,
+        sourceNotebookId: sourceSession.notebookId,
+        notebookId: liveResult.publish.notebookId,
+        viewerUrl: liveResult.publish.viewerUrl,
+        hostedLiveSmoke: liveResult,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await sourceSession.shutdownNotebook().catch(() => {});
+  await sourceSession.close().catch(() => {});
+}
+
+function runNode(args, env, { timeoutMs }) {
+  console.error(`$ node ${args.join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: appDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`node ${args.join(" ")} timed out after ${timeoutMs}ms`));
+      });
+    }, timeoutMs);
+    timeout.unref?.();
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      process.stderr.write(chunk);
+    });
+    child.on("error", (error) => {
+      finish(() => reject(error));
+    });
+    child.on("close", (code) => {
+      finish(() => {
+        if (code === 0) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(
+          new Error(
+            `node ${args.join(" ")} exited with ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+      });
+    });
+
+    function finish(callback) {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    }
+  });
+}
+
+function parseJson(stdout, label) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} did not print JSON: ${error.message}\n${stdout}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/scripts/live-notebook-fixture.mjs
+++ b/apps/notebook-cloud/scripts/live-notebook-fixture.mjs
@@ -1,0 +1,57 @@
+export async function createLiveNotebookFixture(rt, { preset = "mathnet" } = {}) {
+  if (preset !== "mathnet") {
+    throw new Error(`Unknown NOTEBOOK_CLOUD_LIVE_PRESET ${preset}`);
+  }
+  return createMathNetNotebook(rt);
+}
+
+async function createMathNetNotebook(rt) {
+  const session = await rt.createNotebook({
+    runtime: "python",
+    description: "notebook-cloud live publish",
+    dependencies: ["polars", "pyarrow", "datasets", "pillow"],
+    packageManager: "uv",
+    environmentMode: "notebook",
+  });
+
+  try {
+    await session.createCell(
+      [
+        "# MathNet via notebook-cloud",
+        "",
+        "This notebook was executed through a live local runtimed session, exported as a NotebookDoc + RuntimeStateDoc snapshot pair, and published to the Cloudflare notebook-cloud worker.",
+      ].join("\n"),
+      { cellType: "markdown" },
+    );
+    await session.approveTrust();
+    await session.syncEnvironment();
+    await session.runCell(
+      [
+        "import polars as pl",
+        "from datasets import load_dataset",
+        "",
+        "def summarize_value(value):",
+        "    if value is None or isinstance(value, (str, int, float, bool)):",
+        "        return value",
+        "    if hasattr(value, 'size') and hasattr(value, 'mode'):",
+        '        return f"Image({value.size[0]}x{value.size[1]}, {value.mode})"',
+        "    if isinstance(value, list):",
+        '        return f"list[{len(value)}]"',
+        "    text = str(value)",
+        "    return text if len(text) <= 240 else text[:237] + '...'",
+        "",
+        "dataset = load_dataset('ShadenA/MathNet', 'all', split='train[:25]')",
+        "rows = [{key: summarize_value(value) for key, value in example.items()} for example in dataset]",
+        "df = pl.DataFrame(rows)",
+        "print(f'Loaded {df.height} rows and {df.width} columns from ShadenA/MathNet')",
+        "df",
+      ].join("\n"),
+      { timeoutMs: 10 * 60 * 1000 },
+    );
+    return session;
+  } catch (error) {
+    await session.shutdownNotebook().catch(() => {});
+    await session.close().catch(() => {});
+    throw error;
+  }
+}

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
 import { access, readFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { collectBlobRefs } from "../src/blob-refs.ts";
+import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
+import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
 
-const require = createRequire(import.meta.url);
 const rt = loadRuntimedNode();
 
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
@@ -31,7 +31,7 @@ const session = sourceNotebookId
   ? await rt.openNotebook(sourceNotebookId, {
       description: "notebook-cloud live publish",
     })
-  : await createPresetNotebook();
+  : await createLiveNotebookFixture(rt, { preset });
 
 try {
   const snapshot = await session.exportSnapshotPair();
@@ -91,55 +91,6 @@ try {
     await session.shutdownNotebook().catch(() => {});
   }
   await session.close().catch(() => {});
-}
-
-async function createPresetNotebook() {
-  if (preset !== "mathnet") {
-    throw new Error(`Unknown NOTEBOOK_CLOUD_LIVE_PRESET ${preset}`);
-  }
-
-  const session = await rt.createNotebook({
-    runtime: "python",
-    description: "notebook-cloud live publish",
-    dependencies: ["polars", "pyarrow", "datasets", "pillow"],
-    packageManager: "uv",
-    environmentMode: "notebook",
-  });
-
-  await session.createCell(
-    [
-      "# MathNet via notebook-cloud",
-      "",
-      "This notebook was executed through a live local runtimed session, exported as a NotebookDoc + RuntimeStateDoc snapshot pair, and published to the Cloudflare notebook-cloud worker.",
-    ].join("\n"),
-    { cellType: "markdown" },
-  );
-  await session.approveTrust();
-  await session.syncEnvironment();
-  await session.runCell(
-    [
-      "import polars as pl",
-      "from datasets import load_dataset",
-      "",
-      "def summarize_value(value):",
-      "    if value is None or isinstance(value, (str, int, float, bool)):",
-      "        return value",
-      "    if hasattr(value, 'size') and hasattr(value, 'mode'):",
-      '        return f"Image({value.size[0]}x{value.size[1]}, {value.mode})"',
-      "    if isinstance(value, list):",
-      '        return f"list[{len(value)}]"',
-      "    text = str(value)",
-      "    return text if len(text) <= 240 else text[:237] + '...'",
-      "",
-      "dataset = load_dataset('ShadenA/MathNet', 'all', split='train[:25]')",
-      "rows = [{key: summarize_value(value) for key, value in example.items()} for example in dataset]",
-      "df = pl.DataFrame(rows)",
-      "print(f'Loaded {df.height} rows and {df.width} columns from ShadenA/MathNet')",
-      "df",
-    ].join("\n"),
-    { timeoutMs: 10 * 60 * 1000 },
-  );
-  return session;
 }
 
 async function cellsFromSnapshotPair(notebookBytes, runtimeStateBytes) {
@@ -249,18 +200,5 @@ async function assertWasmBuildExists() {
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
-  }
-}
-
-function loadRuntimedNode() {
-  try {
-    return require("@runtimed/node");
-  } catch (error) {
-    if (error?.code !== "MODULE_NOT_FOUND") {
-      throw error;
-    }
-    return require(
-      fileURLToPath(new URL("../../../packages/runtimed-node/src/index.cjs", import.meta.url)),
-    );
   }
 }

--- a/apps/notebook-cloud/scripts/runtimed-node-loader.mjs
+++ b/apps/notebook-cloud/scripts/runtimed-node-loader.mjs
@@ -1,0 +1,17 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+
+export function loadRuntimedNode() {
+  try {
+    return require("@runtimed/node");
+  } catch (error) {
+    if (error?.code !== "MODULE_NOT_FOUND") {
+      throw error;
+    }
+    return require(
+      fileURLToPath(new URL("../../../packages/runtimed-node/src/index.cjs", import.meta.url)),
+    );
+  }
+}

--- a/apps/notebook-cloud/test/live-notebook-fixture.test.mjs
+++ b/apps/notebook-cloud/test/live-notebook-fixture.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createLiveNotebookFixture } from "../scripts/live-notebook-fixture.mjs";
+
+describe("live notebook fixture", () => {
+  it("creates the MathNet live notebook through the expected session lifecycle", async () => {
+    const calls = [];
+    const session = {
+      createCell: async (source, options) => calls.push(["createCell", source, options]),
+      approveTrust: async () => calls.push(["approveTrust"]),
+      syncEnvironment: async () => calls.push(["syncEnvironment"]),
+      runCell: async (source, options) => calls.push(["runCell", source, options]),
+    };
+    const rt = {
+      createNotebook: async (options) => {
+        calls.push(["createNotebook", options]);
+        return session;
+      },
+    };
+
+    const result = await createLiveNotebookFixture(rt, { preset: "mathnet" });
+
+    assert.equal(result, session);
+    assert.deepEqual(
+      calls.map(([name]) => name),
+      ["createNotebook", "createCell", "approveTrust", "syncEnvironment", "runCell"],
+    );
+    assert.deepEqual(calls[0][1].dependencies, ["polars", "pyarrow", "datasets", "pillow"]);
+    assert.equal(calls[1][2].cellType, "markdown");
+    assert.match(calls[3][0], /syncEnvironment/);
+    assert.match(calls[4][1], /ShadenA\/MathNet/);
+    assert.equal(calls[4][2].timeoutMs, 10 * 60 * 1000);
+  });
+
+  it("shuts down the created notebook if fixture setup fails", async () => {
+    const calls = [];
+    const session = {
+      createCell: async () => calls.push("createCell"),
+      approveTrust: async () => calls.push("approveTrust"),
+      syncEnvironment: async () => {
+        calls.push("syncEnvironment");
+        throw new Error("environment failed");
+      },
+      runCell: async () => calls.push("runCell"),
+      shutdownNotebook: async () => calls.push("shutdownNotebook"),
+      close: async () => calls.push("close"),
+    };
+    const rt = {
+      createNotebook: async () => {
+        calls.push("createNotebook");
+        return session;
+      },
+    };
+
+    await assert.rejects(
+      () => createLiveNotebookFixture(rt, { preset: "mathnet" }),
+      /environment failed/,
+    );
+    assert.deepEqual(calls, [
+      "createNotebook",
+      "createCell",
+      "approveTrust",
+      "syncEnvironment",
+      "shutdownNotebook",
+      "close",
+    ]);
+  });
+
+  it("rejects unknown presets before creating a notebook", async () => {
+    const rt = {
+      createNotebook() {
+        throw new Error("createNotebook should not be called for an unknown preset");
+      },
+    };
+
+    await assert.rejects(
+      () => createLiveNotebookFixture(rt, { preset: "unknown" }),
+      /Unknown NOTEBOOK_CLOUD_LIVE_PRESET unknown/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add `smoke:hosted:source-room` to exercise publishing from an already-open live notebook room
- extract the live MathNet notebook fixture so `publish:live` and source-room smoke use the same setup
- share the `@runtimed/node` loader used by notebook-cloud smoke scripts

## Verification

- `pnpm --dir apps/notebook-cloud exec node --test test/live-notebook-fixture.test.mjs test/hosted-live-smoke-env.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-source-room-smoke.mjs`
- `node --check apps/notebook-cloud/scripts/live-notebook-fixture.mjs`
- `node --check apps/notebook-cloud/scripts/runtimed-node-loader.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud run test`
- `cargo xtask lint --fix`
- `git diff --check`
