### PR TITLE
feat(notebook-cloud): share read-only notebook view

### DIFF
--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
+import {
+  ReadOnlyNotebook,
+  type ReadOnlyNotebookCellData,
+} from "@/components/cell/ReadOnlyNotebook";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -179,6 +182,21 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     [config.syncEndpoint],
   );
 
+  const readOnlyCells = useMemo(
+    () =>
+      cells.map(
+        (cell): ReadOnlyNotebookCellData => ({
+          id: cell.id,
+          cellType: cell.cellType,
+          source: cell.source,
+          language: cloudSourceLanguage(cell.language),
+          outputs: cell.outputs,
+          executionCount: cell.executionCount,
+        }),
+      ),
+    [cells],
+  );
+
   return (
     <main className="flex min-h-screen w-full flex-col py-4">
       <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
@@ -189,24 +207,19 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         </div>
       )}
 
-      <section
-        className="flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain pl-8 pr-2"
-        aria-label="Notebook cells"
-      >
-        {cells.map((cell, index) => (
-          <ErrorBoundary
-            key={`${cell.id}:${index}`}
-            resetKeys={[cell]}
-            fallback={(error) => (
-              <div className="cloud-state" data-kind="error">
-                Unable to render cell {index + 1}: {error.message}
-              </div>
-            )}
-          >
-            <ReadonlyNotebookCell cell={cell} outputHostContext={outputHostContext} />
-          </ErrorBoundary>
-        ))}
-      </section>
+      <ReadOnlyNotebook
+        cells={readOnlyCells}
+        priority={CLOUD_VIEWER_PRIORITY}
+        hostContext={outputHostContext}
+        className="pl-8 pr-2"
+        cellClassName="cloud-cell"
+        sourceClassName="cloud-source-block"
+        renderCellError={(error, _cell, index) => (
+          <div className="cloud-state" data-kind="error">
+            Unable to render cell {index + 1}: {error.message}
+          </div>
+        )}
+      />
     </main>
   );
 }
@@ -221,29 +234,6 @@ function ViewerStartupError({ message }: { message: string }) {
         {message}
       </div>
     </main>
-  );
-}
-
-function ReadonlyNotebookCell({
-  cell,
-  outputHostContext,
-}: {
-  cell: ResolvedCell;
-  outputHostContext: NteractEmbedHostContextPatch;
-}) {
-  return (
-    <ReadOnlyNotebookCell
-      id={cell.id}
-      cellType={cell.cellType}
-      source={cell.source}
-      language={cloudSourceLanguage(cell.language)}
-      outputs={cell.outputs}
-      executionCount={cell.executionCount}
-      priority={CLOUD_VIEWER_PRIORITY}
-      hostContext={outputHostContext}
-      className="cloud-cell"
-      sourceClassName="cloud-source-block"
-    />
   );
 }
 

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { ErrorBoundary } from "@/lib/error-boundary";
+import { cn } from "@/lib/utils";
+import type { SupportedLanguage } from "../editor/languages";
+import type { JupyterOutput } from "./jupyter-output";
+import { ReadOnlyNotebookCell } from "./ReadOnlyNotebookCell";
+
+export interface ReadOnlyNotebookCellData {
+  id: string;
+  cellType: string;
+  source: string;
+  language?: SupportedLanguage | null;
+  outputs?: readonly JupyterOutput[];
+  executionCount?: number | null;
+}
+
+export interface ReadOnlyNotebookProps {
+  cells: readonly ReadOnlyNotebookCellData[];
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  className?: string;
+  cellClassName?: string;
+  sourceClassName?: string;
+  outputClassName?: string;
+  lineWrapping?: boolean;
+  label?: string;
+  emptyContent?: ReactNode;
+  renderCellError?: (error: Error, cell: ReadOnlyNotebookCellData, index: number) => ReactNode;
+}
+
+export function ReadOnlyNotebook({
+  cells,
+  priority,
+  hostContext,
+  className,
+  cellClassName,
+  sourceClassName,
+  outputClassName,
+  lineWrapping = true,
+  label = "Notebook cells",
+  emptyContent = null,
+  renderCellError,
+}: ReadOnlyNotebookProps) {
+  return (
+    <section
+      aria-label={label}
+      className={cn("flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain", className)}
+      data-cell-count={cells.length}
+      data-slot="read-only-notebook"
+    >
+      {cells.length === 0
+        ? emptyContent
+        : cells.map((cell, index) => (
+            <ErrorBoundary
+              key={`${cell.id}:${index}`}
+              resetKeys={[
+                cell.id,
+                cell.cellType,
+                cell.source,
+                cell.language,
+                cell.executionCount,
+                cell.outputs?.length ?? 0,
+              ]}
+              fallback={(error) =>
+                renderCellError
+                  ? renderCellError(error, cell, index)
+                  : defaultCellError(error, index)
+              }
+            >
+              <ReadOnlyNotebookCell
+                id={cell.id}
+                cellType={cell.cellType}
+                source={cell.source}
+                language={cell.language}
+                outputs={cell.outputs}
+                executionCount={cell.executionCount}
+                priority={priority}
+                hostContext={hostContext}
+                className={cellClassName}
+                sourceClassName={sourceClassName}
+                outputClassName={outputClassName}
+                lineWrapping={lineWrapping}
+              />
+            </ErrorBoundary>
+          ))}
+    </section>
+  );
+}
+
+function defaultCellError(error: Error, index: number) {
+  return (
+    <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+      Unable to render cell {index + 1}: {error.message}
+    </div>
+  );
+}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useMemo } from "react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { ReadOnlyCodeMirror } from "@/components/editor/readonly-codemirror";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import { cn } from "@/lib/utils";
 import { CellContainer } from "./CellContainer";
 import { ExecutionCount } from "./ExecutionCount";
 import { OutputArea } from "./OutputArea";
@@ -103,6 +104,7 @@ function renderReadOnlyCellSource({
         isolated="auto"
         priority={priority}
         hostContext={hostContext}
+        className={cn("pl-0 pr-0", sourceClassName)}
       />
     );
   }

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ReadOnlyNotebook } from "../ReadOnlyNotebook";
+import type { JupyterOutput } from "../jupyter-output";
+
+const throwAttempts = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("../ReadOnlyNotebookCell", () => ({
+  ReadOnlyNotebookCell: ({
+    cellType,
+    className,
+    executionCount,
+    hostContext,
+    id,
+    language,
+    lineWrapping,
+    outputClassName,
+    outputs,
+    priority,
+    source,
+    sourceClassName,
+  }: {
+    cellType: string;
+    className?: string;
+    executionCount?: number | null;
+    hostContext?: unknown;
+    id: string;
+    language?: string | null;
+    lineWrapping?: boolean;
+    outputClassName?: string;
+    outputs?: readonly JupyterOutput[];
+    priority?: readonly string[];
+    source: string;
+    sourceClassName?: string;
+  }) => {
+    if (id === "throws") {
+      throwAttempts.count += 1;
+      throw new Error("boom");
+    }
+
+    return (
+      <article
+        data-cell-type={cellType}
+        data-class-name={className ?? ""}
+        data-execution-count={executionCount ?? ""}
+        data-host-context={JSON.stringify(hostContext ?? null)}
+        data-language={language ?? ""}
+        data-line-wrapping={String(lineWrapping)}
+        data-output-class-name={outputClassName ?? ""}
+        data-output-count={outputs?.length ?? 0}
+        data-priority={priority?.join(",") ?? ""}
+        data-source-class-name={sourceClassName ?? ""}
+        data-testid="read-only-cell"
+      >
+        {id}:{source}
+      </article>
+    );
+  },
+}));
+
+describe("ReadOnlyNotebook", () => {
+  beforeEach(() => {
+    throwAttempts.count = 0;
+  });
+
+  it("renders read-only notebook cells through the shared cell surface", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "cell-1",
+            cellType: "code",
+            source: "print('hello')",
+            language: "ipython",
+            executionCount: 3,
+            outputs: [{ output_type: "stream", name: "stdout", text: "hello\n" }],
+          },
+          {
+            id: "cell-2",
+            cellType: "markdown",
+            source: "# Title",
+          },
+        ]}
+        priority={["application/vnd.apache.parquet", "text/plain"]}
+        hostContext={{
+          nteract: {
+            rendererAssetsBaseUrl: "https://assets.example.test/renderer-assets/",
+          },
+        }}
+        className="notebook-shell"
+        cellClassName="cell-shell"
+        sourceClassName="source-shell"
+        outputClassName="output-shell"
+      />,
+    );
+
+    const notebook = document.querySelector('[data-slot="read-only-notebook"]');
+    expect(notebook).toHaveAttribute("aria-label", "Notebook cells");
+    expect(notebook).toHaveAttribute("data-cell-count", "2");
+    expect(notebook).toHaveClass("notebook-shell");
+
+    const cells = screen.getAllByTestId("read-only-cell");
+    expect(cells).toHaveLength(2);
+    expect(cells[0]).toHaveTextContent("cell-1:print('hello')");
+    expect(cells[0]).toHaveAttribute("data-cell-type", "code");
+    expect(cells[0]).toHaveAttribute("data-language", "ipython");
+    expect(cells[0]).toHaveAttribute("data-line-wrapping", "true");
+    expect(cells[0]).toHaveAttribute("data-execution-count", "3");
+    expect(cells[0]).toHaveAttribute("data-output-count", "1");
+    expect(cells[0]).toHaveAttribute("data-class-name", "cell-shell");
+    expect(cells[0]).toHaveAttribute("data-source-class-name", "source-shell");
+    expect(cells[0]).toHaveAttribute("data-output-class-name", "output-shell");
+    expect(cells[0]).toHaveAttribute("data-priority", "application/vnd.apache.parquet,text/plain");
+    expect(cells[0].getAttribute("data-host-context")).toContain(
+      "https://assets.example.test/renderer-assets/",
+    );
+  });
+
+  it("allows read-only source wrapping to be disabled", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "cell-1",
+            cellType: "code",
+            source: "x = 1",
+          },
+        ]}
+        lineWrapping={false}
+      />,
+    );
+
+    expect(screen.getByTestId("read-only-cell")).toHaveAttribute("data-line-wrapping", "false");
+  });
+
+  it("does not reset errored cells when unchanged cell data is remapped", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const output = { output_type: "stream", name: "stdout", text: "hi\n" } as const;
+    try {
+      const { rerender } = render(
+        <ReadOnlyNotebook
+          cells={[
+            {
+              id: "throws",
+              cellType: "code",
+              source: "raise Exception()",
+              outputs: [output],
+            },
+          ]}
+        />,
+      );
+
+      expect(screen.getByText("Unable to render cell 1: boom")).toBeInTheDocument();
+      const initialThrowAttempts = throwAttempts.count;
+      expect(initialThrowAttempts).toBeGreaterThan(0);
+
+      rerender(
+        <ReadOnlyNotebook
+          cells={[
+            {
+              id: "throws",
+              cellType: "code",
+              source: "raise Exception()",
+              outputs: [{ ...output }],
+            },
+          ]}
+        />,
+      );
+      expect(throwAttempts.count).toBe(initialThrowAttempts);
+
+      rerender(
+        <ReadOnlyNotebook
+          cells={[{ id: "throws", cellType: "code", source: "raise RuntimeError()" }]}
+        />,
+      );
+      expect(throwAttempts.count).toBeGreaterThan(initialThrowAttempts);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("renders custom empty and cell-error content", () => {
+    const { rerender } = render(
+      <ReadOnlyNotebook cells={[]} emptyContent={<div>No cells yet</div>} />,
+    );
+
+    expect(screen.getByText("No cells yet")).toBeInTheDocument();
+
+    rerender(
+      <ReadOnlyNotebook
+        cells={[{ id: "throws", cellType: "code", source: "raise Exception()" }]}
+        renderCellError={(error, _cell, index) => (
+          <div>
+            Cell {index + 1}: {error.message}
+          </div>
+        )}
+      />,
+    );
+
+    expect(screen.getByText("Cell 1: boom")).toBeInTheDocument();
+  });
+});

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -117,6 +117,7 @@ describe("ReadOnlyNotebookCell", () => {
         source="## Title"
         outputs={[]}
         priority={["text/markdown", "text/plain"]}
+        sourceClassName="markdown-source"
       />,
     );
 
@@ -127,6 +128,7 @@ describe("ReadOnlyNotebookCell", () => {
     expect(outputArea).toHaveAttribute("data-cell-id", "cell-markdown");
     expect(outputArea).toHaveAttribute("data-mimes", "text/markdown");
     expect(outputArea).toHaveAttribute("data-priority", "text/markdown,text/plain");
+    expect(outputArea).toHaveAttribute("data-class-name", "pl-0 pr-0 markdown-source");
   });
 
   it("omits the output row for code cells with no outputs", () => {


### PR DESCRIPTION
## Summary

- Adds a shared `ReadOnlyNotebook` surface that owns static notebook list semantics, per-cell error boundaries, and shared `ReadOnlyNotebookCell` wiring.
- Updates the notebook-cloud viewer so it only loads hosted render data and adapts it into the shared read-only notebook shape.
- Covers the shared list surface with focused React tests.

## Verification

- `pnpm test:run src/components/cell/__tests__/ReadOnlyNotebook.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
- Bedrock Opus 4.6 review loop: clear after fixing reset-key stability.
- Deployed to `https://nteract-notebook-cloud.rgbkrk.workers.dev` as Worker version `771a563d-15bb-4836-a244-4d587a8ea201`.
- `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud-2840.png pnpm --dir apps/notebook-cloud smoke:hosted`
- Chrome-channel visual pass saved `/tmp/notebook-cloud-2840-chrome.png`.
