### PR TITLE
fix(notebook-cloud): skip storing read-only sync no-ops

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -2,7 +2,7 @@
 
 This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates a dev, Cloudflare Access, or anonymous viewer connection, authorizes that principal through the D1 room ACL, stamps a trusted `<principal>/<operator>` actor label, and routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id.
 
-The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync execution/output state into `RuntimeStateDoc` but cannot edit `NotebookDoc` or acquire the frontend notebook editing API.
+The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata for sync frames that actually change a materialized document. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync execution/output state into `RuntimeStateDoc` but cannot edit `NotebookDoc` or acquire the frontend notebook editing API.
 
 `/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
@@ -369,7 +369,8 @@ Useful events while debugging collaboration:
 - `room.frame.rejected` - scope validation, malformed frames, and room-host
   write rejection. Count by `counter=rejected_frames`.
 - `room.materialized_frame.applied` - `NotebookDoc` / `RuntimeStateDoc` frame
-  application duration, changed flags, and outbound fanout.
+  application duration, changed flags, whether the inbound frame was persisted,
+  and outbound fanout.
 - `room.materializer.loaded`, `room.materializer.checkpoint.saved`, and
   `room.materializer.snapshot_pair_missing` - Durable Object materialization and
   persisted snapshot health.
@@ -424,15 +425,17 @@ markdown edit convergence loop when chasing intermittent editor divergence.
 
 Use `GET /api/n/{id}/acl` with an owner credential to confirm editor/viewer
 grants. A healthy throwaway collaboration run should show editor
-`room.materialized_frame.applied` records, viewer `room.peer_sync.completed`
-records, no unexpected `room.frame.rejected` records for Alice/Bob, and
-anonymous viewer presence logged only as `room.presence.local_only`. If the
-browser shows `Offline`, open the key menu first: placeholder or stale dev
-tokens are surfaced there, and the Worker logs token/auth failures as
-`auth.failed` without recording raw token material. The copied browser
-diagnostic should include the requested principal/scope, connected actor/scope
-when available, and the last WebSocket connection error, but never the stored
-token value.
+`room.materialized_frame.applied` records with `persisted=true` when Alice/Bob
+change the document, viewer `room.peer_sync.completed` records, no unexpected
+`room.frame.rejected` records for Alice/Bob, and anonymous viewer presence
+logged only as `room.presence.local_only`. Read-only viewer sync acks/needs may
+emit `room.materialized_frame.applied` with `persisted=false`; they should not
+create stored room-event history. If the browser shows `Offline`, open the key
+menu first: placeholder or stale dev tokens are surfaced there, and the Worker
+logs token/auth failures as `auth.failed` without recording raw token material.
+The copied browser diagnostic should include the requested principal/scope,
+connected actor/scope when available, and the last WebSocket connection error,
+but never the stored token value.
 
 Snapshot and blob stubs:
 

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -344,6 +344,7 @@ export class NotebookRoom {
         );
         return;
       }
+      const persistMaterializedFrame = shouldPersistMaterializedSyncFrame(result);
       cloudLog("debug", "room.materialized_frame.applied", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -355,14 +356,17 @@ export class NotebookRoom {
         changed: result.changed,
         notebook_changed: result.notebook_changed,
         runtime_state_changed: result.runtime_state_changed,
+        persisted: persistMaterializedFrame,
         outbound_frame_count: result.outbound.length,
         counter: "materialized_frames_applied",
         counter_delta: 1,
       });
 
-      this.state.waitUntil(
-        this.persistFrame(peer, normalizedFrame, receivedAt).catch(() => undefined),
-      );
+      if (persistMaterializedFrame) {
+        this.state.waitUntil(
+          this.persistFrame(peer, normalizedFrame, receivedAt).catch(() => undefined),
+        );
+      }
       this.deliverRoomHostFrames(notebookId, result);
       if (result.changed) {
         this.state.waitUntil(materializer.checkpoint().catch(() => undefined));
@@ -670,6 +674,12 @@ export function shouldBroadcastFrame(
   identity: AuthenticatedConnection,
 ): boolean {
   return !(frame.type === FrameType.PRESENCE && isAnonymousViewer(identity));
+}
+
+export function shouldPersistMaterializedSyncFrame(
+  result: Pick<RoomHostFrameResult, "notebook_changed" | "runtime_state_changed">,
+): boolean {
+  return result.notebook_changed || result.runtime_state_changed;
 }
 
 export function webSocketUpgradeHeaders(identity: AuthenticatedConnection): Headers {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -13,6 +13,7 @@ import {
   NotebookRoom,
   rewritePresenceFrame,
   shouldBroadcastFrame,
+  shouldPersistMaterializedSyncFrame,
   webSocketUpgradeHeaders,
 } from "../src/notebook-room.ts";
 import {
@@ -26,6 +27,7 @@ import {
   encodePresenceFrame,
   initializeRuntimedWasm,
 } from "../src/runtimed-wasm.ts";
+import type { RoomHostFrameResult } from "../src/room-materializer.ts";
 
 const wasmBytes = await readFile(
   new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
@@ -212,6 +214,105 @@ describe("NotebookRoom peer lifecycle", () => {
   });
 });
 
+describe("NotebookRoom materialized sync persistence", () => {
+  it("persists only sync frames that changed a materialized document", () => {
+    assert.equal(
+      shouldPersistMaterializedSyncFrame({
+        notebook_changed: false,
+        runtime_state_changed: false,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldPersistMaterializedSyncFrame({
+        notebook_changed: true,
+        runtime_state_changed: false,
+      }),
+      true,
+    );
+    assert.equal(
+      shouldPersistMaterializedSyncFrame({
+        notebook_changed: false,
+        runtime_state_changed: true,
+      }),
+      true,
+    );
+  });
+
+  it("acknowledges no-op sync control frames without persisted room history", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=viewer&operator=desktop:a&scope=viewer"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "viewer",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array()),
+    );
+
+    assert.equal(persisted, 0);
+    assert.equal(socket.sent.length, 1);
+    assert.equal(
+      decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
+      "cloud_frame_accepted",
+    );
+  });
+
+  it("persists materialized sync frames that change document state", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "editor",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    harness.materializers.set(
+      "demo",
+      fakeMaterializer({
+        ...noopMaterializedResult(),
+        changed: true,
+        notebook_changed: true,
+      }),
+    );
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
+    );
+
+    assert.equal(persisted, 1);
+    assert.equal(socket.sent.length, 1);
+    assert.equal(
+      decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
+      "cloud_frame_accepted",
+    );
+  });
+});
+
 type PeerForTest = {
   id: string;
   socket: CloudflareWebSocket;
@@ -221,6 +322,19 @@ type PeerForTest = {
 
 interface RoomHarness {
   peers: Map<string, PeerForTest>;
+  materializers: Map<
+    string,
+    {
+      receiveFrame(): Promise<RoomHostFrameResult>;
+      checkpoint(): Promise<void>;
+    }
+  >;
+  handleMessage(
+    notebookId: string,
+    peer: PeerForTest,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void>;
+  persistFrame(): Promise<void>;
   removePeer(notebookId: string, peer: PeerForTest): void;
   peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
   broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;
@@ -243,6 +357,25 @@ function fakeState(): DurableObjectState {
       list: async <T>() => new Map(values as Map<string, T>),
     },
     waitUntil: () => undefined,
+  };
+}
+
+function noopMaterializedResult(): RoomHostFrameResult {
+  return {
+    changed: false,
+    notebook_changed: false,
+    runtime_state_changed: false,
+    outbound: [],
+  };
+}
+
+function fakeMaterializer(result: RoomHostFrameResult): {
+  receiveFrame(): Promise<RoomHostFrameResult>;
+  checkpoint(): Promise<void>;
+} {
+  return {
+    receiveFrame: async () => result,
+    checkpoint: async () => undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- skip Durable Object frame persistence for materialized sync messages that do not change `NotebookDoc` or `RuntimeStateDoc`
- log whether each materialized sync frame was persisted so deployed tails distinguish editor writes from read-only sync control traffic
- document the read-only viewer sync behavior and add room-level tests for no-op sync ACKs versus document-changing sync frames

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `git diff --check`
