### PR TITLE
fix(notebook-cloud): link traceback cells in cloud viewer

### DIFF
--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -147,6 +147,7 @@ describe("cloud viewer render resolution", () => {
         id: "runtime-count",
         cell_type: "code",
         source: "df",
+        execution_id: "exec-runtime-count",
         execution_count: "null",
         outputs: [
           {
@@ -167,6 +168,7 @@ describe("cloud viewer render resolution", () => {
     );
 
     assert.equal(cell.executionCount, 7);
+    assert.equal(cell.executionId, "exec-runtime-count");
   });
 
   it("uses the first finite execute_result count as the output fallback", async () => {

--- a/apps/notebook-cloud/test/viewer-sift-preload.test.ts
+++ b/apps/notebook-cloud/test/viewer-sift-preload.test.ts
@@ -72,6 +72,7 @@ function cell(outputs: JupyterOutput[]): ResolvedCell {
     cellType: "code",
     source: "df",
     language: "python",
+    executionId: null,
     executionCount: null,
     outputs,
     metadata: {},

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { Code2, Eye, EyeOff, UsersRound } from "lucide-react";
 import {
@@ -8,6 +8,7 @@ import {
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
+import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import type { SessionControlMessage } from "../src/protocol";
@@ -202,6 +203,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
           source: cell.source,
           language: cloudSourceLanguage(cell.language),
           outputs: cell.outputs,
+          executionId: cell.executionId,
           executionCount: cell.executionCount,
         }),
       ),
@@ -211,6 +213,27 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     () => readOnlyCells.filter((cell) => cell.cellType === "code").length,
     [readOnlyCells],
   );
+  const tracebackTargets = useMemo(() => {
+    const targets = new Map<string, TracebackCellTarget>();
+    for (const cell of cells) {
+      if (!cell.executionId) continue;
+      targets.set(cell.executionId, {
+        cellId: cell.id,
+        executionCount: cell.executionCount,
+      });
+    }
+    return targets;
+  }, [cells]);
+  const resolveTracebackExecutionTarget = useCallback(
+    (executionId: string) => tracebackTargets.get(executionId) ?? null,
+    [tracebackTargets],
+  );
+  const handleTracebackCellNavigate = useCallback((target: TracebackCellTarget) => {
+    findCellElement(target.cellId)?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
+  }, []);
 
   return (
     <main className="flex min-h-screen w-full flex-col py-6">
@@ -253,6 +276,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         cellClassName="cloud-cell"
         sourceClassName="cloud-source-block"
         outputClassName="cloud-output-block"
+        resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+        onNavigateToTracebackCell={handleTracebackCellNavigate}
         renderCellError={(error, _cell, index) => (
           <div className="cloud-state" data-kind="error">
             Unable to render cell {index + 1}: {error.message}
@@ -261,6 +286,13 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       />
     </main>
   );
+}
+
+function findCellElement(cellId: string): HTMLElement | null {
+  for (const element of document.querySelectorAll<HTMLElement>("[data-cell-id]")) {
+    if (element.dataset.cellId === cellId) return element;
+  }
+  return null;
 }
 
 function CloudPresenceStatus({ syncEndpoint }: { syncEndpoint: string }) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -219,7 +219,6 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       if (!cell.executionId) continue;
       targets.set(cell.executionId, {
         cellId: cell.id,
-        executionCount: cell.executionCount,
       });
     }
     return targets;

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -10,6 +10,7 @@ export interface RenderCell {
   id?: unknown;
   cell_type?: unknown;
   source?: unknown;
+  execution_id?: unknown;
   execution_count?: unknown;
   outputs?: unknown;
   metadata?: unknown;
@@ -20,6 +21,7 @@ export interface ResolvedCell {
   cellType: "code" | "markdown" | "raw";
   source: string;
   language: string | null;
+  executionId: string | null;
   executionCount: number | null;
   outputs: JupyterOutput[];
   metadata: Record<string, unknown>;
@@ -43,6 +45,7 @@ export async function resolveCell(
     cellType,
     source: typeof cell.source === "string" ? cell.source : "",
     language: cellType === "code" ? (normalizeCellLanguage(metadata) ?? defaultLanguage) : null,
+    executionId: normalizeExecutionId(cell.execution_id),
     executionCount,
     outputs,
     metadata,
@@ -111,6 +114,10 @@ function normalizeExecutionCount(value: unknown): number | null {
   if (typeof value !== "string" || value === "null") return null;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeExecutionId(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 function executionCountFromOutputs(outputs: JupyterOutput[]): number | null {

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type {
+  TracebackCellNavigator,
+  TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import type { SupportedLanguage } from "../editor/languages";
@@ -12,6 +16,7 @@ export interface ReadOnlyNotebookCellData {
   source: string;
   language?: SupportedLanguage | null;
   outputs?: readonly JupyterOutput[];
+  executionId?: string | null;
   executionCount?: number | null;
 }
 
@@ -30,6 +35,8 @@ export interface ReadOnlyNotebookProps {
   label?: string;
   emptyContent?: ReactNode;
   renderCellError?: (error: Error, cell: ReadOnlyNotebookCellData, index: number) => ReactNode;
+  resolveTracebackExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToTracebackCell?: TracebackCellNavigator;
 }
 
 export function ReadOnlyNotebook({
@@ -47,6 +54,8 @@ export function ReadOnlyNotebook({
   label = "Notebook cells",
   emptyContent = null,
   renderCellError,
+  resolveTracebackExecutionTarget,
+  onNavigateToTracebackCell,
 }: ReadOnlyNotebookProps) {
   return (
     <section
@@ -90,6 +99,8 @@ export function ReadOnlyNotebook({
                 sourceClassName={sourceClassName}
                 outputClassName={outputClassName}
                 lineWrapping={lineWrapping}
+                resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+                onNavigateToTracebackCell={onNavigateToTracebackCell}
               />
             </ErrorBoundary>
           ))}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -2,6 +2,10 @@ import { type ReactNode, useMemo } from "react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { ReadOnlyCodeMirror } from "@/components/editor/readonly-codemirror";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import type {
+  TracebackCellNavigator,
+  TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
 import { cn } from "@/lib/utils";
 import { CellContainer } from "./CellContainer";
 import { ExecutionCount } from "./ExecutionCount";
@@ -24,6 +28,8 @@ export interface ReadOnlyNotebookCellProps {
   sourceClassName?: string;
   outputClassName?: string;
   lineWrapping?: boolean;
+  resolveTracebackExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToTracebackCell?: TracebackCellNavigator;
 }
 
 export function ReadOnlyNotebookCell({
@@ -42,6 +48,8 @@ export function ReadOnlyNotebookCell({
   sourceClassName,
   outputClassName,
   lineWrapping = true,
+  resolveTracebackExecutionTarget,
+  onNavigateToTracebackCell,
 }: ReadOnlyNotebookCellProps) {
   const codeContent = useMemo(
     () =>
@@ -70,6 +78,8 @@ export function ReadOnlyNotebookCell({
         priority={priority}
         hostContext={hostContext}
         className={outputClassName}
+        resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+        onNavigateToTracebackCell={onNavigateToTracebackCell}
       />
     ) : null;
 

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -16,9 +16,11 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     id,
     language,
     lineWrapping,
+    onNavigateToTracebackCell,
     outputClassName,
     outputs,
     priority,
+    resolveTracebackExecutionTarget,
     showSource,
     source,
     sourceClassName,
@@ -32,9 +34,11 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     id: string;
     language?: string | null;
     lineWrapping?: boolean;
+    onNavigateToTracebackCell?: unknown;
     outputClassName?: string;
     outputs?: readonly JupyterOutput[];
     priority?: readonly string[];
+    resolveTracebackExecutionTarget?: unknown;
     showSource?: boolean;
     source: string;
     sourceClassName?: string;
@@ -54,6 +58,8 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
         data-host-context={JSON.stringify(hostContext ?? null)}
         data-language={language ?? ""}
         data-line-wrapping={String(lineWrapping)}
+        data-has-traceback-navigator={String(Boolean(onNavigateToTracebackCell))}
+        data-has-traceback-resolver={String(Boolean(resolveTracebackExecutionTarget))}
         data-output-class-name={outputClassName ?? ""}
         data-output-count={outputs?.length ?? 0}
         data-priority={priority?.join(",") ?? ""}
@@ -125,6 +131,32 @@ describe("ReadOnlyNotebook", () => {
     expect(cells[0]).toHaveAttribute("data-priority", "application/vnd.apache.parquet,text/plain");
     expect(cells[0].getAttribute("data-host-context")).toContain(
       "https://assets.example.test/renderer-assets/",
+    );
+  });
+
+  it("passes traceback resolver and navigator to read-only cells", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "cell-1",
+            cellType: "code",
+            source: "raise Exception()",
+            outputs: [{ output_type: "error", ename: "E", evalue: "bad", traceback: [] }],
+          },
+        ]}
+        resolveTracebackExecutionTarget={() => null}
+        onNavigateToTracebackCell={() => undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("read-only-cell")).toHaveAttribute(
+      "data-has-traceback-resolver",
+      "true",
+    );
+    expect(screen.getByTestId("read-only-cell")).toHaveAttribute(
+      "data-has-traceback-navigator",
+      "true",
     );
   });
 

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -14,16 +14,20 @@ vi.mock("../OutputArea", () => ({
     executionCount,
     focused,
     hostContext,
+    onNavigateToTracebackCell,
     outputs,
     priority,
+    resolveTracebackExecutionTarget,
   }: {
     cellId?: string;
     className?: string;
     executionCount?: number | null;
     focused?: boolean;
     hostContext?: unknown;
+    onNavigateToTracebackCell?: unknown;
     outputs: JupyterOutput[];
     priority?: readonly string[];
+    resolveTracebackExecutionTarget?: unknown;
   }) => {
     outputAreaCalls.outputs.push(outputs);
     return (
@@ -33,6 +37,8 @@ vi.mock("../OutputArea", () => ({
         data-execution-count={executionCount ?? ""}
         data-focused={String(focused)}
         data-host-context={JSON.stringify(hostContext ?? null)}
+        data-has-traceback-navigator={String(Boolean(onNavigateToTracebackCell))}
+        data-has-traceback-resolver={String(Boolean(resolveTracebackExecutionTarget))}
         data-mimes={outputs
           .flatMap((output) =>
             output.output_type === "display_data" || output.output_type === "execute_result"
@@ -121,6 +127,28 @@ describe("ReadOnlyNotebookCell", () => {
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-class-name", "cloud-output");
     expect(screen.getByTestId("output-area").getAttribute("data-host-context")).toContain(
       "https://assets.example.test/renderer-assets/",
+    );
+  });
+
+  it("passes traceback cell resolver and navigator to code outputs", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="traceback-code"
+        cellType="code"
+        source="raise Exception()"
+        outputs={[{ output_type: "error", ename: "E", evalue: "bad", traceback: [] }]}
+        resolveTracebackExecutionTarget={() => null}
+        onNavigateToTracebackCell={() => undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("output-area")).toHaveAttribute(
+      "data-has-traceback-resolver",
+      "true",
+    );
+    expect(screen.getByTestId("output-area")).toHaveAttribute(
+      "data-has-traceback-navigator",
+      "true",
     );
   });
 

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -50,12 +50,6 @@ const resolveExecutionTarget = (executionId: string) => {
   return null;
 };
 
-const resolveExecutionTargetWithCounts = (executionId: string) => {
-  if (executionId === "exec-run") return { cellId: "cell-run", executionCount: 3 };
-  if (executionId === "exec-def") return { cellId: "cell-def", executionCount: 2 };
-  return null;
-};
-
 describe("TracebackOutput", () => {
   beforeEach(() => {
     Object.defineProperty(window, "matchMedia", {
@@ -77,15 +71,6 @@ describe("TracebackOutput", () => {
     expect(container.textContent).toContain("Line5inCell cell-defing");
     expect(container.textContent).not.toContain("In[");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
-  });
-
-  it("shows execution counts when traceback cell targets include them", () => {
-    const { container } = render(
-      <TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTargetWithCounts} />,
-    );
-
-    expect(container.textContent).toContain("Line1inCurrent Cell In[3]");
-    expect(container.textContent).toContain("Line5inCell cell-def In[2]ing");
   });
 
   it("shortens displayed Python package paths", () => {

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -50,6 +50,12 @@ const resolveExecutionTarget = (executionId: string) => {
   return null;
 };
 
+const resolveExecutionTargetWithCounts = (executionId: string) => {
+  if (executionId === "exec-run") return { cellId: "cell-run", executionCount: 3 };
+  if (executionId === "exec-def") return { cellId: "cell-def", executionCount: 2 };
+  return null;
+};
+
 describe("TracebackOutput", () => {
   beforeEach(() => {
     Object.defineProperty(window, "matchMedia", {
@@ -71,6 +77,90 @@ describe("TracebackOutput", () => {
     expect(container.textContent).toContain("Line5inCell cell-defing");
     expect(container.textContent).not.toContain("In[");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
+  });
+
+  it("shows execution counts when traceback cell targets include them", () => {
+    const { container } = render(
+      <TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTargetWithCounts} />,
+    );
+
+    expect(container.textContent).toContain("Line1inCurrent Cell In[3]");
+    expect(container.textContent).toContain("Line5inCell cell-def In[2]ing");
+  });
+
+  it("shortens displayed Python package paths", () => {
+    const { container } = render(
+      <TracebackOutput
+        data={{
+          ename: "ColumnNotFoundError",
+          evalue: "missing column",
+          frames: [
+            {
+              filename:
+                "/Users/kylekelley/Library/Caches/runt-nightly/inline-envs/f446e2ef9c92b4c9/lib/python3.13/site-packages/polars/lazyframe/frame.py",
+              lineno: 2630,
+              name: "collect",
+              library: true,
+              lines: [{ lineno: 2630, source: "return wrap_df(ldf.collect())", highlight: true }],
+            },
+          ],
+          language: "python",
+        }}
+      />,
+    );
+
+    expect(container.textContent).toContain("Line2630inpython/polars/lazyframe/frame.pyincollect");
+    expect(container.textContent).not.toContain("/Users/kylekelley/Library/Caches");
+  });
+
+  it("keeps non-Python source paths unchanged when they look package-like", () => {
+    const filename = "/Users/kyle/project/site-packages/example/runtime/frame.jl";
+    const { container } = render(
+      <TracebackOutput
+        data={{
+          ename: "RuntimeError",
+          evalue: "bad module",
+          frames: [
+            {
+              filename,
+              lineno: 7,
+              name: "load",
+              library: true,
+              lines: [{ lineno: 7, source: "await load()", highlight: true }],
+            },
+          ],
+          language: "typescript",
+        }}
+      />,
+    );
+
+    expect(container.textContent).toContain(
+      "Line7in/Users/kyle/project/site-packages/example/runtime/frame.jlinload",
+    );
+    expect(container.textContent).not.toContain("python/example/runtime/frame.jl");
+  });
+
+  it("does not throw when a frame has a malformed filename", () => {
+    const { container } = render(
+      <TracebackOutput
+        data={{
+          ename: "RuntimeError",
+          evalue: "bad frame",
+          frames: [
+            {
+              filename: { path: "/tmp/not-a-string.py" },
+              lineno: 7,
+              name: "load",
+              library: true,
+              lines: [{ lineno: 7, source: "load()", highlight: true }],
+            },
+          ],
+          language: "python",
+        }}
+      />,
+    );
+
+    expect(container.textContent).toContain("Line7inUnknown sourceinload");
   });
 
   it("navigates to a resolved traceback cell", () => {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -130,6 +130,7 @@ interface Props {
 export interface TracebackCellTarget {
   cellId: string;
   label?: string;
+  executionCount?: number | null;
 }
 
 export type TracebackExecutionResolver = (
@@ -520,7 +521,8 @@ function LocationLabel({
   name?: string;
   onNavigateToCell?: TracebackCellNavigator;
 }) {
-  const showName = Boolean(name && name !== "<module>");
+  const displayName = typeof name === "string" ? name : undefined;
+  const showName = Boolean(displayName && displayName !== "<module>");
   const target = location.target && onNavigateToCell ? location.target : undefined;
   return (
     <span className="flex min-w-0 items-center gap-1.5" title={location.title}>
@@ -550,7 +552,7 @@ function LocationLabel({
       {showName && (
         <>
           <span className="shrink-0 text-muted-foreground">in</span>
-          <span className="truncate">{name}</span>
+          <span className="truncate">{displayName}</span>
         </>
       )}
     </span>
@@ -565,29 +567,34 @@ function sourceLocation(
   currentExecutionId: string | undefined,
   resolveExecutionTarget?: TracebackExecutionResolver,
 ): SourceLocation {
-  const sourceRef = source.source_ref;
-  const executionId = sourceRef?.execution_id ?? source.execution_id;
-  const sourceHash = sourceRef?.source_hash ?? source.source_hash;
-  const compiledFilename = sourceRef?.compiled_filename ?? source.filename;
+  const sourceRef = isObjectRecord(source.source_ref) ? source.source_ref : undefined;
+  const filename = asOptionalString(source.filename) ?? "Unknown source";
+  const executionId =
+    asOptionalString(sourceRef?.execution_id) ?? asOptionalString(source.execution_id);
+  const sourceHash =
+    asOptionalString(sourceRef?.source_hash) ?? asOptionalString(source.source_hash);
+  const compiledFilename = asOptionalString(sourceRef?.compiled_filename) ?? filename;
   const titleParts = [];
   if (executionId) titleParts.push(`Execution: ${executionId}`);
   if (sourceHash) titleParts.push(`Source: ${sourceHash}`);
   if (compiledFilename) titleParts.push(`Compiled file: ${compiledFilename}`);
 
   const isNotebookSource =
-    sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(source.filename);
+    sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(filename);
   const target = executionId ? (resolveExecutionTarget?.(executionId, sourceHash) ?? null) : null;
   if (target) titleParts.unshift(`Cell: ${target.cellId}`);
-  const title = titleParts.join("\n") || source.filename || "Unknown source";
+  const title = titleParts.join("\n") || filename;
 
   if (!isNotebookSource) {
-    return { kind: "file", label: source.filename || "Unknown source", title };
+    return {
+      kind: "file",
+      label: shortenPythonPath(filename),
+      title,
+    };
   }
 
   if (target) {
-    const label =
-      target.label ??
-      (executionId === currentExecutionId ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`);
+    const label = target.label ?? notebookTargetLabel(target, executionId === currentExecutionId);
     return {
       kind: "notebook",
       label,
@@ -628,6 +635,25 @@ function sourceLocation(
 
 function shortCellId(cellId: string): string {
   return cellId.length <= 12 ? cellId : cellId.slice(0, 8);
+}
+
+function notebookTargetLabel(target: TracebackCellTarget, isCurrentExecution: boolean): string {
+  const label = isCurrentExecution ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`;
+  if (typeof target.executionCount === "number" && Number.isFinite(target.executionCount)) {
+    return `${label} In[${target.executionCount}]`;
+  }
+  return label;
+}
+
+function shortenPythonPath(filename: string): string {
+  const normalized = filename.replace(/\\/g, "/");
+  const sitePackages = normalized.match(/(?:^|\/)(?:site-packages|dist-packages)\/(.+)$/);
+  const packagePath = sitePackages?.[1];
+  if (packagePath && /^[\w.-]+(?:\/[\w.-]+)*\.py[wi]?$/.test(packagePath)) {
+    return `python/${packagePath}`;
+  }
+
+  return filename;
 }
 
 function isSyntheticNotebookFilename(filename: string): boolean {
@@ -712,9 +738,17 @@ function copyLocationLine(
 }
 
 function isNotebookSource(source: Pick<Frame | SyntaxInfo, "filename" | "source_ref">): boolean {
-  return (
-    source.source_ref?.kind === "notebook_execution" || isSyntheticNotebookFilename(source.filename)
-  );
+  const sourceRef = isObjectRecord(source.source_ref) ? source.source_ref : undefined;
+  const filename = asOptionalString(source.filename) ?? "";
+  return sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(filename);
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function highlightedSourceLine(lines: Line[] | undefined): string | undefined {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -130,7 +130,6 @@ interface Props {
 export interface TracebackCellTarget {
   cellId: string;
   label?: string;
-  executionCount?: number | null;
 }
 
 export type TracebackExecutionResolver = (
@@ -594,7 +593,9 @@ function sourceLocation(
   }
 
   if (target) {
-    const label = target.label ?? notebookTargetLabel(target, executionId === currentExecutionId);
+    const label =
+      target.label ??
+      (executionId === currentExecutionId ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`);
     return {
       kind: "notebook",
       label,
@@ -635,14 +636,6 @@ function sourceLocation(
 
 function shortCellId(cellId: string): string {
   return cellId.length <= 12 ? cellId : cellId.slice(0, 8);
-}
-
-function notebookTargetLabel(target: TracebackCellTarget, isCurrentExecution: boolean): string {
-  const label = isCurrentExecution ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`;
-  if (typeof target.executionCount === "number" && Number.isFinite(target.executionCount)) {
-    return `${label} In[${target.executionCount}]`;
-  }
-  return label;
 }
 
 function shortenPythonPath(filename: string): string {


### PR DESCRIPTION
## Summary

- wire cloud read-only notebooks into the rich traceback cell resolver/navigator
- preserve `execution_id` from snapshot render cells so traceback frames can resolve back to cells
- shorten displayed Python package paths while keeping non-Python and malformed paths safe/fallback-rendered

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx src/components/cell/__tests__/ReadOnlyNotebook.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/render-resolution.test.ts test/viewer-sift-preload.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
