### PR TITLE
feat(notebook-cloud): show viewer presence status

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -23,6 +23,7 @@ const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
 const expectedSourceText = process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "import polars as pl";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
+const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "viewing";
 const expectedFrameTexts = parseExpectedTexts(process.env.NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS, [
   "Loaded 25 rows",
   "PROBLEM_MARKDOWN",
@@ -164,6 +165,13 @@ async function main() {
       expectedExecutionCount,
       { timeout: timeoutMs },
     );
+    if (expectedPresenceText) {
+      await page.waitForFunction(
+        (expected) => document.querySelector(".cloud-presence")?.textContent?.includes(expected),
+        expectedPresenceText,
+        { timeout: timeoutMs },
+      );
+    }
     if (expectedFrameTexts.length > 0) {
       await page.waitForFunction(
         () =>
@@ -193,6 +201,10 @@ async function main() {
       })),
     );
     const reportCellCount = await page.locator("[data-slot='read-only-report-cell']").count();
+    const presenceText = await page
+      .locator(".cloud-presence")
+      .textContent({ timeout: 1_000 })
+      .catch(() => null);
 
     if (requireSiftWasm && siftWasmRequests.length === 0) {
       failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
@@ -238,6 +250,7 @@ async function main() {
           targetUrl,
           expectedSourceText,
           expectedExecutionCount,
+          expectedPresenceText,
           expectedFrameTexts,
           expectedRenderSource,
           expectedCatalogOwnerPrincipal,
@@ -248,6 +261,7 @@ async function main() {
           catalogApiCheck,
           executionCounts,
           reportCellCount,
+          presenceText,
           frameTextMatches,
           iframeMetrics,
           siftWasmRequests,

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -1,0 +1,84 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cloudViewerPresenceDisplay,
+  initialCloudViewerPresence,
+  reduceCloudViewerConnection,
+  reduceCloudViewerPresenceMessage,
+} from "../viewer/presence.ts";
+
+describe("cloud viewer presence", () => {
+  it("tracks the authoritative room count from session-control messages", () => {
+    let state = initialCloudViewerPresence();
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-a",
+      actor_label: "anonymous:viewer:session-a/desktop:browser",
+      connection_scope: "viewer",
+      room_peer_count: 1,
+      timestamp: "2026-05-23T00:00:00.000Z",
+    });
+    assert.deepEqual(
+      {
+        connection: state.connection,
+        ownPeerId: state.ownPeerId,
+        actorLabel: state.actorLabel,
+        roomPeerCount: state.roomPeerCount,
+      },
+      {
+        connection: "connected",
+        ownPeerId: "peer-a",
+        actorLabel: "anonymous:viewer:session-a/desktop:browser",
+        roomPeerCount: 1,
+      },
+    );
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_joined",
+      notebook_id: "demo",
+      peer_id: "peer-b",
+      actor_label: "anonymous:viewer:session-b/desktop:browser",
+      room_peer_count: 2,
+      timestamp: "2026-05-23T00:00:01.000Z",
+    });
+    assert.equal(state.roomPeerCount, 2);
+    assert.equal(cloudViewerPresenceDisplay(state).label, "2 viewing");
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_left",
+      notebook_id: "demo",
+      peer_id: "peer-b",
+      actor_label: "anonymous:viewer:session-b/desktop:browser",
+      room_peer_count: 1,
+      timestamp: "2026-05-23T00:00:02.000Z",
+    });
+    assert.equal(state.roomPeerCount, 1);
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+  });
+
+  it("surfaces disconnected state without losing the last room count", () => {
+    const connected = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-a",
+      actor_label: "anonymous:viewer:session-a/desktop:browser",
+      connection_scope: "viewer",
+      room_peer_count: 3,
+      timestamp: "2026-05-23T00:00:00.000Z",
+    });
+
+    const disconnected = reduceCloudViewerConnection(connected, "disconnected");
+
+    assert.equal(disconnected.roomPeerCount, 3);
+    assert.deepEqual(cloudViewerPresenceDisplay(disconnected), {
+      label: "Offline",
+      title: "Disconnected from the notebook room",
+      connected: false,
+    });
+  });
+});

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -35,9 +35,48 @@ body {
   top: 0.5rem;
   z-index: 20;
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
   pointer-events: none;
+}
+
+.cloud-presence {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  max-width: min(16rem, 52vw);
+  height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 999px;
+  padding-inline: 0.75rem;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--background) 90%, transparent);
+  box-shadow: 0 1px 8px color-mix(in srgb, #000 6%, transparent);
+  backdrop-filter: blur(8px);
+  pointer-events: auto;
+}
+
+.cloud-presence[data-connected="true"] {
+  border-color: color-mix(in srgb, #0f766e 28%, transparent);
+  color: color-mix(in srgb, var(--foreground) 82%, #0f766e 18%);
+}
+
+.cloud-presence svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.cloud-presence span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  line-height: 1;
 }
 
 .cloud-code-toggle {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { Code2, Eye, EyeOff } from "lucide-react";
+import { Code2, Eye, EyeOff, UsersRound } from "lucide-react";
 import {
   ReadOnlyNotebook,
   type ReadOnlyNotebookCellData,
@@ -10,7 +10,15 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
+import type { SessionControlMessage } from "../src/protocol";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
+import {
+  cloudViewerPresenceDisplay,
+  type CloudViewerPresenceState,
+  initialCloudViewerPresence,
+  reduceCloudViewerConnection,
+  reduceCloudViewerPresenceMessage,
+} from "./presence";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
@@ -185,11 +193,6 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     };
   }, [blobResolver, config.renderEndpoint]);
 
-  useEffect(
-    () => connectAnonymousViewer(config.syncEndpoint, () => undefined),
-    [config.syncEndpoint],
-  );
-
   const readOnlyCells = useMemo(
     () =>
       cells.map(
@@ -213,14 +216,10 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     <main className="flex min-h-screen w-full flex-col py-6">
       <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
 
-      {status.kind === "ready" ? null : (
-        <div className="cloud-state mx-8 mr-4" data-kind={status.kind}>
-          {status.message}
-        </div>
-      )}
+      <div className="cloud-report-toolbar" aria-label="Notebook view status and controls">
+        <CloudPresenceStatus syncEndpoint={config.syncEndpoint} />
 
-      {status.kind === "ready" && codeCellCount > 0 ? (
-        <div className="cloud-report-toolbar" aria-label="Notebook display controls">
+        {status.kind === "ready" && codeCellCount > 0 ? (
           <button
             type="button"
             className="cloud-code-toggle"
@@ -232,8 +231,16 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
             {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
             <Code2 aria-hidden="true" />
           </button>
+        ) : (
+          <span aria-hidden="true" />
+        )}
+      </div>
+
+      {status.kind === "ready" ? null : (
+        <div className="cloud-state mx-8 mr-4" data-kind={status.kind}>
+          {status.message}
         </div>
-      ) : null}
+      )}
 
       <ReadOnlyNotebook
         cells={readOnlyCells}
@@ -256,6 +263,33 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   );
 }
 
+function CloudPresenceStatus({ syncEndpoint }: { syncEndpoint: string }) {
+  const [presence, setPresence] = useState(initialCloudViewerPresence);
+
+  useEffect(
+    () =>
+      connectAnonymousViewer(syncEndpoint, (update) => {
+        setPresence(update);
+      }),
+    [syncEndpoint],
+  );
+
+  const presenceDisplay = cloudViewerPresenceDisplay(presence);
+
+  return (
+    <div
+      className="cloud-presence"
+      data-connected={String(presenceDisplay.connected)}
+      title={presenceDisplay.title}
+      aria-label={presenceDisplay.title}
+      aria-live="polite"
+    >
+      <UsersRound aria-hidden="true" />
+      <span>{presenceDisplay.label}</span>
+    </div>
+  );
+}
+
 function ViewerStartupError({ message }: { message: string }) {
   return (
     <main className="flex min-h-screen w-full flex-col px-8 py-4 pr-4">
@@ -271,7 +305,7 @@ function ViewerStartupError({ message }: { message: string }) {
 
 function connectAnonymousViewer(
   syncEndpoint: string,
-  setConnection: (value: string) => void,
+  updatePresence: (update: (state: CloudViewerPresenceState) => CloudViewerPresenceState) => void,
 ): () => void {
   const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
   const url = new URL(syncEndpoint, location.href);
@@ -281,16 +315,21 @@ function connectAnonymousViewer(
   const socket = new WebSocket(url);
   socket.binaryType = "arraybuffer";
   let closed = false;
-  const setConnectionIfActive = (value: string) => {
+  const updatePresenceIfActive = (
+    update: (state: CloudViewerPresenceState) => CloudViewerPresenceState,
+  ) => {
     if (!closed) {
-      setConnection(value);
+      updatePresence(update);
     }
   };
   socket.addEventListener("open", () => {
-    setConnectionIfActive("anonymous viewer connected");
+    updatePresenceIfActive((state) => reduceCloudViewerConnection(state, "connected"));
+  });
+  socket.addEventListener("error", () => {
+    updatePresenceIfActive((state) => reduceCloudViewerConnection(state, "disconnected"));
   });
   socket.addEventListener("close", () => {
-    setConnectionIfActive("anonymous viewer disconnected");
+    updatePresenceIfActive((state) => reduceCloudViewerConnection(state, "disconnected"));
   });
   socket.addEventListener("message", async (event) => {
     if (closed) return;
@@ -298,9 +337,13 @@ function connectAnonymousViewer(
     if (bytes[0] !== 0x07) {
       return;
     }
-    const message = JSON.parse(new TextDecoder().decode(bytes.slice(1))) as Record<string, unknown>;
-    if (message.type === "cloud_room_ready") {
-      setConnectionIfActive(`${message.actor_label} (${message.connection_scope})`);
+    const message = JSON.parse(new TextDecoder().decode(bytes.slice(1))) as SessionControlMessage;
+    if (
+      message.type === "cloud_room_ready" ||
+      message.type === "cloud_peer_joined" ||
+      message.type === "cloud_peer_left"
+    ) {
+      updatePresenceIfActive((state) => reduceCloudViewerPresenceMessage(state, message));
     }
   });
 

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,0 +1,93 @@
+import type { SessionControlMessage } from "../src/protocol";
+
+export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
+
+export interface CloudViewerPresenceState {
+  connection: CloudViewerPresenceConnection;
+  ownPeerId: string | null;
+  actorLabel: string | null;
+  roomPeerCount: number | null;
+}
+
+export interface CloudViewerPresenceDisplay {
+  label: string;
+  title: string;
+  connected: boolean;
+}
+
+export function initialCloudViewerPresence(): CloudViewerPresenceState {
+  return {
+    connection: "connecting",
+    ownPeerId: null,
+    actorLabel: null,
+    roomPeerCount: null,
+  };
+}
+
+export function reduceCloudViewerConnection(
+  state: CloudViewerPresenceState,
+  connection: CloudViewerPresenceConnection,
+): CloudViewerPresenceState {
+  return {
+    ...state,
+    connection,
+  };
+}
+
+export function reduceCloudViewerPresenceMessage(
+  state: CloudViewerPresenceState,
+  message: SessionControlMessage,
+): CloudViewerPresenceState {
+  switch (message.type) {
+    case "cloud_room_ready":
+      return {
+        connection: "connected",
+        ownPeerId: message.peer_id,
+        actorLabel: message.actor_label,
+        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+      };
+    case "cloud_peer_joined":
+    case "cloud_peer_left":
+      return {
+        ...state,
+        connection: "connected",
+        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+      };
+    default:
+      return state;
+  }
+}
+
+export function cloudViewerPresenceDisplay(
+  state: CloudViewerPresenceState,
+): CloudViewerPresenceDisplay {
+  if (state.connection === "disconnected") {
+    return {
+      label: "Offline",
+      title: "Disconnected from the notebook room",
+      connected: false,
+    };
+  }
+
+  if (state.connection === "connecting" || state.roomPeerCount === null) {
+    return {
+      label: "Connecting",
+      title: "Connecting to the notebook room",
+      connected: false,
+    };
+  }
+
+  const count = Math.max(1, state.roomPeerCount);
+  return {
+    label: `${count} viewing`,
+    title:
+      count === 1
+        ? "1 reader connected to this notebook room"
+        : `${count} readers connected to this notebook room`,
+    connected: true,
+  };
+}
+
+function safeRoomPeerCount(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
+}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -555,107 +555,115 @@ export function OutputArea({
   );
 
   // Callback when frame is ready - set up bridge and render outputs
-  const handleFrameReady = useCallback(async () => {
-    if (!frameRef.current) return;
+  const handleFrameReady = useCallback(
+    async (options: { resetInjectedPlugins?: boolean } = {}) => {
+      if (!frameRef.current) return;
 
-    // Bump generation so any in-flight async handleFrameReady from a
-    // previous outputs snapshot will bail out after it awaits.
-    const gen = ++renderGenRef.current;
+      // Bump generation so any in-flight async handleFrameReady from a
+      // previous outputs snapshot will bail out after it awaits.
+      const gen = ++renderGenRef.current;
 
-    // Set up comm bridge if we have widgets and widget context
-    if (shouldUseBridge && widgetContext && !bridgeRef.current) {
-      bridgeRef.current = new CommBridgeManager({
-        frame: frameRef.current,
-        store: widgetContext.store,
-        sendUpdate: widgetContext.sendUpdate,
-        sendCustom: widgetContext.sendCustom,
-        closeComm: widgetContext.closeComm,
-      });
-    }
+      // Set up comm bridge if we have widgets and widget context
+      if (shouldUseBridge && widgetContext && !bridgeRef.current) {
+        bridgeRef.current = new CommBridgeManager({
+          frame: frameRef.current,
+          store: widgetContext.store,
+          sendUpdate: widgetContext.sendUpdate,
+          sendCustom: widgetContext.sendCustom,
+          closeComm: widgetContext.closeComm,
+        });
+      }
 
-    // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
-    // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
-    frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
+      // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
+      // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
+      frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
 
-    // Install renderer plugins required by the outputs (e.g. plotly, vega).
-    // Must happen before clear+render so the installRenderer messages arrive first.
-    // Clear the tracking set on each call — a reloaded iframe has a fresh registry.
-    injectedLibsRef.current.clear();
+      // Install renderer plugins required by the outputs (e.g. plotly, vega).
+      // Must happen before clear+render so the installRenderer messages arrive first.
+      if (options.resetInjectedPlugins) {
+        injectedLibsRef.current.clear();
+      }
 
-    // Collect MIME types that need renderer plugins from the cell's outputs
-    const pluginMimes = new Set<string>();
-    for (const output of outputs) {
-      if (output.output_type === "execute_result" || output.output_type === "display_data") {
-        for (const mime of Object.keys(output.data)) {
-          if (needsPlugin(mime)) pluginMimes.add(mime);
+      // Collect MIME types that need renderer plugins from the cell's outputs
+      const pluginMimes = new Set<string>();
+      for (const output of outputs) {
+        if (output.output_type === "execute_result" || output.output_type === "display_data") {
+          for (const mime of Object.keys(output.data)) {
+            if (needsPlugin(mime)) pluginMimes.add(mime);
+          }
         }
       }
-    }
 
-    // Also scan output widgets for captured outputs that need plugins.
-    // A cell may output a widget view (application/vnd.jupyter.widget-view+json)
-    // whose OutputModel.outputs contain plotly/vega/etc MIME types.
-    if (widgetContext?.store) {
-      for (const output of outputs) {
-        if (
-          (output.output_type === "execute_result" || output.output_type === "display_data") &&
-          output.data?.["application/vnd.jupyter.widget-view+json"]
-        ) {
-          const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
-            model_id?: string;
-          };
-          if (widgetData?.model_id) {
-            const model = widgetContext.store.getModel(widgetData.model_id);
-            if (model?.modelName === "OutputModel" && model.state.outputs) {
-              const widgetOutputs = model.state.outputs as Array<{
-                output_type: string;
-                data?: Record<string, unknown>;
-              }>;
-              for (const wo of widgetOutputs) {
-                for (const mime of Object.keys(wo.data ?? {})) {
-                  if (needsPlugin(mime)) pluginMimes.add(mime);
+      // Also scan output widgets for captured outputs that need plugins.
+      // A cell may output a widget view (application/vnd.jupyter.widget-view+json)
+      // whose OutputModel.outputs contain plotly/vega/etc MIME types.
+      if (widgetContext?.store) {
+        for (const output of outputs) {
+          if (
+            (output.output_type === "execute_result" || output.output_type === "display_data") &&
+            output.data?.["application/vnd.jupyter.widget-view+json"]
+          ) {
+            const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
+              model_id?: string;
+            };
+            if (widgetData?.model_id) {
+              const model = widgetContext.store.getModel(widgetData.model_id);
+              if (model?.modelName === "OutputModel" && model.state.outputs) {
+                const widgetOutputs = model.state.outputs as Array<{
+                  output_type: string;
+                  data?: Record<string, unknown>;
+                }>;
+                for (const wo of widgetOutputs) {
+                  for (const mime of Object.keys(wo.data ?? {})) {
+                    if (needsPlugin(mime)) pluginMimes.add(mime);
+                  }
                 }
               }
             }
           }
         }
       }
-    }
 
-    if (pluginMimes.size > 0) {
-      try {
-        await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
-      } catch (error) {
+      if (pluginMimes.size > 0) {
+        try {
+          await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
+        } catch (error) {
+          if (gen !== renderGenRef.current) return;
+          console.error("[OutputArea] Failed to load renderer plugin:", error);
+          frameRef.current.renderBatch([
+            {
+              mimeType: "text/plain",
+              data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
+              metadata: { isError: true },
+              cellId,
+              outputIndex: 0,
+            },
+          ]);
+          return;
+        }
+        // Stale check: if outputs changed while we were loading the plugin,
+        // bail — a newer handleFrameReady call is already in flight.
         if (gen !== renderGenRef.current) return;
-        console.error("[OutputArea] Failed to load renderer plugin:", error);
-        frameRef.current.renderBatch([
-          {
-            mimeType: "text/plain",
-            data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
-            metadata: { isError: true },
-            cellId,
-            outputIndex: 0,
-          },
-        ]);
-        return;
       }
-      // Stale check: if outputs changed while we were loading the plugin,
-      // bail — a newer handleFrameReady call is already in flight.
-      if (gen !== renderGenRef.current) return;
-    }
 
-    // Build batch of render payloads and send atomically.
-    // This avoids the clear+re-render cycle that causes DOM thrashing
-    // (visible as flickering when interactive widgets update rapidly).
-    const batch = jupyterOutputsToRenderPayloads(outputs, { cellId, priority });
+      // Build batch of render payloads and send atomically.
+      // This avoids the clear+re-render cycle that causes DOM thrashing
+      // (visible as flickering when interactive widgets update rapidly).
+      const batch = jupyterOutputsToRenderPayloads(outputs, { cellId, priority });
 
-    frameRef.current.renderBatch(batch);
+      frameRef.current.renderBatch(batch);
 
-    // Re-apply search highlights after rendering new content
-    if (searchQueryRef.current) {
-      frameRef.current?.search(searchQueryRef.current);
-    }
-  }, [outputs, priority, shouldUseBridge, widgetContext]);
+      // Re-apply search highlights after rendering new content
+      if (searchQueryRef.current) {
+        frameRef.current?.search(searchQueryRef.current);
+      }
+    },
+    [outputs, priority, shouldUseBridge, widgetContext],
+  );
+
+  const handleIsolatedFrameReady = useCallback(() => {
+    void handleFrameReady({ resetInjectedPlugins: true });
+  }, [handleFrameReady]);
 
   // Clean up bridge on unmount
   useEffect(() => {
@@ -774,7 +782,7 @@ export function OutputArea({
                 autoHeight={shouldIsolate && !focused}
                 allowWheelBoundaryScroll={allowWheelBoundaryScroll}
                 scrollPassthrough={shouldScrollPassthroughFrame}
-                onReady={handleFrameReady}
+                onReady={handleIsolatedFrameReady}
                 onLinkClick={onLinkClick}
                 onMouseDown={activateStaticFrameInteraction}
                 onWidgetUpdate={onWidgetUpdate}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -57,13 +57,14 @@ export function ReadOnlyNotebookCell({
       }),
     [cellType, hostContext, id, language, lineWrapping, priority, source, sourceClassName],
   );
+  const outputArray = useMemo(() => [...outputs], [outputs]);
 
   const outputContent =
     outputs.length > 0 ? (
       <OutputArea
         cellId={id}
         executionCount={executionCount}
-        outputs={[...outputs]}
+        outputs={outputArray}
         isolated="auto"
         focused={focusOutputs}
         priority={priority}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -159,6 +159,19 @@ describe("OutputArea iframe theme sync", () => {
     });
   });
 
+  it("does not resend isolated output renders for unrelated parent rerenders", async () => {
+    const outputs = makeMarkdownOutput();
+    const { rerender } = render(<OutputArea outputs={outputs} isolated />);
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<OutputArea outputs={outputs} isolated />);
+
+    expect(mockFrameHandle.renderBatch).toHaveBeenCalledTimes(1);
+  });
+
   it("renders a contained fallback when an isolated renderer plugin fails to load", async () => {
     vi.mocked(needsPlugin).mockReturnValue(true);
     vi.mocked(injectPluginsForMimes).mockRejectedValue(new Error("chunk failed"));

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { ReadOnlyNotebookCell } from "../ReadOnlyNotebookCell";
 import type { JupyterOutput } from "../jupyter-output";
+
+const outputAreaCalls = vi.hoisted(() => ({
+  outputs: [] as unknown[],
+}));
 
 vi.mock("../OutputArea", () => ({
   OutputArea: ({
@@ -20,24 +24,27 @@ vi.mock("../OutputArea", () => ({
     hostContext?: unknown;
     outputs: JupyterOutput[];
     priority?: readonly string[];
-  }) => (
-    <div
-      data-cell-id={cellId}
-      data-class-name={className ?? ""}
-      data-execution-count={executionCount ?? ""}
-      data-focused={String(focused)}
-      data-host-context={JSON.stringify(hostContext ?? null)}
-      data-mimes={outputs
-        .flatMap((output) =>
-          output.output_type === "display_data" || output.output_type === "execute_result"
-            ? Object.keys(output.data)
-            : [output.output_type],
-        )
-        .join(",")}
-      data-priority={priority?.join(",") ?? ""}
-      data-testid="output-area"
-    />
-  ),
+  }) => {
+    outputAreaCalls.outputs.push(outputs);
+    return (
+      <div
+        data-cell-id={cellId}
+        data-class-name={className ?? ""}
+        data-execution-count={executionCount ?? ""}
+        data-focused={String(focused)}
+        data-host-context={JSON.stringify(hostContext ?? null)}
+        data-mimes={outputs
+          .flatMap((output) =>
+            output.output_type === "display_data" || output.output_type === "execute_result"
+              ? Object.keys(output.data)
+              : [output.output_type],
+          )
+          .join(",")}
+        data-priority={priority?.join(",") ?? ""}
+        data-testid="output-area"
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/editor/readonly-codemirror", () => ({
@@ -64,6 +71,10 @@ vi.mock("@/components/editor/readonly-codemirror", () => ({
 }));
 
 describe("ReadOnlyNotebookCell", () => {
+  beforeEach(() => {
+    outputAreaCalls.outputs.length = 0;
+  });
+
   it("renders code through shared cell chrome with execution count and outputs", () => {
     render(
       <ReadOnlyNotebookCell
@@ -140,6 +151,31 @@ describe("ReadOnlyNotebookCell", () => {
 
     expect(screen.getByTestId("readonly-codemirror")).toHaveTextContent("x = 1");
     expect(screen.queryByTestId("output-area")).toBeNull();
+  });
+
+  it("keeps code output props stable across unrelated parent rerenders", () => {
+    const outputs: JupyterOutput[] = [{ output_type: "stream", name: "stdout", text: "visible\n" }];
+    const { rerender } = render(
+      <ReadOnlyNotebookCell
+        id="stable-code"
+        cellType="code"
+        source="print('x')"
+        outputs={outputs}
+      />,
+    );
+
+    const firstOutputs = outputAreaCalls.outputs.at(-1);
+
+    rerender(
+      <ReadOnlyNotebookCell
+        id="stable-code"
+        cellType="code"
+        source="print('x')"
+        outputs={outputs}
+      />,
+    );
+
+    expect(outputAreaCalls.outputs.at(-1)).toBe(firstOutputs);
   });
 
   it("renders report cells without notebook gutter chrome and can focus outputs", () => {


### PR DESCRIPTION
## Summary

- show a live document-level reader indicator in the cloud report toolbar
- derive the indicator from the existing viewer WebSocket session-control frames
- keep presence state outside the notebook render tree so joins/leaves do not churn output iframes
- preserve read-only output prop identity and avoid reinstalling isolated renderer plugins unless the iframe actually reloads
- add pure viewer presence tests plus regression tests for stable isolated output rendering

## Verification

- `pnpm test:run src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test 'test/*.test.ts' 'test/*.test.mjs'`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
- `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/nteract-cloud-hosted-smoke-presence-stable.png pnpm --dir apps/notebook-cloud smoke:hosted`
- Hosted two-tab check: first viewer updated from `1 viewing` to `2 viewing`, iframe count stayed `2 -> 2`, and the first page emitted no isolated renderer / Sift diagnostics after the second viewer joined.

## Deployment

- Deployed to `https://nteract-notebook-cloud.rgbkrk.workers.dev`
- Worker version: `e0a47bb1-e35c-486c-8414-03d2d672abb7`
