### PR TITLE
fix(notebook-cloud): derive render caches from snapshots

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -203,7 +203,9 @@ n/{id}/renders/{notebookHeadsHash}.json
 The render path is derived. Snapshot-pair publishes pre-materialize it to prove
 the pair and all referenced blobs are complete before recording a revision. If
 the render object is later missing, the Worker can load the snapshot pair
-through `runtimed-wasm` and regenerate the materialized render response.
+through `runtimed-wasm` and regenerate the materialized render response. Clients
+cannot upload render-cache JSON directly; the Worker only writes render caches
+from persisted snapshot pairs.
 
 ## Prototype deployment
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -438,37 +438,7 @@ async function routeRender(
       : getRenderObject(env, notebookId, headsHash, true);
   }
 
-  if (request.method !== "PUT") {
-    return json({ error: "method not allowed" }, 405);
-  }
-
-  const identity = authenticateRequestOrResponse(request, env);
-  if (identity instanceof Response) {
-    return identity;
-  }
-  if (!allowsPublish(identity.scope)) {
-    return json({ error: `${identity.scope} cannot publish render caches` }, 403);
-  }
-  if (!env.NOTEBOOK_SNAPSHOTS) {
-    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
-  }
-
-  await ensureNotebook(env, notebookId, identity);
-  const key = renderKey(notebookId, headsHash);
-  const body = await request.text();
-  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
-    httpMetadata: {
-      contentType: request.headers.get("content-type") ?? "application/json; charset=utf-8",
-      cacheControl: "public, max-age=31536000, immutable",
-    },
-    customMetadata: {
-      notebook_id: notebookId,
-      notebook_heads_hash: headsHash,
-      artifact: "render-cache",
-    },
-  });
-
-  return json({ ok: true, key, size: body.length }, 201);
+  return json({ error: "method not allowed" }, 405);
 }
 
 async function getRenderObjectOrMaterialize(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -147,10 +147,6 @@ describe("Worker artifact routes", () => {
         error: "viewer cannot publish snapshots",
       },
       {
-        pathname: "/api/n/readonly-demo/renders/heads-viewer",
-        error: "viewer cannot publish render caches",
-      },
-      {
         pathname: "/api/n/readonly-demo/blobs/sha256-viewer",
         error: "viewer cannot upload blobs",
       },
@@ -176,6 +172,23 @@ describe("Worker artifact routes", () => {
 
     assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
     assert.equal(env.DB.revisions.length, 0);
+  });
+
+  it("keeps render caches derived from snapshot pairs instead of accepting uploads", async () => {
+    const env = fakeEnv();
+    const response = await ownerPut(
+      env,
+      "/api/n/readonly-demo/renders/heads-viewer",
+      new TextEncoder().encode(JSON.stringify({ cells: [] })),
+      {
+        "Content-Type": "application/json",
+      },
+    );
+
+    assert.equal(response.status, 405);
+    assert.deepEqual(await response.json(), { error: "method not allowed" });
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
+    assert.equal(env.DB.notebooks.size, 0);
   });
 
   it("keeps explicit dev viewer scope read-only even with a valid dev token", async () => {


### PR DESCRIPTION
## Summary

- remove direct `PUT /api/n/:id/renders/:headsHash` render-cache uploads
- keep render caches generated only from persisted NotebookDoc + RuntimeStateDoc snapshot pairs
- add a Worker route test proving owner render-cache uploads are rejected without touching R2 or D1

## Test Plan

- `pnpm --dir apps/notebook-cloud test -- test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`

