### PR TITLE
feat(notebook-cloud): gate rooms with ACL authorization

### DIFF
--- a/apps/notebook-cloud/migrations/0003_notebook_acl.sql
+++ b/apps/notebook-cloud/migrations/0003_notebook_acl.sql
@@ -1,0 +1,51 @@
+CREATE TABLE IF NOT EXISTS notebook_acl (
+  notebook_id TEXT NOT NULL,
+  subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),
+  subject TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor', 'runtime_peer', 'owner')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  created_by_actor_label TEXT NOT NULL,
+  PRIMARY KEY (notebook_id, subject_kind, subject, scope),
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE INDEX IF NOT EXISTS notebook_acl_subject_idx
+  ON notebook_acl (subject_kind, subject, notebook_id);
+
+INSERT OR IGNORE INTO notebook_acl (
+  notebook_id,
+  subject_kind,
+  subject,
+  scope,
+  created_at,
+  updated_at,
+  created_by_actor_label
+)
+SELECT id,
+       'principal',
+       owner_principal,
+       'owner',
+       created_at,
+       updated_at,
+       'system/schema:notebook-cloud-owner-acl-backfill'
+  FROM notebooks;
+
+INSERT OR IGNORE INTO notebook_acl (
+  notebook_id,
+  subject_kind,
+  subject,
+  scope,
+  created_at,
+  updated_at,
+  created_by_actor_label
+)
+SELECT id,
+       'public',
+       'anonymous',
+       'viewer',
+       created_at,
+       updated_at,
+       'system/schema:notebook-cloud-public-acl-backfill'
+  FROM notebooks
+ WHERE latest_revision_id IS NOT NULL;

--- a/apps/notebook-cloud/src/authorization.ts
+++ b/apps/notebook-cloud/src/authorization.ts
@@ -1,0 +1,88 @@
+import type { Env } from "./cloudflare-types.ts";
+import {
+  type AuthenticatedConnection,
+  type ConnectionScope,
+  isAnonymousViewer,
+} from "./identity.ts";
+import {
+  ensureCatalogSchema,
+  getNotebookAclRowsForPrincipal,
+  getNotebookRow,
+  getPublicNotebookAclRows,
+  type NotebookAclRow,
+} from "./storage.ts";
+
+const CAP_READ = 1 << 0;
+const CAP_NOTEBOOK_WRITE = 1 << 1;
+const CAP_RUNTIME_WRITE = 1 << 2;
+const CAP_PUBLISH = 1 << 3;
+const CAP_MANAGE_ACL = 1 << 4;
+
+export class AuthorizationError extends Error {
+  constructor(
+    message: string,
+    readonly status = 403,
+  ) {
+    super(message);
+    this.name = "AuthorizationError";
+  }
+}
+
+export async function authorizeNotebookAccess(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: ConnectionScope = identity.scope,
+): Promise<AuthenticatedConnection> {
+  if (!env.DB) {
+    throw new AuthorizationError("D1 binding DB is not configured", 503);
+  }
+
+  await ensureCatalogSchema(env);
+  const notebook = await getNotebookRow(env, notebookId);
+  if (!notebook) {
+    throw new AuthorizationError("notebook not found", 404);
+  }
+
+  if (isAnonymousViewer(identity)) {
+    if (requestedScope !== "viewer") {
+      throw new AuthorizationError("anonymous viewers may only request viewer scope", 403);
+    }
+
+    const publicRows = await getPublicNotebookAclRows(env, notebookId);
+    if (!aclRowsCoverScope(publicRows, "viewer")) {
+      throw new AuthorizationError("notebook not found", 404);
+    }
+
+    return { ...identity, scope: "viewer" };
+  }
+
+  const principalRows = await getNotebookAclRowsForPrincipal(env, notebookId, identity.principal);
+  if (!aclRowsCoverScope(principalRows, requestedScope)) {
+    throw new AuthorizationError(`${identity.principal} cannot access ${notebookId}`, 403);
+  }
+
+  return { ...identity, scope: requestedScope };
+}
+
+export function aclRowsCoverScope(
+  rows: NotebookAclRow[],
+  requestedScope: ConnectionScope,
+): boolean {
+  const granted = rows.reduce((mask, row) => mask | capabilityMask(row.scope), 0);
+  const requested = capabilityMask(requestedScope);
+  return (granted & requested) === requested;
+}
+
+export function capabilityMask(scope: ConnectionScope): number {
+  switch (scope) {
+    case "viewer":
+      return CAP_READ;
+    case "editor":
+      return CAP_READ | CAP_NOTEBOOK_WRITE | CAP_RUNTIME_WRITE;
+    case "runtime_peer":
+      return CAP_READ | CAP_RUNTIME_WRITE;
+    case "owner":
+      return CAP_READ | CAP_NOTEBOOK_WRITE | CAP_RUNTIME_WRITE | CAP_PUBLISH | CAP_MANAGE_ACL;
+  }
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -8,11 +8,14 @@ import {
   DEV_AUTH_TOKEN_HEADER,
   stampTrustedIdentity,
   type AuthenticatedConnection,
+  type ConnectionScope,
 } from "./identity.ts";
+import { AuthorizationError, authorizeNotebookAccess } from "./authorization.ts";
 import {
   blobKey,
+  createNotebookWithOwnerAcl,
   ensureCatalogSchema,
-  ensureNotebook,
+  getNotebookRow,
   getNotebookCatalog,
   recordBlob,
   recordRevision,
@@ -114,7 +117,7 @@ const worker: ExportedHandler<Env> = {
 
     const catalogMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/?$/);
     if (catalogMatch && request.method === "GET") {
-      return routeCatalog(env, decodeURIComponent(catalogMatch[1]));
+      return routeCatalog(request, env, decodeURIComponent(catalogMatch[1]));
     }
 
     const latestRenderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/render$/);
@@ -237,10 +240,14 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   if (!notebookId) {
     return json({ error: "notebook id is required" }, 400);
   }
+  const authorizedIdentity = await authorizeIdentityOrResponse(env, notebookId, identity);
+  if (authorizedIdentity instanceof Response) {
+    return authorizedIdentity;
+  }
 
   const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
   const room = env.NOTEBOOK_ROOMS.get(id);
-  return room.fetch(stampTrustedIdentity(request, identity));
+  return room.fetch(stampTrustedIdentity(request, authorizedIdentity));
 }
 
 async function routeSnapshot(
@@ -252,8 +259,10 @@ async function routeSnapshot(
   const key = snapshotKey(notebookId, headsHash);
 
   if (request.method === "GET") {
-    // Prototype publish reads are intentionally public. Production hosts should
-    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+    if (identity instanceof Response) {
+      return identity;
+    }
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       return json({ error: "snapshot not found" }, 404);
@@ -271,18 +280,14 @@ async function routeSnapshot(
     return json({ error: "method not allowed" }, 405);
   }
 
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authorizePublishOrCreateOrResponse(request, env, notebookId, "snapshots");
   if (identity instanceof Response) {
     return identity;
-  }
-  if (!allowsPublish(identity.scope)) {
-    return json({ error: `${identity.scope} cannot publish snapshots` }, 403);
   }
   if (!env.NOTEBOOK_SNAPSHOTS) {
     return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
   }
 
-  await ensureNotebook(env, notebookId, identity);
   const body = await request.arrayBuffer();
   const runtimeHeadsHash = normalizedRuntimeHeadsHash(request.headers.get("x-runtime-heads-hash"));
   const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
@@ -338,6 +343,7 @@ async function routeSnapshot(
       snapshotKey: key,
       runtimeSnapshotKey: runtimeKey,
       actorLabel: identity.actorLabel,
+      publishPublic: true,
     });
   } catch (error) {
     await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
@@ -359,6 +365,10 @@ async function routeRuntimeSnapshot(
   const key = runtimeSnapshotKey(notebookId, headsHash);
 
   if (request.method === "GET") {
+    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+    if (identity instanceof Response) {
+      return identity;
+    }
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       return json({ error: "runtime snapshot not found" }, 404);
@@ -376,18 +386,19 @@ async function routeRuntimeSnapshot(
     return json({ error: "method not allowed" }, 405);
   }
 
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authorizePublishOrCreateOrResponse(
+    request,
+    env,
+    notebookId,
+    "runtime snapshots",
+  );
   if (identity instanceof Response) {
     return identity;
-  }
-  if (!allowsPublish(identity.scope)) {
-    return json({ error: `${identity.scope} cannot publish runtime snapshots` }, 403);
   }
   if (!env.NOTEBOOK_SNAPSHOTS) {
     return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
   }
 
-  await ensureNotebook(env, notebookId, identity);
   const body = await request.arrayBuffer();
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
@@ -404,9 +415,13 @@ async function routeRuntimeSnapshot(
   return json({ ok: true, key, size: body.byteLength }, 201);
 }
 
-async function routeCatalog(env: Env, notebookId: string): Promise<Response> {
+async function routeCatalog(request: Request, env: Env, notebookId: string): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+  if (identity instanceof Response) {
+    return identity;
   }
 
   const catalog = await getNotebookCatalog(env, notebookId);
@@ -424,6 +439,10 @@ async function routeLatestRender(
 ): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+  if (identity instanceof Response) {
+    return identity;
   }
 
   const catalog = await getNotebookCatalog(env, notebookId);
@@ -448,8 +467,9 @@ async function routeRender(
   headsHash: string,
 ): Promise<Response> {
   if (request.method === "GET") {
-    if (!env.DB) {
-      return getRenderObject(env, notebookId, headsHash, true);
+    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+    if (identity instanceof Response) {
+      return identity;
     }
     const catalog = await getNotebookCatalog(env, notebookId);
     const revision = catalog?.revisions.find(
@@ -676,8 +696,10 @@ async function routeBlob(
   const key = blobKey(notebookId, hash);
 
   if (request.method === "HEAD") {
-    // Prototype publish reads are intentionally public. Production hosts should
-    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+    if (identity instanceof Response) {
+      return identity;
+    }
     const object = await env.NOTEBOOK_SNAPSHOTS?.head(key);
     if (!object) {
       return json({ error: "blob not found" }, 404);
@@ -693,8 +715,10 @@ async function routeBlob(
   }
 
   if (request.method === "GET") {
-    // Prototype publish reads are intentionally public. Production hosts should
-    // gate this path with viewer-or-better auth or signed artifact URLs.
+    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
+    if (identity instanceof Response) {
+      return identity;
+    }
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       return json({ error: "blob not found" }, 404);
@@ -737,7 +761,13 @@ async function routeBlob(
     );
   }
 
-  await ensureNotebook(env, notebookId, identity);
+  const authorizedIdentity = allowsPublish(identity.scope)
+    ? await authorizePublishOrCreate(env, notebookId, identity)
+    : await authorizeIdentityOrResponse(env, notebookId, identity);
+  if (authorizedIdentity instanceof Response) {
+    return authorizedIdentity;
+  }
+
   const contentType = request.headers.get("content-type");
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
@@ -780,6 +810,69 @@ function authenticateRequestOrResponse(
     }
     return json({ error: String(error) }, 400);
   }
+}
+
+async function authenticateAndAuthorizeOrResponse(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  requestedScope: ConnectionScope,
+): Promise<AuthenticatedConnection | Response> {
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  return authorizeIdentityOrResponse(env, notebookId, identity, requestedScope);
+}
+
+async function authorizeIdentityOrResponse(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: ConnectionScope = identity.scope,
+): Promise<AuthenticatedConnection | Response> {
+  try {
+    return await authorizeNotebookAccess(env, notebookId, identity, requestedScope);
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return json({ error: error.message }, error.status);
+    }
+    throw error;
+  }
+}
+
+async function authorizePublishOrCreateOrResponse(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  artifactName: string,
+): Promise<AuthenticatedConnection | Response> {
+  const identity = authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot publish ${artifactName}` }, 403);
+  }
+  return authorizePublishOrCreate(env, notebookId, identity);
+}
+
+async function authorizePublishOrCreate(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+): Promise<AuthenticatedConnection | Response> {
+  if (!env.DB) {
+    return identity;
+  }
+
+  const existing = await getNotebookRow(env, notebookId);
+  if (existing) {
+    return authorizeIdentityOrResponse(env, notebookId, identity, "owner");
+  }
+
+  await createNotebookWithOwnerAcl(env, notebookId, identity);
+  return authorizeIdentityOrResponse(env, notebookId, identity, "owner");
 }
 
 function json(value: unknown, status = 200): Response {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -18,7 +18,6 @@ import {
   type TypedFrame,
 } from "./protocol.ts";
 import { rewritePresenceIngress } from "./runtimed-wasm.ts";
-import { ensureNotebook } from "./storage.ts";
 
 interface Peer {
   id: string;
@@ -56,7 +55,7 @@ export class NotebookRoom {
 
   constructor(
     private readonly state: DurableObjectState,
-    private readonly env: Env,
+    _env: Env,
   ) {
     this.restoreHibernatedPeers();
   }
@@ -78,10 +77,6 @@ export class NotebookRoom {
       identity = readTrustedIdentity(request);
     } catch (error) {
       return json({ error: String(error) }, 401);
-    }
-
-    if (!isAnonymousViewer(identity)) {
-      await ensureNotebook(this.env, notebookId, identity);
     }
 
     const pair = new WebSocketPair();

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1,5 +1,5 @@
 import type { AuthenticatedConnection } from "./identity.ts";
-import type { Env } from "./cloudflare-types.ts";
+import type { D1PreparedStatement, Env } from "./cloudflare-types.ts";
 
 export interface NotebookCatalog {
   notebook: NotebookRow;
@@ -36,6 +36,16 @@ export interface BlobRow {
   uploaded_at: string;
 }
 
+export interface NotebookAclRow {
+  notebook_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: AuthenticatedConnection["scope"];
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+}
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -66,6 +76,19 @@ const SCHEMA_STATEMENTS = [
     PRIMARY KEY (notebook_id, hash),
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
+  `CREATE TABLE IF NOT EXISTS notebook_acl (
+    notebook_id TEXT NOT NULL,
+    subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),
+    subject TEXT NOT NULL,
+    scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor', 'runtime_peer', 'owner')),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    created_by_actor_label TEXT NOT NULL,
+    PRIMARY KEY (notebook_id, subject_kind, subject, scope),
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS notebook_acl_subject_idx
+    ON notebook_acl (subject_kind, subject, notebook_id)`,
 ];
 
 const SCHEMA_MIGRATIONS = [
@@ -114,6 +137,7 @@ export async function ensureCatalogSchema(env: Env): Promise<void> {
 async function initializeCatalogSchema(env: Env): Promise<void> {
   await Promise.all(SCHEMA_STATEMENTS.map((statement) => env.DB!.prepare(statement).run()));
   await runCatalogMigrations(env);
+  await backfillNotebookAcl(env);
 }
 
 async function runCatalogMigrations(env: Env): Promise<void> {
@@ -130,7 +154,126 @@ async function tableHasColumn(env: Env, table: string, column: string): Promise<
   return result.results?.some((row) => row.name === column) ?? false;
 }
 
-export async function ensureNotebook(
+async function backfillNotebookAcl(env: Env): Promise<void> {
+  await env
+    .DB!.prepare(
+      `INSERT OR IGNORE INTO notebook_acl (
+       notebook_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT id,
+            'principal',
+            owner_principal,
+            'owner',
+            created_at,
+            updated_at,
+            'system/schema:notebook-cloud-owner-acl-backfill'
+       FROM notebooks`,
+    )
+    .run();
+
+  await env
+    .DB!.prepare(
+      `INSERT OR IGNORE INTO notebook_acl (
+       notebook_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT id,
+            'public',
+            'anonymous',
+            'viewer',
+            created_at,
+            updated_at,
+            'system/schema:notebook-cloud-public-acl-backfill'
+       FROM notebooks
+       WHERE latest_revision_id IS NOT NULL`,
+    )
+    .run();
+}
+
+export async function getNotebookRow(env: Env, notebookId: string): Promise<NotebookRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT id, owner_principal, title, created_at, updated_at, latest_revision_id
+       FROM notebooks
+       WHERE id = ?`,
+  )
+    .bind(notebookId)
+    .first<NotebookRow>();
+}
+
+export async function getNotebookAclRowsForPrincipal(
+  env: Env,
+  notebookId: string,
+  principal: string,
+): Promise<NotebookAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT notebook_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM notebook_acl
+       WHERE notebook_id = ?
+         AND subject_kind = 'principal'
+         AND subject = ?
+       ORDER BY scope`,
+  )
+    .bind(notebookId, principal)
+    .all<NotebookAclRow>();
+  return rows.results ?? [];
+}
+
+export async function getPublicNotebookAclRows(
+  env: Env,
+  notebookId: string,
+): Promise<NotebookAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT notebook_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM notebook_acl
+       WHERE notebook_id = ?
+         AND subject_kind = 'public'
+         AND subject = 'anonymous'
+       ORDER BY scope`,
+  )
+    .bind(notebookId)
+    .all<NotebookAclRow>();
+  return rows.results ?? [];
+}
+
+export async function createNotebookWithOwnerAcl(
   env: Env,
   notebookId: string,
   identity: AuthenticatedConnection,
@@ -140,13 +283,64 @@ export async function ensureNotebook(
   }
 
   await ensureCatalogSchema(env);
+  const now = new Date().toISOString();
   await env.DB.prepare(
-    `INSERT INTO notebooks (id, owner_principal, updated_at)
-       VALUES (?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET updated_at = excluded.updated_at`,
+    `INSERT INTO notebooks (id, owner_principal, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(id) DO NOTHING`,
   )
-    .bind(notebookId, identity.principal, new Date().toISOString())
+    .bind(notebookId, identity.principal, now, now)
     .run();
+
+  const notebook = await getNotebookRow(env, notebookId);
+  if (notebook?.owner_principal !== identity.principal) {
+    return;
+  }
+
+  await notebookAclInsert(env, {
+    notebookId,
+    subjectKind: "principal",
+    subject: identity.principal,
+    scope: "owner",
+    actorLabel: identity.actorLabel,
+    timestamp: now,
+  }).run();
+}
+
+function notebookAclInsert(
+  env: Env,
+  row: {
+    notebookId: string;
+    subjectKind: NotebookAclRow["subject_kind"];
+    subject: string;
+    scope: NotebookAclRow["scope"];
+    actorLabel: string;
+    timestamp: string;
+  },
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO notebook_acl (
+       notebook_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(
+      row.notebookId,
+      row.subjectKind,
+      row.subject,
+      row.scope,
+      row.timestamp,
+      row.timestamp,
+      row.actorLabel,
+    );
 }
 
 export async function recordRevision(
@@ -158,6 +352,7 @@ export async function recordRevision(
     snapshotKey: string;
     runtimeSnapshotKey: string | null;
     actorLabel: string;
+    publishPublic?: boolean;
   },
 ): Promise<string> {
   if (!env.DB) {
@@ -192,6 +387,18 @@ export async function recordRevision(
        SET latest_revision_id = ?, updated_at = ?
        WHERE id = ?`,
     ).bind(revisionId, createdAt, revision.notebookId),
+    ...(revision.publishPublic
+      ? [
+          notebookAclInsert(env, {
+            notebookId: revision.notebookId,
+            subjectKind: "public",
+            subject: "anonymous",
+            scope: "viewer",
+            actorLabel: revision.actorLabel,
+            timestamp: createdAt,
+          }),
+        ]
+      : []),
   ]);
   return revisionId;
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2,6 +2,7 @@ import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import worker from "../src/index.ts";
+import { authenticateDevRequest } from "../src/identity.ts";
 import type {
   D1Database,
   D1PreparedStatement,
@@ -16,7 +17,13 @@ import type {
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
 import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
-import { blobKey, renderKey, snapshotKey } from "../src/storage.ts";
+import {
+  blobKey,
+  createNotebookWithOwnerAcl,
+  getNotebookAclRowsForPrincipal,
+  renderKey,
+  snapshotKey,
+} from "../src/storage.ts";
 
 const wasmBytes = await readFile(
   new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
@@ -288,6 +295,11 @@ describe("Worker artifact routes", () => {
   it("allows runtime peers to upload content-addressed output blobs", async () => {
     const env = fakeEnv();
     seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
     const body = new Uint8Array([1, 2, 3, 4]);
     const hash = await sha256Hex(body);
 
@@ -317,6 +329,12 @@ describe("Worker artifact routes", () => {
 
   it("rejects blob uploads whose path hash does not match the bytes", async () => {
     const env = fakeEnv();
+    seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
     const body = new Uint8Array([1, 2, 3, 4]);
     const actual = await sha256Hex(body);
     const expected = "0".repeat(64);
@@ -335,7 +353,108 @@ describe("Worker artifact routes", () => {
     });
     assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.has(blobKey("runtime-demo", expected)), false);
     assert.equal(env.DB.blobs.size, 0);
-    assert.equal(env.DB.notebooks.has("runtime-demo"), false);
+    assert.equal(env.DB.notebooks.has("runtime-demo"), true);
+  });
+
+  it("keeps unpublished notebooks private to anonymous readers", async () => {
+    const env = fakeEnv({ DEPLOYMENT_ENV: "prototype" });
+    seedNotebook(env, "private-demo");
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n/private-demo"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "notebook not found" });
+  });
+
+  it("does not let authenticated principals fall back to public ACL rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "public-demo");
+    seedAcl(env, {
+      notebookId: "public-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const anonymous = await worker.fetch(
+      new Request("http://localhost/api/n/public-demo?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(anonymous.status, 200);
+
+    const authenticated = await worker.fetch(
+      new Request("http://localhost/api/n/public-demo?user=bob&operator=desktop:b&scope=viewer"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(authenticated.status, 403);
+    assert.deepEqual(await authenticated.json(), {
+      error: "user:dev:bob cannot access public-demo",
+    });
+  });
+
+  it("does not grant owner ACL to a principal that loses notebook creation", async () => {
+    const env = fakeEnv();
+    const alice = authenticateDevRequest(
+      new Request("http://localhost/n/race-demo/sync?user=alice&operator=desktop:a&scope=owner"),
+    );
+    const bob = authenticateDevRequest(
+      new Request("http://localhost/n/race-demo/sync?user=bob&operator=desktop:b&scope=owner"),
+    );
+
+    await createNotebookWithOwnerAcl(env, "race-demo", alice);
+    await createNotebookWithOwnerAcl(env, "race-demo", bob);
+
+    assert.equal(env.DB.notebooks.get("race-demo")?.owner_principal, "user:dev:alice");
+    assert.equal(
+      (await getNotebookAclRowsForPrincipal(env, "race-demo", "user:dev:alice")).length,
+      1,
+    );
+    assert.equal(
+      (await getNotebookAclRowsForPrincipal(env, "race-demo", "user:dev:bob")).length,
+      0,
+    );
+  });
+
+  it("does not create notebook rows from unauthorized WebSocket opens", async () => {
+    let roomFetches = 0;
+    const env = fakeEnv({
+      DEPLOYMENT_ENV: "prototype",
+      NOTEBOOK_CLOUD_DEV_TOKEN: "secret-token",
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://cloud.test/n/unclaimed-demo/sync?user=alice&operator=desktop:a&scope=editor",
+        {
+          headers: {
+            Upgrade: "websocket",
+            "X-Notebook-Cloud-Dev-Token": "secret-token",
+          },
+        },
+      ),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "notebook not found" });
+    assert.equal(roomFetches, 0);
+    assert.equal(env.DB.notebooks.has("unclaimed-demo"), false);
   });
 
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
@@ -361,6 +480,10 @@ describe("Worker artifact routes", () => {
       runtimeStateBytes,
     );
     assert.equal(runtimePut.status, 201);
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
+      [["route-demo", "principal", "user:dev:alice", "owner"]],
+    );
 
     const notebookPut = await ownerPut(
       env,
@@ -371,6 +494,13 @@ describe("Worker artifact routes", () => {
       },
     );
     assert.equal(notebookPut.status, 201);
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
+      [
+        ["route-demo", "principal", "user:dev:alice", "owner"],
+        ["route-demo", "public", "anonymous", "viewer"],
+      ],
+    );
     assert.equal(
       env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("route-demo", "heads-fixture")),
       true,
@@ -605,6 +735,26 @@ function seedNotebook(env: FakeEnv, notebookId: string): void {
   });
 }
 
+function seedAcl(
+  env: FakeEnv,
+  row: {
+    notebookId: string;
+    subject: string;
+    scope: NotebookAclRow["scope"];
+    subjectKind?: NotebookAclRow["subject_kind"];
+  },
+): void {
+  env.DB.acl.push({
+    notebook_id: row.notebookId,
+    subject_kind: row.subjectKind ?? "principal",
+    subject: row.subject,
+    scope: row.scope,
+    created_at: "2026-05-22T00:00:00.000Z",
+    updated_at: "2026-05-22T00:00:00.000Z",
+    created_by_actor_label: "user:dev:alice/desktop:test",
+  });
+}
+
 async function sha256Hex(body: Uint8Array): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", body);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -647,6 +797,16 @@ interface NotebookRow {
   latest_revision_id: string | null;
 }
 
+interface NotebookAclRow {
+  notebook_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: "viewer" | "editor" | "runtime_peer" | "owner";
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+}
+
 interface RevisionRow {
   id: string;
   notebook_id: string;
@@ -662,6 +822,7 @@ class FakeD1 implements D1Database {
   readonly notebooks = new Map<string, NotebookRow>();
   readonly revisions: RevisionRow[] = [];
   readonly blobs = new Map<string, BlobRow>();
+  readonly acl: NotebookAclRow[] = [];
 
   prepare(query: string): D1PreparedStatement {
     return new FakeD1Statement(this, query);
@@ -694,14 +855,71 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async run<T = unknown>(): Promise<D1Result<T>> {
-    if (this.query.includes("INSERT INTO notebooks")) {
-      const [id, ownerPrincipal, updatedAt] = this.values as [string, string, string];
+    if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
+      if (this.query.includes("'principal'") && this.query.includes("owner_principal")) {
+        for (const notebook of this.db.notebooks.values()) {
+          this.insertAclIfMissing({
+            notebook_id: notebook.id,
+            subject_kind: "principal",
+            subject: notebook.owner_principal,
+            scope: "owner",
+            created_at: notebook.created_at,
+            updated_at: notebook.updated_at,
+            created_by_actor_label: "system/schema:notebook-cloud-owner-acl-backfill",
+          });
+        }
+      } else if (this.query.includes("'public'")) {
+        for (const notebook of this.db.notebooks.values()) {
+          if (notebook.latest_revision_id === null) continue;
+          this.insertAclIfMissing({
+            notebook_id: notebook.id,
+            subject_kind: "public",
+            subject: "anonymous",
+            scope: "viewer",
+            created_at: notebook.created_at,
+            updated_at: notebook.updated_at,
+            created_by_actor_label: "system/schema:notebook-cloud-public-acl-backfill",
+          });
+        }
+      }
+    } else if (this.query.includes("INSERT INTO notebook_acl")) {
+      const [notebookId, subjectKind, subject, scope, createdAt, updatedAt, actorLabel] = this
+        .values as [
+        string,
+        NotebookAclRow["subject_kind"],
+        string,
+        NotebookAclRow["scope"],
+        string,
+        string,
+        string,
+      ];
+      this.insertAclIfMissing({
+        notebook_id: notebookId,
+        subject_kind: subjectKind,
+        subject,
+        scope,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        created_by_actor_label: actorLabel,
+      });
+    } else if (this.query.includes("INSERT INTO notebooks")) {
+      const [id, ownerPrincipal, createdAtOrUpdatedAt, maybeUpdatedAt] = this.values as [
+        string,
+        string,
+        string,
+        string | undefined,
+      ];
+      const createdAt = maybeUpdatedAt ? createdAtOrUpdatedAt : undefined;
+      const updatedAt = maybeUpdatedAt ?? createdAtOrUpdatedAt;
       const existing = this.db.notebooks.get(id);
+      if (existing && this.query.includes("DO NOTHING")) {
+        return okResult();
+      }
       this.db.notebooks.set(id, {
         id,
         owner_principal: existing?.owner_principal ?? ownerPrincipal,
         title: existing?.title ?? null,
-        created_at: existing?.created_at ?? updatedAt,
+        created_at: existing?.created_at ?? createdAt ?? updatedAt,
         updated_at: updatedAt,
         latest_revision_id: existing?.latest_revision_id ?? null,
       });
@@ -725,11 +943,20 @@ class FakeD1Statement implements D1PreparedStatement {
         actor_label: actorLabel,
         created_at: new Date().toISOString(),
       });
-    } else if (this.query.includes("UPDATE notebooks")) {
+    } else if (
+      this.query.includes("UPDATE notebooks") &&
+      this.query.includes("latest_revision_id")
+    ) {
       const [revisionId, updatedAt, notebookId] = this.values as [string, string, string];
       const existing = this.db.notebooks.get(notebookId);
       if (existing) {
         existing.latest_revision_id = revisionId;
+        existing.updated_at = updatedAt;
+      }
+    } else if (this.query.includes("UPDATE notebooks")) {
+      const [updatedAt, notebookId] = this.values as [string, string];
+      const existing = this.db.notebooks.get(notebookId);
+      if (existing) {
         existing.updated_at = updatedAt;
       }
     } else if (this.query.includes("INSERT INTO notebook_blobs")) {
@@ -752,6 +979,21 @@ class FakeD1Statement implements D1PreparedStatement {
     return okResult();
   }
 
+  private insertAclIfMissing(row: NotebookAclRow): void {
+    const existing = this.db.acl.find(
+      (candidate) =>
+        candidate.notebook_id === row.notebook_id &&
+        candidate.subject_kind === row.subject_kind &&
+        candidate.subject === row.subject &&
+        candidate.scope === row.scope,
+    );
+    if (existing) {
+      existing.updated_at = row.updated_at;
+      return;
+    }
+    this.db.acl.push(row);
+  }
+
   async first<T = unknown>(): Promise<T | null> {
     if (this.query.includes("FROM notebooks")) {
       return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;
@@ -760,6 +1002,30 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("FROM notebook_acl")) {
+      const notebookId = this.values[0] as string;
+      if (this.query.includes("subject_kind = 'principal'")) {
+        const principal = this.values[1] as string;
+        return okResult(
+          this.db.acl.filter(
+            (row) =>
+              row.notebook_id === notebookId &&
+              row.subject_kind === "principal" &&
+              row.subject === principal,
+          ) as T[],
+        );
+      }
+      if (this.query.includes("subject_kind = 'public'")) {
+        return okResult(
+          this.db.acl.filter(
+            (row) =>
+              row.notebook_id === notebookId &&
+              row.subject_kind === "public" &&
+              row.subject === "anonymous",
+          ) as T[],
+        );
+      }
+    }
     if (this.query.includes("FROM notebook_revisions")) {
       const notebookId = this.values[0] as string;
       return okResult(


### PR DESCRIPTION
## Summary

- add a `notebook_acl` D1 table with principal/public subjects and viewer/editor/runtime_peer/owner scopes
- authorize notebook-cloud sync, catalog, render, snapshot, and blob reads before reaching the DO or R2
- move notebook row creation out of the Durable Object and into explicit owner publish/import paths
- grant owner ACL when a notebook is created, and grant public viewer ACL only when a notebook snapshot revision publishes successfully

## Tests

- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
