### PR TITLE
fix(notebook-cloud): add collaborator auth diagnostics

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -168,10 +168,15 @@ For local browser-only testing, the same values can be supplied as query params:
 Dev credentials are accepted without an extra token only from loopback Wrangler local development (`localhost`, `127.0.0.1`, or `::1`). Deployed prototype environments require the `NOTEBOOK_CLOUD_DEV_TOKEN` Worker secret to match either the `X-Notebook-Cloud-Dev-Token` header or a WebSocket subprotocol named `nteract-dev-token.<base64url-token>`. `DEPLOYMENT_ENV=development` does not bypass this host check, and URL-carried `dev_token` credentials are rejected on deployed hosts so prototype owner credentials do not appear in URLs. If no scope is supplied, dev auth defaults to `viewer`. Write and publish paths must ask for `editor`, `runtime_peer`, or `owner` explicitly. Blob upload is allowed for runtime-state writers (`editor`, `runtime_peer`, `owner`) and verifies that the uploaded bytes match the SHA-256 digest in the blob route before writing to R2. Runtime peers may write typed-frame `0x05` (`RuntimeStateDoc`) changes through the materialized room host; typed-frame `0x00` (`NotebookDoc`) changes are rejected for runtime_peer scope.
 
 For the browser-hosted editor prototype, the viewer keeps the dev token out of
-URLs by reading local-only storage before it opens `/n/:id/sync`:
+URLs. Open the key menu in the sticky toolbar, paste the Worker dev token, pick
+`alice`/`bob` and `editor`, and apply the identity. The token is stored only in
+origin-local browser storage and is sent to `/n/:id/sync` as a WebSocket
+subprotocol, never as a query parameter.
+
+For scripted browser setup, use the same storage keys the toolbar manages:
 
 ```js
-localStorage.setItem("nteract:notebook-cloud:dev-token", "<NOTEBOOK_CLOUD_DEV_TOKEN>");
+localStorage.setItem("nteract:notebook-cloud:dev-token", "...real token...");
 localStorage.setItem("nteract:notebook-cloud:user", "live-publish");
 localStorage.setItem("nteract:notebook-cloud:scope", "editor");
 location.reload();
@@ -182,7 +187,10 @@ editor-scope markdown editing for existing markdown cells. The CodeMirror
 editor uses the shared presence sender, shared remote cursor renderer, and
 shared presence reducer, so cursor/selection presence carries the room-stamped
 actor label (`<principal>/<operator>`) that also backs CRDT attribution. Clear
-these local storage keys to return the browser to anonymous viewer mode.
+these local storage keys, or use the toolbar's Anonymous action, to return the
+browser to anonymous viewer mode. If the stored token is still a placeholder
+such as `<NOTEBOOK_CLOUD_DEV_TOKEN>`, the viewer refuses to use it, connects as
+an anonymous viewer instead, and shows a visible diagnostic with a reset button.
 
 ## Cloudflare Access auth
 
@@ -389,7 +397,10 @@ Use `GET /api/n/{id}/acl` with an owner credential to confirm editor/viewer
 grants. A healthy throwaway collaboration run should show editor
 `room.materialized_frame.applied` records, viewer `room.peer_sync.completed`
 records, no unexpected `room.frame.rejected` records for Alice/Bob, and
-anonymous viewer presence logged only as `room.presence.local_only`.
+anonymous viewer presence logged only as `room.presence.local_only`. If the
+browser shows `Offline`, open the key menu first: placeholder or stale dev
+tokens are surfaced there, and the Worker logs token/auth failures as
+`auth.failed` without recording raw token material.
 
 Snapshot and blob stubs:
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1081,8 +1081,24 @@ async function authenticateRequestOrResponse(
     return await authenticateRequestWithProviders(request, env);
   } catch (error) {
     if (error instanceof AuthError) {
+      cloudLog(error.status >= 500 ? "warn" : "info", "auth.failed", {
+        status: error.status,
+        reason: error.message,
+        has_dev_token_header: request.headers.has(DEV_AUTH_TOKEN_HEADER),
+        has_websocket_protocol: request.headers.has("sec-websocket-protocol"),
+        counter: "auth_failures",
+        counter_delta: 1,
+      });
       return json({ error: error.message }, error.status);
     }
+    cloudLog("info", "auth.failed", {
+      status: 400,
+      reason: String(error),
+      has_dev_token_header: request.headers.has(DEV_AUTH_TOKEN_HEADER),
+      has_websocket_protocol: request.headers.has("sec-websocket-protocol"),
+      counter: "auth_failures",
+      counter_delta: 1,
+    });
     return json({ error: String(error) }, 400);
   }
 }

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
+  NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
+  NOTEBOOK_CLOUD_USER_STORAGE_KEY,
+  clearCloudPrototypeDevAuth,
+  cloudSyncAuthFromPrototypeAuthState,
+  prototypeAuthSummary,
+  readCloudPrototypeAuth,
+  storeCloudPrototypeDevAuth,
+  validatePrototypeToken,
+  type CloudPrototypeAuthStorage,
+} from "../viewer/collaborator-auth.ts";
+
+describe("cloud collaborator auth", () => {
+  it("uses anonymous viewer auth when no prototype token is stored", () => {
+    const state = readCloudPrototypeAuth(new MemoryStorage());
+
+    assert.equal(state.mode, "anonymous");
+    assert.deepEqual(cloudSyncAuthFromPrototypeAuthState(state), {
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: null,
+    });
+  });
+
+  it("builds WebSocket subprotocol auth without putting the token in the URL", () => {
+    const storage = new MemoryStorage();
+    storeCloudPrototypeDevAuth(storage, {
+      token: "secret",
+      user: "alice",
+      scope: "editor",
+    });
+
+    const state = readCloudPrototypeAuth(storage);
+    const auth = cloudSyncAuthFromPrototypeAuthState(state);
+
+    assert.equal(state.mode, "dev");
+    assert.equal(auth.user, "alice");
+    assert.equal(auth.requestedScope, "editor");
+    assert.deepEqual(auth.protocols, ["nteract-dev-token.c2VjcmV0"]);
+  });
+
+  it("preserves every explicit connection scope supported by the protocol", () => {
+    for (const scope of ["viewer", "editor", "runtime_peer", "owner"] as const) {
+      const storage = new MemoryStorage();
+      storeCloudPrototypeDevAuth(storage, {
+        token: "secret",
+        user: "alice",
+        scope,
+      });
+
+      assert.equal(readCloudPrototypeAuth(storage).requestedScope, scope);
+    }
+  });
+
+  it("falls back to anonymous auth for placeholder tokens", () => {
+    const storage = new MemoryStorage();
+    storeCloudPrototypeDevAuth(storage, {
+      token: "<NOTEBOOK_CLOUD_DEV_TOKEN>",
+      user: "alice",
+      scope: "editor",
+    });
+
+    const state = readCloudPrototypeAuth(storage);
+
+    assert.equal(state.mode, "invalid");
+    assert.match(prototypeAuthSummary(state), /placeholder/);
+    assert.deepEqual(cloudSyncAuthFromPrototypeAuthState(state), {
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: null,
+    });
+  });
+
+  it("clears all prototype collaborator keys", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY, "secret");
+    storage.setItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY, "alice");
+    storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, "editor");
+
+    clearCloudPrototypeDevAuth(storage);
+
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY), null);
+  });
+
+  it("recognizes common placeholder token shapes", () => {
+    assert.match(validatePrototypeToken("<NOTEBOOK_CLOUD_DEV_TOKEN>") ?? "", /placeholder/);
+    assert.match(validatePrototypeToken("NOTEBOOK_CLOUD_DEV_TOKEN") ?? "", /placeholder/);
+    assert.match(validatePrototypeToken("<paste token here>") ?? "", /placeholder/);
+    assert.equal(validatePrototypeToken("real-token"), null);
+  });
+});
+
+class MemoryStorage implements CloudPrototypeAuthStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2,7 +2,7 @@ import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import worker from "../src/index.ts";
-import { authenticateDevRequest } from "../src/identity.ts";
+import { DEV_AUTH_TOKEN_PROTOCOL_PREFIX, authenticateDevRequest } from "../src/identity.ts";
 import type {
   D1Database,
   D1PreparedStatement,
@@ -780,6 +780,44 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.notebooks.has("unclaimed-demo"), false);
   });
 
+  it("logs deployed dev auth failures without token material", async () => {
+    const env = fakeEnv({
+      DEPLOYMENT_ENV: "prototype",
+      NOTEBOOK_CLOUD_DEV_TOKEN: "secret-token",
+    });
+    const originalInfo = console.info;
+    const logs: unknown[][] = [];
+    console.info = (...args: unknown[]) => {
+      logs.push(args);
+    };
+    try {
+      const response = await worker.fetch(
+        new Request("https://cloud.test/n/unclaimed-demo/sync?user=alice&scope=editor", {
+          headers: {
+            Upgrade: "websocket",
+            "Sec-WebSocket-Protocol": `${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+              "<NOTEBOOK_CLOUD_DEV_TOKEN>",
+            )}`,
+          },
+        }),
+        env,
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 401);
+      const record = logs
+        .filter((entry) => entry[0] === "[notebook-cloud]")
+        .map((entry) => entry[1] as { event?: string; reason?: string; [key: string]: unknown })
+        .find((entry) => entry.event === "auth.failed");
+      assert.ok(record, "expected auth.failed log record");
+      assert.equal(record.counter, "auth_failures");
+      assert.equal(record.has_websocket_protocol, true);
+      assert.doesNotMatch(JSON.stringify(record), /<NOTEBOOK_CLOUD_DEV_TOKEN>|secret-token/);
+    } finally {
+      console.info = originalInfo;
+    }
+  });
+
   it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes] = await Promise.all([
@@ -1142,6 +1180,10 @@ function fakeContext(): ExecutionContext {
     waitUntil: () => undefined,
     passThroughOnException: () => undefined,
   };
+}
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
 interface NotebookRow {

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -1,0 +1,157 @@
+import {
+  DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
+  isConnectionScope,
+  type ConnectionScope,
+} from "../src/auth-shared";
+
+export const NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY = "nteract:notebook-cloud:dev-token";
+export const NOTEBOOK_CLOUD_USER_STORAGE_KEY = "nteract:notebook-cloud:user";
+export const NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY = "nteract:notebook-cloud:scope";
+
+export interface CloudSyncAuth {
+  protocols: string[];
+  user: string | null;
+  operator: string | null;
+  requestedScope: ConnectionScope | null;
+}
+
+export interface CloudPrototypeAuthState {
+  mode: "anonymous" | "dev" | "invalid";
+  token: string | null;
+  user: string | null;
+  requestedScope: ConnectionScope | null;
+  problem: string | null;
+}
+
+export interface CloudPrototypeAuthStorage {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+export interface CloudPrototypeAuthInput {
+  token: string;
+  user: string;
+  scope: ConnectionScope;
+}
+
+export function cloudPrototypeAuthFromWindow(): CloudPrototypeAuthState {
+  if (typeof window === "undefined") {
+    return anonymousAuthState();
+  }
+  try {
+    if (!window.localStorage) {
+      return anonymousAuthState();
+    }
+    return readCloudPrototypeAuth(window.localStorage);
+  } catch {
+    return anonymousAuthState();
+  }
+}
+
+export function readCloudPrototypeAuth(
+  storage: Pick<CloudPrototypeAuthStorage, "getItem">,
+): CloudPrototypeAuthState {
+  const token = storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY)?.trim() ?? "";
+  if (!token) {
+    return anonymousAuthState();
+  }
+
+  const requestedScope = parseStoredScope(storage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY));
+  const user = storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY)?.trim() || "browser-editor";
+  const problem = validatePrototypeToken(token);
+  if (problem) {
+    return {
+      mode: "invalid",
+      token,
+      user,
+      requestedScope: requestedScope ?? "editor",
+      problem,
+    };
+  }
+
+  return {
+    mode: "dev",
+    token,
+    user,
+    requestedScope: requestedScope ?? "editor",
+    problem: null,
+  };
+}
+
+export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthState): CloudSyncAuth {
+  if (state.mode !== "dev" || !state.token) {
+    return { protocols: [], user: null, operator: null, requestedScope: null };
+  }
+
+  return {
+    protocols: [`${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64UrlEncode(state.token)}`],
+    user: state.user ?? "browser-editor",
+    operator: null,
+    requestedScope: state.requestedScope ?? "editor",
+  };
+}
+
+export function storeCloudPrototypeDevAuth(
+  storage: CloudPrototypeAuthStorage,
+  input: CloudPrototypeAuthInput,
+): void {
+  storage.setItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY, input.token.trim());
+  storage.setItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY, input.user.trim() || "browser-editor");
+  storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
+}
+
+export function clearCloudPrototypeDevAuth(
+  storage: Pick<CloudPrototypeAuthStorage, "removeItem">,
+): void {
+  storage.removeItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY);
+  storage.removeItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY);
+  storage.removeItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY);
+}
+
+export function validatePrototypeToken(token: string): string | null {
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return "Token is empty.";
+  }
+  if (trimmed === "<NOTEBOOK_CLOUD_DEV_TOKEN>" || trimmed === "NOTEBOOK_CLOUD_DEV_TOKEN") {
+    return "Token is still the NOTEBOOK_CLOUD_DEV_TOKEN placeholder.";
+  }
+  if (/^<[^>]+>$/.test(trimmed)) {
+    return "Token still looks like a placeholder value.";
+  }
+  return null;
+}
+
+export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
+  if (state.mode === "dev") {
+    return `${state.user ?? "browser-editor"} requesting ${state.requestedScope ?? "editor"}`;
+  }
+  if (state.mode === "invalid") {
+    return `${state.problem ?? "Stored collaborator token is invalid"} Connected anonymously.`;
+  }
+  return "Anonymous read-only viewer";
+}
+
+function anonymousAuthState(): CloudPrototypeAuthState {
+  return {
+    mode: "anonymous",
+    token: null,
+    user: null,
+    requestedScope: null,
+    problem: null,
+  };
+}
+
+function parseStoredScope(value: string | null): ConnectionScope | null {
+  return isConnectionScope(value) ? value : null;
+}
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -79,6 +79,151 @@ body {
   line-height: 1;
 }
 
+.cloud-toolbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  pointer-events: auto;
+}
+
+.cloud-auth-menu {
+  position: relative;
+}
+
+.cloud-auth-menu summary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-width: 0;
+  max-width: min(12rem, 38vw);
+  height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 999px;
+  padding-inline: 0.75rem;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--background) 90%, transparent);
+  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  list-style: none;
+}
+
+.cloud-auth-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.cloud-auth-menu summary:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
+}
+
+.cloud-auth-menu summary:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-auth-menu svg,
+.cloud-auth-state svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+}
+
+.cloud-auth-menu summary span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.8125rem;
+  line-height: 1;
+}
+
+.cloud-auth-menu form {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 0.625rem;
+  width: min(20rem, calc(100vw - 1.5rem));
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 8px;
+  padding: 0.875rem;
+  color: var(--foreground);
+  background: var(--background);
+  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
+}
+
+.cloud-auth-menu p {
+  margin: 0;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-auth-menu label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  line-height: 1.2;
+}
+
+.cloud-auth-menu input,
+.cloud-auth-menu select {
+  min-width: 0;
+  height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding-inline: 0.625rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+}
+
+.cloud-auth-form-error {
+  border: 1px solid color-mix(in srgb, #b42318 40%, transparent);
+  border-radius: 6px;
+  padding: 0.5rem 0.625rem;
+  color: #b42318;
+  background: color-mix(in srgb, #b42318 8%, var(--background));
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cloud-auth-actions button,
+.cloud-auth-state button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding-inline: 0.625rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font-size: 0.8125rem;
+}
+
+.cloud-auth-actions button:hover,
+.cloud-auth-state button:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 10%);
+}
+
+.cloud-auth-state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
 .cloud-code-toggle {
   display: inline-flex;
   align-items: center;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { createRoot } from "react-dom/client";
-import { Code2, Eye, EyeOff, UsersRound } from "lucide-react";
+import { Code2, Eye, EyeOff, KeyRound, RotateCcw, UsersRound } from "lucide-react";
 import {
   ReadOnlyNotebook,
   type ReadOnlyNotebookCellData,
@@ -15,10 +15,16 @@ import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import { EditableMarkdownCell } from "./editable-markdown-cell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import {
-  cloudSyncAuthFromLocalStorage,
-  connectCloudSyncRuntime,
-  type CloudSyncRuntime,
-} from "./live-sync";
+  clearCloudPrototypeDevAuth,
+  cloudPrototypeAuthFromWindow,
+  cloudSyncAuthFromPrototypeAuthState,
+  prototypeAuthSummary,
+  storeCloudPrototypeDevAuth,
+  validatePrototypeToken,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
+import type { ConnectionScope } from "../src/auth-shared";
 import {
   CloudLivePresenceStore,
   emptyCloudLivePresenceSnapshot,
@@ -162,6 +168,10 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   const [presence, setPresence] = useState(initialCloudViewerPresence);
   const [livePresence, setLivePresence] = useState(emptyCloudLivePresenceSnapshot);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
+    cloudPrototypeAuthFromWindow(),
+  );
 
   useEffect(() => {
     cellsRef.current = cells;
@@ -266,12 +276,13 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
 
     setPresence(initialCloudViewerPresence());
     setLivePresence(emptyCloudLivePresenceSnapshot());
+    setConnectionError(null);
     void connectCloudSyncRuntime({
       syncEndpoint: config.syncEndpoint,
       runtimedWasmModulePath: config.runtimedWasmModulePath,
       runtimedWasmPath: config.runtimedWasmPath,
       sessionId,
-      auth: cloudSyncAuthFromLocalStorage(),
+      auth: cloudSyncAuthFromPrototypeAuthState(authState),
       onControl: (message) => {
         if (disposed) return;
         if (
@@ -282,6 +293,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
           setPresence((state) => reduceCloudViewerPresenceMessage(state, message));
         }
         if (message.type === "cloud_room_ready") {
+          setConnectionError(null);
           setConnectionScope(message.connection_scope);
         }
         if (message.type === "cloud_frame_rejected") {
@@ -318,6 +330,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         if (disposed) return;
         setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
         setConnectionScope(null);
+        setConnectionError(error instanceof Error ? error.message : String(error));
         console.warn("[notebook-cloud] live room connection failed", error);
       });
 
@@ -334,7 +347,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
       setLivePresence(emptyCloudLivePresenceSnapshot());
     };
-  }, [blobResolver, config.syncEndpoint]);
+  }, [authState, blobResolver, config.syncEndpoint]);
 
   const readOnlyCells = useMemo(
     () =>
@@ -407,6 +420,10 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     },
     [],
   );
+  const resetPrototypeAuth = useCallback(() => {
+    clearCloudPrototypeDevAuth(window.localStorage);
+    setAuthState(cloudPrototypeAuthFromWindow());
+  }, []);
 
   return (
     <main className="flex min-h-screen w-full flex-col py-6">
@@ -415,22 +432,48 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       <div className="cloud-report-toolbar" aria-label="Notebook view status and controls">
         <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
 
-        {status.kind === "ready" && codeCellCount > 0 ? (
-          <button
-            type="button"
-            className="cloud-code-toggle"
-            aria-pressed={showCode}
-            aria-label={showCode ? "Hide code cells" : "Show code cells"}
-            title={showCode ? "Hide code cells" : "Show code cells"}
-            onClick={() => setShowCode((current) => !current)}
-          >
-            {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
-            <Code2 aria-hidden="true" />
-          </button>
-        ) : (
-          <span aria-hidden="true" />
-        )}
+        <div className="cloud-toolbar-actions">
+          <CloudAuthControls
+            authState={authState}
+            connectionScope={connectionScope}
+            onAuthStateChange={() => setAuthState(cloudPrototypeAuthFromWindow())}
+          />
+
+          {status.kind === "ready" && codeCellCount > 0 ? (
+            <button
+              type="button"
+              className="cloud-code-toggle"
+              aria-pressed={showCode}
+              aria-label={showCode ? "Hide code cells" : "Show code cells"}
+              title={showCode ? "Hide code cells" : "Show code cells"}
+              onClick={() => setShowCode((current) => !current)}
+            >
+              {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
+              <Code2 aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
       </div>
+
+      {authState.mode === "invalid" ? (
+        <div className="cloud-state cloud-auth-state mx-8 mr-4" data-kind="error">
+          <span>{prototypeAuthSummary(authState)}</span>
+          <button type="button" onClick={resetPrototypeAuth}>
+            <RotateCcw aria-hidden="true" />
+            Reset to anonymous
+          </button>
+        </div>
+      ) : null}
+
+      {connectionError ? (
+        <div className="cloud-state cloud-auth-state mx-8 mr-4" data-kind="error">
+          <span>Live room connection failed: {connectionError}</span>
+          <button type="button" onClick={resetPrototypeAuth}>
+            <RotateCcw aria-hidden="true" />
+            Reset to anonymous
+          </button>
+        </div>
+      ) : null}
 
       {status.kind === "ready" ? null : (
         <div className="cloud-state mx-8 mr-4" data-kind={status.kind}>
@@ -473,6 +516,106 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         />
       )}
     </main>
+  );
+}
+
+function CloudAuthControls({
+  authState,
+  connectionScope,
+  onAuthStateChange,
+}: {
+  authState: CloudPrototypeAuthState;
+  connectionScope: string | null;
+  onAuthStateChange: () => void;
+}) {
+  const [token, setToken] = useState("");
+  const [user, setUser] = useState(authState.user ?? "alice");
+  const [scope, setScope] = useState<ConnectionScope>(authState.requestedScope ?? "editor");
+  const [formError, setFormError] = useState<string | null>(null);
+  const summary =
+    authState.mode === "dev"
+      ? `Dev ${authState.user ?? "browser-editor"}`
+      : authState.mode === "invalid"
+        ? "Auth needs attention"
+        : "Anonymous";
+
+  const applyDevAuth = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const problem = validatePrototypeToken(token);
+    if (problem) {
+      setFormError(problem);
+      return;
+    }
+    storeCloudPrototypeDevAuth(window.localStorage, { token, user, scope });
+    setToken("");
+    setFormError(null);
+    onAuthStateChange();
+  };
+
+  const resetAuth = () => {
+    clearCloudPrototypeDevAuth(window.localStorage);
+    setToken("");
+    setFormError(null);
+    onAuthStateChange();
+  };
+
+  return (
+    <details className="cloud-auth-menu">
+      <summary title="Prototype collaborator identity">
+        <KeyRound aria-hidden="true" />
+        <span>{summary}</span>
+      </summary>
+      <form onSubmit={applyDevAuth}>
+        <p>{prototypeAuthSummary(authState)}</p>
+        {connectionScope ? <p>Connected as {connectionScope}.</p> : <p>Live room not connected.</p>}
+        <label>
+          <span>Dev token</span>
+          <input
+            type="password"
+            value={token}
+            placeholder="Worker dev token"
+            autoComplete="off"
+            onChange={(event) => setToken(event.target.value)}
+          />
+        </label>
+        <label>
+          <span>User</span>
+          <input
+            type="text"
+            value={user}
+            autoComplete="off"
+            onChange={(event) => setUser(event.target.value)}
+          />
+        </label>
+        <label>
+          <span>Scope</span>
+          <select
+            value={scope}
+            onChange={(event) => setScope(event.target.value as ConnectionScope)}
+          >
+            <option value="editor">editor</option>
+            <option value="owner">owner</option>
+            <option value="runtime_peer">runtime_peer</option>
+            <option value="viewer">viewer</option>
+          </select>
+        </label>
+        {formError ? (
+          <div className="cloud-auth-form-error" role="alert">
+            {formError}
+          </div>
+        ) : null}
+        <div className="cloud-auth-actions">
+          <button type="submit">
+            <KeyRound aria-hidden="true" />
+            Use dev identity
+          </button>
+          <button type="button" onClick={resetAuth}>
+            <RotateCcw aria-hidden="true" />
+            Anonymous
+          </button>
+        </div>
+      </form>
+    </details>
   );
 }
 

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -6,12 +6,13 @@ import {
   type NotebookTransport,
   type SyncableHandle,
 } from "runtimed";
-import {
-  DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
-  isConnectionScope,
-  type ConnectionScope,
-} from "../src/auth-shared";
+import { isConnectionScope, type ConnectionScope } from "../src/auth-shared";
 import { FrameType, type SessionControlMessage } from "../src/protocol";
+import {
+  cloudPrototypeAuthFromWindow,
+  cloudSyncAuthFromPrototypeAuthState,
+  type CloudSyncAuth,
+} from "./collaborator-auth";
 import {
   createBootstrapNotebookHandle,
   encodeCursorPresenceAfterInit,
@@ -38,13 +39,6 @@ export interface CloudSyncRuntime {
   ) => void;
 }
 
-export interface CloudSyncAuth {
-  protocols: string[];
-  user: string | null;
-  operator: string | null;
-  requestedScope: ConnectionScope | null;
-}
-
 export interface CloudSyncConnectOptions {
   syncEndpoint: string;
   runtimedWasmModulePath: string;
@@ -57,29 +51,9 @@ export interface CloudSyncConnectOptions {
 type FrameListener = Parameters<NotebookTransport["onFrame"]>[0];
 
 const LIVE_SYNC_READY_TIMEOUT_MS = 30_000;
-export const NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY = "nteract:notebook-cloud:dev-token";
-export const NOTEBOOK_CLOUD_USER_STORAGE_KEY = "nteract:notebook-cloud:user";
-export const NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY = "nteract:notebook-cloud:scope";
 
 export function cloudSyncAuthFromLocalStorage(): CloudSyncAuth {
-  if (typeof window === "undefined") {
-    return { protocols: [], user: null, operator: null, requestedScope: null };
-  }
-
-  const token = window.localStorage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY)?.trim();
-  if (!token) {
-    return { protocols: [], user: null, operator: null, requestedScope: null };
-  }
-
-  const requestedScope = parseStoredScope(
-    window.localStorage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY),
-  );
-  return {
-    protocols: [`${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64UrlEncode(token)}`],
-    user: window.localStorage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY)?.trim() || "browser-editor",
-    operator: null,
-    requestedScope: requestedScope ?? "editor",
-  };
+  return cloudSyncAuthFromPrototypeAuthState(cloudPrototypeAuthFromWindow());
 }
 
 export async function connectCloudSyncRuntime({
@@ -345,19 +319,6 @@ function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): 
     url.searchParams.set("scope", auth.requestedScope);
   }
   return url;
-}
-
-function parseStoredScope(value: string | null): ConnectionScope | null {
-  return isConnectionScope(value) ? value : null;
-}
-
-function base64UrlEncode(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
 async function bytesFromWebSocketMessage(data: unknown): Promise<Uint8Array> {


### PR DESCRIPTION
## Summary

- Adds a small notebook-cloud collaborator auth helper for the browser prototype.
- Detects placeholder dev tokens like `<NOTEBOOK_CLOUD_DEV_TOKEN>` and falls back to anonymous viewer sync instead of leaving the page offline.
- Adds a sticky key-menu for applying/resetting prototype dev identity without putting tokens in URLs.
- Logs deployed auth failures as structured `auth.failed` records without raw token material.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/live-sync.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- Deployed to `https://nteract-notebook-cloud.rgbkrk.workers.dev` as Worker version `f3cfd964-b0b2-43a2-ae77-355dd30f9612`.
- Chrome verified `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-collab-1779621125786` shows `1 viewing · viewing`, surfaces the placeholder-token diagnostic, and resets back to anonymous viewer mode.
