### PR TITLE
perf(kernel-launcher): defer optional renderer imports

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -20,8 +20,9 @@ user code runs. Four things happen on ``load_ipython_extension``:
    pick up table buffers from the same pending-bytes stash.
 
 4. Third-party visualization libraries (altair, plotly) are flipped to
-   their ``"nteract"`` renderer if they happen to be importable. Each
-   is guarded so the bootstrap stays a no-op in minimal envs.
+   their ``"nteract"`` renderer if they are already imported, or lazily
+   when they are first imported by user code. The bootstrap never imports
+   these optional packages on the kernel startup path.
 
 No ``ipython_display_formatter`` handlers. The dx wheel needed one to
 divert bare-``df``-on-last-line from the bufferless displayhook path
@@ -36,8 +37,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import sys
 import threading
 from collections.abc import Callable
+from time import perf_counter
 from typing import Any
 
 from IPython.core.formatters import BaseFormatter
@@ -67,6 +70,8 @@ log = logging.getLogger("nteract_kernel_launcher")
 
 # Server-side blob ceiling is ~100 MiB; leave ~10 MiB for overhead.
 _MAX_PAYLOAD_BYTES = int(os.environ.get("DX_MAX_PAYLOAD_BYTES", str(90 * 1024 * 1024)))
+_RENDERER_IMPORT_TARGETS = frozenset({"altair", "plotly.io"})
+_renderer_import_hook: Any | None = None
 
 
 class LLMFormatter(BaseFormatter):
@@ -506,32 +511,139 @@ def _install_buffer_hooks(ip: Any) -> None:
     _buffer_hook.install(ip)
 
 
-def _enable_third_party_renderers() -> None:
-    """Flip altair / plotly to their ``"nteract"`` renderer if present.
-
-    ImportError-guarded; safe in a minimal env. Non-ImportError failures
-    get logged at debug level — a missing renderer shouldn't crash the
-    kernel startup.
-    """
+def _enable_altair_renderer(alt: Any) -> None:
     try:
-        import altair as alt  # ty: ignore[unresolved-import]
-
         alt.renderers.enable("nteract")
         log.debug("enabled altair 'nteract' renderer")
-    except ImportError:
-        pass
     except Exception as exc:  # noqa: BLE001
         log.debug("altair 'nteract' renderer enable failed: %s", exc)
 
-    try:
-        import plotly.io as pio
 
+def _enable_plotly_renderer(pio: Any) -> None:
+    try:
         pio.renderers.default = "nteract"
         log.debug("set plotly default renderer to 'nteract'")
-    except ImportError:
-        pass
     except Exception as exc:  # noqa: BLE001
         log.debug("plotly 'nteract' renderer set failed: %s", exc)
+
+
+def _enable_loaded_renderer_modules() -> None:
+    alt = sys.modules.get("altair")
+    if alt is not None:
+        _enable_altair_renderer(alt)
+
+    pio = sys.modules.get("plotly.io")
+    if pio is not None:
+        _enable_plotly_renderer(pio)
+
+
+def _enable_renderer_for_module(fullname: str, module: Any) -> None:
+    if fullname == "altair":
+        _enable_altair_renderer(module)
+    elif fullname == "plotly.io":
+        _enable_plotly_renderer(module)
+
+
+class _RendererLoader:
+    """Loader wrapper that configures renderers after optional imports complete."""
+
+    def __init__(self, loader: Any, fullname: str) -> None:
+        self._loader = loader
+        self._fullname = fullname
+
+    def create_module(self, spec: Any) -> Any:
+        create_module = getattr(self._loader, "create_module", None)
+        if create_module is None:
+            return None
+        return create_module(spec)
+
+    def exec_module(self, module: Any) -> None:
+        self._loader.exec_module(module)
+        _enable_renderer_for_module(self._fullname, module)
+
+    def load_module(self, fullname: str) -> Any:
+        module = self._loader.load_module(fullname)
+        _enable_renderer_for_module(fullname, module)
+        return module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._loader, name)
+
+
+class _RendererImportHook:
+    """Meta-path hook that defers optional renderer setup until first import."""
+
+    _nteract_renderer_import_hook = True
+
+    def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+        if fullname not in _RENDERER_IMPORT_TARGETS:
+            return None
+
+        for finder in sys.meta_path:
+            if getattr(finder, "_nteract_renderer_import_hook", False):
+                continue
+            find_spec = getattr(finder, "find_spec", None)
+            if find_spec is None:
+                continue
+            spec = find_spec(fullname, path, target)
+            if spec is None:
+                continue
+            loader = spec.loader
+            if (
+                loader is not None
+                and not isinstance(loader, _RendererLoader)
+                and getattr(loader, "exec_module", None) is not None
+            ):
+                spec.loader = _RendererLoader(loader, fullname)
+            return spec
+
+        return None
+
+
+def _install_renderer_import_hook() -> None:
+    global _renderer_import_hook
+
+    for finder in sys.meta_path:
+        if getattr(finder, "_nteract_renderer_import_hook", False):
+            _renderer_import_hook = finder
+            return
+
+    hook = _RendererImportHook()
+    sys.meta_path.insert(0, hook)
+    _renderer_import_hook = hook
+
+
+def _uninstall_renderer_import_hook() -> None:
+    global _renderer_import_hook
+
+    sys.meta_path[:] = [
+        finder
+        for finder in sys.meta_path
+        if not getattr(finder, "_nteract_renderer_import_hook", False)
+    ]
+    _renderer_import_hook = None
+
+
+def _enable_third_party_renderers() -> None:
+    """Flip altair / plotly to their ``"nteract"`` renderer without importing them.
+
+    Already-loaded modules are configured immediately. Otherwise a tiny import
+    hook configures each renderer after the corresponding optional module is
+    first imported by user code.
+    """
+    _enable_loaded_renderer_modules()
+    _install_renderer_import_hook()
+
+
+def _run_bootstrap_step(name: str, step: Callable[[], Any]) -> None:
+    started = perf_counter()
+    try:
+        step()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("%s failed: %s", name, exc)
+    finally:
+        elapsed_ms = (perf_counter() - started) * 1000
+        log.debug("bootstrap %s took %.2fms", name, elapsed_ms)
 
 
 # ─── IPython extension contract ────────────────────────────────────────────
@@ -545,32 +657,14 @@ def load_ipython_extension(ip: Any) -> None:
     further guard each install step so a single failure doesn't abort
     the others.
     """
-    try:
-        _install_llm_formatter(ip)
-    except Exception as exc:  # noqa: BLE001
-        log.warning("LLM formatter install failed: %s", exc)
-
-    try:
-        _install_dataframe_formatters(ip)
-    except Exception as exc:  # noqa: BLE001
-        log.warning("dataframe formatter install failed: %s", exc)
-
-    try:
-        _install_buffer_hooks(ip)
-    except Exception as exc:  # noqa: BLE001
-        log.warning("buffer hook install failed: %s", exc)
-
-    try:
-        _enable_third_party_renderers()
-    except Exception as exc:  # noqa: BLE001
-        log.warning("third-party renderer enable failed: %s", exc)
+    _run_bootstrap_step("LLM formatter install", lambda: _install_llm_formatter(ip))
+    _run_bootstrap_step("dataframe formatter install", lambda: _install_dataframe_formatters(ip))
+    _run_bootstrap_step("buffer hook install", lambda: _install_buffer_hooks(ip))
+    _run_bootstrap_step("third-party renderer enable", _enable_third_party_renderers)
 
     # Traceback install goes last so earlier failures can't prevent it.
     # The wrapper itself is bulletproof — see `_traceback.install`.
-    try:
-        _traceback.install(ip)
-    except Exception as exc:  # noqa: BLE001
-        log.warning("traceback install failed: %s", exc)
+    _run_bootstrap_step("traceback install", lambda: _traceback.install(ip))
 
 
 def unload_ipython_extension(ip: Any) -> None:
@@ -589,3 +683,4 @@ def unload_ipython_extension(ip: Any) -> None:
                         unregister(h)
     except Exception as exc:  # noqa: BLE001
         log.debug("unload cleanup: %s", exc)
+    _uninstall_renderer_import_hook()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -70,7 +70,10 @@ log = logging.getLogger("nteract_kernel_launcher")
 
 # Server-side blob ceiling is ~100 MiB; leave ~10 MiB for overhead.
 _MAX_PAYLOAD_BYTES = int(os.environ.get("DX_MAX_PAYLOAD_BYTES", str(90 * 1024 * 1024)))
-_RENDERER_IMPORT_TARGETS = frozenset({"altair", "plotly.io"})
+_PLOTLY_RENDERER_ENTRYPOINTS = frozenset(
+    {"plotly.express", "plotly.graph_objects", "plotly.graph_objs"}
+)
+_RENDERER_IMPORT_TARGETS = frozenset({"altair", "plotly.io"}) | _PLOTLY_RENDERER_ENTRYPOINTS
 _renderer_import_hook: Any | None = None
 
 
@@ -535,6 +538,19 @@ def _enable_loaded_renderer_modules() -> None:
     pio = sys.modules.get("plotly.io")
     if pio is not None:
         _enable_plotly_renderer(pio)
+    elif any(name in sys.modules for name in _PLOTLY_RENDERER_ENTRYPOINTS):
+        _enable_plotly_renderer_from_entrypoint()
+
+
+def _enable_plotly_renderer_from_entrypoint() -> None:
+    try:
+        import plotly.io as pio
+
+        _enable_plotly_renderer(pio)
+    except ImportError:
+        pass
+    except Exception as exc:  # noqa: BLE001
+        log.debug("plotly.io import for nteract renderer failed: %s", exc)
 
 
 def _enable_renderer_for_module(fullname: str, module: Any) -> None:
@@ -542,6 +558,8 @@ def _enable_renderer_for_module(fullname: str, module: Any) -> None:
         _enable_altair_renderer(module)
     elif fullname == "plotly.io":
         _enable_plotly_renderer(module)
+    elif fullname in _PLOTLY_RENDERER_ENTRYPOINTS:
+        _enable_plotly_renderer_from_entrypoint()
 
 
 class _RendererLoader:

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -327,8 +327,14 @@ def _isolate_renderer_import_hook(monkeypatch, _bootstrap):
         ],
     )
     monkeypatch.setattr(_bootstrap, "_renderer_import_hook", None)
-    for name in ("altair", "plotly", "plotly.io"):
-        monkeypatch.delitem(sys.modules, name, raising=False)
+    for name in list(sys.modules):
+        if (
+            name == "altair"
+            or name.startswith("altair.")
+            or name == "plotly"
+            or name.startswith("plotly.")
+        ):
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
 
 def test_load_extension_invokes_the_install_steps(monkeypatch):
@@ -453,6 +459,70 @@ def test_enable_third_party_renderers_lazily_configures_modules(monkeypatch):
     pio = importlib.import_module("plotly.io")
 
     assert enabled == ["nteract"]
+    assert pio.renderers.default == "nteract"
+
+
+@pytest.mark.parametrize(
+    "entrypoint",
+    ["plotly.express", "plotly.graph_objects", "plotly.graph_objs"],
+)
+def test_plotly_entrypoint_imports_lazily_configure_plotly_io(monkeypatch, entrypoint):
+    from nteract_kernel_launcher import _bootstrap
+
+    _isolate_renderer_import_hook(monkeypatch, _bootstrap)
+
+    class FakePlotlyRenderers:
+        def __init__(self):
+            self.default = "plotly_mimetype"
+
+    class FakeLoader(importlib.abc.Loader):
+        def __init__(self, configure=lambda _module: None):
+            self.configure = configure
+
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            self.configure(module)
+
+    class FakeFinder:
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname == "plotly":
+                spec = ModuleSpec(fullname, FakeLoader(), is_package=True)
+                spec.submodule_search_locations = []
+                return spec
+            if fullname == "plotly.io":
+                return ModuleSpec(
+                    fullname,
+                    FakeLoader(lambda module: setattr(module, "renderers", FakePlotlyRenderers())),
+                )
+            if fullname == entrypoint:
+                return ModuleSpec(fullname, FakeLoader())
+            return None
+
+    sys.meta_path.insert(0, FakeFinder())
+    _bootstrap._enable_third_party_renderers()
+
+    assert "plotly.io" not in sys.modules
+
+    importlib.import_module(entrypoint)
+
+    pio = sys.modules["plotly.io"]
+    assert pio.renderers.default == "nteract"
+
+
+def test_real_plotly_express_import_lazily_configures_plotly_io(monkeypatch):
+    pytest.importorskip("plotly.express")
+
+    from nteract_kernel_launcher import _bootstrap
+
+    _isolate_renderer_import_hook(monkeypatch, _bootstrap)
+    _bootstrap._enable_third_party_renderers()
+
+    import plotly.express as px
+    import plotly.io as pio
+
+    assert px.__name__ == "plotly.express"
     assert pio.renderers.default == "nteract"
 
 

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -9,6 +9,11 @@ tests against a running kernel.
 from __future__ import annotations
 
 import hashlib
+import importlib
+import importlib.abc
+import sys
+import types
+from importlib.machinery import ModuleSpec
 from types import SimpleNamespace
 
 import pytest
@@ -311,6 +316,21 @@ def test_llm_formatter_supports_for_type_registration():
 # ─── load_ipython_extension contract ─────────────────────────────────────
 
 
+def _isolate_renderer_import_hook(monkeypatch, _bootstrap):
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [
+            finder
+            for finder in sys.meta_path
+            if not getattr(finder, "_nteract_renderer_import_hook", False)
+        ],
+    )
+    monkeypatch.setattr(_bootstrap, "_renderer_import_hook", None)
+    for name in ("altair", "plotly", "plotly.io"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
 def test_load_extension_invokes_the_install_steps(monkeypatch):
     from nteract_kernel_launcher import _bootstrap
 
@@ -346,6 +366,94 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     # Must not raise.
     _bootstrap.load_ipython_extension(SimpleNamespace())
     assert called == ["hooks", "r"]
+
+
+def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):
+    from nteract_kernel_launcher import _bootstrap
+
+    _isolate_renderer_import_hook(monkeypatch, _bootstrap)
+
+    enabled = []
+
+    class FakeAltairRenderers:
+        def enable(self, name):
+            enabled.append(name)
+
+    class FakePlotlyRenderers:
+        def __init__(self):
+            self.default = "plotly_mimetype"
+
+    fake_alt = types.ModuleType("altair")
+    fake_alt.renderers = FakeAltairRenderers()
+    fake_pio = types.ModuleType("plotly.io")
+    fake_pio.renderers = FakePlotlyRenderers()
+    monkeypatch.setitem(sys.modules, "altair", fake_alt)
+    monkeypatch.setitem(sys.modules, "plotly.io", fake_pio)
+
+    _bootstrap._enable_third_party_renderers()
+
+    assert enabled == ["nteract"]
+    assert fake_pio.renderers.default == "nteract"
+
+
+def test_enable_third_party_renderers_lazily_configures_modules(monkeypatch):
+    from nteract_kernel_launcher import _bootstrap
+
+    _isolate_renderer_import_hook(monkeypatch, _bootstrap)
+    enabled = []
+
+    class FakeAltairRenderers:
+        def enable(self, name):
+            enabled.append(name)
+
+    class FakePlotlyRenderers:
+        def __init__(self):
+            self.default = "plotly_mimetype"
+
+    class FakeLoader(importlib.abc.Loader):
+        def __init__(self, configure):
+            self.configure = configure
+
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            self.configure(module)
+
+    class FakeFinder:
+        def __init__(self):
+            self.requests = []
+
+        def find_spec(self, fullname, path=None, target=None):
+            self.requests.append(fullname)
+            if fullname == "altair":
+                return ModuleSpec(
+                    fullname,
+                    FakeLoader(lambda module: setattr(module, "renderers", FakeAltairRenderers())),
+                )
+            if fullname == "plotly":
+                spec = ModuleSpec(fullname, FakeLoader(lambda _module: None), is_package=True)
+                spec.submodule_search_locations = []
+                return spec
+            if fullname == "plotly.io":
+                return ModuleSpec(
+                    fullname,
+                    FakeLoader(lambda module: setattr(module, "renderers", FakePlotlyRenderers())),
+                )
+            return None
+
+    fake_finder = FakeFinder()
+    sys.meta_path.insert(0, fake_finder)
+
+    _bootstrap._enable_third_party_renderers()
+
+    assert fake_finder.requests == []
+
+    importlib.import_module("altair")
+    pio = importlib.import_module("plotly.io")
+
+    assert enabled == ["nteract"]
+    assert pio.renderers.default == "nteract"
 
 
 def test_install_registers_iterable_dataset_formatter():


### PR DESCRIPTION
## Summary

- defer optional Altair and Plotly renderer activation out of kernel bootstrap
- keep the existing nteract renderer behavior for already-imported modules and first user import through a targeted import hook, including `plotly.express`, `plotly.graph_objects`, and `plotly.graph_objs`
- add debug timing logs for each bootstrap install step

## Timing Notes

- before: `full extension load after imports` median 140.10ms; `enable third-party renderers` median 142.24ms; true cold import + extension load median 306.88ms
- after: `full extension load after imports` median 0.35ms; `enable third-party renderers` median 0.00ms; true cold import + extension load median 187.04ms
- deferred cost still lands when used: lazy Altair first import median 322.45ms; lazy Plotly first import median 232.30ms

## Verification

- `uv run pytest python/nteract-kernel-launcher/tests/test_bootstrap.py`
- `uv run ruff check python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py python/nteract-kernel-launcher/tests/test_bootstrap.py`
- `uv run ty check python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py python/nteract-kernel-launcher/tests/test_bootstrap.py`
- `uv run --project python/nteract-kernel-launcher --with altair --with plotly python - <<'PY' ...`
- `uv run --project python/nteract-kernel-launcher --with plotly python - <<'PY' ...`
- `git diff --check`

## Known Local Issues

- `uv run pytest python/nteract-kernel-launcher/tests` has two pre-existing progressive Arrow failures in `tests/test_progressive.py`; those files are untouched on this branch.
- `cargo xtask lint --fix` reaches Python ruff/ty successfully, but the JS/TS `vp check` phase fails in this worktree because `vite.config.ts` cannot resolve `vite-plus`.
