### PR TITLE
test(settings): isolate sync failure hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7491,6 +7491,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"
 
 [build-dependencies]
 build-metadata = { path = "../build-metadata" }

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1490,6 +1490,14 @@ impl SettingsDoc {
     }
 
     #[cfg(debug_assertions)]
+    #[doc(hidden)]
+    pub fn __reset_sync_failure_hooks_for_test() {
+        PANIC_ON_NEXT_GENERATE_SYNC_CALLS.store(0, Ordering::SeqCst);
+        PANIC_ON_NEXT_RECEIVE_SYNC_CALLS.store(0, Ordering::SeqCst);
+        PATCH_LOG_MISMATCH_ON_NEXT_RECEIVE_SYNC_CALLS.store(0, Ordering::SeqCst);
+    }
+
+    #[cfg(debug_assertions)]
     fn panic_if_requested(counter: &AtomicUsize, operation: &str) {
         if counter
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
@@ -1577,7 +1585,23 @@ pub fn read_nested_list(doc: &AutoCommit, map_key: &str, sub_key: &str) -> Vec<S
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
+
+    struct SettingsSyncFailureHookGuard;
+
+    impl SettingsSyncFailureHookGuard {
+        fn new() -> Self {
+            SettingsDoc::__reset_sync_failure_hooks_for_test();
+            Self
+        }
+    }
+
+    impl Drop for SettingsSyncFailureHookGuard {
+        fn drop(&mut self) {
+            SettingsDoc::__reset_sync_failure_hooks_for_test();
+        }
+    }
 
     #[test]
     fn test_new_has_defaults() {
@@ -2429,7 +2453,9 @@ mod tests {
     }
 
     #[test]
+    #[serial(settings_sync_panic_hooks)]
     fn test_recovering_generate_sync_catches_injected_panic() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let mut doc = SettingsDoc::new();
         let mut peer_state = sync::State::new();
 
@@ -2443,7 +2469,9 @@ mod tests {
     }
 
     #[test]
+    #[serial(settings_sync_panic_hooks)]
     fn test_recovering_receive_sync_catches_injected_panic() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let mut sender = SettingsDoc::new();
         sender.put("theme", "dark");
         let mut sender_state = sync::State::new();

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -265,6 +265,21 @@ mod tests {
     use serial_test::serial;
     use tempfile::TempDir;
 
+    struct SettingsSyncFailureHookGuard;
+
+    impl SettingsSyncFailureHookGuard {
+        fn new() -> Self {
+            SettingsDoc::__reset_sync_failure_hooks_for_test();
+            Self
+        }
+    }
+
+    impl Drop for SettingsSyncFailureHookGuard {
+        fn drop(&mut self) {
+            SettingsDoc::__reset_sync_failure_hooks_for_test();
+        }
+    }
+
     fn write_settings_json(path: &Path, settings: &SyncedSettings) {
         let json = serde_json::to_string_pretty(settings).expect("settings serialize");
         std::fs::write(path, json).expect("settings write");
@@ -273,6 +288,7 @@ mod tests {
     #[test]
     #[serial(settings_sync_panic_hooks)]
     fn generate_panic_returns_error_without_rebuild_or_retry() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         let canonical = SyncedSettings {
@@ -298,6 +314,7 @@ mod tests {
     #[test]
     #[serial(settings_sync_panic_hooks)]
     fn receive_panic_returns_error_without_persisting_or_broadcasting() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         let canonical = SyncedSettings::default();
@@ -335,6 +352,7 @@ mod tests {
     #[test]
     #[serial(settings_sync_panic_hooks)]
     fn receive_patch_log_mismatch_does_not_persist_or_broadcast_client_edit() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         let canonical = SyncedSettings::default();
@@ -371,6 +389,7 @@ mod tests {
     #[test]
     #[serial(settings_sync_panic_hooks)]
     fn invalid_json_recovery_keeps_last_known_good_and_file_contents() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         std::fs::write(&json_path, "{ invalid json").expect("settings write");
@@ -407,6 +426,7 @@ mod tests {
     #[test]
     #[serial(settings_sync_panic_hooks)]
     fn repeated_generate_panic_returns_first_error_without_retry() {
+        let _hook_guard = SettingsSyncFailureHookGuard::new();
         let tmp = TempDir::new().expect("temp dir");
         let json_path = tmp.path().join("settings.json");
         write_settings_json(&json_path, &SyncedSettings::default());


### PR DESCRIPTION
## Summary

- reset debug-only settings sync failure hooks before and after the daemon panic-hook tests
- serialize the two runtimed-client recovery tests that mutate those hooks
- keep the panic injection helpers test-only while preventing order-dependent leaked counters

## Verification

- `cargo test -p runtimed-client --lib test_recovering_generate_sync_catches_injected_panic -- --nocapture`
- `cargo test -p runtimed-client --lib test_recovering_receive_sync_catches_injected_panic -- --nocapture`
- `cargo test -p runtimed --lib sync_server::tests -- --nocapture`
- `cargo test -p runtimed --lib`
- `cargo test -p runtimed-client --lib`
- `cargo xtask lint --fix`
