### PR TITLE
feat(notebook-cloud): add owner ACL management routes

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -199,6 +199,42 @@ users only receive that scope when the notebook has an explicit public
 `notebook_acl` row. Production hosts should move output blobs to signed URLs or
 a dedicated output origin before accepting private notebook data at scale.
 
+## ACL management
+
+The prototype exposes a small owner-only ACL API:
+
+```text
+GET    /api/n/{notebookId}/acl
+POST   /api/n/{notebookId}/acl
+DELETE /api/n/{notebookId}/acl
+```
+
+`GET` returns the current flat D1 ACL rows. `POST` grants one row and `DELETE`
+revokes one row using this JSON body:
+
+```json
+{
+  "subject_kind": "principal",
+  "subject": "user:cloudflare-access:alice",
+  "scope": "editor"
+}
+```
+
+Public read is explicit:
+
+```json
+{
+  "subject_kind": "public",
+  "subject": "anonymous",
+  "scope": "viewer"
+}
+```
+
+Public rows may only grant `viewer`, and principal rows cannot target `system`
+or anonymous principals. Deleting the final owner row is rejected. Group/org
+expansion, owner transfer workflow, audit events, and Zanzibar/Authzed-style
+relationship evaluation remain outside this prototype API.
+
 ## Storage shape
 
 Bindings in `wrangler.toml`:

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -453,16 +453,15 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
   }
 
   if (request.method === "DELETE") {
-    if (await wouldRemoveLastOwner(env, notebookId, aclInput)) {
-      return json({ error: "cannot remove the last owner ACL row" }, 409);
-    }
-
-    await revokeNotebookAclRow(env, {
+    const revoked = await revokeNotebookAclRow(env, {
       notebookId,
       subjectKind: aclInput.subject_kind,
       subject: aclInput.subject,
       scope: aclInput.scope,
     });
+    if (!revoked && (await isOnlyRemainingOwner(env, notebookId, aclInput))) {
+      return json({ error: "cannot remove the last owner ACL row" }, 409);
+    }
     return json({
       ok: true,
       notebook_id: notebookId,
@@ -943,7 +942,7 @@ function stringField(value: unknown, fieldName: string): string | Response {
   return value.trim();
 }
 
-async function wouldRemoveLastOwner(
+async function isOnlyRemainingOwner(
   env: Env,
   notebookId: string,
   row: ParsedNotebookAclInput,
@@ -953,13 +952,10 @@ async function wouldRemoveLastOwner(
   }
 
   const rows = await getNotebookAclRows(env, notebookId);
-  const remainingOwners = rows.filter(
-    (candidate) =>
-      candidate.subject_kind === "principal" &&
-      candidate.scope === "owner" &&
-      candidate.subject !== row.subject,
+  const ownerRows = rows.filter(
+    (candidate) => candidate.subject_kind === "principal" && candidate.scope === "owner",
   );
-  return remainingOwners.length === 0;
+  return ownerRows.length === 1 && ownerRows[0]?.subject === row.subject;
 }
 
 async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise<void> {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -459,13 +459,17 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
       subject: aclInput.subject,
       scope: aclInput.scope,
     });
-    if (!revoked && (await isOnlyRemainingOwner(env, notebookId, aclInput))) {
-      return json({ error: "cannot remove the last owner ACL row" }, 409);
+    const acl = await getNotebookAclRows(env, notebookId);
+    if (!revoked && isOwnerAclInput(aclInput) && aclContainsInput(acl, aclInput)) {
+      if (isOnlyOwnerAclRow(acl, aclInput)) {
+        return json({ error: "cannot remove the last owner ACL row" }, 409);
+      }
+      return json({ error: "owner ACL row was not removed; retry the request" }, 409);
     }
     return json({
       ok: true,
       notebook_id: notebookId,
-      acl: await getNotebookAclRows(env, notebookId),
+      acl,
     });
   }
 
@@ -942,16 +946,24 @@ function stringField(value: unknown, fieldName: string): string | Response {
   return value.trim();
 }
 
-async function isOnlyRemainingOwner(
-  env: Env,
-  notebookId: string,
-  row: ParsedNotebookAclInput,
-): Promise<boolean> {
+function isOwnerAclInput(row: ParsedNotebookAclInput): boolean {
+  return row.subject_kind === "principal" && row.scope === "owner";
+}
+
+function aclContainsInput(rows: NotebookAclRow[], row: ParsedNotebookAclInput): boolean {
+  return rows.some(
+    (candidate) =>
+      candidate.subject_kind === row.subject_kind &&
+      candidate.subject === row.subject &&
+      candidate.scope === row.scope,
+  );
+}
+
+function isOnlyOwnerAclRow(rows: NotebookAclRow[], row: ParsedNotebookAclInput): boolean {
   if (row.subject_kind !== "principal" || row.scope !== "owner") {
     return false;
   }
 
-  const rows = await getNotebookAclRows(env, notebookId);
   const ownerRows = rows.filter(
     (candidate) => candidate.subject_kind === "principal" && candidate.scope === "owner",
   );

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -6,22 +6,28 @@ import {
   allowsPublish,
   authenticateRequestWithProviders,
   DEV_AUTH_TOKEN_HEADER,
+  parseScope,
   stampTrustedIdentity,
   type AuthenticatedConnection,
   type ConnectionScope,
+  validatePrincipal,
 } from "./identity.ts";
 import { AuthorizationError, authorizeNotebookAccess } from "./authorization.ts";
 import {
   blobKey,
   createNotebookWithOwnerAcl,
   ensureCatalogSchema,
+  getNotebookAclRows,
   getNotebookRow,
   getNotebookCatalog,
+  grantNotebookAclRow,
   recordBlob,
   recordRevision,
   renderKey,
+  revokeNotebookAclRow,
   runtimeSnapshotKey,
   snapshotKey,
+  type NotebookAclRow,
   type RevisionRow,
 } from "./storage.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
@@ -123,6 +129,11 @@ const worker: ExportedHandler<Env> = {
     const latestRenderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/render$/);
     if (latestRenderMatch && request.method === "GET") {
       return routeLatestRender(request, env, decodeURIComponent(latestRenderMatch[1]));
+    }
+
+    const aclMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/acl\/?$/);
+    if (aclMatch) {
+      return routeNotebookAcl(request, env, decodeURIComponent(aclMatch[1]));
     }
 
     const renderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/renders\/([^/]+)$/);
@@ -413,6 +424,67 @@ async function routeRuntimeSnapshot(
   });
 
   return json({ ok: true, key, size: body.byteLength }, 201);
+}
+
+async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    return json({
+      notebook_id: notebookId,
+      acl: await getNotebookAclRows(env, notebookId),
+    });
+  }
+
+  if (request.method !== "POST" && request.method !== "DELETE") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const aclInput = await parseNotebookAclInput(request);
+  if (aclInput instanceof Response) {
+    return aclInput;
+  }
+
+  if (request.method === "DELETE") {
+    if (await wouldRemoveLastOwner(env, notebookId, aclInput)) {
+      return json({ error: "cannot remove the last owner ACL row" }, 409);
+    }
+
+    await revokeNotebookAclRow(env, {
+      notebookId,
+      subjectKind: aclInput.subject_kind,
+      subject: aclInput.subject,
+      scope: aclInput.scope,
+    });
+    return json({
+      ok: true,
+      notebook_id: notebookId,
+      acl: await getNotebookAclRows(env, notebookId),
+    });
+  }
+
+  await grantNotebookAclRow(env, {
+    notebookId,
+    subjectKind: aclInput.subject_kind,
+    subject: aclInput.subject,
+    scope: aclInput.scope,
+    actorLabel: identity.actorLabel,
+  });
+  return json(
+    {
+      ok: true,
+      notebook_id: notebookId,
+      acl: await getNotebookAclRows(env, notebookId),
+    },
+    201,
+  );
 }
 
 async function routeCatalog(request: Request, env: Env, notebookId: string): Promise<Response> {
@@ -790,6 +862,106 @@ async function routeBlob(
   return json({ ok: true, key, size: body.byteLength }, 201);
 }
 
+interface NotebookAclPayload {
+  subject_kind?: unknown;
+  subjectKind?: unknown;
+  subject?: unknown;
+  scope?: unknown;
+}
+
+interface ParsedNotebookAclInput {
+  subject_kind: NotebookAclRow["subject_kind"];
+  subject: string;
+  scope: NotebookAclRow["scope"];
+}
+
+async function parseNotebookAclInput(request: Request): Promise<ParsedNotebookAclInput | Response> {
+  let payload: NotebookAclPayload;
+  try {
+    payload = (await request.json()) as NotebookAclPayload;
+  } catch {
+    return json({ error: "ACL mutation body must be JSON" }, 400);
+  }
+
+  const subjectKind = stringField(payload.subject_kind ?? payload.subjectKind, "subject_kind");
+  if (subjectKind instanceof Response) {
+    return subjectKind;
+  }
+  if (subjectKind !== "principal" && subjectKind !== "public") {
+    return json({ error: "subject_kind must be 'principal' or 'public'" }, 400);
+  }
+
+  const subject = stringField(payload.subject, "subject");
+  if (subject instanceof Response) {
+    return subject;
+  }
+
+  const scopeValue = stringField(payload.scope, "scope");
+  if (scopeValue instanceof Response) {
+    return scopeValue;
+  }
+
+  let scope: ConnectionScope;
+  try {
+    scope = parseScope(scopeValue);
+  } catch (error) {
+    return json({ error: errorMessage(error) }, 400);
+  }
+
+  if (subjectKind === "public") {
+    if (subject !== "anonymous") {
+      return json({ error: "public ACL rows must use subject 'anonymous'" }, 400);
+    }
+    if (scope !== "viewer") {
+      return json({ error: "public ACL rows may only grant viewer scope" }, 400);
+    }
+  } else {
+    try {
+      validatePrincipal(subject);
+    } catch (error) {
+      return json({ error: errorMessage(error) }, 400);
+    }
+    if (subject === "system" || subject.startsWith("anonymous:")) {
+      return json(
+        { error: "principal ACL rows cannot target system or anonymous principals" },
+        400,
+      );
+    }
+  }
+
+  return {
+    subject_kind: subjectKind,
+    subject,
+    scope,
+  };
+}
+
+function stringField(value: unknown, fieldName: string): string | Response {
+  if (typeof value !== "string" || value.trim() === "") {
+    return json({ error: `${fieldName} must be a non-empty string` }, 400);
+  }
+  return value.trim();
+}
+
+async function wouldRemoveLastOwner(
+  env: Env,
+  notebookId: string,
+  row: ParsedNotebookAclInput,
+): Promise<boolean> {
+  if (row.subject_kind !== "principal" || row.scope !== "owner") {
+    return false;
+  }
+
+  const rows = await getNotebookAclRows(env, notebookId);
+  const remainingOwners = rows.filter(
+    (candidate) =>
+      candidate.subject_kind === "principal" &&
+      candidate.scope === "owner" &&
+      candidate.subject !== row.subject,
+  );
+  return remainingOwners.length === 0;
+}
+
 async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise<void> {
   ctx.waitUntil(
     ensureCatalogSchema(env).catch((error: unknown) => {
@@ -895,10 +1067,10 @@ async function sha256Hex(body: ArrayBuffer): Promise<string> {
 
 function withCors(response: Response): Response {
   response.headers.set("Access-Control-Allow-Origin", "*");
-  response.headers.set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, OPTIONS");
+  response.headers.set("Access-Control-Allow-Methods", "DELETE, GET, HEAD, POST, PUT, OPTIONS");
   response.headers.set(
     "Access-Control-Allow-Headers",
-    `Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
+    `Authorization, Cf-Access-Jwt-Assertion, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
   );
   return response;
 }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -46,6 +46,14 @@ export interface NotebookAclRow {
   created_by_actor_label: string;
 }
 
+export interface NotebookAclInput {
+  notebookId: string;
+  subjectKind: NotebookAclRow["subject_kind"];
+  subject: string;
+  scope: NotebookAclRow["scope"];
+  actorLabel: string;
+}
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -271,6 +279,65 @@ export async function getPublicNotebookAclRows(
     .bind(notebookId)
     .all<NotebookAclRow>();
   return rows.results ?? [];
+}
+
+export async function getNotebookAclRows(env: Env, notebookId: string): Promise<NotebookAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT notebook_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM notebook_acl
+       WHERE notebook_id = ?
+       ORDER BY subject_kind, subject, scope`,
+  )
+    .bind(notebookId)
+    .all<NotebookAclRow>();
+  return rows.results ?? [];
+}
+
+export async function grantNotebookAclRow(env: Env, row: NotebookAclInput): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await notebookAclInsert(env, {
+    notebookId: row.notebookId,
+    subjectKind: row.subjectKind,
+    subject: row.subject,
+    scope: row.scope,
+    actorLabel: row.actorLabel,
+    timestamp: new Date().toISOString(),
+  }).run();
+}
+
+export async function revokeNotebookAclRow(
+  env: Env,
+  row: Omit<NotebookAclInput, "actorLabel">,
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `DELETE FROM notebook_acl
+       WHERE notebook_id = ?
+         AND subject_kind = ?
+         AND subject = ?
+         AND scope = ?`,
+  )
+    .bind(row.notebookId, row.subjectKind, row.subject, row.scope)
+    .run();
 }
 
 export async function createNotebookWithOwnerAcl(

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -323,21 +323,34 @@ export async function grantNotebookAclRow(env: Env, row: NotebookAclInput): Prom
 export async function revokeNotebookAclRow(
   env: Env,
   row: Omit<NotebookAclInput, "actorLabel">,
-): Promise<void> {
+): Promise<boolean> {
   if (!env.DB) {
-    return;
+    return false;
   }
 
   await ensureCatalogSchema(env);
-  await env.DB.prepare(
+  const result = await env.DB.prepare(
     `DELETE FROM notebook_acl
        WHERE notebook_id = ?
          AND subject_kind = ?
          AND subject = ?
-         AND scope = ?`,
+         AND scope = ?
+         AND (
+           subject_kind != 'principal'
+           OR scope != 'owner'
+           OR (
+             SELECT COUNT(*)
+               FROM notebook_acl
+              WHERE notebook_id = ?
+                AND subject_kind = 'principal'
+                AND scope = 'owner'
+                AND subject != ?
+           ) > 0
+         )`,
   )
-    .bind(row.notebookId, row.subjectKind, row.subject, row.scope)
+    .bind(row.notebookId, row.subjectKind, row.subject, row.scope, row.notebookId, row.subject)
     .run();
+  return d1Changes(result) > 0;
 }
 
 export async function createNotebookWithOwnerAcl(
@@ -560,4 +573,9 @@ export async function getNotebookCatalog(
 
 function encodePathComponent(value: string): string {
   return encodeURIComponent(value).replaceAll("%2F", "%252F");
+}
+
+function d1Changes(result: { meta: Record<string, unknown> }): number {
+  const changes = result.meta.changes;
+  return typeof changes === "number" ? changes : 0;
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -590,6 +590,43 @@ describe("Worker artifact routes", () => {
     assert.equal((await getNotebookAclRows(env, "last-owner-demo")).length, 1);
   });
 
+  it("does not report success when a guarded owner delete leaves the row present", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "owner-delete-race-demo");
+    seedAcl(env, {
+      notebookId: "owner-delete-race-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    env.DB.afterBlockedOwnerDelete = () => {
+      seedAcl(env, {
+        notebookId: "owner-delete-race-demo",
+        subject: "user:dev:bob",
+        scope: "owner",
+      });
+    };
+
+    const response = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:alice",
+        scope: "owner",
+      },
+      "owner-delete-race-demo",
+    );
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(await response.json(), {
+      error: "owner ACL row was not removed; retry the request",
+    });
+    assert.deepEqual(
+      (await getNotebookAclRows(env, "owner-delete-race-demo")).map((row) => row.subject).sort(),
+      ["user:dev:alice", "user:dev:bob"],
+    );
+  });
+
   it("allows owner revocation only while another owner row remains", async () => {
     const env = fakeEnv();
     seedNotebook(env, "two-owner-demo");
@@ -1087,6 +1124,7 @@ class FakeD1 implements D1Database {
   readonly revisions: RevisionRow[] = [];
   readonly blobs = new Map<string, BlobRow>();
   readonly acl: NotebookAclRow[] = [];
+  afterBlockedOwnerDelete?: () => void;
 
   prepare(query: string): D1PreparedStatement {
     return new FakeD1Statement(this, query);
@@ -1184,6 +1222,8 @@ class FakeD1Statement implements D1PreparedStatement {
             row.subject !== subject,
         )
       ) {
+        this.db.afterBlockedOwnerDelete?.();
+        this.db.afterBlockedOwnerDelete = undefined;
         return okResult(undefined, { changes: 0 });
       }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -590,6 +590,50 @@ describe("Worker artifact routes", () => {
     assert.equal((await getNotebookAclRows(env, "last-owner-demo")).length, 1);
   });
 
+  it("allows owner revocation only while another owner row remains", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "two-owner-demo");
+    seedAcl(env, {
+      notebookId: "two-owner-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "two-owner-demo",
+      subject: "user:dev:bob",
+      scope: "owner",
+    });
+
+    const removeBob = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:bob",
+        scope: "owner",
+      },
+      "two-owner-demo",
+    );
+    assert.equal(removeBob.status, 200);
+    assert.deepEqual(
+      (await getNotebookAclRows(env, "two-owner-demo")).map((row) => row.subject),
+      ["user:dev:alice"],
+    );
+
+    const removeAlice = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:alice",
+        scope: "owner",
+      },
+      "two-owner-demo",
+    );
+    assert.equal(removeAlice.status, 409);
+    assert.deepEqual(await removeAlice.json(), { error: "cannot remove the last owner ACL row" });
+  });
+
   it("does not grant owner ACL to a principal that loses notebook creation", async () => {
     const env = fakeEnv();
     const alice = authenticateDevRequest(
@@ -1129,6 +1173,21 @@ class FakeD1Statement implements D1PreparedStatement {
         string,
         NotebookAclRow["scope"],
       ];
+      if (
+        subjectKind === "principal" &&
+        scope === "owner" &&
+        !this.db.acl.some(
+          (row) =>
+            row.notebook_id === notebookId &&
+            row.subject_kind === "principal" &&
+            row.scope === "owner" &&
+            row.subject !== subject,
+        )
+      ) {
+        return okResult(undefined, { changes: 0 });
+      }
+
+      const countBefore = this.db.acl.length;
       const retained = this.db.acl.filter(
         (row) =>
           !(
@@ -1139,6 +1198,7 @@ class FakeD1Statement implements D1PreparedStatement {
           ),
       );
       this.db.acl.splice(0, this.db.acl.length, ...retained);
+      return okResult(undefined, { changes: countBefore - retained.length });
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, createdAtOrUpdatedAt, maybeUpdatedAt] = this.values as [
         string,
@@ -1294,11 +1354,11 @@ interface BlobRow {
   uploaded_at: string;
 }
 
-function okResult<T = unknown>(results?: T[]): D1Result<T> {
+function okResult<T = unknown>(results?: T[], meta: Record<string, unknown> = {}): D1Result<T> {
   return {
     results,
     success: true,
-    meta: {},
+    meta,
   };
 }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -20,6 +20,7 @@ import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
 import {
   blobKey,
   createNotebookWithOwnerAcl,
+  getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
   renderKey,
   snapshotKey,
@@ -424,6 +425,171 @@ describe("Worker artifact routes", () => {
     assert.equal(catalog.notebook.id, "access-demo");
   });
 
+  it("lets owners inspect and grant principal ACL rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "acl-demo");
+    seedAcl(env, {
+      notebookId: "acl-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const before = await aclRequest(env, "GET", undefined);
+    assert.equal(before.status, 200);
+    const beforeBody = (await before.json()) as { notebook_id: string; acl: NotebookAclRow[] };
+    assert.equal(beforeBody.notebook_id, "acl-demo");
+    assert.deepEqual(
+      beforeBody.acl.map((row) => [row.subject_kind, row.subject, row.scope]),
+      [["principal", "user:dev:alice", "owner"]],
+    );
+
+    const grant = await aclRequest(env, "POST", {
+      subject_kind: "principal",
+      subject: "user:dev:bob",
+      scope: "editor",
+    });
+    assert.equal(grant.status, 201);
+    assert.deepEqual(
+      (await getNotebookAclRowsForPrincipal(env, "acl-demo", "user:dev:bob")).map(
+        (row) => row.scope,
+      ),
+      ["editor"],
+    );
+
+    const bobCatalog = await worker.fetch(
+      new Request("http://localhost/api/n/acl-demo?user=bob&operator=desktop:b&scope=editor"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(bobCatalog.status, 200);
+  });
+
+  it("lets owners grant and revoke explicit public viewer ACL rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "public-acl-demo");
+    seedAcl(env, {
+      notebookId: "public-acl-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const hidden = await worker.fetch(
+      new Request("http://localhost/api/n/public-acl-demo?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(hidden.status, 404);
+
+    const grant = await aclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "public",
+        subject: "anonymous",
+        scope: "viewer",
+      },
+      "public-acl-demo",
+    );
+    assert.equal(grant.status, 201);
+
+    const visible = await worker.fetch(
+      new Request("http://localhost/api/n/public-acl-demo?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(visible.status, 200);
+
+    const revoke = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "public",
+        subject: "anonymous",
+        scope: "viewer",
+      },
+      "public-acl-demo",
+    );
+    assert.equal(revoke.status, 200);
+
+    const hiddenAgain = await worker.fetch(
+      new Request("http://localhost/api/n/public-acl-demo?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(hiddenAgain.status, 404);
+  });
+
+  it("keeps ACL management owner-only and public grants viewer-only", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "acl-private-demo");
+    seedAcl(env, {
+      notebookId: "acl-private-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "acl-private-demo",
+      subject: "user:dev:bob",
+      scope: "editor",
+    });
+
+    const bobGrant = await aclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:mallory",
+        scope: "viewer",
+      },
+      "acl-private-demo",
+      {
+        "X-User": "bob",
+        "X-Scope": "editor",
+      },
+    );
+    assert.equal(bobGrant.status, 403);
+
+    const publicEditor = await aclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "public",
+        subject: "anonymous",
+        scope: "editor",
+      },
+      "acl-private-demo",
+    );
+    assert.equal(publicEditor.status, 400);
+    assert.deepEqual(await publicEditor.json(), {
+      error: "public ACL rows may only grant viewer scope",
+    });
+  });
+
+  it("rejects deleting the last owner ACL row", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "last-owner-demo");
+    seedAcl(env, {
+      notebookId: "last-owner-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const response = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:alice",
+        scope: "owner",
+      },
+      "last-owner-demo",
+    );
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(await response.json(), { error: "cannot remove the last owner ACL row" });
+    assert.equal((await getNotebookAclRows(env, "last-owner-demo")).length, 1);
+  });
+
   it("does not grant owner ACL to a principal that loses notebook creation", async () => {
     const env = fakeEnv();
     const alice = authenticateDevRequest(
@@ -728,6 +894,34 @@ async function ownerPut(
   });
 }
 
+async function aclRequest(
+  env: FakeEnv,
+  method: "GET" | "POST" | "DELETE",
+  body: Record<string, unknown> | undefined,
+  notebookId = "acl-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/n/${notebookId}/acl`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
 async function scopedPut(
   env: FakeEnv,
   pathname: string,
@@ -928,6 +1122,23 @@ class FakeD1Statement implements D1PreparedStatement {
         updated_at: updatedAt,
         created_by_actor_label: actorLabel,
       });
+    } else if (this.query.includes("DELETE FROM notebook_acl")) {
+      const [notebookId, subjectKind, subject, scope] = this.values as [
+        string,
+        NotebookAclRow["subject_kind"],
+        string,
+        NotebookAclRow["scope"],
+      ];
+      const retained = this.db.acl.filter(
+        (row) =>
+          !(
+            row.notebook_id === notebookId &&
+            row.subject_kind === subjectKind &&
+            row.subject === subject &&
+            row.scope === scope
+          ),
+      );
+      this.db.acl.splice(0, this.db.acl.length, ...retained);
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, createdAtOrUpdatedAt, maybeUpdatedAt] = this.values as [
         string,
@@ -1030,6 +1241,12 @@ class FakeD1Statement implements D1PreparedStatement {
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (this.query.includes("FROM notebook_acl")) {
       const notebookId = this.values[0] as string;
+      if (
+        !this.query.includes("subject_kind = 'principal'") &&
+        !this.query.includes("subject_kind = 'public'")
+      ) {
+        return okResult(this.db.acl.filter((row) => row.notebook_id === notebookId) as T[]);
+      }
       if (this.query.includes("subject_kind = 'principal'")) {
         const principal = this.values[1] as string;
         return okResult(

--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -77,12 +77,9 @@ What this changes from the older framing: rooms are no longer implicitly scoped 
 
 ### ACL mechanics
 
-The minimum v1 ACL is a flat mapping from subject to scope. The hosted
-Cloudflare shape, including D1 rows, public-read entries, and scope derivation,
-is drafted in `docs/architecture/hosted-room-authorization.md`. The protocol
-shape locked here is: rooms have ACLs, ACLs reference principals or explicit
-public-read subjects, principals authenticate against the host's configured
-IdPs, and the room ACL is the source of truth for the connection scope.
+The minimum v1 ACL is a flat set of rows keyed by `(room, subject_kind, subject, scope)`. The hosted Worker prototype persists those rows in D1 as `notebook_acl`. Owner-scoped HTTP requests can inspect, grant, and revoke individual rows; anonymous public read is represented as a normal row with `subject_kind = public`, `subject = anonymous`, and `scope = viewer`. Public rows cannot grant write scopes, and the prototype rejects removal of the final owner row.
+
+The protocol shape locked here is: rooms have ACLs, ACLs reference principals or explicit public-read subjects, principals authenticate against the host's configured IdPs, and the room ACL is the source of truth for the connection scope. Inheritance from a containing org, group expansion, owner-transfer workflow, audit events, and Zanzibar/Authzed-style relationship evaluation are future layers on top of the flat ACL.
 
 ## Decision 3: Authentication at connect, scope checks per frame
 
@@ -266,7 +263,7 @@ Scope is enforced server-side at three points, each with a clear boundary:
 
 1. **Frame ingress** (in `peer_notebook_sync.rs::handle_notebook_doc_frame` and equivalents): the validator already runs here. Extend it to consult `AuthenticatedConnection.scope` and reject frames that exceed the scope: viewer with non-empty changes on any doc, runtime_peer sending changes to `NotebookDoc`. Editor writes pass at the frame layer for both docs in the local same-UID daemon. Hosted multi-user rooms must additionally validate that editor `RuntimeStateDoc` changes touch only `doc.comms/*/state/*` before enabling untrusted editor clients.
 2. **Request dispatch**: each `NotebookRequest` variant declares its minimum required scope via an annotation or registry lookup. The request handler rejects with a typed `Unauthorized` response before any side effect. New scope-gated requests declare their requirement at the definition site; no scattered `if scope == ...` checks elsewhere.
-3. **ACL mutations** are owner-only. The room-host enforces this at the request-dispatch layer; no in-band ACL change is honored from a non-owner connection.
+3. **ACL mutations** are owner-only. The hosted Worker prototype exposes owner-only HTTP ACL management for individual D1 rows. No in-band Automerge ACL change is honored from a non-owner connection.
 
 ### Adding new scope-gated functionality
 
@@ -332,7 +329,7 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 6. **Federation.** A notebook host trusting another notebook host's identity claims (e.g., JupyterHub Anaconda interop). Not v1.
 7. **`runtime_peer` connection topology.** The hosted prototype now supports direct `runtime_peer` `RuntimeStateDoc` ingress into the room. Still open: whether the production kernel sidecar connects to the room directly with its own `runtime_peer` scope credential, or whether a separate runtime-coordination protocol relays writes. Tied to the future remote-runtime work.
 8. **Deployment topology.** How clients reach rooms (browser-direct WebSocket, local-daemon proxy, native client), where kernels run, TLS/CORS, credential keyring placement. Drafted in `docs/architecture/deployment-topology.md`.
-9. **ACL mechanics beyond the Cloudflare v1 shape.** `docs/architecture/hosted-room-authorization.md` defines the first D1-backed ACL shape. Still open: owner transfer UX, group/org expansion, inherited ACLs, and product policy for anonymous public presence.
+9. **ACL mechanics beyond the Cloudflare v1 shape.** The hosted prototype covers flat D1 rows, public-read rows, and owner-only row mutation. Still open: owner transfer UX, group/org expansion, inherited ACLs, audit event retention, Zanzibar/Authzed-style evaluation, and product policy for anonymous public presence.
 10. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. Until then, publish produces a fresh document in the destination space (see Decision 6).
 11. **Bearer-token replay mitigation.** DPoP / proof-of-possession tokens, mTLS for system-to-system, short token lifetimes. v1 inherits the bearer-token threat model; tightening it is future work.
 12. **Lower-cost actor-label validator.** Replace the v1 clone-preview validator with parsing of `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/architecture/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.


### PR DESCRIPTION
## Summary

Adds the first owner-managed ACL API for notebook-cloud:

- exposes `GET /api/n/{notebookId}/acl` for owner-only ACL inspection
- exposes `POST /api/n/{notebookId}/acl` to grant one flat D1 ACL row
- exposes `DELETE /api/n/{notebookId}/acl` to revoke one flat D1 ACL row
- keeps public ACL rows explicit and viewer-only
- rejects principal ACL rows for `system` and anonymous principals
- rejects deletion of the final owner ACL row
- documents the prototype API and updates the identity ADR so ACL mechanics are no longer described as fully deferred

## Stack

Base: `quod/notebook-cloud-runtime-peer-ingress` / #2871.

Keep this draft until the Bedrock rerun completes cleanly.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `git diff --check`

## Review status

- GitHub Actions: green
- Bedrock PR review: first pass found a TOCTOU last-owner deletion race; fixed in `22c2416f`
- Bedrock rerun: pending; two local reviewer runs stalled without producing a report
