### PR TITLE
feat(notebook-cloud): limit editor room edits to markdown

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -1,8 +1,8 @@
 # nteract notebook cloud prototype
 
-This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates a dev or anonymous viewer connection, stamps a trusted `<principal>/<operator>` actor label, routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id, and relays typed-frame-v4-shaped WebSocket frames.
+This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates a dev, Cloudflare Access, or anonymous viewer connection, authorizes that principal through the D1 room ACL, stamps a trusted `<principal>/<operator>` actor label, and routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id.
 
-The current Durable Object does not host kernels and does not parse Automerge sync messages. It enforces connection scope, rewrites canonical CBOR presence through the shared `runtimed-wasm` helper, stores bounded frame metadata, and broadcasts accepted binary typed frames to other peers in the same room.
+The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope.
 
 `/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
@@ -39,6 +39,8 @@ The smoke script proves:
 - Viewer-scope rejection for blob, request, and pool-state writes.
 - Explicit anonymous viewer identity (`anonymous:<session>/browser:<session>`).
 - Local-only anonymous presence: accepted to the sender, not broadcast or persisted.
+- Materialized room sync for real `NotebookDoc` and `RuntimeStateDoc` frames.
+- Editor-scope markdown source edits are accepted, while code-cell edits and structural `NotebookDoc` changes are rejected.
 
 If the volatile frontend WASM package exists at `apps/notebook/src/wasm/runtimed-wasm`,
 the deeper roundtrip smoke sends real `runtimed-wasm` Automerge sync payloads through

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -62,9 +62,18 @@ export class RoomMaterializer {
       frame.type === FrameType.AUTOMERGE_SYNC
         ? allowsNotebookWrite(peer.identity.scope)
         : allowsRuntimeStateWrite(peer.identity.scope);
+    const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);
     return this.withHost((host) =>
-      normalizeResult(host.receive_peer_frame(peer.id, peer.identity.principal, canWrite, encoded)),
+      normalizeResult(
+        host.receive_peer_frame(
+          peer.id,
+          peer.identity.principal,
+          canWrite,
+          canWriteAllNotebookChanges,
+          encoded,
+        ),
+      ),
     );
   }
 

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -22,18 +22,19 @@ before(async () => {
 describe("RoomHostHandle", () => {
   it("hosts NotebookDoc sync with per-peer state", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
-    const editor = NotebookHandle.create_bootstrap("user:dev:alice/desktop:a");
+    const owner = NotebookHandle.create_bootstrap("user:dev:alice/desktop:a");
     const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
 
-    syncHostWithClient(host, "peer-editor", "user:dev:alice", true, editor);
-    editor.add_cell(0, "cell-1", "markdown");
-    editor.update_source("cell-1", "# Hosted markdown\n");
-    const message = editor.flush_local_changes();
+    syncHostWithClient(host, "peer-owner", "user:dev:alice", true, true, owner);
+    owner.add_cell(0, "cell-1", "markdown");
+    owner.update_source("cell-1", "# Hosted markdown\n");
+    const message = owner.flush_local_changes();
     assert.ok(message);
 
-    const editorResult = host.receive_peer_frame(
-      "peer-editor",
+    const ownerResult = host.receive_peer_frame(
+      "peer-owner",
       "user:dev:alice",
+      true,
       true,
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
     ) as {
@@ -41,9 +42,9 @@ describe("RoomHostHandle", () => {
       outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
     };
 
-    assert.equal(editorResult.changed, true);
+    assert.equal(ownerResult.changed, true);
 
-    syncHostWithClient(host, "peer-viewer", "user:dev:bob", false, viewer);
+    syncHostWithClient(host, "peer-viewer", "user:dev:bob", false, false, viewer);
 
     const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
     assert.deepEqual(
@@ -52,10 +53,81 @@ describe("RoomHostHandle", () => {
     );
   });
 
+  it("allows editor-scoped source edits to existing markdown cells", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const owner = NotebookHandle.create_bootstrap("user:dev:alice/desktop:owner");
+    const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+    const viewer = NotebookHandle.create_bootstrap("user:dev:carol/desktop:viewer");
+
+    syncHostWithClient(host, "peer-owner", "user:dev:alice", true, true, owner);
+    owner.add_cell(0, "markdown-cell", "markdown");
+    owner.update_source("markdown-cell", "Draft\n");
+    applyClientChangesToHost(host, "peer-owner", "user:dev:alice", true, true, owner);
+
+    syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
+    editor.update_source("markdown-cell", "Edited collaboratively\n");
+    applyClientChangesToHost(host, "peer-editor", "user:dev:bob", true, false, editor);
+
+    syncHostWithClient(host, "peer-viewer", "user:dev:carol", false, false, viewer);
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.equal(cells[0].id, "markdown-cell");
+    assert.equal(cells[0].source, "Edited collaboratively\n");
+  });
+
+  it("rejects editor-scoped source edits to code cells", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const owner = NotebookHandle.create_bootstrap("user:dev:alice/desktop:owner");
+    const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+
+    syncHostWithClient(host, "peer-owner", "user:dev:alice", true, true, owner);
+    owner.add_cell(0, "code-cell", "code");
+    owner.update_source("code-cell", "x = 1\n");
+    applyClientChangesToHost(host, "peer-owner", "user:dev:alice", true, true, owner);
+
+    syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
+    editor.update_source("code-cell", "x = 2\n");
+    const message = editor.flush_local_changes();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-editor",
+          "user:dev:bob",
+          true,
+          false,
+          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+        ),
+      /cannot edit code or raw cells/,
+    );
+  });
+
+  it("rejects editor-scoped structural NotebookDoc changes", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+
+    syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
+    editor.add_cell(0, "new-markdown", "markdown");
+    const message = editor.flush_local_changes();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-editor",
+          "user:dev:bob",
+          true,
+          false,
+          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+        ),
+      /cannot add, remove, or reorder cells/,
+    );
+  });
+
   it("rejects document changes authored by a foreign principal", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
     const forged = NotebookHandle.create_bootstrap("user:dev:mallory/desktop:forge");
-    syncHostWithClient(host, "peer-alice", "user:dev:alice", true, forged);
+    syncHostWithClient(host, "peer-alice", "user:dev:alice", true, true, forged);
     forged.add_cell(0, "cell-forged", "markdown");
     const message = forged.flush_local_changes();
     assert.ok(message);
@@ -66,6 +138,7 @@ describe("RoomHostHandle", () => {
           "peer-alice",
           "user:dev:alice",
           true,
+          true,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
       /not authorized/,
@@ -75,7 +148,7 @@ describe("RoomHostHandle", () => {
   it("rejects viewer-authored document changes", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
     const viewer = NotebookHandle.create_bootstrap("user:dev:alice/desktop:a");
-    syncHostWithClient(host, "peer-viewer", "user:dev:alice", false, viewer);
+    syncHostWithClient(host, "peer-viewer", "user:dev:alice", false, false, viewer);
     viewer.add_cell(0, "cell-viewer", "markdown");
     const message = viewer.flush_local_changes();
     assert.ok(message);
@@ -85,6 +158,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-viewer",
           "user:dev:alice",
+          false,
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -97,7 +171,7 @@ describe("RoomMaterializer", () => {
   it("persists and reloads a durable room checkpoint", async () => {
     const state = fakeState();
     const editorIdentity = authenticateDevRequest(
-      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner"),
     );
     const editorPeer = {
       id: "peer-editor",
@@ -152,6 +226,7 @@ function syncHostWithClient(
   peerId: string,
   principal: string,
   canWrite: boolean,
+  canWriteAllNotebookChanges: boolean,
   client: NotebookHandle,
 ): void {
   let result = host.sync_peer(peerId) as {
@@ -164,13 +239,38 @@ function syncHostWithClient(
     }
     const outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }> = [];
     for (const reply of replies) {
-      const next = host.receive_peer_frame(peerId, principal, canWrite, reply) as {
+      const next = host.receive_peer_frame(
+        peerId,
+        principal,
+        canWrite,
+        canWriteAllNotebookChanges,
+        reply,
+      ) as {
         outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
       };
       outbound.push(...next.outbound);
     }
     result = { outbound };
   }
+}
+
+function applyClientChangesToHost(
+  host: Awaited<ReturnType<typeof createEmptyRoomHost>>,
+  peerId: string,
+  principal: string,
+  canWrite: boolean,
+  canWriteAllNotebookChanges: boolean,
+  client: NotebookHandle,
+): void {
+  const message = client.flush_local_changes();
+  assert.ok(message);
+  host.receive_peer_frame(
+    peerId,
+    principal,
+    canWrite,
+    canWriteAllNotebookChanges,
+    encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+  );
 }
 
 async function syncMaterializerWithClient(

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -336,6 +336,7 @@ impl RoomHostHandle {
         peer_id: &str,
         principal: &str,
         can_write: bool,
+        can_write_all_notebook_changes: bool,
         frame_bytes: &[u8],
     ) -> Result<JsValue, JsError> {
         if frame_bytes.is_empty() {
@@ -345,9 +346,13 @@ impl RoomHostHandle {
         let frame_type = frame_bytes[0];
         let payload = &frame_bytes[1..];
         let result = match frame_type {
-            frame_types::AUTOMERGE_SYNC => {
-                self.receive_notebook_sync(peer_id, principal, can_write, payload)?
-            }
+            frame_types::AUTOMERGE_SYNC => self.receive_notebook_sync(
+                peer_id,
+                principal,
+                can_write,
+                can_write_all_notebook_changes,
+                payload,
+            )?,
             frame_types::RUNTIME_STATE_SYNC => {
                 self.receive_runtime_state_sync(peer_id, principal, can_write, payload)?
             }
@@ -388,6 +393,7 @@ impl RoomHostHandle {
         peer_id: &str,
         principal: &str,
         can_write: bool,
+        can_write_all_notebook_changes: bool,
         payload: &[u8],
     ) -> Result<RoomHostFrameResult, JsError> {
         let message = sync::Message::decode(payload)
@@ -415,6 +421,9 @@ impl RoomHostHandle {
                 .map_err(|e| JsError::new(&format!("notebook auth preview failed: {e}")))?;
             let actors = extract_change_actors(preview.doc_mut(), &heads_before);
             validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+            if !can_write_all_notebook_changes {
+                validate_markdown_source_only_changes(&mut preview, &heads_before)?;
+            }
         }
 
         let heads_before = self.doc.get_heads();
@@ -616,6 +625,37 @@ fn validate_room_actor_labels<'a>(
                     "actor label {label:?} is invalid: {error}"
                 )));
             }
+        }
+    }
+    Ok(())
+}
+
+fn validate_markdown_source_only_changes(
+    preview: &mut NotebookDoc,
+    heads_before: &[automerge::ChangeHash],
+) -> Result<(), JsError> {
+    let heads_after = preview.get_heads();
+    let changeset = diff_doc(preview.doc_mut(), heads_before, &heads_after);
+    if changeset.metadata_changed {
+        return Err(JsError::new(
+            "editor scope cannot change notebook metadata in hosted markdown-only mode",
+        ));
+    }
+    if changeset.cells.is_structural() {
+        return Err(JsError::new(
+            "editor scope cannot add, remove, or reorder cells in hosted markdown-only mode",
+        ));
+    }
+    for changed in &changeset.cells.changed {
+        if !changed.fields.is_source_only() {
+            return Err(JsError::new(
+                "editor scope can only edit markdown source in hosted markdown-only mode",
+            ));
+        }
+        if preview.get_cell_type(&changed.cell_id).as_deref() != Some("markdown") {
+            return Err(JsError::new(
+                "editor scope cannot edit code or raw cells in hosted markdown-only mode",
+            ));
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

Adds the first hosted-room markdown collaboration guard on top of the materialized Durable Object room host:

- keeps owner-scope connections able to apply full `NotebookDoc` changes for import/bootstrap paths
- limits editor-scope live `NotebookDoc` writes to existing markdown-cell source edits
- rejects editor attempts to edit code/raw cells, change metadata, or add/remove/reorder cells
- keeps viewer and runtime_peer `NotebookDoc` writes read-only
- documents that the current cloud prototype has a materialized `runtimed-wasm` room host, not a byte-only relay

## Stack

Base: `quod/notebook-cloud-access-auth` / #2869.

Keep this draft until #2868 and #2869 land.

## Verification

- `cargo check -p runtimed-wasm`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- Bedrock PR review: clear, no actionable findings

## CI

- GitHub Actions: green
