### PR TITLE
Harden MCP app plugin output fallbacks

### DIFF
--- a/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { loadPluginForMime } from "../../lib/plugin-loader";
+import { MimeRenderer } from "../mime-renderer";
+
+vi.mock("../../lib/plugin-loader", () => ({
+  needsDaemonPlugin: () => true,
+  loadPluginForMime: vi.fn(),
+}));
+
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+describe("MimeRenderer", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () => "shape: (3, 2)\ncolumn_1  column_2",
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches blob-backed text/plain before rendering plugin fallback text", async () => {
+    vi.mocked(loadPluginForMime).mockReturnValue(Promise.reject(new Error("blocked by CSP")));
+
+    render(
+      <MimeRenderer
+        blobBaseUrl="http://localhost:47830"
+        data={{
+          [ARROW_STREAM_MANIFEST_MIME]: JSON.stringify({ chunks: [] }),
+          "text/plain": "http://localhost:47830/blob/plain-fallback",
+        }}
+      />,
+    );
+
+    expect(await screen.findByText(/shape: \(3, 2\)/)).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith("http://localhost:47830/blob/plain-fallback");
+  });
+});

--- a/apps/mcp-app/src/components/mime-renderer.tsx
+++ b/apps/mcp-app/src/components/mime-renderer.tsx
@@ -100,7 +100,13 @@ function PluginRenderer({
             : parsedData,
         );
       })
-      .catch(() => {
+      .catch((err) => {
+        console.warn("[mcp-app] plugin render failed", {
+          mime,
+          blobBaseUrl,
+          rawPreview: raw.slice(0, 200),
+          err,
+        });
         if (!cancelled) setFailed(true);
       });
 
@@ -110,7 +116,7 @@ function PluginRenderer({
   }, [mime, raw, blobBaseUrl]);
 
   if (failed) {
-    if (plainFallback) return <AnsiText text={plainFallback} />;
+    if (plainFallback) return <PlainFallback text={plainFallback} />;
     return null;
   }
 
@@ -118,7 +124,7 @@ function PluginRenderer({
 
   const RendererComponent = getPluginRenderer(mime);
   if (!RendererComponent) {
-    if (plainFallback) return <AnsiText text={plainFallback} />;
+    if (plainFallback) return <PlainFallback text={plainFallback} />;
     return null;
   }
 
@@ -169,7 +175,7 @@ function FetchAndRender({
   }, [raw]);
 
   if (failed) {
-    if (plainFallback) return <AnsiText text={plainFallback} />;
+    if (plainFallback) return <PlainFallback text={plainFallback} />;
     return null;
   }
 
@@ -187,6 +193,34 @@ function FetchAndRender({
     default:
       return <AnsiText text={content} />;
   }
+}
+
+function PlainFallback({ text }: { text: string }) {
+  const [resolvedText, setResolvedText] = useState<string | null>(isBlobUrl(text) ? null : text);
+
+  useEffect(() => {
+    if (!isBlobUrl(text)) {
+      setResolvedText(text);
+      return;
+    }
+
+    let cancelled = false;
+    setResolvedText(null);
+    fetchBlobText(text)
+      .then((content) => {
+        if (!cancelled) setResolvedText(content);
+      })
+      .catch(() => {
+        if (!cancelled) setResolvedText(text);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [text]);
+
+  if (resolvedText == null) return null;
+  return <AnsiText text={resolvedText} />;
 }
 
 export function StreamOutput({ output }: { output: CellOutput }) {

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -47,21 +47,28 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> Option<Meta> {
 }
 
 /// List available MCP resources.
-pub async fn list_resources(_server: &NteractMcp) -> Result<ListResourcesResult, McpError> {
-    let mut raw = RawResource::new(OUTPUT_RESOURCE_URI, "nteract output");
-    raw.description = Some("Interactive output renderer for notebook cells".into());
-    raw.mime_type = Some(OUTPUT_MIME_TYPE.into());
-
-    let resources = vec![Annotated {
-        raw,
-        annotations: None,
-    }];
+pub async fn list_resources(server: &NteractMcp) -> Result<ListResourcesResult, McpError> {
+    let resources = vec![output_resource(&server.blob_base_url)];
 
     Ok(ListResourcesResult {
         resources,
         next_cursor: None,
         meta: None,
     })
+}
+
+fn output_resource(blob_base_url: &Option<String>) -> Annotated<RawResource> {
+    let mut raw = RawResource::new(OUTPUT_RESOURCE_URI, "nteract output");
+    raw.description = Some("Interactive output renderer for notebook cells".into());
+    raw.mime_type = Some(OUTPUT_MIME_TYPE.into());
+    // Advertise CSP in resources/list as a fallback for hosts that snapshot
+    // sandbox policy before reading the concrete resource content.
+    raw.meta = resource_ui_meta(blob_base_url);
+
+    Annotated {
+        raw,
+        annotations: None,
+    }
 }
 
 /// Read an MCP resource by URI.
@@ -90,7 +97,7 @@ pub async fn read_resource(
 
 #[cfg(test)]
 mod tests {
-    use super::resource_ui_meta;
+    use super::{output_resource, resource_ui_meta};
 
     #[test]
     fn output_resource_meta_includes_blob_domains_for_mcp_ui_csp() {
@@ -116,5 +123,30 @@ mod tests {
     #[test]
     fn output_resource_meta_is_absent_without_blob_base_url() {
         assert!(resource_ui_meta(&None).is_none());
+    }
+
+    #[test]
+    fn output_resource_listing_includes_csp_meta() {
+        let resource = output_resource(&Some("https://outputs.example.test".into()));
+        let ui = resource
+            .raw
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.0.get("ui"))
+            .expect("resource listing should include ui metadata");
+        let csp = ui.get("csp").expect("csp metadata");
+
+        assert_eq!(
+            csp.get("resourceDomains")
+                .and_then(|value| value.as_array())
+                .expect("resource domains")[0],
+            "https://outputs.example.test"
+        );
+        assert_eq!(
+            csp.get("connectDomains")
+                .and_then(|value| value.as_array())
+                .expect("connect domains")[0],
+            "https://outputs.example.test"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Advertise the MCP output app CSP on `resources/list` as well as `resources/read`.
- Resolve blob-backed `text/plain` fallbacks before displaying them when plugin loading/rendering fails.
- Add a focused MCP app regression test for the plugin-failure fallback path.

## Verification

- `pnpm test:run apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx apps/mcp-app/src/lib/__tests__/plugin-loader.test.ts apps/mcp-app/src/lib/__tests__/plugin-executor.test.ts`
- `cargo test -p runt-mcp output_resource --quiet`
- `cargo fmt --check -p runt-mcp`
- `git diff --check`

## Notes

- The local MCP widget build was regenerated after the source change, but `crates/runt-mcp/assets/_output.html`, `python/nteract/src/nteract/_widget.html`, and `apps/mcp-app/dist/*` are ignored and not part of this PR.
- The PR stays draft for external review and CI handoff.
