### PR TITLE
refactor(outputs): use arrow stream protocol formatters

### DIFF
--- a/python/dx/README.md
+++ b/python/dx/README.md
@@ -2,7 +2,7 @@
 
 **Smart DataFrame display for Jupyter, built for [nteract](https://nteract.io).**
 
-`dx` upgrades how pandas and polars DataFrames render in a notebook. Instead of serializing megabytes of HTML into your output cells, dx hands the data to nteract's content-addressed blob store and renders it through a fast Arrow/parquet grid. Your `.ipynb` stays tiny, the cell stays snappy, and AI agents reading the notebook get a compact per-column summary — dtypes, ranges, distinct/top values, null counts — instead of raw bytes.
+`dx` upgrades Arrow-stream-capable DataFrames in a notebook. Instead of serializing megabytes of HTML into your output cells, dx hands Arrow IPC data to nteract's content-addressed blob store and renders it through a fast grid. Your `.ipynb` stays tiny, the cell stays snappy, and AI agents reading the notebook get a compact per-column summary — dtypes, ranges, distinct/top values, null counts — instead of raw bytes.
 
 ## Install
 
@@ -37,7 +37,7 @@ That's it. `dx.install()` is idempotent and automatically called by nteract's ke
 - **Fast rendering.** Large DataFrames stream through the blob store; the `.ipynb` payload stays small.
 - **AI-friendly summaries.** Every DataFrame ships a `text/llm+plain` column summary — dtypes, numeric ranges, string distinct/top values, null counts — so agents reason about the shape without materializing the whole table.
 - **Visualization integration.** [Altair](https://altair-viz.github.io) and [Plotly](https://plotly.com/python/) are automatically switched to their nteract renderers for interactive output that works inside nteract's isolated iframe sandbox.
-- **Narwhals-aware.** [narwhals](https://narwhals-dev.github.io/narwhals/)-wrapped DataFrames are unwrapped via `.to_native()` and dispatched through the pandas/polars path.
+- **Arrow protocol first.** pandas, polars, pyarrow, [narwhals](https://narwhals-dev.github.io/narwhals/), and other producers that expose `__arrow_c_stream__()` use the same Arrow IPC path.
 - **Safe outside nteract.** When no nteract runtime is reachable, `dx.install()` is a no-op. `import dx` is safe from plain Python, vanilla Jupyter, scripts, CI.
 
 ## Links

--- a/python/dx/src/dx/__init__.py
+++ b/python/dx/src/dx/__init__.py
@@ -41,10 +41,10 @@ def install() -> None:
 
     What it does:
 
-    1. Registers pandas / polars DataFrame formatters. Bare ``df`` on the
-       last cell line publishes a ``display_data`` whose bundle carries
+    1. Registers formatters for Arrow-stream-capable DataFrames. Bare ``df``
+       on the last cell line publishes a ``display_data`` whose bundle carries
        ``application/vnd.nteract.blob-ref+json`` + ``text/llm+plain``.
-       Parquet bytes are attached to the Jupyter messaging envelope's
+       Arrow IPC bytes are attached to the Jupyter messaging envelope's
        trailing ZMQ ``buffers`` field, not base64'd inside the JSON.
        IPython's default chain fills in ``text/html`` / ``text/plain`` as
        a fallback for hosts that don't understand the ref MIME.

--- a/python/dx/src/dx/_format.py
+++ b/python/dx/src/dx/_format.py
@@ -1,74 +1,267 @@
-"""DataFrame → parquet serialization (best-available encoder).
+"""Arrow stream serialization for legacy ``dx`` display enrichment.
 
-Pandas uses pyarrow (or fastparquet as a fallback). Polars uses its native
-parquet writer. If the serialized payload would exceed ``max_bytes``, the
-serializer downsamples via ``head(n)`` with a binary-search-ish loop and
-annotates the result so the caller can advertise partial data in the
-``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
+The nteract kernel launcher owns the active bootstrap path. ``dx`` keeps this
+small compatibility copy so direct ``dx.install()`` users follow the same
+object protocol: if an object exposes ``__arrow_c_stream__``, serialize that
+Arrow stream instead of branching on pandas, polars, or wrapper types.
 """
 
 from __future__ import annotations
 
-import io
+import hashlib
+from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 
-PARQUET_MIME = "application/vnd.apache.parquet"
+ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
+ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
+DEFAULT_ARROW_CHUNK_BYTES = 8 * 1024 * 1024
 
 
-def _detect_flavor(df: Any) -> str:
-    mod = type(df).__module__.split(".")[0]
-    return mod if mod in ("pandas", "polars") else "unknown"
+@dataclass(frozen=True)
+class ArrowStreamChunk:
+    index: int
+    data: bytes
+    content_hash: str
+    size: int
+    row_count: int
+    record_batch_count: int
+
+    def manifest_entry(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "hash": self.content_hash,
+            "size": self.size,
+            "row_count": self.row_count,
+            "record_batch_count": self.record_batch_count,
+            "encoding": "arrow-ipc-stream",
+        }
 
 
-def _serialize_pandas(df: Any, rows: int | None = None) -> bytes:
+def row_count(obj: Any) -> int | None:
+    for attr in ("num_rows", "height"):
+        value = getattr(obj, attr, None)
+        if isinstance(value, int):
+            return value
+
+    shape = getattr(obj, "shape", None)
+    if isinstance(shape, tuple) and shape and isinstance(shape[0], int):
+        return shape[0]
+
+    try:
+        return len(obj)
+    except TypeError:
+        return None
+
+
+def has_arrow_stream_protocol(obj: Any) -> bool:
+    if callable(getattr(obj, "__arrow_c_stream__", None)):
+        return True
+    try:
+        import pyarrow as pa
+
+        return isinstance(obj, pa.RecordBatchReader)
+    except Exception:
+        return False
+
+
+def _record_batch_reader_from_stream(source: Any) -> Any:
     import pyarrow as pa
-    import pyarrow.parquet as pq
 
-    if rows is not None:
-        df = df.head(rows)
-    table = pa.Table.from_pandas(df, preserve_index=False)
-    buf = io.BytesIO()
-    pq.write_table(table, buf, compression="snappy")
-    return buf.getvalue()
+    from_stream = getattr(pa.RecordBatchReader, "from_stream", None)
+    if callable(from_stream):
+        return from_stream(source)
 
+    import_capsule = getattr(pa.RecordBatchReader, "_import_from_c_capsule", None)
+    if callable(import_capsule) and hasattr(source, "__arrow_c_stream__"):
+        return import_capsule(source.__arrow_c_stream__())
 
-def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
-    if rows is not None:
-        df = df.head(rows)
-    buf = io.BytesIO()
-    df.write_parquet(buf, compression="snappy")
-    return buf.getvalue()
+    raise TypeError("pyarrow does not support Arrow PyCapsule stream import")
 
 
-def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str]:
-    """Serialize ``df`` to parquet; downsample if it would exceed ``max_bytes``.
+def _serialize_record_batches(schema: Any, batches: list[Any]) -> bytes:
+    import pyarrow as pa
 
-    Returns ``(bytes, content_type)``. Raises ``ValueError`` for unsupported
-    DataFrame types.
-    """
-    flavor = _detect_flavor(df)
-    if flavor == "pandas":
-        encoder = _serialize_pandas
-    elif flavor == "polars":
-        encoder = _serialize_polars
-    else:
-        raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, schema) as writer:
+        for batch in batches:
+            writer.write_batch(batch)
+    return sink.getvalue().to_pybytes()
 
-    full = encoder(df)
-    if len(full) <= max_bytes:
-        return full, PARQUET_MIME
 
-    # Estimate a row count that fits. Parquet compression is non-linear in
-    # row count; try a few downsample rounds before giving up.
-    n = len(df) if flavor == "pandas" else df.height
-    if n <= 1:
-        return full, PARQUET_MIME
-    target_rows = max(1, int(n * (max_bytes / len(full))))
-    for _ in range(4):
-        sampled = encoder(df, rows=target_rows)
-        if len(sampled) <= max_bytes:
-            return sampled, PARQUET_MIME
-        target_rows = max(1, target_rows // 2)
+def _record_batch_estimated_bytes(batch: Any) -> int:
+    nbytes = getattr(batch, "nbytes", None)
+    if isinstance(nbytes, int):
+        return nbytes
+    get_total_buffer_size = getattr(batch, "get_total_buffer_size", None)
+    if callable(get_total_buffer_size):
+        size = get_total_buffer_size()
+        if isinstance(size, int):
+            return size
+    return 0
 
-    # Last resort: a single row. Never raise for sampling.
-    return encoder(df, rows=1), PARQUET_MIME
+
+def _split_record_batch(batch: Any, *, max_chunk_bytes: int) -> Iterator[Any]:
+    batch_rows = getattr(batch, "num_rows", 0)
+    if batch_rows <= 1:
+        yield batch
+        return
+
+    batch_bytes = _record_batch_estimated_bytes(batch)
+    if batch_bytes <= max_chunk_bytes:
+        yield batch
+        return
+
+    bytes_per_row = max(1, batch_bytes // batch_rows)
+    rows_per_chunk = max(1, max_chunk_bytes // bytes_per_row)
+    for offset in range(0, batch_rows, rows_per_chunk):
+        yield batch.slice(offset, min(rows_per_chunk, batch_rows - offset))
+
+
+def _make_arrow_stream_chunk(
+    *,
+    index: int,
+    schema: Any,
+    batches: list[Any],
+    row_count: int,
+) -> ArrowStreamChunk:
+    data = _serialize_record_batches(schema, batches)
+    return ArrowStreamChunk(
+        index=index,
+        data=data,
+        content_hash=hashlib.sha256(data).hexdigest(),
+        size=len(data),
+        row_count=row_count,
+        record_batch_count=len(batches),
+    )
+
+
+def iter_arrow_stream_chunks(
+    source: Any,
+    *,
+    max_chunk_bytes: int = DEFAULT_ARROW_CHUNK_BYTES,
+) -> Iterator[ArrowStreamChunk]:
+    if max_chunk_bytes <= 0:
+        raise ValueError("max_chunk_bytes must be positive")
+
+    reader = _record_batch_reader_from_stream(source)
+    schema = reader.schema
+    chunk_index = 0
+    batches: list[Any] = []
+    rows = 0
+    estimated_bytes = 0
+
+    for batch in reader:
+        batch_bytes = _record_batch_estimated_bytes(batch)
+        if batch_bytes > max_chunk_bytes and getattr(batch, "num_rows", 0) > 1:
+            if batches:
+                yield _make_arrow_stream_chunk(
+                    index=chunk_index,
+                    schema=schema,
+                    batches=batches,
+                    row_count=rows,
+                )
+                chunk_index += 1
+                batches = []
+                rows = 0
+                estimated_bytes = 0
+
+            for piece in _split_record_batch(batch, max_chunk_bytes=max_chunk_bytes):
+                yield _make_arrow_stream_chunk(
+                    index=chunk_index,
+                    schema=schema,
+                    batches=[piece],
+                    row_count=getattr(piece, "num_rows", 0),
+                )
+                chunk_index += 1
+            continue
+
+        batch_rows = getattr(batch, "num_rows", 0)
+        if batches and estimated_bytes + batch_bytes > max_chunk_bytes:
+            yield _make_arrow_stream_chunk(
+                index=chunk_index,
+                schema=schema,
+                batches=batches,
+                row_count=rows,
+            )
+            chunk_index += 1
+            batches = []
+            rows = 0
+            estimated_bytes = 0
+
+        batches.append(batch)
+        rows += batch_rows
+        estimated_bytes += batch_bytes
+
+    if batches or chunk_index == 0:
+        yield _make_arrow_stream_chunk(
+            index=chunk_index,
+            schema=schema,
+            batches=batches,
+            row_count=rows,
+        )
+
+
+def serialize_arrow_stream(source: Any, *, max_bytes: int) -> tuple[bytes, str, int, int]:
+    """Serialize one Arrow-stream-capable object into a single IPC blob."""
+    if not has_arrow_stream_protocol(source):
+        raise ValueError(
+            f"unsupported DataFrame type: {type(source).__module__}.{type(source).__name__}"
+        )
+
+    chunks = list(iter_arrow_stream_chunks(source, max_chunk_bytes=max_bytes))
+    if len(chunks) != 1 or chunks[0].size > max_bytes:
+        raise ValueError("Arrow stream exceeds max_bytes; chunked manifest is required")
+    chunk = chunks[0]
+    return chunk.data, ARROW_STREAM_MIME, chunk.row_count, chunk.record_batch_count
+
+
+def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
+    data, content_type, included_rows, _record_batch_count = serialize_arrow_stream(
+        df,
+        max_bytes=max_bytes,
+    )
+    return data, content_type, included_rows
+
+
+def build_arrow_stream_manifest_from_chunks(
+    chunks: list[ArrowStreamChunk],
+    *,
+    complete: bool,
+    summary: dict[str, Any] | None = None,
+    schema: Any | None = None,
+) -> dict[str, Any]:
+    import pyarrow as pa
+
+    if not chunks:
+        raise ValueError("at least one Arrow stream chunk is required")
+
+    if schema is None:
+        schema = pa.ipc.open_stream(pa.BufferReader(chunks[0].data)).schema
+    schema_bytes = schema.serialize().to_pybytes()
+    metadata = schema.metadata or {}
+
+    return {
+        "version": 1,
+        "content_type": ARROW_STREAM_MIME,
+        "schema": {
+            "hash": hashlib.sha256(schema_bytes).hexdigest(),
+            "content_type": "application/vnd.apache.arrow.schema",
+            "fields": len(schema),
+            "columns": [
+                {
+                    "name": field.name,
+                    "type": str(field.type),
+                    "nullable": bool(field.nullable),
+                }
+                for field in schema
+            ],
+            "metadata": {
+                "pandas": b"pandas" in metadata,
+                "huggingface": b"huggingface" in metadata,
+            },
+        },
+        "chunks": [chunk.manifest_entry() for chunk in chunks],
+        "complete": complete,
+        "summary": summary or {},
+    }

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -46,7 +46,6 @@ All three extension points are documented public API
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import threading
@@ -56,12 +55,12 @@ from dx._env import Environment, detect_environment
 from dx._format import (
     ARROW_STREAM_MANIFEST_MIME,
     ARROW_STREAM_MIME,
-    ArrowStreamChunk,
+    DEFAULT_ARROW_CHUNK_BYTES,
     build_arrow_stream_manifest_from_chunks,
     has_arrow_stream_protocol,
-    serialize_arrow_stream,
+    iter_arrow_stream_chunks,
 )
-from dx._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
+from dx._refs import BLOB_REF_MIME, BlobRef, build_multi_ref_bundle, build_ref_bundle
 from dx._summary import summarize_dataframe, summarize_dataset
 
 log = logging.getLogger("dx")
@@ -224,17 +223,24 @@ def _dx_display_pub_hook(msg: dict) -> dict | None:
             ref = json.loads(ref_raw) if isinstance(ref_raw, str) else None
         if not isinstance(ref, dict):
             return msg
-        h = ref.get("hash")
-        if not isinstance(h, str):
+        entries = _ref_entries(ref)
+        if not entries:
             return msg
 
-        buffers = _pending_buffers().pop(h, None)
-        if buffers is None:
+        hashes = [entry.get("hash") for entry in entries]
+        if not all(isinstance(h, str) for h in hashes):
+            return msg
+
+        pending = _pending_buffers()
+        if not all(h in pending for h in hashes):
             # No stashed payload for this hash — maybe re-publish of a
             # historical message, or a ref emitted by something other
             # than our formatter. Pass through unchanged; the agent can
             # still resolve via BlobStore::exists on the hash.
             return msg
+        buffers = [pending.pop(h) for h in hashes if isinstance(h, str)]
+        for index, entry in enumerate(entries):
+            entry["buffer_index"] = index
 
         pub = _display_pub()
         if pub is None:
@@ -243,7 +249,7 @@ def _dx_display_pub_hook(msg: dict) -> dict | None:
             pub.pub_socket,
             msg,
             ident=pub.topic,
-            buffers=[buffers],
+            buffers=buffers,
         )
         return None
     except Exception as exc:
@@ -252,6 +258,15 @@ def _dx_display_pub_hook(msg: dict) -> dict | None:
 
 
 _dx_display_pub_hook._dx_installed = True  # ty: ignore[unresolved-attribute]
+
+
+def _ref_entries(ref: dict) -> list[dict]:
+    refs = ref.get("refs")
+    if isinstance(refs, list):
+        return [entry for entry in refs if isinstance(entry, dict)]
+    if isinstance(ref.get("hash"), str):
+        return [ref]
+    return []
 
 
 def _arrow_stream_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
@@ -346,9 +361,11 @@ def _emit_dataframe(df: Any, *, total_rows: int | None) -> dict | None:
         return None
 
     try:
-        data, content_type, included, record_batch_count = serialize_arrow_stream(
-            df,
-            max_bytes=_MAX_PAYLOAD_BYTES,
+        chunks = list(
+            iter_arrow_stream_chunks(
+                df,
+                max_chunk_bytes=min(DEFAULT_ARROW_CHUNK_BYTES, _MAX_PAYLOAD_BYTES),
+            )
         )
     except Exception as exc:
         log.debug("dx: serialize failed: %s — emitting summary-only bundle", exc)
@@ -365,20 +382,16 @@ def _emit_dataframe(df: Any, *, total_rows: int | None) -> dict | None:
         except Exception:
             return None
 
+    included = sum(chunk.row_count for chunk in chunks)
     if total_rows is None:
         total_rows = included
     sampled = included != total_rows
-
-    h = hashlib.sha256(data).hexdigest()
-    ref = BlobRef(hash=h, size=len(data))
     summary_hints = {
         "total_rows": total_rows,
         "included_rows": included,
         "sampled": sampled,
         "sample_strategy": "head" if sampled else "none",
     }
-    ref_bundle = build_ref_bundle(ref, content_type=content_type, summary=summary_hints)
-    ref_bundle["buffer_index"] = 0
 
     summary_source = _summary_source(df)
     try:
@@ -392,28 +405,34 @@ def _emit_dataframe(df: Any, *, total_rows: int | None) -> dict | None:
         log.debug("dx: summary build failed: %s", exc)
         llm = f"Arrow stream table: {included} rows"
 
-    # Stash the Arrow bytes for the display_pub hook to pick up on
-    # the upcoming publish. Keyed by hash so the hook can match exactly.
-    _pending_buffers()[h] = data
+    pending = _pending_buffers()
+    for chunk in chunks:
+        pending[chunk.content_hash] = chunk.data
+
+    if len(chunks) == 1:
+        chunk = chunks[0]
+        ref_bundle = build_ref_bundle(
+            BlobRef(hash=chunk.content_hash, size=chunk.size),
+            content_type=ARROW_STREAM_MIME,
+            summary=summary_hints,
+        )
+        ref_bundle["buffer_index"] = 0
+    else:
+        ref_bundle = build_multi_ref_bundle(
+            [BlobRef(hash=chunk.content_hash, size=chunk.size) for chunk in chunks],
+            content_type=ARROW_STREAM_MIME,
+            summary=summary_hints,
+        )
 
     bundle = {BLOB_REF_MIME: ref_bundle, "text/llm+plain": llm}
-    if content_type == ARROW_STREAM_MIME:
-        chunk = ArrowStreamChunk(
-            index=0,
-            data=data,
-            content_hash=h,
-            size=len(data),
-            row_count=included,
-            record_batch_count=record_batch_count,
+    try:
+        bundle[ARROW_STREAM_MANIFEST_MIME] = build_arrow_stream_manifest_from_chunks(
+            chunks,
+            complete=True,
+            summary=summary_hints,
         )
-        try:
-            bundle[ARROW_STREAM_MANIFEST_MIME] = build_arrow_stream_manifest_from_chunks(
-                [chunk],
-                complete=True,
-                summary=summary_hints,
-            )
-        except Exception as exc:
-            log.debug("dx: arrow manifest build failed: %s", exc)
+    except Exception as exc:
+        log.debug("dx: arrow manifest build failed: %s", exc)
 
     return bundle
 

--- a/python/dx/src/dx/_format_install.py
+++ b/python/dx/src/dx/_format_install.py
@@ -3,8 +3,8 @@
 Three IPython extension points, each via documented public ``for_type``
 registration or hook API — no internals are patched:
 
-1. A ``mimebundle_formatter`` for pandas / polars DataFrames serializes
-   the frame to parquet, hashes locally, stashes the bytes in a
+1. A ``mimebundle_formatter`` for Arrow-stream-capable table objects serializes
+   the stream to Arrow IPC, hashes locally, stashes the bytes in a
    thread-local keyed by hash, and returns
    ``{BLOB_REF_MIME: {...}, "text/llm+plain": ...}``. IPython's default
    chain then merges pandas' ``text/html`` and ``text/plain`` so hosts
@@ -13,14 +13,14 @@ registration or hook API — no internals are patched:
 2. A ``ZMQDisplayPublisher.register_hook`` callback attaches the
    stashed bytes to every outgoing ``display_data`` / ``update_display_data``
    message whose bundle carries the ref MIME. The hook pops the bytes
-   by hash and calls ``session.send(..., buffers=[parquet])`` directly,
+   by hash and calls ``session.send(..., buffers=[arrow])`` directly,
    returning ``None`` so the default (buffer-less) send is skipped.
    This is why ``h.update(df2)`` on a ``DisplayHandle`` works — the
    hook fires on updates just like initial displays, with
    ``transient.display_id`` already populated on the message.
 
-3. An ``ipython_display_formatter`` handler for pandas / polars
-   DataFrames handles the **last-expression** case (``df`` at the end
+3. ``ipython_display_formatter`` handlers for Arrow-stream-capable
+   DataFrames handle the **last-expression** case (``df`` at the end
    of a cell, not wrapped in ``display()``). That path goes through
    ``ZMQShellDisplayHook``, which has no ``register_hook`` equivalent —
    the publisher hook alone can't attach buffers to the resulting
@@ -53,7 +53,14 @@ import threading
 from typing import Any
 
 from dx._env import Environment, detect_environment
-from dx._format import serialize_dataframe
+from dx._format import (
+    ARROW_STREAM_MANIFEST_MIME,
+    ARROW_STREAM_MIME,
+    ArrowStreamChunk,
+    build_arrow_stream_manifest_from_chunks,
+    has_arrow_stream_protocol,
+    serialize_arrow_stream,
+)
 from dx._refs import BLOB_REF_MIME, BlobRef, build_ref_bundle
 from dx._summary import summarize_dataframe, summarize_dataset
 
@@ -65,7 +72,7 @@ _INSTALLED = False
 # 100 MiB; leave ~10 MiB for overhead and safety.
 _MAX_PAYLOAD_BYTES = int(os.environ.get("DX_MAX_PAYLOAD_BYTES", str(90 * 1024 * 1024)))
 
-# Pending parquet bytes waiting to be attached to the next IOPub message
+# Pending Arrow bytes waiting to be attached to the next IOPub message
 # that references them. Keyed by content hash (hex SHA-256) so lookups
 # match the ref MIME's ``hash`` field. Thread-local: each execution
 # context owns its own pending slot.
@@ -126,31 +133,33 @@ def install_formatters() -> None:
     try:
         import pandas as pd
 
-        mimebundle.for_type(pd.DataFrame, _pandas_mimebundle)
-        ipython_display.for_type(pd.DataFrame, _pandas_ipython_display)
+        mimebundle.for_type(pd.DataFrame, _arrow_stream_mimebundle)
+        ipython_display.for_type(pd.DataFrame, _arrow_stream_ipython_display)
     except ImportError:
         pass
 
     try:
         import polars as pl
 
-        mimebundle.for_type(pl.DataFrame, _polars_mimebundle)
-        ipython_display.for_type(pl.DataFrame, _polars_ipython_display)
+        mimebundle.for_type(pl.DataFrame, _arrow_stream_mimebundle)
+        ipython_display.for_type(pl.DataFrame, _arrow_stream_ipython_display)
     except ImportError:
         pass
 
-    # Narwhals wraps pandas/polars/pyarrow/modin/dask/cudf behind a common
-    # DataFrame API. Users may type an nw.DataFrame as a last expression
-    # without thinking about the underlying flavor. We unwrap via
-    # `.to_native()` and dispatch through the pandas/polars paths, with
-    # a `.to_pandas()` fallback for other narwhals-supported backends.
-    # LazyFrame is deliberately not handled here — displaying a lazy
-    # query would force `.collect()`, which has side effects.
     try:
         import narwhals as nw
 
-        mimebundle.for_type(nw.DataFrame, _narwhals_mimebundle)
-        ipython_display.for_type(nw.DataFrame, _narwhals_ipython_display)
+        mimebundle.for_type(nw.DataFrame, _arrow_stream_mimebundle)
+        ipython_display.for_type(nw.DataFrame, _arrow_stream_ipython_display)
+    except ImportError:
+        pass
+
+    try:
+        import pyarrow as pa
+
+        for cls in (pa.Table, pa.RecordBatch, pa.RecordBatchReader):
+            mimebundle.for_type(cls, _arrow_stream_mimebundle)
+            ipython_display.for_type(cls, _arrow_stream_ipython_display)
     except ImportError:
         pass
 
@@ -245,38 +254,20 @@ def _dx_display_pub_hook(msg: dict) -> dict | None:
 _dx_display_pub_hook._dx_installed = True  # ty: ignore[unresolved-attribute]
 
 
-def _pandas_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    return _emit_dataframe(df, total_rows=len(df))
+def _arrow_stream_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
+    total_rows = _total_rows(df)
+    return _emit_dataframe(df, total_rows=total_rows)
 
 
-def _polars_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    return _emit_dataframe(df, total_rows=df.height)
-
-
-def _narwhals_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    """`mimebundle_formatter` handler for `narwhals.DataFrame`.
-
-    Mirrors the display-formatter path below: unwrap via `.to_native()`
-    and delegate to the flavor-specific emitter. Kept alongside its
-    pandas/polars siblings so any tooling that bypasses the
-    `ipython_display_formatter` short-circuit still gets a parquet
-    bundle from a narwhals wrapper.
-    """
-    native, total_rows = _unwrap_narwhals(df)
-    if native is None:
-        return None
-    return _emit_dataframe(native, total_rows=total_rows)
-
-
-def _pandas_ipython_display(df: Any) -> None:
-    """`ipython_display_formatter` handler for `pd.DataFrame`.
+def _arrow_stream_ipython_display(df: Any) -> None:
+    """`ipython_display_formatter` handler for Arrow stream objects.
 
     IPython's `DisplayFormatter.format()` checks `ipython_display_formatter`
     before walking mimebundle/per-MIME formatters. If our handler matches,
     `format()` returns `({}, {})` and the displayhook's send is suppressed.
     We publish our own `display_data` message via `publish_display_data`,
     which flows through `ZMQDisplayPublisher.publish` → the existing
-    `_dx_display_pub_hook`, which attaches parquet buffers.
+    `_dx_display_pub_hook`, which attaches Arrow buffers.
 
     Net effect for a last-expression `df`: one `display_data` message goes
     on the wire (with buffers). No `execute_result` is emitted — the saved
@@ -285,75 +276,39 @@ def _pandas_ipython_display(df: Any) -> None:
     they run at steps 4–5 of `DisplayHook.__call__`, independently of the
     message send.
     """
-    _publish_via_ipython_display(df, total_rows=len(df))
+    _publish_via_ipython_display(df)
 
 
-def _polars_ipython_display(df: Any) -> None:
-    """`ipython_display_formatter` handler for `pl.DataFrame`."""
-    _publish_via_ipython_display(df, total_rows=df.height)
+def _total_rows(obj: Any) -> int | None:
+    for attr in ("num_rows", "height"):
+        value = getattr(obj, attr, None)
+        if isinstance(value, int):
+            return value
 
+    shape = getattr(obj, "shape", None)
+    if isinstance(shape, tuple) and shape and isinstance(shape[0], int):
+        return shape[0]
 
-def _narwhals_ipython_display(nw_df: Any) -> None:
-    """`ipython_display_formatter` handler for `narwhals.DataFrame`.
-
-    Unwrap via `.to_native()` and dispatch through the native-type path.
-    Falls back to `.to_pandas()` for backends `serialize_dataframe` doesn't
-    natively encode (modin, pyarrow Table, dask, cudf).
-    """
-    native, total_rows = _unwrap_narwhals(nw_df)
-    if native is None:
-        # Couldn't unwrap — surface a best-effort repr instead of silently
-        # dropping the output.
-        print(repr(nw_df))
-        return
-    _publish_via_ipython_display(native, total_rows=total_rows)
-
-
-def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
-    """Return ``(native_df, row_count)`` for a ``narwhals.DataFrame``.
-
-    - If the underlying native is pandas or polars, return it directly so
-      ``serialize_dataframe`` hits its fast path.
-    - Otherwise, convert to pandas via narwhals's own adapter. This may
-      materialize a potentially-expensive frame (modin/dask/cudf), which
-      is the expected cost of "show me this DataFrame."
-    - On any unexpected error, return ``(None, 0)`` and let the caller
-      decide on a fallback.
-    """
     try:
-        native = nw_df.to_native()
-    except Exception as exc:
-        log.debug("dx: narwhals to_native failed: %s", exc)
-        return None, 0
-
-    # Fast path: the native is pandas or polars — use their row counts directly.
-    try:
-        import pandas as pd
-
-        if isinstance(native, pd.DataFrame):
-            return native, len(native)
-    except ImportError:
-        pass
-    try:
-        import polars as pl
-
-        if isinstance(native, pl.DataFrame):
-            return native, native.height
-    except ImportError:
-        pass
-
-    # Fallback: round-trip through narwhals's to_pandas. Works for pyarrow,
-    # modin, dask, cudf, etc. — anything narwhals understands.
-    try:
-        as_pandas = nw_df.to_pandas()
-        return as_pandas, len(as_pandas)
-    except Exception as exc:
-        log.debug("dx: narwhals to_pandas failed: %s", exc)
-        return None, 0
+        return len(obj)
+    except TypeError:
+        return None
 
 
-def _publish_via_ipython_display(df: Any, *, total_rows: int) -> None:
-    """Shared body for the pandas / polars `ipython_display` handlers."""
+def _summary_source(source: Any) -> Any:
+    to_native = getattr(source, "to_native", None)
+    if callable(to_native):
+        try:
+            native = to_native()
+            if native is not source:
+                return native
+        except Exception as exc:
+            log.debug("dx: to_native summary unwrap failed: %s", exc)
+    return source
+
+
+def _publish_via_ipython_display(df: Any) -> None:
+    """Shared body for Arrow stream `ipython_display` handlers."""
     # Lazy import so dx.install() doesn't hard-depend on IPython being
     # importable from the install site (it already is under ipykernel,
     # but stay symmetrical with _emit_dataframe).
@@ -363,7 +318,7 @@ def _publish_via_ipython_display(df: Any, *, total_rows: int) -> None:
         return
 
     try:
-        bundle = _emit_dataframe(df, total_rows=total_rows)
+        bundle = _arrow_stream_mimebundle(df)
     except Exception as exc:
         log.debug("dx: _emit_dataframe failed: %s — falling back to repr", exc)
         bundle = None
@@ -375,23 +330,31 @@ def _publish_via_ipython_display(df: Any, *, total_rows: int) -> None:
         print(repr(df))
 
 
-def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
-    """Serialize df → parquet, stash bytes in the pending buffer map, and
+def _emit_dataframe(df: Any, *, total_rows: int | None) -> dict | None:
+    """Serialize df → Arrow IPC, stash bytes in the pending buffer map, and
     return a mimebundle containing the ref MIME + text/llm+plain.
 
     IPython's default formatter chain fills in text/html / text/plain
     as a fallback bundle for hosts that don't understand the ref MIME;
-    nteract frontends pick the parquet renderer via the ref MIME.
+    nteract frontends pick the Arrow renderer via the ref MIME.
 
-    Returns ``None`` only when both parquet serialization and summary
-    generation fail. When parquet fails but the summary succeeds
+    Returns ``None`` only when both Arrow serialization and summary
+    generation fail. When Arrow serialization fails but the summary succeeds
     (e.g. pyarrow missing), returns a summary-only bundle.
     """
+    if not has_arrow_stream_protocol(df):
+        return None
+
     try:
-        data, content_type = serialize_dataframe(df, max_bytes=_MAX_PAYLOAD_BYTES)
+        data, content_type, included, record_batch_count = serialize_arrow_stream(
+            df,
+            max_bytes=_MAX_PAYLOAD_BYTES,
+        )
     except Exception as exc:
         log.debug("dx: serialize failed: %s — emitting summary-only bundle", exc)
-        # Parquet serialization failed (e.g. pyarrow missing), but the
+        if total_rows is None:
+            return None
+        # Arrow serialization failed (e.g. pyarrow missing), but the
         # summary is pure Python — still emit text/llm+plain so the agent
         # gets column stats instead of a raw repr.
         try:
@@ -402,20 +365,9 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
         except Exception:
             return None
 
-    # Detect downsampling by reading parquet metadata (cheap — footer only).
-    sampled = False
-    included = total_rows
-    try:
-        import io
-
-        import pyarrow.parquet as pq
-
-        meta = pq.read_metadata(io.BytesIO(data))
-        if meta.num_rows != total_rows:
-            sampled = True
-            included = meta.num_rows
-    except Exception:
-        pass
+    if total_rows is None:
+        total_rows = included
+    sampled = included != total_rows
 
     h = hashlib.sha256(data).hexdigest()
     ref = BlobRef(hash=h, size=len(data))
@@ -428,13 +380,42 @@ def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
     ref_bundle = build_ref_bundle(ref, content_type=content_type, summary=summary_hints)
     ref_bundle["buffer_index"] = 0
 
-    llm = summarize_dataframe(df, total_rows=total_rows, included_rows=included, sampled=sampled)
+    summary_source = _summary_source(df)
+    try:
+        llm = summarize_dataframe(
+            summary_source,
+            total_rows=total_rows,
+            included_rows=included,
+            sampled=sampled,
+        )
+    except Exception as exc:
+        log.debug("dx: summary build failed: %s", exc)
+        llm = f"Arrow stream table: {included} rows"
 
-    # Stash the parquet bytes for the display_pub hook to pick up on
+    # Stash the Arrow bytes for the display_pub hook to pick up on
     # the upcoming publish. Keyed by hash so the hook can match exactly.
     _pending_buffers()[h] = data
 
-    return {BLOB_REF_MIME: ref_bundle, "text/llm+plain": llm}
+    bundle = {BLOB_REF_MIME: ref_bundle, "text/llm+plain": llm}
+    if content_type == ARROW_STREAM_MIME:
+        chunk = ArrowStreamChunk(
+            index=0,
+            data=data,
+            content_hash=h,
+            size=len(data),
+            row_count=included,
+            record_batch_count=record_batch_count,
+        )
+        try:
+            bundle[ARROW_STREAM_MANIFEST_MIME] = build_arrow_stream_manifest_from_chunks(
+                [chunk],
+                complete=True,
+                summary=summary_hints,
+            )
+        except Exception as exc:
+            log.debug("dx: arrow manifest build failed: %s", exc)
+
+    return bundle
 
 
 def _enable_third_party_nteract_renderers() -> None:
@@ -468,7 +449,7 @@ def _enable_third_party_nteract_renderers() -> None:
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
     """`mimebundle_formatter` handler for `datasets.Dataset`.
 
-    Returns a bundle with only `text/llm+plain` — no parquet ref. Keeps the
+    Returns a bundle with only `text/llm+plain` — no Arrow ref. Keeps the
     dataset lazy and lets IPython fill in `text/plain` from the dataset's
     own repr.
     """

--- a/python/dx/src/dx/_refs.py
+++ b/python/dx/src/dx/_refs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 BLOB_REF_MIME = "application/vnd.nteract.blob-ref+json"
 
@@ -48,6 +49,33 @@ def build_ref_bundle(
         "content_type": content_type,
         "size": ref.size,
         "query": query,
+    }
+    if summary is not None:
+        bundle["summary"] = summary
+    return bundle
+
+
+def build_multi_ref_bundle(
+    refs: list[BlobRef],
+    *,
+    content_type: str,
+    summary: dict | None = None,
+    query: dict | None = None,
+) -> dict[str, Any]:
+    """Build a transport envelope for multiple attached blob buffers."""
+    bundle: dict[str, Any] = {
+        "content_type": content_type,
+        "refs": [
+            {
+                "hash": ref.hash,
+                "content_type": content_type,
+                "size": ref.size,
+                "buffer_index": index,
+            }
+            for index, ref in enumerate(refs)
+        ],
+        "query": query,
+        "size": sum(ref.size for ref in refs),
     }
     if summary is not None:
         bundle["summary"] = summary

--- a/python/dx/src/dx/_summary.py
+++ b/python/dx/src/dx/_summary.py
@@ -1,7 +1,7 @@
 """Generate ``text/llm+plain`` summaries for DataFrames, computed Python-side.
 
 Python has direct access to the schema, dtypes, and null counts; deriving the
-summary in-place is far simpler than reparsing parquet server-side. The
+summary in-place is far simpler than reparsing Arrow IPC server-side. The
 ``repr-llm`` crate remains the fallback when dx is not in the loop.
 """
 
@@ -298,7 +298,7 @@ def summarize_dataframe(
     """Produce a ``text/llm+plain`` summary for ``df``.
 
     The summary includes shape, per-column dtype + stats + null count, and a
-    small head sample. If the serialized parquet was downsampled, the header
+    small head sample. If the serialized Arrow payload was sampled, the header
     explicitly calls that out.
     """
     flavor = _detect_flavor(df)

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -44,11 +44,13 @@ class TestEmitDataFrameFallbackWithoutPyarrow:
     def test_emit_returns_summary_only_on_serialize_failure(self, monkeypatch):
         import dx._format_install as fi
 
-        # Make serialize_arrow_stream raise to simulate missing pyarrow
+        # Make iter_arrow_stream_chunks raise to simulate missing pyarrow
         monkeypatch.setattr(
             fi,
-            "serialize_arrow_stream",
-            lambda df, max_bytes: (_ for _ in ()).throw(ImportError("No module named 'pyarrow'")),
+            "iter_arrow_stream_chunks",
+            lambda df, max_chunk_bytes: (_ for _ in ()).throw(
+                ImportError("No module named 'pyarrow'")
+            ),
         )
 
         data: dict = {"score": [0.1, 0.5, 0.9], "name": ["a", "b", "c"]}

--- a/python/dx/tests/test_dx_integration.py
+++ b/python/dx/tests/test_dx_integration.py
@@ -44,10 +44,10 @@ class TestEmitDataFrameFallbackWithoutPyarrow:
     def test_emit_returns_summary_only_on_serialize_failure(self, monkeypatch):
         import dx._format_install as fi
 
-        # Make serialize_dataframe raise to simulate missing pyarrow
+        # Make serialize_arrow_stream raise to simulate missing pyarrow
         monkeypatch.setattr(
             fi,
-            "serialize_dataframe",
+            "serialize_arrow_stream",
             lambda df, max_bytes: (_ for _ in ()).throw(ImportError("No module named 'pyarrow'")),
         )
 
@@ -59,7 +59,7 @@ class TestEmitDataFrameFallbackWithoutPyarrow:
 
         assert bundle is not None
         assert "text/llm+plain" in bundle
-        # No blob ref — parquet serialization failed
+        # No blob ref — Arrow serialization failed
         from dx._refs import BLOB_REF_MIME
 
         assert BLOB_REF_MIME not in bundle
@@ -96,8 +96,8 @@ class TestDatasetEmitsDisplayDataWithSummary:
         assert "text" in summary
         assert "label" in summary
 
-    def test_dataset_mimebundle_no_parquet_ref(self, monkeypatch):
-        """Dataset handler must NOT emit parquet ref MIME — keeps data lazy."""
+    def test_dataset_mimebundle_no_arrow_ref(self, monkeypatch):
+        """Dataset handler must NOT emit Arrow ref MIME — keeps data lazy."""
         import dx._format_install as fi
         from datasets import Dataset
         from dx._refs import BLOB_REF_MIME

--- a/python/dx/tests/test_format.py
+++ b/python/dx/tests/test_format.py
@@ -2,41 +2,43 @@ import io
 
 import pandas as pd
 import pytest
-from dx._format import PARQUET_MIME, serialize_dataframe
+from dx._format import ARROW_STREAM_MIME, iter_arrow_stream_chunks, serialize_dataframe
 
 
-def test_serialize_pandas_to_parquet():
+def test_serialize_pandas_to_arrow_stream():
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    data, content_type = serialize_dataframe(df, max_bytes=10_000_000)
-    assert content_type == PARQUET_MIME
+    data, content_type, included_rows = serialize_dataframe(df, max_bytes=10_000_000)
+    assert content_type == ARROW_STREAM_MIME
+    assert included_rows == 3
     assert isinstance(data, bytes)
-    assert data[:4] == b"PAR1"
 
 
 def test_serialize_pandas_round_trip():
-    import pyarrow.parquet as pq
+    import pyarrow as pa
 
     df = pd.DataFrame({"a": [1, 2, 3]})
-    data, _ = serialize_dataframe(df, max_bytes=10_000_000)
-    table = pq.read_table(io.BytesIO(data))
+    data, _, _ = serialize_dataframe(df, max_bytes=10_000_000)
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
     assert table.column("a").to_pylist() == [1, 2, 3]
 
 
-def test_serialize_downsamples_when_oversized():
-    """When the full payload would exceed max_bytes, downsample."""
+def test_iter_arrow_stream_chunks_when_oversized():
     big = pd.DataFrame({"a": list(range(200_000))})
-    data, content_type = serialize_dataframe(big, max_bytes=2_000)
-    assert content_type == PARQUET_MIME
-    # Parquet has a fixed footer overhead; allow generous slack.
-    assert len(data) <= 8_000
+    chunks = list(iter_arrow_stream_chunks(big, max_chunk_bytes=2_000))
+    assert len(chunks) > 1
+    assert sum(chunk.row_count for chunk in chunks) == len(big)
 
 
 def test_serialize_polars_when_available():
+    import pyarrow as pa
+
     pl = pytest.importorskip("polars")
     df = pl.DataFrame({"a": [1, 2, 3]})
-    data, content_type = serialize_dataframe(df, max_bytes=10_000_000)
-    assert content_type == PARQUET_MIME
-    assert data[:4] == b"PAR1"
+    data, content_type, included_rows = serialize_dataframe(df, max_bytes=10_000_000)
+    assert content_type == ARROW_STREAM_MIME
+    assert included_rows == 3
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert table.column("a").to_pylist() == [1, 2, 3]
 
 
 def test_serialize_rejects_unsupported():

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -189,7 +189,7 @@ def test_mimebundle_returns_summary_only_on_serialize_failure(monkeypatch):
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
     monkeypatch.setattr(
-        "dx._format_install.serialize_arrow_stream",
+        "dx._format_install.iter_arrow_stream_chunks",
         lambda df, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
@@ -248,6 +248,54 @@ def test_display_pub_hook_attaches_buffers_on_display_data(monkeypatch):
     # The pending slot is consumed so a later publish for the same hash
     # doesn't accidentally re-attach the bytes.
     assert h not in fi._pending_buffers()
+
+
+def test_display_pub_hook_attaches_multiple_buffers(monkeypatch):
+    """Chunked Arrow manifests carry multiple blob refs and buffers."""
+    _reset_installed(monkeypatch)
+    ip = FakeIPython()
+    monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
+
+    import dx
+    import dx._format_install as fi
+
+    dx.install()
+    hook = ip.display_pub._hooks[0]
+
+    payloads = [b"arrow-chunk-0", b"arrow-chunk-1"]
+    hashes = [hashlib.sha256(payload).hexdigest() for payload in payloads]
+    for h, payload in zip(hashes, payloads, strict=True):
+        fi._pending_buffers()[h] = payload
+
+    msg = {
+        "header": {"msg_type": "display_data"},
+        "content": {
+            "data": {
+                BLOB_REF_MIME: {
+                    "content_type": "application/vnd.apache.arrow.stream",
+                    "refs": [
+                        {
+                            "hash": h,
+                            "content_type": "application/vnd.apache.arrow.stream",
+                            "size": len(payload),
+                        }
+                        for h, payload in zip(hashes, payloads, strict=True)
+                    ],
+                },
+            },
+            "metadata": {},
+            "transient": {},
+        },
+    }
+
+    result = hook(msg)
+    assert result is None
+    assert len(ip.display_pub.session.sent) == 1
+    sent = ip.display_pub.session.sent[0]
+    assert sent["buffers"] == payloads
+    refs = sent["msg"]["content"]["data"][BLOB_REF_MIME]["refs"]
+    assert [ref["buffer_index"] for ref in refs] == [0, 1]
+    assert all(h not in fi._pending_buffers() for h in hashes)
 
 
 def test_display_pub_hook_fires_for_update_display_data(monkeypatch):

--- a/python/dx/tests/test_install.py
+++ b/python/dx/tests/test_install.py
@@ -81,10 +81,9 @@ def test_install_is_idempotent(monkeypatch):
     import dx
 
     dx.install()
+    registrations = dict(ip.display_formatter.mimebundle_formatter.registrations)
     dx.install()
-    assert (
-        len(ip.display_formatter.mimebundle_formatter.registrations) <= 4
-    )  # pandas + optional polars + optional narwhals + optional datasets
+    assert ip.display_formatter.mimebundle_formatter.registrations == registrations
 
 
 def test_install_treats_display_formatter_as_attribute_not_method(monkeypatch):
@@ -156,7 +155,7 @@ def test_install_skips_hook_when_display_pub_lacks_kernel_surface(monkeypatch):
 
 def test_mimebundle_returns_ref_mime_and_stashes_bytes(monkeypatch):
     """Formatter returns {BLOB_REF_MIME: ..., text/llm+plain: ...} and
-    stashes the parquet bytes in the pending buffer map keyed by hash."""
+    stashes the Arrow bytes in the pending buffer map keyed by hash."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
@@ -173,25 +172,24 @@ def test_mimebundle_returns_ref_mime_and_stashes_bytes(monkeypatch):
     assert BLOB_REF_MIME in bundle
     assert "text/llm+plain" in bundle
     ref = bundle[BLOB_REF_MIME]
-    assert ref["content_type"] == "application/vnd.apache.parquet"
+    assert ref["content_type"] == "application/vnd.apache.arrow.stream"
     assert ref["buffer_index"] == 0
 
     # Bytes were stashed at the ref's hash.
     pending = fi._pending_buffers()
     assert ref["hash"] in pending
     buf = pending[ref["hash"]]
-    assert buf[:4] == b"PAR1"
     assert hashlib.sha256(buf).hexdigest() == ref["hash"]
 
 
 def test_mimebundle_returns_summary_only_on_serialize_failure(monkeypatch):
-    """When parquet serialization raises, formatter returns a summary-only
+    """When Arrow serialization raises, formatter returns a summary-only
     bundle (text/llm+plain without blob ref) instead of None."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
     monkeypatch.setattr(
-        "dx._format_install.serialize_dataframe",
+        "dx._format_install.serialize_arrow_stream",
         lambda df, **kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
@@ -221,7 +219,7 @@ def test_display_pub_hook_attaches_buffers_on_display_data(monkeypatch):
     dx.install()
     hook = ip.display_pub._hooks[0]
 
-    payload = b"PAR1parquet-bytes"
+    payload = b"arrow-bytes"
     h = hashlib.sha256(payload).hexdigest()
     fi._pending_buffers()[h] = payload
 
@@ -231,7 +229,7 @@ def test_display_pub_hook_attaches_buffers_on_display_data(monkeypatch):
             "data": {
                 BLOB_REF_MIME: {
                     "hash": h,
-                    "content_type": "application/vnd.apache.parquet",
+                    "content_type": "application/vnd.apache.arrow.stream",
                     "size": len(payload),
                     "buffer_index": 0,
                 },
@@ -267,7 +265,7 @@ def test_display_pub_hook_fires_for_update_display_data(monkeypatch):
     dx.install()
     hook = ip.display_pub._hooks[0]
 
-    payload = b"PAR1updated"
+    payload = b"arrow-updated"
     h = hashlib.sha256(payload).hexdigest()
     fi._pending_buffers()[h] = payload
 
@@ -277,7 +275,7 @@ def test_display_pub_hook_fires_for_update_display_data(monkeypatch):
             "data": {
                 BLOB_REF_MIME: {
                     "hash": h,
-                    "content_type": "application/vnd.apache.parquet",
+                    "content_type": "application/vnd.apache.arrow.stream",
                     "size": len(payload),
                     "buffer_index": 0,
                 },
@@ -430,7 +428,7 @@ def test_install_registers_ipython_display_handler_for_pandas(monkeypatch):
 
 def test_ipython_display_handler_publishes_and_stashes_buffers(monkeypatch):
     """The handler builds a mimebundle via _emit_dataframe (which stashes
-    parquet bytes in _pending_buffers keyed by hash) and publishes a
+    Arrow bytes in _pending_buffers keyed by hash) and publishes a
     display_data message carrying BLOB_REF_MIME. The publisher hook is
     the piece that later attaches the buffers — this test covers just
     the formatter side."""
@@ -463,10 +461,10 @@ def test_ipython_display_handler_publishes_and_stashes_buffers(monkeypatch):
     bundle = published[0]["data"]
     assert BLOB_REF_MIME in bundle, f"expected BLOB_REF_MIME in bundle keys: {list(bundle)}"
     ref = bundle[BLOB_REF_MIME]
-    assert ref["content_type"] == "application/vnd.apache.parquet"
+    assert ref["content_type"] == "application/vnd.apache.arrow.stream"
     assert isinstance(ref["hash"], str) and len(ref["hash"]) == 64  # sha256 hex
 
-    # The parquet bytes must be in the pending stash so the publisher hook
+    # The Arrow bytes must be in the pending stash so the publisher hook
     # can pop them on the subsequent IOPub send.
     assert ref["hash"] in fi._pending_buffers(), "buffer not stashed for hash"
 
@@ -489,9 +487,8 @@ def test_install_registers_ipython_display_handler_for_narwhals(monkeypatch):
     assert nw.DataFrame in ip.display_formatter.ipython_display_formatter.registrations
 
 
-def test_narwhals_handler_unwraps_pandas_and_publishes(monkeypatch):
-    """Fast path: nw.DataFrame backed by pandas — unwrap via to_native()
-    and emit via the pandas encoder directly (no to_pandas() round-trip)."""
+def test_narwhals_handler_publishes_pandas_backed_stream(monkeypatch):
+    """nw.DataFrame backed by pandas emits through the Arrow stream protocol."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
@@ -520,12 +517,12 @@ def test_narwhals_handler_unwraps_pandas_and_publishes(monkeypatch):
     bundle = published[0]["data"]
     assert BLOB_REF_MIME in bundle
     ref = bundle[BLOB_REF_MIME]
-    assert ref["content_type"] == "application/vnd.apache.parquet"
+    assert ref["content_type"] == "application/vnd.apache.arrow.stream"
     assert ref["hash"] in fi._pending_buffers()
 
 
-def test_narwhals_handler_unwraps_polars_and_publishes(monkeypatch):
-    """Fast path: nw.DataFrame backed by polars — unwrap + polars encoder."""
+def test_narwhals_handler_publishes_polars_backed_stream(monkeypatch):
+    """nw.DataFrame backed by polars emits through the Arrow stream protocol."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)
@@ -557,10 +554,8 @@ def test_narwhals_handler_unwraps_polars_and_publishes(monkeypatch):
     assert bundle[BLOB_REF_MIME]["hash"] in fi._pending_buffers()
 
 
-def test_narwhals_handler_falls_back_to_pandas_for_pyarrow_table(monkeypatch):
-    """pyarrow Table isn't supported by serialize_dataframe directly.
-    The narwhals handler should round-trip via .to_pandas() so the fast
-    path in _emit_dataframe still hits the pandas encoder."""
+def test_narwhals_handler_publishes_pyarrow_backed_stream(monkeypatch):
+    """nw.DataFrame backed by pyarrow emits through the Arrow stream protocol."""
     _reset_installed(monkeypatch)
     ip = FakeIPython()
     monkeypatch.setattr("dx._format_install._get_ipython_for_format", lambda: ip)

--- a/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
+++ b/python/nteract-kernel-launcher/docs/arrow-native-outputs.md
@@ -61,21 +61,21 @@ The phases below are intended as targeted commits in this PR, not separate PRs.
 
 ## Current Merged State
 
-The launcher registers lazy IPython `mimebundle_formatter` handlers in
-`nteract_kernel_launcher/_bootstrap.py` for pandas, polars, narwhals,
-`pyarrow.Table`, `pyarrow.RecordBatch`, and Hugging Face datasets.
+The launcher installs generic per-MIME Arrow stream formatters in
+`nteract_kernel_launcher/_bootstrap.py`. Those formatters look for
+`__arrow_c_stream__()` on every object, so pandas, polars, pyarrow, narwhals,
+and other PyCapsule producers share one output path. Hugging Face datasets keep
+type-specific `mimebundle_formatter` registrations because they add
+dataset-specific feature summaries.
 
 Serialization helpers live in `nteract_kernel_launcher/_format.py`:
 
-- `_serialize_pandas` writes parquet via
-  `pa.Table.from_pandas(df, preserve_index=False)` plus
-  `pq.write_table(..., compression="snappy")`.
-- `_serialize_polars` writes parquet via
-  `df.write_parquet(buf, compression="snappy")`.
-- `_serialize_arrow_stream_table` already writes Arrow IPC stream bytes for
-  `pyarrow.Table` and `pyarrow.RecordBatch`.
-- `serialize_dataframe` returns `(bytes, PARQUET_MIME, included_rows)`. Phase 1
-  flips that to `ARROW_STREAM_MIME` and removes `preserve_index=False`.
+- `iter_arrow_stream_chunks` imports producers through
+  `pa.RecordBatchReader.from_stream(obj)` / the PyCapsule fallback and writes
+  self-contained Arrow IPC mini-stream chunks.
+- `serialize_dataframe` is now a compatibility wrapper over the generic Arrow
+  stream serializer and returns `(bytes, ARROW_STREAM_MIME, included_rows)` for
+  one-blob outputs.
 
 Today rich table outputs are stored as content-addressed blobs via
 `application/vnd.nteract.blob-ref+json`:
@@ -110,11 +110,11 @@ priority, notebook rendering, MCP rendering, Sift plugin loading, and Sift/WASM
 schema hints. `nteract-predicate` now owns the canonical pandas/Hugging Face
 schema interpretation for both parquet metadata and Arrow IPC schema metadata.
 
-The remaining asymmetry is Python-side production:
+The remaining work is no longer Python-side format selection:
 
-- `pyarrow.Table`, `pyarrow.RecordBatch`, and materialized Hugging Face datasets
-  emit Arrow IPC stream bytes.
-- pandas and polars still emit parquet.
+- pandas, polars, pyarrow tables, pyarrow record batches, narwhals wrappers, and
+  other PyCapsule producers emit Arrow IPC stream bytes through the same
+  `__arrow_c_stream__()` path.
 - Sift can render Arrow IPC, but buffers complete Arrow IPC bytes before loading
   them into WASM.
 - The blob-ref MIME points at one complete blob, not a chunk manifest.
@@ -593,8 +593,8 @@ for the staged implementation.
   - pandas, polars, pyarrow tables, record batches, and PyCapsule-compatible
     dataframe objects now emit `application/vnd.apache.arrow.stream` through the
     launcher.
-  - `serialize_dataframe` prefers `__arrow_c_stream__()` and falls back to
-    pandas/polars-specific Arrow IPC writers for older library versions.
+  - `serialize_dataframe` imports objects through `__arrow_c_stream__()` /
+    `RecordBatchReader.from_stream()`.
   - Tests cover pandas IPC output, pandas index metadata, polars IPC output, and
     a protocol-only PyCapsule stream object.
 - Done: `f039cd2b docs(outputs): clarify arrow stream chunking`
@@ -720,25 +720,12 @@ Goal: all new dataframe display outputs use Arrow IPC stream by default.
 Changes (all in `python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py`
 unless noted):
 
-- `_serialize_pandas` switches to `pa.Table.from_pandas(df)` (drop
-  `preserve_index=False`) plus `pa.ipc.new_stream` writing into a
-  `pa.BufferOutputStream`.
-- `_serialize_polars` switches to `df.write_ipc_stream(buf)`.
-- `serialize_dataframe` first checks for `__arrow_c_stream__()` and imports via
-  `pa.RecordBatchReader.from_stream(obj)` / PyCapsule fallback. The pandas and
-  polars helpers remain compatibility fallbacks for older library versions.
-- `serialize_dataframe` returns `ARROW_STREAM_MIME` instead of `PARQUET_MIME`.
-  Drop `PARQUET_MIME` from the dataframe return path; keep the constant for
-  parsing old fixtures only.
-- Audit `_bootstrap.py` formatter registrations and tests in
-  `python/nteract-kernel-launcher/tests/` for any callers that branch on
-  `PARQUET_MIME` for pandas/polars output and update them.
-- Rename helpers from parquet-specific names to Arrow/table names where the
-  behavior is now generic. A single `serialize_table` codepath shared by
-  pandas/polars/pyarrow is fine.
-- For narwhals, dispatch on backend: prefer the native object's
-  `__arrow_c_stream__()` protocol, fall back to pandas conversion only if no
-  Arrow export is available.
+- `serialize_dataframe` imports via `pa.RecordBatchReader.from_stream(obj)` /
+  PyCapsule fallback. pandas, polars, pyarrow, and narwhals wrappers share that
+  protocol path.
+- `_bootstrap.py` installs generic Arrow stream MIME formatters instead of
+  pandas/polars/narwhals/pyarrow type-specific table formatters.
+- For narwhals, use the wrapper's own `__arrow_c_stream__()` protocol.
 - Hugging Face: keep the Arrow-table-backed path. `IterableDataset` and other
   streaming HF objects materialize a head sample then fall through to
   `text/llm+plain`; do not silently consume the stream.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/__init__.py
@@ -5,7 +5,7 @@ Subclasses ``IPKernelApp``/``IPythonKernel``/``ZMQInteractiveShell``/
 
 - A hook chain on the shell's displayhook (lets ``execute_result`` carry
   buffers, matching ``display_data``'s existing hook chain).
-- An auto-loaded bootstrap extension that registers DataFrame formatters
+- An auto-loaded bootstrap extension that registers Arrow stream formatters
   and publisher hooks for the nteract data-experience integration.
 
 The daemon invokes this module in place of ``ipykernel_launcher`` by default.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -7,10 +7,11 @@ user code runs. Four things happen on ``load_ipython_extension``:
    ``_repr_llm_``. This mirrors the original ``repr_llm`` convention while
    keeping the launcher self-contained.
 
-2. ``mimebundle_formatter`` entries for pandas / polars / narwhals /
-   datasets are registered by **dotted type name** (no eager imports).
-   IPython binds them lazily on first encounter — dx's historical
-   ``import pandas as pd`` at install time becomes unnecessary.
+2. Generic Arrow stream MIME formatters look for ``__arrow_c_stream__`` on
+   every object. pandas, polars, pyarrow, narwhals, and other producers that
+   implement the PyCapsule protocol all flow through the same path. The only
+   dotted type registrations left are for HuggingFace datasets, where nteract
+   adds dataset-specific summary semantics.
 
 3. :func:`_buffer_hook.install` registers the single buffer-attachment
    hook on *both* ``ip.display_pub`` and ``ip.displayhook``. With the
@@ -35,6 +36,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -47,11 +49,11 @@ from nteract_kernel_launcher._format import (
     ARROW_STREAM_MANIFEST_MIME,
     ARROW_STREAM_MIME,
     DEFAULT_ARROW_CHUNK_BYTES,
+    arrow_stream_row_count,
     build_arrow_stream_manifest,
     build_arrow_stream_manifest_from_chunks,
-    iter_arrow_table_chunks,
-    serialize_arrow_table,
-    serialize_dataframe,
+    has_arrow_stream_protocol,
+    iter_arrow_stream_chunks,
 )
 from nteract_kernel_launcher._refs import (
     BLOB_REF_MIME,
@@ -77,34 +79,115 @@ class LLMFormatter(BaseFormatter):
     format_type = Unicode("text/llm+plain")
     print_method = ObjectName("_repr_llm_")
 
+    def __init__(self, *args, arrow_state: _ArrowFormatterState | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._arrow_state = arrow_state
 
-# ─── mimebundle formatters (lazy-bound via for_type_by_name) ──────────────
+    def __call__(self, obj: Any) -> Any:
+        data = super().__call__(obj)
+        if data is not None or self._arrow_state is None:
+            return data
+        return self._arrow_state.value_for(obj, "text/llm+plain")
 
 
-def _pandas_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    return _emit_dataframe(df, total_rows=len(df))
+class ArrowBlobRefFormatter(BaseFormatter):
+    """Per-MIME formatter that emits nteract blob refs for Arrow streams."""
+
+    format_type = Unicode(BLOB_REF_MIME)
+
+    def __init__(self, *args, arrow_state: _ArrowFormatterState, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._arrow_state = arrow_state
+
+    def __call__(self, obj: Any) -> Any:
+        if not self.enabled:
+            return None
+        try:
+            printer = self.lookup(obj)
+        except KeyError:
+            return self._arrow_state.value_for(obj, BLOB_REF_MIME)
+        return printer(obj)
 
 
-def _polars_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    return _emit_dataframe(df, total_rows=df.height)
+class ArrowStreamManifestFormatter(BaseFormatter):
+    """Per-MIME formatter that emits Arrow stream manifests."""
+
+    format_type = Unicode(ARROW_STREAM_MANIFEST_MIME)
+
+    def __init__(self, *args, arrow_state: _ArrowFormatterState, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._arrow_state = arrow_state
+
+    def __call__(self, obj: Any) -> Any:
+        if not self.enabled:
+            return None
+        try:
+            printer = self.lookup(obj)
+        except KeyError:
+            return self._arrow_state.value_for(obj, ARROW_STREAM_MANIFEST_MIME)
+        return printer(obj)
 
 
-def _narwhals_mimebundle(df: Any, include=None, exclude=None) -> dict | None:
-    native, total_rows = _unwrap_narwhals(df)
-    if native is None:
+class _ArrowFormatterState:
+    """Share one serialized Arrow bundle across per-MIME formatter calls."""
+
+    def __init__(self) -> None:
+        self._tls = threading.local()
+
+    def _cached_bundle(self, obj: Any) -> dict[str, Any] | None:
+        cache = getattr(self._tls, "cache", None)
+        if isinstance(cache, dict) and cache.get("obj") is obj:
+            bundle = cache.get("bundle")
+            return bundle if isinstance(bundle, dict) else None
         return None
-    return _emit_dataframe(native, total_rows=total_rows)
+
+    def _set_cache(self, obj: Any, bundle: dict[str, Any]) -> None:
+        self._tls.cache = {
+            "obj": obj,
+            "bundle": bundle,
+            "remaining": {
+                mime
+                for mime in (BLOB_REF_MIME, ARROW_STREAM_MANIFEST_MIME, "text/llm+plain")
+                if mime in bundle
+            },
+        }
+
+    def _mark_used(self, obj: Any, mime: str) -> None:
+        cache = getattr(self._tls, "cache", None)
+        if not isinstance(cache, dict) or cache.get("obj") is not obj:
+            return
+        remaining = cache.get("remaining")
+        if isinstance(remaining, set):
+            remaining.discard(mime)
+            if not remaining:
+                self._tls.cache = None
+
+    def value_for(self, obj: Any, mime: str) -> Any | None:
+        bundle = self._cached_bundle(obj)
+        if bundle is None:
+            bundle = _arrow_stream_mimebundle(obj)
+            if not bundle:
+                return None
+            self._set_cache(obj, bundle)
+        value = bundle.get(mime)
+        self._mark_used(obj, mime)
+        return value
 
 
-def _pyarrow_table_mimebundle(table: Any, include=None, exclude=None) -> dict | None:
-    return _emit_arrow_table(table, total_rows=table.num_rows)
+def _arrow_state_for(ip: Any) -> _ArrowFormatterState:
+    display_formatter = ip.display_formatter
+    state = getattr(display_formatter, "_nteract_arrow_state", None)
+    if not isinstance(state, _ArrowFormatterState):
+        state = _ArrowFormatterState()
+        display_formatter._nteract_arrow_state = state
+    return state
 
 
-def _pyarrow_record_batch_mimebundle(batch: Any, include=None, exclude=None) -> dict | None:
-    import pyarrow as pa
+# ─── formatters ──────────────────────────────────────────────────────────
 
-    table = pa.Table.from_batches([batch])
-    return _emit_arrow_table(table, total_rows=table.num_rows)
+
+def _arrow_stream_mimebundle(source: Any, include=None, exclude=None) -> dict | None:
+    return _emit_arrow_stream(source)
 
 
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
@@ -133,143 +216,73 @@ def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
     return _emit_arrow_table(table, total_rows=total_rows, summary_fn=summary)
 
 
-def _unwrap_narwhals(nw_df: Any) -> tuple[Any, int] | tuple[None, int]:
-    """Return ``(native_df, row_count)`` for a ``narwhals.DataFrame``.
-
-    Fast path: native is pandas or polars — pass through. Fallback:
-    round-trip via ``.to_pandas()`` for any backend narwhals understands
-    (pyarrow, modin, dask, cudf). ``LazyFrame`` isn't handled here —
-    displaying a lazy query would force ``.collect()``, which has side
-    effects.
-    """
-    try:
-        native = nw_df.to_native()
-    except Exception as exc:  # noqa: BLE001
-        log.debug("narwhals to_native failed: %s", exc)
-        return None, 0
-
-    try:
-        import pandas as pd
-
-        if isinstance(native, pd.DataFrame):
-            return native, len(native)
-    except ImportError:
-        pass
-    try:
-        import polars as pl
-
-        if isinstance(native, pl.DataFrame):
-            return native, native.height
-    except ImportError:
-        pass
-
-    try:
-        as_pandas = nw_df.to_pandas()
-        return as_pandas, len(as_pandas)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("narwhals to_pandas failed: %s", exc)
-        return None, 0
-
-
-def _emit_dataframe(df: Any, *, total_rows: int) -> dict | None:
-    """Serialize → stash bytes keyed by sha256 → return ref-mime bundle.
-
-    When Arrow IPC serialization fails (e.g. pyarrow missing), fall back to
-    a summary-only ``text/llm+plain`` bundle so agents still get column
-    stats instead of a raw repr. IPython's default formatter chain merges
-    pandas' ``text/html`` / ``text/plain`` on top for host-side fallback.
-    """
-    try:
-        data, content_type, included_rows = serialize_dataframe(df, max_bytes=_MAX_PAYLOAD_BYTES)
-    except Exception as exc:  # noqa: BLE001
-        log.debug("serialize failed: %s — emitting summary-only bundle", exc)
-        try:
-            llm = summarize_dataframe(
-                df, total_rows=total_rows, included_rows=total_rows, sampled=False
-            )
-            return {"text/llm+plain": llm}
-        except Exception:  # noqa: BLE001
-            return None
-
-    return _emit_table_bytes(
-        data,
-        content_type=content_type,
-        total_rows=total_rows,
-        included_rows=included_rows,
-        summary_fn=lambda included, sampled: summarize_dataframe(
-            df, total_rows=total_rows, included_rows=included, sampled=sampled
-        ),
-    )
-
-
-def _emit_arrow_table(
-    table: Any,
+def _emit_arrow_stream(
+    source: Any,
     *,
-    total_rows: int,
-    summary_fn: Callable[[], str] | None = None,
+    total_rows: int | None = None,
+    summary_fn: Callable[..., str] | None = None,
 ) -> dict | None:
-    """Serialize a ``pa.Table`` to Arrow IPC, preserving schema KV metadata.
+    """Serialize any Arrow stream producer into a nteract output bundle."""
+    if not has_arrow_stream_protocol(source):
+        return None
 
-    Distinct from :func:`_emit_dataframe` because the dataframe path runs
-    bytes through the Arrow PyCapsule stream protocol or a ``pa.Table`` fallback,
-    so the ``huggingface`` key survives for Sift's rich-type detection.
-
-    ``summary_fn`` lets callers (notably ``_dataset_mimebundle``) provide
-    a richer per-domain summary (HF features) instead of the generic
-    pandas-style preview.
-    """
     try:
-        data, content_type, included_rows = serialize_arrow_table(
-            table, max_bytes=_MAX_PAYLOAD_BYTES
+        chunks = list(
+            iter_arrow_stream_chunks(
+                source,
+                max_chunk_bytes=min(DEFAULT_ARROW_CHUNK_BYTES, _MAX_PAYLOAD_BYTES),
+            )
         )
     except Exception as exc:  # noqa: BLE001
-        log.debug("arrow serialize failed: %s — emitting summary-only bundle", exc)
-        if summary_fn is not None:
-            try:
-                return {"text/llm+plain": summary_fn()}
-            except Exception:  # noqa: BLE001
-                return None
+        log.debug("arrow stream emit failed: %s", exc)
         return None
+
+    included_rows = sum(chunk.row_count for chunk in chunks)
+    if total_rows is None:
+        total_rows = arrow_stream_row_count(source)
+    if total_rows is None:
+        total_rows = included_rows
 
     def _summary(included: int, sampled: bool) -> str:
         if summary_fn is not None:
-            return summary_fn()
-        return _summarize_arrow_table(
-            table, total_rows=total_rows, included_rows=included, sampled=sampled
+            try:
+                return summary_fn(included, sampled)
+            except TypeError:
+                return summary_fn()
+        return _summarize_arrow_source(
+            source,
+            total_rows=total_rows,
+            included_rows=included,
+            sampled=sampled,
         )
 
-    if content_type == ARROW_STREAM_MIME and included_rows != total_rows:
-        try:
-            return _emit_arrow_table_chunks(
-                table,
-                total_rows=total_rows,
-                summary_fn=_summary,
-            )
-        except Exception as exc:  # noqa: BLE001
-            log.debug("arrow chunked emit failed: %s — keeping sampled bundle", exc)
+    if len(chunks) == 1:
+        chunk = chunks[0]
+        return _emit_table_bytes(
+            chunk.data,
+            content_type=ARROW_STREAM_MIME,
+            total_rows=total_rows,
+            included_rows=included_rows,
+            record_batch_count=chunk.record_batch_count,
+            summary_fn=_summary,
+        )
 
-    return _emit_table_bytes(
-        data,
-        content_type=content_type,
+    return _emit_arrow_stream_chunks(
+        chunks,
         total_rows=total_rows,
-        included_rows=included_rows,
         summary_fn=_summary,
     )
 
 
-def _emit_arrow_table_chunks(
-    table: Any,
+def _emit_arrow_stream_chunks(
+    chunks: list[Any],
     *,
     total_rows: int,
     summary_fn: Callable[[int, bool], str],
 ) -> dict:
-    """Emit a complete multi-chunk Arrow stream manifest for a pyarrow Table."""
-    chunks = list(
-        iter_arrow_table_chunks(
-            table,
-            max_chunk_bytes=min(DEFAULT_ARROW_CHUNK_BYTES, _MAX_PAYLOAD_BYTES),
-        )
-    )
+    """Emit a complete multi-chunk Arrow stream manifest."""
+    if not chunks:
+        raise ValueError("at least one Arrow stream chunk is required")
     included_rows = sum(chunk.row_count for chunk in chunks)
     sampled = included_rows != total_rows
     llm_text: str | None = None
@@ -295,7 +308,6 @@ def _emit_arrow_table_chunks(
             chunks,
             complete=True,
             summary=summary_hints,
-            schema=table.schema,
         ),
     }
     if llm_text is not None:
@@ -305,6 +317,65 @@ def _emit_arrow_table_chunks(
     for chunk in chunks:
         pending[chunk.content_hash] = chunk.data
     return bundle
+
+
+def _emit_arrow_table(
+    table: Any,
+    *,
+    total_rows: int,
+    summary_fn: Callable[[], str] | None = None,
+) -> dict | None:
+    """Compatibility wrapper for dataset-backed Arrow tables."""
+    return _emit_arrow_stream(table, total_rows=total_rows, summary_fn=summary_fn)
+
+
+def _summary_source(source: Any) -> Any:
+    to_native = getattr(source, "to_native", None)
+    if callable(to_native):
+        try:
+            native = to_native()
+            if native is not source:
+                return native
+        except Exception as exc:  # noqa: BLE001
+            log.debug("to_native summary unwrap failed: %s", exc)
+    return source
+
+
+def _summarize_arrow_source(
+    source: Any, *, total_rows: int, included_rows: int, sampled: bool
+) -> str:
+    source = _summary_source(source)
+    try:
+        import pyarrow as pa
+
+        if isinstance(source, pa.Table):
+            return _summarize_arrow_table(
+                source,
+                total_rows=total_rows,
+                included_rows=included_rows,
+                sampled=sampled,
+            )
+        if isinstance(source, pa.RecordBatch):
+            table = pa.Table.from_batches([source])
+            return _summarize_arrow_table(
+                table,
+                total_rows=total_rows,
+                included_rows=included_rows,
+                sampled=sampled,
+            )
+    except Exception as exc:  # noqa: BLE001
+        log.debug("pyarrow summary conversion failed: %s", exc)
+
+    try:
+        return summarize_dataframe(
+            source,
+            total_rows=total_rows,
+            included_rows=included_rows,
+            sampled=sampled,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.debug("dataframe summary failed: %s", exc)
+        return f"Arrow stream table: {included_rows} rows"
 
 
 def _summarize_arrow_table(
@@ -328,6 +399,7 @@ def _emit_table_bytes(
     content_type: str,
     total_rows: int,
     included_rows: int,
+    record_batch_count: int | None = None,
     summary_fn: Callable[[int, bool], str],
 ) -> dict:
     """Stash bytes, build the ref bundle, attach a summary.
@@ -361,6 +433,7 @@ def _emit_table_bytes(
                 content_hash=h,
                 content_size=len(data),
                 row_count=included_rows,
+                record_batch_count=record_batch_count,
                 summary=summary_hints,
             )
         except Exception as exc:  # noqa: BLE001
@@ -381,57 +454,44 @@ def _install_llm_formatter(ip: Any) -> BaseFormatter | None:
     formatters = getattr(display_formatter, "formatters", None)
     if not isinstance(formatters, dict):
         return None
+    arrow_state = _arrow_state_for(ip)
 
     existing = formatters.get("text/llm+plain")
     if existing is not None:
+        if isinstance(existing, LLMFormatter) and existing._arrow_state is None:
+            existing._arrow_state = arrow_state
         return existing
 
-    llm_formatter = LLMFormatter(parent=display_formatter)
+    llm_formatter = LLMFormatter(parent=display_formatter, arrow_state=arrow_state)
     formatters["text/llm+plain"] = llm_formatter
     return llm_formatter
 
 
 def _install_dataframe_formatters(ip: Any) -> None:
-    """Register mimebundle formatters lazily via ``for_type_by_name``.
+    """Install generic Arrow stream formatters and dataset summaries."""
+    display_formatter = ip.display_formatter
+    formatters = getattr(display_formatter, "formatters", None)
+    if isinstance(formatters, dict):
+        arrow_state = _arrow_state_for(ip)
+        if not isinstance(formatters.get(BLOB_REF_MIME), ArrowBlobRefFormatter):
+            formatters[BLOB_REF_MIME] = ArrowBlobRefFormatter(
+                parent=display_formatter,
+                arrow_state=arrow_state,
+            )
+        if not isinstance(
+            formatters.get(ARROW_STREAM_MANIFEST_MIME),
+            ArrowStreamManifestFormatter,
+        ):
+            formatters[ARROW_STREAM_MANIFEST_MIME] = ArrowStreamManifestFormatter(
+                parent=display_formatter,
+                arrow_state=arrow_state,
+            )
 
-    IPython's ``for_type_by_name`` keys on ``type.__module__`` + class
-    name. Library-by-library that's:
-
-    - pandas: ``pandas`` (pandas sets ``DataFrame.__module__ = "pandas"``)
-    - polars: ``polars.dataframe.frame``
-    - narwhals: ``narwhals.dataframe``
-    - pyarrow: ``pyarrow.lib`` (Table / RecordBatch are C-extension types)
-    - datasets: ``datasets.arrow_dataset`` / ``datasets.iterable_dataset``
-
-    We register the definitive module each library stamps on the class,
-    plus a short-name fallback for pandas/polars/narwhals/pyarrow. Short
-    names cover both conservative stamping by the library and any future
-    flattening. Registration is cheap and idempotent, so the spray
-    costs nothing.
-    """
     mimebundle = ip.display_formatter.mimebundle_formatter
 
-    # (module_path, type_name, formatter). Keep definitive entries first so
-    # a first-dispatch lookup short-circuits before the fallbacks matter.
+    # Datasets remain type-registered because they add HuggingFace feature
+    # summaries in addition to the generic Arrow stream payload.
     for module_path, type_name, fn in (
-        # pandas — public DataFrame ships with __module__ == "pandas".
-        ("pandas", "DataFrame", _pandas_mimebundle),
-        ("pandas.core.frame", "DataFrame", _pandas_mimebundle),
-        # polars — class module is the deep path; register both.
-        ("polars.dataframe.frame", "DataFrame", _polars_mimebundle),
-        ("polars", "DataFrame", _polars_mimebundle),
-        # narwhals — class lives in narwhals.dataframe.
-        ("narwhals.dataframe", "DataFrame", _narwhals_mimebundle),
-        ("narwhals", "DataFrame", _narwhals_mimebundle),
-        # pyarrow — Table / RecordBatch are stamped to pyarrow.lib by
-        # the C extension. Preserves schema KV metadata end-to-end so
-        # Sift's HF rich-type detection lights up for Arrow-native tables.
-        ("pyarrow.lib", "Table", _pyarrow_table_mimebundle),
-        ("pyarrow", "Table", _pyarrow_table_mimebundle),
-        ("pyarrow.lib", "RecordBatch", _pyarrow_record_batch_mimebundle),
-        ("pyarrow", "RecordBatch", _pyarrow_record_batch_mimebundle),
-        # datasets — materialized datasets can emit parquet; iterable
-        # datasets fall back to summary-only because they have no table.
         ("datasets.arrow_dataset", "Dataset", _dataset_mimebundle),
         ("datasets.iterable_dataset", "IterableDataset", _dataset_mimebundle),
     ):

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_buffer_hook.py
@@ -1,6 +1,6 @@
 """Buffer-attachment hook — shared between ``display_pub`` and ``displayhook``.
 
-When the DataFrame formatter emits an output bundle, it stashes the parquet
+When the DataFrame formatter emits an output bundle, it stashes the Arrow
 bytes in a thread-local dict keyed by the blob-ref hash. Later, when the
 Jupyter message is about to go on the wire, this hook:
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -1,22 +1,18 @@
-"""DataFrame / Arrow serialization (best-available encoder).
+"""Arrow stream serialization helpers.
 
 Arrow IPC stream is the canonical rich table payload. Producers that implement
-the Arrow PyCapsule stream protocol are imported through ``__arrow_c_stream__``;
-pandas and polars keep direct fallbacks for older versions. If the serialized
-payload would exceed ``max_bytes``, the serializer downsamples via ``head(n)`` /
-``slice(0, n)`` with a halving loop and the caller advertises the partial-data
-state in the ``text/llm+plain`` summary and the ref-MIME ``summary`` hints.
+the Arrow PyCapsule stream protocol are imported through ``__arrow_c_stream__``.
+The formatter layer handles small streams as one blob and larger streams as an
+Arrow manifest with multiple independently decodable stream chunks.
 """
 
 from __future__ import annotations
 
 import hashlib
-import io
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
-PARQUET_MIME = "application/vnd.apache.parquet"
 ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
 ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
 DEFAULT_ARROW_CHUNK_BYTES = 8 * 1024 * 1024
@@ -44,11 +40,6 @@ class ArrowStreamChunk:
         }
 
 
-def _detect_flavor(df: Any) -> str:
-    mod = type(df).__module__.split(".")[0]
-    return mod if mod in ("pandas", "polars") else "unknown"
-
-
 def _row_count(obj: Any) -> int | None:
     for attr in ("num_rows", "height"):
         value = getattr(obj, attr, None)
@@ -65,20 +56,21 @@ def _row_count(obj: Any) -> int | None:
         return None
 
 
-def _limit_rows(obj: Any, rows: int) -> Any:
-    head = getattr(obj, "head", None)
-    if callable(head):
-        return head(rows)
+def arrow_stream_row_count(obj: Any) -> int | None:
+    """Return the best available row count for an Arrow stream producer."""
+    return _row_count(obj)
 
-    slice_ = getattr(obj, "slice", None)
-    if callable(slice_):
-        return slice_(0, rows)
 
-    limit = getattr(obj, "limit", None)
-    if callable(limit):
-        return limit(rows)
+def has_arrow_stream_protocol(obj: Any) -> bool:
+    """Return ``True`` when ``obj`` can be consumed as an Arrow stream."""
+    if callable(getattr(obj, "__arrow_c_stream__", None)):
+        return True
+    try:
+        import pyarrow as pa
 
-    raise TypeError(f"{type(obj).__module__}.{type(obj).__name__} cannot be row-limited")
+        return isinstance(obj, pa.RecordBatchReader)
+    except Exception:
+        return False
 
 
 def _record_batch_reader_from_stream(source: Any) -> Any:
@@ -97,16 +89,6 @@ def _record_batch_reader_from_stream(source: Any) -> Any:
         return import_capsule(source.__arrow_c_stream__())
 
     raise TypeError("pyarrow does not support Arrow PyCapsule stream import")
-
-
-def _serialize_record_batch_reader(reader: Any) -> bytes:
-    import pyarrow as pa
-
-    sink = pa.BufferOutputStream()
-    with pa.ipc.new_stream(sink, reader.schema) as writer:
-        for batch in reader:
-            writer.write_batch(batch)
-    return sink.getvalue().to_pybytes()
 
 
 def _serialize_record_batches(schema: Any, batches: list[Any]) -> bytes:
@@ -129,6 +111,23 @@ def _record_batch_estimated_bytes(batch: Any) -> int:
         if isinstance(size, int):
             return size
     return 0
+
+
+def _split_record_batch(batch: Any, *, max_chunk_bytes: int) -> Iterator[Any]:
+    batch_rows = getattr(batch, "num_rows", 0)
+    if batch_rows <= 1:
+        yield batch
+        return
+
+    batch_bytes = _record_batch_estimated_bytes(batch)
+    if batch_bytes <= max_chunk_bytes:
+        yield batch
+        return
+
+    bytes_per_row = max(1, batch_bytes // batch_rows)
+    rows_per_chunk = max(1, max_chunk_bytes // bytes_per_row)
+    for offset in range(0, batch_rows, rows_per_chunk):
+        yield batch.slice(offset, min(rows_per_chunk, batch_rows - offset))
 
 
 def _make_arrow_stream_chunk(
@@ -157,8 +156,8 @@ def iter_arrow_stream_chunks(
     """Yield independently decodable Arrow IPC stream chunks from ``source``.
 
     The source is consumed once as a ``RecordBatchReader``. Chunk boundaries are
-    record-batch boundaries; this intentionally avoids splitting serialized IPC
-    bytes after the fact.
+    record-batch boundaries unless a single batch is itself too large, in which
+    case the batch is sliced into smaller Arrow batches before IPC encoding.
     """
     if max_chunk_bytes <= 0:
         raise ValueError("max_chunk_bytes must be positive")
@@ -171,6 +170,33 @@ def iter_arrow_stream_chunks(
     estimated_bytes = 0
 
     for batch in reader:
+        if (
+            _record_batch_estimated_bytes(batch) > max_chunk_bytes
+            and getattr(batch, "num_rows", 0) > 1
+        ):
+            if batches:
+                yield _make_arrow_stream_chunk(
+                    index=chunk_index,
+                    schema=schema,
+                    batches=batches,
+                    row_count=row_count,
+                )
+                chunk_index += 1
+                batches = []
+                row_count = 0
+                estimated_bytes = 0
+
+            for piece in _split_record_batch(batch, max_chunk_bytes=max_chunk_bytes):
+                piece_rows = getattr(piece, "num_rows", 0)
+                yield _make_arrow_stream_chunk(
+                    index=chunk_index,
+                    schema=schema,
+                    batches=[piece],
+                    row_count=piece_rows,
+                )
+                chunk_index += 1
+            continue
+
         batch_rows = getattr(batch, "num_rows", 0)
         batch_bytes = _record_batch_estimated_bytes(batch)
         if batches and estimated_bytes + batch_bytes > max_chunk_bytes:
@@ -196,69 +222,6 @@ def iter_arrow_stream_chunks(
             batches=batches,
             row_count=row_count,
         )
-
-
-def iter_arrow_table_chunks(
-    table: Any,
-    *,
-    max_chunk_bytes: int = DEFAULT_ARROW_CHUNK_BYTES,
-) -> Iterator[ArrowStreamChunk]:
-    """Yield bounded Arrow IPC stream chunks from a pyarrow Table."""
-    if max_chunk_bytes <= 0:
-        raise ValueError("max_chunk_bytes must be positive")
-    if table.num_rows == 0:
-        yield from iter_arrow_stream_chunks(table, max_chunk_bytes=max_chunk_bytes)
-        return
-
-    table_bytes = getattr(table, "nbytes", 0)
-    bytes_per_row = max(1, table_bytes // table.num_rows)
-    rows_per_chunk = max(1, max_chunk_bytes // bytes_per_row)
-    for index, batch in enumerate(table.to_batches(max_chunksize=rows_per_chunk)):
-        yield _make_arrow_stream_chunk(
-            index=index,
-            schema=table.schema,
-            batches=[batch],
-            row_count=batch.num_rows,
-        )
-
-
-def _serialize_arrow_stream_exportable(source: Any, rows: int | None = None) -> bytes:
-    if rows is not None:
-        source = _limit_rows(source, rows)
-    reader = _record_batch_reader_from_stream(source)
-    return _serialize_record_batch_reader(reader)
-
-
-def _serialize_arrow_table_direct(table: Any) -> bytes:
-    import pyarrow as pa
-
-    sink = pa.BufferOutputStream()
-    with pa.ipc.new_stream(sink, table.schema) as writer:
-        writer.write_table(table)
-    return sink.getvalue().to_pybytes()
-
-
-def _serialize_pandas(df: Any, rows: int | None = None) -> bytes:
-    import pyarrow as pa
-
-    if rows is not None:
-        df = df.head(rows)
-    table = pa.Table.from_pandas(df)
-    return _serialize_arrow_table_direct(table)
-
-
-def _serialize_polars(df: Any, rows: int | None = None) -> bytes:
-    if rows is not None:
-        df = df.head(rows)
-    buf = io.BytesIO()
-    df.write_ipc_stream(buf)
-    return buf.getvalue()
-
-
-def _serialize_arrow_stream_table(table: Any, rows: int | None = None) -> bytes:
-    if rows is not None:
-        table = table.slice(0, rows)
-    return _serialize_arrow_table_direct(table)
 
 
 def build_arrow_stream_manifest(
@@ -340,77 +303,44 @@ def build_arrow_stream_manifest_from_chunks(
     return manifest
 
 
-def _downsample_loop(
-    encode: Callable[..., bytes], total_rows: int, *, max_bytes: int
-) -> tuple[bytes, int]:
-    """Encode at full size; if too big, halve target rows up to four rounds.
+def serialize_arrow_stream(source: Any, *, max_bytes: int) -> tuple[bytes, str, int, int]:
+    """Serialize an Arrow stream producer into one IPC stream blob.
 
-    Compression and Arrow encoding overhead are non-linear in row count, so the
-    first guess (``rows * max_bytes / full_bytes``) tends to overshoot. Halving
-    from there converges quickly; bottoming out at one row keeps this from
-    raising for sampling.
+    Returns ``(bytes, content_type, row_count, record_batch_count)``. Raises
+    ``ValueError`` when the stream needs multiple chunks; callers that can emit
+    manifests should use :func:`iter_arrow_stream_chunks` instead.
     """
-    full = encode()
-    if len(full) <= max_bytes:
-        return full, total_rows
-    if total_rows <= 1:
-        return full, total_rows
-    target_rows = max(1, int(total_rows * (max_bytes / len(full))))
-    for _ in range(4):
-        sampled = encode(rows=target_rows)
-        if len(sampled) <= max_bytes:
-            return sampled, target_rows
-        target_rows = max(1, target_rows // 2)
-    return encode(rows=1), 1
+    chunks = list(iter_arrow_stream_chunks(source, max_chunk_bytes=max_bytes))
+    if len(chunks) != 1 or chunks[0].size > max_bytes:
+        raise ValueError("Arrow stream exceeds max_bytes; chunked manifest is required")
+    chunk = chunks[0]
+    return chunk.data, ARROW_STREAM_MIME, chunk.row_count, chunk.record_batch_count
 
 
 def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
-    """Serialize ``df`` to Arrow IPC; downsample if it would exceed ``max_bytes``.
+    """Serialize an Arrow-stream-capable dataframe-like object to Arrow IPC.
 
     Returns ``(bytes, content_type, included_rows)``. Raises ``ValueError`` for
-    unsupported DataFrame types.
+    objects that do not expose the Arrow stream protocol or that need a chunked
+    manifest.
     """
-    flavor = _detect_flavor(df)
-    if flavor == "polars":
-        encoder = _serialize_polars
-        n = df.height
-    elif flavor == "pandas":
-        encoder = _serialize_pandas
-        n = len(df)
-    elif hasattr(df, "__arrow_c_stream__"):
-        n = _row_count(df)
-        if n is None:
-            raise ValueError(
-                f"unsupported row count for: {type(df).__module__}.{type(df).__name__}"
-            )
-        data = _serialize_arrow_stream_exportable(df)
-        if len(data) > max_bytes:
-            raise ValueError(
-                "generic Arrow PyCapsule stream exceeds max_bytes; progressive chunking is required"
-            )
-        return data, ARROW_STREAM_MIME, n
-    else:
+    if not has_arrow_stream_protocol(df):
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
-
-    if n is None:
-        raise ValueError(f"unsupported row count for: {type(df).__module__}.{type(df).__name__}")
-
-    data, included_rows = _downsample_loop(
-        lambda rows=None: encoder(df, rows=rows), n, max_bytes=max_bytes
+    data, content_type, included_rows, _record_batch_count = serialize_arrow_stream(
+        df,
+        max_bytes=max_bytes,
     )
-    return data, ARROW_STREAM_MIME, included_rows
+    return data, content_type, included_rows
 
 
 def serialize_arrow_table(table: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
-    """Serialize ``pa.Table`` to Arrow IPC stream bytes.
+    """Serialize an Arrow table-like object to one Arrow IPC stream blob.
 
-    Same downsample semantics as :func:`serialize_dataframe`. Schema KV metadata
-    (``huggingface``, ``content_defined_chunking``, etc.) survives because the
-    stream carries the Arrow schema directly.
+    Schema KV metadata (``huggingface``, ``content_defined_chunking``, etc.)
+    survives because the stream carries the Arrow schema directly.
     """
-    data, included_rows = _downsample_loop(
-        lambda rows=None: _serialize_arrow_stream_table(table, rows=rows),
-        table.num_rows,
+    data, content_type, included_rows, _record_batch_count = serialize_arrow_stream(
+        table,
         max_bytes=max_bytes,
     )
-    return data, ARROW_STREAM_MIME, included_rows
+    return data, content_type, included_rows

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_summary.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_summary.py
@@ -1,7 +1,7 @@
 """Generate ``text/llm+plain`` summaries for DataFrames, computed Python-side.
 
 Python has direct access to the schema, dtypes, and null counts; deriving the
-summary in-place is far simpler than reparsing parquet server-side. The
+summary in-place is far simpler than reparsing Arrow IPC server-side. The
 ``repr-llm`` crate remains the fallback when dx is not in the loop.
 """
 
@@ -298,7 +298,7 @@ def summarize_dataframe(
     """Produce a ``text/llm+plain`` summary for ``df``.
 
     The summary includes shape, per-column dtype + stats + null count, and a
-    small head sample. If the serialized parquet was downsampled, the header
+    small head sample. If the serialized Arrow payload was sampled, the header
     explicitly calls that out.
     """
     flavor = _detect_flavor(df)

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -132,7 +132,7 @@ def test_buffer_hook_routes_execute_result_via_displayhook(monkeypatch):
     ip, sent, pub, dh = _fake_ip_with_pubs()
     monkeypatch.setattr(_buffer_hook, "_get_ipython", lambda: ip)
 
-    data = b"fake-parquet"
+    data = b"fake-arrow"
     h = hashlib.sha256(data).hexdigest()
     _buffer_hook.pending_buffers()[h] = data
 
@@ -154,7 +154,7 @@ def test_buffer_hook_routes_display_data_via_display_pub(monkeypatch):
     ip, sent, pub, dh = _fake_ip_with_pubs()
     monkeypatch.setattr(_buffer_hook, "_get_ipython", lambda: ip)
 
-    data = b"display-parquet"
+    data = b"display-arrow"
     h = hashlib.sha256(data).hexdigest()
     _buffer_hook.pending_buffers()[h] = data
 
@@ -352,12 +352,22 @@ def test_install_registers_iterable_dataset_formatter():
     """Streaming HF datasets must reach the summary-only formatter path."""
     from IPython.core.formatters import DisplayFormatter
     from nteract_kernel_launcher import _bootstrap
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
 
     display_formatter = DisplayFormatter()
     ip = SimpleNamespace(display_formatter=display_formatter)
 
     _bootstrap._install_dataframe_formatters(ip)
 
+    assert isinstance(
+        display_formatter.formatters[BLOB_REF_MIME],
+        _bootstrap.ArrowBlobRefFormatter,
+    )
+    assert isinstance(
+        display_formatter.formatters[ARROW_STREAM_MANIFEST_MIME],
+        _bootstrap.ArrowStreamManifestFormatter,
+    )
     deferred = display_formatter.mimebundle_formatter.deferred_printers
     assert ("datasets.iterable_dataset", "IterableDataset") in deferred
 
@@ -365,7 +375,7 @@ def test_install_registers_iterable_dataset_formatter():
 # ─── emit path — only runs if pandas + pyarrow are importable ────────────
 
 
-def test_emit_dataframe_stashes_bytes_and_returns_bundle():
+def test_arrow_stream_formatter_stashes_bytes_and_returns_bundle():
     pd = pytest.importorskip("pandas")
     pytest.importorskip("pyarrow")
 
@@ -375,7 +385,7 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
 
     _buffer_hook.pending_buffers().clear()
     df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    bundle = _bootstrap._pandas_mimebundle(df)
+    bundle = _bootstrap._arrow_stream_mimebundle(df)
     assert bundle is not None
     assert BLOB_REF_MIME in bundle
     assert "text/llm+plain" in bundle
@@ -392,7 +402,7 @@ def test_emit_dataframe_stashes_bytes_and_returns_bundle():
     ]
 
 
-# ─── pyarrow.Table path — preserves schema KV metadata ───────────────────
+# ─── Arrow stream path — preserves schema KV metadata ────────────────────
 
 
 def _pa_table_with_hf_metadata():
@@ -438,7 +448,7 @@ def test_emit_pyarrow_table_preserves_huggingface_kv_metadata():
     _buffer_hook.pending_buffers().clear()
     table = _pa_table_with_hf_metadata()
 
-    bundle = _bootstrap._pyarrow_table_mimebundle(table)
+    bundle = _bootstrap._arrow_stream_mimebundle(table)
 
     assert bundle is not None
     assert BLOB_REF_MIME in bundle
@@ -464,7 +474,7 @@ def test_emit_pyarrow_table_chunks_when_full_stream_exceeds_limit(monkeypatch):
     monkeypatch.setattr(_bootstrap, "_MAX_PAYLOAD_BYTES", 1)
     table = _pa_table_with_hf_metadata()
 
-    bundle = _bootstrap._pyarrow_table_mimebundle(table)
+    bundle = _bootstrap._arrow_stream_mimebundle(table)
 
     assert bundle is not None
     manifest = bundle[ARROW_STREAM_MANIFEST_MIME]
@@ -495,7 +505,7 @@ def test_emit_pyarrow_record_batch_promotes_to_table():
     table = _pa_table_with_hf_metadata()
     batch = table.to_batches()[0]
 
-    bundle = _bootstrap._pyarrow_record_batch_mimebundle(batch)
+    bundle = _bootstrap._arrow_stream_mimebundle(batch)
 
     assert bundle is not None
     assert BLOB_REF_MIME in bundle

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -1,7 +1,7 @@
 """Tests for the table serialization helpers in ``_format``.
 
 Coverage focus: table-like producers emit Arrow IPC, preserve schema metadata,
-and downsample through the same bounded head/slice loop.
+and expose chunked manifests when one blob would be too large.
 """
 
 from __future__ import annotations
@@ -36,19 +36,16 @@ def test_serialize_arrow_table_preserves_schema_metadata():
     assert md[b"custom"] == b"value"
 
 
-def test_serialize_arrow_table_downsamples_when_oversized():
-    pa = pytest.importorskip("pyarrow")
+def test_serialize_arrow_table_requires_manifest_when_oversized():
+    pytest.importorskip("pyarrow")
     from nteract_kernel_launcher._format import serialize_arrow_table
 
     table = _pa_table_with_hf_metadata()
-    # Force the loop to fire by setting the cap below the full size.
     full_data, _, _ = serialize_arrow_table(table, max_bytes=10_000_000)
     cap = max(1, len(full_data) // 4)
 
-    data, _, included_rows = serialize_arrow_table(table, max_bytes=cap)
-    decoded = pa.ipc.open_stream(io.BytesIO(data)).read_all()
-    assert decoded.num_rows == included_rows
-    assert len(data) <= cap or included_rows < table.num_rows
+    with pytest.raises(ValueError, match="chunked manifest is required"):
+        serialize_arrow_table(table, max_bytes=cap)
 
 
 def test_serialize_dataframe_pandas_round_trips_data():
@@ -79,14 +76,19 @@ def test_serialize_dataframe_pandas_preserves_index_metadata():
     assert "label" in table.column_names
 
 
-def test_serialize_dataframe_pandas_uses_direct_table_writer(monkeypatch):
+def test_serialize_dataframe_pandas_uses_arrow_stream_protocol(monkeypatch):
     pd = pytest.importorskip("pandas")
     import nteract_kernel_launcher._format as fmt
 
-    def fail_pycapsule_path(*_args, **_kwargs):
-        raise AssertionError("pandas should write its pa.Table directly")
+    calls = 0
+    original = fmt._record_batch_reader_from_stream
 
-    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", fail_pycapsule_path)
+    def spy(source):
+        nonlocal calls
+        calls += 1
+        return original(source)
+
+    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", spy)
 
     data, ct, included_rows = fmt.serialize_dataframe(
         pd.DataFrame({"a": [1, 2, 3]}),
@@ -96,6 +98,7 @@ def test_serialize_dataframe_pandas_uses_direct_table_writer(monkeypatch):
     assert ct == fmt.ARROW_STREAM_MIME
     assert included_rows == 3
     assert data
+    assert calls == 1
 
 
 def test_serialize_dataframe_polars_emits_arrow_stream():
@@ -113,14 +116,19 @@ def test_serialize_dataframe_polars_emits_arrow_stream():
     assert table.num_rows == 3
 
 
-def test_serialize_dataframe_polars_uses_native_writer(monkeypatch):
+def test_serialize_dataframe_polars_uses_arrow_stream_protocol(monkeypatch):
     pl = pytest.importorskip("polars")
     import nteract_kernel_launcher._format as fmt
 
-    def fail_pycapsule_path(*_args, **_kwargs):
-        raise AssertionError("polars should use its native IPC writer")
+    calls = 0
+    original = fmt._record_batch_reader_from_stream
 
-    monkeypatch.setattr(fmt, "_serialize_arrow_stream_exportable", fail_pycapsule_path)
+    def spy(source):
+        nonlocal calls
+        calls += 1
+        return original(source)
+
+    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", spy)
 
     data, ct, included_rows = fmt.serialize_dataframe(
         pl.DataFrame({"a": [1, 2, 3]}),
@@ -130,6 +138,7 @@ def test_serialize_dataframe_polars_uses_native_writer(monkeypatch):
     assert ct == fmt.ARROW_STREAM_MIME
     assert included_rows == 3
     assert data
+    assert calls == 1
 
 
 def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
@@ -177,18 +186,23 @@ def test_serialize_dataframe_rejects_oversized_generic_pycapsule_stream():
         def __len__(self):
             return self._table.num_rows
 
-    with pytest.raises(ValueError, match="progressive chunking is required"):
+    with pytest.raises(ValueError, match="chunked manifest is required"):
         serialize_dataframe(SinglePassStream(), max_bytes=1)
 
 
-def test_serialize_arrow_table_uses_direct_writer(monkeypatch):
+def test_serialize_arrow_table_uses_arrow_stream_protocol(monkeypatch):
     pa = pytest.importorskip("pyarrow")
     import nteract_kernel_launcher._format as fmt
 
-    def fail_pycapsule_path(*_args, **_kwargs):
-        raise AssertionError("pyarrow.Table should use direct IPC writer")
+    calls = 0
+    original = fmt._record_batch_reader_from_stream
 
-    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", fail_pycapsule_path)
+    def spy(source):
+        nonlocal calls
+        calls += 1
+        return original(source)
+
+    monkeypatch.setattr(fmt, "_record_batch_reader_from_stream", spy)
 
     data, ct, included_rows = fmt.serialize_arrow_table(
         pa.table({"a": [1, 2, 3]}),
@@ -199,6 +213,7 @@ def test_serialize_arrow_table_uses_direct_writer(monkeypatch):
     assert ct == fmt.ARROW_STREAM_MIME
     assert included_rows == 3
     assert table.num_rows == 3
+    assert calls == 1
 
 
 def test_build_arrow_stream_manifest_describes_one_chunk():
@@ -251,12 +266,12 @@ def test_iter_arrow_stream_chunks_yields_decodable_mini_streams():
 
     chunks = list(iter_arrow_stream_chunks(reader, max_chunk_bytes=1))
 
-    assert [chunk.index for chunk in chunks] == [0, 1, 2]
-    assert [chunk.row_count for chunk in chunks] == [2, 2, 2]
-    assert [chunk.record_batch_count for chunk in chunks] == [1, 1, 1]
+    assert [chunk.index for chunk in chunks] == list(range(len(chunks)))
+    assert sum(chunk.row_count for chunk in chunks) == 6
+    assert [chunk.record_batch_count for chunk in chunks] == [1] * len(chunks)
     decoded = [pa.ipc.open_stream(io.BytesIO(chunk.data)).read_all() for chunk in chunks]
-    assert [part.num_rows for part in decoded] == [2, 2, 2]
-    assert [part.column_names for part in decoded] == [["a", "b"], ["a", "b"], ["a", "b"]]
+    assert sum(part.num_rows for part in decoded) == 6
+    assert [part.column_names for part in decoded] == [["a", "b"]] * len(chunks)
     assert [chunk.manifest_entry()["hash"] for chunk in chunks] == [
         chunk.content_hash for chunk in chunks
     ]
@@ -271,7 +286,8 @@ def test_iter_arrow_stream_chunks_preserves_schema_metadata():
 
     chunks = list(iter_arrow_stream_chunks(reader, max_chunk_bytes=1))
 
-    assert len(chunks) == 2
+    assert len(chunks) > 2
+    assert sum(chunk.row_count for chunk in chunks) == table.num_rows
     for chunk in chunks:
         decoded = pa.ipc.open_stream(io.BytesIO(chunk.data)).read_all()
         md = decoded.schema.metadata or {}
@@ -297,8 +313,8 @@ def test_iter_arrow_stream_chunks_consumes_pycapsule_stream_once():
     source = SinglePassStream()
     chunks = list(iter_arrow_stream_chunks(source, max_chunk_bytes=1))
 
-    assert len(chunks) == 1
-    assert chunks[0].row_count == 4
+    assert len(chunks) == 4
+    assert sum(chunk.row_count for chunk in chunks) == 4
     assert source._used is True
 
 

--- a/python/runtimed/tests/test_dx_integration.py
+++ b/python/runtimed/tests/test_dx_integration.py
@@ -4,14 +4,13 @@ Verifies that `dx.display(df)` rides the ``display_data`` + IOPub ``buffers``
 path (not the legacy raw-bytes-in-JSON path):
 
 - The kernel publishes one ``display_data`` whose wire envelope carries a
-  trailing ZMQ buffer frame with the parquet bytes.
+  trailing ZMQ buffer frame with Arrow IPC stream bytes.
 - The runtime agent writes the buffer to the blob store via
   ``preflight_ref_buffers`` and composes a ``ContentRef::Blob`` under
-  ``application/vnd.apache.parquet`` (the ``BLOB_REF_MIME`` entry is consumed,
-  never emitted as a manifest entry).
-- The resolved cell output surfaces the parquet bytes (read back through the
-  Python bindings) with a matching SHA-256 hash, plus the Python-side
-  ``text/llm+plain`` summary.
+  ``application/vnd.apache.arrow.stream`` (the ``BLOB_REF_MIME`` entry is
+  consumed, never emitted as a manifest entry).
+- The resolved cell output surfaces Arrow stream bytes or an Arrow stream
+  manifest with chunk refs, plus the Python-side ``text/llm+plain`` summary.
 
 Running locally (with dev daemon already running):
     .venv/bin/python -m pytest python/runtimed/tests/test_dx_integration.py -v
@@ -30,6 +29,7 @@ test no longer needs anything special.
 from __future__ import annotations
 
 import hashlib
+import json
 import sys
 from pathlib import Path
 
@@ -58,11 +58,28 @@ from test_daemon_integration import (  # noqa: E402, F401, F811
 )
 
 _BOOTSTRAP = "import dx\ndx.install()\n"
+ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
+ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
+BLOB_REF_MIME = "application/vnd.nteract.blob-ref+json"
+
+
+def _read_arrow_table(data: bytes):
+    import pyarrow as pa
+
+    return pa.ipc.open_stream(pa.BufferReader(bytes(data))).read_all()
+
+
+def _arrow_manifest(data: dict) -> dict:
+    raw = data[ARROW_STREAM_MANIFEST_MIME]
+    if isinstance(raw, str):
+        return json.loads(raw)
+    assert isinstance(raw, dict), type(raw).__name__
+    return raw
 
 
 @pytest.mark.integration
 async def test_dx_display_emits_blob_ref_with_buffers(session):  # noqa: F811
-    """`dx.display(df)` produces a display_data whose parquet entry resolves
+    """`dx.display(df)` produces a display_data whose Arrow stream resolves
     to content matching the Python-side SHA-256 — proof the bytes rode the
     IOPub buffer frame and the agent stored them in the blob store."""
     await async_start_kernel_with_retry(session, env_source="uv:pyproject")
@@ -75,7 +92,7 @@ async def test_dx_display_emits_blob_ref_with_buffers(session):  # noqa: F811
 
     # Emit a DataFrame. Bare `df` on the last line triggers dx's
     # `ipython_display_formatter` — it serializes, hashes, and publishes a
-    # display_data via kernel.session.send with buffers=[parquet].
+    # display_data via kernel.session.send with buffers=[arrow_stream].
     display_id = await async_create_cell_and_wait_for_sync(
         session,
         """
@@ -97,20 +114,19 @@ df
 
     # The ref MIME is a transport detail — consumed by the agent, never in
     # the resolved manifest.
-    assert "application/vnd.nteract.blob-ref+json" not in display.data, (
+    assert BLOB_REF_MIME not in display.data, (
         "BLOB_REF_MIME leaked into the inline manifest — the ref-MIME branch "
         "in create_manifest should have consumed it."
     )
 
-    # Parquet bytes — resolved from the blob store by the Python bindings.
-    assert "application/vnd.apache.parquet" in display.data, (
-        f"parquet MIME missing. keys: {list(display.data.keys())}"
+    # Arrow stream bytes — resolved from the blob store by the Python bindings.
+    assert ARROW_STREAM_MIME in display.data, (
+        f"Arrow stream MIME missing. keys: {list(display.data.keys())}"
     )
-    parquet_bytes = display.data["application/vnd.apache.parquet"]
-    assert isinstance(parquet_bytes, (bytes, bytearray)), (
-        f"expected parquet bytes, got {type(parquet_bytes).__name__}"
+    arrow_bytes = display.data[ARROW_STREAM_MIME]
+    assert isinstance(arrow_bytes, (bytes, bytearray)), (
+        f"expected Arrow stream bytes, got {type(arrow_bytes).__name__}"
     )
-    assert parquet_bytes[:4] == b"PAR1", "not a parquet file (bad magic)"
 
     # Python-side llm summary.
     assert "text/llm+plain" in display.data, (
@@ -123,53 +139,49 @@ df
     # Python-generated summary, not repr-llm — distinctive header format.
     assert llm.startswith("DataFrame (pandas)"), llm
 
-    # Content-addressed round-trip: the parquet we read back from the blob
+    # Content-addressed round-trip: the Arrow stream we read back from the blob
     # store hashes to the same digest the kernel computed before uploading.
     # This proves the bytes we got are the exact bytes that rode the IOPub
     # buffer frame, not something re-encoded server-side.
-    computed = hashlib.sha256(bytes(parquet_bytes)).hexdigest()
+    computed = hashlib.sha256(bytes(arrow_bytes)).hexdigest()
 
-    # Use pyarrow to round-trip the parquet and confirm row count matches —
+    # Use pyarrow to round-trip the stream and confirm row count matches —
     # extra sanity that what we got back is the DataFrame the kernel serialized.
-    import io
-
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
-    table = pq.read_table(io.BytesIO(bytes(parquet_bytes)))
+    table = _read_arrow_table(bytes(arrow_bytes))
     assert table.num_rows == 3
     assert set(table.column_names) == {"a", "b"}
+    manifest = _arrow_manifest(display.data)
+    assert manifest["content_type"] == ARROW_STREAM_MIME
+    assert manifest["chunks"][0]["hash"] == computed
+    assert manifest["chunks"][0]["row_count"] == 3
     # sanity: the hash we computed is a valid hex sha256 (64 hex chars).
     assert len(computed) == 64 and all(c in "0123456789abcdef" for c in computed)
 
 
 @pytest.mark.integration
-async def test_dx_display_large_df_downsamples_and_flags_summary(session):  # noqa: F811
+async def test_dx_display_large_df_emits_chunked_arrow_manifest(session):  # noqa: F811
     """When the serialized payload would exceed the per-message ceiling,
-    dx downsamples via df.head(n) and the ref-MIME summary hints should
-    flag ``sampled=true`` with the total row count.
-
-    We can't observe summary hints in the resolved manifest (they're
-    transport-only), but we can observe the downsampling outcome: the
-    parquet we read back has fewer rows than the DataFrame we emitted,
-    and the llm summary explicitly calls out the sampling."""
+    dx emits a multi-chunk Arrow stream manifest whose chunks ride attached
+    IOPub buffers and are stored as blob refs."""
     await async_start_kernel_with_retry(session, env_source="uv:pyproject")
 
     bootstrap_id = await async_create_cell_and_wait_for_sync(session, _BOOTSTRAP)
     assert (await session.execute_cell(bootstrap_id)).success
 
-    # Force downsampling via a low DX_MAX_PAYLOAD_BYTES. 2 KiB ceiling; a
-    # 200_000-row int64 DataFrame is orders of magnitude over that.
+    # Force chunking via a low DX_MAX_PAYLOAD_BYTES. The payload is large
+    # enough to split, but small enough to keep the integration test quick.
+    row_count = 10_000
     display_id = await async_create_cell_and_wait_for_sync(
         session,
-        """
+        f"""
 import os, importlib
-os.environ["DX_MAX_PAYLOAD_BYTES"] = "2048"
+os.environ["DX_MAX_PAYLOAD_BYTES"] = "4096"
 # re-import so _format_install picks up the env
 import dx._format_install as _fi
 importlib.reload(_fi)
 
 import pandas as pd
-big = pd.DataFrame({"i": list(range(200_000))})
+big = pd.DataFrame({{"i": list(range({row_count}))}})
 big
 """,
     )
@@ -179,29 +191,26 @@ big
     assert len(result.display_data) == 1
     display = result.display_data[0]
 
-    parquet_bytes = display.data["application/vnd.apache.parquet"]
-    assert parquet_bytes[:4] == b"PAR1"
-
-    import io
-
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
-    table = pq.read_table(io.BytesIO(bytes(parquet_bytes)))
-    # Downsampled to fit under 2 KiB — must be strictly less than 200_000.
-    assert table.num_rows < 200_000, f"expected downsampled parquet, got {table.num_rows} rows"
-    assert table.num_rows >= 1, "must keep at least one row"
+    assert ARROW_STREAM_MIME not in display.data, (
+        "multi-chunk tables should resolve through the manifest rather than "
+        "a single direct Arrow stream blob"
+    )
+    manifest = _arrow_manifest(display.data)
+    assert manifest["content_type"] == ARROW_STREAM_MIME
+    assert len(manifest["chunks"]) > 1
+    assert sum(chunk["row_count"] for chunk in manifest["chunks"]) == row_count
+    assert manifest["summary"]["total_rows"] == row_count
+    assert manifest["summary"]["included_rows"] == row_count
+    assert manifest["summary"]["sampled"] is False
 
     llm = display.data["text/llm+plain"]
-    assert "sampled" in llm.lower(), f"summary did not mention sampling: {llm!r}"
-    assert "200,000" in llm, f"summary did not include total row count: {llm!r}"
+    assert "10,000" in llm, f"summary did not include total row count: {llm!r}"
 
 
 @pytest.mark.integration
 async def test_dx_polars_display_emits_blob_ref_with_buffers(session):  # noqa: F811
     """Same content-addressed round-trip as the pandas test, but exercising
-    the polars encoder path in `_format._serialize_polars`. Polars writes
-    parquet via its own native encoder (not pyarrow), so this is a real
-    end-to-end check that the polars side hashes/uploads/resolves correctly.
+    a polars object through the shared Arrow stream protocol.
 
     Skipped if polars isn't installed — dx ships with polars as an optional
     extra (`dx[polars]`), and minimal environments may not have it.
@@ -235,48 +244,34 @@ df
     assert output.output_type == "display_data"
 
     # The transport ref MIME is consumed by the agent, never surfaces.
-    assert "application/vnd.nteract.blob-ref+json" not in output.data, (
+    assert BLOB_REF_MIME not in output.data, (
         "BLOB_REF_MIME leaked into the inline manifest — the ref-MIME branch "
         "in create_manifest should have consumed it."
     )
 
-    # Parquet bytes resolved from the blob store.
-    parquet_bytes = output.data.get("application/vnd.apache.parquet")
-    assert parquet_bytes is not None, (
-        f"parquet MIME missing — polars encoder may not have run. keys: {list(output.data.keys())}"
+    # Arrow stream bytes resolved from the blob store.
+    arrow_bytes = output.data.get(ARROW_STREAM_MIME)
+    assert arrow_bytes is not None, (
+        f"Arrow stream MIME missing — stream protocol may not have run. "
+        f"keys: {list(output.data.keys())}"
     )
-    assert isinstance(parquet_bytes, (bytes, bytearray))
-    assert parquet_bytes[:4] == b"PAR1", "not a parquet file (bad magic)"
+    assert isinstance(arrow_bytes, (bytes, bytearray))
 
     # Python-side llm summary identifies polars specifically.
     llm = output.data.get("text/llm+plain", "")
     assert llm.startswith("DataFrame (polars)"), f"expected polars summary, got: {llm[:80]!r}"
 
-    # Round-trip via pyarrow to verify the bytes are valid parquet AND
+    # Round-trip via pyarrow to verify the bytes are a valid Arrow stream AND
     # contain the columns we sent.
-    import io
-
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
-    table = pq.read_table(io.BytesIO(bytes(parquet_bytes)))
+    table = _read_arrow_table(bytes(arrow_bytes))
     assert table.num_rows == 3
     assert set(table.column_names) == {"a", "b"}
 
 
 @pytest.mark.integration
-async def test_dx_polars_last_expression_uses_polars_encoder(session):  # noqa: F811
-    """Belt-and-suspenders for the polars path: confirm the parquet payload
-    was actually written by polars's native writer, not pyarrow.
-
-    Skipped if polars isn't installed.
-
-    The `text/llm+plain` summary alone isn't a reliable proof — it's
-    derived from `type(df).__module__` in `summarize_dataframe`, so it
-    would still say `(polars)` if `_serialize_polars` accidentally fell
-    through to a pyarrow path. We check the parquet file metadata
-    instead: polars writes `created_by = "Polars"`, while pyarrow writes
-    `created_by = "parquet-cpp-arrow ..."`. This catches an encoder
-    swap that the summary text would miss."""
+async def test_dx_polars_last_expression_uses_arrow_stream_protocol(session):  # noqa: F811
+    """Belt-and-suspenders for the polars path: confirm the payload is an
+    Arrow stream and the manifest keeps the schema/row metadata."""
     pytest.importorskip("polars")
     await async_start_kernel_with_retry(session, env_source="uv:pyproject")
 
@@ -298,26 +293,21 @@ pl.DataFrame({"id": list(range(100)), "name": [f"row-{i}" for i in range(100)]})
     output = rich[0]
 
     # Sanity on the summary side first — a useful diagnostic if the
-    # parquet check below fails.
+    # Arrow stream check below fails.
     llm = output.data.get("text/llm+plain", "")
     assert "(polars)" in llm, f"expected (polars) marker in summary, got: {llm[:120]!r}"
     assert "100 rows" in llm
     assert "2 columns" in llm
 
-    # The actual encoder check: read the parquet's `created_by` metadata.
-    # Polars writes "Polars"; pyarrow writes "parquet-cpp-arrow version …".
-    import io
+    arrow_bytes = output.data[ARROW_STREAM_MIME]
+    table = _read_arrow_table(bytes(arrow_bytes))
+    assert table.num_rows == 100
+    assert set(table.column_names) == {"id", "name"}
 
-    import pyarrow.parquet as pq  # noqa: PLC0415
-
-    parquet_bytes = output.data["application/vnd.apache.parquet"]
-    pq_file = pq.ParquetFile(io.BytesIO(bytes(parquet_bytes)))
-    created_by = pq_file.metadata.created_by or ""
-    assert created_by.startswith("Polars"), (
-        f"parquet was not written by polars's native encoder. "
-        f"created_by={created_by!r}. If this says 'parquet-cpp-arrow ...', "
-        f"`_serialize_polars` was bypassed and pyarrow ran instead."
-    )
+    manifest = _arrow_manifest(output.data)
+    assert manifest["content_type"] == ARROW_STREAM_MIME
+    assert manifest["chunks"][0]["row_count"] == 100
+    assert [field["name"] for field in manifest["schema"]["columns"]] == ["id", "name"]
 
 
 @pytest.mark.integration
@@ -332,7 +322,7 @@ async def test_dx_last_expression_emits_display_data_not_execute_result(session)
     ``({}, {})`` once our handler fires, which causes ``finish_displayhook``
     to skip its guarded send — no ``execute_result`` message is published.
     Our handler publishes a ``display_data`` directly via
-    ``publish_display_data``, which the publisher hook augments with parquet
+    ``publish_display_data``, which the publisher hook augments with Arrow stream
     buffers.
 
     The lumped ``ExecutionResult.display_data`` accessor in the Python
@@ -373,8 +363,8 @@ df
         f"ipython_display_formatter registration in dx._format_install may have "
         f"regressed."
     )
-    assert "application/vnd.apache.parquet" in output.data, (
-        f"parquet MIME missing — bytes did not ride through to the daemon: "
+    assert ARROW_STREAM_MIME in output.data, (
+        f"Arrow stream MIME missing — bytes did not ride through to the daemon: "
         f"{list(output.data.keys())}"
     )
 


### PR DESCRIPTION
## Summary

- replace library-specific Arrow output formatter registration in the kernel launcher with generic per-MIME formatters that detect `__arrow_c_stream__`
- route pandas, polars, pyarrow, narwhals, and other Arrow PyCapsule producers through the same IPC stream/chunk path
- update legacy `dx` to follow the same Arrow stream protocol model and refresh docs/tests

## Verification

- `uv run --project python/nteract-kernel-launcher --with pandas --with pyarrow --with polars --with narwhals --with datasets pytest python/nteract-kernel-launcher/tests/test_format.py python/nteract-kernel-launcher/tests/test_bootstrap.py -q`
- `uv run --project python/dx --with pandas --with pyarrow --with polars --with narwhals --with datasets pytest python/dx/tests/test_format.py python/dx/tests/test_install.py python/dx/tests/test_dx_integration.py -q`
- `uv run ruff check python/nteract-kernel-launcher python/dx`
- `uv run ty check python/nteract-kernel-launcher python/dx`

## Known Local Issue

- `cargo xtask lint --fix` reaches Python ruff/ty successfully, but the JS/TS `vp check` phase fails in this worktree because `vite.config.ts` cannot resolve the local `vite-plus` package.
