### PR TITLE
feat(traceback): link frames to notebook cells

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -26,7 +26,11 @@ import {
 import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
-import { useCellExecutionId, useExecution } from "../lib/notebook-executions";
+import {
+  getCellIdForExecutionId,
+  useCellExecutionId,
+  useExecution,
+} from "../lib/notebook-executions";
 import { useCellOutputs } from "../lib/notebook-outputs";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
@@ -52,6 +56,7 @@ interface CodeCellProps {
   onDelete: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
+  onNavigateToCell?: (cellId: string) => void;
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
@@ -146,6 +151,7 @@ export const CodeCell = memo(function CodeCell({
   onDelete,
   onFocusPrevious,
   onFocusNext,
+  onNavigateToCell,
   onInsertCellAfter,
   isLastCell = false,
   dragHandleProps,
@@ -347,6 +353,16 @@ export const CodeCell = memo(function CodeCell({
     editorRef.current?.getEditor()?.contentDOM.blur();
     onFocus();
   }, [onFocus]);
+  const resolveTracebackExecutionTarget = useCallback((executionId: string) => {
+    const cellId = getCellIdForExecutionId(executionId);
+    return cellId ? { cellId } : null;
+  }, []);
+  const handleTracebackCellNavigate = useCallback(
+    (target: { cellId: string }) => {
+      onNavigateToCell?.(target.cellId);
+    },
+    [onNavigateToCell],
+  );
 
   const gutterContent = bothHidden ? null : (
     <CompactExecutionButton
@@ -466,6 +482,8 @@ export const CodeCell = memo(function CodeCell({
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
               onIframeMouseDown={handleOutputMouseDown}
+              resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+              onNavigateToTracebackCell={handleTracebackCellNavigate}
               focused={outputFocused}
               useOutputWell={showOutputChrome}
             />

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -721,6 +721,13 @@ function NotebookViewContent({
         }
       };
 
+      const onNavigateToCell = (targetCellId: string) => {
+        logger.debug(`[cell-nav] Navigating to traceback cell: ${targetCellId.slice(0, 8)}`);
+        onFocusCell(targetCellId);
+        presence?.setFocus(targetCellId);
+        focusCell(targetCellId, "start");
+      };
+
       // Build right gutter content — delete button for all cells,
       // plus source toggle for code cells
       const deleteButton = (
@@ -791,6 +798,7 @@ function NotebookViewContent({
             onDelete={() => onDeleteCell(cell.id)}
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
+            onNavigateToCell={onNavigateToCell}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -36,6 +36,20 @@ pub struct ExecutionResult {
     pub success: bool,
 }
 
+/// Build the current execution_id -> cell_id map from NotebookDoc pointers.
+///
+/// RuntimeStateDoc intentionally does not require cell IDs, because some
+/// executions are notebook-less. Notebook callers can still provide this
+/// best-effort map to LLM output resolution for traceback provenance.
+pub fn execution_cell_map(handle: &DocHandle) -> HashMap<String, String> {
+    handle
+        .get_cell_execution_pointers()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(cell_id, execution_id)| execution_id.map(|eid| (eid, cell_id)))
+        .collect()
+}
+
 /// Execute a cell and wait for completion.
 ///
 /// 1. Captures current Automerge heads as a causal precondition.
@@ -138,6 +152,12 @@ pub async fn execute_and_wait(
     };
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
+    let mut execution_cell_map = execution_cell_map(handle);
+    if let Some(eid) = &execution_id {
+        execution_cell_map
+            .entry(eid.clone())
+            .or_insert_with(|| cell_id.to_string());
+    }
     // Execute paths (and `and_run` variants) always use preview mode —
     // agents that need unabridged output should call `get_cell(full_output=true)`
     // afterwards rather than paying for it on every run.
@@ -145,6 +165,7 @@ pub async fn execute_and_wait(
         blob_base_url: blob_base_url.as_deref(),
         blob_store_path: blob_store_path.as_deref(),
         comms: comms.as_ref(),
+        execution_cell_map: Some(&execution_cell_map),
         ..Default::default()
     };
     let outputs = if !output_manifests.is_empty() {

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -84,6 +84,14 @@ pub async fn get_cell(
         raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
     }
 
+    let execution_id = handle.get_cell_execution_id(cell_id);
+    let mut execution_cell_map = crate::execution::execution_cell_map(&handle);
+    if let Some(eid) = &execution_id {
+        execution_cell_map
+            .entry(eid.clone())
+            .or_insert_with(|| cell_id.to_string());
+    }
+
     // Resolve outputs (with widget state synthesis). `get_cell` is the
     // only tool that honors `full_output=true`; all other paths hardcode
     // preview mode to protect the agent's context budget.
@@ -99,11 +107,10 @@ pub async fn get_cell(
             } else {
                 output_resolver::OutputLength::Preview
             },
+            execution_cell_map: Some(&execution_cell_map),
         },
     )
     .await;
-
-    let execution_id = handle.get_cell_execution_id(cell_id);
 
     // Get execution status from RuntimeState
     let status = get_cell_status(&handle, cell_id);
@@ -197,6 +204,7 @@ pub async fn get_all_cells(
     let cell_status_map = build_cell_status_map(&handle);
     let cell_ec_map = build_cell_execution_count_map(&handle);
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
+    let execution_cell_map = crate::execution::execution_cell_map(&handle);
     let outputs_by_cell = handle.get_all_outputs();
     let empty_outputs: Vec<serde_json::Value> = Vec::new();
 
@@ -221,6 +229,7 @@ pub async fn get_all_cells(
                         blob_base_url: server.blob_base_url.as_deref(),
                         blob_store_path: server.blob_store_path.as_deref(),
                         comms: comms.as_ref(),
+                        execution_cell_map: Some(&execution_cell_map),
                         ..Default::default()
                     },
                 )
@@ -268,6 +277,7 @@ pub async fn get_all_cells(
                         blob_base_url: server.blob_base_url.as_deref(),
                         blob_store_path: server.blob_store_path.as_deref(),
                         comms: comms.as_ref(),
+                        execution_cell_map: Some(&execution_cell_map),
                         ..Default::default()
                     },
                 )
@@ -331,6 +341,7 @@ pub async fn get_all_cells(
                             blob_base_url: server.blob_base_url.as_deref(),
                             blob_store_path: server.blob_store_path.as_deref(),
                             comms: comms.as_ref(),
+                            execution_cell_map: Some(&execution_cell_map),
                             ..Default::default()
                         },
                     )

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -133,6 +133,10 @@ pub async fn run_all_cells(
 
     let cells = handle.get_cells();
     let runtime_state = handle.get_runtime_state().ok();
+    let mut execution_cell_map = execution::execution_cell_map(&handle);
+    for (cell_id, execution_id) in &result.cell_execution_ids {
+        execution_cell_map.insert(execution_id.clone(), cell_id.clone());
+    }
 
     // Look up this run's execution state for a given cell.
     let run_exec = |cell_id: &str| -> Option<&runtime_doc::ExecutionState> {
@@ -231,6 +235,7 @@ pub async fn run_all_cells(
                     blob_base_url: server.blob_base_url.as_deref(),
                     blob_store_path: server.blob_store_path.as_deref(),
                     comms,
+                    execution_cell_map: Some(&execution_cell_map),
                     ..Default::default()
                 },
             )
@@ -336,12 +341,19 @@ pub async fn get_results(
             let cell = handle.get_cells().into_iter().find(|cell| {
                 handle.get_cell_execution_id(&cell.id).as_deref() == Some(execution_id)
             });
+            let mut execution_cell_map = execution::execution_cell_map(handle);
+            if let Some(cell) = &cell {
+                execution_cell_map
+                    .entry(execution_id.to_string())
+                    .or_insert_with(|| cell.id.clone());
+            }
             return render_execution_result(
                 server,
                 execution_id,
                 exec,
                 Some(&runtime_state.comms),
                 cell,
+                Some(execution_cell_map),
                 full_output,
             )
             .await;
@@ -359,7 +371,19 @@ pub async fn get_results(
             source: record.source,
             seq: record.seq,
         };
-        return render_execution_result(server, execution_id, &exec, None, None, full_output).await;
+        let execution_cell_map = record
+            .cell_id
+            .map(|cell_id| std::collections::HashMap::from([(execution_id.to_string(), cell_id)]));
+        return render_execution_result(
+            server,
+            execution_id,
+            &exec,
+            None,
+            None,
+            execution_cell_map,
+            full_output,
+        )
+        .await;
     }
 
     tool_error(&format!(
@@ -373,6 +397,7 @@ async fn render_execution_result(
     exec: &runtime_doc::ExecutionState,
     comms: Option<&std::collections::HashMap<String, runtime_doc::CommDocEntry>>,
     cell: Option<notebook_doc::CellSnapshot>,
+    execution_cell_map: Option<std::collections::HashMap<String, String>>,
     full_output: bool,
 ) -> Result<CallToolResult, McpError> {
     // Determine display status with clear indication of completeness
@@ -413,6 +438,7 @@ async fn render_execution_result(
                 } else {
                     output_resolver::OutputLength::Preview
                 },
+                execution_cell_map: execution_cell_map.as_ref(),
             },
         )
         .await

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -49,6 +49,12 @@ pub struct ResolveCtx<'a> {
     /// Whether to render the blob-preview marker (default) or fetch the
     /// full blob text. See [`OutputLength`].
     pub length: OutputLength,
+    /// Current notebook provenance map: execution_id -> cell_id.
+    ///
+    /// This is intentionally optional because runtime executions can exist
+    /// without a notebook. When present, rich traceback resolution can name
+    /// the cell that still points at each execution.
+    pub execution_cell_map: Option<&'a HashMap<String, String>>,
 }
 
 /// MIME type for Jupyter widget view references.
@@ -645,6 +651,19 @@ pub async fn resolve_output_for_llm(
             if ctx.length == OutputLength::Preview {
                 if let Some(blob_hash) = traceback_val.get("blob").and_then(|v| v.as_str()) {
                     if let Some(preview) = manifest.get("llm_preview") {
+                        if let Some(cell_map) = ctx.execution_cell_map {
+                            if let Some(tb) = rich_traceback_lines_for_llm(
+                                manifest,
+                                cell_map,
+                                &blob_base_url,
+                                &blob_store_path,
+                                ctx.length,
+                            )
+                            .await
+                            {
+                                return Some(Output::error(&ename, &evalue, tb));
+                            }
+                        }
                         let tb = render_error_preview(preview, blob_hash, &blob_base_url);
                         return Some(Output::error(&ename, &evalue, tb));
                     }
@@ -658,6 +677,19 @@ pub async fn resolve_output_for_llm(
                 let tb_str =
                     resolve_text_ref(traceback_val, &blob_base_url, &blob_store_path).await?;
                 serde_json::from_str::<Vec<String>>(&tb_str).ok()?
+            };
+            let traceback = if let Some(cell_map) = ctx.execution_cell_map {
+                rich_traceback_lines_for_llm(
+                    manifest,
+                    cell_map,
+                    &blob_base_url,
+                    &blob_store_path,
+                    ctx.length,
+                )
+                .await
+                .unwrap_or(traceback)
+            } else {
+                traceback
             };
             Some(Output::error(&ename, &evalue, traceback))
         }
@@ -673,6 +705,189 @@ pub async fn resolve_output_for_llm(
         }
         _ => None,
     }
+}
+
+async fn rich_traceback_lines_for_llm(
+    manifest: &serde_json::Value,
+    execution_cell_map: &HashMap<String, String>,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+    length: OutputLength,
+) -> Option<Vec<String>> {
+    let rich_ref = manifest.get("rich")?;
+    if length == OutputLength::Preview && rich_ref.get("blob").is_some() {
+        return None;
+    }
+    let rich_json = resolve_text_ref(rich_ref, blob_base_url, blob_store_path).await?;
+    let payload: Value = serde_json::from_str(&rich_json).ok()?;
+    synthesize_rich_traceback_lines(&payload, execution_cell_map)
+}
+
+fn synthesize_rich_traceback_lines(
+    payload: &Value,
+    execution_cell_map: &HashMap<String, String>,
+) -> Option<Vec<String>> {
+    let ename = payload.get("ename")?.as_str()?;
+    let evalue = payload.get("evalue").and_then(Value::as_str).unwrap_or("");
+    let mut out = vec!["Traceback (most recent call last):".to_string()];
+
+    if let Some(syntax) = payload.get("syntax").filter(|v| v.is_object()) {
+        out.push(format!(
+            "  {}",
+            rich_location_line(syntax, execution_cell_map, None)?
+        ));
+        if let Some(text) = syntax.get("text").and_then(Value::as_str) {
+            if !text.is_empty() {
+                out.push(format!("    {text}"));
+                if let Some(caret) = rich_syntax_caret_line(syntax) {
+                    out.push(format!("    {caret}"));
+                }
+            }
+        }
+    } else {
+        let frames = payload.get("frames")?.as_array()?;
+        if frames.is_empty() {
+            return None;
+        }
+        for frame in frames {
+            let name = frame.get("name").and_then(Value::as_str);
+            out.push(format!(
+                "  {}",
+                rich_location_line(frame, execution_cell_map, name)?
+            ));
+            if let Some(source) = rich_highlighted_source_line(frame) {
+                out.push(format!("    {source}"));
+            }
+        }
+    }
+
+    out.push(format!("{ename}: {evalue}"));
+    Some(out)
+}
+
+fn rich_location_line(
+    source: &Value,
+    execution_cell_map: &HashMap<String, String>,
+    name: Option<&str>,
+) -> Option<String> {
+    let filename = source.get("filename").and_then(Value::as_str).unwrap_or("");
+    let lineno = source.get("lineno").and_then(Value::as_i64).unwrap_or(0);
+    if !rich_is_notebook_source(source) {
+        return Some(format!(
+            "File \"{}\", line {}, in {}",
+            if filename.is_empty() {
+                "<unknown>"
+            } else {
+                filename
+            },
+            lineno,
+            name.unwrap_or("<module>")
+        ));
+    }
+
+    let source_ref = source.get("source_ref").filter(|v| v.is_object());
+    let execution_id = source_ref
+        .and_then(|r| r.get("execution_id"))
+        .or_else(|| source.get("execution_id"))
+        .and_then(Value::as_str);
+    let execution_count = source_ref
+        .and_then(|r| r.get("execution_count"))
+        .or_else(|| source.get("execution_count"))
+        .and_then(Value::as_u64);
+    let source_hash = source_ref
+        .and_then(|r| r.get("source_hash"))
+        .or_else(|| source.get("source_hash"))
+        .and_then(Value::as_str);
+    let cell_id = execution_id.and_then(|eid| execution_cell_map.get(eid));
+
+    let label = cell_id
+        .map(|cid| format!("Cell {cid}"))
+        .unwrap_or_else(|| "Notebook Execution".to_string());
+    let mut details = Vec::new();
+    if let Some(cid) = cell_id {
+        details.push(format!("cell_id={cid}"));
+    }
+    if let Some(eid) = execution_id {
+        details.push(format!("execution_id={eid}"));
+    }
+    if let Some(count) = execution_count {
+        details.push(format!("In[{count}]"));
+    }
+    if let Some(hash) = source_hash {
+        details.push(format!("source_hash={hash}"));
+    }
+
+    let mut line = format!("Line {lineno} in {label}");
+    if !details.is_empty() {
+        line.push_str(&format!(" ({})", details.join(", ")));
+    }
+    if let Some(name) = name.filter(|n| *n != "<module>") {
+        line.push_str(&format!(", in {name}"));
+    }
+    Some(line)
+}
+
+fn rich_is_notebook_source(source: &Value) -> bool {
+    let source_ref = source.get("source_ref").filter(|v| v.is_object());
+    source_ref
+        .and_then(|r| r.get("kind"))
+        .and_then(Value::as_str)
+        == Some("notebook_execution")
+        || source
+            .get("filename")
+            .and_then(Value::as_str)
+            .is_some_and(is_synthetic_notebook_filename)
+}
+
+fn is_synthetic_notebook_filename(filename: &str) -> bool {
+    (filename.starts_with("<ipython-input-") && filename.ends_with('>'))
+        || ((filename.contains("/ipykernel_") || filename.contains("\\ipykernel_"))
+            && filename.ends_with(".py"))
+}
+
+fn rich_highlighted_source_line(frame: &Value) -> Option<&str> {
+    let lines = frame.get("lines")?.as_array()?;
+    lines
+        .iter()
+        .find(|line| {
+            line.get("highlight")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .or_else(|| lines.first())
+        .and_then(|line| line.get("source"))
+        .and_then(Value::as_str)
+}
+
+fn rich_syntax_caret_line(syntax: &Value) -> Option<String> {
+    let text = syntax.get("text")?.as_str()?;
+    if text.is_empty() {
+        return None;
+    }
+    let line_len = text.chars().count() as u64;
+    let offset = syntax.get("offset").and_then(Value::as_u64).unwrap_or(1);
+    let start_col = offset.max(1).min(line_len + 1);
+    let same_line = syntax
+        .get("end_lineno")
+        .and_then(Value::as_u64)
+        .is_none_or(|end_lineno| {
+            let lineno = syntax.get("lineno").and_then(Value::as_u64).unwrap_or(1);
+            end_lineno == lineno
+        });
+    let end_offset = syntax
+        .get("end_offset")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let end_col = if same_line && end_offset > start_col {
+        end_offset.min(line_len + 1)
+    } else {
+        start_col + 1
+    };
+    Some(format!(
+        "{}{}",
+        " ".repeat((start_col - 1) as usize),
+        "^".repeat((end_col - start_col).max(1) as usize)
+    ))
 }
 
 /// Selectively resolve a display_data or execute_result manifest for LLM use.
@@ -2400,6 +2615,76 @@ mod tests {
         assert_eq!(tb[0], "RecursionError: maximum recursion depth");
         assert!(tb[1].contains("200"));
         assert!(tb[1].contains("http://localhost:9999/blob/tb_hash"));
+    }
+
+    #[tokio::test]
+    async fn llm_error_uses_rich_traceback_cell_ids_when_available() {
+        let rich = json!({
+            "ename": "AttributeError",
+            "evalue": "module 'pandas' has no attribute 'not_real'",
+            "execution": {"execution_id": "exec-run", "execution_count": 3},
+            "frames": [
+                {
+                    "filename": "/var/folders/x/T/ipykernel_39879/258099874.py",
+                    "lineno": 1,
+                    "name": "<module>",
+                    "source_ref": {
+                        "kind": "notebook_execution",
+                        "execution_id": "exec-run",
+                        "execution_count": 3,
+                        "compiled_filename": "/var/folders/x/T/ipykernel_39879/258099874.py"
+                    },
+                    "lines": [{"lineno": 1, "source": "g()", "highlight": true}]
+                },
+                {
+                    "filename": "/var/folders/x/T/ipykernel_39879/3398808089.py",
+                    "lineno": 5,
+                    "name": "g",
+                    "source_ref": {
+                        "kind": "notebook_execution",
+                        "execution_id": "exec-def",
+                        "execution_count": 2,
+                        "compiled_filename": "/var/folders/x/T/ipykernel_39879/3398808089.py"
+                    },
+                    "lines": [{"lineno": 5, "source": "pd.not_real()", "highlight": true}]
+                }
+            ],
+            "text": "fallback text"
+        });
+        let fallback_traceback = serde_json::to_string(&json!(["fallback traceback"])).unwrap();
+        let rich_json = serde_json::to_string(&rich).unwrap();
+        let manifest = serde_json::json!({
+            "output_type": "error",
+            "ename": "AttributeError",
+            "evalue": "module 'pandas' has no attribute 'not_real'",
+            "traceback": inline_ref(&fallback_traceback),
+            "rich": inline_ref(&rich_json),
+        });
+        let execution_cell_map = HashMap::from([
+            ("exec-run".to_string(), "cell-run".to_string()),
+            ("exec-def".to_string(), "cell-def".to_string()),
+        ]);
+
+        let Some(out) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                execution_cell_map: Some(&execution_cell_map),
+                ..Default::default()
+            },
+        )
+        .await
+        else {
+            panic!("resolve should succeed");
+        };
+        let traceback = out.traceback.unwrap_or_default().join("\n");
+
+        assert!(traceback
+            .contains("Line 1 in Cell cell-run (cell_id=cell-run, execution_id=exec-run, In[3])"));
+        assert!(traceback.contains(
+            "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def, In[2]), in g"
+        ));
+        assert!(traceback.contains("pd.not_real()"));
+        assert!(!traceback.contains("/var/folders/x/T/ipykernel_39879"));
     }
 
     #[tokio::test]

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -24,7 +24,11 @@ import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-out
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
 import { selectMimeType } from "@/components/outputs/mime-priority";
-import { TracebackOutput } from "@/components/outputs/traceback-output";
+import {
+  TracebackOutput,
+  type TracebackCellNavigator,
+  type TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
 import { useWidgetStore } from "@/components/widgets/widget-store-context";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -177,6 +181,14 @@ interface OutputAreaProps {
    * keep relying on the default daemon-local context.
    */
   hostContext?: NteractEmbedHostContextPatch;
+  /**
+   * Resolve a traceback frame's execution_id back to a current notebook cell,
+   * when the execution still belongs to one. Omitted in read-only/isolated
+   * contexts that cannot navigate notebook cells.
+   */
+  resolveTracebackExecutionTarget?: TracebackExecutionResolver;
+  /** Navigate to the cell resolved for a traceback frame. */
+  onNavigateToTracebackCell?: TracebackCellNavigator;
 }
 
 /**
@@ -315,6 +327,8 @@ function renderOutput(
   index: number,
   renderers?: OutputAreaProps["renderers"],
   priority?: readonly string[],
+  resolveTracebackExecutionTarget?: OutputAreaProps["resolveTracebackExecutionTarget"],
+  onNavigateToTracebackCell?: OutputAreaProps["onNavigateToTracebackCell"],
 ) {
   const key = `output-${index}`;
 
@@ -343,7 +357,14 @@ function renderOutput(
       // When absent, fall back to the plain ANSI render — the classic
       // path still works for vanilla ipykernel_launcher.
       if (output.rich != null && typeof output.rich === "object") {
-        return <TracebackOutput key={key} data={output.rich} />;
+        return (
+          <TracebackOutput
+            key={key}
+            data={output.rich}
+            resolveExecutionTarget={resolveTracebackExecutionTarget}
+            onNavigateToCell={onNavigateToTracebackCell}
+          />
+        );
       }
       return (
         <AnsiErrorOutput
@@ -396,6 +417,8 @@ export function OutputArea({
   onSearchMatchCount,
   onIframeMouseDown,
   hostContext,
+  resolveTracebackExecutionTarget,
+  onNavigateToTracebackCell,
 }: OutputAreaProps) {
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
@@ -823,7 +846,14 @@ export function OutputArea({
                         );
                       }}
                     >
-                      {renderOutput(output, index, renderers, priority)}
+                      {renderOutput(
+                        output,
+                        index,
+                        renderers,
+                        priority,
+                        resolveTracebackExecutionTarget,
+                        onNavigateToTracebackCell,
+                      )}
                     </ErrorBoundary>
                   </div>
                 );

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -44,6 +44,12 @@ const payload = {
     "Traceback (most recent call last):\n  File \"/var/folders/x/T/ipykernel_39879/258099874.py\", line 1, in <module>\n    g()\n  File \"/var/folders/x/T/ipykernel_39879/3398808089.py\", line 5, in g\n    pd.not_real()\nAttributeError: module 'pandas' has no attribute 'not_real'",
 };
 
+const resolveExecutionTarget = (executionId: string) => {
+  if (executionId === "exec-run") return { cellId: "cell-run" };
+  if (executionId === "exec-def") return { cellId: "cell-def" };
+  return null;
+};
+
 describe("TracebackOutput", () => {
   beforeEach(() => {
     Object.defineProperty(window, "matchMedia", {
@@ -57,11 +63,28 @@ describe("TracebackOutput", () => {
   });
 
   it("renders notebook source labels instead of synthetic ipykernel paths", () => {
-    const { container } = render(<TracebackOutput data={payload} />);
+    const { container } = render(
+      <TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTarget} />,
+    );
 
     expect(container.textContent).toContain("Line1inCurrent CellIn[3]");
-    expect(container.textContent).toContain("Line5inEarlier CellIn[2]ing");
+    expect(container.textContent).toContain("Line5inCell cell-defIn[2]ing");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
+  });
+
+  it("navigates to a resolved traceback cell", () => {
+    const onNavigateToCell = vi.fn();
+
+    render(
+      <TracebackOutput
+        data={payload}
+        resolveExecutionTarget={resolveExecutionTarget}
+        onNavigateToCell={onNavigateToCell}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-def" }));
+
+    expect(onNavigateToCell).toHaveBeenCalledWith({ cellId: "cell-def" });
   });
 
   it("copies the sanitized traceback text", async () => {
@@ -71,13 +94,17 @@ describe("TracebackOutput", () => {
       value: { writeText },
     });
 
-    render(<TracebackOutput data={payload} />);
+    render(<TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTarget} />);
     fireEvent.click(screen.getByRole("button", { name: "Copy traceback" }));
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const copied = writeText.mock.calls[0][0] as string;
-    expect(copied).toContain("Line 1 in Current Cell (In[3])");
-    expect(copied).toContain("Line 5 in Earlier Cell (In[2]), in g");
+    expect(copied).toContain(
+      "Line 1 in Current Cell (cell_id=cell-run, execution_id=exec-run, In[3])",
+    );
+    expect(copied).toContain(
+      "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def, In[2]), in g",
+    );
     expect(copied).not.toContain("/var/folders/x/T/ipykernel_39879");
   });
 });

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -11,7 +11,7 @@
  * no persistence, no plugin build step — main-DOM React all the way.
  */
 
-import { Check, ChevronRight, Copy, OctagonAlert } from "lucide-react";
+import { Check, ChevronRight, Copy, LocateFixed, OctagonAlert } from "lucide-react";
 import { useState } from "react";
 import { highlight } from "@/components/editor/static-highlight";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
@@ -123,7 +123,21 @@ interface SourceRef {
 interface Props {
   data: unknown;
   className?: string;
+  resolveExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToCell?: TracebackCellNavigator;
 }
+
+export interface TracebackCellTarget {
+  cellId: string;
+  label?: string;
+}
+
+export type TracebackExecutionResolver = (
+  executionId: string,
+  sourceHash?: string,
+) => TracebackCellTarget | null | undefined;
+
+export type TracebackCellNavigator = (target: TracebackCellTarget) => void;
 
 /** A single frame, or a run of consecutive identical frames (recursion). */
 interface Cluster {
@@ -158,7 +172,12 @@ function clusterFrames(frames: Frame[]): Cluster[] {
   return out;
 }
 
-export function TracebackOutput({ data, className }: Props) {
+export function TracebackOutput({
+  data,
+  className,
+  resolveExecutionTarget,
+  onNavigateToCell,
+}: Props) {
   const payload = toPayload(data);
   if (!payload) {
     return <RawJsonFallback data={data} className={className} />;
@@ -204,6 +223,7 @@ export function TracebackOutput({ data, className }: Props) {
         // for cell users — the caret block shows location already.
         evalue={payload.syntax?.msg || payload.evalue}
         payload={payload}
+        resolveExecutionTarget={resolveExecutionTarget}
         inlineEvalue={inlineEvalue || Boolean(payload.syntax?.msg)}
       />
       {payload.syntax ? (
@@ -211,6 +231,8 @@ export function TracebackOutput({ data, className }: Props) {
           syntax={payload.syntax}
           language={language}
           currentExecutionId={currentExecutionId}
+          resolveExecutionTarget={resolveExecutionTarget}
+          onNavigateToCell={onNavigateToCell}
         />
       ) : (
         clusters.length > 0 && (
@@ -222,6 +244,8 @@ export function TracebackOutput({ data, className }: Props) {
                 defaultOpen={shouldOpen(cluster, i)}
                 language={language}
                 currentExecutionId={currentExecutionId}
+                resolveExecutionTarget={resolveExecutionTarget}
+                onNavigateToCell={onNavigateToCell}
               />
             ))}
           </ol>
@@ -237,11 +261,13 @@ function Header({
   ename,
   evalue,
   payload,
+  resolveExecutionTarget,
   inlineEvalue,
 }: {
   ename: string;
   evalue: string;
   payload: TracebackPayload;
+  resolveExecutionTarget?: TracebackExecutionResolver;
   /**
    * When true, render `ename: evalue` on a single line (for the
    * single-frame and SyntaxError cases where the two-line header
@@ -278,7 +304,7 @@ function Header({
           </>
         )}
       </div>
-      <CopyButton payload={payload} />
+      <CopyButton payload={payload} resolveExecutionTarget={resolveExecutionTarget} />
     </div>
   );
 }
@@ -293,10 +319,14 @@ function SyntaxErrorBlock({
   syntax,
   language,
   currentExecutionId,
+  resolveExecutionTarget,
+  onNavigateToCell,
 }: {
   syntax: SyntaxInfo;
   language: string;
   currentExecutionId?: string;
+  resolveExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToCell?: TracebackCellNavigator;
 }) {
   const isDark = useDarkMode();
   const rawTheme = useColorTheme();
@@ -321,12 +351,16 @@ function SyntaxErrorBlock({
   const underline = "^".repeat(underlineLen);
 
   const gutterWidth = String(syntax.lineno || 1).length;
-  const location = sourceLocation(syntax, currentExecutionId);
+  const location = sourceLocation(syntax, currentExecutionId, resolveExecutionTarget);
 
   return (
     <div className="px-3 pb-2">
       <div className="mb-1.5 font-mono text-xs text-muted-foreground" title={location.title}>
-        <LocationLabel location={location} line={syntax.lineno || 1} />
+        <LocationLabel
+          location={location}
+          line={syntax.lineno || 1}
+          onNavigateToCell={onNavigateToCell}
+        />
       </div>
       <pre
         className={cn(
@@ -363,11 +397,17 @@ function SyntaxErrorBlock({
   );
 }
 
-function CopyButton({ payload }: { payload: TracebackPayload }) {
+function CopyButton({
+  payload,
+  resolveExecutionTarget,
+}: {
+  payload: TracebackPayload;
+  resolveExecutionTarget?: TracebackExecutionResolver;
+}) {
   const [copied, setCopied] = useState(false);
 
   const onClick = async () => {
-    const text = tracebackCopyText(payload);
+    const text = tracebackCopyText(payload, resolveExecutionTarget);
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
@@ -407,31 +447,40 @@ function FrameRow({
   defaultOpen,
   language,
   currentExecutionId,
+  resolveExecutionTarget,
+  onNavigateToCell,
 }: {
   cluster: Cluster;
   defaultOpen: boolean;
   language: string;
   currentExecutionId?: string;
+  resolveExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToCell?: TracebackCellNavigator;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const { frame, count } = cluster;
-  const location = sourceLocation(frame, currentExecutionId);
+  const location = sourceLocation(frame, currentExecutionId, resolveExecutionTarget);
   return (
     <li className={cn("px-3 py-1.5", frame.library && "opacity-60")}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 text-left font-mono text-xs hover:text-destructive"
-        aria-expanded={open}
-      >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn(
-            "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
-            open && "rotate-90",
-          )}
+      <div className="flex w-full items-center gap-2 font-mono text-xs">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-sm text-muted-foreground transition-colors hover:text-destructive"
+          aria-expanded={open}
+          aria-label={open ? "Collapse traceback frame" : "Expand traceback frame"}
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={cn("h-3 w-3 shrink-0 transition-transform", open && "rotate-90")}
+          />
+        </button>
+        <LocationLabel
+          location={location}
+          line={frame.lineno}
+          name={frame.name}
+          onNavigateToCell={onNavigateToCell}
         />
-        <LocationLabel location={location} line={frame.lineno} name={frame.name} />
         {count > 1 && (
           <span
             className={cn(
@@ -443,7 +492,7 @@ function FrameRow({
             ×{count.toLocaleString()}
           </span>
         )}
-      </button>
+      </div>
       {open && frame.lines && frame.lines.length > 0 && (
         <SourceBlock lines={frame.lines} language={language} />
       )}
@@ -455,6 +504,9 @@ interface SourceLocation {
   kind: "notebook" | "file";
   label: string;
   executionLabel?: string;
+  executionId?: string;
+  sourceHash?: string;
+  target?: TracebackCellTarget;
   title: string;
 }
 
@@ -462,18 +514,40 @@ function LocationLabel({
   location,
   line,
   name,
+  onNavigateToCell,
 }: {
   location: SourceLocation;
   line: number;
   name?: string;
+  onNavigateToCell?: TracebackCellNavigator;
 }) {
   const showName = Boolean(name && name !== "<module>");
+  const target = location.target && onNavigateToCell ? location.target : undefined;
   return (
     <span className="flex min-w-0 items-center gap-1.5" title={location.title}>
       <span className="shrink-0 text-muted-foreground">Line</span>
       <span className="shrink-0 tabular-nums text-muted-foreground">{line}</span>
       <span className="shrink-0 text-muted-foreground">in</span>
-      <span className="truncate text-muted-foreground">{location.label}</span>
+      {target ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onNavigateToCell?.(target);
+          }}
+          className={cn(
+            "inline-flex min-w-0 items-center gap-1 rounded-sm px-1 py-0.5",
+            "text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive",
+          )}
+          aria-label={`Go to cell ${target.cellId}`}
+          title={`Go to cell ${target.cellId}`}
+        >
+          <LocateFixed aria-hidden="true" className="h-3 w-3 shrink-0" />
+          <span className="truncate">{location.label}</span>
+        </button>
+      ) : (
+        <span className="truncate text-muted-foreground">{location.label}</span>
+      )}
       {location.executionLabel && (
         <code className="shrink-0 rounded bg-muted px-1 py-0.5 text-[11px] text-muted-foreground">
           {location.executionLabel}
@@ -495,6 +569,7 @@ function sourceLocation(
     "filename" | "execution_id" | "execution_count" | "source_hash" | "source_ref"
   >,
   currentExecutionId: string | undefined,
+  resolveExecutionTarget?: TracebackExecutionResolver,
 ): SourceLocation {
   const sourceRef = source.source_ref;
   const executionId = sourceRef?.execution_id ?? source.execution_id;
@@ -506,20 +581,40 @@ function sourceLocation(
   if (executionCount !== undefined) titleParts.push(`Input: In[${executionCount}]`);
   if (sourceHash) titleParts.push(`Source: ${sourceHash}`);
   if (compiledFilename) titleParts.push(`Compiled file: ${compiledFilename}`);
-  const title = titleParts.join("\n") || source.filename || "Unknown source";
 
   const isNotebookSource =
     sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(source.filename);
+  const target = executionId ? (resolveExecutionTarget?.(executionId, sourceHash) ?? null) : null;
+  if (target) titleParts.unshift(`Cell: ${target.cellId}`);
+  const title = titleParts.join("\n") || source.filename || "Unknown source";
 
   if (!isNotebookSource) {
     return { kind: "file", label: source.filename || "Unknown source", title };
+  }
+
+  const executionLabel = executionCount === undefined ? undefined : `In[${executionCount}]`;
+  if (target) {
+    const label =
+      target.label ??
+      (executionId === currentExecutionId ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`);
+    return {
+      kind: "notebook",
+      label,
+      executionLabel,
+      executionId,
+      sourceHash,
+      target,
+      title,
+    };
   }
 
   if (executionId && executionId === currentExecutionId) {
     return {
       kind: "notebook",
       label: "Current Cell",
-      executionLabel: executionCount === undefined ? undefined : `In[${executionCount}]`,
+      executionLabel,
+      executionId,
+      sourceHash,
       title,
     };
   }
@@ -527,8 +622,10 @@ function sourceLocation(
   if (executionId) {
     return {
       kind: "notebook",
-      label: "Earlier Cell",
-      executionLabel: executionCount === undefined ? undefined : `In[${executionCount}]`,
+      label: "Notebook Execution",
+      executionLabel,
+      executionId,
+      sourceHash,
       title,
     };
   }
@@ -536,9 +633,14 @@ function sourceLocation(
   return {
     kind: "notebook",
     label: "Notebook Cell",
-    executionLabel: executionCount === undefined ? undefined : `In[${executionCount}]`,
+    executionLabel,
+    sourceHash,
     title,
   };
+}
+
+function shortCellId(cellId: string): string {
+  return cellId.length <= 12 ? cellId : cellId.slice(0, 8);
 }
 
 function isSyntheticNotebookFilename(filename: string): boolean {
@@ -549,8 +651,11 @@ function isSyntheticNotebookFilename(filename: string): boolean {
   );
 }
 
-function tracebackCopyText(payload: TracebackPayload): string {
-  const synthesized = synthesizeTracebackText(payload);
+function tracebackCopyText(
+  payload: TracebackPayload,
+  resolveExecutionTarget?: TracebackExecutionResolver,
+): string {
+  const synthesized = synthesizeTracebackText(payload, resolveExecutionTarget);
   if (synthesized) return synthesized;
   return (
     payload.text ??
@@ -560,7 +665,10 @@ function tracebackCopyText(payload: TracebackPayload): string {
   );
 }
 
-function synthesizeTracebackText(payload: TracebackPayload): string | null {
+function synthesizeTracebackText(
+  payload: TracebackPayload,
+  resolveExecutionTarget?: TracebackExecutionResolver,
+): string | null {
   const frames = payload.frames ?? [];
   const currentExecutionId = payload.execution?.execution_id;
   const hasNotebookSource =
@@ -571,7 +679,7 @@ function synthesizeTracebackText(payload: TracebackPayload): string | null {
 
   const out = ["Traceback (most recent call last):"];
   if (payload.syntax) {
-    out.push(`  ${copyLocationLine(payload.syntax, currentExecutionId)}`);
+    out.push(`  ${copyLocationLine(payload.syntax, currentExecutionId, resolveExecutionTarget)}`);
     if (payload.syntax.text) {
       out.push(`    ${payload.syntax.text}`);
       const caret = syntaxCaretLine(payload.syntax);
@@ -579,7 +687,9 @@ function synthesizeTracebackText(payload: TracebackPayload): string | null {
     }
   } else {
     for (const frame of frames) {
-      out.push(`  ${copyLocationLine(frame, currentExecutionId, frame.name)}`);
+      out.push(
+        `  ${copyLocationLine(frame, currentExecutionId, resolveExecutionTarget, frame.name)}`,
+      );
       const source = highlightedSourceLine(frame.lines);
       if (source) out.push(`    ${source}`);
     }
@@ -591,9 +701,10 @@ function synthesizeTracebackText(payload: TracebackPayload): string | null {
 function copyLocationLine(
   source: Pick<
     Frame | SyntaxInfo,
-    "filename" | "lineno" | "execution_id" | "execution_count" | "source_ref"
+    "filename" | "lineno" | "execution_id" | "execution_count" | "source_hash" | "source_ref"
   >,
   currentExecutionId: string | undefined,
+  resolveExecutionTarget?: TracebackExecutionResolver,
   name?: string,
 ): string {
   if (!isNotebookSource(source)) {
@@ -602,9 +713,14 @@ function copyLocationLine(
     }`;
   }
 
-  const location = sourceLocation(source, currentExecutionId);
+  const location = sourceLocation(source, currentExecutionId, resolveExecutionTarget);
   let line = `Line ${source.lineno} in ${location.label}`;
-  if (location.executionLabel) line += ` (${location.executionLabel})`;
+  const details = [];
+  if (location.target) details.push(`cell_id=${location.target.cellId}`);
+  if (location.executionId) details.push(`execution_id=${location.executionId}`);
+  if (location.executionLabel) details.push(location.executionLabel);
+  if (location.sourceHash) details.push(`source_hash=${location.sourceHash}`);
+  if (details.length > 0) line += ` (${details.join(", ")})`;
   if (name && name !== "<module>") line += `, in ${name}`;
   return line;
 }


### PR DESCRIPTION
## Summary

- Adds optional traceback frame resolution from `execution_id` to the current notebook cell, with a visible "go to cell" affordance in rich traceback rows.
- Threads that resolver through notebook `CodeCell` / `OutputArea` without making the shared renderer depend on notebook state.
- Enriches MCP LLM traceback text with `cell_id`, `execution_id`, `In[N]`, and `source_hash` when the rich payload and current notebook execution pointers can prove the mapping.

## Notes

- Runtime execution state still stays notebook-agnostic. The cell mapping is supplied by notebook callers from the current NotebookDoc execution pointers.
- Stale or notebook-less executions degrade to notebook execution labels and keep the existing traceback fallback.

## Verification

- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx`
- `cargo test -p runtimed-outputs`
- `cargo test -p runt-mcp --lib`
- `cargo xtask lint --fix`
- `pnpm notebook:build`
