### PR TITLE
feat(notebook-cloud): authenticate Cloudflare Access JWTs

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -165,6 +165,25 @@ For local browser-only testing, the same values can be supplied as query params:
 
 Dev credentials are accepted without an extra token only from loopback Wrangler local development (`localhost`, `127.0.0.1`, or `::1`). Deployed prototype environments require the `NOTEBOOK_CLOUD_DEV_TOKEN` Worker secret to match either the `X-Notebook-Cloud-Dev-Token` header or a WebSocket subprotocol named `nteract-dev-token.<base64url-token>`. `DEPLOYMENT_ENV=development` does not bypass this host check, and URL-carried `dev_token` credentials are rejected on deployed hosts so prototype owner credentials do not appear in URLs. If no scope is supplied, dev auth defaults to `viewer`. Write and publish paths must ask for `editor`, `runtime_peer`, or `owner` explicitly. Blob upload is allowed for runtime-state writers (`editor`, `runtime_peer`, `owner`) and verifies that the uploaded bytes match the SHA-256 digest in the blob route before writing to R2.
 
+## Cloudflare Access auth
+
+When `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` and `NOTEBOOK_CLOUD_ACCESS_AUD`
+are configured, the Worker can authenticate Cloudflare Access/OIDC-style JWTs
+before running the D1 ACL lookup. Tokens are accepted from:
+
+- `Cf-Access-Jwt-Assertion` for Cloudflare Access-protected requests
+- `Authorization: Bearer <jwt>` for native/system clients
+- WebSocket subprotocol `nteract-access-token.<base64url-jwt>` for browser
+  WebSockets that cannot set custom headers
+- `CF_Authorization` cookie as a browser fallback
+
+URL-carried Access tokens are intentionally ignored. The JWT must validate with
+RS256 against `https://<team-domain>/cdn-cgi/access/certs`, with `iss` matching
+the team domain and `aud` matching `NOTEBOOK_CLOUD_ACCESS_AUD`. The resulting
+principal is `user:cloudflare-access:<sub>`, and the requested `scope` is still
+only a request: the room ACL decides whether that principal may enter as
+`viewer`, `editor`, `runtime_peer`, or `owner`.
+
 Requests with no dev credential become anonymous public viewers. The Worker derives:
 
 ```text
@@ -173,7 +192,10 @@ anonymous:<session>/browser:<session>
 
 from the `viewer_session` query parameter, `X-Viewer-Session` header, or a generated UUID. This is intentionally not `system`: `system` is reserved for seed/import authorship, while anonymous viewers are real room connections with read-only `viewer` scope. Anonymous viewers cannot write `NotebookDoc`, `RuntimeStateDoc`, blob, pool, or request frames. Anonymous presence is local-only so public page views do not appear as collaborators to editors.
 
-Snapshot and blob reads are public in this prototype so `/n/:id` can act like a publish viewer without a product auth flow. Production hosts should move those reads behind viewer-or-better auth, signed URLs, or a dedicated output origin before accepting private notebooks.
+Snapshot, render, and blob reads require `viewer` authorization. Anonymous
+users only receive that scope when the notebook has an explicit public
+`notebook_acl` row. Production hosts should move output blobs to signed URLs or
+a dedicated output origin before accepting private notebook data at scale.
 
 ## Storage shape
 

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -4,6 +4,9 @@ export interface Env {
   NOTEBOOK_SNAPSHOTS?: R2Bucket;
   ASSETS?: WorkerAssets;
   DEPLOYMENT_ENV?: string;
+  NOTEBOOK_CLOUD_ACCESS_AUD?: string;
+  NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?: string;
+  NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?: string;
   NOTEBOOK_CLOUD_DEV_TOKEN?: string;
   RENDERER_ASSETS_BASE_URL?: string;
 }

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -17,6 +17,9 @@ export interface AuthenticatedConnection {
 export interface IdentityEnvironment {
   DEPLOYMENT_ENV?: string;
   NOTEBOOK_CLOUD_DEV_TOKEN?: string;
+  NOTEBOOK_CLOUD_ACCESS_AUD?: string;
+  NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?: string;
+  NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?: string;
 }
 
 const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
@@ -25,8 +28,43 @@ export const TRUSTED_PRINCIPAL_HEADER = "x-nteract-principal";
 export const TRUSTED_OPERATOR_HEADER = "x-nteract-operator";
 export const TRUSTED_SCOPE_HEADER = "x-nteract-scope";
 export const TRUSTED_WEBSOCKET_PROTOCOL_HEADER = "x-nteract-websocket-protocol";
+export const ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-access-token.";
+export const CLOUDFLARE_ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
 export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";
 export const DEV_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-dev-token.";
+
+interface AccessCredential {
+  token: string;
+  webSocketProtocol?: string;
+}
+
+interface AccessConfig {
+  audience: string;
+  issuer: string;
+  jwksJson?: string;
+}
+
+interface JsonWebKeySet {
+  keys?: JsonWebKey[];
+}
+
+interface JwtHeader {
+  alg?: string;
+  kid?: string;
+  typ?: string;
+}
+
+interface AccessJwtPayload {
+  aud?: string | string[];
+  email?: string;
+  exp?: number;
+  iss?: string;
+  nbf?: number;
+  sub?: string;
+}
+
+const ACCESS_CLOCK_TOLERANCE_SECONDS = 60;
+const accessJwksCache = new Map<string, Promise<JsonWebKeySet>>();
 
 export class AuthError extends Error {
   constructor(
@@ -57,6 +95,57 @@ export function authenticateRequest(
   const identity = authenticateDevRequest(request);
   return devCredential.webSocketProtocol
     ? { ...identity, webSocketProtocol: devCredential.webSocketProtocol }
+    : identity;
+}
+
+export async function authenticateRequestWithProviders(
+  request: Request,
+  env: IdentityEnvironment = {},
+): Promise<AuthenticatedConnection> {
+  const accessCredential = accessCredentialFromRequest(request);
+  if (accessCredential) {
+    return authenticateCloudflareAccessRequest(request, env, accessCredential);
+  }
+
+  return authenticateRequest(request, env);
+}
+
+export async function authenticateCloudflareAccessRequest(
+  request: Request,
+  env: IdentityEnvironment,
+  credential = accessCredentialFromRequest(request),
+): Promise<AuthenticatedConnection> {
+  if (!credential) {
+    throw new AuthError("missing Cloudflare Access token", 401);
+  }
+
+  const config = accessConfigFromEnv(env);
+  if (!config) {
+    throw new AuthError("Cloudflare Access auth is not configured", 503);
+  }
+
+  const payload = await verifyCloudflareAccessJwt(credential.token, config);
+  const subject = payload.sub?.trim();
+  if (!subject) {
+    throw new AuthError("Cloudflare Access token is missing sub", 401);
+  }
+
+  const url = new URL(request.url);
+  const principal = `user:cloudflare-access:${encodePrincipalComponent(subject)}`;
+  const operator = headerOrQuery(request, url, "x-operator", "operator") ?? defaultOperator();
+  const scope = parseScope(headerOrQuery(request, url, "x-scope", "scope") ?? "viewer");
+
+  validatePrincipal(principal);
+  validateOperator(operator);
+
+  const identity = {
+    principal,
+    operator,
+    actorLabel: `${principal}/${operator}`,
+    scope,
+  };
+  return credential.webSocketProtocol
+    ? { ...identity, webSocketProtocol: credential.webSocketProtocol }
     : identity;
 }
 
@@ -312,15 +401,196 @@ function validDevTokenCredential(
   return undefined;
 }
 
+function accessCredentialFromRequest(request: Request): AccessCredential | undefined {
+  const headerToken =
+    request.headers.get(CLOUDFLARE_ACCESS_JWT_HEADER) ??
+    bearerTokenFromAuthorization(request.headers.get("authorization")) ??
+    cookieValue(request.headers.get("cookie"), "CF_Authorization");
+  if (headerToken) {
+    return { token: headerToken };
+  }
+
+  const webSocketProtocol = tokenFromWebSocketProtocol(
+    request.headers.get("sec-websocket-protocol"),
+    ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
+  );
+  if (webSocketProtocol) {
+    return { token: webSocketProtocol.token, webSocketProtocol: webSocketProtocol.protocol };
+  }
+
+  return undefined;
+}
+
+function accessConfigFromEnv(env: IdentityEnvironment): AccessConfig | undefined {
+  const audience = env.NOTEBOOK_CLOUD_ACCESS_AUD?.trim();
+  const rawTeamDomain = env.NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?.trim();
+  if (!audience || !rawTeamDomain) {
+    return undefined;
+  }
+
+  return {
+    audience,
+    issuer: normalizeAccessIssuer(rawTeamDomain),
+    jwksJson: env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON,
+  };
+}
+
+function normalizeAccessIssuer(value: string): string {
+  if (value.startsWith("https://")) {
+    return value.replace(/\/+$/, "");
+  }
+  const host = value.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+  return `https://${host}`;
+}
+
+async function verifyCloudflareAccessJwt(
+  token: string,
+  config: AccessConfig,
+): Promise<AccessJwtPayload> {
+  const { header, payload, signingInput, signature } = decodeJwt(token);
+  if (header.alg !== "RS256") {
+    throw new AuthError("Cloudflare Access token must use RS256", 401);
+  }
+
+  const jwks = await loadAccessJwks(config);
+  const key = selectAccessJwk(jwks, header);
+  const cryptoKey = await crypto.subtle.importKey(
+    "jwk",
+    key,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  const verified = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    cryptoKey,
+    signature,
+    new TextEncoder().encode(signingInput),
+  );
+  if (!verified) {
+    throw new AuthError("Cloudflare Access token signature is invalid", 401);
+  }
+
+  validateAccessJwtClaims(payload, config);
+  return payload;
+}
+
+function decodeJwt(token: string): {
+  header: JwtHeader;
+  payload: AccessJwtPayload;
+  signingInput: string;
+  signature: Uint8Array;
+} {
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    throw new AuthError("Cloudflare Access token must be a JWT", 401);
+  }
+
+  return {
+    header: decodeBase64UrlJson<JwtHeader>(encodedHeader),
+    payload: decodeBase64UrlJson<AccessJwtPayload>(encodedPayload),
+    signingInput: `${encodedHeader}.${encodedPayload}`,
+    signature: decodeBase64UrlBytes(encodedSignature),
+  };
+}
+
+async function loadAccessJwks(config: AccessConfig): Promise<JsonWebKeySet> {
+  if (config.jwksJson?.trim()) {
+    return parseJwks(config.jwksJson);
+  }
+
+  const url = `${config.issuer}/cdn-cgi/access/certs`;
+  let ready = accessJwksCache.get(url);
+  if (!ready) {
+    ready = fetch(url)
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new AuthError(`Cloudflare Access JWKS fetch failed: ${response.status}`, 503);
+        }
+        return parseJwks(await response.text());
+      })
+      .catch((error: unknown) => {
+        accessJwksCache.delete(url);
+        throw error;
+      });
+    accessJwksCache.set(url, ready);
+  }
+  return ready;
+}
+
+function parseJwks(value: string): JsonWebKeySet {
+  try {
+    const parsed = JSON.parse(value) as JsonWebKeySet;
+    if (!Array.isArray(parsed.keys)) {
+      throw new Error("JWKS keys must be an array");
+    }
+    return parsed;
+  } catch (error) {
+    throw new AuthError(`Cloudflare Access JWKS is invalid: ${String(error)}`, 503);
+  }
+}
+
+function selectAccessJwk(jwks: JsonWebKeySet, header: JwtHeader): JsonWebKey {
+  const keys = jwks.keys ?? [];
+  const candidates = keys.filter((key) => {
+    if (key.kty !== "RSA") return false;
+    if (key.alg && key.alg !== "RS256") return false;
+    if (header.kid && (key as JsonWebKey & { kid?: string }).kid !== header.kid) return false;
+    return true;
+  });
+
+  if (candidates.length !== 1) {
+    throw new AuthError("Cloudflare Access signing key was not found", 401);
+  }
+  return candidates[0];
+}
+
+function validateAccessJwtClaims(payload: AccessJwtPayload, config: AccessConfig): void {
+  if (payload.iss !== config.issuer) {
+    throw new AuthError("Cloudflare Access token issuer is invalid", 401);
+  }
+
+  const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (!audiences.includes(config.audience)) {
+    throw new AuthError("Cloudflare Access token audience is invalid", 401);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp !== "number" || payload.exp <= now - ACCESS_CLOCK_TOLERANCE_SECONDS) {
+    throw new AuthError("Cloudflare Access token is expired", 401);
+  }
+  if (typeof payload.nbf === "number" && payload.nbf > now + ACCESS_CLOCK_TOLERANCE_SECONDS) {
+    throw new AuthError("Cloudflare Access token is not valid yet", 401);
+  }
+}
+
+function bearerTokenFromAuthorization(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const match = value.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+function cookieValue(value: string | null, name: string): string | undefined {
+  if (!value) return undefined;
+  for (const part of value.split(";")) {
+    const [rawKey, ...rawValue] = part.trim().split("=");
+    if (rawKey === name) {
+      return rawValue.join("=") || undefined;
+    }
+  }
+  return undefined;
+}
+
 function tokenFromWebSocketProtocol(
   value: string | null,
+  prefix = DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
 ): { protocol: string; token: string } | undefined {
   if (!value) return undefined;
 
   for (const protocol of value.split(",")) {
     const trimmed = protocol.trim();
-    if (!trimmed.startsWith(DEV_AUTH_TOKEN_PROTOCOL_PREFIX)) continue;
-    const token = decodeBase64Url(trimmed.slice(DEV_AUTH_TOKEN_PROTOCOL_PREFIX.length));
+    if (!trimmed.startsWith(prefix)) continue;
+    const token = decodeBase64Url(trimmed.slice(prefix.length));
     if (!token) continue;
     return { protocol: trimmed, token };
   }
@@ -332,14 +602,30 @@ function decodeBase64Url(value: string): string | undefined {
   if (value.length === 0) return undefined;
 
   try {
-    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
-    const binary = atob(padded);
-    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    const bytes = decodeBase64UrlBytes(value);
     return new TextDecoder().decode(bytes);
   } catch {
     return undefined;
   }
+}
+
+function decodeBase64UrlJson<T>(value: string): T {
+  const decoded = decodeBase64Url(value);
+  if (!decoded) {
+    throw new AuthError("Cloudflare Access token contains invalid base64url JSON", 401);
+  }
+  try {
+    return JSON.parse(decoded) as T;
+  } catch (error) {
+    throw new AuthError(`Cloudflare Access token contains invalid JSON: ${String(error)}`, 401);
+  }
+}
+
+function decodeBase64UrlBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }
 
 function defaultOperator(): string {

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -64,7 +64,14 @@ interface AccessJwtPayload {
 }
 
 const ACCESS_CLOCK_TOLERANCE_SECONDS = 60;
-const accessJwksCache = new Map<string, Promise<JsonWebKeySet>>();
+const ACCESS_JWKS_CACHE_TTL_MS = 5 * 60 * 1000;
+const accessJwksCache = new Map<
+  string,
+  {
+    expiresAt: number;
+    ready: Promise<JsonWebKeySet>;
+  }
+>();
 
 export class AuthError extends Error {
   constructor(
@@ -103,7 +110,7 @@ export async function authenticateRequestWithProviders(
   env: IdentityEnvironment = {},
 ): Promise<AuthenticatedConnection> {
   const accessCredential = accessCredentialFromRequest(request);
-  if (accessCredential) {
+  if (accessCredential && accessConfigFromEnv(env)) {
     return authenticateCloudflareAccessRequest(request, env, accessCredential);
   }
 
@@ -452,21 +459,8 @@ async function verifyCloudflareAccessJwt(
     throw new AuthError("Cloudflare Access token must use RS256", 401);
   }
 
-  const jwks = await loadAccessJwks(config);
-  const key = selectAccessJwk(jwks, header);
-  const cryptoKey = await crypto.subtle.importKey(
-    "jwk",
-    key,
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["verify"],
-  );
-  const verified = await crypto.subtle.verify(
-    "RSASSA-PKCS1-v1_5",
-    cryptoKey,
-    signature,
-    new TextEncoder().encode(signingInput),
-  );
+  const keys = selectAccessJwks(await loadAccessJwks(config), header);
+  const verified = await verifyWithAnyAccessKey(keys, signingInput, signature);
   if (!verified) {
     throw new AuthError("Cloudflare Access token signature is invalid", 401);
   }
@@ -500,21 +494,26 @@ async function loadAccessJwks(config: AccessConfig): Promise<JsonWebKeySet> {
   }
 
   const url = `${config.issuer}/cdn-cgi/access/certs`;
-  let ready = accessJwksCache.get(url);
-  if (!ready) {
-    ready = fetch(url)
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new AuthError(`Cloudflare Access JWKS fetch failed: ${response.status}`, 503);
-        }
-        return parseJwks(await response.text());
-      })
-      .catch((error: unknown) => {
-        accessJwksCache.delete(url);
-        throw error;
-      });
-    accessJwksCache.set(url, ready);
+  const cached = accessJwksCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.ready;
   }
+
+  const ready = fetch(url)
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new AuthError(`Cloudflare Access JWKS fetch failed: ${response.status}`, 503);
+      }
+      return parseJwks(await response.text());
+    })
+    .catch((error: unknown) => {
+      accessJwksCache.delete(url);
+      throw error;
+    });
+  accessJwksCache.set(url, {
+    expiresAt: Date.now() + ACCESS_JWKS_CACHE_TTL_MS,
+    ready,
+  });
   return ready;
 }
 
@@ -530,7 +529,7 @@ function parseJwks(value: string): JsonWebKeySet {
   }
 }
 
-function selectAccessJwk(jwks: JsonWebKeySet, header: JwtHeader): JsonWebKey {
+function selectAccessJwks(jwks: JsonWebKeySet, header: JwtHeader): JsonWebKey[] {
   const keys = jwks.keys ?? [];
   const candidates = keys.filter((key) => {
     if (key.kty !== "RSA") return false;
@@ -539,10 +538,37 @@ function selectAccessJwk(jwks: JsonWebKeySet, header: JwtHeader): JsonWebKey {
     return true;
   });
 
-  if (candidates.length !== 1) {
+  if (candidates.length === 0) {
     throw new AuthError("Cloudflare Access signing key was not found", 401);
   }
-  return candidates[0];
+  return candidates;
+}
+
+async function verifyWithAnyAccessKey(
+  keys: JsonWebKey[],
+  signingInput: string,
+  signature: Uint8Array,
+): Promise<boolean> {
+  for (const key of keys) {
+    const cryptoKey = await crypto.subtle.importKey(
+      "jwk",
+      key,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+    if (
+      await crypto.subtle.verify(
+        "RSASSA-PKCS1-v1_5",
+        cryptoKey,
+        signature,
+        new TextEncoder().encode(signingInput),
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function validateAccessJwtClaims(payload: AccessJwtPayload, config: AccessConfig): void {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4,7 +4,7 @@ import {
   AuthError,
   allowsBlobUpload,
   allowsPublish,
-  authenticateRequest,
+  authenticateRequestWithProviders,
   DEV_AUTH_TOKEN_HEADER,
   stampTrustedIdentity,
   type AuthenticatedConnection,
@@ -231,7 +231,7 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
     return json({ error: "expected WebSocket upgrade" }, 426);
   }
 
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env);
   if (identity instanceof Response) {
     return identity;
   }
@@ -737,7 +737,7 @@ async function routeBlob(
     return json({ error: "method not allowed" }, 405);
   }
 
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env);
   if (identity instanceof Response) {
     return identity;
   }
@@ -798,12 +798,12 @@ async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise
   );
 }
 
-function authenticateRequestOrResponse(
+async function authenticateRequestOrResponse(
   request: Request,
   env: Env,
-): AuthenticatedConnection | Response {
+): Promise<AuthenticatedConnection | Response> {
   try {
-    return authenticateRequest(request, env);
+    return await authenticateRequestWithProviders(request, env);
   } catch (error) {
     if (error instanceof AuthError) {
       return json({ error: error.message }, error.status);
@@ -818,7 +818,7 @@ async function authenticateAndAuthorizeOrResponse(
   notebookId: string,
   requestedScope: ConnectionScope,
 ): Promise<AuthenticatedConnection | Response> {
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env);
   if (identity instanceof Response) {
     return identity;
   }
@@ -847,7 +847,7 @@ async function authorizePublishOrCreateOrResponse(
   notebookId: string,
   artifactName: string,
 ): Promise<AuthenticatedConnection | Response> {
-  const identity = authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env);
   if (identity instanceof Response) {
     return identity;
   }

--- a/apps/notebook-cloud/test/access-jwt-fixture.ts
+++ b/apps/notebook-cloud/test/access-jwt-fixture.ts
@@ -1,0 +1,69 @@
+export interface AccessTokenFixture {
+  env: {
+    NOTEBOOK_CLOUD_ACCESS_AUD: string;
+    NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: string;
+    NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN: string;
+  };
+  token: string;
+}
+
+export async function accessTokenFixture(options: {
+  audience?: string;
+  subject: string;
+}): Promise<AccessTokenFixture> {
+  const issuer = "https://team.cloudflareaccess.com";
+  const audience = "notebook-cloud-aud";
+  const kid = "test-key";
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  const now = Math.floor(Date.now() / 1000);
+  const header = {
+    alg: "RS256",
+    kid,
+    typ: "JWT",
+  };
+  const payload = {
+    aud: options.audience ?? audience,
+    exp: now + 300,
+    iss: issuer,
+    sub: options.subject,
+  };
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(payload))}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    keyPair.privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+
+  return {
+    env: {
+      NOTEBOOK_CLOUD_ACCESS_AUD: audience,
+      NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: JSON.stringify({
+        keys: [{ ...publicJwk, alg: "RS256", kid, use: "sig" }],
+      }),
+      NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN: issuer,
+    },
+    token: `${signingInput}.${base64UrlBytes(new Uint8Array(signature))}`,
+  };
+}
+
+export function base64Url(value: string): string {
+  return base64UrlBytes(new TextEncoder().encode(value));
+}
+
+function base64UrlBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}

--- a/apps/notebook-cloud/test/access-jwt-fixture.ts
+++ b/apps/notebook-cloud/test/access-jwt-fixture.ts
@@ -9,6 +9,8 @@ export interface AccessTokenFixture {
 
 export async function accessTokenFixture(options: {
   audience?: string;
+  includeKid?: boolean;
+  includeUnmatchedKey?: boolean;
   subject: string;
 }): Promise<AccessTokenFixture> {
   const issuer = "https://team.cloudflareaccess.com";
@@ -25,10 +27,27 @@ export async function accessTokenFixture(options: {
     ["sign", "verify"],
   );
   const publicJwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  const unmatchedPublicJwk = options.includeUnmatchedKey
+    ? await crypto.subtle.exportKey(
+        "jwk",
+        (
+          await crypto.subtle.generateKey(
+            {
+              name: "RSASSA-PKCS1-v1_5",
+              modulusLength: 2048,
+              publicExponent: new Uint8Array([1, 0, 1]),
+              hash: "SHA-256",
+            },
+            true,
+            ["sign", "verify"],
+          )
+        ).publicKey,
+      )
+    : null;
   const now = Math.floor(Date.now() / 1000);
   const header = {
     alg: "RS256",
-    kid,
+    ...(options.includeKid === false ? {} : { kid }),
     typ: "JWT",
   };
   const payload = {
@@ -48,7 +67,12 @@ export async function accessTokenFixture(options: {
     env: {
       NOTEBOOK_CLOUD_ACCESS_AUD: audience,
       NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: JSON.stringify({
-        keys: [{ ...publicJwk, alg: "RS256", kid, use: "sig" }],
+        keys: [
+          ...(unmatchedPublicJwk
+            ? [{ ...unmatchedPublicJwk, alg: "RS256", kid: "unmatched", use: "sig" }]
+            : []),
+          { ...publicJwk, alg: "RS256", kid, use: "sig" },
+        ],
       }),
       NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN: issuer,
     },

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -314,6 +314,41 @@ describe("Cloudflare Access identity", () => {
     );
   });
 
+  it("ignores bearer tokens when Access auth is not configured", async () => {
+    const { token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?viewer_session=anon-bearer", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      {},
+    );
+
+    assert.equal(identity.actorLabel, "anonymous:anon-bearer/browser:anon-bearer");
+    assert.equal(identity.scope, "viewer");
+  });
+
+  it("tries matching RSA keys when a rotating Access JWT omits kid", async () => {
+    const { env, token } = await accessTokenFixture({
+      includeKid: false,
+      includeUnmatchedKey: true,
+      subject: "alice",
+    });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=desktop:a", {
+        headers: {
+          "Cf-Access-Jwt-Assertion": token,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/desktop:a");
+  });
+
   it("does not treat URL-carried Access tokens as credentials", async () => {
     const { env, token } = await accessTokenFixture({ subject: "alice" });
 

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -1,11 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
   AuthError,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   authenticateAnonymousViewer,
   authenticateDevRequest,
   authenticateRequest,
+  authenticateRequestWithProviders,
   isAnonymousViewer,
   parseActorLabel,
   parseScope,
@@ -16,6 +18,7 @@ import {
   validateOperator,
   validatePrincipal,
 } from "../src/identity.ts";
+import { accessTokenFixture, base64Url } from "./access-jwt-fixture.ts";
 
 describe("dev identity", () => {
   it("uses explicit anonymous viewer auth when no dev credential is presented", () => {
@@ -252,11 +255,74 @@ describe("dev identity", () => {
   });
 });
 
-function base64Url(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
-}
+describe("Cloudflare Access identity", () => {
+  it("validates Access JWT assertions and maps sub to a room principal", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "user/123" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=desktop:a&scope=editor", {
+        headers: {
+          "Cf-Access-Jwt-Assertion": token,
+        },
+      }),
+      env,
+    );
+
+    assert.deepEqual(identity, {
+      principal: "user:cloudflare-access:user%2F123",
+      operator: "desktop:a",
+      actorLabel: "user:cloudflare-access:user%2F123/desktop:a",
+      scope: "editor",
+    });
+  });
+
+  it("accepts browser WebSocket Access tokens through subprotocols", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+    const protocol = `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`;
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=browser:tab&scope=viewer", {
+        headers: {
+          "Sec-WebSocket-Protocol": `other-proto, ${protocol}`,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/browser:tab");
+    assert.equal(identity.webSocketProtocol, protocol);
+  });
+
+  it("rejects Access tokens with the wrong audience", async () => {
+    const { env, token } = await accessTokenFixture({
+      audience: "wrong-audience",
+      subject: "alice",
+    });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync", {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError && error.status === 401 && /audience/.test(error.message),
+    );
+  });
+
+  it("does not treat URL-carried Access tokens as credentials", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request(`https://cloud.test/n/demo/sync?access_token=${encodeURIComponent(token)}`),
+      env,
+    );
+
+    assert.equal(identity.principal.startsWith("anonymous:"), true);
+    assert.equal(identity.scope, "viewer");
+  });
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -24,6 +24,7 @@ import {
   renderKey,
   snapshotKey,
 } from "../src/storage.ts";
+import { accessTokenFixture } from "./access-jwt-fixture.ts";
 
 const wasmBytes = await readFile(
   new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
@@ -396,6 +397,31 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await authenticated.json(), {
       error: "user:dev:bob cannot access public-demo",
     });
+  });
+
+  it("authorizes Cloudflare Access principals through notebook ACL rows", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv(accessEnv);
+    seedNotebook(env, "access-demo");
+    seedAcl(env, {
+      notebookId: "access-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-demo?scope=viewer", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const catalog = (await response.json()) as { notebook: { id: string } };
+    assert.equal(catalog.notebook.id, "access-demo");
   });
 
   it("does not grant owner ACL to a principal that loses notebook creation", async () => {


### PR DESCRIPTION
## Summary

Adds a real Cloudflare Access/OIDC-style authentication path for notebook-cloud after the ACL layer:

- validates Access JWTs with WebCrypto against the configured Access JWKS/audience/issuer
- accepts browser WebSocket tokens through `Sec-WebSocket-Protocol: nteract-access-token.<base64url-jwt>` instead of URL tokens
- accepts native/system tokens through `Cf-Access-Jwt-Assertion`, `Authorization: Bearer`, or the `CF_Authorization` cookie fallback
- maps validated `sub` claims to `user:cloudflare-access:<sub>` principals and still lets D1 ACL rows decide the granted room scope
- updates docs so public access is explicitly ACL-backed, not implicit public snapshot/blob reads

## Stack

Base: `quod/notebook-cloud-room-materialize` / #2868.

Keep this draft until #2868 lands. #2867 has already landed, and this stack is intentionally using merge commits rather than rebasing.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- Bedrock PR review rerun: clear, no actionable findings

## CI

- GitHub Actions: green after rerunning the transient `E2E: UV Prewarmed` failure.
