### PR TITLE
fix(outputs): keep mixed isolated renders unsplit

### DIFF
--- a/apps/notebook/e2e/isolated-rich-output.spec.ts
+++ b/apps/notebook/e2e/isolated-rich-output.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "./helpers";
 
 test.describe("isolated rich output rendering", () => {
-  test("keeps stream text visible outside the iframe when a pandas dataframe is isolated", async ({
+  test("keeps stream text visible when a pandas dataframe renders in the iframe", async ({
     page,
   }) => {
     test.setTimeout(180_000);
@@ -43,16 +43,12 @@ test.describe("isolated rich output rendering", () => {
     await executeCell(cell);
     await waitForKernelStatus(page, "idle", 120_000);
 
-    await expect(cell.locator('[data-slot="ansi-stream-output"]')).toContainText("stream before", {
-      timeout: 60_000,
-    });
-
     const frame = cell.frameLocator('[data-slot="isolated-frame"]');
     const frameBody = frame.locator("body");
+    await expect(frameBody).toContainText("stream before", { timeout: 60_000 });
     await expect
       .poll(async () => normalizeOutputText(await frameBody.innerText()), { timeout: 60_000 })
       .toMatch(/a\s*#\s*1|b\s*#\s*3|a b 0 1 3 1 2 4/i);
-    await expect(frameBody).not.toContainText("stream before");
     await expect.poll(() => isolatedRootHeight(cell), { timeout: 30_000 }).toBeGreaterThan(20);
 
     expect(isolatedLogs.join("\n")).not.toContain("rendered-empty-after-paint");

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -16,16 +16,18 @@ import {
   type IframeToParentMessage,
   IsolatedFrame,
   type IsolatedFrameHandle,
+  type RenderPayload,
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
-import { jupyterOutputToRenderPayload } from "@/components/isolated/output-payloads";
+import { jupyterOutputsToRenderPayloads } from "@/components/isolated/output-payloads";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
 import { selectMimeType } from "@/components/outputs/mime-priority";
 import {
   TracebackOutput,
+  type TracebackCellTarget,
   type TracebackCellNavigator,
   type TracebackExecutionResolver,
 } from "@/components/outputs/traceback-output";
@@ -288,37 +290,19 @@ function outputNeedsIsolation(
   return false;
 }
 
-interface IndexedOutput {
-  output: JupyterOutput;
-  index: number;
-}
-
-interface OutputSegment {
-  kind: "dom" | "isolated";
-  items: IndexedOutput[];
-  key: string;
-}
-
-function splitOutputSegments(
+/**
+ * Check if any outputs in the array need iframe isolation.
+ * If any output needs isolation, ALL outputs should go to the iframe.
+ *
+ * Not exported: keeping every `.tsx` export limited to components and
+ * hooks lets React Fast Refresh hot-patch this module instead of bailing
+ * to a full reload on every edit.
+ */
+function anyOutputNeedsIsolation(
   outputs: JupyterOutput[],
-  isolated: OutputAreaProps["isolated"],
   priority: readonly string[] = DEFAULT_PRIORITY,
-): OutputSegment[] {
-  const forceKind = isolated === true ? "isolated" : isolated === false ? "dom" : null;
-  const segments: OutputSegment[] = [];
-
-  for (let index = 0; index < outputs.length; index++) {
-    const output = outputs[index]!;
-    const kind = forceKind ?? (outputNeedsIsolation(output, priority) ? "isolated" : "dom");
-    const last = segments[segments.length - 1];
-    if (last?.kind === kind) {
-      last.items.push({ output, index });
-    } else {
-      segments.push({ kind, items: [{ output, index }], key: `${kind}-${index}` });
-    }
-  }
-
-  return segments;
+): boolean {
+  return outputs.some((output) => outputNeedsIsolation(output, priority));
 }
 
 /**
@@ -398,323 +382,76 @@ function renderOutput(
   }
 }
 
-interface IsolatedOutputSegmentProps {
-  items: IndexedOutput[];
-  hidden?: boolean;
-  cellId?: string;
-  executionCount?: number | null;
-  focused: boolean;
-  frameMaxHeight: number;
-  priority: readonly string[];
-  onLinkClick?: OutputAreaProps["onLinkClick"];
-  onWidgetUpdate?: OutputAreaProps["onWidgetUpdate"];
-  searchQuery?: string;
-  onSearchMatchCount?: OutputAreaProps["onSearchMatchCount"];
-  onIframeMouseDown?: OutputAreaProps["onIframeMouseDown"];
-  hostContext?: OutputAreaProps["hostContext"];
+interface TracebackExecutionTargetEntry {
+  execution_id: string;
+  source_hash?: string;
+  target: TracebackCellTarget;
 }
 
-function IsolatedOutputSegment({
-  items,
-  hidden = false,
-  cellId,
-  executionCount,
-  focused,
-  frameMaxHeight,
-  priority,
-  onLinkClick,
-  onWidgetUpdate,
-  searchQuery,
-  onSearchMatchCount,
-  onIframeMouseDown,
-  hostContext,
-}: IsolatedOutputSegmentProps) {
-  const outputs = useMemo(() => items.map((item) => item.output), [items]);
-  const frameRef = useRef<IsolatedFrameHandle>(null);
-  const bridgeRef = useRef<CommBridgeManager | null>(null);
-  const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
-  const injectedLibsRef = useRef(new Set<string>());
-  const renderGenRef = useRef(0);
-  const searchQueryRef = useRef(searchQuery);
-  searchQueryRef.current = searchQuery;
-  const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
 
-  const darkMode = useDarkMode();
-  const colorTheme = useColorTheme();
-  const darkModeRef = useRef(darkMode);
-  darkModeRef.current = darkMode;
-  const colorThemeRef = useRef(colorTheme);
-  colorThemeRef.current = colorTheme;
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
-  const widgetContext = useWidgetStore();
-  const hasWidgets = hasWidgetOutputs(outputs, priority);
-  const hasSiftOutputs = outputs.some((output) => outputUsesSift(output, priority));
-  const shouldUseBridge = !hidden && hasWidgets && widgetContext !== null;
-  const shouldUseScrollPassthroughFrame =
-    !hidden &&
-    !focused &&
-    !hasWidgets &&
-    outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
-  const shouldScrollPassthroughFrame =
-    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const allowWheelBoundaryScroll =
-    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
-  const showSiftInteractionCue =
-    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
-  const siftFrameStyle = hasSiftOutputs
-    ? ({
-        "--notebook-sift-focus": siftFrameAccent,
-        "--notebook-sift-focus-hover": `${siftFrameAccent}66`,
-        boxShadow: staticFrameInteractionActive
-          ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
-          : undefined,
-      } as React.CSSProperties)
-    : undefined;
+function collectTracebackExecutionTargets(
+  data: unknown,
+  resolveExecutionTarget?: TracebackExecutionResolver,
+): TracebackExecutionTargetEntry[] {
+  if (!resolveExecutionTarget) return [];
 
-  const firstOutputIndex = items[0]?.index;
-  const frameName = cellId
-    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}${
-        firstOutputIndex == null ? "" : `-${firstOutputIndex}`
-      }`
-    : undefined;
+  const payload = objectRecord(data);
+  if (!payload) return [];
 
-  useEffect(() => {
-    if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
-      setStaticFrameInteractionActive(false);
+  const entries: TracebackExecutionTargetEntry[] = [];
+  const seen = new Set<string>();
+
+  const addSource = (source: unknown) => {
+    const record = objectRecord(source);
+    if (!record) return;
+
+    const sourceRef = objectRecord(record.source_ref);
+    const executionId = stringField(sourceRef?.execution_id) ?? stringField(record.execution_id);
+    if (!executionId) return;
+
+    const sourceHash = stringField(sourceRef?.source_hash) ?? stringField(record.source_hash);
+    const key = `${executionId}\u0000${sourceHash ?? ""}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    const target = resolveExecutionTarget(executionId, sourceHash);
+    if (target) {
+      entries.push({ execution_id: executionId, source_hash: sourceHash, target });
     }
-  }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
+  };
 
-  useEffect(() => {
-    if (!hasSiftOutputs) return;
-    frameRef.current?.send({
-      type: "interaction_state",
-      payload: { active: staticFrameInteractionActive },
-    });
-  }, [hasSiftOutputs, staticFrameInteractionActive]);
+  addSource(payload.syntax);
+  const frames = payload.frames;
+  if (Array.isArray(frames)) {
+    frames.forEach(addSource);
+  }
 
-  useEffect(() => {
-    if (!staticFrameInteractionActive) return;
+  return entries;
+}
 
-    const handlePointerDown = (event: globalThis.PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
-        return;
-      }
-      setStaticFrameInteractionActive(false);
-    };
+function withTracebackExecutionTargets(
+  payload: RenderPayload,
+  resolveExecutionTarget?: TracebackExecutionResolver,
+): RenderPayload {
+  if (payload.mimeType !== "application/vnd.nteract.traceback+json") return payload;
 
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [staticFrameInteractionActive]);
+  const targets = collectTracebackExecutionTargets(payload.data, resolveExecutionTarget);
+  if (targets.length === 0) return payload;
 
-  const activateStaticFrameInteraction = useCallback(() => {
-    if (shouldUseScrollPassthroughFrame) {
-      if (!staticFrameInteractionActive && hasSiftOutputs) {
-        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
-      }
-      setStaticFrameInteractionActive(true);
-      staticFrameInteractionRef.current?.focus({ preventScroll: true });
-    }
-    onIframeMouseDown?.();
-  }, [
-    hasSiftOutputs,
-    shouldUseScrollPassthroughFrame,
-    staticFrameInteractionActive,
-    onIframeMouseDown,
-  ]);
-
-  const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Escape") {
-      setStaticFrameInteractionActive(false);
-    }
-  }, []);
-
-  const handleIframeMessage = useCallback(
-    (message: IframeToParentMessage) => {
-      if (bridgeRef.current) {
-        bridgeRef.current.handleIframeMessage(message);
-      }
-
-      if (message.type === "widget_update" && onWidgetUpdate) {
-        onWidgetUpdate(message.payload.commId, message.payload.state);
-      }
-
-      if (message.type === "search_results") {
-        onSearchMatchCount?.(message.payload.count);
-      }
+  return {
+    ...payload,
+    metadata: {
+      ...payload.metadata,
+      tracebackExecutionTargets: targets,
     },
-    [onWidgetUpdate, onSearchMatchCount],
-  );
-
-  const handleFrameReady = useCallback(
-    async (options: { resetInjectedPlugins?: boolean } = {}) => {
-      if (!frameRef.current) return;
-      const gen = ++renderGenRef.current;
-
-      if (shouldUseBridge && widgetContext && !bridgeRef.current) {
-        bridgeRef.current = new CommBridgeManager({
-          frame: frameRef.current,
-          store: widgetContext.store,
-          sendUpdate: widgetContext.sendUpdate,
-          sendCustom: widgetContext.sendCustom,
-          closeComm: widgetContext.closeComm,
-        });
-      }
-
-      frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
-
-      if (options.resetInjectedPlugins) {
-        injectedLibsRef.current.clear();
-      }
-      const pluginMimes = new Set<string>();
-      for (const output of outputs) {
-        if (output.output_type === "execute_result" || output.output_type === "display_data") {
-          for (const mime of Object.keys(output.data)) {
-            if (needsPlugin(mime)) pluginMimes.add(mime);
-          }
-        }
-      }
-
-      if (widgetContext?.store) {
-        for (const output of outputs) {
-          if (
-            (output.output_type === "execute_result" || output.output_type === "display_data") &&
-            output.data?.["application/vnd.jupyter.widget-view+json"]
-          ) {
-            const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
-              model_id?: string;
-            };
-            if (widgetData?.model_id) {
-              const model = widgetContext.store.getModel(widgetData.model_id);
-              if (model?.modelName === "OutputModel" && model.state.outputs) {
-                const widgetOutputs = model.state.outputs as Array<{
-                  output_type: string;
-                  data?: Record<string, unknown>;
-                }>;
-                for (const widgetOutput of widgetOutputs) {
-                  for (const mime of Object.keys(widgetOutput.data ?? {})) {
-                    if (needsPlugin(mime)) pluginMimes.add(mime);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      if (pluginMimes.size > 0) {
-        try {
-          await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
-        } catch (error) {
-          if (gen !== renderGenRef.current) return;
-          console.error("[OutputArea] Failed to load renderer plugin:", error);
-          frameRef.current.renderBatch([
-            {
-              mimeType: "text/plain",
-              data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
-              metadata: { isError: true },
-              cellId,
-              outputIndex: firstOutputIndex ?? 0,
-            },
-          ]);
-          return;
-        }
-        if (gen !== renderGenRef.current) return;
-      }
-
-      const batch = items.flatMap((item) => {
-        const payload = jupyterOutputToRenderPayload(item.output, item.index, { cellId, priority });
-        return payload ? [payload] : [];
-      });
-      frameRef.current.renderBatch(batch);
-
-      if (searchQueryRef.current) {
-        frameRef.current.search(searchQueryRef.current);
-      }
-    },
-    [cellId, firstOutputIndex, items, outputs, priority, shouldUseBridge, widgetContext],
-  );
-
-  const handleIsolatedFrameReady = useCallback(() => {
-    void handleFrameReady({ resetInjectedPlugins: true });
-  }, [handleFrameReady]);
-
-  useEffect(() => {
-    return () => {
-      if (bridgeRef.current) {
-        bridgeRef.current.dispose();
-        bridgeRef.current = null;
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (frameRef.current?.isReady) {
-      handleFrameReady();
-    }
-  }, [handleFrameReady]);
-
-  useEffect(() => {
-    if (frameRef.current?.isIframeReady) {
-      frameRef.current.search(searchQuery || "");
-    }
-  }, [searchQuery]);
-
-  return (
-    <div
-      ref={staticFrameInteractionRef}
-      className={cn(
-        hidden ? "hidden" : "relative outline-none transition-shadow",
-        hasSiftOutputs && "group/sift rounded-md overflow-hidden",
-        hasSiftOutputs &&
-          shouldUseScrollPassthroughFrame &&
-          !staticFrameInteractionActive &&
-          "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
-        hasSiftOutputs && staticFrameInteractionActive && "bg-background",
-      )}
-      style={siftFrameStyle}
-      data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
-      data-sift-output={hasSiftOutputs ? "true" : undefined}
-      tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
-      onPointerDown={shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined}
-      onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
-    >
-      <IsolatedFrame
-        ref={frameRef}
-        name={frameName}
-        darkMode={darkMode}
-        colorTheme={colorTheme}
-        minHeight={24}
-        maxHeight={frameMaxHeight}
-        autoHeight={!hidden && !focused}
-        allowWheelBoundaryScroll={allowWheelBoundaryScroll}
-        scrollPassthrough={shouldScrollPassthroughFrame}
-        onReady={handleIsolatedFrameReady}
-        onLinkClick={onLinkClick}
-        onMouseDown={activateStaticFrameInteraction}
-        onWidgetUpdate={onWidgetUpdate}
-        onMessage={handleIframeMessage}
-        onError={handleIframeError}
-        hostContext={hostContext}
-      />
-      {showSiftInteractionCue && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
-          <SiftScrollHandoffCue
-            className="pointer-events-auto"
-            onPointerDown={(event) => {
-              event.stopPropagation();
-              activateStaticFrameInteraction();
-            }}
-            onClick={(event) => {
-              event.stopPropagation();
-              activateStaticFrameInteraction();
-            }}
-          />
-        </div>
-      )}
-    </div>
-  );
+  };
 }
 
 /**
@@ -758,35 +495,307 @@ export function OutputArea({
   onNavigateToTracebackCell,
 }: OutputAreaProps) {
   const id = useId();
+  const frameRef = useRef<IsolatedFrameHandle>(null);
+  const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
+  const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
+  const injectedLibsRef = useRef(new Set<string>());
+  const renderGenRef = useRef(0);
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+  const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
+
+  const darkMode = useDarkMode();
+  const colorTheme = useColorTheme();
   const focusedOutputWellMaxHeight = useOutputWellMaxHeight(FOCUSED_OUTPUT_WELL_VIEWPORT_RATIO);
-  const segments = useMemo(
-    () => splitOutputSegments(outputs, isolated, priority),
-    [outputs, isolated, priority],
-  );
-  const hasIsolatedSegments = segments.some((segment) => segment.kind === "isolated");
-  const shouldConstrainOutputArea = hasIsolatedSegments && (focused || maxHeight != null);
-  const outputWellMaxHeight = focused
+  const inDomMaxHeight = useOutputWell ? (maxHeight ?? null) : null;
+  const maxHeightStyle = useMemo<React.CSSProperties | undefined>(() => {
+    if (!inDomMaxHeight) return undefined;
+    return { maxHeight: `${inDomMaxHeight}px` };
+  }, [inDomMaxHeight]);
+  // Ref for reading current darkMode in callbacks without adding to deps
+  const darkModeRef = useRef(darkMode);
+  darkModeRef.current = darkMode;
+  const colorThemeRef = useRef(colorTheme);
+  colorThemeRef.current = colorTheme;
+
+  // Get widget store context (may be null if not in provider)
+  const widgetContext = useWidgetStore();
+
+  // Determine if we should use isolation (when we have outputs)
+  const shouldIsolate =
+    outputs.length > 0 &&
+    (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
+  const shouldConstrainIsolatedOutput = shouldIsolate && (focused || maxHeight != null);
+  const isolatedOutputWellMaxHeight = focused
     ? focusedOutputWellMaxHeight
     : (maxHeight ?? focusedOutputWellMaxHeight);
-  const inDomMaxHeight = useOutputWell ? (maxHeight ?? null) : null;
-  const outputWellStyle = shouldConstrainOutputArea
+  const isolatedOutputWellStyle = shouldConstrainIsolatedOutput
     ? {
-        maxHeight: `${outputWellMaxHeight}px`,
+        maxHeight: `${isolatedOutputWellMaxHeight}px`,
         ...(focused ? { minHeight: `${MIN_OUTPUT_WELL_HEIGHT}px` } : {}),
       }
-    : inDomMaxHeight !== null
-      ? { maxHeight: `${inDomMaxHeight}px` }
-      : undefined;
+    : undefined;
 
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
+
+  // Frame name for dev-tools picker. `code-Out[N]-{cellId}` mirrors the
+  // Jupyter `Out[N]` convention with the cell ID appended so the picker can
+  // distinguish reruns and concurrent cells. `*` matches Jupyter's queued /
+  // never-run indicator.
+  const frameName = cellId
+    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}`
+    : undefined;
+
+  // Check if we have widgets and should set up comm bridge
+  const hasWidgets = hasWidgetOutputs(outputs, priority);
+  const hasSiftOutputs = outputs.some((output) => outputUsesSift(output, priority));
+  const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
+  const shouldUseScrollPassthroughFrame =
+    shouldIsolate &&
+    !focused &&
+    !hasWidgets &&
+    outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
+  const shouldScrollPassthroughFrame =
+    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const allowWheelBoundaryScroll =
+    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
+  const showSiftInteractionCue =
+    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+  const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
+  const siftFrameStyle = hasSiftOutputs
+    ? ({
+        "--notebook-sift-focus": siftFrameAccent,
+        "--notebook-sift-focus-hover": `${siftFrameAccent}66`,
+        boxShadow: staticFrameInteractionActive
+          ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
+          : undefined,
+      } as React.CSSProperties)
+    : undefined;
+
   const hasCollapseControl = onToggleCollapse !== undefined;
+
+  useEffect(() => {
+    if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
+      setStaticFrameInteractionActive(false);
+    }
+  }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!hasSiftOutputs) return;
+    frameRef.current?.send({
+      type: "interaction_state",
+      payload: { active: staticFrameInteractionActive },
+    });
+  }, [hasSiftOutputs, staticFrameInteractionActive]);
+
+  useEffect(() => {
+    if (!staticFrameInteractionActive) return;
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
+        return;
+      }
+      setStaticFrameInteractionActive(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [staticFrameInteractionActive]);
+
+  const activateStaticFrameInteraction = useCallback(() => {
+    if (shouldUseScrollPassthroughFrame) {
+      if (!staticFrameInteractionActive && hasSiftOutputs) {
+        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
+      }
+      setStaticFrameInteractionActive(true);
+      // Move DOM focus off CodeMirror without scrolling; this wrapper owns
+      // focus until iframe pointer interaction is active.
+      staticFrameInteractionRef.current?.focus({ preventScroll: true });
+    }
+    onIframeMouseDown?.();
+  }, [
+    hasSiftOutputs,
+    shouldUseScrollPassthroughFrame,
+    staticFrameInteractionActive,
+    onIframeMouseDown,
+  ]);
+
+  const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      setStaticFrameInteractionActive(false);
+    }
+  }, []);
+
+  // Handle messages from iframe, routing widget messages to comm bridge
+  const handleIframeMessage = useCallback(
+    (message: IframeToParentMessage) => {
+      // Route widget messages to bridge
+      if (bridgeRef.current) {
+        bridgeRef.current.handleIframeMessage(message);
+      }
+
+      // Also handle widget_update for backward compatibility
+      if (message.type === "widget_update" && onWidgetUpdate) {
+        onWidgetUpdate(message.payload.commId, message.payload.state);
+      }
+
+      // Capture search result count from iframe
+      if (message.type === "search_results") {
+        onSearchMatchCount?.(message.payload.count);
+      }
+
+      if (message.type === "traceback_navigate") {
+        onNavigateToTracebackCell?.(message.payload.target);
+      }
+    },
+    [onWidgetUpdate, onSearchMatchCount, onNavigateToTracebackCell],
+  );
+
+  // Callback when frame is ready - set up bridge and render outputs
+  const handleFrameReady = useCallback(
+    async (options: { resetInjectedPlugins?: boolean } = {}) => {
+      if (!frameRef.current) return;
+
+      // Bump generation so any in-flight async handleFrameReady from a
+      // previous outputs snapshot will bail out after it awaits.
+      const gen = ++renderGenRef.current;
+
+      // Set up comm bridge if we have widgets and widget context
+      if (shouldUseBridge && widgetContext && !bridgeRef.current) {
+        bridgeRef.current = new CommBridgeManager({
+          frame: frameRef.current,
+          store: widgetContext.store,
+          sendUpdate: widgetContext.sendUpdate,
+          sendCustom: widgetContext.sendCustom,
+          closeComm: widgetContext.closeComm,
+        });
+      }
+
+      // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
+      // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
+      frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
+
+      // Install renderer plugins required by the outputs (e.g. plotly, vega).
+      // Must happen before clear+render so the installRenderer messages arrive first.
+      if (options.resetInjectedPlugins) {
+        injectedLibsRef.current.clear();
+      }
+
+      // Collect MIME types that need renderer plugins from the cell's outputs
+      const pluginMimes = new Set<string>();
+      for (const output of outputs) {
+        if (output.output_type === "execute_result" || output.output_type === "display_data") {
+          for (const mime of Object.keys(output.data)) {
+            if (needsPlugin(mime)) pluginMimes.add(mime);
+          }
+        }
+      }
+
+      // Also scan output widgets for captured outputs that need plugins.
+      // A cell may output a widget view (application/vnd.jupyter.widget-view+json)
+      // whose OutputModel.outputs contain plotly/vega/etc MIME types.
+      if (widgetContext?.store) {
+        for (const output of outputs) {
+          if (
+            (output.output_type === "execute_result" || output.output_type === "display_data") &&
+            output.data?.["application/vnd.jupyter.widget-view+json"]
+          ) {
+            const widgetData = output.data["application/vnd.jupyter.widget-view+json"] as {
+              model_id?: string;
+            };
+            if (widgetData?.model_id) {
+              const model = widgetContext.store.getModel(widgetData.model_id);
+              if (model?.modelName === "OutputModel" && model.state.outputs) {
+                const widgetOutputs = model.state.outputs as Array<{
+                  output_type: string;
+                  data?: Record<string, unknown>;
+                }>;
+                for (const wo of widgetOutputs) {
+                  for (const mime of Object.keys(wo.data ?? {})) {
+                    if (needsPlugin(mime)) pluginMimes.add(mime);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (pluginMimes.size > 0) {
+        try {
+          await injectPluginsForMimes(frameRef.current, pluginMimes, injectedLibsRef.current);
+        } catch (error) {
+          if (gen !== renderGenRef.current) return;
+          console.error("[OutputArea] Failed to load renderer plugin:", error);
+          frameRef.current.renderBatch([
+            {
+              mimeType: "text/plain",
+              data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
+              metadata: { isError: true },
+              cellId,
+              outputIndex: 0,
+            },
+          ]);
+          return;
+        }
+        // Stale check: if outputs changed while we were loading the plugin,
+        // bail — a newer handleFrameReady call is already in flight.
+        if (gen !== renderGenRef.current) return;
+      }
+
+      // Build batch of render payloads and send atomically.
+      // This avoids the clear+re-render cycle that causes DOM thrashing
+      // (visible as flickering when interactive widgets update rapidly).
+      const batch = jupyterOutputsToRenderPayloads(outputs, { cellId, priority }).map((payload) =>
+        withTracebackExecutionTargets(payload, resolveTracebackExecutionTarget),
+      );
+
+      frameRef.current.renderBatch(batch);
+
+      // Re-apply search highlights after rendering new content
+      if (searchQueryRef.current) {
+        frameRef.current?.search(searchQueryRef.current);
+      }
+    },
+    [cellId, outputs, priority, resolveTracebackExecutionTarget, shouldUseBridge, widgetContext],
+  );
+
+  const handleIsolatedFrameReady = useCallback(() => {
+    void handleFrameReady({ resetInjectedPlugins: true });
+  }, [handleFrameReady]);
+
+  // Clean up bridge on unmount
+  useEffect(() => {
+    return () => {
+      if (bridgeRef.current) {
+        bridgeRef.current.dispose();
+        bridgeRef.current = null;
+      }
+    };
+  }, []);
+
+  // Re-render outputs when they change (after initial ready)
+  useEffect(() => {
+    if (frameRef.current?.isReady) {
+      handleFrameReady();
+    }
+  }, [handleFrameReady]);
+
+  // Forward search query to the iframe (for isolated outputs)
+  useEffect(() => {
+    if (frameRef.current?.isIframeReady) {
+      frameRef.current.search(searchQuery || "");
+    }
+  }, [searchQuery]);
 
   // Highlight search matches in in-DOM outputs
   // Re-run when outputs array ref changes so new content gets highlighted
   useEffect(() => {
+    if (shouldIsolate) return; // iframe reports its own count via search_results
     if (!searchQuery || !inDomOutputRef.current || outputs.length === 0) {
       // Only report 0 if we were previously tracking matches for this cell
       if (searchQuery) onSearchMatchCount?.(0);
@@ -796,7 +805,7 @@ export function OutputArea({
     const count = inDomOutputRef.current.querySelectorAll(".global-find-match").length;
     onSearchMatchCount?.(count);
     return cleanup;
-  }, [searchQuery, outputs, onSearchMatchCount]);
+  }, [searchQuery, shouldIsolate, outputs, onSearchMatchCount]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -836,86 +845,108 @@ export function OutputArea({
       {/* Output content */}
       {!collapsed && (
         <div
-          ref={inDomOutputRef}
           id={id}
           className={cn(
             "space-y-2",
-            inDomMaxHeight !== null && "overflow-y-auto",
-            shouldConstrainOutputArea && "overflow-y-auto",
+            !shouldIsolate && inDomMaxHeight !== null && "overflow-y-auto",
+            shouldConstrainIsolatedOutput && "overflow-y-auto",
           )}
-          style={outputWellStyle}
+          style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
         >
-          {showPreloadedIframe && outputs.length === 0 && (
-            <IsolatedOutputSegment
-              items={[]}
-              hidden
-              cellId={cellId}
-              executionCount={executionCount}
-              focused={focused}
-              frameMaxHeight={outputWellMaxHeight}
-              priority={priority}
-              onLinkClick={onLinkClick}
-              onWidgetUpdate={onWidgetUpdate}
-              searchQuery={searchQuery}
-              onSearchMatchCount={onSearchMatchCount}
-              onIframeMouseDown={onIframeMouseDown}
-              hostContext={hostContext}
-            />
-          )}
-
-          {segments.map((segment) =>
-            segment.kind === "isolated" ? (
-              <IsolatedOutputSegment
-                key={segment.key}
-                items={segment.items}
-                cellId={cellId}
-                executionCount={executionCount}
-                focused={focused}
-                frameMaxHeight={outputWellMaxHeight}
-                priority={priority}
+          {/* Preloaded or active isolated frame */}
+          {(shouldIsolate || showPreloadedIframe) && (
+            <div
+              ref={staticFrameInteractionRef}
+              className={cn(
+                shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
+                hasSiftOutputs && "group/sift rounded-md overflow-hidden",
+                hasSiftOutputs &&
+                  shouldUseScrollPassthroughFrame &&
+                  !staticFrameInteractionActive &&
+                  "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
+                hasSiftOutputs && staticFrameInteractionActive && "bg-background",
+              )}
+              style={siftFrameStyle}
+              data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
+              data-sift-output={hasSiftOutputs ? "true" : undefined}
+              tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
+              onPointerDown={
+                shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
+              }
+              onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
+            >
+              <IsolatedFrame
+                ref={frameRef}
+                name={frameName}
+                darkMode={darkMode}
+                colorTheme={colorTheme}
+                minHeight={24}
+                maxHeight={isolatedOutputWellMaxHeight}
+                autoHeight={shouldIsolate && !focused}
+                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+                scrollPassthrough={shouldScrollPassthroughFrame}
+                onReady={handleIsolatedFrameReady}
                 onLinkClick={onLinkClick}
+                onMouseDown={activateStaticFrameInteraction}
                 onWidgetUpdate={onWidgetUpdate}
-                searchQuery={searchQuery}
-                onSearchMatchCount={onSearchMatchCount}
-                onIframeMouseDown={onIframeMouseDown}
+                onMessage={handleIframeMessage}
+                onError={handleIframeError}
                 hostContext={hostContext}
               />
-            ) : (
-              <div key={segment.key} data-slot="output-segment" data-output-segment="dom">
-                {segment.items.map(({ output, index }) => {
-                  // Prefer daemon-stamped output_id for stable React keys so a
-                  // stream append doesn't re-mount sibling outputs. Fall back
-                  // to positional when a render path skipped the id.
-                  const key = output.output_id ?? `output-${index}`;
-                  return (
-                    <div key={key} data-slot="output-item" data-output-index={index}>
-                      <ErrorBoundary
-                        resetKeys={[output]}
-                        fallback={(error, reset) => (
-                          <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
-                        )}
-                        onError={(error, errorInfo) => {
-                          console.error(
-                            `[OutputArea] Error rendering output ${index}:`,
-                            error,
-                            errorInfo.componentStack,
-                          );
-                        }}
-                      >
-                        {renderOutput(
-                          output,
-                          index,
-                          renderers,
-                          priority,
-                          resolveTracebackExecutionTarget,
-                          onNavigateToTracebackCell,
-                        )}
-                      </ErrorBoundary>
-                    </div>
-                  );
-                })}
-              </div>
-            ),
+              {showSiftInteractionCue && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
+                  <SiftScrollHandoffCue
+                    className="pointer-events-auto"
+                    onPointerDown={(event) => {
+                      event.stopPropagation();
+                      activateStaticFrameInteraction();
+                    }}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      activateStaticFrameInteraction();
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* In-DOM outputs (when not using isolation) */}
+          {!shouldIsolate && (
+            <div ref={inDomOutputRef}>
+              {outputs.map((output, index) => {
+                // Prefer daemon-stamped output_id for stable React keys so a
+                // stream append doesn't re-mount sibling outputs. Fall back
+                // to positional when a render path skipped the id.
+                const key = output.output_id ?? `output-${index}`;
+                return (
+                  <div key={key} data-slot="output-item" data-output-index={index}>
+                    <ErrorBoundary
+                      resetKeys={[output]}
+                      fallback={(error, reset) => (
+                        <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
+                      )}
+                      onError={(error, errorInfo) => {
+                        console.error(
+                          `[OutputArea] Error rendering output ${index}:`,
+                          error,
+                          errorInfo.componentStack,
+                        );
+                      }}
+                    >
+                      {renderOutput(
+                        output,
+                        index,
+                        renderers,
+                        priority,
+                        resolveTracebackExecutionTarget,
+                        onNavigateToTracebackCell,
+                      )}
+                    </ErrorBoundary>
+                  </div>
+                );
+              })}
+            </div>
           )}
         </div>
       )}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -5,6 +5,7 @@ import { OutputArea, type JupyterOutput } from "../OutputArea";
 
 let mockDarkMode = false;
 let mockColorTheme: string | undefined;
+let lastFrameMessageHandler: ((message: unknown) => void) | undefined;
 
 const mockFrameHandle = {
   send: vi.fn(),
@@ -40,11 +41,12 @@ vi.mock("@/components/isolated", async () => {
       allowWheelBoundaryScroll?: boolean;
       autoHeight?: boolean;
       hostContext?: unknown;
+      onMessage?: (message: unknown) => void;
       scrollPassthrough?: boolean;
       onReady?: () => void;
     }
   >(function MockIsolatedFrame(
-    { allowWheelBoundaryScroll, autoHeight, hostContext, scrollPassthrough, onReady },
+    { allowWheelBoundaryScroll, autoHeight, hostContext, onMessage, scrollPassthrough, onReady },
     ref,
   ) {
     React.useImperativeHandle(ref, () => mockFrameHandle);
@@ -52,6 +54,15 @@ vi.mock("@/components/isolated", async () => {
     React.useEffect(() => {
       onReady?.();
     }, [onReady]);
+
+    React.useEffect(() => {
+      lastFrameMessageHandler = onMessage;
+      return () => {
+        if (lastFrameMessageHandler === onMessage) {
+          lastFrameMessageHandler = undefined;
+        }
+      };
+    }, [onMessage]);
 
     return (
       <div
@@ -90,7 +101,7 @@ function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
   ];
 }
 
-function makeStreamThenHtmlOutput(): JupyterOutput[] {
+function makeMixedIsolatedOutputs(): JupyterOutput[] {
   return [
     {
       output_type: "stream",
@@ -100,16 +111,6 @@ function makeStreamThenHtmlOutput(): JupyterOutput[] {
     {
       output_type: "display_data",
       data: { "text/html": "<b>unsafe html</b>" },
-      metadata: {},
-    },
-  ];
-}
-
-function makeHtmlThenTracebackOutput(): JupyterOutput[] {
-  return [
-    {
-      output_type: "display_data",
-      data: { "text/html": "<b>test</b>" },
       metadata: {},
     },
     {
@@ -129,22 +130,9 @@ function makeHtmlThenTracebackOutput(): JupyterOutput[] {
             source_ref: {
               kind: "notebook_execution",
               execution_id: "exec-run",
-              execution_count: 6,
-              compiled_filename: "/var/folders/x/T/ipykernel_39879/258099874.py",
+              source_hash: "source-hash-run",
             },
             lines: [{ lineno: 4, source: "f(200)", highlight: true }],
-          },
-          {
-            filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
-            lineno: 4,
-            name: "f",
-            source_ref: {
-              kind: "notebook_execution",
-              execution_id: "exec-def",
-              execution_count: 3,
-              compiled_filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
-            },
-            lines: [{ lineno: 4, source: "return f(n) + f(n - 1)", highlight: true }],
           },
         ],
       },
@@ -194,6 +182,7 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.clear.mockClear();
     mockFrameHandle.search.mockClear();
     mockFrameHandle.searchNavigate.mockClear();
+    lastFrameMessageHandler = undefined;
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
     vi.mocked(needsPlugin).mockReturnValue(false);
   });
@@ -462,52 +451,62 @@ describe("OutputArea iframe theme sync", () => {
     expect(outputContent.style.maxHeight).toBe("");
   });
 
-  it("keeps safe stream outputs in-DOM before an isolated HTML output", async () => {
-    render(<OutputArea outputs={makeStreamThenHtmlOutput()} />);
-
-    expect(screen.getByText("stream before")).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
-        expect.objectContaining({
-          mimeType: "text/html",
-          data: "<b>unsafe html</b>",
-          outputIndex: 1,
-        }),
-      ]);
-    });
-
-    expect(mockFrameHandle.renderBatch).not.toHaveBeenCalledWith([
-      expect.objectContaining({ data: expect.stringContaining("stream before") }),
-    ]);
-  });
-
-  it("keeps rich tracebacks in-DOM when a sibling output needs isolation", async () => {
+  it("keeps mixed auto-isolated outputs together in one iframe render batch", async () => {
     const onNavigateToTracebackCell = vi.fn();
 
     render(
       <OutputArea
-        outputs={makeHtmlThenTracebackOutput()}
-        resolveTracebackExecutionTarget={(executionId) => {
-          if (executionId === "exec-run") return { cellId: "cell-run" };
-          if (executionId === "exec-def") return { cellId: "cell-def" };
-          return null;
-        }}
+        outputs={makeMixedIsolatedOutputs()}
+        resolveTracebackExecutionTarget={(executionId, sourceHash) =>
+          executionId === "exec-run" && sourceHash === "source-hash-run"
+            ? { cellId: "cell-run", label: "Run Cell" }
+            : null
+        }
         onNavigateToTracebackCell={onNavigateToTracebackCell}
       />,
     );
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
-        expect.objectContaining({ mimeType: "text/html", data: "<b>test</b>", outputIndex: 0 }),
+        expect.objectContaining({
+          mimeType: "text/plain",
+          data: "stream before\n",
+          outputIndex: 0,
+        }),
+        expect.objectContaining({
+          mimeType: "text/html",
+          data: "<b>unsafe html</b>",
+          outputIndex: 1,
+        }),
+        expect.objectContaining({
+          mimeType: "application/vnd.nteract.traceback+json",
+          data: expect.objectContaining({ ename: "RecursionError" }),
+          metadata: expect.objectContaining({
+            tracebackExecutionTargets: [
+              {
+                execution_id: "exec-run",
+                source_hash: "source-hash-run",
+                target: { cellId: "cell-run", label: "Run Cell" },
+              },
+            ],
+          }),
+          outputIndex: 2,
+        }),
       ]);
     });
 
-    expect(screen.getByText("RecursionError")).toBeInTheDocument();
-    expect(screen.queryByText("In[6]")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-def" }));
+    expect(screen.queryByText("stream before")).toBeNull();
+    expect(screen.queryByText("RecursionError")).toBeNull();
 
-    expect(onNavigateToTracebackCell).toHaveBeenCalledWith({ cellId: "cell-def" });
+    lastFrameMessageHandler?.({
+      type: "traceback_navigate",
+      payload: { target: { cellId: "cell-run", label: "Run Cell" } },
+    });
+
+    expect(onNavigateToTracebackCell).toHaveBeenCalledWith({
+      cellId: "cell-run",
+      label: "Run Cell",
+    });
   });
 
   it("constrains isolated iframe outputs when maxHeight is explicit", () => {

--- a/src/components/isolated/__tests__/frame-bridge.test.ts
+++ b/src/components/isolated/__tests__/frame-bridge.test.ts
@@ -117,12 +117,15 @@ describe("message type whitelist completeness", () => {
       "render_complete",
       "resize",
       "link_click",
+      "traceback_navigate",
+      "dblclick",
       "widget_update",
       "error",
       "renderer_ready",
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "search_results",
     ];
 
     for (const type of allIframeMessageTypes) {

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -345,6 +345,20 @@ export interface LinkClickMessage {
 }
 
 /**
+ * User requested navigation from an iframe-rendered traceback frame back to
+ * the owning notebook cell.
+ */
+export interface TracebackNavigateMessage {
+  type: "traceback_navigate";
+  payload: {
+    target: {
+      cellId: string;
+      label?: string;
+    };
+  };
+}
+
+/**
  * User double-clicked in the iframe.
  */
 export interface DoubleClickMessage {
@@ -451,6 +465,7 @@ export type IframeToParentMessage =
   | RenderCompleteMessage
   | ResizeMessage
   | LinkClickMessage
+  | TracebackNavigateMessage
   | DoubleClickMessage
   | WidgetUpdateMessage
   | IframeErrorMessage
@@ -487,6 +502,7 @@ export function isIframeMessage(data: unknown): data is IframeToParentMessage {
       "render_complete",
       "resize",
       "link_click",
+      "traceback_navigate",
       "dblclick",
       "widget_update",
       "error",

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -22,6 +22,7 @@ export type {
   RenderPayload,
   ResizeMessage,
   ThemeMessage,
+  TracebackNavigateMessage,
   WidgetStateMessage,
   WidgetUpdateMessage,
 } from "./frame-bridge";

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -49,7 +49,11 @@ import { ImageOutput } from "@/components/outputs/image-output";
 import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { PdfOutput } from "@/components/outputs/pdf-output";
-import { TracebackOutput } from "@/components/outputs/traceback-output";
+import {
+  TracebackOutput,
+  type TracebackCellTarget,
+  type TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -620,6 +624,53 @@ function IsolatedRendererApp() {
   );
 }
 
+interface TracebackExecutionTargetEntry {
+  execution_id: string;
+  source_hash?: string;
+  target: TracebackCellTarget;
+}
+
+function tracebackTargetKey(executionId: string, sourceHash?: string): string {
+  return `${executionId}\u0000${sourceHash ?? ""}`;
+}
+
+function tracebackExecutionResolver(
+  metadata: RenderPayload["metadata"],
+): TracebackExecutionResolver | undefined {
+  const entries = metadata?.tracebackExecutionTargets;
+  if (!Array.isArray(entries)) return undefined;
+
+  const targets = new Map<string, TracebackCellTarget>();
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Partial<TracebackExecutionTargetEntry>;
+    if (typeof record.execution_id !== "string") continue;
+    if (record.source_hash != null && typeof record.source_hash !== "string") continue;
+    const target = record.target;
+    if (typeof target !== "object" || target === null || typeof target.cellId !== "string") {
+      continue;
+    }
+    targets.set(tracebackTargetKey(record.execution_id, record.source_hash), target);
+  }
+
+  if (targets.size === 0) return undefined;
+
+  return (executionId, sourceHash) =>
+    targets.get(tracebackTargetKey(executionId, sourceHash)) ??
+    targets.get(tracebackTargetKey(executionId)) ??
+    null;
+}
+
+function postTracebackNavigation(target: TracebackCellTarget): void {
+  window.parent.postMessage(
+    {
+      type: "traceback_navigate",
+      payload: { target },
+    },
+    "*",
+  );
+}
+
 /**
  * Render a single output based on its MIME type.
  * Uses direct component imports (not lazy loading) for isolated iframe compatibility.
@@ -648,7 +699,13 @@ function OutputRenderer({
   // fallback so cells that mix rich outputs with errors (e.g., display
   // HTML then raise) still get the rich render inside the iframe.
   if (mimeType === "application/vnd.nteract.traceback+json") {
-    return <TracebackOutput data={data} />;
+    return (
+      <TracebackOutput
+        data={data}
+        resolveExecutionTarget={tracebackExecutionResolver(metadata)}
+        onNavigateToCell={postTracebackNavigation}
+      />
+    );
   }
 
   // Handle error output (classic ANSI path — fallback when no rich


### PR DESCRIPTION
## Summary

- restore all-or-nothing auto-isolation for mixed output batches, so stream/text/error siblings stay in the same iframe render batch as unsafe rich media
- remove the segmented output rendering path that split safe DOM outputs from isolated rich outputs
- preserve rich traceback cell navigation for iframe-rendered mixed batches by passing resolved traceback targets through the render payload and back over the iframe message channel
- update unit and E2E expectations to lock the unsplit mixed-media behavior

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/frame-bridge.test.ts`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `cargo xtask lint --fix`
- `git diff --check`
