### PR TITLE
test(notebook-cloud): add hosted collaboration browser smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -22,6 +22,7 @@ With Wrangler running:
 pnpm --dir apps/notebook-cloud smoke
 pnpm --dir apps/notebook-cloud smoke:hosted
 pnpm --dir apps/notebook-cloud smoke:hosted:live
+pnpm --dir apps/notebook-cloud smoke:hosted:collab
 pnpm --dir apps/notebook-cloud publish:demo
 pnpm --dir apps/notebook-cloud publish:fixture
 pnpm --dir apps/notebook-cloud publish:live
@@ -140,6 +141,19 @@ executes the same live MathNet notebook first, then calls `smoke:hosted:live`
 with `NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID=<created-room-id>` so `publish:live`
 must reopen and export that existing room instead of creating its own preset
 session.
+
+`smoke:hosted:collab` covers the deployed browser collaboration path. By
+default it seeds a throwaway markdown room through `wasm:roundtrip`, then opens
+four isolated Chromium contexts: Alice (`owner`), Bob (`editor`), anonymous
+viewer, and ungranted Charlie (`editor`). Alice and Bob get the dev token only
+through the same browser localStorage keys as the viewer's prototype
+collaborator menu, matching the production viewer path where the WebSocket
+sends the token as a subprotocol instead of a URL parameter. The smoke verifies
+that Alice edits reach Bob and anonymous without reload, Bob edits reach Alice
+and anonymous without reload, Charlie is denied editor access, and no request
+URL contains the dev token. Pass
+`NOTEBOOK_CLOUD_COLLAB_VIEWER_URL=https://.../n/<id>` to reuse an existing room
+instead of seeding a new one.
 
 ## Dev auth
 
@@ -380,6 +394,10 @@ NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud smoke:hosted:live
 
+NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
+NOTEBOOK_CLOUD_DEV_TOKEN=... \
+pnpm --dir apps/notebook-cloud smoke:hosted:collab
+
 NOTEBOOK_CLOUD_HOSTED_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev/n/<id> \
 NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0 \
 pnpm --dir apps/notebook-cloud smoke:hosted
@@ -392,6 +410,11 @@ seeding, ACL grants, peer connection, and both Alice/Bob/anonymous convergence
 directions; use those values with `room.peer_sync.completed` and
 `room.materialized_frame.applied` logs to separate WebSocket latency from room
 materialization cost.
+
+`smoke:hosted:collab` builds on that protocol roundtrip with a browser-level
+check. Its JSON result includes the throwaway `viewerUrl`, the room id, and
+per-step timings for browser open, connection, Alice/Bob edit propagation,
+anonymous live updates, and Charlie's denied editor session.
 
 Use `GET /api/n/{id}/acl` with an owner credential to confirm editor/viewer
 grants. A healthy throwaway collaboration run should show editor

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -13,6 +13,7 @@
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
+    "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
     "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
@@ -1,0 +1,54 @@
+import { isLoopbackBaseUrl } from "./wasm-roundtrip-env.mjs";
+import {
+  NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
+  NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
+  NOTEBOOK_CLOUD_USER_STORAGE_KEY,
+} from "../viewer/collaborator-auth.ts";
+
+export function assertHostedCollabSmokeEnv({ baseUrl, devAuthToken }) {
+  if (devAuthToken || isLoopbackBaseUrl(baseUrl)) {
+    return;
+  }
+
+  throw new Error(
+    "NOTEBOOK_CLOUD_DEV_TOKEN is required when hosted collaboration smoke targets a deployed notebook-cloud host. The browser smoke stores it in localStorage and sends it through the WebSocket subprotocol; it must not be placed in URLs.",
+  );
+}
+
+export function browserDevTokenForSmoke({ baseUrl, devAuthToken }) {
+  if (devAuthToken) {
+    return devAuthToken;
+  }
+  if (isLoopbackBaseUrl(baseUrl)) {
+    return "local-dev-token";
+  }
+  throw new Error("NOTEBOOK_CLOUD_DEV_TOKEN is required for deployed browser collaboration smoke");
+}
+
+export function viewerUrlForRoom(baseUrl, roomId) {
+  return new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href;
+}
+
+export function storageStateForDevIdentity({ origin, token, user, scope }) {
+  return {
+    origins: [
+      {
+        origin,
+        localStorage: [
+          {
+            name: NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
+            value: token,
+          },
+          {
+            name: NOTEBOOK_CLOUD_USER_STORAGE_KEY,
+            value: user,
+          },
+          {
+            name: NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
+            value: scope,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -247,7 +247,7 @@ function instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure })
   });
   page.on("console", (message) => {
     const text = message.text();
-    if (message.type() === "error" && !isBenignConsoleError(text)) {
+    if (message.type() === "error" && !isBenignConsoleError(text, { allowSyncFailure })) {
       failures.push({ page: name, kind: "console-error", text });
     }
   });
@@ -289,13 +289,35 @@ async function waitForPresence(page, expectedText) {
 }
 
 async function waitForPageText(page, expectedText, label) {
-  await page
-    .waitForFunction((text) => document.body.innerText.includes(text), expectedText, {
-      timeout: timeoutMs,
-    })
-    .catch((error) => {
-      throw new Error(`${label} did not receive expected markdown text: ${error.message}`);
-    });
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await pageContainsText(page, expectedText)) {
+      return;
+    }
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`${label} did not receive expected markdown text`);
+}
+
+async function pageContainsText(page, expectedText) {
+  const parentText = await page
+    .locator("body")
+    .innerText({ timeout: 1_000 })
+    .catch(() => "");
+  if (parentText.includes(expectedText)) {
+    return true;
+  }
+
+  for (const frame of page.frames().filter((candidate) => candidate !== page.mainFrame())) {
+    const frameText = await frame
+      .locator("body")
+      .innerText({ timeout: 1_000 })
+      .catch(() => "");
+    if (frameText.includes(expectedText)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function runNode(args, env) {
@@ -389,9 +411,14 @@ function isRelevantRequestUrl(url) {
   );
 }
 
-function isBenignConsoleError(text) {
+function isBenignConsoleError(text, { allowSyncFailure } = {}) {
   return (
     text.includes("A listener indicated an asynchronous response") ||
-    text.includes("Failed to execute 'observe' on 'MutationObserver'")
+    text.includes("Failed to execute 'observe' on 'MutationObserver'") ||
+    text.includes("Failed to load resource: the server responded with a status of 404") ||
+    (allowSyncFailure &&
+      text.includes("WebSocket connection") &&
+      text.includes("/sync") &&
+      text.includes("403"))
   );
 }

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -1,0 +1,397 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium } from "@playwright/test";
+
+import {
+  assertHostedCollabSmokeEnv,
+  browserDevTokenForSmoke,
+  storageStateForDevIdentity,
+  viewerUrlForRoom,
+} from "./hosted-collab-smoke-env.mjs";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const requestedBaseUrl = process.env.NOTEBOOK_CLOUD_URL ?? DEFAULT_BASE_URL;
+const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
+const providedViewerUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_COLLAB_VIEWER_URL;
+const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
+const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
+const timingsMs = {};
+
+const startedAt = performance.now();
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const authBaseUrl = providedViewerUrl ? new URL(providedViewerUrl).origin : requestedBaseUrl;
+  assertHostedCollabSmokeEnv({ baseUrl: authBaseUrl, devAuthToken });
+  const token = browserDevTokenForSmoke({ baseUrl: authBaseUrl, devAuthToken });
+  const room = providedViewerUrl
+    ? roomFromViewerUrl(providedViewerUrl)
+    : await timed("protocol_seed", seedThrowawayRoom);
+  const viewerUrl = room.viewerUrl;
+  const origin = new URL(viewerUrl).origin;
+  const checks = [providedViewerUrl ? "reused_existing_room" : "protocol_seeded_throwaway_room"];
+  const browser = await chromium.launch({
+    headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1",
+    timeout: timeoutMs,
+  });
+  const failures = [];
+  const visitedUrls = new Set();
+  const contexts = [];
+
+  try {
+    const alice = await timed("alice_open", () =>
+      openNotebookContext({
+        browser,
+        name: "alice",
+        viewerUrl,
+        storageState: storageStateForDevIdentity({
+          origin,
+          token,
+          user: "alice",
+          scope: "owner",
+        }),
+        failures,
+        visitedUrls,
+      }),
+    );
+    const bob = await timed("bob_open", () =>
+      openNotebookContext({
+        browser,
+        name: "bob",
+        viewerUrl,
+        storageState: storageStateForDevIdentity({
+          origin,
+          token,
+          user: "bob",
+          scope: "editor",
+        }),
+        failures,
+        visitedUrls,
+      }),
+    );
+    const anonymous = await timed("anonymous_open", () =>
+      openNotebookContext({
+        browser,
+        name: "anonymous",
+        viewerUrl,
+        storageState: undefined,
+        failures,
+        visitedUrls,
+      }),
+    );
+    contexts.push(alice.context, bob.context, anonymous.context);
+
+    await timed("alice_connected", () => waitForPresence(alice.page, "editing"));
+    await timed("bob_connected", () => waitForPresence(bob.page, "editing"));
+    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "viewing"));
+    checks.push("browser_alice_connected", "browser_bob_connected", "anonymous_viewer_connected");
+
+    await waitForEditableMarkdown(alice.page);
+    await waitForEditableMarkdown(bob.page);
+    checks.push("alice_markdown_editor_available", "bob_markdown_editor_available");
+
+    const aliceMarker = `Alice propagated ${Date.now()}`;
+    const aliceText = `# Browser collaboration smoke
+
+${aliceMarker}
+`;
+    await timed("alice_edit", () => replaceMarkdown(alice.page, aliceText, aliceMarker));
+    await timed("alice_to_bob", () => waitForPageText(bob.page, aliceMarker, "Bob"));
+    await timed("alice_to_anonymous", () =>
+      waitForPageText(anonymous.page, aliceMarker, "anonymous viewer"),
+    );
+    checks.push("alice_edit_reached_bob", "alice_edit_reached_anonymous");
+
+    const bobMarker = `Bob propagated ${Date.now()}`;
+    const bobText = `# Browser collaboration smoke
+
+${aliceMarker}
+
+${bobMarker}
+`;
+    await timed("bob_edit", () => replaceMarkdown(bob.page, bobText, bobMarker));
+    await timed("bob_to_alice", () => waitForPageText(alice.page, bobMarker, "Alice"));
+    await timed("bob_to_anonymous", () =>
+      waitForPageText(anonymous.page, bobMarker, "anonymous viewer"),
+    );
+    checks.push("bob_edit_reached_alice", "bob_edit_reached_anonymous");
+
+    const charlie = await timed("charlie_open", () =>
+      openNotebookContext({
+        browser,
+        name: "charlie",
+        viewerUrl,
+        storageState: storageStateForDevIdentity({
+          origin,
+          token,
+          user: "charlie",
+          scope: "editor",
+        }),
+        failures,
+        visitedUrls,
+        allowSyncFailure: true,
+      }),
+    );
+    contexts.push(charlie.context);
+    await timed("charlie_denied", () => waitForPresence(charlie.page, "Offline"));
+    await assertNoEditableMarkdown(charlie.page);
+    checks.push("ungranted_editor_denied");
+
+    assertTokenAbsentFromUrls(visitedUrls, token);
+    checks.push("token_absent_from_urls");
+
+    if (screenshotPath) {
+      await alice.page.screenshot({ path: screenshotPath, fullPage: true });
+      checks.push("screenshot_saved");
+    }
+
+    if (failures.length > 0) {
+      throw new Error(
+        `browser collaboration smoke failures:\n${JSON.stringify(failures, null, 2)}`,
+      );
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          viewerUrl,
+          roomId: room.roomId,
+          checks,
+          timings_ms: {
+            ...timingsMs,
+            total: elapsedMs(startedAt),
+          },
+          screenshot: screenshotPath ?? null,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await Promise.all(contexts.map((context) => context.close().catch(() => {})));
+    await browser.close().catch(() => {});
+  }
+}
+
+async function seedThrowawayRoom() {
+  const childEnv = {
+    ...process.env,
+    NOTEBOOK_CLOUD_URL: requestedBaseUrl,
+  };
+  const result = await runNode(["--import", "tsx", "scripts/wasm-roundtrip.mjs"], childEnv);
+  const output = parseJson(result.stdout, "wasm-roundtrip");
+  if (!output.ok || !output.baseUrl || !output.roomId) {
+    throw new Error(`wasm-roundtrip did not return a usable room:\n${result.stdout}`);
+  }
+  return {
+    roomId: output.roomId,
+    viewerUrl: viewerUrlForRoom(output.baseUrl, output.roomId),
+    seed: output,
+  };
+}
+
+async function openNotebookContext({
+  browser,
+  name,
+  viewerUrl,
+  storageState,
+  failures,
+  visitedUrls,
+  allowSyncFailure = false,
+}) {
+  const context = await browser.newContext({
+    storageState,
+    viewport: { width: 1240, height: 900 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure });
+  await page.goto(viewerUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
+  return { context, page };
+}
+
+function instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure }) {
+  page.on("request", (request) => {
+    visitedUrls.add(request.url());
+  });
+  page.on("response", (response) => {
+    visitedUrls.add(response.url());
+  });
+  page.on("requestfailed", (request) => {
+    const url = request.url();
+    visitedUrls.add(url);
+    if (allowSyncFailure && url.includes("/sync")) {
+      return;
+    }
+    if (!isRelevantRequestUrl(url)) {
+      return;
+    }
+    failures.push({
+      page: name,
+      kind: "request-failed",
+      url,
+      error: request.failure()?.errorText ?? "unknown",
+    });
+  });
+  page.on("pageerror", (error) => {
+    failures.push({ page: name, kind: "page-error", text: error.message });
+  });
+  page.on("console", (message) => {
+    const text = message.text();
+    if (message.type() === "error" && !isBenignConsoleError(text)) {
+      failures.push({ page: name, kind: "console-error", text });
+    }
+  });
+}
+
+async function replaceMarkdown(page, source, localEvidenceText) {
+  const editor = page
+    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
+    .first();
+  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  await editor.click();
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
+  await page.keyboard.insertText(source);
+  await waitForPageText(page, localEvidenceText, "editing page");
+}
+
+async function waitForEditableMarkdown(page) {
+  await page
+    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
+    .first()
+    .waitFor({ state: "visible", timeout: timeoutMs });
+}
+
+async function assertNoEditableMarkdown(page) {
+  const count = await page
+    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
+    .count();
+  if (count !== 0) {
+    throw new Error("ungranted editor unexpectedly received an editable markdown surface");
+  }
+}
+
+async function waitForPresence(page, expectedText) {
+  await page.waitForFunction(
+    (expected) => document.querySelector(".cloud-presence")?.textContent?.includes(expected),
+    expectedText,
+    { timeout: timeoutMs },
+  );
+}
+
+async function waitForPageText(page, expectedText, label) {
+  await page
+    .waitForFunction((text) => document.body.innerText.includes(text), expectedText, {
+      timeout: timeoutMs,
+    })
+    .catch((error) => {
+      throw new Error(`${label} did not receive expected markdown text: ${error.message}`);
+    });
+}
+
+function runNode(args, env) {
+  console.error(`$ node ${args.join(" ")}`);
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: appDir,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      process.stderr.write(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(
+        new Error(
+          `node ${args.join(" ")} exited with ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    });
+  });
+}
+
+async function timed(name, fn) {
+  const started = performance.now();
+  try {
+    return await fn();
+  } finally {
+    timingsMs[name] = elapsedMs(started);
+  }
+}
+
+function elapsedMs(started) {
+  return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
+}
+
+function parseJson(stdout, label) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`${label} did not print JSON: ${error.message}\n${stdout}`);
+  }
+}
+
+function roomFromViewerUrl(viewerUrl) {
+  const parsed = new URL(viewerUrl);
+  const [, prefix, encodedRoomId] = parsed.pathname.split("/");
+  if (prefix !== "n" || !encodedRoomId) {
+    throw new Error(`NOTEBOOK_CLOUD_COLLAB_VIEWER_URL must point at /n/:id, got ${viewerUrl}`);
+  }
+  return {
+    roomId: decodeURIComponent(encodedRoomId),
+    viewerUrl: parsed.href,
+  };
+}
+
+function assertTokenAbsentFromUrls(visitedUrls, token) {
+  for (const url of visitedUrls) {
+    if (url.includes(token)) {
+      throw new Error(`dev token leaked into request URL: ${redactToken(url, token)}`);
+    }
+  }
+}
+
+function redactToken(value, token) {
+  return value.replaceAll(token, "<redacted>");
+}
+
+function isRelevantRequestUrl(url) {
+  const parsed = new URL(url);
+  return (
+    parsed.protocol === "ws:" ||
+    parsed.protocol === "wss:" ||
+    parsed.pathname.startsWith("/n/") ||
+    parsed.pathname.startsWith("/api/n/") ||
+    parsed.pathname.includes("runtimed_wasm")
+  );
+}
+
+function isBenignConsoleError(text) {
+  return (
+    text.includes("A listener indicated an asynchronous response") ||
+    text.includes("Failed to execute 'observe' on 'MutationObserver'")
+  );
+}

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -97,6 +97,7 @@ async function main() {
     await waitForEditableMarkdown(bob.page);
     checks.push("alice_markdown_editor_available", "bob_markdown_editor_available");
 
+    await focusEditableMarkdown(bob.page);
     const aliceMarker = `Alice propagated ${Date.now()}`;
     const aliceText = `# Browser collaboration smoke
 
@@ -104,11 +105,17 @@ ${aliceMarker}
 `;
     await timed("alice_edit", () => replaceMarkdown(alice.page, aliceText, aliceMarker));
     await timed("alice_to_bob", () => waitForPageText(bob.page, aliceMarker, "Bob"));
+    await timed("alice_to_bob_editor", () => waitForEditableMarkdownText(bob.page, aliceMarker));
     await timed("alice_to_anonymous", () =>
       waitForPageText(anonymous.page, aliceMarker, "anonymous viewer"),
     );
-    checks.push("alice_edit_reached_bob", "alice_edit_reached_anonymous");
+    checks.push(
+      "alice_edit_reached_bob",
+      "alice_edit_reached_bob_editor",
+      "alice_edit_reached_anonymous",
+    );
 
+    await focusEditableMarkdown(alice.page);
     const bobMarker = `Bob propagated ${Date.now()}`;
     const bobText = `# Browser collaboration smoke
 
@@ -118,10 +125,15 @@ ${bobMarker}
 `;
     await timed("bob_edit", () => replaceMarkdown(bob.page, bobText, bobMarker));
     await timed("bob_to_alice", () => waitForPageText(alice.page, bobMarker, "Alice"));
+    await timed("bob_to_alice_editor", () => waitForEditableMarkdownText(alice.page, bobMarker));
     await timed("bob_to_anonymous", () =>
       waitForPageText(anonymous.page, bobMarker, "anonymous viewer"),
     );
-    checks.push("bob_edit_reached_alice", "bob_edit_reached_anonymous");
+    checks.push(
+      "bob_edit_reached_alice",
+      "bob_edit_reached_alice_editor",
+      "bob_edit_reached_anonymous",
+    );
 
     const charlie = await timed("charlie_open", () =>
       openNotebookContext({
@@ -269,6 +281,29 @@ async function waitForEditableMarkdown(page) {
     .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
     .first()
     .waitFor({ state: "visible", timeout: timeoutMs });
+}
+
+async function focusEditableMarkdown(page) {
+  const editor = page
+    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
+    .first();
+  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  await editor.click();
+}
+
+async function waitForEditableMarkdownText(page, expectedText) {
+  const editor = page
+    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
+    .first();
+  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  await page.waitForFunction(
+    ([selector, expected]) => document.querySelector(selector)?.textContent?.includes(expected),
+    [
+      "[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']",
+      expectedText,
+    ],
+    { timeout: timeoutMs },
+  );
 }
 
 async function assertNoEditableMarkdown(page) {

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -377,7 +377,10 @@ function authenticateDevCredential(
   env: IdentityEnvironment,
 ): { webSocketProtocol?: string } | undefined {
   if (isLocalDevRequest(request)) {
-    return {};
+    const webSocketProtocol = tokenFromWebSocketProtocol(
+      request.headers.get("sec-websocket-protocol"),
+    );
+    return webSocketProtocol ? { webSocketProtocol: webSocketProtocol.protocol } : {};
   }
 
   return validDevTokenCredential(request, env);

--- a/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
@@ -45,14 +45,15 @@ describe("hosted browser collaboration smoke environment", () => {
   });
 
   it("builds the viewer URL without credential material", () => {
-    const token = "super-secret-token";
     const url = viewerUrlForRoom(
       "https://nteract-notebook-cloud.rgbkrk.workers.dev",
       "room/with/slashes",
     );
+    const parsed = new URL(url);
 
     assert.equal(url, "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/room%2Fwith%2Fslashes");
-    assert.equal(url.includes(token), false);
+    assert.equal(parsed.search, "");
+    assert.equal(parsed.hash, "");
   });
 
   it("stores browser dev identity in localStorage state", () => {

--- a/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  assertHostedCollabSmokeEnv,
+  browserDevTokenForSmoke,
+  storageStateForDevIdentity,
+  viewerUrlForRoom,
+} from "../scripts/hosted-collab-smoke-env.mjs";
+
+describe("hosted browser collaboration smoke environment", () => {
+  it("allows loopback browser smoke without a real dev token", () => {
+    assert.doesNotThrow(() =>
+      assertHostedCollabSmokeEnv({
+        baseUrl: "http://127.0.0.1:8787",
+        devAuthToken: undefined,
+      }),
+    );
+    assert.equal(
+      browserDevTokenForSmoke({
+        baseUrl: "http://localhost:8787",
+        devAuthToken: undefined,
+      }),
+      "local-dev-token",
+    );
+  });
+
+  it("requires an environment dev token when targeting a deployed Worker", () => {
+    assert.throws(
+      () =>
+        assertHostedCollabSmokeEnv({
+          baseUrl: "https://nteract-notebook-cloud.rgbkrk.workers.dev",
+          devAuthToken: undefined,
+        }),
+      /NOTEBOOK_CLOUD_DEV_TOKEN is required/,
+    );
+    assert.throws(
+      () =>
+        browserDevTokenForSmoke({
+          baseUrl: "https://nteract-notebook-cloud.rgbkrk.workers.dev",
+          devAuthToken: undefined,
+        }),
+      /NOTEBOOK_CLOUD_DEV_TOKEN is required/,
+    );
+  });
+
+  it("builds the viewer URL without credential material", () => {
+    const token = "super-secret-token";
+    const url = viewerUrlForRoom(
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev",
+      "room/with/slashes",
+    );
+
+    assert.equal(url, "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/room%2Fwith%2Fslashes");
+    assert.equal(url.includes(token), false);
+  });
+
+  it("stores browser dev identity in localStorage state", () => {
+    const state = storageStateForDevIdentity({
+      origin: "https://nteract-notebook-cloud.rgbkrk.workers.dev",
+      token: "token-from-env",
+      user: "alice",
+      scope: "owner",
+    });
+
+    assert.deepEqual(state, {
+      origins: [
+        {
+          origin: "https://nteract-notebook-cloud.rgbkrk.workers.dev",
+          localStorage: [
+            { name: "nteract:notebook-cloud:dev-token", value: "token-from-env" },
+            { name: "nteract:notebook-cloud:user", value: "alice" },
+            { name: "nteract:notebook-cloud:scope", value: "owner" },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -194,6 +194,22 @@ describe("dev identity", () => {
     assert.equal(identity.actorLabel, "user:dev:alice/desktop:a");
   });
 
+  it("echoes a loopback dev-token WebSocket subprotocol for browser localStorage auth", () => {
+    const protocol = `${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url("local-dev-token")}`;
+    const identity = authenticateRequest(
+      new Request("http://127.0.0.1:8787/n/demo/sync?user=alice&scope=owner", {
+        headers: {
+          "Sec-WebSocket-Protocol": protocol,
+        },
+      }),
+      { DEPLOYMENT_ENV: "prototype" },
+    );
+
+    assert.equal(identity.principal, "user:dev:alice");
+    assert.equal(identity.scope, "owner");
+    assert.equal(identity.webSocketProtocol, protocol);
+  });
+
   it("defaults missing dev scope to viewer", () => {
     const identity = authenticateDevRequest(
       new Request("https://cloud.test/n/demo/sync?user=anonymous&operator=desktop:a"),

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { externalChangeAnnotation, CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import {
@@ -52,7 +52,7 @@ export function EditableMarkdownCell({
     return editorExtensions;
   }, [cell.id, onPresenceCursor, onPresenceSelection]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const view = editorRef.current?.getEditor();
     if (!view) return;
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -169,6 +169,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   const [livePresence, setLivePresence] = useState(emptyCloudLivePresenceSnapshot);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [connectAttempt, setConnectAttempt] = useState(0);
   const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
     cloudPrototypeAuthFromWindow(),
   );
@@ -243,7 +244,29 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     let subscriptions: Array<{ unsubscribe: () => void }> = [];
     let materializeSequence = 0;
     let livePresenceStore: CloudLivePresenceStore | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
+    const disposeCurrentRuntime = () => {
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return;
+      liveRuntimeRef.current = null;
+      disposeCloudSyncRuntime(liveRuntime);
+    };
+    const scheduleReconnect = (reason: Error) => {
+      if (disposed) return;
+      console.warn("[notebook-cloud] live room connection closed", reason);
+      setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
+      setConnectionScope(null);
+      setConnectionError(reason.message);
+      disposeCurrentRuntime();
+      if (reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        if (!disposed) {
+          setConnectAttempt((attempt) => attempt + 1);
+        }
+      }, 1_000);
+    };
 
     const materializeLiveCells = async (liveRuntime: CloudSyncRuntime) => {
       const sequence = ++materializeSequence;
@@ -283,6 +306,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       runtimedWasmPath: config.runtimedWasmPath,
       sessionId,
       auth: cloudSyncAuthFromPrototypeAuthState(authState),
+      onDisconnect: scheduleReconnect,
       onControl: (message) => {
         if (disposed) return;
         if (
@@ -339,15 +363,15 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       for (const subscription of subscriptions) {
         subscription.unsubscribe();
       }
-      if (liveRuntimeRef.current) {
-        disposeCloudSyncRuntime(liveRuntimeRef.current);
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
       }
-      liveRuntimeRef.current = null;
+      disposeCurrentRuntime();
       livePresenceStore = null;
       setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
       setLivePresence(emptyCloudLivePresenceSnapshot());
     };
-  }, [authState, blobResolver, config.syncEndpoint]);
+  }, [authState, blobResolver, config.syncEndpoint, connectAttempt]);
 
   const readOnlyCells = useMemo(
     () =>

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -46,6 +46,7 @@ export interface CloudSyncConnectOptions {
   sessionId: string;
   auth: CloudSyncAuth;
   onControl?: (message: SessionControlMessage) => void;
+  onDisconnect?: (reason: Error) => void;
 }
 
 type FrameListener = Parameters<NotebookTransport["onFrame"]>[0];
@@ -63,9 +64,10 @@ export async function connectCloudSyncRuntime({
   sessionId,
   auth,
   onControl,
+  onDisconnect,
 }: CloudSyncConnectOptions): Promise<CloudSyncRuntime> {
   const url = syncUrl(syncEndpoint, sessionId, auth);
-  const transport = new CloudWebSocketTransport(url, auth.protocols, onControl);
+  const transport = new CloudWebSocketTransport(url, auth.protocols, onControl, onDisconnect);
   try {
     const ready = await withReadyTimeout(
       transport.ready,
@@ -184,6 +186,10 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private socket: WebSocket;
   private listeners = new Set<FrameListener>();
   private queuedFrames: number[][] = [];
+  private readySettled = false;
+  private readyResolved = false;
+  private closed = false;
+  private manualDisconnect = false;
   private readyResolve!: (
     message: Extract<SessionControlMessage, { type: "cloud_room_ready" }>,
   ) => void;
@@ -194,10 +200,18 @@ export class CloudWebSocketTransport implements NotebookTransport {
     url: URL,
     protocols: string[],
     private readonly onControl?: (message: SessionControlMessage) => void,
+    private readonly onDisconnect?: (reason: Error) => void,
   ) {
     this.ready = new Promise((resolve, reject) => {
-      this.readyResolve = resolve;
-      this.readyReject = reject;
+      this.readyResolve = (message) => {
+        this.readySettled = true;
+        this.readyResolved = true;
+        resolve(message);
+      };
+      this.readyReject = (error) => {
+        this.readySettled = true;
+        reject(error);
+      };
     });
     this.socket = protocols.length > 0 ? new WebSocket(url, protocols) : new WebSocket(url);
     this.socket.binaryType = "arraybuffer";
@@ -207,8 +221,18 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.socket.addEventListener("error", () => {
       this.readyReject(new Error(`failed to connect ${url.href}`));
     });
-    this.socket.addEventListener("close", () => {
-      this.readyReject(new Error(`cloud sync socket closed before ready`));
+    this.socket.addEventListener("close", (event) => {
+      this.closed = true;
+      this.listeners.clear();
+      this.queuedFrames = [];
+      const detail = event.reason ? `: ${event.reason}` : "";
+      const reason = new Error(`cloud sync socket closed (${event.code})${detail}`);
+      if (!this.readySettled) {
+        this.readyReject(new Error(`cloud sync socket closed before ready`));
+      }
+      if (this.readyResolved && !this.manualDisconnect) {
+        this.onDisconnect?.(reason);
+      }
     });
   }
 
@@ -217,6 +241,9 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 
   async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error("cloud sync socket is closed"));
+    }
     await this.waitUntilOpen();
     const frame = new Uint8Array(payload.byteLength + 1);
     frame[0] = frameType;
@@ -249,6 +276,8 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 
   disconnect(): void {
+    this.manualDisconnect = true;
+    this.closed = true;
     this.listeners.clear();
     this.queuedFrames = [];
     this.socket.close();


### PR DESCRIPTION
## Summary

- add `smoke:hosted:collab`, a Playwright browser smoke for the deployed live-room collaboration path
- seed a throwaway room through the existing `wasm:roundtrip` protocol smoke, then open Alice, Bob, anonymous viewer, and denied Charlie in isolated browser contexts
- keep the dev token in browser localStorage using the shared collaborator-auth storage keys, and assert no request URL contains the token
- echo loopback dev-token WebSocket subprotocols so local Wrangler browser smoke exercises the same localStorage auth path as deployed rooms
- reconcile remote markdown source into focused editor DOM before paint and reconnect cleanly after cloud WebSocket closes
- document the deployed collaboration smoke in the notebook-cloud runbook

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-collab-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/notebook-room.test.ts test/hosted-collab-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts test/hosted-collab-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test 'test/*.test.ts' 'test/*.test.mjs'`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `NOTEBOOK_CLOUD_URL=http://127.0.0.1:8787 NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=90000 pnpm --dir apps/notebook-cloud smoke:hosted:collab`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml`
- `set -a; source .env; set +a; NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=120000 pnpm --dir apps/notebook-cloud smoke:hosted:collab`
- `NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev pnpm --dir apps/notebook-cloud smoke:hosted:collab` fails early without `NOTEBOOK_CLOUD_DEV_TOKEN`, as intended

## Notes

The latest deployed smoke passed with the local `.env` token and created throwaway room `wasm-1779633236259`. The Worker deployed as version `022df130-635e-4321-a7e6-2f8ac25a9cbb`. It intentionally refuses to accept deployed credentials in URLs.
