### PR TITLE
feat(traceback): segment mixed output rendering

### DIFF
--- a/apps/notebook/e2e/isolated-rich-output.spec.ts
+++ b/apps/notebook/e2e/isolated-rich-output.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "./helpers";
 
 test.describe("isolated rich output rendering", () => {
-  test("keeps stream text visible when a pandas dataframe renders in the iframe", async ({
+  test("keeps stream text visible outside the iframe when a pandas dataframe is isolated", async ({
     page,
   }) => {
     test.setTimeout(180_000);
@@ -43,12 +43,16 @@ test.describe("isolated rich output rendering", () => {
     await executeCell(cell);
     await waitForKernelStatus(page, "idle", 120_000);
 
+    await expect(cell.locator('[data-slot="ansi-stream-output"]')).toContainText("stream before", {
+      timeout: 60_000,
+    });
+
     const frame = cell.frameLocator('[data-slot="isolated-frame"]');
     const frameBody = frame.locator("body");
-    await expect(frameBody).toContainText("stream before", { timeout: 60_000 });
     await expect
       .poll(async () => normalizeOutputText(await frameBody.innerText()), { timeout: 60_000 })
       .toMatch(/a\s*#\s*1|b\s*#\s*3|a b 0 1 3 1 2 4/i);
+    await expect(frameBody).not.toContainText("stream before");
     await expect.poll(() => isolatedRootHeight(cell), { timeout: 30_000 }).toBeGreaterThan(20);
 
     expect(isolatedLogs.join("\n")).not.toContain("rendered-empty-after-paint");

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -790,10 +790,6 @@ fn rich_location_line(
         .and_then(|r| r.get("execution_id"))
         .or_else(|| source.get("execution_id"))
         .and_then(Value::as_str);
-    let execution_count = source_ref
-        .and_then(|r| r.get("execution_count"))
-        .or_else(|| source.get("execution_count"))
-        .and_then(Value::as_u64);
     let source_hash = source_ref
         .and_then(|r| r.get("source_hash"))
         .or_else(|| source.get("source_hash"))
@@ -809,9 +805,6 @@ fn rich_location_line(
     }
     if let Some(eid) = execution_id {
         details.push(format!("execution_id={eid}"));
-    }
-    if let Some(count) = execution_count {
-        details.push(format!("In[{count}]"));
     }
     if let Some(hash) = source_hash {
         details.push(format!("source_hash={hash}"));
@@ -2678,11 +2671,12 @@ mod tests {
         };
         let traceback = out.traceback.unwrap_or_default().join("\n");
 
+        assert!(
+            traceback.contains("Line 1 in Cell cell-run (cell_id=cell-run, execution_id=exec-run)")
+        );
         assert!(traceback
-            .contains("Line 1 in Cell cell-run (cell_id=cell-run, execution_id=exec-run, In[3])"));
-        assert!(traceback.contains(
-            "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def, In[2]), in g"
-        ));
+            .contains("Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def), in g"));
+        assert!(!traceback.contains("In["));
         assert!(traceback.contains("pd.not_real()"));
         assert!(!traceback.contains("/var/folders/x/T/ipykernel_39879"));
     }

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
-import { jupyterOutputsToRenderPayloads } from "@/components/isolated/output-payloads";
+import { jupyterOutputToRenderPayload } from "@/components/isolated/output-payloads";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
@@ -288,19 +288,37 @@ function outputNeedsIsolation(
   return false;
 }
 
-/**
- * Check if any outputs in the array need iframe isolation.
- * If any output needs isolation, ALL outputs should go to the iframe.
- *
- * Not exported: keeping every `.tsx` export limited to components and
- * hooks lets React Fast Refresh hot-patch this module instead of bailing
- * to a full reload on every edit.
- */
-function anyOutputNeedsIsolation(
+interface IndexedOutput {
+  output: JupyterOutput;
+  index: number;
+}
+
+interface OutputSegment {
+  kind: "dom" | "isolated";
+  items: IndexedOutput[];
+  key: string;
+}
+
+function splitOutputSegments(
   outputs: JupyterOutput[],
+  isolated: OutputAreaProps["isolated"],
   priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  return outputs.some((output) => outputNeedsIsolation(output, priority));
+): OutputSegment[] {
+  const forceKind = isolated === true ? "isolated" : isolated === false ? "dom" : null;
+  const segments: OutputSegment[] = [];
+
+  for (let index = 0; index < outputs.length; index++) {
+    const output = outputs[index]!;
+    const kind = forceKind ?? (outputNeedsIsolation(output, priority) ? "isolated" : "dom");
+    const last = segments[segments.length - 1];
+    if (last?.kind === kind) {
+      last.items.push({ output, index });
+    } else {
+      segments.push({ kind, items: [{ output, index }], key: `${kind}-${index}` });
+    }
+  }
+
+  return segments;
 }
 
 /**
@@ -380,6 +398,325 @@ function renderOutput(
   }
 }
 
+interface IsolatedOutputSegmentProps {
+  items: IndexedOutput[];
+  hidden?: boolean;
+  cellId?: string;
+  executionCount?: number | null;
+  focused: boolean;
+  frameMaxHeight: number;
+  priority: readonly string[];
+  onLinkClick?: OutputAreaProps["onLinkClick"];
+  onWidgetUpdate?: OutputAreaProps["onWidgetUpdate"];
+  searchQuery?: string;
+  onSearchMatchCount?: OutputAreaProps["onSearchMatchCount"];
+  onIframeMouseDown?: OutputAreaProps["onIframeMouseDown"];
+  hostContext?: OutputAreaProps["hostContext"];
+}
+
+function IsolatedOutputSegment({
+  items,
+  hidden = false,
+  cellId,
+  executionCount,
+  focused,
+  frameMaxHeight,
+  priority,
+  onLinkClick,
+  onWidgetUpdate,
+  searchQuery,
+  onSearchMatchCount,
+  onIframeMouseDown,
+  hostContext,
+}: IsolatedOutputSegmentProps) {
+  const outputs = useMemo(() => items.map((item) => item.output), [items]);
+  const frameRef = useRef<IsolatedFrameHandle>(null);
+  const bridgeRef = useRef<CommBridgeManager | null>(null);
+  const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
+  const injectedLibsRef = useRef(new Set<string>());
+  const renderGenRef = useRef(0);
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+  const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
+
+  const darkMode = useDarkMode();
+  const colorTheme = useColorTheme();
+  const darkModeRef = useRef(darkMode);
+  darkModeRef.current = darkMode;
+  const colorThemeRef = useRef(colorTheme);
+  colorThemeRef.current = colorTheme;
+
+  const widgetContext = useWidgetStore();
+  const hasWidgets = hasWidgetOutputs(outputs, priority);
+  const hasSiftOutputs = outputs.some((output) => outputUsesSift(output, priority));
+  const shouldUseBridge = !hidden && hasWidgets && widgetContext !== null;
+  const shouldUseScrollPassthroughFrame =
+    !hidden &&
+    !focused &&
+    !hasWidgets &&
+    outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
+  const shouldScrollPassthroughFrame =
+    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const allowWheelBoundaryScroll =
+    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
+  const showSiftInteractionCue =
+    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
+  const siftFrameStyle = hasSiftOutputs
+    ? ({
+        "--notebook-sift-focus": siftFrameAccent,
+        "--notebook-sift-focus-hover": `${siftFrameAccent}66`,
+        boxShadow: staticFrameInteractionActive
+          ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
+          : undefined,
+      } as React.CSSProperties)
+    : undefined;
+
+  const firstOutputIndex = items[0]?.index;
+  const frameName = cellId
+    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}${
+        firstOutputIndex == null ? "" : `-${firstOutputIndex}`
+      }`
+    : undefined;
+
+  useEffect(() => {
+    if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
+      setStaticFrameInteractionActive(false);
+    }
+  }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!hasSiftOutputs) return;
+    frameRef.current?.send({
+      type: "interaction_state",
+      payload: { active: staticFrameInteractionActive },
+    });
+  }, [hasSiftOutputs, staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!staticFrameInteractionActive) return;
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
+        return;
+      }
+      setStaticFrameInteractionActive(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [staticFrameInteractionActive]);
+
+  const activateStaticFrameInteraction = useCallback(() => {
+    if (shouldUseScrollPassthroughFrame) {
+      if (!staticFrameInteractionActive && hasSiftOutputs) {
+        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
+      }
+      setStaticFrameInteractionActive(true);
+      staticFrameInteractionRef.current?.focus({ preventScroll: true });
+    }
+    onIframeMouseDown?.();
+  }, [
+    hasSiftOutputs,
+    shouldUseScrollPassthroughFrame,
+    staticFrameInteractionActive,
+    onIframeMouseDown,
+  ]);
+
+  const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      setStaticFrameInteractionActive(false);
+    }
+  }, []);
+
+  const handleIframeMessage = useCallback(
+    (message: IframeToParentMessage) => {
+      if (bridgeRef.current) {
+        bridgeRef.current.handleIframeMessage(message);
+      }
+
+      if (message.type === "widget_update" && onWidgetUpdate) {
+        onWidgetUpdate(message.payload.commId, message.payload.state);
+      }
+
+      if (message.type === "search_results") {
+        onSearchMatchCount?.(message.payload.count);
+      }
+    },
+    [onWidgetUpdate, onSearchMatchCount],
+  );
+
+  const handleFrameReady = useCallback(
+    async (options: { resetInjectedPlugins?: boolean } = {}) => {
+      if (!frameRef.current) return;
+      const gen = ++renderGenRef.current;
+
+      if (shouldUseBridge && widgetContext && !bridgeRef.current) {
+        bridgeRef.current = new CommBridgeManager({
+          frame: frameRef.current,
+          store: widgetContext.store,
+          sendUpdate: widgetContext.sendUpdate,
+          sendCustom: widgetContext.sendCustom,
+          closeComm: widgetContext.closeComm,
+        });
+      }
+
+      frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
+
+      if (options.resetInjectedPlugins) {
+        injectedLibsRef.current.clear();
+      }
+      const pluginMimes = new Set<string>();
+      for (const output of outputs) {
+        if (output.output_type === "execute_result" || output.output_type === "display_data") {
+          for (const mime of Object.keys(output.data)) {
+            if (needsPlugin(mime)) pluginMimes.add(mime);
+          }
+        }
+      }
+
+      if (widgetContext?.store) {
+        for (const output of outputs) {
+          if (
+            (output.output_type === "execute_result" || output.output_type === "display_data") &&
+            output.data?.["application/vnd.jupyter.widget-view+json"]
+          ) {
+            const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
+              model_id?: string;
+            };
+            if (widgetData?.model_id) {
+              const model = widgetContext.store.getModel(widgetData.model_id);
+              if (model?.modelName === "OutputModel" && model.state.outputs) {
+                const widgetOutputs = model.state.outputs as Array<{
+                  output_type: string;
+                  data?: Record<string, unknown>;
+                }>;
+                for (const widgetOutput of widgetOutputs) {
+                  for (const mime of Object.keys(widgetOutput.data ?? {})) {
+                    if (needsPlugin(mime)) pluginMimes.add(mime);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (pluginMimes.size > 0) {
+        try {
+          await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
+        } catch (error) {
+          if (gen !== renderGenRef.current) return;
+          console.error("[OutputArea] Failed to load renderer plugin:", error);
+          frameRef.current.renderBatch([
+            {
+              mimeType: "text/plain",
+              data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
+              metadata: { isError: true },
+              cellId,
+              outputIndex: firstOutputIndex ?? 0,
+            },
+          ]);
+          return;
+        }
+        if (gen !== renderGenRef.current) return;
+      }
+
+      const batch = items.flatMap((item) => {
+        const payload = jupyterOutputToRenderPayload(item.output, item.index, { cellId, priority });
+        return payload ? [payload] : [];
+      });
+      frameRef.current.renderBatch(batch);
+
+      if (searchQueryRef.current) {
+        frameRef.current.search(searchQueryRef.current);
+      }
+    },
+    [cellId, firstOutputIndex, items, outputs, priority, shouldUseBridge, widgetContext],
+  );
+
+  const handleIsolatedFrameReady = useCallback(() => {
+    void handleFrameReady({ resetInjectedPlugins: true });
+  }, [handleFrameReady]);
+
+  useEffect(() => {
+    return () => {
+      if (bridgeRef.current) {
+        bridgeRef.current.dispose();
+        bridgeRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (frameRef.current?.isReady) {
+      handleFrameReady();
+    }
+  }, [handleFrameReady]);
+
+  useEffect(() => {
+    if (frameRef.current?.isIframeReady) {
+      frameRef.current.search(searchQuery || "");
+    }
+  }, [searchQuery]);
+
+  return (
+    <div
+      ref={staticFrameInteractionRef}
+      className={cn(
+        hidden ? "hidden" : "relative outline-none transition-shadow",
+        hasSiftOutputs && "group/sift rounded-md overflow-hidden",
+        hasSiftOutputs &&
+          shouldUseScrollPassthroughFrame &&
+          !staticFrameInteractionActive &&
+          "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
+        hasSiftOutputs && staticFrameInteractionActive && "bg-background",
+      )}
+      style={siftFrameStyle}
+      data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
+      data-sift-output={hasSiftOutputs ? "true" : undefined}
+      tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
+      onPointerDown={shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined}
+      onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
+    >
+      <IsolatedFrame
+        ref={frameRef}
+        name={frameName}
+        darkMode={darkMode}
+        colorTheme={colorTheme}
+        minHeight={24}
+        maxHeight={frameMaxHeight}
+        autoHeight={!hidden && !focused}
+        allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+        scrollPassthrough={shouldScrollPassthroughFrame}
+        onReady={handleIsolatedFrameReady}
+        onLinkClick={onLinkClick}
+        onMouseDown={activateStaticFrameInteraction}
+        onWidgetUpdate={onWidgetUpdate}
+        onMessage={handleIframeMessage}
+        onError={handleIframeError}
+        hostContext={hostContext}
+      />
+      {showSiftInteractionCue && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
+          <SiftScrollHandoffCue
+            className="pointer-events-auto"
+            onPointerDown={(event) => {
+              event.stopPropagation();
+              activateStaticFrameInteraction();
+            }}
+            onClick={(event) => {
+              event.stopPropagation();
+              activateStaticFrameInteraction();
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 /**
  * OutputArea renders multiple Jupyter outputs with proper layout.
  *
@@ -421,301 +758,35 @@ export function OutputArea({
   onNavigateToTracebackCell,
 }: OutputAreaProps) {
   const id = useId();
-  const frameRef = useRef<IsolatedFrameHandle>(null);
-  const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
-  const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
-  const injectedLibsRef = useRef(new Set<string>());
-  const renderGenRef = useRef(0);
-  const searchQueryRef = useRef(searchQuery);
-  searchQueryRef.current = searchQuery;
-  const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
-
-  const darkMode = useDarkMode();
-  const colorTheme = useColorTheme();
   const focusedOutputWellMaxHeight = useOutputWellMaxHeight(FOCUSED_OUTPUT_WELL_VIEWPORT_RATIO);
-  const inDomMaxHeight = useOutputWell ? (maxHeight ?? null) : null;
-  const maxHeightStyle = useMemo<React.CSSProperties | undefined>(() => {
-    if (!inDomMaxHeight) return undefined;
-    return { maxHeight: `${inDomMaxHeight}px` };
-  }, [inDomMaxHeight]);
-  // Ref for reading current darkMode in callbacks without adding to deps
-  const darkModeRef = useRef(darkMode);
-  darkModeRef.current = darkMode;
-  const colorThemeRef = useRef(colorTheme);
-  colorThemeRef.current = colorTheme;
-
-  // Get widget store context (may be null if not in provider)
-  const widgetContext = useWidgetStore();
-
-  // Determine if we should use isolation (when we have outputs)
-  const shouldIsolate =
-    outputs.length > 0 &&
-    (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
-  const shouldConstrainIsolatedOutput = shouldIsolate && (focused || maxHeight != null);
-  const isolatedOutputWellMaxHeight = focused
+  const segments = useMemo(
+    () => splitOutputSegments(outputs, isolated, priority),
+    [outputs, isolated, priority],
+  );
+  const hasIsolatedSegments = segments.some((segment) => segment.kind === "isolated");
+  const shouldConstrainOutputArea = hasIsolatedSegments && (focused || maxHeight != null);
+  const outputWellMaxHeight = focused
     ? focusedOutputWellMaxHeight
     : (maxHeight ?? focusedOutputWellMaxHeight);
-  const isolatedOutputWellStyle = shouldConstrainIsolatedOutput
+  const inDomMaxHeight = useOutputWell ? (maxHeight ?? null) : null;
+  const outputWellStyle = shouldConstrainOutputArea
     ? {
-        maxHeight: `${isolatedOutputWellMaxHeight}px`,
+        maxHeight: `${outputWellMaxHeight}px`,
         ...(focused ? { minHeight: `${MIN_OUTPUT_WELL_HEIGHT}px` } : {}),
       }
-    : undefined;
+    : inDomMaxHeight !== null
+      ? { maxHeight: `${inDomMaxHeight}px` }
+      : undefined;
 
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
-
-  // Frame name for dev-tools picker. `code-Out[N]-{cellId}` mirrors the
-  // Jupyter `Out[N]` convention with the cell ID appended so the picker can
-  // distinguish reruns and concurrent cells. `*` matches Jupyter's queued /
-  // never-run indicator.
-  const frameName = cellId
-    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}`
-    : undefined;
-
-  // Check if we have widgets and should set up comm bridge
-  const hasWidgets = hasWidgetOutputs(outputs, priority);
-  const hasSiftOutputs = outputs.some((output) => outputUsesSift(output, priority));
-  const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
-  const shouldUseScrollPassthroughFrame =
-    shouldIsolate &&
-    !focused &&
-    !hasWidgets &&
-    outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
-  const shouldScrollPassthroughFrame =
-    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const allowWheelBoundaryScroll =
-    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
-  const showSiftInteractionCue =
-    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
-  const siftFrameStyle = hasSiftOutputs
-    ? ({
-        "--notebook-sift-focus": siftFrameAccent,
-        "--notebook-sift-focus-hover": `${siftFrameAccent}66`,
-        boxShadow: staticFrameInteractionActive
-          ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
-          : undefined,
-      } as React.CSSProperties)
-    : undefined;
-
   const hasCollapseControl = onToggleCollapse !== undefined;
-
-  useEffect(() => {
-    if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
-      setStaticFrameInteractionActive(false);
-    }
-  }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
-
-  useEffect(() => {
-    if (!hasSiftOutputs) return;
-    frameRef.current?.send({
-      type: "interaction_state",
-      payload: { active: staticFrameInteractionActive },
-    });
-  }, [hasSiftOutputs, staticFrameInteractionActive]);
-
-  useEffect(() => {
-    if (!staticFrameInteractionActive) return;
-
-    const handlePointerDown = (event: globalThis.PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
-        return;
-      }
-      setStaticFrameInteractionActive(false);
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [staticFrameInteractionActive]);
-
-  const activateStaticFrameInteraction = useCallback(() => {
-    if (shouldUseScrollPassthroughFrame) {
-      if (!staticFrameInteractionActive && hasSiftOutputs) {
-        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
-      }
-      setStaticFrameInteractionActive(true);
-      // Move DOM focus off CodeMirror without scrolling; this wrapper owns
-      // focus until iframe pointer interaction is active.
-      staticFrameInteractionRef.current?.focus({ preventScroll: true });
-    }
-    onIframeMouseDown?.();
-  }, [
-    hasSiftOutputs,
-    shouldUseScrollPassthroughFrame,
-    staticFrameInteractionActive,
-    onIframeMouseDown,
-  ]);
-
-  const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      setStaticFrameInteractionActive(false);
-    }
-  }, []);
-
-  // Handle messages from iframe, routing widget messages to comm bridge
-  const handleIframeMessage = useCallback(
-    (message: IframeToParentMessage) => {
-      // Route widget messages to bridge
-      if (bridgeRef.current) {
-        bridgeRef.current.handleIframeMessage(message);
-      }
-
-      // Also handle widget_update for backward compatibility
-      if (message.type === "widget_update" && onWidgetUpdate) {
-        onWidgetUpdate(message.payload.commId, message.payload.state);
-      }
-
-      // Capture search result count from iframe
-      if (message.type === "search_results") {
-        onSearchMatchCount?.(message.payload.count);
-      }
-    },
-    [onWidgetUpdate, onSearchMatchCount],
-  );
-
-  // Callback when frame is ready - set up bridge and render outputs
-  const handleFrameReady = useCallback(
-    async (options: { resetInjectedPlugins?: boolean } = {}) => {
-      if (!frameRef.current) return;
-
-      // Bump generation so any in-flight async handleFrameReady from a
-      // previous outputs snapshot will bail out after it awaits.
-      const gen = ++renderGenRef.current;
-
-      // Set up comm bridge if we have widgets and widget context
-      if (shouldUseBridge && widgetContext && !bridgeRef.current) {
-        bridgeRef.current = new CommBridgeManager({
-          frame: frameRef.current,
-          store: widgetContext.store,
-          sendUpdate: widgetContext.sendUpdate,
-          sendCustom: widgetContext.sendCustom,
-          closeComm: widgetContext.closeComm,
-        });
-      }
-
-      // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
-      // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
-      frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
-
-      // Install renderer plugins required by the outputs (e.g. plotly, vega).
-      // Must happen before clear+render so the installRenderer messages arrive first.
-      if (options.resetInjectedPlugins) {
-        injectedLibsRef.current.clear();
-      }
-
-      // Collect MIME types that need renderer plugins from the cell's outputs
-      const pluginMimes = new Set<string>();
-      for (const output of outputs) {
-        if (output.output_type === "execute_result" || output.output_type === "display_data") {
-          for (const mime of Object.keys(output.data)) {
-            if (needsPlugin(mime)) pluginMimes.add(mime);
-          }
-        }
-      }
-
-      // Also scan output widgets for captured outputs that need plugins.
-      // A cell may output a widget view (application/vnd.jupyter.widget-view+json)
-      // whose OutputModel.outputs contain plotly/vega/etc MIME types.
-      if (widgetContext?.store) {
-        for (const output of outputs) {
-          if (
-            (output.output_type === "execute_result" || output.output_type === "display_data") &&
-            output.data?.["application/vnd.jupyter.widget-view+json"]
-          ) {
-            const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
-              model_id?: string;
-            };
-            if (widgetData?.model_id) {
-              const model = widgetContext.store.getModel(widgetData.model_id);
-              if (model?.modelName === "OutputModel" && model.state.outputs) {
-                const widgetOutputs = model.state.outputs as Array<{
-                  output_type: string;
-                  data?: Record<string, unknown>;
-                }>;
-                for (const wo of widgetOutputs) {
-                  for (const mime of Object.keys(wo.data ?? {})) {
-                    if (needsPlugin(mime)) pluginMimes.add(mime);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      if (pluginMimes.size > 0) {
-        try {
-          await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
-        } catch (error) {
-          if (gen !== renderGenRef.current) return;
-          console.error("[OutputArea] Failed to load renderer plugin:", error);
-          frameRef.current.renderBatch([
-            {
-              mimeType: "text/plain",
-              data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
-              metadata: { isError: true },
-              cellId,
-              outputIndex: 0,
-            },
-          ]);
-          return;
-        }
-        // Stale check: if outputs changed while we were loading the plugin,
-        // bail — a newer handleFrameReady call is already in flight.
-        if (gen !== renderGenRef.current) return;
-      }
-
-      // Build batch of render payloads and send atomically.
-      // This avoids the clear+re-render cycle that causes DOM thrashing
-      // (visible as flickering when interactive widgets update rapidly).
-      const batch = jupyterOutputsToRenderPayloads(outputs, { cellId, priority });
-
-      frameRef.current.renderBatch(batch);
-
-      // Re-apply search highlights after rendering new content
-      if (searchQueryRef.current) {
-        frameRef.current?.search(searchQueryRef.current);
-      }
-    },
-    [outputs, priority, shouldUseBridge, widgetContext],
-  );
-
-  const handleIsolatedFrameReady = useCallback(() => {
-    void handleFrameReady({ resetInjectedPlugins: true });
-  }, [handleFrameReady]);
-
-  // Clean up bridge on unmount
-  useEffect(() => {
-    return () => {
-      if (bridgeRef.current) {
-        bridgeRef.current.dispose();
-        bridgeRef.current = null;
-      }
-    };
-  }, []);
-
-  // Re-render outputs when they change (after initial ready)
-  useEffect(() => {
-    if (frameRef.current?.isReady) {
-      handleFrameReady();
-    }
-  }, [handleFrameReady]);
-
-  // Forward search query to the iframe (for isolated outputs)
-  useEffect(() => {
-    if (frameRef.current?.isIframeReady) {
-      frameRef.current.search(searchQuery || "");
-    }
-  }, [searchQuery]);
 
   // Highlight search matches in in-DOM outputs
   // Re-run when outputs array ref changes so new content gets highlighted
   useEffect(() => {
-    if (shouldIsolate) return; // iframe reports its own count via search_results
     if (!searchQuery || !inDomOutputRef.current || outputs.length === 0) {
       // Only report 0 if we were previously tracking matches for this cell
       if (searchQuery) onSearchMatchCount?.(0);
@@ -725,7 +796,7 @@ export function OutputArea({
     const count = inDomOutputRef.current.querySelectorAll(".global-find-match").length;
     onSearchMatchCount?.(count);
     return cleanup;
-  }, [searchQuery, shouldIsolate, outputs, onSearchMatchCount]);
+  }, [searchQuery, outputs, onSearchMatchCount]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -765,108 +836,86 @@ export function OutputArea({
       {/* Output content */}
       {!collapsed && (
         <div
+          ref={inDomOutputRef}
           id={id}
           className={cn(
             "space-y-2",
-            !shouldIsolate && inDomMaxHeight !== null && "overflow-y-auto",
-            shouldConstrainIsolatedOutput && "overflow-y-auto",
+            inDomMaxHeight !== null && "overflow-y-auto",
+            shouldConstrainOutputArea && "overflow-y-auto",
           )}
-          style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
+          style={outputWellStyle}
         >
-          {/* Preloaded or active isolated frame */}
-          {(shouldIsolate || showPreloadedIframe) && (
-            <div
-              ref={staticFrameInteractionRef}
-              className={cn(
-                shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
-                hasSiftOutputs && "group/sift rounded-md overflow-hidden",
-                hasSiftOutputs &&
-                  shouldUseScrollPassthroughFrame &&
-                  !staticFrameInteractionActive &&
-                  "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
-                hasSiftOutputs && staticFrameInteractionActive && "bg-background",
-              )}
-              style={siftFrameStyle}
-              data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
-              data-sift-output={hasSiftOutputs ? "true" : undefined}
-              tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
-              onPointerDown={
-                shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
-              }
-              onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
-            >
-              <IsolatedFrame
-                ref={frameRef}
-                name={frameName}
-                darkMode={darkMode}
-                colorTheme={colorTheme}
-                minHeight={24}
-                maxHeight={isolatedOutputWellMaxHeight}
-                autoHeight={shouldIsolate && !focused}
-                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
-                scrollPassthrough={shouldScrollPassthroughFrame}
-                onReady={handleIsolatedFrameReady}
-                onLinkClick={onLinkClick}
-                onMouseDown={activateStaticFrameInteraction}
-                onWidgetUpdate={onWidgetUpdate}
-                onMessage={handleIframeMessage}
-                onError={handleIframeError}
-                hostContext={hostContext}
-              />
-              {showSiftInteractionCue && (
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
-                  <SiftScrollHandoffCue
-                    className="pointer-events-auto"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                      activateStaticFrameInteraction();
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      activateStaticFrameInteraction();
-                    }}
-                  />
-                </div>
-              )}
-            </div>
+          {showPreloadedIframe && outputs.length === 0 && (
+            <IsolatedOutputSegment
+              items={[]}
+              hidden
+              cellId={cellId}
+              executionCount={executionCount}
+              focused={focused}
+              frameMaxHeight={outputWellMaxHeight}
+              priority={priority}
+              onLinkClick={onLinkClick}
+              onWidgetUpdate={onWidgetUpdate}
+              searchQuery={searchQuery}
+              onSearchMatchCount={onSearchMatchCount}
+              onIframeMouseDown={onIframeMouseDown}
+              hostContext={hostContext}
+            />
           )}
 
-          {/* In-DOM outputs (when not using isolation) */}
-          {!shouldIsolate && (
-            <div ref={inDomOutputRef}>
-              {outputs.map((output, index) => {
-                // Prefer daemon-stamped output_id for stable React keys so a
-                // stream append doesn't re-mount sibling outputs. Fall back
-                // to positional when a render path skipped the id.
-                const key = output.output_id ?? `output-${index}`;
-                return (
-                  <div key={key} data-slot="output-item" data-output-index={index}>
-                    <ErrorBoundary
-                      resetKeys={[output]}
-                      fallback={(error, reset) => (
-                        <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
-                      )}
-                      onError={(error, errorInfo) => {
-                        console.error(
-                          `[OutputArea] Error rendering output ${index}:`,
-                          error,
-                          errorInfo.componentStack,
-                        );
-                      }}
-                    >
-                      {renderOutput(
-                        output,
-                        index,
-                        renderers,
-                        priority,
-                        resolveTracebackExecutionTarget,
-                        onNavigateToTracebackCell,
-                      )}
-                    </ErrorBoundary>
-                  </div>
-                );
-              })}
-            </div>
+          {segments.map((segment) =>
+            segment.kind === "isolated" ? (
+              <IsolatedOutputSegment
+                key={segment.key}
+                items={segment.items}
+                cellId={cellId}
+                executionCount={executionCount}
+                focused={focused}
+                frameMaxHeight={outputWellMaxHeight}
+                priority={priority}
+                onLinkClick={onLinkClick}
+                onWidgetUpdate={onWidgetUpdate}
+                searchQuery={searchQuery}
+                onSearchMatchCount={onSearchMatchCount}
+                onIframeMouseDown={onIframeMouseDown}
+                hostContext={hostContext}
+              />
+            ) : (
+              <div key={segment.key} data-slot="output-segment" data-output-segment="dom">
+                {segment.items.map(({ output, index }) => {
+                  // Prefer daemon-stamped output_id for stable React keys so a
+                  // stream append doesn't re-mount sibling outputs. Fall back
+                  // to positional when a render path skipped the id.
+                  const key = output.output_id ?? `output-${index}`;
+                  return (
+                    <div key={key} data-slot="output-item" data-output-index={index}>
+                      <ErrorBoundary
+                        resetKeys={[output]}
+                        fallback={(error, reset) => (
+                          <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
+                        )}
+                        onError={(error, errorInfo) => {
+                          console.error(
+                            `[OutputArea] Error rendering output ${index}:`,
+                            error,
+                            errorInfo.componentStack,
+                          );
+                        }}
+                      >
+                        {renderOutput(
+                          output,
+                          index,
+                          renderers,
+                          priority,
+                          resolveTracebackExecutionTarget,
+                          onNavigateToTracebackCell,
+                        )}
+                      </ErrorBoundary>
+                    </div>
+                  );
+                })}
+              </div>
+            ),
           )}
         </div>
       )}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -90,6 +90,68 @@ function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
   ];
 }
 
+function makeStreamThenHtmlOutput(): JupyterOutput[] {
+  return [
+    {
+      output_type: "stream",
+      name: "stdout",
+      text: "stream before\n",
+    },
+    {
+      output_type: "display_data",
+      data: { "text/html": "<b>unsafe html</b>" },
+      metadata: {},
+    },
+  ];
+}
+
+function makeHtmlThenTracebackOutput(): JupyterOutput[] {
+  return [
+    {
+      output_type: "display_data",
+      data: { "text/html": "<b>test</b>" },
+      metadata: {},
+    },
+    {
+      output_type: "error",
+      ename: "RecursionError",
+      evalue: "maximum recursion depth exceeded",
+      traceback: ["RecursionError: maximum recursion depth exceeded"],
+      rich: {
+        ename: "RecursionError",
+        evalue: "maximum recursion depth exceeded",
+        execution: { execution_id: "exec-run", execution_count: 6 },
+        frames: [
+          {
+            filename: "/var/folders/x/T/ipykernel_39879/258099874.py",
+            lineno: 4,
+            name: "<module>",
+            source_ref: {
+              kind: "notebook_execution",
+              execution_id: "exec-run",
+              execution_count: 6,
+              compiled_filename: "/var/folders/x/T/ipykernel_39879/258099874.py",
+            },
+            lines: [{ lineno: 4, source: "f(200)", highlight: true }],
+          },
+          {
+            filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
+            lineno: 4,
+            name: "f",
+            source_ref: {
+              kind: "notebook_execution",
+              execution_id: "exec-def",
+              execution_count: 3,
+              compiled_filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
+            },
+            lines: [{ lineno: 4, source: "return f(n) + f(n - 1)", highlight: true }],
+          },
+        ],
+      },
+    },
+  ];
+}
+
 function makeParquetOutput(): JupyterOutput[] {
   return [
     {
@@ -398,6 +460,54 @@ describe("OutputArea iframe theme sync", () => {
     const outputContent = getOutputContent(container);
     expect(outputContent.getAttribute("class") ?? "").not.toContain("overflow-y-auto");
     expect(outputContent.style.maxHeight).toBe("");
+  });
+
+  it("keeps safe stream outputs in-DOM before an isolated HTML output", async () => {
+    render(<OutputArea outputs={makeStreamThenHtmlOutput()} />);
+
+    expect(screen.getByText("stream before")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/html",
+          data: "<b>unsafe html</b>",
+          outputIndex: 1,
+        }),
+      ]);
+    });
+
+    expect(mockFrameHandle.renderBatch).not.toHaveBeenCalledWith([
+      expect.objectContaining({ data: expect.stringContaining("stream before") }),
+    ]);
+  });
+
+  it("keeps rich tracebacks in-DOM when a sibling output needs isolation", async () => {
+    const onNavigateToTracebackCell = vi.fn();
+
+    render(
+      <OutputArea
+        outputs={makeHtmlThenTracebackOutput()}
+        resolveTracebackExecutionTarget={(executionId) => {
+          if (executionId === "exec-run") return { cellId: "cell-run" };
+          if (executionId === "exec-def") return { cellId: "cell-def" };
+          return null;
+        }}
+        onNavigateToTracebackCell={onNavigateToTracebackCell}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({ mimeType: "text/html", data: "<b>test</b>", outputIndex: 0 }),
+      ]);
+    });
+
+    expect(screen.getByText("RecursionError")).toBeInTheDocument();
+    expect(screen.queryByText("In[6]")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-def" }));
+
+    expect(onNavigateToTracebackCell).toHaveBeenCalledWith({ cellId: "cell-def" });
   });
 
   it("constrains isolated iframe outputs when maxHeight is explicit", () => {

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -39,7 +39,7 @@ const payload = {
       lines: [{ lineno: 5, source: "pd.not_real()", highlight: true }],
     },
   ],
-  text: "Traceback (most recent call last):\n  Line 1 in Current Cell (In[3])\n    g()\n  Line 5 in Earlier Cell (In[2]), in g\n    pd.not_real()\nAttributeError: module 'pandas' has no attribute 'not_real'",
+  text: "Traceback (most recent call last):\n  Line 1 in Current Cell\n    g()\n  Line 5 in Cell cell-def, in g\n    pd.not_real()\nAttributeError: module 'pandas' has no attribute 'not_real'",
   raw_text:
     "Traceback (most recent call last):\n  File \"/var/folders/x/T/ipykernel_39879/258099874.py\", line 1, in <module>\n    g()\n  File \"/var/folders/x/T/ipykernel_39879/3398808089.py\", line 5, in g\n    pd.not_real()\nAttributeError: module 'pandas' has no attribute 'not_real'",
 };
@@ -67,8 +67,9 @@ describe("TracebackOutput", () => {
       <TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTarget} />,
     );
 
-    expect(container.textContent).toContain("Line1inCurrent CellIn[3]");
-    expect(container.textContent).toContain("Line5inCell cell-defIn[2]ing");
+    expect(container.textContent).toContain("Line1inCurrent Cell");
+    expect(container.textContent).toContain("Line5inCell cell-defing");
+    expect(container.textContent).not.toContain("In[");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
   });
 
@@ -99,12 +100,11 @@ describe("TracebackOutput", () => {
 
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain("Line 1 in Current Cell (cell_id=cell-run, execution_id=exec-run)");
     expect(copied).toContain(
-      "Line 1 in Current Cell (cell_id=cell-run, execution_id=exec-run, In[3])",
+      "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def), in g",
     );
-    expect(copied).toContain(
-      "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def, In[2]), in g",
-    );
+    expect(copied).not.toContain("In[");
     expect(copied).not.toContain("/var/folders/x/T/ipykernel_39879");
   });
 });

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -503,7 +503,6 @@ function FrameRow({
 interface SourceLocation {
   kind: "notebook" | "file";
   label: string;
-  executionLabel?: string;
   executionId?: string;
   sourceHash?: string;
   target?: TracebackCellTarget;
@@ -548,11 +547,6 @@ function LocationLabel({
       ) : (
         <span className="truncate text-muted-foreground">{location.label}</span>
       )}
-      {location.executionLabel && (
-        <code className="shrink-0 rounded bg-muted px-1 py-0.5 text-[11px] text-muted-foreground">
-          {location.executionLabel}
-        </code>
-      )}
       {showName && (
         <>
           <span className="shrink-0 text-muted-foreground">in</span>
@@ -573,12 +567,10 @@ function sourceLocation(
 ): SourceLocation {
   const sourceRef = source.source_ref;
   const executionId = sourceRef?.execution_id ?? source.execution_id;
-  const executionCount = sourceRef?.execution_count ?? source.execution_count;
   const sourceHash = sourceRef?.source_hash ?? source.source_hash;
   const compiledFilename = sourceRef?.compiled_filename ?? source.filename;
   const titleParts = [];
   if (executionId) titleParts.push(`Execution: ${executionId}`);
-  if (executionCount !== undefined) titleParts.push(`Input: In[${executionCount}]`);
   if (sourceHash) titleParts.push(`Source: ${sourceHash}`);
   if (compiledFilename) titleParts.push(`Compiled file: ${compiledFilename}`);
 
@@ -592,7 +584,6 @@ function sourceLocation(
     return { kind: "file", label: source.filename || "Unknown source", title };
   }
 
-  const executionLabel = executionCount === undefined ? undefined : `In[${executionCount}]`;
   if (target) {
     const label =
       target.label ??
@@ -600,7 +591,6 @@ function sourceLocation(
     return {
       kind: "notebook",
       label,
-      executionLabel,
       executionId,
       sourceHash,
       target,
@@ -612,7 +602,6 @@ function sourceLocation(
     return {
       kind: "notebook",
       label: "Current Cell",
-      executionLabel,
       executionId,
       sourceHash,
       title,
@@ -623,7 +612,6 @@ function sourceLocation(
     return {
       kind: "notebook",
       label: "Notebook Execution",
-      executionLabel,
       executionId,
       sourceHash,
       title,
@@ -633,7 +621,6 @@ function sourceLocation(
   return {
     kind: "notebook",
     label: "Notebook Cell",
-    executionLabel,
     sourceHash,
     title,
   };
@@ -718,7 +705,6 @@ function copyLocationLine(
   const details = [];
   if (location.target) details.push(`cell_id=${location.target.cellId}`);
   if (location.executionId) details.push(`execution_id=${location.executionId}`);
-  if (location.executionLabel) details.push(location.executionLabel);
   if (location.sourceHash) details.push(`source_hash=${location.sourceHash}`);
   if (details.length > 0) line += ` (${details.join(", ")})`;
   if (name && name !== "<module>") line += `, in ${name}`;


### PR DESCRIPTION
## Summary

- Split `OutputArea` auto-isolation into ordered DOM/iframe output segments, so one HTML or plugin output no longer pulls neighboring safe outputs into the iframe
- Keep rich tracebacks in the notebook DOM for mixed-output cells, preserving cell navigation links and CodeMirror focus behavior
- Remove `In[n]` from rich traceback UI labels and copied/LLM traceback text

## Verification

- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo test -p runtimed-outputs llm_error_uses_rich_traceback_cell_ids_when_available`
- `cargo xtask lint --fix`
- `pnpm notebook:build`
- `cargo clippy -p runtimed-outputs --all-targets -- -D warnings`
