### PR TITLE
fix(notebook-cloud): remove prototype room events api

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -39,7 +39,6 @@ The smoke script proves:
 - Viewer-scope rejection for blob, request, and pool-state writes.
 - Explicit anonymous viewer identity (`anonymous:<session>/browser:<session>`).
 - Local-only anonymous presence: accepted to the sender, not broadcast or persisted.
-- D1 room-event readback.
 
 If the volatile frontend WASM package exists at `apps/notebook/src/wasm/runtimed-wasm`,
 the deeper roundtrip smoke sends real `runtimed-wasm` Automerge sync payloads through
@@ -181,16 +180,16 @@ Snapshot and blob reads are public in this prototype so `/n/:id` can act like a 
 Bindings in `wrangler.toml`:
 
 - `NOTEBOOK_ROOMS`: Durable Object namespace, one object per notebook id.
-- `DB`: D1 catalog for notebooks, revisions, blobs, and room event metadata.
+- `DB`: D1 catalog for notebooks, revisions, and blobs.
 - `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, generated render caches, and blobs.
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 
 The dedicated renderer asset Worker serves only public, build-time sidecar files from the plugin asset bundle. It intentionally sends `Access-Control-Allow-Origin: *` so sandboxed `srcdoc` iframes with opaque origins can fetch renderer WASM. Do not serve authenticated, notebook-specific, or user-generated blobs from this origin; those belong behind the notebook host's blob resolver or a future signed output origin. Deploy the renderer asset Worker before the main Worker when `RENDERER_ASSETS_BASE_URL` points at the separate origin.
 
-Schema lives in `migrations/0001_initial.sql`. The Worker also creates the same tables lazily in local dev so the WebSocket path can run before applying migrations.
+Schema lives in `migrations/`. The Worker also creates the current catalog tables lazily in local dev so the WebSocket path can run before applying migrations.
 
-Accepted WebSocket frame payload caps mirror `notebook-wire` per-frame limits: Automerge sync and runtime-state frames may be up to 64 MiB, `PUT_BLOB` up to 32 MiB, request frames up to 16 MiB, and presence/pool-state/session-control frames up to 1 MiB. The Durable Object keeps only the latest 500 `frame:*` metadata entries in object storage; D1 room events are observability rows, not the replay log.
+Accepted WebSocket frame payload caps mirror `notebook-wire` per-frame limits: Automerge sync and runtime-state frames may be up to 64 MiB, `PUT_BLOB` up to 32 MiB, request frames up to 16 MiB, and presence/pool-state/session-control frames up to 1 MiB. The Durable Object keeps only the latest 500 `frame:*` metadata entries in object storage; D1 is not a frame replay log.
 
 Published revision artifacts follow `docs/architecture/hosted-notebook-artifacts.md`:
 
@@ -261,11 +260,10 @@ curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
   --data-binary @output.bin
 ```
 
-Catalog and event readback:
+Catalog and render readback:
 
 ```bash
 curl "http://127.0.0.1:8787/api/n/demo"
-curl "http://127.0.0.1:8787/api/n/demo/events?limit=20"
 curl "http://127.0.0.1:8787/api/n/demo/render"
 ```
 

--- a/apps/notebook-cloud/migrations/0002_drop_room_events.sql
+++ b/apps/notebook-cloud/migrations/0002_drop_room_events.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS room_events;

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -202,15 +202,6 @@ const leakedAnonymousPresence = await bob
   .catch(() => undefined);
 assert(leakedAnonymousPresence === undefined, "anonymous presence was broadcast to room peers");
 
-const events = await waitForEvents(
-  roomId,
-  (event) => event.frame_type === FrameType.AUTOMERGE_SYNC,
-);
-assert(
-  events.events.some((event) => event.frame_type === FrameType.AUTOMERGE_SYNC),
-  "D1 event readback did not include the accepted sync frame",
-);
-
 const snapshotHeads = `heads-${roomId}`;
 const runtimeHeads = `runtime-${roomId}`;
 const runtimePath = `/api/n/${encodeURIComponent(roomId)}/runtime-snapshots/${encodeURIComponent(runtimeHeads)}`;
@@ -298,7 +289,6 @@ console.log(
         "anonymous_viewer_identity",
         "anonymous_viewer_write_rejection",
         "anonymous_presence_local_only",
-        "d1_room_event_readback",
         "invalid_auth_structured_rejection",
         "r2_runtime_snapshot_roundtrip",
         "r2_snapshot_roundtrip",
@@ -488,20 +478,6 @@ async function fetchHead(pathname) {
   const response = await fetch(url, { method: "HEAD" });
   assert(response.ok, `${url.href} returned ${response.status}`);
   return response;
-}
-
-async function waitForEvents(notebookId, predicate, timeoutMs = 5_000) {
-  const deadline = Date.now() + timeoutMs;
-  const pathname = `/api/n/${encodeURIComponent(notebookId)}/events?limit=20`;
-  let lastEvents;
-  while (Date.now() < deadline) {
-    lastEvents = await fetchJson(pathname);
-    if (lastEvents.events.some(predicate)) {
-      return lastEvents;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-  return lastEvents ?? { events: [] };
 }
 
 function assertBytesEqual(actual, expected, message) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -13,7 +13,6 @@ import {
   ensureCatalogSchema,
   ensureNotebook,
   getNotebookCatalog,
-  listRoomEvents,
   recordBlob,
   recordRevision,
   renderKey,
@@ -115,11 +114,6 @@ const worker: ExportedHandler<Env> = {
     const catalogMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/?$/);
     if (catalogMatch && request.method === "GET") {
       return routeCatalog(env, decodeURIComponent(catalogMatch[1]));
-    }
-
-    const eventsMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/events$/);
-    if (eventsMatch && request.method === "GET") {
-      return routeRoomEvents(request, env, decodeURIComponent(eventsMatch[1]));
     }
 
     const latestRenderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/render$/);
@@ -399,26 +393,6 @@ async function routeCatalog(env: Env, notebookId: string): Promise<Response> {
   }
 
   return json(catalog);
-}
-
-async function routeRoomEvents(request: Request, env: Env, notebookId: string): Promise<Response> {
-  const identity = authenticateRequestOrResponse(request, env);
-  if (identity instanceof Response) {
-    return identity;
-  }
-  if (!allowsPublish(identity.scope)) {
-    return json({ error: `${identity.scope} cannot read room events` }, 403);
-  }
-  if (!env.DB) {
-    return json({ error: "D1 binding DB is not configured" }, 503);
-  }
-
-  const url = new URL(request.url);
-  const limit = parseLimit(url.searchParams.get("limit"));
-  return json({
-    notebook_id: notebookId,
-    events: await listRoomEvents(env, notebookId, limit),
-  });
 }
 
 async function routeLatestRender(
@@ -827,19 +801,6 @@ function withCors(response: Response): Response {
   return response;
 }
 
-function parseLimit(value: string | null): number {
-  if (!value) {
-    return 25;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    return 25;
-  }
-
-  return Math.min(parsed, 100);
-}
-
 function normalizedRuntimeHeadsHash(value: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed !== "none" ? trimmed : null;
@@ -931,10 +892,6 @@ function debugViewer(notebookId: string): Response {
         <h2>Catalog</h2>
         <pre id="catalog"></pre>
       </section>
-      <section>
-        <h2>Events</h2>
-        <pre id="events"></pre>
-      </section>
     </div>
   </main>
   <script type="module">
@@ -942,7 +899,6 @@ function debugViewer(notebookId: string): Response {
     const frameType = { presence: 0x04, sessionControl: 0x07 };
     const log = document.querySelector("#log");
     const catalog = document.querySelector("#catalog");
-    const events = document.querySelector("#events");
     const status = document.querySelector("#status");
     const urlCell = document.querySelector("#url");
     const base = new URL(location.href);
@@ -969,16 +925,10 @@ function debugViewer(notebookId: string): Response {
     });
     document.querySelector("#refresh").addEventListener("click", refreshCatalog);
     async function refreshCatalog() {
-      const [catalogResponse, eventsResponse] = await Promise.all([
-        fetch("/api/n/" + encodeURIComponent(notebookId)),
-        fetch("/api/n/" + encodeURIComponent(notebookId) + "/events?limit=10"),
-      ]);
+      const catalogResponse = await fetch("/api/n/" + encodeURIComponent(notebookId));
       catalog.textContent = catalogResponse.ok
         ? JSON.stringify(await catalogResponse.json(), null, 2)
         : "No catalog row yet";
-      events.textContent = eventsResponse.ok
-        ? JSON.stringify(await eventsResponse.json(), null, 2)
-        : "No room events yet";
     }
     refreshCatalog();
   </script>

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -18,7 +18,7 @@ import {
   type TypedFrame,
 } from "./protocol.ts";
 import { rewritePresenceIngress } from "./runtimed-wasm.ts";
-import { ensureNotebook, recordRoomEvent } from "./storage.ts";
+import { ensureNotebook } from "./storage.ts";
 
 interface Peer {
   id: string;
@@ -302,7 +302,7 @@ export class NotebookRoom {
     }
 
     try {
-      await this.persistFrame(notebookId, peer, normalizedFrame, receivedAt);
+      await this.persistFrame(peer, normalizedFrame, receivedAt);
     } catch (error) {
       this.rejectFrame(
         notebookId,
@@ -346,12 +346,7 @@ export class NotebookRoom {
     }
   }
 
-  private async persistFrame(
-    notebookId: string,
-    peer: Peer,
-    frame: TypedFrame,
-    receivedAt: string,
-  ): Promise<void> {
+  private async persistFrame(peer: Peer, frame: TypedFrame, receivedAt: string): Promise<void> {
     const operation = this.framePersistQueue
       .catch(() => undefined)
       .then(async () => {
@@ -372,18 +367,6 @@ export class NotebookRoom {
         this.nextFrameSequence = sequence;
         this.state.waitUntil(
           this.evictStoredFrame(sequence - MAX_STORED_FRAMES).catch(() => undefined),
-        );
-        // D1 event rows are observability only; relay delivery must not depend on D1.
-        this.state.waitUntil(
-          recordRoomEvent(this.env, {
-            notebookId,
-            peerId: peer.id,
-            actorLabel: peer.identity.actorLabel,
-            connectionScope: peer.identity.scope,
-            frameType: frame.type,
-            byteLength: frame.payload.byteLength,
-            receivedAt,
-          }).catch(() => undefined),
         );
       });
 

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -36,17 +36,6 @@ export interface BlobRow {
   uploaded_at: string;
 }
 
-export interface RoomEventRow {
-  id: string;
-  notebook_id: string;
-  peer_id: string;
-  actor_label: string;
-  connection_scope: string;
-  frame_type: number;
-  byte_length: number;
-  received_at: string;
-}
-
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -75,17 +64,6 @@ const SCHEMA_STATEMENTS = [
     r2_key TEXT NOT NULL,
     uploaded_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     PRIMARY KEY (notebook_id, hash),
-    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
-  )`,
-  `CREATE TABLE IF NOT EXISTS room_events (
-    id TEXT PRIMARY KEY,
-    notebook_id TEXT NOT NULL,
-    peer_id TEXT NOT NULL,
-    actor_label TEXT NOT NULL,
-    connection_scope TEXT NOT NULL,
-    frame_type INTEGER NOT NULL,
-    byte_length INTEGER NOT NULL,
-    received_at TEXT NOT NULL,
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
 ];
@@ -168,48 +146,6 @@ export async function ensureNotebook(
        ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at`,
   )
     .bind(notebookId, identity.principal, new Date().toISOString())
-    .run();
-}
-
-export async function recordRoomEvent(
-  env: Env,
-  event: {
-    notebookId: string;
-    peerId: string;
-    actorLabel: string;
-    connectionScope: string;
-    frameType: number;
-    byteLength: number;
-    receivedAt: string;
-  },
-): Promise<void> {
-  if (!env.DB) {
-    return;
-  }
-
-  await ensureCatalogSchema(env);
-  await env.DB.prepare(
-    `INSERT INTO room_events (
-       id,
-       notebook_id,
-       peer_id,
-       actor_label,
-       connection_scope,
-       frame_type,
-       byte_length,
-       received_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-  )
-    .bind(
-      crypto.randomUUID(),
-      event.notebookId,
-      event.peerId,
-      event.actorLabel,
-      event.connectionScope,
-      event.frameType,
-      event.byteLength,
-      event.receivedAt,
-    )
     .run();
 }
 
@@ -346,36 +282,6 @@ export async function getNotebookCatalog(
     revisions: revisions.results ?? [],
     blobs: blobs.results ?? [],
   };
-}
-
-export async function listRoomEvents(
-  env: Env,
-  notebookId: string,
-  limit: number,
-): Promise<RoomEventRow[]> {
-  if (!env.DB) {
-    return [];
-  }
-
-  await ensureCatalogSchema(env);
-  const result = await env.DB.prepare(
-    `SELECT id,
-            notebook_id,
-            peer_id,
-            actor_label,
-            connection_scope,
-            frame_type,
-            byte_length,
-            received_at
-       FROM room_events
-       WHERE notebook_id = ?
-       ORDER BY received_at DESC
-       LIMIT ?`,
-  )
-    .bind(notebookId, limit)
-    .all<RoomEventRow>();
-
-  return result.results ?? [];
 }
 
 function encodePathComponent(value: string): string {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -122,44 +122,16 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(seenPaths, ["/plugins/sift_wasm.wasm"]);
   });
 
-  it("keeps room event observability owner-scoped", async () => {
+  it("does not expose prototype room event observability", async () => {
     const env = fakeEnv();
 
-    const anonymous = await worker.fetch(
+    const response = await worker.fetch(
       new Request("http://localhost/api/n/route-demo/events"),
       env,
       fakeContext(),
     );
-    assert.equal(anonymous.status, 403);
-    assert.deepEqual(await anonymous.json(), { error: "viewer cannot read room events" });
-
-    const viewer = await worker.fetch(
-      new Request("http://localhost/api/n/route-demo/events", {
-        headers: {
-          "X-User": "alice",
-          "X-Operator": "desktop:test",
-          "X-Scope": "viewer",
-        },
-      }),
-      env,
-      fakeContext(),
-    );
-    assert.equal(viewer.status, 403);
-    assert.deepEqual(await viewer.json(), { error: "viewer cannot read room events" });
-
-    const owner = await worker.fetch(
-      new Request("http://localhost/api/n/route-demo/events", {
-        headers: {
-          "X-User": "alice",
-          "X-Operator": "desktop:test",
-          "X-Scope": "owner",
-        },
-      }),
-      env,
-      fakeContext(),
-    );
-    assert.equal(owner.status, 200);
-    assert.deepEqual(await owner.json(), { notebook_id: "route-demo", events: [] });
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "not found" });
   });
 
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {


### PR DESCRIPTION
## Summary

- remove the prototype `/api/n/:id/events` route and debug panel event readback
- stop writing accepted WebSocket frame metadata to D1
- add a D1 migration to drop the legacy `room_events` table while keeping DO-local frame metadata bounded

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test 'test/*.test.ts' 'test/*.test.mjs'`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`
