### PR TITLE
feat(notebook-cloud): materialize room sync in durable objects

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1,6 +1,5 @@
 import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
 import {
-  allowsNotebookWrite,
   allowsRuntimeStateWrite,
   isAnonymousViewer,
   readTrustedIdentity,
@@ -18,6 +17,12 @@ import {
   type TypedFrame,
 } from "./protocol.ts";
 import { rewritePresenceIngress } from "./runtimed-wasm.ts";
+import {
+  isMaterializedSyncFrame,
+  RoomMaterializer,
+  typedFrameFromRoomHostOutbound,
+  type RoomHostFrameResult,
+} from "./room-materializer.ts";
 
 interface Peer {
   id: string;
@@ -52,10 +57,11 @@ export class NotebookRoom {
   private frameSequenceReady: Promise<void> | undefined;
   private framePersistQueue: Promise<void> = Promise.resolve();
   private broadcastDepth = 0;
+  private readonly materializers = new Map<string, RoomMaterializer>();
 
   constructor(
     private readonly state: DurableObjectState,
-    _env: Env,
+    private readonly env: Env,
   ) {
     this.restoreHibernatedPeers();
   }
@@ -115,6 +121,7 @@ export class NotebookRoom {
       },
       peer.id,
     );
+    this.state.waitUntil(this.syncPeerFromRoomHost(notebookId, peer));
 
     return new Response(null, {
       status: 101,
@@ -297,6 +304,39 @@ export class NotebookRoom {
       return;
     }
 
+    if (isMaterializedSyncFrame(normalizedFrame.type)) {
+      let result: RoomHostFrameResult;
+      const materializer = this.materializerFor(notebookId);
+      try {
+        result = await materializer.receiveFrame(peer, normalizedFrame);
+      } catch (error) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `room host rejected ${frameTypeName(normalizedFrame.type)} frame: ${String(error)}`,
+        );
+        return;
+      }
+
+      this.state.waitUntil(
+        this.persistFrame(peer, normalizedFrame, receivedAt).catch(() => undefined),
+      );
+      this.deliverRoomHostFrames(notebookId, result);
+      if (result.changed) {
+        this.state.waitUntil(materializer.checkpoint().catch(() => undefined));
+      }
+      this.sendControl(notebookId, peer, {
+        type: "cloud_frame_accepted",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        frame_type: normalizedFrame.type,
+        byte_length: normalizedFrame.payload.byteLength,
+        timestamp: receivedAt,
+      });
+      return;
+    }
+
     try {
       await this.persistFrame(peer, normalizedFrame, receivedAt);
     } catch (error) {
@@ -327,8 +367,11 @@ export class NotebookRoom {
   private scopeAllowsFrame(identity: AuthenticatedConnection, frame: TypedFrame): boolean {
     switch (frame.type) {
       case FrameType.AUTOMERGE_SYNC:
-        return allowsNotebookWrite(identity.scope);
       case FrameType.RUNTIME_STATE_SYNC:
+        // These frames are both data and protocol control. Read-only peers may
+        // send empty sync acks/needs; RoomMaterializer rejects messages carrying
+        // document changes when the connection lacks write scope.
+        return true;
       case FrameType.PUT_BLOB:
         return allowsRuntimeStateWrite(identity.scope);
       case FrameType.POOL_STATE_SYNC:
@@ -339,6 +382,33 @@ export class NotebookRoom {
         return true;
       default:
         return false;
+    }
+  }
+
+  private async syncPeerFromRoomHost(notebookId: string, peer: Peer): Promise<void> {
+    try {
+      this.deliverRoomHostFrames(notebookId, await this.materializerFor(notebookId).syncPeer(peer));
+    } catch {
+      this.removePeer(notebookId, peer);
+    }
+  }
+
+  private materializerFor(notebookId: string): RoomMaterializer {
+    let materializer = this.materializers.get(notebookId);
+    if (!materializer) {
+      materializer = new RoomMaterializer(notebookId, this.state, this.env);
+      this.materializers.set(notebookId, materializer);
+    }
+    return materializer;
+  }
+
+  private deliverRoomHostFrames(notebookId: string, result: RoomHostFrameResult): void {
+    for (const outbound of result.outbound) {
+      const target = this.peers.get(outbound.peer_id);
+      if (!target) {
+        continue;
+      }
+      this.sendFrameToPeer(notebookId, target, typedFrameFromRoomHostOutbound(outbound));
     }
   }
 
@@ -479,6 +549,11 @@ export class NotebookRoom {
     if (!this.peers.delete(peer.id)) {
       return;
     }
+    this.state.waitUntil(
+      this.materializerFor(notebookId)
+        .removePeer(peer.id)
+        .catch(() => undefined),
+    );
 
     try {
       peer.socket.close();

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -1,0 +1,194 @@
+import type { DurableObjectState, Env } from "./cloudflare-types.ts";
+import { FrameType, encodeTypedFrame, type FrameTypeValue, type TypedFrame } from "./protocol.ts";
+import { createEmptyRoomHost, loadRoomHostSnapshot, type RoomHostHandle } from "./runtimed-wasm.ts";
+import { getNotebookCatalog } from "./storage.ts";
+import {
+  allowsNotebookWrite,
+  allowsRuntimeStateWrite,
+  type AuthenticatedConnection,
+} from "./identity.ts";
+
+const ROOM_HOST_ACTOR_LABEL = "system/schema:notebook-cloud-room";
+const CHECKPOINT_NOTEBOOK_KEY = "room-host:notebook-doc";
+const CHECKPOINT_RUNTIME_STATE_KEY = "room-host:runtime-state-doc";
+const CHECKPOINT_META_KEY = "room-host:checkpoint";
+
+interface RoomHostOutboundFrame {
+  peer_id: string;
+  frame_type: FrameTypeValue;
+  payload: Uint8Array | number[];
+}
+
+export interface RoomHostFrameResult {
+  changed: boolean;
+  notebook_changed: boolean;
+  runtime_state_changed: boolean;
+  outbound: RoomHostOutboundFrame[];
+}
+
+interface RoomCheckpointMetadata {
+  notebook_heads: string[];
+  runtime_state_heads: string[];
+  saved_at: string;
+}
+
+interface RoomPeer {
+  id: string;
+  identity: AuthenticatedConnection;
+}
+
+export class RoomMaterializer {
+  private hostReady: Promise<RoomHostHandle> | undefined;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly notebookId: string,
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {}
+
+  async syncPeer(peer: RoomPeer): Promise<RoomHostFrameResult> {
+    return this.withHost((host) => normalizeResult(host.sync_peer(peer.id)));
+  }
+
+  async removePeer(peerId: string): Promise<void> {
+    await this.withHost((host) => {
+      host.remove_peer(peerId);
+    });
+  }
+
+  async receiveFrame(peer: RoomPeer, frame: TypedFrame): Promise<RoomHostFrameResult> {
+    const canWrite =
+      frame.type === FrameType.AUTOMERGE_SYNC
+        ? allowsNotebookWrite(peer.identity.scope)
+        : allowsRuntimeStateWrite(peer.identity.scope);
+    const encoded = encodeTypedFrame(frame.type, frame.payload);
+    return this.withHost((host) =>
+      normalizeResult(host.receive_peer_frame(peer.id, peer.identity.principal, canWrite, encoded)),
+    );
+  }
+
+  async checkpoint(): Promise<void> {
+    await this.withHost(async (host) => {
+      const [notebookBytes, runtimeStateBytes] = [
+        toStoredArrayBuffer(host.save_notebook()),
+        toStoredArrayBuffer(host.save_runtime_state_doc()),
+      ];
+      const metadata: RoomCheckpointMetadata = {
+        notebook_heads: Array.from(host.get_heads_hex()),
+        runtime_state_heads: Array.from(host.get_runtime_state_heads_hex()),
+        saved_at: new Date().toISOString(),
+      };
+      await Promise.all([
+        this.state.storage.put(CHECKPOINT_NOTEBOOK_KEY, notebookBytes),
+        this.state.storage.put(CHECKPOINT_RUNTIME_STATE_KEY, runtimeStateBytes),
+        this.state.storage.put(CHECKPOINT_META_KEY, metadata),
+      ]);
+    });
+  }
+
+  private async withHost<T>(operation: (host: RoomHostHandle) => T | Promise<T>): Promise<T> {
+    const run = this.operationQueue.then(async () => operation(await this.loadHost()));
+    this.operationQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async loadHost(): Promise<RoomHostHandle> {
+    this.hostReady ??= this.loadHostFromStorage().catch((error: unknown) => {
+      this.hostReady = undefined;
+      throw error;
+    });
+    return this.hostReady;
+  }
+
+  private async loadHostFromStorage(): Promise<RoomHostHandle> {
+    const checkpoint = await this.loadCheckpoint();
+    if (checkpoint) {
+      return loadRoomHostSnapshot(checkpoint.notebookBytes, checkpoint.runtimeStateBytes);
+    }
+
+    const published = await this.loadLatestPublishedSnapshotPair();
+    if (published) {
+      return loadRoomHostSnapshot(published.notebookBytes, published.runtimeStateBytes);
+    }
+
+    return createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
+  }
+
+  private async loadCheckpoint(): Promise<{
+    notebookBytes: Uint8Array;
+    runtimeStateBytes: Uint8Array;
+  } | null> {
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      this.state.storage.get<ArrayBuffer>(CHECKPOINT_NOTEBOOK_KEY),
+      this.state.storage.get<ArrayBuffer>(CHECKPOINT_RUNTIME_STATE_KEY),
+    ]);
+    if (!notebookBytes || !runtimeStateBytes) {
+      return null;
+    }
+    return {
+      notebookBytes: new Uint8Array(notebookBytes),
+      runtimeStateBytes: new Uint8Array(runtimeStateBytes),
+    };
+  }
+
+  private async loadLatestPublishedSnapshotPair(): Promise<{
+    notebookBytes: Uint8Array;
+    runtimeStateBytes: Uint8Array;
+  } | null> {
+    if (!this.env.DB || !this.env.NOTEBOOK_SNAPSHOTS) {
+      return null;
+    }
+
+    const catalog = await getNotebookCatalog(this.env, this.notebookId);
+    const latest = catalog?.revisions.find(
+      (revision) => revision.id === catalog.notebook.latest_revision_id,
+    );
+    if (!latest?.runtime_snapshot_key) {
+      return null;
+    }
+
+    const [notebookObject, runtimeObject] = await Promise.all([
+      this.env.NOTEBOOK_SNAPSHOTS.get(latest.snapshot_key),
+      this.env.NOTEBOOK_SNAPSHOTS.get(latest.runtime_snapshot_key),
+    ]);
+    if (!notebookObject || !runtimeObject) {
+      return null;
+    }
+
+    return {
+      notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
+      runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
+    };
+  }
+}
+
+export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {
+  return type === FrameType.AUTOMERGE_SYNC || type === FrameType.RUNTIME_STATE_SYNC;
+}
+
+export function typedFrameFromRoomHostOutbound(frame: RoomHostOutboundFrame): Uint8Array {
+  return encodeTypedFrame(frame.frame_type, toUint8Array(frame.payload));
+}
+
+function normalizeResult(value: unknown): RoomHostFrameResult {
+  const result = value as Partial<RoomHostFrameResult> | undefined;
+  return {
+    changed: result?.changed ?? false,
+    notebook_changed: result?.notebook_changed ?? false,
+    runtime_state_changed: result?.runtime_state_changed ?? false,
+    outbound: result?.outbound ?? [],
+  };
+}
+
+function toUint8Array(value: Uint8Array | number[]): Uint8Array {
+  return value instanceof Uint8Array ? value : new Uint8Array(value);
+}
+
+function toStoredArrayBuffer(value: Uint8Array | number[]): ArrayBuffer {
+  const bytes = toUint8Array(value);
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -3,6 +3,7 @@ import initWasm, {
   encode_presence_frame,
   rewrite_presence_ingress,
   NotebookHandle,
+  RoomHostHandle,
 } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 
 let initialized: Promise<void> | undefined;
@@ -57,3 +58,21 @@ export async function loadSnapshotPair(
   await initializeRuntimedWasm();
   return NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
 }
+
+export async function createEmptyRoomHost(
+  notebookId: string,
+  actorLabel: string,
+): Promise<RoomHostHandle> {
+  await initializeRuntimedWasm();
+  return RoomHostHandle.create_empty(notebookId, actorLabel);
+}
+
+export async function loadRoomHostSnapshot(
+  notebookBytes: Uint8Array,
+  runtimeStateBytes: Uint8Array,
+): Promise<RoomHostHandle> {
+  await initializeRuntimedWasm();
+  return RoomHostHandle.load_snapshot(notebookBytes, runtimeStateBytes);
+}
+
+export { NotebookHandle, RoomHostHandle };

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1,0 +1,245 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import type { DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import { authenticateDevRequest } from "../src/identity.ts";
+import { FrameType, encodeTypedFrame, type FrameTypeValue } from "../src/protocol.ts";
+import { RoomMaterializer } from "../src/room-materializer.ts";
+import {
+  createEmptyRoomHost,
+  initializeRuntimedWasm,
+  NotebookHandle,
+} from "../src/runtimed-wasm.ts";
+
+const wasmBytes = await readFile(
+  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
+);
+
+before(async () => {
+  await initializeRuntimedWasm(wasmBytes);
+});
+
+describe("RoomHostHandle", () => {
+  it("hosts NotebookDoc sync with per-peer state", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const editor = NotebookHandle.create_bootstrap("user:dev:alice/desktop:a");
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+
+    syncHostWithClient(host, "peer-editor", "user:dev:alice", true, editor);
+    editor.add_cell(0, "cell-1", "markdown");
+    editor.update_source("cell-1", "# Hosted markdown\n");
+    const message = editor.flush_local_changes();
+    assert.ok(message);
+
+    const editorResult = host.receive_peer_frame(
+      "peer-editor",
+      "user:dev:alice",
+      true,
+      encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+    ) as {
+      changed: boolean;
+      outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
+    };
+
+    assert.equal(editorResult.changed, true);
+
+    syncHostWithClient(host, "peer-viewer", "user:dev:bob", false, viewer);
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["cell-1", "# Hosted markdown\n"]],
+    );
+  });
+
+  it("rejects document changes authored by a foreign principal", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const forged = NotebookHandle.create_bootstrap("user:dev:mallory/desktop:forge");
+    syncHostWithClient(host, "peer-alice", "user:dev:alice", true, forged);
+    forged.add_cell(0, "cell-forged", "markdown");
+    const message = forged.flush_local_changes();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-alice",
+          "user:dev:alice",
+          true,
+          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+        ),
+      /not authorized/,
+    );
+  });
+
+  it("rejects viewer-authored document changes", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const viewer = NotebookHandle.create_bootstrap("user:dev:alice/desktop:a");
+    syncHostWithClient(host, "peer-viewer", "user:dev:alice", false, viewer);
+    viewer.add_cell(0, "cell-viewer", "markdown");
+    const message = viewer.flush_local_changes();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-viewer",
+          "user:dev:alice",
+          false,
+          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+        ),
+      /cannot write NotebookDoc/,
+    );
+  });
+});
+
+describe("RoomMaterializer", () => {
+  it("persists and reloads a durable room checkpoint", async () => {
+    const state = fakeState();
+    const editorIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const editorPeer = {
+      id: "peer-editor",
+      identity: editorIdentity,
+    };
+    const editor = NotebookHandle.create_bootstrap(editorIdentity.actorLabel);
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    await syncMaterializerWithClient(materializer, editorPeer, editor);
+    editor.add_cell(0, "cell-1", "markdown");
+    editor.update_source("cell-1", "Durable room checkpoint\n");
+    const message = editor.flush_local_changes();
+    assert.ok(message);
+
+    const applied = await materializer.receiveFrame(editorPeer, {
+      type: FrameType.AUTOMERGE_SYNC,
+      payload: message,
+    });
+    assert.equal(applied.changed, true);
+    await materializer.checkpoint();
+
+    const keys = [...(await state.storage.list({ prefix: "room-host:" })).keys()].sort();
+    assert.deepEqual(keys, [
+      "room-host:checkpoint",
+      "room-host:notebook-doc",
+      "room-host:runtime-state-doc",
+    ]);
+
+    const reloaded = new RoomMaterializer("demo", state, {} as Env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => cell.id),
+      ["cell-1"],
+    );
+    assert.equal(cells[0].source, "Durable room checkpoint\n");
+  });
+});
+
+function syncHostWithClient(
+  host: Awaited<ReturnType<typeof createEmptyRoomHost>>,
+  peerId: string,
+  principal: string,
+  canWrite: boolean,
+  client: NotebookHandle,
+): void {
+  let result = host.sync_peer(peerId) as {
+    outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
+  };
+  for (let round = 0; round < 8; round += 1) {
+    const replies = applyOutboundToClient(result.outbound, peerId, client);
+    if (replies.length === 0) {
+      return;
+    }
+    const outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }> = [];
+    for (const reply of replies) {
+      const next = host.receive_peer_frame(peerId, principal, canWrite, reply) as {
+        outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
+      };
+      outbound.push(...next.outbound);
+    }
+    result = { outbound };
+  }
+}
+
+async function syncMaterializerWithClient(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  client: NotebookHandle,
+): Promise<void> {
+  let result = await materializer.syncPeer(peer);
+  for (let round = 0; round < 8; round += 1) {
+    const replies = applyOutboundToClient(result.outbound, peer.id, client);
+    if (replies.length === 0) {
+      return;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.AUTOMERGE_SYNC,
+        payload: reply.slice(1),
+      });
+      outbound.push(...next.outbound);
+    }
+    result = {
+      changed: false,
+      notebook_changed: false,
+      runtime_state_changed: false,
+      outbound,
+    };
+  }
+}
+
+function applyOutboundToClient(
+  outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: Uint8Array | number[] }>,
+  peerId: string,
+  client: NotebookHandle,
+): Uint8Array[] {
+  const replies: Uint8Array[] = [];
+  for (const frame of outbound) {
+    if (frame.peer_id !== peerId || frame.frame_type !== FrameType.AUTOMERGE_SYNC) {
+      continue;
+    }
+    const events = client.receive_frame(
+      encodeTypedFrame(frame.frame_type, new Uint8Array(frame.payload)),
+    ) as Array<{ type: string; reply?: number[] }>;
+    for (const event of events ?? []) {
+      if (event.type === "sync_applied" && event.reply) {
+        replies.push(encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(event.reply)));
+      }
+    }
+  }
+  return replies;
+}
+
+function fakeState(): DurableObjectState {
+  const values = new Map<string, unknown>();
+  return {
+    id: { toString: () => "room-id" },
+    storage: {
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => values.delete(key),
+      list: async <T>(options?: { prefix?: string }) => {
+        const entries = [...values.entries()].filter(
+          ([key]) => !options?.prefix || key.startsWith(options.prefix),
+        );
+        return new Map(entries) as Map<string, T>;
+      },
+    },
+    waitUntil: () => undefined,
+  };
+}

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -10,7 +10,7 @@
 
 use automerge::sync;
 use automerge::sync::SyncDoc;
-use notebook_doc::diff::{diff_doc, CellChangeset, TextPatch};
+use notebook_doc::diff::{diff_doc, extract_change_actors, CellChangeset, TextPatch};
 use notebook_doc::mime::{is_binary_mime, ResolvedContentRef};
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
@@ -226,6 +226,399 @@ pub enum FrameEvent {
     },
     /// Unknown frame type — frontend can log and ignore.
     Unknown { frame_type: u8 },
+}
+
+/// Outbound frame produced by [`RoomHostHandle`].
+///
+/// The Worker owns WebSocket I/O; the WASM room host owns document state and
+/// per-peer Automerge sync state. Each event tells the Worker which peer should
+/// receive which typed-frame payload.
+#[derive(Serialize)]
+pub struct RoomHostOutboundFrame {
+    pub peer_id: String,
+    pub frame_type: u8,
+    pub payload: Vec<u8>,
+}
+
+/// Result returned after the room host processes one peer frame.
+#[derive(Serialize)]
+pub struct RoomHostFrameResult {
+    pub changed: bool,
+    pub notebook_changed: bool,
+    pub runtime_state_changed: bool,
+    pub outbound: Vec<RoomHostOutboundFrame>,
+}
+
+impl RoomHostFrameResult {
+    fn empty() -> Self {
+        Self {
+            changed: false,
+            notebook_changed: false,
+            runtime_state_changed: false,
+            outbound: Vec::new(),
+        }
+    }
+}
+
+/// Durable-Object room host for NotebookDoc + RuntimeStateDoc sync.
+///
+/// Unlike [`NotebookHandle`], this is not a frontend/client handle. It owns the
+/// authoritative document pair for one room and keeps a separate Automerge
+/// `sync::State` per connected peer. That per-peer state is load-bearing:
+/// sharing one sync state across browser tabs would make the Worker acknowledge
+/// the wrong heads and eventually suppress valid sync messages.
+#[wasm_bindgen]
+pub struct RoomHostHandle {
+    doc: NotebookDoc,
+    state_doc: RuntimeStateDoc,
+    notebook_peer_states: HashMap<String, sync::State>,
+    runtime_peer_states: HashMap<String, sync::State>,
+}
+
+#[wasm_bindgen]
+impl RoomHostHandle {
+    /// Create an empty room host from the canonical schema seeds.
+    pub fn create_empty(notebook_id: &str, actor_label: &str) -> Result<RoomHostHandle, JsError> {
+        Ok(RoomHostHandle {
+            doc: NotebookDoc::new_with_actor(notebook_id, actor_label),
+            state_doc: RuntimeStateDoc::try_new_empty()
+                .map_err(|e| JsError::new(&format!("create runtime state doc failed: {e}")))?,
+            notebook_peer_states: HashMap::new(),
+            runtime_peer_states: HashMap::new(),
+        })
+    }
+
+    /// Load a room host from persisted NotebookDoc + RuntimeStateDoc bytes.
+    pub fn load_snapshot(
+        notebook_bytes: &[u8],
+        runtime_state_bytes: &[u8],
+    ) -> Result<RoomHostHandle, JsError> {
+        let doc = NotebookDoc::load_with_encoding(
+            notebook_bytes,
+            notebook_doc::TextEncoding::Utf16CodeUnit,
+        )
+        .map_err(|e| JsError::new(&format!("load notebook snapshot failed: {e}")))?;
+        let runtime_doc = automerge::AutoCommit::load(runtime_state_bytes)
+            .map_err(|e| JsError::new(&format!("load runtime snapshot failed: {e}")))?;
+        Ok(RoomHostHandle {
+            doc,
+            state_doc: RuntimeStateDoc::from_doc(runtime_doc),
+            notebook_peer_states: HashMap::new(),
+            runtime_peer_states: HashMap::new(),
+        })
+    }
+
+    /// Drop all sync state for a disconnected peer.
+    pub fn remove_peer(&mut self, peer_id: &str) {
+        self.notebook_peer_states.remove(peer_id);
+        self.runtime_peer_states.remove(peer_id);
+    }
+
+    /// Generate current sync frames for a peer.
+    ///
+    /// The Worker calls this immediately after accepting a socket and after the
+    /// peer receives `cloud_room_ready`. It lets read-only viewers receive the
+    /// current document without authoring any local Automerge changes.
+    pub fn sync_peer(&mut self, peer_id: &str) -> Result<JsValue, JsError> {
+        let mut result = RoomHostFrameResult::empty();
+        self.queue_current_sync_for_peer(peer_id, &mut result.outbound)?;
+        serialize_to_js(&result).map_err(|e| JsError::new(&format!("serialize room result: {e}")))
+    }
+
+    /// Apply a typed-frame from a peer to the room host.
+    ///
+    /// `can_write` is the server-side scope decision for this document stream.
+    /// Viewers and runtime peers may still send empty sync acks/needs so the
+    /// Automerge protocol can converge, but any message carrying changes is
+    /// rejected unless `can_write` is true.
+    pub fn receive_peer_frame(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        frame_bytes: &[u8],
+    ) -> Result<JsValue, JsError> {
+        if frame_bytes.is_empty() {
+            return Err(JsError::new("typed frame cannot be empty"));
+        }
+
+        let frame_type = frame_bytes[0];
+        let payload = &frame_bytes[1..];
+        let result = match frame_type {
+            frame_types::AUTOMERGE_SYNC => {
+                self.receive_notebook_sync(peer_id, principal, can_write, payload)?
+            }
+            frame_types::RUNTIME_STATE_SYNC => {
+                self.receive_runtime_state_sync(peer_id, principal, can_write, payload)?
+            }
+            _ => RoomHostFrameResult::empty(),
+        };
+
+        serialize_to_js(&result).map_err(|e| JsError::new(&format!("serialize room result: {e}")))
+    }
+
+    /// Export the current NotebookDoc bytes for room checkpointing.
+    pub fn save_notebook(&mut self) -> Vec<u8> {
+        self.doc.save()
+    }
+
+    /// Export the current RuntimeStateDoc bytes for room checkpointing.
+    pub fn save_runtime_state_doc(&mut self) -> Vec<u8> {
+        self.state_doc.doc_mut().save()
+    }
+
+    /// Current NotebookDoc heads as hex strings.
+    pub fn get_heads_hex(&mut self) -> Vec<String> {
+        self.doc.get_heads_hex()
+    }
+
+    /// Current RuntimeStateDoc heads as hex strings.
+    pub fn get_runtime_state_heads_hex(&mut self) -> Vec<String> {
+        self.state_doc
+            .get_heads()
+            .into_iter()
+            .map(|head| hex::encode(head.as_ref()))
+            .collect()
+    }
+}
+
+impl RoomHostHandle {
+    fn receive_notebook_sync(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        payload: &[u8],
+    ) -> Result<RoomHostFrameResult, JsError> {
+        let message = sync::Message::decode(payload)
+            .map_err(|e| JsError::new(&format!("decode notebook sync: {e}")))?;
+        let has_changes = !message.changes.is_empty();
+        if has_changes && !can_write {
+            return Err(JsError::new(
+                "connection scope cannot write NotebookDoc changes",
+            ));
+        }
+        if has_changes {
+            let heads_before = self.doc.get_heads();
+            let peer_state = self
+                .notebook_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(sync::State::new);
+            let mut preview = NotebookDoc::wrap(self.doc.doc().clone());
+            let mut preview_peer_state = peer_state.clone();
+            preview
+                .receive_sync_message_recovering(
+                    &mut preview_peer_state,
+                    message.clone(),
+                    "cloud-room-doc-auth-preview",
+                )
+                .map_err(|e| JsError::new(&format!("notebook auth preview failed: {e}")))?;
+            let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+            validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+        }
+
+        let heads_before = self.doc.get_heads();
+        {
+            let peer_state = self
+                .notebook_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(sync::State::new);
+            self.doc
+                .receive_sync_message_recovering(peer_state, message, "cloud-room-doc-receive-sync")
+                .map_err(|e| JsError::new(&format!("receive notebook sync: {e}")))?;
+        }
+        let heads_after = self.doc.get_heads();
+        let changed = heads_before != heads_after;
+
+        let mut result = RoomHostFrameResult {
+            changed,
+            notebook_changed: changed,
+            runtime_state_changed: false,
+            outbound: Vec::new(),
+        };
+        self.queue_notebook_sync_for_peer(peer_id, &mut result.outbound)?;
+        if changed {
+            self.queue_notebook_sync_for_other_peers(peer_id, &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+
+    fn receive_runtime_state_sync(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        payload: &[u8],
+    ) -> Result<RoomHostFrameResult, JsError> {
+        let message = sync::Message::decode(payload)
+            .map_err(|e| JsError::new(&format!("decode runtime state sync: {e}")))?;
+        let has_changes = !message.changes.is_empty();
+        if has_changes && !can_write {
+            return Err(JsError::new(
+                "connection scope cannot write RuntimeStateDoc changes",
+            ));
+        }
+        if has_changes {
+            let heads_before = self.state_doc.get_heads();
+            let peer_state = self
+                .runtime_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(sync::State::new);
+            let mut preview = RuntimeStateDoc::from_doc(self.state_doc.doc().clone());
+            let mut preview_peer_state = peer_state.clone();
+            preview
+                .receive_sync_message_with_changes_recovering(
+                    &mut preview_peer_state,
+                    message.clone(),
+                    "cloud-room-state-auth-preview",
+                )
+                .map_err(|e| JsError::new(&format!("runtime state auth preview failed: {e}")))?;
+            let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+            validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+        }
+
+        let heads_before = self.state_doc.get_heads();
+        {
+            let peer_state = self
+                .runtime_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(sync::State::new);
+            self.state_doc
+                .receive_sync_message_with_changes_recovering(
+                    peer_state,
+                    message,
+                    "cloud-room-state-receive-sync",
+                )
+                .map_err(|e| JsError::new(&format!("receive runtime state sync: {e}")))?;
+        }
+        let heads_after = self.state_doc.get_heads();
+        let changed = heads_before != heads_after;
+
+        let mut result = RoomHostFrameResult {
+            changed,
+            notebook_changed: false,
+            runtime_state_changed: changed,
+            outbound: Vec::new(),
+        };
+        self.queue_runtime_state_sync_for_peer(peer_id, &mut result.outbound)?;
+        if changed {
+            self.queue_runtime_state_sync_for_other_peers(peer_id, &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+
+    fn queue_current_sync_for_peer(
+        &mut self,
+        peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        self.queue_notebook_sync_for_peer(peer_id, outbound)?;
+        self.queue_runtime_state_sync_for_peer(peer_id, outbound)?;
+        Ok(())
+    }
+
+    fn queue_notebook_sync_for_peer(
+        &mut self,
+        peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peer_state = self
+            .notebook_peer_states
+            .entry(peer_id.to_string())
+            .or_insert_with(sync::State::new);
+        if let Some(message) = self
+            .doc
+            .generate_sync_message_recovering(peer_state, "cloud-room-doc-sync-outbound")
+            .map_err(|e| JsError::new(&format!("generate notebook sync: {e}")))?
+        {
+            outbound.push(RoomHostOutboundFrame {
+                peer_id: peer_id.to_string(),
+                frame_type: frame_types::AUTOMERGE_SYNC,
+                payload: message.encode(),
+            });
+        }
+        Ok(())
+    }
+
+    fn queue_notebook_sync_for_other_peers(
+        &mut self,
+        changed_peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peers: Vec<String> = self.notebook_peer_states.keys().cloned().collect();
+        for peer_id in peers {
+            if peer_id == changed_peer_id {
+                continue;
+            }
+            self.queue_notebook_sync_for_peer(&peer_id, outbound)?;
+        }
+        Ok(())
+    }
+
+    fn queue_runtime_state_sync_for_peer(
+        &mut self,
+        peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peer_state = self
+            .runtime_peer_states
+            .entry(peer_id.to_string())
+            .or_insert_with(sync::State::new);
+        if let Some(message) = self
+            .state_doc
+            .generate_sync_message_recovering(peer_state, "cloud-room-state-sync-outbound")
+            .map_err(|e| JsError::new(&format!("generate runtime state sync: {e}")))?
+        {
+            outbound.push(RoomHostOutboundFrame {
+                peer_id: peer_id.to_string(),
+                frame_type: frame_types::RUNTIME_STATE_SYNC,
+                payload: message.encode(),
+            });
+        }
+        Ok(())
+    }
+
+    fn queue_runtime_state_sync_for_other_peers(
+        &mut self,
+        changed_peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peers: Vec<String> = self.runtime_peer_states.keys().cloned().collect();
+        for peer_id in peers {
+            if peer_id == changed_peer_id {
+                continue;
+            }
+            self.queue_runtime_state_sync_for_peer(&peer_id, outbound)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_room_actor_labels<'a>(
+    principal: &str,
+    labels: impl IntoIterator<Item = &'a str>,
+) -> Result<(), JsError> {
+    let expected = Principal::new(principal.to_string())
+        .map_err(|e| JsError::new(&format!("authenticated principal is invalid: {e}")))?;
+    for label in labels {
+        match ActorLabel::parse(label.to_string()) {
+            Ok(actor) if actor.principal() == Principal::SYSTEM => {}
+            Ok(actor) if actor.principal() == expected.as_str() => {}
+            Ok(actor) => {
+                return Err(JsError::new(&format!(
+                    "actor principal {} is not authorized for authenticated principal {}",
+                    actor.principal(),
+                    expected
+                )));
+            }
+            Err(error) => {
+                return Err(JsError::new(&format!(
+                    "actor label {label:?} is invalid: {error}"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// A handle to a local Automerge notebook document.


### PR DESCRIPTION
## Summary

Builds the next notebook-cloud room-host slice on top of #2867:

- adds a `RoomHostHandle` WASM export that owns authoritative `NotebookDoc` + `RuntimeStateDoc` state and per-peer Automerge sync state
- routes `AUTOMERGE_SYNC` and `RUNTIME_STATE_SYNC` frames through the room host instead of rebroadcasting them as raw bytes
- enforces write scope and actor-principal validation before applying document changes
- checkpoints materialized room snapshots into Durable Object storage and reloads them before falling back to the latest published snapshot pair

This intentionally keeps kernels out of the DO. Runtime peers get the shape needed to write `RuntimeStateDoc`, while notebook edits remain ACL/scope-gated.

## Stack

Base: `main`.

#2867 has landed; this PR is ready once CI and review are green.

## Verification

- `cargo check -p runtimed-wasm`
- `pnpm --dir apps/notebook-cloud wasm`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo test -p runtimed-wasm`
- `cargo xtask lint --fix`
- Bedrock Opus 4.6 review: clear, no findings (`.context/reviews/pr-2868.json`)
- GitHub CI: green as of 2026-05-23 16:49 PDT
