### PR TITLE
chore(notebook): refresh isolated renderer bundle

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:932b280861a2c306e760c7da3ab4a1e3e98d236d2884cae6e779df93e3fba353
-size 1601199
+oid sha256:4f93d5e07539f52e32848c555489e1da09de4fdaa36e422b42ff3b6ec6a8bd76
+size 1601293

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74cce54927eac44b8a70b54ed305a5d0911f0c4a1b38ac864725f59923dc6219
-size 1480937
+oid sha256:af4edc9ecd366d1116a32920bf1bb02b704b073fef98690101aa4a99cefcff6f
+size 1486266


### PR DESCRIPTION
## Summary

- Refresh the committed isolated renderer plugin bundle after PR #2876.
- Keep the follow-up scoped to the generated LFS artifacts from `cargo xtask wasm`.

## Verification

- `cargo xtask wasm`
- `cargo xtask lint --fix`
