### PR TITLE
fix(notebook-cloud): keep dev auth tokens out of deployed URLs

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -155,7 +155,7 @@ becomes:
 user:dev:alice%40example.com/desktop:local
 ```
 
-For browser-only testing, the same values can be supplied as query params:
+For local browser-only testing, the same values can be supplied as query params:
 
 ```text
 /n/demo/sync?user=alice&operator=desktop:browser&scope=viewer
@@ -163,7 +163,7 @@ For browser-only testing, the same values can be supplied as query params:
 
 `X-Principal` or `principal` may be used to provide a full principal directly. The Worker stamps internal `x-nteract-*` headers before forwarding to the Durable Object, modeling the ADR boundary where the room host trusts an upstream-authenticated identity.
 
-Dev credentials are accepted without an extra token only from Wrangler local development (`localhost`, `127.0.0.1`, `::1`, or `DEPLOYMENT_ENV=development`). Deployed prototype environments require the `NOTEBOOK_CLOUD_DEV_TOKEN` Worker secret to match either the `X-Notebook-Cloud-Dev-Token` header or `dev_token` query parameter. If no scope is supplied, dev auth defaults to `viewer`. Write and publish paths must ask for `editor`, `runtime_peer`, or `owner` explicitly.
+Dev credentials are accepted without an extra token only from Wrangler local development (`localhost`, `127.0.0.1`, `::1`, or `DEPLOYMENT_ENV=development`). Deployed prototype environments require the `NOTEBOOK_CLOUD_DEV_TOKEN` Worker secret to match either the `X-Notebook-Cloud-Dev-Token` header or a WebSocket subprotocol named `nteract-dev-token.<base64url-token>`. URL-carried `dev_token` credentials are rejected on deployed hosts so prototype owner credentials do not appear in URLs. If no scope is supplied, dev auth defaults to `viewer`. Write and publish paths must ask for `editor`, `runtime_peer`, or `owner` explicitly.
 
 Requests with no dev credential become anonymous public viewers. The Worker derives:
 

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -310,12 +310,10 @@ async function connect(notebookId, user, operator, scope) {
   url.searchParams.set("user", user);
   url.searchParams.set("operator", operator);
   url.searchParams.set("scope", scope);
-  if (devAuthToken) {
-    url.searchParams.set("dev_token", devAuthToken);
-  }
-  const safeUrl = redactDevToken(url);
+  const safeUrl = url.href;
+  const protocols = devAuthProtocols();
 
-  const socket = new WebSocket(url);
+  const socket = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
   socket.binaryType = "arraybuffer";
   const queue = [];
   const waiters = [];
@@ -538,10 +536,12 @@ function devAuthHeaders() {
   return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
 }
 
-function redactDevToken(url) {
-  const copy = new URL(url.href);
-  copy.searchParams.delete("dev_token");
-  return copy.href;
+function devAuthProtocols() {
+  return devAuthToken ? [`nteract-dev-token.${base64Url(devAuthToken)}`] : undefined;
+}
+
+function base64Url(value) {
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
+++ b/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
@@ -111,12 +111,10 @@ async function connect(notebookId, user, operator, scope) {
   url.searchParams.set("user", user);
   url.searchParams.set("operator", operator);
   url.searchParams.set("scope", scope);
-  if (devAuthToken) {
-    url.searchParams.set("dev_token", devAuthToken);
-  }
-  const safeUrl = redactDevToken(url);
+  const safeUrl = url.href;
+  const protocols = devAuthProtocols();
 
-  const socket = new WebSocket(url);
+  const socket = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
   socket.binaryType = "arraybuffer";
   const queue = [];
   const waiters = [];
@@ -219,10 +217,12 @@ async function closeClient(client) {
   });
 }
 
-function redactDevToken(url) {
-  const copy = new URL(url.href);
-  copy.searchParams.delete("dev_token");
-  return copy.href;
+function devAuthProtocols() {
+  return devAuthToken ? [`nteract-dev-token.${base64Url(devAuthToken)}`] : undefined;
+}
+
+function base64Url(value) {
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -11,6 +11,7 @@ export interface AuthenticatedConnection {
   operator: string;
   actorLabel: string;
   scope: ConnectionScope;
+  webSocketProtocol?: string;
 }
 
 export interface IdentityEnvironment {
@@ -23,8 +24,9 @@ const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
 export const TRUSTED_PRINCIPAL_HEADER = "x-nteract-principal";
 export const TRUSTED_OPERATOR_HEADER = "x-nteract-operator";
 export const TRUSTED_SCOPE_HEADER = "x-nteract-scope";
+export const TRUSTED_WEBSOCKET_PROTOCOL_HEADER = "x-nteract-websocket-protocol";
 export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";
-export const DEV_AUTH_TOKEN_QUERY = "dev_token";
+export const DEV_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-dev-token.";
 
 export class AuthError extends Error {
   constructor(
@@ -44,11 +46,15 @@ export function authenticateRequest(
     return authenticateAnonymousViewer(request);
   }
 
-  if (!allowsDevCredential(request, env)) {
+  const devCredential = authenticateDevCredential(request, env);
+  if (!devCredential) {
     throw new AuthError("dev credentials require a local request or NOTEBOOK_CLOUD_DEV_TOKEN", 401);
   }
 
-  return authenticateDevRequest(request);
+  const identity = authenticateDevRequest(request);
+  return devCredential.webSocketProtocol
+    ? { ...identity, webSocketProtocol: devCredential.webSocketProtocol }
+    : identity;
 }
 
 export function authenticateDevRequest(request: Request): AuthenticatedConnection {
@@ -100,6 +106,11 @@ export function stampTrustedIdentity(request: Request, identity: AuthenticatedCo
   headers.set(TRUSTED_PRINCIPAL_HEADER, identity.principal);
   headers.set(TRUSTED_OPERATOR_HEADER, identity.operator);
   headers.set(TRUSTED_SCOPE_HEADER, identity.scope);
+  if (identity.webSocketProtocol) {
+    headers.set(TRUSTED_WEBSOCKET_PROTOCOL_HEADER, identity.webSocketProtocol);
+  } else {
+    headers.delete(TRUSTED_WEBSOCKET_PROTOCOL_HEADER);
+  }
   return new Request(request, { headers });
 }
 
@@ -107,6 +118,7 @@ export function readTrustedIdentity(request: Request): AuthenticatedConnection {
   const principal = request.headers.get(TRUSTED_PRINCIPAL_HEADER);
   const operator = request.headers.get(TRUSTED_OPERATOR_HEADER);
   const scope = request.headers.get(TRUSTED_SCOPE_HEADER);
+  const webSocketProtocol = request.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER) ?? undefined;
 
   if (!principal || !operator || !scope) {
     throw new Error("missing trusted identity headers");
@@ -116,12 +128,13 @@ export function readTrustedIdentity(request: Request): AuthenticatedConnection {
   validateOperator(operator);
 
   const parsedScope = parseScope(scope);
-  return {
+  const identity = {
     principal,
     operator,
     actorLabel: `${principal}/${operator}`,
     scope: parsedScope,
   };
+  return webSocketProtocol ? { ...identity, webSocketProtocol } : identity;
 }
 
 export function principalForDevUser(user: string): string {
@@ -252,8 +265,15 @@ function hasDevCredential(request: Request): boolean {
   );
 }
 
-function allowsDevCredential(request: Request, env: IdentityEnvironment): boolean {
-  return isLocalDevRequest(request, env) || hasValidDevToken(request, env);
+function authenticateDevCredential(
+  request: Request,
+  env: IdentityEnvironment,
+): { webSocketProtocol?: string } | undefined {
+  if (isLocalDevRequest(request, env)) {
+    return {};
+  }
+
+  return validDevTokenCredential(request, env);
 }
 
 function isLocalDevRequest(request: Request, env: IdentityEnvironment): boolean {
@@ -265,15 +285,58 @@ function isLocalDevRequest(request: Request, env: IdentityEnvironment): boolean 
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 }
 
-function hasValidDevToken(request: Request, env: IdentityEnvironment): boolean {
+function validDevTokenCredential(
+  request: Request,
+  env: IdentityEnvironment,
+): { webSocketProtocol?: string } | undefined {
   const expected = env.NOTEBOOK_CLOUD_DEV_TOKEN?.trim();
   if (!expected) {
-    return false;
+    return undefined;
   }
 
-  const url = new URL(request.url);
-  const presented = headerOrQuery(request, url, DEV_AUTH_TOKEN_HEADER, DEV_AUTH_TOKEN_QUERY);
-  return timingSafeStringEqual(presented, expected);
+  const headerToken = request.headers.get(DEV_AUTH_TOKEN_HEADER) ?? undefined;
+  if (timingSafeStringEqual(headerToken, expected)) {
+    return {};
+  }
+
+  const webSocketProtocol = tokenFromWebSocketProtocol(
+    request.headers.get("sec-websocket-protocol"),
+  );
+  if (webSocketProtocol && timingSafeStringEqual(webSocketProtocol.token, expected)) {
+    return { webSocketProtocol: webSocketProtocol.protocol };
+  }
+
+  return undefined;
+}
+
+function tokenFromWebSocketProtocol(
+  value: string | null,
+): { protocol: string; token: string } | undefined {
+  if (!value) return undefined;
+
+  for (const protocol of value.split(",")) {
+    const trimmed = protocol.trim();
+    if (!trimmed.startsWith(DEV_AUTH_TOKEN_PROTOCOL_PREFIX)) continue;
+    const token = decodeBase64Url(trimmed.slice(DEV_AUTH_TOKEN_PROTOCOL_PREFIX.length));
+    if (!token) continue;
+    return { protocol: trimmed, token };
+  }
+
+  return undefined;
+}
+
+function decodeBase64Url(value: string): string | undefined {
+  if (value.length === 0) return undefined;
+
+  try {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
 }
 
 function defaultOperator(): string {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -123,6 +123,7 @@ export class NotebookRoom {
 
     return new Response(null, {
       status: 101,
+      headers: webSocketUpgradeHeaders(identity),
       webSocket: client,
     } as ResponseInit & { webSocket: CloudflareWebSocket });
   }
@@ -506,6 +507,14 @@ export function shouldBroadcastFrame(
   identity: AuthenticatedConnection,
 ): boolean {
   return !(frame.type === FrameType.PRESENCE && isAnonymousViewer(identity));
+}
+
+export function webSocketUpgradeHeaders(identity: AuthenticatedConnection): Headers {
+  const headers = new Headers();
+  if (identity.webSocketProtocol) {
+    headers.set("Sec-WebSocket-Protocol", identity.webSocketProtocol);
+  }
+  return headers;
 }
 
 export function rewritePresenceFrame(

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   AuthError,
+  DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   authenticateAnonymousViewer,
   authenticateDevRequest,
   authenticateRequest,
@@ -87,7 +88,7 @@ describe("dev identity", () => {
     assert.equal(identity.scope, "owner");
   });
 
-  it("rejects remote dev credentials unless the prototype admin token matches", () => {
+  it("rejects remote dev credentials unless the prototype admin token is presented out of band", () => {
     const request = new Request(
       "https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner",
     );
@@ -97,14 +98,36 @@ describe("dev identity", () => {
       (error) => error instanceof AuthError && error.status === 401,
     );
 
-    const authenticated = authenticateRequest(
-      new Request(
-        "https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner&dev_token=secret",
-      ),
+    const queryToken = new Request(
+      "https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner&dev_token=secret",
+    );
+    assert.throws(
+      () =>
+        authenticateRequest(queryToken, {
+          DEPLOYMENT_ENV: "prototype",
+          NOTEBOOK_CLOUD_DEV_TOKEN: "secret",
+        }),
+      (error) => error instanceof AuthError && error.status === 401,
+    );
+
+    const devProtocol = `${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url("secret")}`;
+    const websocketProtocolToken = authenticateRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner", {
+        headers: {
+          "Sec-WebSocket-Protocol": devProtocol,
+        },
+      }),
       { DEPLOYMENT_ENV: "prototype", NOTEBOOK_CLOUD_DEV_TOKEN: "secret" },
     );
-    assert.equal(authenticated.actorLabel, "user:dev:alice/desktop:a");
-    assert.equal(authenticated.scope, "owner");
+    assert.equal(websocketProtocolToken.actorLabel, "user:dev:alice/desktop:a");
+    assert.equal(websocketProtocolToken.scope, "owner");
+    assert.equal(websocketProtocolToken.webSocketProtocol, devProtocol);
+    assert.equal(
+      readTrustedIdentity(
+        stampTrustedIdentity(new Request("https://cloud.test/n/demo/sync"), websocketProtocolToken),
+      ).webSocketProtocol,
+      devProtocol,
+    );
   });
 
   it("accepts remote dev token from headers and rejects same-prefix guesses", () => {
@@ -205,3 +228,12 @@ describe("dev identity", () => {
     );
   });
 });
+
+function base64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -2,8 +2,19 @@ import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import type { CloudflareWebSocket, DurableObjectState, Env } from "../src/cloudflare-types.ts";
-import { authenticateAnonymousViewer, authenticateDevRequest } from "../src/identity.ts";
-import { NotebookRoom, rewritePresenceFrame, shouldBroadcastFrame } from "../src/notebook-room.ts";
+import {
+  DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
+  TRUSTED_WEBSOCKET_PROTOCOL_HEADER,
+  authenticateAnonymousViewer,
+  authenticateDevRequest,
+  stampTrustedIdentity,
+} from "../src/identity.ts";
+import {
+  NotebookRoom,
+  rewritePresenceFrame,
+  shouldBroadcastFrame,
+  webSocketUpgradeHeaders,
+} from "../src/notebook-room.ts";
 import {
   FrameType,
   decodeJsonPayload,
@@ -110,6 +121,31 @@ describe("NotebookRoom presence rewrite", () => {
 });
 
 describe("NotebookRoom peer lifecycle", () => {
+  it("echoes the trusted dev auth WebSocket subprotocol in upgrade headers", () => {
+    const webSocketProtocol = `${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url("secret")}`;
+    const identity = {
+      ...authenticateAnonymousViewer(
+        new Request("https://cloud.test/n/demo/sync?viewer_session=anon-a"),
+      ),
+      webSocketProtocol,
+    };
+    const stamped = stampTrustedIdentity(new Request("https://cloud.test/n/demo/sync"), identity);
+
+    assert.equal(
+      webSocketUpgradeHeaders(identity).get("Sec-WebSocket-Protocol"),
+      webSocketProtocol,
+    );
+    assert.equal(
+      webSocketUpgradeHeaders(
+        authenticateAnonymousViewer(
+          new Request("https://cloud.test/n/demo/sync?viewer_session=anon-b"),
+        ),
+      ).has("Sec-WebSocket-Protocol"),
+      false,
+    );
+    assert.equal(stamped.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER), webSocketProtocol);
+  });
+
   it("does not silently resurrect a removed hibernated peer", () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
@@ -250,4 +286,13 @@ class FakeSocket {
   asCloudflareWebSocket(): CloudflareWebSocket {
     return this as unknown as CloudflareWebSocket;
   }
+}
+
+function base64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }


### PR DESCRIPTION
## Summary

- reject `dev_token` query auth on deployed notebook-cloud hosts
- accept deployed WebSocket dev auth through a `nteract-dev-token.<base64url-token>` subprotocol and echo the selected protocol in the upgrade response
- update hosted smoke scripts to keep the prototype dev token out of WebSocket URLs
- document that query-param dev auth is local Wrangler-only

## Why

The prototype dev token gates owner/editor access in deployed notebook-cloud environments. Carrying that token in the URL makes it too easy to leak through browser history, logs, screenshots, and referrers. Headers already cover HTTP publish/upload routes; WebSocket connections need a browser-compatible non-URL carrier, so this uses an explicit dev-auth subprotocol and preserves local query-param convenience for loopback Wrangler testing only.

## Verification

- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`
