### PR TITLE
fix(notebook-cloud): harden hosted viewer shell

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -801,6 +801,73 @@ function withCors(response: Response): Response {
   return response;
 }
 
+function withBrowserSecurityHeaders(response: Response, contentSecurityPolicy?: string): Response {
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "no-referrer");
+  response.headers.set(
+    "Permissions-Policy",
+    [
+      "accelerometer=()",
+      "ambient-light-sensor=()",
+      "autoplay=()",
+      "camera=()",
+      "display-capture=()",
+      "encrypted-media=()",
+      "fullscreen=()",
+      "geolocation=()",
+      "gyroscope=()",
+      "magnetometer=()",
+      "microphone=()",
+      "midi=()",
+      "payment=()",
+      "picture-in-picture=()",
+      "publickey-credentials-get=()",
+      "screen-wake-lock=()",
+      "usb=()",
+      "web-share=()",
+      "xr-spatial-tracking=()",
+    ].join(", "),
+  );
+  if (contentSecurityPolicy) {
+    response.headers.set("Content-Security-Policy", contentSecurityPolicy);
+  }
+  return response;
+}
+
+function viewerContentSecurityPolicy(env: Env): string {
+  const connectSources = new Set(["'self'", "ws:", "wss:"]);
+  const rendererAssetOrigin = absoluteOrigin(rendererAssetsBasePath(env));
+  if (rendererAssetOrigin) {
+    connectSources.add(rendererAssetOrigin);
+  }
+
+  // The shared isolated output renderer currently boots from about:srcdoc,
+  // which inherits the parent page CSP. Do not set default-src/script-src here:
+  // that blocks the sandboxed renderer bootstrap unless the iframe moves to a
+  // separate origin or every generated script carries a matching nonce/hash.
+  return [
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    `connect-src ${Array.from(connectSources).join(" ")}`,
+    "worker-src 'self' blob:",
+    "frame-src 'self' blob: data:",
+    "form-action 'none'",
+  ].join("; ");
+}
+
+function absoluteOrigin(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
 function normalizedRuntimeHeadsHash(value: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed !== "none" ? trimmed : null;
@@ -836,9 +903,12 @@ function viewer(notebookId: string, env: Env, headsHash?: string): Response {
 </html>`;
 
   return withCors(
-    new Response(html, {
-      headers: { "Content-Type": "text/html; charset=utf-8" },
-    }),
+    withBrowserSecurityHeaders(
+      new Response(html, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+      viewerContentSecurityPolicy(env),
+    ),
   );
 }
 
@@ -936,9 +1006,11 @@ function debugViewer(notebookId: string): Response {
 </html>`;
 
   return withCors(
-    new Response(html, {
-      headers: { "Content-Type": "text/html; charset=utf-8" },
-    }),
+    withBrowserSecurityHeaders(
+      new Response(html, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+    ),
   );
 }
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -35,8 +35,21 @@ describe("HTML script serialization", () => {
     const html = await response.text();
 
     assert.equal(response.status, 200);
+    assert.equal(response.headers.get("X-Content-Type-Options"), "nosniff");
+    assert.equal(response.headers.get("Referrer-Policy"), "no-referrer");
+    assert.match(response.headers.get("Permissions-Policy") ?? "", /camera=\(\)/);
+    assert.match(response.headers.get("Permissions-Policy") ?? "", /microphone=\(\)/);
+    assert.match(response.headers.get("Content-Security-Policy") ?? "", /object-src 'none'/);
+    assert.match(response.headers.get("Content-Security-Policy") ?? "", /frame-ancestors 'none'/);
+    assert.doesNotMatch(response.headers.get("Content-Security-Policy") ?? "", /default-src/);
+    assert.doesNotMatch(response.headers.get("Content-Security-Policy") ?? "", /script-src/);
+    assert.match(
+      response.headers.get("Content-Security-Policy") ?? "",
+      /connect-src 'self' ws: wss:/,
+    );
     assert.match(html, /id="root"/);
     assert.match(html, /id="nteract-cloud-viewer-config"/);
+    assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
     assert.match(html, /"renderEndpoint":"\/api\/n\/demo\/renders\/heads-123"/);
@@ -58,6 +71,24 @@ describe("HTML script serialization", () => {
 
     assert.equal(response.status, 200);
     assert.match(html, /"rendererAssetsBasePath":"https:\/\/outputs\.example\/plugins\/"/);
+    assert.match(
+      response.headers.get("Content-Security-Policy") ?? "",
+      /connect-src 'self' ws: wss: https:\/\/outputs\.example/,
+    );
+  });
+
+  it("serves the debug shell with browser hardening headers but no broad page CSP", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/debug"),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("X-Content-Type-Options"), "nosniff");
+    assert.equal(response.headers.get("Referrer-Policy"), "no-referrer");
+    assert.match(response.headers.get("Permissions-Policy") ?? "", /camera=\(\)/);
+    assert.equal(response.headers.get("Content-Security-Policy"), null);
   });
 });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -134,6 +134,76 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), { error: "not found" });
   });
 
+  it("keeps anonymous viewer requests read-only on publish and upload routes", async () => {
+    const env = fakeEnv({ DEPLOYMENT_ENV: "prototype" });
+    const body = new TextEncoder().encode("viewer cannot write this");
+    const routes = [
+      {
+        pathname: "/api/n/readonly-demo/runtime-snapshots/runtime-viewer",
+        error: "viewer cannot publish runtime snapshots",
+      },
+      {
+        pathname: "/api/n/readonly-demo/snapshots/heads-viewer",
+        error: "viewer cannot publish snapshots",
+      },
+      {
+        pathname: "/api/n/readonly-demo/renders/heads-viewer",
+        error: "viewer cannot publish render caches",
+      },
+      {
+        pathname: "/api/n/readonly-demo/blobs/sha256-viewer",
+        error: "viewer cannot upload blobs",
+      },
+    ];
+
+    for (const route of routes) {
+      const response = await worker.fetch(
+        new Request(
+          new URL(`${route.pathname}?scope=owner&viewer_session=anon`, "https://cloud.test"),
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/octet-stream" },
+            body,
+          },
+        ),
+        env,
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 403, route.pathname);
+      assert.deepEqual(await response.json(), { error: route.error });
+    }
+
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
+    assert.equal(env.DB.revisions.length, 0);
+  });
+
+  it("keeps explicit dev viewer scope read-only even with a valid dev token", async () => {
+    const env = fakeEnv({
+      DEPLOYMENT_ENV: "prototype",
+      NOTEBOOK_CLOUD_DEV_TOKEN: "secret-token",
+    });
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n/readonly-demo/blobs/sha256-viewer", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "X-Notebook-Cloud-Dev-Token": "secret-token",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+          "X-User": "alice",
+        },
+        body: new Uint8Array([1, 2, 3]),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), { error: "viewer cannot upload blobs" });
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
+  });
+
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes] = await Promise.all([


### PR DESCRIPTION
## Summary

- adds browser security headers to the hosted notebook viewer shell
- adds a viewer-shell CSP for base/object/frame/connect/form hardening without applying parent `script-src` to inherited `about:srcdoc` renderer frames
- adds route tests proving anonymous/viewer-scoped requests cannot publish snapshots, runtime snapshots, render caches, or blobs

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- hosted smoke against `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet`

## Notes

This intentionally does not set `default-src` or `script-src` on the viewer shell yet. The shared isolated renderer still boots from `about:srcdoc`, and srcdoc frames inherit the parent CSP. Enforcing parent `script-src` here blocks the renderer bootstrap unless the output frame moves to a separate origin or every generated bootstrap script carries a compatible nonce/hash.

This keeps the debug shell without a broad page CSP because it still contains inline diagnostic script/style. It now gets the same non-CSP browser hardening headers.
