### PR TITLE
fix(notebook-cloud): surface collaborator auth diagnostics

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -185,7 +185,11 @@ For the browser-hosted editor prototype, the viewer keeps the dev token out of
 URLs. Open the key menu in the sticky toolbar, paste the Worker dev token, pick
 `alice`/`bob` and `editor`, and apply the identity. The token is stored only in
 origin-local browser storage and is sent to `/n/:id/sync` as a WebSocket
-subprotocol, never as a query parameter.
+subprotocol, never as a query parameter. The same menu shows sanitized
+diagnostics for the requested principal/scope, connected room actor/scope,
+placeholder-token fallback, and the latest connection error. Use **Copy
+diagnostics** when sharing an `Offline` report; it intentionally omits the dev
+token.
 
 For scripted browser setup, use the same storage keys the toolbar manages:
 
@@ -425,7 +429,10 @@ records, no unexpected `room.frame.rejected` records for Alice/Bob, and
 anonymous viewer presence logged only as `room.presence.local_only`. If the
 browser shows `Offline`, open the key menu first: placeholder or stale dev
 tokens are surfaced there, and the Worker logs token/auth failures as
-`auth.failed` without recording raw token material.
+`auth.failed` without recording raw token material. The copied browser
+diagnostic should include the requested principal/scope, connected actor/scope
+when available, and the last WebSocket connection error, but never the stored
+token value.
 
 Snapshot and blob stubs:
 

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -6,6 +6,7 @@ import {
   NOTEBOOK_CLOUD_USER_STORAGE_KEY,
   clearCloudPrototypeDevAuth,
   cloudSyncAuthFromPrototypeAuthState,
+  prototypeAuthDiagnostics,
   prototypeAuthSummary,
   readCloudPrototypeAuth,
   storeCloudPrototypeDevAuth,
@@ -94,6 +95,46 @@ describe("cloud collaborator auth", () => {
     assert.match(validatePrototypeToken("NOTEBOOK_CLOUD_DEV_TOKEN") ?? "", /placeholder/);
     assert.match(validatePrototypeToken("<paste token here>") ?? "", /placeholder/);
     assert.equal(validatePrototypeToken("real-token"), null);
+  });
+
+  it("builds safe diagnostics without exposing token material", () => {
+    const storage = new MemoryStorage();
+    storeCloudPrototypeDevAuth(storage, {
+      token: "secret-token",
+      user: "alice@example.com",
+      scope: "editor",
+    });
+
+    const diagnostics = prototypeAuthDiagnostics(readCloudPrototypeAuth(storage), {
+      actorLabel: "user:dev:alice%40example.com/desktop:browser",
+      connectionError: null,
+      connectionScope: "editor",
+    });
+
+    assert.match(diagnostics.copyText, /Requested principal: user:dev:alice%40example\.com/);
+    assert.match(diagnostics.copyText, /Connected scope: editor/);
+    assert.match(diagnostics.copyText, /Room actor: user:dev:alice%40example\.com/);
+    assert.doesNotMatch(diagnostics.copyText, /secret-token/);
+  });
+
+  it("diagnoses invalid stored credentials as anonymous fallback", () => {
+    const storage = new MemoryStorage();
+    storeCloudPrototypeDevAuth(storage, {
+      token: "<NOTEBOOK_CLOUD_DEV_TOKEN>",
+      user: "alice",
+      scope: "owner",
+    });
+
+    const diagnostics = prototypeAuthDiagnostics(readCloudPrototypeAuth(storage), {
+      actorLabel: null,
+      connectionError: "failed to connect",
+      connectionScope: null,
+    });
+
+    assert.match(diagnostics.copyText, /Effective auth: Anonymous viewer/);
+    assert.match(diagnostics.copyText, /Connected scope: Offline/);
+    assert.match(diagnostics.copyText, /Last connection error: failed to connect/);
+    assert.doesNotMatch(diagnostics.copyText, /<NOTEBOOK_CLOUD_DEV_TOKEN>/);
   });
 });
 

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -35,6 +35,23 @@ export interface CloudPrototypeAuthInput {
   scope: ConnectionScope;
 }
 
+export interface CloudPrototypeConnectionDiagnostics {
+  actorLabel: string | null;
+  connectionError: string | null;
+  connectionScope: string | null;
+}
+
+export interface CloudPrototypeAuthDiagnosticRow {
+  label: string;
+  value: string;
+  tone?: "default" | "warning" | "success";
+}
+
+export interface CloudPrototypeAuthDiagnostics {
+  rows: CloudPrototypeAuthDiagnosticRow[];
+  copyText: string;
+}
+
 export function cloudPrototypeAuthFromWindow(): CloudPrototypeAuthState {
   if (typeof window === "undefined") {
     return anonymousAuthState();
@@ -133,6 +150,100 @@ export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
   return "Anonymous read-only viewer";
 }
 
+export function prototypeAuthDiagnostics(
+  state: CloudPrototypeAuthState,
+  connection: CloudPrototypeConnectionDiagnostics,
+): CloudPrototypeAuthDiagnostics {
+  const rows: CloudPrototypeAuthDiagnosticRow[] = [];
+  if (state.mode === "dev") {
+    rows.push(
+      {
+        label: "Requested principal",
+        value: devPrincipalLabel(state.user ?? "browser-editor"),
+      },
+      {
+        label: "Requested scope",
+        value: state.requestedScope ?? "editor",
+      },
+      {
+        label: "Dev token",
+        value: "Stored locally; sent as a WebSocket subprotocol, never in the URL.",
+      },
+    );
+  } else if (state.mode === "invalid") {
+    rows.push(
+      {
+        label: "Stored identity",
+        value: `${devPrincipalLabel(state.user ?? "browser-editor")} requesting ${
+          state.requestedScope ?? "editor"
+        }`,
+        tone: "warning",
+      },
+      {
+        label: "Dev token",
+        value: state.problem ?? "Stored token is invalid.",
+        tone: "warning",
+      },
+      {
+        label: "Effective auth",
+        value: "Anonymous viewer until the token is replaced or reset.",
+        tone: "warning",
+      },
+    );
+  } else {
+    rows.push(
+      {
+        label: "Effective auth",
+        value: "Anonymous read-only viewer.",
+      },
+      {
+        label: "Dev token",
+        value: "Not stored.",
+      },
+    );
+  }
+
+  if (connection.connectionScope) {
+    rows.push({
+      label: "Connected scope",
+      value: connection.connectionScope,
+      tone: "success",
+    });
+  } else if (connection.connectionError) {
+    rows.push({
+      label: "Connected scope",
+      value: "Offline",
+      tone: "warning",
+    });
+  } else {
+    rows.push({
+      label: "Connected scope",
+      value: "Connecting...",
+    });
+  }
+
+  if (connection.actorLabel) {
+    rows.push({
+      label: "Room actor",
+      value: connection.actorLabel,
+      tone: "success",
+    });
+  }
+
+  if (connection.connectionError) {
+    rows.push({
+      label: "Last connection error",
+      value: connection.connectionError,
+      tone: "warning",
+    });
+  }
+
+  return {
+    rows,
+    copyText: rows.map((row) => `${row.label}: ${row.value}`).join("\n"),
+  };
+}
+
 function anonymousAuthState(): CloudPrototypeAuthState {
   return {
     mode: "anonymous",
@@ -154,4 +265,8 @@ function base64UrlEncode(value: string): string {
     binary += String.fromCharCode(byte);
   }
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+function devPrincipalLabel(user: string): string {
+  return `user:dev:${encodeURIComponent(user.trim() || "browser-editor")}`;
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -163,6 +163,47 @@ body {
   line-height: 1.35;
 }
 
+.cloud-auth-diagnostics {
+  display: grid;
+  gap: 0.375rem;
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  border-radius: 6px;
+  padding: 0.5rem;
+  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+}
+
+.cloud-auth-diagnostics div {
+  display: grid;
+  grid-template-columns: minmax(6rem, 0.42fr) minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+.cloud-auth-diagnostics dt,
+.cloud-auth-diagnostics dd {
+  min-width: 0;
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.cloud-auth-diagnostics dt {
+  color: color-mix(in srgb, var(--foreground) 52%, transparent);
+}
+
+.cloud-auth-diagnostics dd {
+  overflow-wrap: anywhere;
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
+}
+
+.cloud-auth-diagnostics div[data-tone="warning"] dd {
+  color: #b42318;
+}
+
+.cloud-auth-diagnostics div[data-tone="success"] dd {
+  color: #0f766e;
+}
+
 .cloud-auth-menu label {
   display: grid;
   gap: 0.25rem;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { createRoot } from "react-dom/client";
-import { Code2, Eye, EyeOff, KeyRound, RotateCcw, UsersRound } from "lucide-react";
+import { Code2, Copy, Eye, EyeOff, KeyRound, RotateCcw, UsersRound } from "lucide-react";
 import {
   ReadOnlyNotebook,
   type ReadOnlyNotebookCellData,
@@ -19,6 +19,7 @@ import {
   clearCloudPrototypeDevAuth,
   cloudPrototypeAuthFromWindow,
   cloudSyncAuthFromPrototypeAuthState,
+  prototypeAuthDiagnostics,
   prototypeAuthSummary,
   storeCloudPrototypeDevAuth,
   validatePrototypeToken,
@@ -482,6 +483,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         <div className="cloud-toolbar-actions">
           <CloudAuthControls
             authState={authState}
+            connectionActorLabel={connectionActorLabel}
+            connectionError={connectionError}
             connectionScope={connectionScope}
             onAuthStateChange={() => setAuthState(cloudPrototypeAuthFromWindow())}
           />
@@ -572,10 +575,14 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
 
 function CloudAuthControls({
   authState,
+  connectionActorLabel,
+  connectionError,
   connectionScope,
   onAuthStateChange,
 }: {
   authState: CloudPrototypeAuthState;
+  connectionActorLabel: string | null;
+  connectionError: string | null;
   connectionScope: string | null;
   onAuthStateChange: () => void;
 }) {
@@ -583,12 +590,21 @@ function CloudAuthControls({
   const [user, setUser] = useState(authState.user ?? "alice");
   const [scope, setScope] = useState<ConnectionScope>(authState.requestedScope ?? "editor");
   const [formError, setFormError] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const summary =
     authState.mode === "dev"
       ? `Dev ${authState.user ?? "browser-editor"}`
       : authState.mode === "invalid"
         ? "Auth needs attention"
         : "Anonymous";
+  const diagnostics = prototypeAuthDiagnostics(authState, {
+    actorLabel: connectionActorLabel,
+    connectionError,
+    connectionScope,
+  });
+  useEffect(() => {
+    setCopyState("idle");
+  }, [authState, connectionActorLabel, connectionError, connectionScope]);
 
   const applyDevAuth = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -610,6 +626,15 @@ function CloudAuthControls({
     onAuthStateChange();
   };
 
+  const copyDiagnostics = async () => {
+    try {
+      await navigator.clipboard.writeText(diagnostics.copyText);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  };
+
   return (
     <details className="cloud-auth-menu">
       <summary title="Prototype collaborator identity">
@@ -618,7 +643,14 @@ function CloudAuthControls({
       </summary>
       <form onSubmit={applyDevAuth}>
         <p>{prototypeAuthSummary(authState)}</p>
-        {connectionScope ? <p>Connected as {connectionScope}.</p> : <p>Live room not connected.</p>}
+        <dl className="cloud-auth-diagnostics" aria-label="Prototype auth diagnostics">
+          {diagnostics.rows.map((row) => (
+            <div key={row.label} data-tone={row.tone ?? "default"}>
+              <dt>{row.label}</dt>
+              <dd>{row.value}</dd>
+            </div>
+          ))}
+        </dl>
         <label>
           <span>Dev token</span>
           <input
@@ -659,6 +691,14 @@ function CloudAuthControls({
           <button type="submit">
             <KeyRound aria-hidden="true" />
             Use dev identity
+          </button>
+          <button type="button" onClick={() => void copyDiagnostics()}>
+            <Copy aria-hidden="true" />
+            {copyState === "copied"
+              ? "Copied"
+              : copyState === "failed"
+                ? "Copy failed"
+                : "Copy diagnostics"}
           </button>
           <button type="button" onClick={resetAuth}>
             <RotateCcw aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Add a sanitized collaborator-auth diagnostics model for the notebook-cloud viewer.
- Surface requested principal/scope, connected actor/scope, placeholder-token fallback, and last connection error in the key menu.
- Add a copy-diagnostics action that intentionally omits the stored dev token.
- Document the diagnostics path for deployed collaboration and Offline debugging.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/hosted-collab-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
- `git diff --check`
