### PR TITLE
fix(outputs): resolve dataframe blobs through host URLs

### DIFF
--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -226,6 +226,46 @@ describe("cloud viewer render resolution", () => {
     assert.equal(cell.executionCount, null);
   });
 
+  it("resolves direct Arrow and Parquet blob refs to cloud blob URLs", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_type: "execute_result",
+          execution_count: 1,
+          data: {
+            "application/vnd.apache.arrow.stream": {
+              blob: "sha256:arrow",
+              size: 18744,
+            },
+            "application/vnd.apache.parquet": {
+              blob: "sha256:parquet",
+              size: 4096,
+            },
+            "text/plain": {
+              inline: "shape: (25, 10)",
+            },
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_type, "execute_result");
+    if (outputs[0].output_type === "execute_result") {
+      assert.equal(
+        outputs[0].data["application/vnd.apache.arrow.stream"],
+        "https://cloud.test/blobs/sha256%3Aarrow",
+      );
+      assert.equal(
+        outputs[0].data["application/vnd.apache.parquet"],
+        "https://cloud.test/blobs/sha256%3Aparquet",
+      );
+      assert.equal(outputs[0].data["text/plain"], "shape: (25, 10)");
+    }
+  });
+
   it("keeps an explicit cell execution count over output fallbacks", async () => {
     const cell = await resolveCell(
       {

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -433,6 +433,22 @@ describe("resolveContentRef", () => {
       credentials: "include",
     });
   });
+
+  it.each([
+    ["application/vnd.apache.arrow.stream", "sha256:arrow"],
+    ["application/vnd.apache.parquet", "sha256:parquet"],
+  ])("resolves %s blob refs through the host URL resolver", async (mimeType, blob) => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("should not fetch", { status: 200 }));
+    const resolver = createBlobResolver({
+      url: (ref) => `https://assets.example.test/blobs/${encodeURIComponent(ref.blob)}`,
+      fetchImpl,
+    });
+
+    const result = await resolveContentRef({ blob, size: 128 }, resolver, mimeType);
+
+    expect(result).toBe(`https://assets.example.test/blobs/${encodeURIComponent(blob)}`);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -499,6 +515,32 @@ describe("resolveDataBundle", () => {
         },
       ],
     });
+  });
+
+  it("keeps direct Arrow and Parquet blob refs as host-owned URLs", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("should not fetch", { status: 200 }));
+    const resolver = createBlobResolver({
+      url: (ref) => `https://assets.example.test/blobs/${encodeURIComponent(ref.blob)}`,
+      fetchImpl,
+    });
+
+    const result = await resolveDataBundle(
+      {
+        "application/vnd.apache.arrow.stream": { blob: "sha256:arrow", size: 1024 },
+        "application/vnd.apache.parquet": { blob: "sha256:parquet", size: 2048 },
+        "text/plain": { inline: "shape: (25, 10)" },
+      },
+      resolver,
+    );
+
+    expect(result["application/vnd.apache.arrow.stream"]).toBe(
+      "https://assets.example.test/blobs/sha256%3Aarrow",
+    );
+    expect(result["application/vnd.apache.parquet"]).toBe(
+      "https://assets.example.test/blobs/sha256%3Aparquet",
+    );
+    expect(result["text/plain"]).toBe("shape: (25, 10)");
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("falls back to raw string for invalid JSON in json MIME type", async () => {

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -77,10 +77,17 @@ export type ResolvedJupyterOutput =
       rich?: unknown;
     };
 
+const URL_BACKED_BINARY_MIME_TYPES = new Set([
+  "application/octet-stream",
+  "application/pdf",
+  "application/vnd.apache.arrow.stream",
+  "application/vnd.apache.parquet",
+]);
+
 function looksLikeBinaryMime(mime: string): boolean {
   if (mime.startsWith("image/") && !mime.endsWith("+xml")) return true;
   if (mime.startsWith("audio/") || mime.startsWith("video/")) return true;
-  return mime === "application/pdf" || mime === "application/octet-stream";
+  return URL_BACKED_BINARY_MIME_TYPES.has(mime);
 }
 
 function isContentRef(value: unknown): value is ContentRef {


### PR DESCRIPTION
## Summary

- Treat direct Arrow IPC and Parquet output blob refs as URL-backed binary payloads in the shared output manifest resolver.
- Keep the host-owned `BlobResolver` in charge of the final URL shape for desktop and cloud.
- Add shared and notebook-cloud tests proving direct dataframe blobs resolve to URLs without fetching binary data as text.

## Why

The deployed MathNet notebook currently renders through the Arrow manifest MIME path, which already materializes chunk URLs correctly. This hardens the sibling direct-blob path so cloud-published outputs that only include `application/vnd.apache.arrow.stream` or `application/vnd.apache.parquet` still flow into Sift as fetchable host URLs.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/manifest-resolution.test.ts`
- `pnpm --dir apps/notebook-cloud test -- test/render-resolution.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `cargo xtask lint --fix`
- `git diff --check`
