### PR TITLE
fix(notebook-cloud): reconnect on send-side socket failure

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -1,11 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  CloudWebSocketTransport,
   normalizeConnectionScope,
   startCloudBootstrapSync,
   syncableCloudHandle,
   withReadyTimeout,
 } from "../viewer/live-sync.ts";
+import { FrameType } from "../src/protocol.ts";
 
 describe("cloud live sync", () => {
   it("accepts known connection scopes", () => {
@@ -117,4 +119,143 @@ describe("cloud live sync", () => {
     handle.cancel_last_pool_state_flush();
     assert.deepEqual(calls, []);
   });
+
+  it("notifies disconnect when a send sees a closing socket before the close event", async () => {
+    const fake = installFakeWebSocket();
+    const disconnects: string[] = [];
+    try {
+      const transport = new CloudWebSocketTransport(
+        new URL("wss://example.test/n/room/sync"),
+        [],
+        undefined,
+        (reason) => disconnects.push(reason.message),
+      );
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      socket.readyState = FakeWebSocket.CLOSING;
+      await assert.rejects(
+        transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
+        /cloud sync socket is closed/,
+      );
+      socket.close({ code: 1006 });
+
+      assert.deepEqual(disconnects, ["cloud sync socket is closed"]);
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("notifies disconnect when WebSocket.send throws", async () => {
+    const fake = installFakeWebSocket();
+    const disconnects: string[] = [];
+    try {
+      const transport = new CloudWebSocketTransport(
+        new URL("wss://example.test/n/room/sync"),
+        [],
+        undefined,
+        (reason) => disconnects.push(reason.message),
+      );
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      socket.throwOnSend = true;
+      await assert.rejects(
+        transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
+        /cloud sync socket send failed: synthetic send failure/,
+      );
+      assert.deepEqual(disconnects, ["cloud sync socket send failed: synthetic send failure"]);
+    } finally {
+      fake.restore();
+    }
+  });
 });
+
+function installFakeWebSocket(): {
+  restore: () => void;
+  socket: FakeWebSocket;
+} {
+  const original = globalThis.WebSocket;
+  FakeWebSocket.instances = [];
+  globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  return {
+    restore: () => {
+      globalThis.WebSocket = original;
+    },
+    get socket() {
+      const socket = FakeWebSocket.instances[0];
+      assert.ok(socket, "expected a WebSocket instance");
+      return socket;
+    },
+  };
+}
+
+class FakeWebSocket extends EventTarget {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  binaryType: BinaryType = "arraybuffer";
+  readyState = FakeWebSocket.CONNECTING;
+  throwOnSend = false;
+
+  constructor() {
+    super();
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(): void {
+    if (this.throwOnSend) {
+      throw new Error("synthetic send failure");
+    }
+  }
+
+  close({ code = 1000, reason = "" }: { code?: number; reason?: string } = {}): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatchEvent(closeEvent(code, reason));
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.dispatchEvent(new Event("open"));
+  }
+
+  ready(peerId: string): void {
+    const payload = new TextEncoder().encode(
+      JSON.stringify({
+        type: "cloud_room_ready",
+        protocol: "v4",
+        notebook_id: "room",
+        peer_id: peerId,
+        actor_label: `user:dev:alice/desktop:${peerId}`,
+        connection_scope: "editor",
+        timestamp: "2026-05-24T00:00:00.000Z",
+      }),
+    );
+    const frame = new Uint8Array(payload.byteLength + 1);
+    frame[0] = FrameType.SESSION_CONTROL;
+    frame.set(payload, 1);
+    this.dispatchEvent(messageEvent(frame.buffer));
+  }
+}
+
+function messageEvent(data: ArrayBuffer): Event {
+  const event = new Event("message");
+  Object.defineProperty(event, "data", { value: data });
+  return event;
+}
+
+function closeEvent(code: number, reason: string): Event {
+  const event = new Event("close");
+  Object.defineProperties(event, {
+    code: { value: code },
+    reason: { value: reason },
+  });
+  return event;
+}

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -219,25 +219,24 @@ export class CloudWebSocketTransport implements NotebookTransport {
       void this.handleMessage(event.data);
     });
     this.socket.addEventListener("error", () => {
-      this.readyReject(new Error(`failed to connect ${url.href}`));
+      const reason = new Error(`cloud sync socket failed`);
+      if (!this.readySettled) {
+        this.readyReject(new Error(`failed to connect ${url.href}`));
+      }
+      this.markClosed(reason);
     });
     this.socket.addEventListener("close", (event) => {
-      this.closed = true;
-      this.listeners.clear();
-      this.queuedFrames = [];
       const detail = event.reason ? `: ${event.reason}` : "";
       const reason = new Error(`cloud sync socket closed (${event.code})${detail}`);
       if (!this.readySettled) {
         this.readyReject(new Error(`cloud sync socket closed before ready`));
       }
-      if (this.readyResolved && !this.manualDisconnect) {
-        this.onDisconnect?.(reason);
-      }
+      this.markClosed(reason);
     });
   }
 
   get connected(): boolean {
-    return this.socket.readyState === WebSocket.OPEN;
+    return !this.closed && this.socket.readyState === WebSocket.OPEN;
   }
 
   async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
@@ -248,7 +247,16 @@ export class CloudWebSocketTransport implements NotebookTransport {
     const frame = new Uint8Array(payload.byteLength + 1);
     frame[0] = frameType;
     frame.set(payload, 1);
-    this.socket.send(frame);
+    try {
+      this.socket.send(frame);
+    } catch (error) {
+      const reason =
+        error instanceof Error
+          ? new Error(`cloud sync socket send failed: ${error.message}`)
+          : new Error(`cloud sync socket send failed: ${String(error)}`);
+      this.markClosed(reason);
+      throw reason;
+    }
   }
 
   async sendTypedRequest(
@@ -318,7 +326,9 @@ export class CloudWebSocketTransport implements NotebookTransport {
       this.socket.readyState === WebSocket.CLOSED ||
       this.socket.readyState === WebSocket.CLOSING
     ) {
-      return Promise.reject(new Error("cloud sync socket is closed"));
+      const reason = new Error("cloud sync socket is closed");
+      this.markClosed(reason);
+      return Promise.reject(reason);
     }
 
     return new Promise((resolve, reject) => {
@@ -330,6 +340,16 @@ export class CloudWebSocketTransport implements NotebookTransport {
         once: true,
       });
     });
+  }
+
+  private markClosed(reason: Error): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.listeners.clear();
+    this.queuedFrames = [];
+    if (this.readyResolved && !this.manualDisconnect) {
+      this.onDisconnect?.(reason);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Treat send-side WebSocket closed/closing states as real disconnects for notebook-cloud live sync.
- Notify the React reconnect loop when `WebSocket.send()` throws so stale editors do not keep typing against a dead transport.
- Add transport unit coverage for closing sockets discovered before the close event and synthetic send failures.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts test/collaborator-auth.test.ts test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
- Deployed to Cloudflare Worker version `4a72085a-5187-4a42-8a23-420047cb6527`
- `NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev pnpm --dir apps/notebook-cloud smoke:hosted:collab`
  - throwaway room: `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/wasm-1779634669548`
