### PR TITLE
fix(notebook-cloud): harden hosted asset routes

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -175,6 +175,9 @@ async function routeAsset(request: Request, env: Env): Promise<Response | null> 
   if (!assetPathname) {
     return null;
   }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return json({ error: "method not allowed" }, 405);
+  }
   if (!env.ASSETS) {
     return json({ error: "viewer assets are not configured" }, 503);
   }
@@ -186,19 +189,37 @@ async function routeAsset(request: Request, env: Env): Promise<Response | null> 
 }
 
 function assetPathnameForRequest(pathname: string): string | null {
-  if (pathname.startsWith("/assets/") || pathname.startsWith("/plugins/")) {
+  if (pathname.startsWith("/assets/")) {
     return pathname;
   }
+  if (pathname.startsWith("/plugins/")) {
+    return pluginAssetPathname(pathname.slice("/plugins/".length));
+  }
   if (pathname.startsWith("/renderer-assets/")) {
-    return `/plugins/${pathname.slice("/renderer-assets/".length)}`;
+    return pluginAssetPathname(pathname.slice("/renderer-assets/".length));
   }
   if (pathname.startsWith("/api/assets/")) {
     return pathname.slice("/api".length);
   }
   if (pathname.startsWith("/api/plugins/")) {
-    return pathname.slice("/api".length);
+    return pluginAssetPathname(pathname.slice("/api/plugins/".length));
   }
   return null;
+}
+
+function pluginAssetPathname(rawName: string): string | null {
+  let name: string;
+  try {
+    name = decodeURIComponent(rawName);
+  } catch {
+    return null;
+  }
+
+  if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\\")) {
+    return null;
+  }
+
+  return `/plugins/${name}`;
 }
 
 async function routeRoomSync(request: Request, env: Env): Promise<Response> {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -99,6 +99,74 @@ describe("Worker artifact routes", () => {
     assert.equal(response.headers.get("Content-Type"), "application/wasm");
   });
 
+  it("supports HEAD requests for Worker-owned renderer sidecars", async () => {
+    const seenRequests: Array<{ method: string; pathname: string }> = [];
+    const env = fakeEnv({
+      ASSETS: {
+        fetch: async (request: Request) => {
+          seenRequests.push({
+            method: request.method,
+            pathname: new URL(request.url).pathname,
+          });
+          return new Response(null, {
+            headers: { "Content-Type": "application/wasm" },
+          });
+        },
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/renderer-assets/sift_wasm.wasm?v=test", { method: "HEAD" }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenRequests, [{ method: "HEAD", pathname: "/plugins/sift_wasm.wasm" }]);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Content-Type"), "application/wasm");
+  });
+
+  it("rejects non-read asset requests before the assets binding", async () => {
+    const env = fakeEnv({
+      ASSETS: {
+        fetch: async () => new Response("should not be reached"),
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/renderer-assets/sift_wasm.wasm", { method: "POST" }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.deepEqual(await response.json(), { error: "method not allowed" });
+  });
+
+  it("rejects traversal-shaped renderer sidecar aliases before asset lookup", async () => {
+    const requests = [
+      "http://localhost/renderer-assets/%2e%2e%2fassets%2fnotebook-cloud-viewer.js",
+      "http://localhost/renderer-assets/nested/sift_wasm.wasm",
+      "http://localhost/plugins/%2e%2e%5csift_wasm.wasm",
+      "http://localhost/api/plugins/nested/sift_wasm.wasm",
+    ];
+
+    for (const request of requests) {
+      const env = fakeEnv({
+        ASSETS: {
+          fetch: async () => new Response("should not be reached"),
+        },
+      });
+
+      const response = await worker.fetch(new Request(request), env, fakeContext());
+
+      assert.equal(response.status, 404, request);
+      assert.deepEqual(await response.json(), { error: "not found" }, request);
+    }
+  });
+
   it("keeps the api plugin path as a compatibility alias for older viewers", async () => {
     const seenPaths: string[] = [];
     const env = fakeEnv({


### PR DESCRIPTION
## Summary

- restrict notebook-cloud asset routes to `GET`/`HEAD` before the Worker assets binding is reached
- keep viewer bundle assets under `/assets`, but make plugin and renderer sidecar aliases filename-only
- add route tests for hosted sidecar `HEAD`, non-read rejection, and traversal-shaped alias rejection

## Why

The hosted viewer serves renderer sidecar assets through Worker-owned routes so sandboxed iframes can fetch them with explicit CORS. Those routes should not accept write-like methods or pass traversal-shaped plugin paths into the generic asset binding. This keeps the main Worker aligned with the dedicated renderer asset Worker while preserving the existing `/plugins`, `/api/plugins`, and `/renderer-assets` compatibility aliases for single-file sidecars.

## Verification

- `pnpm --dir apps/notebook-cloud test -- test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`
