### PR TITLE
fix(mcp-app): send host-facing renderer logs

### DIFF
--- a/apps/mcp-app/package.json
+++ b/apps/mcp-app/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.3.0",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "anser": "^2.1.1",
     "escape-carriage": "^1.3.1",
     "react": "^19.1.0",

--- a/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { loadPluginForMime } from "../../lib/plugin-loader";
+import { setHostLogSink, type HostLogParams } from "../../lib/host-log";
+import { MimeRenderer } from "../mime-renderer";
+
+vi.mock("../../lib/plugin-loader", () => ({
+  needsDaemonPlugin: () => true,
+  loadPluginForMime: vi.fn(),
+}));
+
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+describe("MimeRenderer", () => {
+  let logs: HostLogParams[];
+
+  beforeEach(() => {
+    logs = [];
+    setHostLogSink({
+      sendLog: (params) => {
+        logs.push(params);
+      },
+    });
+  });
+
+  afterEach(() => {
+    setHostLogSink(null);
+    vi.restoreAllMocks();
+  });
+
+  it("sends host-facing logs when plugin rendering fails", async () => {
+    vi.mocked(loadPluginForMime).mockReturnValue(Promise.reject(new Error("blocked by CSP")));
+
+    render(
+      <MimeRenderer
+        blobBaseUrl="http://localhost:47830"
+        data={{
+          [ARROW_STREAM_MANIFEST_MIME]: JSON.stringify({ chunks: [] }),
+          "text/plain": "shape: (3, 2)\ncolumn_1  column_2",
+        }}
+      />,
+    );
+
+    expect(await screen.findByText(/shape: \(3, 2\)/)).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        logs.some((log) => (log.data as { event?: string }).event === "plugin-render-failed"),
+      ).toBe(true);
+    });
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        logger: "nteract.mcp-app",
+        data: expect.objectContaining({
+          event: "plugin-render-failed",
+          mime: ARROW_STREAM_MANIFEST_MIME,
+          hasPlainFallback: true,
+          error: expect.objectContaining({
+            message: "blocked by CSP",
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/apps/mcp-app/src/components/error-output.tsx
+++ b/apps/mcp-app/src/components/error-output.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { AnsiText } from "./ansi-text";
 import { isBlobUrl } from "../lib/blob-fetch";
 import type { CellOutput } from "../types";
+import { errorDetails, hostLog, stringDetails } from "../lib/host-log";
 
 interface ErrorOutputProps {
   output: CellOutput;
@@ -23,7 +24,16 @@ export function ErrorOutput({ output }: ErrorOutputProps) {
         .then((lines: string[]) => {
           if (Array.isArray(lines)) setTracebackLines(lines);
         })
-        .catch(() => setFetchFailed(true));
+        .catch((error) => {
+          hostLog("error", "traceback-blob-fetch-failed", {
+            traceback: {
+              isBlobUrl: true,
+              ...stringDetails(tb),
+            },
+            error: errorDetails(error),
+          });
+          setFetchFailed(true);
+        });
     }
   }, [output.traceback]);
 

--- a/apps/mcp-app/src/components/html-output.tsx
+++ b/apps/mcp-app/src/components/html-output.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { errorDetails, hostLog } from "../lib/host-log";
 
 interface HtmlOutputProps {
   html: string;
@@ -13,9 +14,18 @@ export function HtmlOutput({ html }: HtmlOutputProps) {
     const handleLoad = () => {
       try {
         const h = frame.contentDocument?.documentElement?.scrollHeight;
-        if (h) frame.style.height = `${h + 2}px`;
-      } catch {
-        /* cross-origin */
+        if (h) {
+          frame.style.height = `${h + 2}px`;
+          hostLog("debug", "html-output-iframe-resized", {
+            height: h + 2,
+          });
+        } else {
+          hostLog("warning", "html-output-iframe-missing-height");
+        }
+      } catch (error) {
+        hostLog("warning", "html-output-iframe-resize-failed", {
+          error: errorDetails(error),
+        });
       }
     };
     frame.addEventListener("load", handleLoad);

--- a/apps/mcp-app/src/components/mime-renderer.tsx
+++ b/apps/mcp-app/src/components/mime-renderer.tsx
@@ -8,6 +8,7 @@ import { HtmlOutput } from "./html-output";
 import { ImageOutput } from "./image-output";
 import { JsonOutput } from "./json-output";
 import type { CellOutput } from "../types";
+import { errorDetails, hostLog, stringDetails } from "../lib/host-log";
 
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
@@ -19,9 +20,23 @@ interface MimeRendererProps {
 
 export function MimeRenderer({ data, blobBaseUrl }: MimeRendererProps) {
   const mime = selectMimeType(data);
-  if (!mime) return null;
-  const raw = data[mime];
-  if (raw == null) return null;
+  const raw = mime ? data[mime] : undefined;
+
+  useEffect(() => {
+    if (!mime) {
+      hostLog("warning", "mime-renderer-no-supported-mime", {
+        availableMimes: Object.keys(data),
+        hasBlobBaseUrl: blobBaseUrl !== undefined,
+      });
+    } else if (raw == null) {
+      hostLog("warning", "mime-renderer-missing-selected-data", {
+        mime,
+        availableMimes: Object.keys(data),
+      });
+    }
+  }, [data, mime, raw, blobBaseUrl]);
+
+  if (!mime || raw == null) return null;
 
   // Images: use blob URL directly as <img src>, no fetch needed
   if (mime.startsWith("image/") && mime !== "image/svg+xml") {
@@ -48,6 +63,13 @@ export function MimeRenderer({ data, blobBaseUrl }: MimeRendererProps) {
   return <FetchAndRender mime={mime} raw={String(raw)} plainFallback={plainFallback} />;
 }
 
+function outputValueDetails(value: string): Record<string, unknown> {
+  return {
+    isBlobUrl: isBlobUrl(value),
+    ...stringDetails(value),
+  };
+}
+
 /**
  * Load a daemon-served plugin via <script> tag and render data with it.
  * Loads plugin and fetches blob data in parallel.
@@ -69,6 +91,14 @@ function PluginRenderer({
 
   useEffect(() => {
     let cancelled = false;
+
+    hostLog("debug", "plugin-render-start", {
+      mime,
+      hasBlobBaseUrl: blobBaseUrl !== undefined,
+      raw: outputValueDetails(raw),
+      hasPlainFallback: plainFallback !== undefined,
+      plainFallbackIsBlobUrl: plainFallback ? isBlobUrl(plainFallback) : false,
+    });
 
     // Load plugin via <script> tag and fetch/parse data in parallel
     const pluginPromise = loadPluginForMime(mime, blobBaseUrl) ?? Promise.resolve();
@@ -93,6 +123,13 @@ function PluginRenderer({
     Promise.all([pluginPromise, dataPromise])
       .then(([, parsedData]) => {
         if (cancelled) return;
+        const hasRenderer = getPluginRenderer(mime) !== undefined;
+        hostLog(hasRenderer ? "info" : "error", "plugin-render-ready", {
+          mime,
+          hasRenderer,
+          dataType: typeof parsedData,
+          dataIsArray: Array.isArray(parsedData),
+        });
         setPluginReady(true);
         setData(
           mime === ARROW_STREAM_MANIFEST_MIME
@@ -100,14 +137,22 @@ function PluginRenderer({
             : parsedData,
         );
       })
-      .catch(() => {
+      .catch((error) => {
+        hostLog("error", "plugin-render-failed", {
+          mime,
+          blobBaseUrl,
+          raw: outputValueDetails(raw),
+          hasPlainFallback: plainFallback !== undefined,
+          plainFallbackIsBlobUrl: plainFallback ? isBlobUrl(plainFallback) : false,
+          error: errorDetails(error),
+        });
         if (!cancelled) setFailed(true);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [mime, raw, blobBaseUrl]);
+  }, [mime, raw, blobBaseUrl, plainFallback]);
 
   if (failed) {
     if (plainFallback) return <AnsiText text={plainFallback} />;
@@ -164,9 +209,18 @@ function FetchAndRender({
     if (isBlobUrl(raw)) {
       fetchBlobText(raw)
         .then(setContent)
-        .catch(() => setFailed(true));
+        .catch((error) => {
+          hostLog("error", "mime-blob-fetch-failed", {
+            mime,
+            raw: outputValueDetails(raw),
+            hasPlainFallback: plainFallback !== undefined,
+            plainFallbackIsBlobUrl: plainFallback ? isBlobUrl(plainFallback) : false,
+            error: errorDetails(error),
+          });
+          setFailed(true);
+        });
     }
-  }, [raw]);
+  }, [mime, raw, plainFallback]);
 
   if (failed) {
     if (plainFallback) return <AnsiText text={plainFallback} />;
@@ -197,7 +251,14 @@ export function StreamOutput({ output }: { output: CellOutput }) {
     if (isBlobUrl(raw)) {
       fetchBlobText(raw)
         .then(setText)
-        .catch(() => setText(raw));
+        .catch((error) => {
+          hostLog("error", "stream-blob-fetch-failed", {
+            streamName: output.name,
+            raw: outputValueDetails(raw),
+            error: errorDetails(error),
+          });
+          setText(raw);
+        });
     } else {
       setText(raw);
     }

--- a/apps/mcp-app/src/dev/main.tsx
+++ b/apps/mcp-app/src/dev/main.tsx
@@ -48,7 +48,7 @@ function AppFrame({ toolResult }: { toolResult: CallToolResult }) {
     const bridge = new AppBridge(
       null,
       { name: "nteract-dev-preview", version: "0.1.0" },
-      {},
+      { logging: {} },
       {
         hostContext: {
           theme: "dark",
@@ -56,6 +56,10 @@ function AppFrame({ toolResult }: { toolResult: CallToolResult }) {
       },
     );
     bridgeRef.current = bridge;
+
+    bridge.onloggingmessage = ({ level, logger, data }) => {
+      console.log(`[${logger ?? "mcp-app"}] ${level}`, data);
+    };
 
     // Resize iframe to match content
     bridge.onsizechange = ({ height: h }) => {

--- a/apps/mcp-app/src/lib/host-log.ts
+++ b/apps/mcp-app/src/lib/host-log.ts
@@ -1,0 +1,93 @@
+import type { LoggingMessageNotification } from "@modelcontextprotocol/sdk/types.js";
+
+export type HostLogParams = LoggingMessageNotification["params"];
+export type HostLogLevel = HostLogParams["level"];
+
+export interface HostLogSink {
+  sendLog(params: HostLogParams): void | Promise<void>;
+}
+
+const DEFAULT_LOGGER = "nteract.mcp-app";
+const PREVIEW_LIMIT = 200;
+
+let sink: HostLogSink | null = null;
+
+export function setHostLogSink(nextSink: HostLogSink | null): void {
+  sink = nextSink;
+}
+
+export function hostLog(
+  level: HostLogLevel,
+  event: string,
+  details: Record<string, unknown> = {},
+): void {
+  const params: HostLogParams = {
+    level,
+    logger: DEFAULT_LOGGER,
+    data: {
+      event,
+      ...details,
+    },
+  };
+
+  if (sink) {
+    try {
+      void Promise.resolve(sink.sendLog(params)).catch((error) => {
+        logToConsole("warning", "host-log-send-failed", {
+          originalEvent: event,
+          error: errorDetails(error),
+        });
+      });
+      return;
+    } catch (error) {
+      logToConsole("warning", "host-log-send-threw", {
+        originalEvent: event,
+        error: errorDetails(error),
+      });
+    }
+  }
+
+  logToConsole(level, event, details);
+}
+
+export function errorDetails(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}
+
+export function stringDetails(value: string): Record<string, unknown> {
+  const truncated = value.length > PREVIEW_LIMIT;
+  return {
+    length: value.length,
+    preview: truncated ? `${value.slice(0, PREVIEW_LIMIT)}...` : value,
+    truncated,
+  };
+}
+
+function logToConsole(
+  level: HostLogLevel,
+  event: string,
+  details: Record<string, unknown>,
+): void {
+  const consoleLevel =
+    level === "error" ||
+    level === "critical" ||
+    level === "alert" ||
+    level === "emergency"
+      ? "error"
+      : level === "warning"
+        ? "warn"
+        : level === "debug"
+          ? "debug"
+          : "log";
+  console[consoleLevel](`[${DEFAULT_LOGGER}] ${event}`, details);
+}

--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -13,6 +13,7 @@ import type { NteractContent } from "./types";
 import { Cell } from "./components/cell";
 import { SummaryHeader } from "./components/summary-header";
 import { hasRichOutput } from "./lib/rich-output";
+import { errorDetails, hostLog, setHostLogSink } from "./lib/host-log";
 
 /**
  * Collapse the widget to 0px when there's nothing to render.
@@ -32,6 +33,37 @@ function useCollapseWhenEmpty(hasCells: boolean) {
   }, [hasCells]);
 }
 
+function contentDetails(content: NteractContent | null): Record<string, unknown> {
+  const cells = content?.cells || (content?.cell ? [content.cell] : []);
+  const outputMimes = cells.flatMap((cell) =>
+    (cell.outputs ?? []).flatMap((output) => Object.keys(output.data ?? {})),
+  );
+
+  return {
+    cellCount: cells.length,
+    outputCount: cells.reduce((count, cell) => count + (cell.outputs?.length ?? 0), 0),
+    outputMimes,
+    hasBlobBaseUrl: typeof content?.blob_base_url === "string",
+  };
+}
+
+function layoutDetails(): Record<string, unknown> {
+  const html = document.documentElement;
+  const body = document.body;
+
+  return {
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
+    documentRectHeight: Math.ceil(html.getBoundingClientRect().height),
+    documentScrollHeight: html.scrollHeight,
+    bodyRectHeight: Math.ceil(body.getBoundingClientRect().height),
+    bodyScrollHeight: body.scrollHeight,
+    htmlStyleHeight: html.style.height || null,
+    bodyStyleHeight: body.style.height || null,
+    bodyStyleOverflow: body.style.overflow || null,
+  };
+}
+
 function McpApp() {
   const [content, setContent] = useState<NteractContent | null>(null);
   const [allExpanded, setAllExpanded] = useState<boolean | null>(null);
@@ -41,7 +73,15 @@ function McpApp() {
 
     app.ontoolresult = (result: CallToolResult) => {
       const structured = result.structuredContent as NteractContent | undefined;
-      if (!structured) return;
+      if (!structured) {
+        hostLog("info", "tool-result-without-structured-content", {
+          contentItems: result.content?.length ?? 0,
+          isError: result.isError ?? false,
+          layout: layoutDetails(),
+        });
+        return;
+      }
+      hostLog("info", "tool-result-received", contentDetails(structured));
       setContent(structured);
       setAllExpanded(null); // Reset expand-all state for new content
     };
@@ -52,17 +92,41 @@ function McpApp() {
       if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
     };
 
-    app.onerror = console.error;
+    app.onerror = (error) => {
+      hostLog("error", "app-protocol-error", {
+        error: errorDetails(error),
+      });
+    };
 
     // Apply initial theme after connecting
-    app.connect().then(() => {
-      const ctx = app.getHostContext();
-      if (ctx?.theme) applyDocumentTheme(ctx.theme);
-      if (ctx?.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
-      if (ctx?.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
-    });
+    app
+      .connect()
+      .then(() => {
+        setHostLogSink({
+          sendLog: (params) => app.sendLog(params),
+        });
+        const ctx = app.getHostContext();
+        const capabilities = app.getHostCapabilities();
+        hostLog("info", "app-connected", {
+          host: app.getHostVersion(),
+          loggingAdvertised: capabilities?.logging !== undefined,
+          sandboxCsp: capabilities?.sandbox?.csp,
+          displayMode: ctx?.displayMode,
+          containerSize: ctx?.containerSize,
+        });
+        if (ctx?.theme) applyDocumentTheme(ctx.theme);
+        if (ctx?.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
+        if (ctx?.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+      })
+      .catch((error) => {
+        hostLog("error", "app-connect-failed", {
+          error: errorDetails(error),
+        });
+      });
 
     return () => {
+      hostLog("debug", "app-dispose");
+      setHostLogSink(null);
       setContent(null);
     };
   }, []);
@@ -71,6 +135,16 @@ function McpApp() {
   const isMultiCell = cells.length > 1;
 
   useCollapseWhenEmpty(cells.length > 0);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      hostLog("debug", "layout-measured", {
+        ...contentDetails(content),
+        layout: layoutDetails(),
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [content]);
 
   const blobBaseUrl = content?.blob_base_url;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@modelcontextprotocol/ext-apps':
         specifier: ^1.3.0
         version: 1.3.2(@modelcontextprotocol/sdk@1.28.0(zod@4.3.6))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.28.0
+        version: 1.28.0(zod@4.3.6)
       anser:
         specifier: ^2.1.1
         version: 2.3.5


### PR DESCRIPTION
## Summary

- add a reusable MCP app host-log sink backed by `App.sendLog()`
- emit standard MCP `notifications/message` events for app lifecycle, tool result shape, layout measurements, plugin render/load failures, and blob fetch failures
- advertise and print host-facing logs in the MCP app dev bridge

Replaces #2849. This PR keeps the old CSP/listing change out of the replacement branch so nightly can collect real host-side signal first.

## Verification

- `pnpm --dir apps/mcp-app exec tsc --noEmit`
- `pnpm test:run apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx`
- `pnpm exec vp run nteract-mcp-app#build`
- `cargo xtask lint --fix`
