### PR TITLE
fix(outputs): resolve OutputWidget images as blobs

### DIFF
--- a/apps/notebook/e2e/output-widget-image.spec.ts
+++ b/apps/notebook/e2e/output-widget-image.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type Locator } from "@playwright/test";
+import {
+  ensureCodeCell,
+  executeCell,
+  openNotebookRoom,
+  setCellSource,
+  waitForKernelStatus,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test.describe("OutputWidget image outputs", () => {
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("renders and updates image/png emitted by interact", async ({ page }) => {
+    test.setTimeout(180_000);
+
+    const isolatedLogs: string[] = [];
+    page.on("console", (message) => {
+      const text = message.text();
+      if (
+        text.includes("[isolated-frame]") ||
+        text.includes("[isolated-renderer]") ||
+        text.includes("[OutputWidget]") ||
+        text.includes("[OutputArea]")
+      ) {
+        isolatedLogs.push(`[${message.type()}] ${text}`);
+      }
+    });
+
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.manageDependencies(["ipywidgets>=8,<9"]);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const cell = await ensureCodeCell(page);
+    await setCellSource(
+      cell,
+      [
+        "from IPython.display import Image, display",
+        "import ipywidgets as widgets",
+        "import struct",
+        "import zlib",
+        "",
+        "def make_png(value):",
+        "    value = int(value)",
+        "    width = 64 + value * 8",
+        "    height = 64",
+        "    r = 40 + value * 80",
+        "    g = 70 + value * 35",
+        "    b = 210 - value * 60",
+        "    seed = 12345 + value",
+        "    rows = []",
+        "    for _y in range(height):",
+        "        row = bytearray([0])",
+        "        for _x in range(width):",
+        "            seed = (1103515245 * seed + 12345) & 0x7fffffff",
+        "            row.extend([(seed >> 16) & 255, ((seed >> 8) + g) & 255, (seed + b) & 255])",
+        "        rows.append(bytes(row))",
+        "    raw = b''.join(rows)",
+        "",
+        "    def chunk(kind, data):",
+        "        crc = zlib.crc32(kind + data) & 0xFFFFFFFF",
+        "        return struct.pack('>I', len(data)) + kind + data + struct.pack('>I', crc)",
+        "",
+        "    return (",
+        "        b'\\x89PNG\\r\\n\\x1a\\n'",
+        "        + chunk(b'IHDR', struct.pack('>IIBBBBB', width, height, 8, 2, 0, 0, 0))",
+        "        + chunk(b'IDAT', zlib.compress(raw))",
+        "        + chunk(b'IEND', b'')",
+        "    )",
+        "",
+        "@widgets.interact(x=widgets.IntSlider(value=0, min=0, max=2, step=1, description='x'))",
+        "def show_plot(x):",
+        "    display(Image(data=make_png(x), format='png'))",
+      ].join("\n"),
+    );
+
+    await executeCell(cell);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const widgetFrame = cell.frameLocator('[data-slot="isolated-frame"]');
+    const outputImages = widgetFrame.locator('[data-widget-type="Output"] img');
+    await expect(outputImages).toHaveCount(1, { timeout: 60_000 });
+    await expect.poll(() => loadedImageWidth(outputImages.first()), { timeout: 60_000 }).toBe(64);
+    await expect
+      .poll(() => imageSrc(outputImages.first()), { timeout: 60_000 })
+      .toMatch(/^http:\/\/127\.0\.0\.1:\d+\/blob\/[a-f0-9]+$/);
+
+    const slider = widgetFrame.getByRole("slider").first();
+    await expect(slider).toBeVisible({ timeout: 60_000 });
+    await slider.click();
+    await slider.press("ArrowRight");
+
+    await expect(slider).toHaveAttribute("aria-valuenow", "1", { timeout: 30_000 });
+    await expect.poll(() => loadedImageWidth(outputImages.first()), { timeout: 60_000 }).toBe(72);
+    await expect
+      .poll(() => imageSrc(outputImages.first()), { timeout: 60_000 })
+      .toMatch(/^http:\/\/127\.0\.0\.1:\d+\/blob\/[a-f0-9]+$/);
+    await expect(outputImages).toHaveCount(1);
+
+    const logs = isolatedLogs.join("\n");
+    expect(logs).not.toContain("rendered-empty-after-paint");
+    expect(logs).not.toContain("renderer-error");
+    expect(logs).not.toContain("[OutputWidget] Error rendering");
+  });
+});
+
+async function loadedImageWidth(image: Locator): Promise<number> {
+  return await image.evaluate((element) => {
+    const img = element as HTMLImageElement;
+    return img.complete && img.naturalWidth > 0 ? img.naturalWidth : 0;
+  });
+}
+
+async function imageSrc(image: Locator): Promise<string> {
+  return await image.evaluate((element) => {
+    const img = element as HTMLImageElement;
+    return img.currentSrc || img.src;
+  });
+}

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -454,6 +454,39 @@ fn walk_and_resolve_comm_state(
     }
 }
 
+fn path_starts_with_outputs(path: &[String]) -> bool {
+    path.first().map(String::as_str) == Some("outputs")
+}
+
+fn resolve_comm_state_for_frontend(
+    state: &serde_json::Value,
+    port: u16,
+    is_output_model: bool,
+) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
+    let mut buffer_paths: Vec<Vec<String>> = Vec::new();
+    let mut text_paths: Vec<Vec<String>> = Vec::new();
+    let mut resolved = walk_and_resolve_comm_state(
+        state,
+        port,
+        &mut Vec::new(),
+        &mut buffer_paths,
+        &mut text_paths,
+    );
+
+    if is_output_model {
+        // OutputModel.outputs contains notebook output manifests. Those
+        // ContentRefs are resolved by the output-manifest resolver, not by the
+        // ipywidgets binary-traitlet path that fetches URLs into DataViews.
+        if let serde_json::Value::Object(obj) = &mut resolved {
+            obj.remove("outputs");
+        }
+        buffer_paths.retain(|path| !path_starts_with_outputs(path));
+        text_paths.retain(|path| !path_starts_with_outputs(path));
+    }
+
+    (resolved, buffer_paths, text_paths)
+}
+
 #[wasm_bindgen]
 impl NotebookHandle {
     /// Create a new empty notebook document.
@@ -1622,6 +1655,9 @@ impl NotebookHandle {
     ///   string at that path with the decoded content before handing the state
     ///   to widget code. Widgets that consume synced string traits (e.g.
     ///   anywidget `_py_render`) expect the actual content, not a URL.
+    /// - `OutputModel.outputs` is omitted from `state` and from both path
+    ///   lists. Output widget manifests are resolved through the notebook
+    ///   output resolver, not through the widget binary-traitlet protocol.
     ///
     /// Returns undefined if blob_port is not set or comm doesn't exist.
     pub fn resolve_comm_state(&self, comm_id: &str) -> JsValue {
@@ -1633,15 +1669,10 @@ impl NotebookHandle {
             return JsValue::UNDEFINED;
         };
 
-        let mut buffer_paths: Vec<Vec<String>> = Vec::new();
-        let mut text_paths: Vec<Vec<String>> = Vec::new();
-        let resolved = walk_and_resolve_comm_state(
-            &entry.state,
-            port,
-            &mut Vec::new(),
-            &mut buffer_paths,
-            &mut text_paths,
-        );
+        let is_output_model = entry.model_name == "OutputModel"
+            || entry.state.get("_model_name").and_then(|v| v.as_str()) == Some("OutputModel");
+        let (resolved, buffer_paths, text_paths) =
+            resolve_comm_state_for_frontend(&entry.state, port, is_output_model);
 
         serialize_to_js(&serde_json::json!({
             "state": resolved,
@@ -2296,16 +2327,13 @@ mod tests {
     use serde_json::json;
 
     fn resolve(val: serde_json::Value) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
-        let mut buffer_paths: Vec<Vec<String>> = Vec::new();
-        let mut text_paths: Vec<Vec<String>> = Vec::new();
-        let resolved = walk_and_resolve_comm_state(
-            &val,
-            1234,
-            &mut Vec::new(),
-            &mut buffer_paths,
-            &mut text_paths,
-        );
-        (resolved, buffer_paths, text_paths)
+        resolve_comm_state_for_frontend(&val, 1234, false)
+    }
+
+    fn resolve_output_model(
+        val: serde_json::Value,
+    ) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
+        resolve_comm_state_for_frontend(&val, 1234, true)
     }
 
     #[test]
@@ -2328,6 +2356,30 @@ mod tests {
             json!({ "image": "http://127.0.0.1:1234/blob/abc123" })
         );
         assert_eq!(buffer_paths, vec![vec!["image".to_string()]]);
+        assert!(text_paths.is_empty());
+    }
+
+    #[test]
+    fn output_model_outputs_are_not_widget_buffer_paths() {
+        let (resolved, buffer_paths, text_paths) = resolve_output_model(json!({
+            "_model_name": "OutputModel",
+            "outputs": [{
+                "output_type": "display_data",
+                "data": {
+                    "image/png": { "blob": "pnghash", "size": 2048, "media_type": "image/png" },
+                    "text/plain": { "blob": "txthash", "size": 12, "media_type": "text/plain" },
+                },
+                "metadata": {},
+            }],
+            "value": { "blob": "traitlet-bin", "size": 8, "media_type": "application/octet-stream" },
+        }));
+
+        assert!(resolved.as_object().unwrap().get("outputs").is_none());
+        assert_eq!(
+            resolved["value"],
+            json!("http://127.0.0.1:1234/blob/traitlet-bin")
+        );
+        assert_eq!(buffer_paths, vec![vec!["value".to_string()]]);
         assert!(text_paths.is_empty());
     }
 

--- a/packages/runtimed/src/comm-diff.ts
+++ b/packages/runtimed/src/comm-diff.ts
@@ -40,6 +40,9 @@ export interface ResolvedComm {
    * Resolved widget state. Binary blob ContentRefs appear as URL strings;
    * text blob ContentRefs are fetched from the blob server and inlined as
    * their decoded string content. Inline ContentRefs are unwrapped.
+   * For OutputModel widgets, `outputs` is omitted and delivered through
+   * `unresolvedOutputs` so notebook output manifests stay out of widget
+   * binary traitlet resolution.
    */
   state: Record<string, unknown>;
   /** JSON paths where blob URLs replaced binary ContentRef objects (for ArrayBuffer fetch). */


### PR DESCRIPTION
## Summary

- Resolve OutputModel comm state in WASM so `outputs` stays out of widget binary traitlet `buffer_paths` and continues through the notebook output resolver.
- Document the `ResolvedComm.state` contract for OutputModel widgets.
- Add a browser E2E regression for `ipywidgets.interact` emitting a blob-backed `image/png` through an OutputWidget.

Fixes #2857.

## Verification

- `direnv exec . cargo test -p runtimed-wasm output_model_outputs_are_not_widget_buffer_paths`
- `direnv exec . cargo xtask wasm runtimed`
- `direnv exec . env NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- output-widget-image.spec.ts`
- `direnv exec . cargo xtask lint --fix`
