### PR TITLE
feat(notebook-cloud): add report viewer mode

### DIFF
--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -21,6 +21,7 @@
     "wasm:roundtrip": "node --import tsx scripts/wasm-roundtrip.mjs"
   },
   "dependencies": {
+    "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "runtimed": "workspace:*"

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -150,13 +150,16 @@ async function main() {
     }
     await page.waitForFunction(
       (expected) => {
+        const reportCellCount = document.querySelectorAll(
+          "[data-slot='read-only-report-cell']",
+        ).length;
         const counts = Array.from(document.querySelectorAll("[data-slot='execution-count']")).map(
           (node) => node.textContent?.trim() ?? "",
         );
         if (expected) {
           return counts.includes(expected);
         }
-        return counts.some((count) => /^\[\d+\]:$/.test(count));
+        return reportCellCount > 0 || counts.some((count) => /^\[\d+\]:$/.test(count));
       },
       expectedExecutionCount,
       { timeout: timeoutMs },
@@ -189,6 +192,7 @@ async function main() {
         allow: iframe.getAttribute("allow"),
       })),
     );
+    const reportCellCount = await page.locator("[data-slot='read-only-report-cell']").count();
 
     if (requireSiftWasm && siftWasmRequests.length === 0) {
       failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
@@ -243,6 +247,7 @@ async function main() {
           renderApiCheck,
           catalogApiCheck,
           executionCounts,
+          reportCellCount,
           frameTextMatches,
           iframeMetrics,
           siftWasmRequests,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -402,6 +402,13 @@ async function routeCatalog(env: Env, notebookId: string): Promise<Response> {
 }
 
 async function routeRoomEvents(request: Request, env: Env, notebookId: string): Promise<Response> {
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot read room events` }, 403);
+  }
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
   }

--- a/apps/notebook-cloud/test/viewer-sift-preload.test.ts
+++ b/apps/notebook-cloud/test/viewer-sift-preload.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { JupyterOutput } from "../../../src/components/cell/jupyter-output.ts";
+import type { ResolvedCell } from "../viewer/render-resolution.ts";
+import { cellsUseSift, siftWasmPreloadUrlForCells } from "../viewer/sift-preload.ts";
+
+describe("cloud viewer Sift WASM preload", () => {
+  it("skips notebooks without Sift-backed outputs", () => {
+    const cells = [cell([{ output_type: "stream", name: "stdout", text: "hello\n" }])];
+
+    assert.equal(cellsUseSift(cells), false);
+    assert.equal(siftWasmPreloadUrlForCells(cells, preloadOptions()), null);
+  });
+
+  it("preloads the exact renderer asset URL for Arrow manifest outputs", () => {
+    const cells = [
+      cell([
+        {
+          output_type: "display_data",
+          data: {
+            "text/html": "<table></table>",
+            "application/vnd.nteract.arrow-stream-manifest+json": {
+              chunks: [{ url: "https://cloud.test/api/n/demo/blobs/sha256-table" }],
+            },
+          },
+          metadata: {},
+        },
+      ]),
+    ];
+
+    assert.equal(cellsUseSift(cells), true);
+    assert.equal(
+      siftWasmPreloadUrlForCells(
+        cells,
+        preloadOptions({
+          rendererAssetsBasePath: "https://outputs.example/renderer-assets/",
+        }),
+      ),
+      "https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev",
+    );
+  });
+
+  it("supports host-relative renderer asset routes", () => {
+    const cells = [
+      cell([
+        {
+          output_type: "execute_result",
+          execution_count: 1,
+          data: {
+            "application/vnd.apache.arrow.stream": "https://cloud.test/api/n/demo/blobs/sha256",
+          },
+          metadata: {},
+        },
+      ]),
+    ];
+
+    assert.equal(
+      siftWasmPreloadUrlForCells(
+        cells,
+        preloadOptions({
+          rendererAssetsBasePath: "/renderer-assets/",
+        }),
+      ),
+      "https://cloud.test/renderer-assets/sift_wasm.wasm?v=dev",
+    );
+  });
+});
+
+function cell(outputs: JupyterOutput[]): ResolvedCell {
+  return {
+    id: "cell-1",
+    cellType: "code",
+    source: "df",
+    language: "python",
+    executionCount: null,
+    outputs,
+    metadata: {},
+  };
+}
+
+function preloadOptions(overrides: Partial<Parameters<typeof siftWasmPreloadUrlForCells>[1]> = {}) {
+  return {
+    blobBasePath: "/api/n/demo/blobs/",
+    rendererAssetsBasePath: "/renderer-assets/",
+    pageUrl: "https://cloud.test/n/demo",
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -122,6 +122,46 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(seenPaths, ["/plugins/sift_wasm.wasm"]);
   });
 
+  it("keeps room event observability owner-scoped", async () => {
+    const env = fakeEnv();
+
+    const anonymous = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/events"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(anonymous.status, 403);
+    assert.deepEqual(await anonymous.json(), { error: "viewer cannot read room events" });
+
+    const viewer = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/events", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(viewer.status, 403);
+    assert.deepEqual(await viewer.json(), { error: "viewer cannot read room events" });
+
+    const owner = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/events", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "owner",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(owner.status, 200);
+    assert.deepEqual(await owner.json(), { notebook_id: "route-demo", events: [] });
+  });
+
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes] = await Promise.all([

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -30,13 +30,62 @@ body {
   background: color-mix(in srgb, #b42318 8%, var(--background));
 }
 
+.cloud-report-toolbar {
+  position: sticky;
+  top: 0.5rem;
+  z-index: 20;
+  display: flex;
+  justify-content: flex-end;
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+  pointer-events: none;
+}
+
+.cloud-code-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  width: 3.25rem;
+  height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 999px;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--background) 90%, transparent);
+  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.cloud-code-toggle:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
+}
+
+.cloud-code-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-code-toggle svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-report-notebook {
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 0.75rem);
+}
+
 .cloud-cell {
-  margin-inline: -1rem;
-  padding-inline: 1rem;
+  padding-block: 0.75rem clamp(1rem, 3vw, 1.5rem);
+}
+
+.cloud-cell[data-cell-type="markdown"] {
+  padding-block: 0.25rem 1rem;
 }
 
 .cloud-source-block .cm-editor {
   background: transparent !important;
+  margin-top: 0 !important;
 }
 
 .cloud-source-block .cm-scroller {
@@ -45,5 +94,13 @@ body {
 }
 
 .cloud-source-block .cm-content {
-  padding-bottom: 0.125rem;
+  padding: 0.125rem 0 !important;
+}
+
+.cloud-source-block .cm-line {
+  padding-inline: 0 !important;
+}
+
+.cloud-output-block {
+  padding-inline: 0 !important;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { Code2, Eye, EyeOff } from "lucide-react";
 import {
   ReadOnlyNotebook,
   type ReadOnlyNotebookCellData,
@@ -11,6 +12,7 @@ import { ErrorBoundary } from "@/lib/error-boundary";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
+import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { installDocumentThemeSync } from "./theme";
 import "./index.css";
@@ -124,6 +126,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     message: "Loading notebook snapshot...",
   });
   const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const [showCode, setShowCode] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -154,6 +157,11 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         );
         if (cancelled) return;
 
+        preloadSiftWasmForCells(resolvedCells, {
+          blobBasePath: config.blobBasePath,
+          rendererAssetsBasePath: config.rendererAssetsBasePath,
+          pageUrl: location.href,
+        });
         setCells(resolvedCells);
         if (resolvedCells.length === 0) {
           setStatus({ kind: "empty", message: "This published notebook has no cells." });
@@ -196,9 +204,13 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       ),
     [cells],
   );
+  const codeCellCount = useMemo(
+    () => readOnlyCells.filter((cell) => cell.cellType === "code").length,
+    [readOnlyCells],
+  );
 
   return (
-    <main className="flex min-h-screen w-full flex-col py-4">
+    <main className="flex min-h-screen w-full flex-col py-6">
       <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
 
       {status.kind === "ready" ? null : (
@@ -207,13 +219,33 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         </div>
       )}
 
+      {status.kind === "ready" && codeCellCount > 0 ? (
+        <div className="cloud-report-toolbar" aria-label="Notebook display controls">
+          <button
+            type="button"
+            className="cloud-code-toggle"
+            aria-pressed={showCode}
+            aria-label={showCode ? "Hide code cells" : "Show code cells"}
+            title={showCode ? "Hide code cells" : "Show code cells"}
+            onClick={() => setShowCode((current) => !current)}
+          >
+            {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
+            <Code2 aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
+
       <ReadOnlyNotebook
         cells={readOnlyCells}
         priority={CLOUD_VIEWER_PRIORITY}
         hostContext={outputHostContext}
-        className="pl-8 pr-2"
+        displayMode="report"
+        showCode={showCode}
+        focusOutputs
+        className="cloud-report-notebook"
         cellClassName="cloud-cell"
         sourceClassName="cloud-source-block"
+        outputClassName="cloud-output-block"
         renderCellError={(error, _cell, index) => (
           <div className="cloud-state" data-kind="error">
             Unable to render cell {index + 1}: {error.message}

--- a/apps/notebook-cloud/viewer/sift-preload.ts
+++ b/apps/notebook-cloud/viewer/sift-preload.ts
@@ -1,0 +1,66 @@
+import type { JupyterOutput } from "../../../src/components/cell/jupyter-output";
+import { selectMimeType } from "../../../src/components/outputs/mime-priority";
+import { resolveSiftWasmUrl } from "../../../src/isolated-renderer/sift-assets";
+import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
+import type { ResolvedCell } from "./render-resolution";
+
+const SIFT_MIME_TYPES = new Set([
+  "application/vnd.apache.parquet",
+  "application/vnd.apache.arrow.stream",
+  "application/vnd.nteract.arrow-stream-manifest+json",
+]);
+
+interface SiftWasmPreloadOptions {
+  blobBasePath: string;
+  rendererAssetsBasePath: string;
+  pageUrl: string;
+}
+
+export function cellsUseSift(cells: readonly ResolvedCell[]): boolean {
+  return cells.some((cell) => cell.outputs.some(outputUsesSift));
+}
+
+export function siftWasmPreloadUrlForCells(
+  cells: readonly ResolvedCell[],
+  { blobBasePath, rendererAssetsBasePath, pageUrl }: SiftWasmPreloadOptions,
+): string | null {
+  if (!cellsUseSift(cells)) return null;
+
+  return resolveSiftWasmUrl({
+    tableUrl: new URL(blobBasePath, pageUrl).href,
+    rendererAssetsBaseUrl: new URL(rendererAssetsBasePath, pageUrl).href,
+  });
+}
+
+export function preloadSiftWasmForCells(
+  cells: readonly ResolvedCell[],
+  options: SiftWasmPreloadOptions,
+  targetDocument: Document = document,
+): string | null {
+  const href = siftWasmPreloadUrlForCells(cells, options);
+  if (!href) return null;
+
+  const existing = Array.from(targetDocument.head.querySelectorAll<HTMLLinkElement>("link")).some(
+    (link) => link.rel === "preload" && link.href === href,
+  );
+  if (existing) return href;
+
+  const link = targetDocument.createElement("link");
+  link.rel = "preload";
+  link.as = "fetch";
+  link.type = "application/wasm";
+  link.href = href;
+  link.crossOrigin = "anonymous";
+  link.dataset.nteractPreload = "sift-wasm";
+  targetDocument.head.append(link);
+  return href;
+}
+
+function outputUsesSift(output: JupyterOutput): boolean {
+  if (output.output_type !== "display_data" && output.output_type !== "execute_result") {
+    return false;
+  }
+
+  const mimeType = selectMimeType(output.data, CLOUD_VIEWER_PRIORITY);
+  return mimeType != null && SIFT_MIME_TYPES.has(mimeType);
+}

--- a/apps/notebook-cloud/vite.config.ts
+++ b/apps/notebook-cloud/vite.config.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite-plus";
+import { siftWasmCacheKey } from "../../src/build/renderer-plugin-builder";
 import { isolatedRendererPlugin } from "../notebook/vite-plugin-isolated-renderer";
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
@@ -47,6 +48,7 @@ export default defineConfig({
     },
   },
   define: {
+    __SIFT_WASM_CACHE_KEY__: JSON.stringify(siftWasmCacheKey()),
     "process.env.NODE_ENV": JSON.stringify("production"),
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,9 @@ importers:
 
   apps/notebook-cloud:
     dependencies:
+      lucide-react:
+        specifier: ^0.513.0
+        version: 0.513.0(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -73,7 +73,7 @@ function resolveWasmGlue(): string {
   return fs.existsSync(realPath) ? realPath : mockPath;
 }
 
-function siftWasmCacheKey(): string {
+export function siftWasmCacheKey(): string {
   const wasmPath = path.resolve(srcDir, "../crates/sift-wasm/pkg/sift_wasm_bg.wasm");
   if (!fs.existsSync(wasmPath)) {
     return "missing";

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -19,6 +19,9 @@ export interface ReadOnlyNotebookProps {
   cells: readonly ReadOnlyNotebookCellData[];
   priority?: readonly string[];
   hostContext?: NteractEmbedHostContextPatch;
+  displayMode?: "notebook" | "report";
+  showCode?: boolean;
+  focusOutputs?: boolean;
   className?: string;
   cellClassName?: string;
   sourceClassName?: string;
@@ -33,6 +36,9 @@ export function ReadOnlyNotebook({
   cells,
   priority,
   hostContext,
+  displayMode = "notebook",
+  showCode = true,
+  focusOutputs = false,
   className,
   cellClassName,
   sourceClassName,
@@ -77,6 +83,9 @@ export function ReadOnlyNotebook({
                 executionCount={cell.executionCount}
                 priority={priority}
                 hostContext={hostContext}
+                displayMode={displayMode}
+                showSource={displayMode === "report" ? cell.cellType !== "code" || showCode : true}
+                focusOutputs={focusOutputs}
                 className={cellClassName}
                 sourceClassName={sourceClassName}
                 outputClassName={outputClassName}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -17,6 +17,9 @@ export interface ReadOnlyNotebookCellProps {
   executionCount?: number | null;
   priority?: readonly string[];
   hostContext?: NteractEmbedHostContextPatch;
+  displayMode?: "notebook" | "report";
+  showSource?: boolean;
+  focusOutputs?: boolean;
   className?: string;
   sourceClassName?: string;
   outputClassName?: string;
@@ -32,6 +35,9 @@ export function ReadOnlyNotebookCell({
   executionCount = null,
   priority,
   hostContext,
+  displayMode = "notebook",
+  showSource = true,
+  focusOutputs = false,
   className,
   sourceClassName,
   outputClassName,
@@ -59,17 +65,42 @@ export function ReadOnlyNotebookCell({
         executionCount={executionCount}
         outputs={[...outputs]}
         isolated="auto"
+        focused={focusOutputs}
         priority={priority}
         hostContext={hostContext}
         className={outputClassName}
       />
     ) : null;
 
+  if (displayMode === "report") {
+    if (!showSource && !outputContent) return null;
+
+    return (
+      <article
+        className={cn("flex min-w-0 flex-col", className)}
+        data-cell-id={id}
+        data-cell-type={cellType}
+        data-slot="read-only-report-cell"
+      >
+        {showSource ? (
+          <div className="min-w-0" data-slot="read-only-cell-source">
+            {codeContent}
+          </div>
+        ) : null}
+        {outputContent ? (
+          <div className="min-w-0" data-slot="read-only-cell-output">
+            {outputContent}
+          </div>
+        ) : null}
+      </article>
+    );
+  }
+
   return (
     <CellContainer
       id={id}
       cellType={cellType}
-      codeContent={codeContent}
+      codeContent={showSource ? codeContent : null}
       outputContent={outputContent}
       gutterContent={cellType === "code" ? <ExecutionCount count={executionCount} /> : null}
       className={className}

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -9,7 +9,9 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
   ReadOnlyNotebookCell: ({
     cellType,
     className,
+    displayMode,
     executionCount,
+    focusOutputs,
     hostContext,
     id,
     language,
@@ -17,12 +19,15 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     outputClassName,
     outputs,
     priority,
+    showSource,
     source,
     sourceClassName,
   }: {
     cellType: string;
     className?: string;
+    displayMode?: "notebook" | "report";
     executionCount?: number | null;
+    focusOutputs?: boolean;
     hostContext?: unknown;
     id: string;
     language?: string | null;
@@ -30,6 +35,7 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     outputClassName?: string;
     outputs?: readonly JupyterOutput[];
     priority?: readonly string[];
+    showSource?: boolean;
     source: string;
     sourceClassName?: string;
   }) => {
@@ -42,13 +48,16 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
       <article
         data-cell-type={cellType}
         data-class-name={className ?? ""}
+        data-display-mode={displayMode ?? "notebook"}
         data-execution-count={executionCount ?? ""}
+        data-focus-outputs={String(focusOutputs)}
         data-host-context={JSON.stringify(hostContext ?? null)}
         data-language={language ?? ""}
         data-line-wrapping={String(lineWrapping)}
         data-output-class-name={outputClassName ?? ""}
         data-output-count={outputs?.length ?? 0}
         data-priority={priority?.join(",") ?? ""}
+        data-show-source={String(showSource)}
         data-source-class-name={sourceClassName ?? ""}
         data-testid="read-only-cell"
       >
@@ -103,9 +112,12 @@ describe("ReadOnlyNotebook", () => {
     expect(cells).toHaveLength(2);
     expect(cells[0]).toHaveTextContent("cell-1:print('hello')");
     expect(cells[0]).toHaveAttribute("data-cell-type", "code");
+    expect(cells[0]).toHaveAttribute("data-display-mode", "notebook");
     expect(cells[0]).toHaveAttribute("data-language", "ipython");
     expect(cells[0]).toHaveAttribute("data-line-wrapping", "true");
     expect(cells[0]).toHaveAttribute("data-execution-count", "3");
+    expect(cells[0]).toHaveAttribute("data-show-source", "true");
+    expect(cells[0]).toHaveAttribute("data-focus-outputs", "false");
     expect(cells[0]).toHaveAttribute("data-output-count", "1");
     expect(cells[0]).toHaveAttribute("data-class-name", "cell-shell");
     expect(cells[0]).toHaveAttribute("data-source-class-name", "source-shell");
@@ -131,6 +143,36 @@ describe("ReadOnlyNotebook", () => {
     );
 
     expect(screen.getByTestId("read-only-cell")).toHaveAttribute("data-line-wrapping", "false");
+  });
+
+  it("supports report display mode with local code visibility", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "code-cell",
+            cellType: "code",
+            source: "print('hidden')",
+            outputs: [{ output_type: "stream", name: "stdout", text: "visible\n" }],
+          },
+          {
+            id: "markdown-cell",
+            cellType: "markdown",
+            source: "# Still visible",
+          },
+        ]}
+        displayMode="report"
+        showCode={false}
+        focusOutputs
+      />,
+    );
+
+    const cells = screen.getAllByTestId("read-only-cell");
+    expect(cells[0]).toHaveAttribute("data-display-mode", "report");
+    expect(cells[0]).toHaveAttribute("data-show-source", "false");
+    expect(cells[0]).toHaveAttribute("data-focus-outputs", "true");
+    expect(cells[1]).toHaveAttribute("data-display-mode", "report");
+    expect(cells[1]).toHaveAttribute("data-show-source", "true");
   });
 
   it("does not reset errored cells when unchanged cell data is remapped", () => {

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../OutputArea", () => ({
     cellId,
     className,
     executionCount,
+    focused,
     hostContext,
     outputs,
     priority,
@@ -15,6 +16,7 @@ vi.mock("../OutputArea", () => ({
     cellId?: string;
     className?: string;
     executionCount?: number | null;
+    focused?: boolean;
     hostContext?: unknown;
     outputs: JupyterOutput[];
     priority?: readonly string[];
@@ -23,6 +25,7 @@ vi.mock("../OutputArea", () => ({
       data-cell-id={cellId}
       data-class-name={className ?? ""}
       data-execution-count={executionCount ?? ""}
+      data-focused={String(focused)}
       data-host-context={JSON.stringify(hostContext ?? null)}
       data-mimes={outputs
         .flatMap((output) =>
@@ -101,6 +104,7 @@ describe("ReadOnlyNotebookCell", () => {
     expect(screen.getByText("[7]:")).toHaveAttribute("data-slot", "execution-count");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "cell-code");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-execution-count", "7");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-focused", "false");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-mimes", "stream");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-priority", "text/plain");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-class-name", "cloud-output");
@@ -136,5 +140,29 @@ describe("ReadOnlyNotebookCell", () => {
 
     expect(screen.getByTestId("readonly-codemirror")).toHaveTextContent("x = 1");
     expect(screen.queryByTestId("output-area")).toBeNull();
+  });
+
+  it("renders report cells without notebook gutter chrome and can focus outputs", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="report-code"
+        cellType="code"
+        source="print('hidden')"
+        showSource={false}
+        displayMode="report"
+        focusOutputs
+        outputs={[{ output_type: "stream", name: "stdout", text: "visible\n" }]}
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="cell-container"]')).toBeNull();
+    const reportCell = document.querySelector('[data-slot="read-only-report-cell"]');
+    expect(reportCell).toHaveAttribute("data-cell-id", "report-code");
+    expect(reportCell).toHaveAttribute("data-cell-type", "code");
+    expect(screen.queryByTestId("readonly-codemirror")).toBeNull();
+    expect(document.querySelector('[data-slot="execution-count"]')).toBeNull();
+    expect(document.querySelector('[data-slot="read-only-cell-source"]')).toBeNull();
+    expect(document.querySelector('[data-slot="read-only-cell-output"]')).not.toBeNull();
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-focused", "true");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a report display mode to the shared `ReadOnlyNotebook` components so hosted read-only notebooks can render without notebook gutters, execution-count chrome, or desktop cell framing.
- Updates the Cloudflare notebook-cloud viewer to use report mode with focused outputs and a local-only code show/hide toggle.
- Preloads Sift's WASM sidecar only when the selected output MIME needs Sift, using the same hashed renderer-asset URL the isolated iframe will fetch.
- Gates `/api/n/:id/events` observability behind owner scope so public/anonymous viewers do not receive peer IDs or actor labels.
- Updates hosted smoke coverage so report cells are accepted instead of requiring execution-count gutters.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/cell/__tests__/ReadOnlyNotebook.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test 'test/*.test.ts' 'test/*.test.mjs'`
- `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud-report-view.png pnpm --dir apps/notebook-cloud smoke:hosted`

## Deploy / Visual Check

- Deployed renderer assets Worker: `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev`
- Deployed notebook-cloud Worker: `https://nteract-notebook-cloud.rgbkrk.workers.dev`
- Verified `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet` in Chrome and with a mobile Playwright viewport.
