### PR TITLE
fix(notebook): abbreviate traceback package paths with ellipsis

### DIFF
--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -94,7 +94,7 @@ describe("TracebackOutput", () => {
       />,
     );
 
-    expect(container.textContent).toContain("Line2630inpython/polars/lazyframe/frame.pyincollect");
+    expect(container.textContent).toContain("Line2630in.../polars/lazyframe/frame.pyincollect");
     expect(container.textContent).not.toContain("/Users/kylekelley/Library/Caches");
   });
 
@@ -122,7 +122,7 @@ describe("TracebackOutput", () => {
     expect(container.textContent).toContain(
       "Line7in/Users/kyle/project/site-packages/example/runtime/frame.jlinload",
     );
-    expect(container.textContent).not.toContain("python/example/runtime/frame.jl");
+    expect(container.textContent).not.toContain(".../example/runtime/frame.jl");
   });
 
   it("does not throw when a frame has a malformed filename", () => {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -643,7 +643,7 @@ function shortenPythonPath(filename: string): string {
   const sitePackages = normalized.match(/(?:^|\/)(?:site-packages|dist-packages)\/(.+)$/);
   const packagePath = sitePackages?.[1];
   if (packagePath && /^[\w.-]+(?:\/[\w.-]+)*\.py[wi]?$/.test(packagePath)) {
-    return `python/${packagePath}`;
+    return `.../${packagePath}`;
   }
 
   return filename;


### PR DESCRIPTION
## Summary

- Display shortened Python package traceback paths as `.../<package path>` instead of `python/<package path>`
- Update the focused traceback renderer test expectations

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx`
