### PR TITLE
feat(notebook-cloud): add Access demo ops runbook

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -240,13 +240,10 @@ principal namespace, display name, and email only through Worker-stamped
 trusted headers, and the `cloud_room_ready` control frame may expose that
 non-secret metadata to clients.
 
-Browser WebSocket upgrades must come from the Worker origin or an origin listed
-in `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` as a comma-separated list. Cookie-backed
-WebSocket upgrades without an `Origin` header are rejected.
-
-Set `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` on Access-backed browser deployments to a
-comma-separated list of notebook application origins that may open
-`/n/:id/sync`, for example:
+The Worker treats same-origin notebook pages as allowed WebSocket origins by
+default. Set `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` on Access-backed browser
+deployments to a comma-separated list of additional notebook application
+origins that may open `/n/:id/sync`, for example:
 
 ```text
 NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com
@@ -255,6 +252,7 @@ NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com
 Do not include the renderer asset origin in this list. It serves public
 build-time sidecars, not authenticated notebook room traffic.
 
+Cookie-backed Access WebSocket upgrades must always send an allowed `Origin`.
 When this allowlist is set, every `/n/:id/sync` WebSocket client must send a
 matching `Origin`; the hosted Access smoke does this with
 `NOTEBOOK_CLOUD_ACCESS_ORIGIN`.
@@ -346,7 +344,7 @@ Bindings in `wrangler.toml`:
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 - `RUNTIMED_WASM_BASE_URL` (optional): base URL for `runtimed_wasm.js` and `runtimed_wasm_bg.wasm`. The prototype deployment also points this at the dedicated asset Worker so the large WASM module is loaded as a CDN cacheable file instead of being inlined into the viewer bundle.
-- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` (optional): comma- or whitespace-separated notebook application origins allowed to initiate WebSocket upgrades when the origin gate is enabled.
+- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` (optional): comma- or whitespace-separated notebook application origins added to the same-origin WebSocket allowlist. Cookie-backed Access WebSocket upgrades always require an allowed `Origin`; setting this variable also requires `Origin` on non-cookie WebSocket clients.
 
 The dedicated renderer asset Worker serves only public, build-time sidecar files from the plugin asset bundle. It intentionally sends `Access-Control-Allow-Origin: *` so sandboxed `srcdoc` iframes with opaque origins can fetch renderer WASM and so the parent viewer can import runtime WASM from a CDN origin. Do not serve authenticated, notebook-specific, or user-generated blobs from this origin; those belong behind the notebook host's blob resolver or a future signed output origin. Deploy the renderer asset Worker before the main Worker when `RENDERER_ASSETS_BASE_URL` or `RUNTIMED_WASM_BASE_URL` points at the separate origin.
 

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -219,6 +219,7 @@ are configured, the Worker can authenticate Cloudflare Access/OIDC-style JWTs
 before running the D1 ACL lookup. Tokens are accepted from:
 
 - `Cf-Access-Jwt-Assertion` for Cloudflare Access-protected requests
+- `CF-Access-Token` for CLI/API requests using `cloudflared access token`
 - `Authorization: Bearer <jwt>` for native/system clients
 - WebSocket subprotocol `nteract-access-token.<base64url-jwt>` for browser
   WebSockets that cannot set custom headers
@@ -242,6 +243,45 @@ non-secret metadata to clients.
 Browser WebSocket upgrades must come from the Worker origin or an origin listed
 in `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` as a comma-separated list. Cookie-backed
 WebSocket upgrades without an `Origin` header are rejected.
+
+Set `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` on Access-backed browser deployments to a
+comma-separated list of notebook application origins that may open
+`/n/:id/sync`, for example:
+
+```text
+NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com
+```
+
+Do not include the renderer asset origin in this list. It serves public
+build-time sidecars, not authenticated notebook room traffic.
+
+When this allowlist is set, every `/n/:id/sync` WebSocket client must send a
+matching `Origin`; the hosted Access smoke does this with
+`NOTEBOOK_CLOUD_ACCESS_ORIGIN`.
+
+The hosted Access smoke uses a real Access JWT from `cloudflared`, grants
+principal ACL rows, sends real Automerge frames, and verifies that a granted
+viewer sees owner/editor markdown edits:
+
+```bash
+cloudflared access login https://<notebook-host>
+export NOTEBOOK_CLOUD_ACCESS_JWT="$(cloudflared access token -app=https://<notebook-host>)"
+
+cargo xtask wasm runtimed --skip-renderer-plugins
+NOTEBOOK_CLOUD_URL=https://<notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_ORIGIN=https://<notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_NOTEBOOK_ID=access-demo-$(date +%Y%m%d%H%M%S) \
+pnpm --dir apps/notebook-cloud smoke:hosted:access
+```
+
+Use `NOTEBOOK_CLOUD_ACCESS_EDITOR_JWT` and
+`NOTEBOOK_CLOUD_ACCESS_VIEWER_JWT` to run the same smoke with separate Access
+users. Add `NOTEBOOK_CLOUD_ACCESS_PUBLIC_SMOKE=1` only for a host that allows
+unauthenticated public viewer sockets to reach the Worker. A hostname protected
+entirely by Access should block anonymous public viewers at the edge.
+
+The complete Access + Anaconda runbook is
+`docs/architecture/hosted-access-anaconda-demo-runbook.md`.
 
 The viewer auth menu has a "Use browser session" mode for Cloudflare Access
 trials. It stores only the requested room scope in localStorage; the credential
@@ -306,6 +346,7 @@ Bindings in `wrangler.toml`:
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 - `RUNTIMED_WASM_BASE_URL` (optional): base URL for `runtimed_wasm.js` and `runtimed_wasm_bg.wasm`. The prototype deployment also points this at the dedicated asset Worker so the large WASM module is loaded as a CDN cacheable file instead of being inlined into the viewer bundle.
+- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` (optional): comma- or whitespace-separated notebook application origins allowed to initiate WebSocket upgrades when the origin gate is enabled.
 
 The dedicated renderer asset Worker serves only public, build-time sidecar files from the plugin asset bundle. It intentionally sends `Access-Control-Allow-Origin: *` so sandboxed `srcdoc` iframes with opaque origins can fetch renderer WASM and so the parent viewer can import runtime WASM from a CDN origin. Do not serve authenticated, notebook-specific, or user-generated blobs from this origin; those belong behind the notebook host's blob resolver or a future signed output origin. Deploy the renderer asset Worker before the main Worker when `RENDERER_ASSETS_BASE_URL` or `RUNTIMED_WASM_BASE_URL` points at the separate origin.
 
@@ -420,6 +461,11 @@ pnpm --dir apps/notebook-cloud smoke:hosted:live
 NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud smoke:hosted:collab
+
+NOTEBOOK_CLOUD_URL=https://<access-protected-notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_ORIGIN=https://<access-protected-notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_JWT="$(cloudflared access token -app=https://<access-protected-notebook-host>)" \
+pnpm --dir apps/notebook-cloud smoke:hosted:access
 
 NOTEBOOK_CLOUD_HOSTED_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev/n/<id> \
 NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0 \

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
+    "smoke:hosted:access": "node --import tsx scripts/hosted-access-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",

--- a/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
@@ -1,0 +1,58 @@
+import { ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX } from "../src/auth-shared.ts";
+
+export function assertHostedAccessSmokeEnv({ ownerToken }) {
+  if (ownerToken) {
+    return;
+  }
+
+  throw new Error(
+    "NOTEBOOK_CLOUD_ACCESS_JWT is required. Use a Cloudflare Access application JWT for the notebook-cloud app.",
+  );
+}
+
+export function accessPrincipalFromJwt(token) {
+  const payload = decodeJwtPayload(token);
+  const subject = typeof payload.sub === "string" ? payload.sub.trim() : "";
+  if (!subject) {
+    throw new Error("Cloudflare Access JWT is missing a non-empty sub claim");
+  }
+  return `user:cloudflare-access:${encodeURIComponent(subject)}`;
+}
+
+export function accessEmailFromJwt(token) {
+  const payload = decodeJwtPayload(token);
+  return typeof payload.email === "string" && payload.email.trim() ? payload.email.trim() : null;
+}
+
+export function accessAuthHeaders(token, { operator, scope, contentType } = {}) {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "CF-Access-Token": token,
+  };
+  if (operator) {
+    headers["X-Operator"] = operator;
+  }
+  if (scope) {
+    headers["X-Scope"] = scope;
+  }
+  if (contentType) {
+    headers["Content-Type"] = contentType;
+  }
+  return headers;
+}
+
+export function accessAuthProtocols(token) {
+  return [`${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`];
+}
+
+export function decodeJwtPayload(token) {
+  const [, payload] = token.split(".");
+  if (!payload) {
+    throw new Error("Cloudflare Access token must be a JWT");
+  }
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+}
+
+function base64Url(value) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}

--- a/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
@@ -26,7 +26,6 @@ export function accessEmailFromJwt(token) {
 
 export function accessAuthHeaders(token, { operator, scope, contentType } = {}) {
   const headers = {
-    Authorization: `Bearer ${token}`,
     "CF-Access-Token": token,
   };
   if (operator) {
@@ -39,6 +38,30 @@ export function accessAuthHeaders(token, { operator, scope, contentType } = {}) 
     headers["Content-Type"] = contentType;
   }
   return headers;
+}
+
+export function webSocketUpgradeRequestHeaders(
+  target,
+  { key, origin, accessToken, protocols = [] } = {},
+) {
+  const requestHeaders = [
+    `GET ${target.pathname}${target.search} HTTP/1.1`,
+    `Host: ${target.host}`,
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${key}`,
+    "Sec-WebSocket-Version: 13",
+  ];
+  if (origin) {
+    requestHeaders.push(`Origin: ${origin}`);
+  }
+  if (accessToken) {
+    requestHeaders.push(`CF-Access-Token: ${accessToken}`);
+  }
+  if (protocols.length > 0) {
+    requestHeaders.push(`Sec-WebSocket-Protocol: ${protocols.join(", ")}`);
+  }
+  return requestHeaders;
 }
 
 export function accessAuthProtocols(token) {

--- a/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
@@ -8,10 +8,10 @@ import { FrameType } from "runtimed";
 
 import {
   accessAuthHeaders,
-  accessAuthProtocols,
   accessEmailFromJwt,
   accessPrincipalFromJwt,
   assertHostedAccessSmokeEnv,
+  webSocketUpgradeRequestHeaders,
 } from "./hosted-access-smoke-env.mjs";
 
 const DEFAULT_BASE_URL = "https://nteract-notebook-cloud.rgbkrk.workers.dev";
@@ -305,7 +305,6 @@ async function connectAccess(notebookId, token, operator, scope) {
   const socket = await openWebSocket(url, {
     accessToken: token,
     origin: smokeOrigin,
-    protocols: accessAuthProtocols(token),
   });
   const client = await clientForSocket(socket, safeWebSocketUrl(url));
   const ready = await client.nextFrame(
@@ -450,22 +449,12 @@ async function openWebSocket(url, { accessToken, origin, protocols = [] } = {}) 
   const target = new URL(url);
   const key = randomBytes(16).toString("base64");
   const socket = await openTcpSocket(target);
-  const requestHeaders = [
-    `GET ${target.pathname}${target.search} HTTP/1.1`,
-    `Host: ${target.host}`,
-    "Upgrade: websocket",
-    "Connection: Upgrade",
-    `Sec-WebSocket-Key: ${key}`,
-    "Sec-WebSocket-Version: 13",
-    `Origin: ${origin}`,
-  ];
-  if (accessToken) {
-    requestHeaders.push(`CF-Access-Token: ${accessToken}`);
-    requestHeaders.push(`Authorization: Bearer ${accessToken}`);
-  }
-  if (protocols.length > 0) {
-    requestHeaders.push(`Sec-WebSocket-Protocol: ${protocols.join(", ")}`);
-  }
+  const requestHeaders = webSocketUpgradeRequestHeaders(target, {
+    key,
+    origin,
+    accessToken,
+    protocols,
+  });
   socket.write(`${requestHeaders.join("\r\n")}\r\n\r\n`);
 
   const { headers, leftover } = await readUpgradeResponse(socket);

--- a/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
@@ -1,0 +1,677 @@
+import { createHash, randomBytes } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import net from "node:net";
+import tls from "node:tls";
+import { fileURLToPath } from "node:url";
+
+import { FrameType } from "runtimed";
+
+import {
+  accessAuthHeaders,
+  accessAuthProtocols,
+  accessEmailFromJwt,
+  accessPrincipalFromJwt,
+  assertHostedAccessSmokeEnv,
+} from "./hosted-access-smoke-env.mjs";
+
+const DEFAULT_BASE_URL = "https://nteract-notebook-cloud.rgbkrk.workers.dev";
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? DEFAULT_BASE_URL;
+const smokeOrigin = process.env.NOTEBOOK_CLOUD_ACCESS_ORIGIN ?? new URL(baseUrl).origin;
+const ownerToken = process.env.NOTEBOOK_CLOUD_ACCESS_JWT;
+const editorToken = process.env.NOTEBOOK_CLOUD_ACCESS_EDITOR_JWT ?? ownerToken;
+const viewerToken = process.env.NOTEBOOK_CLOUD_ACCESS_VIEWER_JWT ?? editorToken;
+const roomId = process.env.NOTEBOOK_CLOUD_ACCESS_NOTEBOOK_ID ?? `access-${Date.now()}`;
+const includePublicViewer = process.env.NOTEBOOK_CLOUD_ACCESS_PUBLIC_SMOKE === "1";
+const timingsMs = {};
+const wasmJsUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBytesUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+const startedAt = performance.now();
+assertHostedAccessSmokeEnv({ ownerToken });
+await assertWasmBuildExists();
+
+const ownerPrincipal = accessPrincipalFromJwt(ownerToken);
+const editorPrincipal = accessPrincipalFromJwt(editorToken);
+const viewerPrincipal = accessPrincipalFromJwt(viewerToken);
+
+const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
+const wasmBytes = await readFile(wasmBytesUrl);
+await timed("runtimed_wasm_init", () => initSync({ module: wasmBytes }));
+
+await timed("owner_seed", () => seedNotebookOwner(roomId));
+await timed("acl_grants", async () => {
+  await grantAcl(roomId, {
+    subject_kind: "principal",
+    subject: editorPrincipal,
+    scope: "editor",
+  });
+  await grantAcl(roomId, {
+    subject_kind: "principal",
+    subject: viewerPrincipal,
+    scope: "viewer",
+  });
+  if (includePublicViewer) {
+    await grantAcl(roomId, {
+      subject_kind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+  }
+});
+
+const { owner, editor, viewer, anonymous } = await timed("connect_peers", async () => {
+  const peers = {
+    owner: await connectAccess(roomId, ownerToken, "smoke:owner", "owner"),
+    editor: await connectAccess(roomId, editorToken, "smoke:editor", "editor"),
+    viewer: await connectAccess(roomId, viewerToken, "smoke:viewer", "viewer"),
+    anonymous: null,
+  };
+  if (includePublicViewer) {
+    peers.anonymous = await connectAnonymous(roomId, "access-smoke-anonymous");
+  }
+  return peers;
+});
+
+const ownerHandle = NotebookHandle.create_bootstrap(owner.ready.actor_label);
+const editorHandle = NotebookHandle.create_bootstrap(editor.ready.actor_label);
+const viewerHandle = NotebookHandle.create_bootstrap(viewer.ready.actor_label);
+const anonymousHandle = anonymous
+  ? NotebookHandle.create_bootstrap(anonymous.ready.actor_label)
+  : null;
+const participants = [
+  { name: "owner", client: owner, handle: ownerHandle },
+  { name: "editor", client: editor, handle: editorHandle },
+  { name: "viewer", client: viewer, handle: viewerHandle },
+];
+if (anonymous && anonymousHandle) {
+  participants.push({ name: "anonymous", client: anonymous, handle: anonymousHandle });
+}
+
+ownerHandle.add_cell_after("cell-access-smoke-1", "markdown", null);
+ownerHandle.update_source("cell-access-smoke-1", "Access owner seeded markdown\n");
+sendHandleChanges(owner, ownerHandle);
+
+let processedFrames = await timed("owner_to_editor_viewers_convergence", () =>
+  driveSyncUntil(
+    participants,
+    () =>
+      cellSource(editorHandle, "cell-access-smoke-1") === "Access owner seeded markdown\n" &&
+      cellSource(viewerHandle, "cell-access-smoke-1") === "Access owner seeded markdown\n" &&
+      (!anonymousHandle ||
+        cellSource(anonymousHandle, "cell-access-smoke-1") === "Access owner seeded markdown\n"),
+    "Access owner markdown did not converge to editor and viewers",
+  ),
+);
+
+editorHandle.update_source("cell-access-smoke-1", "Access editor updated markdown\n");
+sendHandleChanges(editor, editorHandle);
+processedFrames += await timed("editor_to_owner_viewers_convergence", () =>
+  driveSyncUntil(
+    participants,
+    () =>
+      cellSource(ownerHandle, "cell-access-smoke-1") === "Access editor updated markdown\n" &&
+      cellSource(viewerHandle, "cell-access-smoke-1") === "Access editor updated markdown\n" &&
+      (!anonymousHandle ||
+        cellSource(anonymousHandle, "cell-access-smoke-1") === "Access editor updated markdown\n"),
+    "Access editor markdown edit did not converge to owner and viewers",
+  ),
+);
+
+assert(
+  owner.ready.actor_label.startsWith(`${ownerPrincipal}/`),
+  `owner actor ${owner.ready.actor_label} did not use principal ${ownerPrincipal}`,
+);
+assert(
+  editor.ready.actor_label.startsWith(`${editorPrincipal}/`),
+  `editor actor ${editor.ready.actor_label} did not use principal ${editorPrincipal}`,
+);
+assert(
+  viewer.ready.actor_label.startsWith(`${viewerPrincipal}/`),
+  `viewer actor ${viewer.ready.actor_label} did not use principal ${viewerPrincipal}`,
+);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      auth_mode: "cloudflare_access",
+      baseUrl,
+      origin: smokeOrigin,
+      roomId,
+      viewerUrl: new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href,
+      principals: {
+        owner: ownerPrincipal,
+        editor: editorPrincipal,
+        viewer: viewerPrincipal,
+      },
+      emails: {
+        owner: accessEmailFromJwt(ownerToken),
+        editor: accessEmailFromJwt(editorToken),
+        viewer: accessEmailFromJwt(viewerToken),
+      },
+      checks: [
+        "cloudflare_access_jwt_validated_by_worker",
+        "owner_acl_room_seeded",
+        "editor_principal_acl_granted",
+        "viewer_principal_acl_granted",
+        "real_automerge_sync_payload",
+        "access_owner_seeded_markdown",
+        "access_editor_edited_markdown",
+        "access_viewer_live_convergence",
+        "actor_principals_match_access_subjects",
+        ...(includePublicViewer
+          ? ["public_viewer_acl_granted", "anonymous_public_viewer_live_convergence"]
+          : []),
+      ],
+      timings_ms: {
+        ...timingsMs,
+        total: elapsedMs(startedAt),
+      },
+      processedFrames,
+      finalSource: ownerHandle.get_cell_source("cell-access-smoke-1"),
+    },
+    null,
+    2,
+  ),
+);
+
+await Promise.all([owner, editor, viewer, anonymous].filter(Boolean).map(closeClient));
+process.exit(0);
+
+async function timed(name, fn) {
+  const started = performance.now();
+  try {
+    return await fn();
+  } finally {
+    timingsMs[name] = elapsedMs(started);
+  }
+}
+
+function elapsedMs(started) {
+  return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
+}
+
+async function assertWasmBuildExists() {
+  try {
+    await access(fileURLToPath(wasmJsUrl));
+    await access(fileURLToPath(wasmBytesUrl));
+  } catch {
+    throw new Error(
+      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
+    );
+  }
+}
+
+async function seedNotebookOwner(notebookId) {
+  const response = await fetch(
+    new URL(
+      `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/bootstrap-runtime`,
+      baseUrl,
+    ),
+    {
+      method: "PUT",
+      headers: accessAuthHeaders(ownerToken, {
+        operator: "smoke:owner",
+        scope: "owner",
+        contentType: "application/octet-stream",
+      }),
+      body: new Uint8Array([0]),
+    },
+  );
+  assert(
+    response.status === 201,
+    `owner bootstrap runtime snapshot failed: ${response.status} ${await response.text()}`,
+  );
+}
+
+async function grantAcl(notebookId, body) {
+  const response = await fetch(new URL(`/api/n/${encodeURIComponent(notebookId)}/acl`, baseUrl), {
+    method: "POST",
+    headers: accessAuthHeaders(ownerToken, {
+      operator: "smoke:owner",
+      scope: "owner",
+      contentType: "application/json",
+    }),
+    body: JSON.stringify(body),
+  });
+  assert(response.status === 201, `ACL grant failed: ${response.status} ${await response.text()}`);
+}
+
+function sendHandleChanges(client, handle) {
+  const payload = handle.flush_local_changes();
+  assert(payload?.byteLength > 0, "expected handle to flush local Automerge changes");
+  sendBinaryFrame(client.socket, FrameType.AUTOMERGE_SYNC, payload);
+}
+
+async function driveSyncUntil(participants, predicate, failureMessage) {
+  const deadline = Date.now() + 5_000;
+  let processedFrames = 0;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return processedFrames;
+    }
+
+    let progressed = false;
+    for (const participant of participants) {
+      const frame = await participant.client
+        .nextFrame((candidate) => candidate.type === FrameType.AUTOMERGE_SYNC, 50)
+        .catch(() => undefined);
+      if (!frame) {
+        continue;
+      }
+
+      progressed = true;
+      processedFrames += 1;
+      const events = participant.handle.receive_frame(frame.bytes);
+      for (const event of events) {
+        if (Array.isArray(event.reply)) {
+          sendBinaryFrame(
+            participant.client.socket,
+            FrameType.AUTOMERGE_SYNC,
+            new Uint8Array(event.reply),
+          );
+        }
+      }
+    }
+
+    if (!progressed) {
+      await sleep(25);
+    }
+  }
+
+  throw new Error(failureMessage);
+}
+
+function cellSource(handle, cellId) {
+  try {
+    return handle.get_cell_source(cellId);
+  } catch {
+    return undefined;
+  }
+}
+
+async function connectAccess(notebookId, token, operator, scope) {
+  const url = new URL(`/n/${encodeURIComponent(notebookId)}/sync`, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("operator", operator);
+  url.searchParams.set("scope", scope);
+  const socket = await openWebSocket(url, {
+    accessToken: token,
+    origin: smokeOrigin,
+    protocols: accessAuthProtocols(token),
+  });
+  const client = await clientForSocket(socket, safeWebSocketUrl(url));
+  const ready = await client.nextFrame(
+    (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_room_ready",
+  );
+  return { ...client, ready: ready.json };
+}
+
+async function connectAnonymous(notebookId, viewerSession) {
+  const url = new URL(`/n/${encodeURIComponent(notebookId)}/sync`, baseUrl);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.searchParams.set("viewer_session", viewerSession);
+  const socket = await openWebSocket(url, { origin: smokeOrigin });
+  const client = await clientForSocket(socket, url.href);
+  const ready = await client.nextFrame(
+    (frame) => frame.type === FrameType.SESSION_CONTROL && frame.json.type === "cloud_room_ready",
+  );
+  return { ...client, ready: ready.json };
+}
+
+async function clientForSocket(socket, safeUrl) {
+  const queue = [];
+  const waiters = [];
+  socket.addEventListener("message", async (event) => {
+    const frame = await decodeFrame(event.data);
+    const index = waiters.findIndex((waiter) => waiter.predicate(frame));
+    if (index === -1) {
+      queue.push(frame);
+      return;
+    }
+
+    const [waiter] = waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+    waiter.resolve(frame);
+  });
+
+  if (socket.readyState !== RawWebSocketClient.OPEN) {
+    await new Promise((resolve, reject) => {
+      socket.addEventListener("open", resolve, { once: true });
+      socket.addEventListener("error", () => reject(new Error(`failed to connect ${safeUrl}`)), {
+        once: true,
+      });
+    });
+  }
+
+  return {
+    socket,
+    nextFrame(predicate, timeoutMs = 5_000) {
+      const queued = queue.findIndex(predicate);
+      if (queued !== -1) {
+        const [frame] = queue.splice(queued, 1);
+        return Promise.resolve(frame);
+      }
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const index = waiters.findIndex((waiter) => waiter.timer === timer);
+          if (index !== -1) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`timed out waiting for frame from ${safeUrl}`));
+        }, timeoutMs);
+        waiters.push({ predicate, resolve, timer });
+      });
+    },
+  };
+}
+
+function sendBinaryFrame(socket, type, payload) {
+  const frame = new Uint8Array(payload.byteLength + 1);
+  frame[0] = type;
+  frame.set(payload, 1);
+  socket.send(frame);
+}
+
+async function decodeFrame(data) {
+  let buffer;
+  if (data instanceof ArrayBuffer) {
+    buffer = data;
+  } else if (ArrayBuffer.isView(data)) {
+    buffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength);
+  } else if (typeof Blob !== "undefined" && data instanceof Blob) {
+    buffer = await data.arrayBuffer();
+  } else {
+    throw new Error(`unsupported WebSocket message ${Object.prototype.toString.call(data)}`);
+  }
+
+  const bytes = new Uint8Array(buffer);
+  const type = bytes[0];
+  const payload = bytes.slice(1);
+  let json;
+  if (type === FrameType.SESSION_CONTROL) {
+    try {
+      json = JSON.parse(new TextDecoder().decode(payload));
+    } catch {
+      json = undefined;
+    }
+  }
+  return { type, payload, bytes, json };
+}
+
+async function closeClient(client) {
+  if (client.socket.readyState === RawWebSocketClient.CLOSED) {
+    return;
+  }
+
+  await new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 250);
+    client.socket.addEventListener(
+      "close",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+    client.socket.close();
+  });
+}
+
+function safeWebSocketUrl(url) {
+  const safe = new URL(url.href);
+  for (const [key, value] of safe.searchParams) {
+    if (key.toLowerCase().includes("token") || value.startsWith("eyJ")) {
+      safe.searchParams.set(key, "<redacted>");
+    }
+  }
+  return safe.href;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function openWebSocket(url, { accessToken, origin, protocols = [] } = {}) {
+  const target = new URL(url);
+  const key = randomBytes(16).toString("base64");
+  const socket = await openTcpSocket(target);
+  const requestHeaders = [
+    `GET ${target.pathname}${target.search} HTTP/1.1`,
+    `Host: ${target.host}`,
+    "Upgrade: websocket",
+    "Connection: Upgrade",
+    `Sec-WebSocket-Key: ${key}`,
+    "Sec-WebSocket-Version: 13",
+    `Origin: ${origin}`,
+  ];
+  if (accessToken) {
+    requestHeaders.push(`CF-Access-Token: ${accessToken}`);
+    requestHeaders.push(`Authorization: Bearer ${accessToken}`);
+  }
+  if (protocols.length > 0) {
+    requestHeaders.push(`Sec-WebSocket-Protocol: ${protocols.join(", ")}`);
+  }
+  socket.write(`${requestHeaders.join("\r\n")}\r\n\r\n`);
+
+  const { headers, leftover } = await readUpgradeResponse(socket);
+  const expectedAccept = createHash("sha1")
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest("base64");
+  assert(
+    headers.statusCode === 101,
+    `WebSocket upgrade failed with HTTP ${headers.statusCode}: ${headers.bodyPreview}`,
+  );
+  assert(
+    headers.fields.get("sec-websocket-accept") === expectedAccept,
+    "WebSocket upgrade returned an invalid Sec-WebSocket-Accept header",
+  );
+
+  return new RawWebSocketClient(socket, leftover);
+}
+
+function openTcpSocket(url) {
+  const isTls = url.protocol === "wss:";
+  const port = Number(url.port || (isTls ? 443 : 80));
+  const options = { host: url.hostname, port };
+  return new Promise((resolve, reject) => {
+    const socket = isTls
+      ? tls.connect({ ...options, servername: url.hostname })
+      : net.connect(options);
+    socket.once(isTls ? "secureConnect" : "connect", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function readUpgradeResponse(socket) {
+  return new Promise((resolve, reject) => {
+    let buffer = Buffer.alloc(0);
+    const onData = (chunk) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const headerEnd = buffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) {
+        return;
+      }
+
+      socket.off("data", onData);
+      socket.off("error", reject);
+      const rawHeader = buffer.slice(0, headerEnd).toString("latin1");
+      const leftover = buffer.slice(headerEnd + 4);
+      const lines = rawHeader.split("\r\n");
+      const statusCode = Number(lines[0]?.match(/^HTTP\/\d(?:\.\d)?\s+(\d+)/)?.[1] ?? 0);
+      const fields = new Map();
+      for (const line of lines.slice(1)) {
+        const delimiter = line.indexOf(":");
+        if (delimiter === -1) {
+          continue;
+        }
+        fields.set(line.slice(0, delimiter).trim().toLowerCase(), line.slice(delimiter + 1).trim());
+      }
+      resolve({
+        headers: {
+          statusCode,
+          fields,
+          bodyPreview: buffer.slice(headerEnd + 4, headerEnd + 260).toString("utf8"),
+        },
+        leftover,
+      });
+    };
+
+    socket.on("data", onData);
+    socket.once("error", reject);
+  });
+}
+
+class RawWebSocketClient {
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  constructor(socket, initialBuffer) {
+    this.socket = socket;
+    this.readyState = RawWebSocketClient.OPEN;
+    this.listeners = new Map();
+    this.buffer = initialBuffer ?? Buffer.alloc(0);
+    this.socket.on("data", (chunk) => this.receive(chunk));
+    this.socket.on("close", () => {
+      this.readyState = RawWebSocketClient.CLOSED;
+      this.dispatch("close", {});
+    });
+    this.socket.on("error", (error) => this.dispatch("error", { error }));
+    if (this.buffer.length > 0) {
+      this.receive(Buffer.alloc(0));
+    }
+  }
+
+  addEventListener(type, listener, options = {}) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push({ listener, once: Boolean(options.once) });
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type, event) {
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+    const remaining = [];
+    for (const entry of listeners) {
+      entry.listener(event);
+      if (!entry.once) {
+        remaining.push(entry);
+      }
+    }
+    this.listeners.set(type, remaining);
+  }
+
+  send(data) {
+    assert(this.readyState === RawWebSocketClient.OPEN, "cannot send on a closed WebSocket");
+    this.socket.write(encodeClientFrame(0x2, Buffer.from(data)));
+  }
+
+  close() {
+    if (this.readyState !== RawWebSocketClient.OPEN) {
+      return;
+    }
+    this.readyState = RawWebSocketClient.CLOSING;
+    this.socket.write(encodeClientFrame(0x8, Buffer.alloc(0)));
+    this.socket.end();
+  }
+
+  receive(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.buffer.length >= 2) {
+      const first = this.buffer[0];
+      const second = this.buffer[1];
+      const opcode = first & 0x0f;
+      const masked = Boolean(second & 0x80);
+      let length = second & 0x7f;
+      let offset = 2;
+      if (length === 126) {
+        if (this.buffer.length < offset + 2) {
+          return;
+        }
+        length = this.buffer.readUInt16BE(offset);
+        offset += 2;
+      } else if (length === 127) {
+        if (this.buffer.length < offset + 8) {
+          return;
+        }
+        const longLength = this.buffer.readBigUInt64BE(offset);
+        assert(longLength <= BigInt(Number.MAX_SAFE_INTEGER), "WebSocket frame is too large");
+        length = Number(longLength);
+        offset += 8;
+      }
+
+      const maskOffset = offset;
+      if (masked) {
+        offset += 4;
+      }
+      if (this.buffer.length < offset + length) {
+        return;
+      }
+
+      let payload = this.buffer.slice(offset, offset + length);
+      if (masked) {
+        const mask = this.buffer.slice(maskOffset, maskOffset + 4);
+        payload = Buffer.from(payload.map((byte, index) => byte ^ mask[index % 4]));
+      }
+      this.buffer = this.buffer.slice(offset + length);
+
+      if (opcode === 0x8) {
+        this.readyState = RawWebSocketClient.CLOSED;
+        this.socket.end();
+        this.dispatch("close", {});
+      } else if (opcode === 0x9) {
+        this.socket.write(encodeClientFrame(0x0a, payload));
+      } else if (opcode === 0x2) {
+        this.dispatch("message", { data: new Uint8Array(payload) });
+      } else if (opcode === 0x1) {
+        this.dispatch("message", { data: payload.toString("utf8") });
+      }
+    }
+  }
+}
+
+function encodeClientFrame(opcode, payload) {
+  const length = payload.length;
+  let headerLength = 2;
+  if (length >= 126 && length <= 0xffff) {
+    headerLength += 2;
+  } else if (length > 0xffff) {
+    headerLength += 8;
+  }
+
+  const frame = Buffer.alloc(headerLength + 4 + length);
+  frame[0] = 0x80 | opcode;
+  if (length < 126) {
+    frame[1] = 0x80 | length;
+  } else if (length <= 0xffff) {
+    frame[1] = 0x80 | 126;
+    frame.writeUInt16BE(length, 2);
+  } else {
+    frame[1] = 0x80 | 127;
+    frame.writeBigUInt64BE(BigInt(length), 2);
+  }
+
+  const mask = randomBytes(4);
+  mask.copy(frame, headerLength);
+  for (let index = 0; index < payload.length; index += 1) {
+    frame[headerLength + 4 + index] = payload[index] ^ mask[index % 4];
+  }
+  return frame;
+}

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -608,6 +608,11 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
     });
   }
 
+  const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
+  if (accessToken) {
+    candidates.push({ token: accessToken });
+  }
+
   const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));
   if (bearerToken) {
     candidates.push({ token: bearerToken, transport: "access-bearer" });

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -44,6 +44,7 @@ export interface AuthenticatedConnectionMetadata {
     | "dev-token-header"
     | "dev-token-subprotocol"
     | "access-assertion"
+    | "access-token-header"
     | "access-bearer"
     | "access-cookie"
     | "access-cookie-assertion"
@@ -494,6 +495,7 @@ function isMetadataTransport(value: string): value is AuthenticatedConnectionMet
     value === "dev-token-header" ||
     value === "dev-token-subprotocol" ||
     value === "access-assertion" ||
+    value === "access-token-header" ||
     value === "access-bearer" ||
     value === "access-cookie" ||
     value === "access-cookie-assertion" ||
@@ -610,7 +612,7 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
 
   const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
   if (accessToken) {
-    candidates.push({ token: accessToken });
+    candidates.push({ token: accessToken, transport: "access-token-header" });
   }
 
   const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -264,9 +264,9 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
     return json({ error: "expected WebSocket upgrade" }, 426);
   }
 
-  const originResponse = validateWebSocketOriginOrResponse(request, env);
-  if (originResponse) {
-    return originResponse;
+  const originRejection = rejectUntrustedWebSocketOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
   }
 
   const identity = await authenticateRequestOrResponse(request, env);
@@ -288,59 +288,45 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   return room.fetch(stampTrustedIdentity(request, authorizedIdentity));
 }
 
-function validateWebSocketOriginOrResponse(request: Request, env: Env): Response | undefined {
-  const origin = request.headers.get("Origin")?.trim();
+function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | null {
+  const allowedOrigins = allowedWebSocketOrigins(env);
+  if (!allowedOrigins) {
+    return null;
+  }
+
+  const origin = normalizedOrigin(request.headers.get("Origin"));
   if (!origin) {
-    if (hasCloudflareAccessCookie(request)) {
-      return json({ error: "WebSocket Origin is required" }, 403);
-    }
-    return undefined;
+    return json({ error: "websocket origin is required" }, 403);
   }
-
-  if (isAllowedWebSocketOrigin(origin, request.url, env)) {
-    return undefined;
+  if (!allowedOrigins.has(origin)) {
+    return json({ error: "websocket origin is not allowed" }, 403);
   }
-
-  return json({ error: "WebSocket Origin is not allowed" }, 403);
+  return null;
 }
 
-function isAllowedWebSocketOrigin(origin: string, requestUrl: string, env: Env): boolean {
-  let normalizedOrigin: string;
+function allowedWebSocketOrigins(env: Env): Set<string> | null {
+  const raw = env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS?.trim();
+  if (!raw) {
+    return null;
+  }
+
+  return new Set(
+    raw
+      .split(/[\s,]+/)
+      .map((entry) => normalizedOrigin(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+}
+
+function normalizedOrigin(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
   try {
-    normalizedOrigin = new URL(origin).origin;
+    return new URL(value).origin;
   } catch {
-    return false;
+    return null;
   }
-
-  if (normalizedOrigin === new URL(requestUrl).origin) {
-    return true;
-  }
-
-  return configuredWebSocketOrigins(env).includes(normalizedOrigin);
-}
-
-function configuredWebSocketOrigins(env: Env): string[] {
-  return (env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS ?? "")
-    .split(",")
-    .map((origin) => origin.trim())
-    .filter(Boolean)
-    .map((origin) => {
-      try {
-        return new URL(origin).origin;
-      } catch {
-        return "";
-      }
-    })
-    .filter(Boolean);
-}
-
-function hasCloudflareAccessCookie(request: Request): boolean {
-  const cookie = request.headers.get("Cookie");
-  if (!cookie) {
-    return false;
-  }
-
-  return cookie.split(";").some((part) => part.trim().split("=")[0] === "CF_Authorization");
 }
 
 async function routeSnapshot(

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -289,13 +289,12 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
 }
 
 function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | null {
-  const allowedOrigins = allowedWebSocketOrigins(env);
-  if (!allowedOrigins) {
-    return null;
-  }
-
+  const allowedOrigins = allowedWebSocketOrigins(request, env);
   const origin = normalizedOrigin(request.headers.get("Origin"));
   if (!origin) {
+    if (!requiresWebSocketOrigin(request, env)) {
+      return null;
+    }
     return json({ error: "websocket origin is required" }, 403);
   }
   if (!allowedOrigins.has(origin)) {
@@ -304,18 +303,24 @@ function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | 
   return null;
 }
 
-function allowedWebSocketOrigins(env: Env): Set<string> | null {
+function requiresWebSocketOrigin(request: Request, env: Env): boolean {
+  return Boolean(env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS?.trim()) || hasCloudflareAccessCookie(request);
+}
+
+function allowedWebSocketOrigins(request: Request, env: Env): Set<string> {
+  const origins = new Set<string>([new URL(request.url).origin]);
   const raw = env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS?.trim();
   if (!raw) {
-    return null;
+    return origins;
   }
 
-  return new Set(
-    raw
-      .split(/[\s,]+/)
-      .map((entry) => normalizedOrigin(entry))
-      .filter((entry): entry is string => Boolean(entry)),
-  );
+  for (const origin of raw
+    .split(/[\s,]+/)
+    .map((entry) => normalizedOrigin(entry))
+    .filter((entry): entry is string => Boolean(entry))) {
+    origins.add(origin);
+  }
+  return origins;
 }
 
 function normalizedOrigin(value: string | null): string | null {
@@ -327,6 +332,15 @@ function normalizedOrigin(value: string | null): string | null {
   } catch {
     return null;
   }
+}
+
+function hasCloudflareAccessCookie(request: Request): boolean {
+  const cookie = request.headers.get("Cookie");
+  if (!cookie) {
+    return false;
+  }
+
+  return cookie.split(";").some((part) => part.trim().split("=")[0] === "CF_Authorization");
 }
 
 async function routeSnapshot(

--- a/apps/notebook-cloud/src/sharing.ts
+++ b/apps/notebook-cloud/src/sharing.ts
@@ -1,0 +1,214 @@
+import type { ConnectionScope } from "./auth-shared.ts";
+
+export type InviteStatus = "pending" | "accepted" | "revoked" | "expired";
+
+export interface PendingNotebookInvite {
+  id: string;
+  notebookId: string;
+  email: string;
+  providerHint: string | null;
+  scope: Exclude<ConnectionScope, "owner" | "runtime_peer">;
+  status: InviteStatus;
+  createdByActorLabel: string;
+  createdAt: string;
+  expiresAt: string | null;
+  acceptedByPrincipal?: string | null;
+  acceptedAt?: string | null;
+}
+
+export interface AuthenticatedLoginProfile {
+  principal: string;
+  provider: string;
+  email: string | null;
+  emailVerified: boolean;
+  displayName: string | null;
+}
+
+export interface PrincipalProfile {
+  principal: string;
+  provider: string;
+  email: string | null;
+  displayName: string | null;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface InviteAclGrant {
+  notebookId: string;
+  subjectKind: "principal";
+  subject: string;
+  scope: PendingNotebookInvite["scope"];
+  actorLabel: string;
+  inviteId: string;
+}
+
+export interface InviteResolution {
+  profile: PrincipalProfile;
+  acceptedInvites: PendingNotebookInvite[];
+  aclGrants: InviteAclGrant[];
+}
+
+export type ShareTargetDisplay =
+  | {
+      kind: "principal";
+      label: string;
+      principal: string;
+      email: string | null;
+    }
+  | {
+      kind: "pending_invite";
+      label: string;
+      email: string;
+    }
+  | {
+      kind: "public_viewer";
+      label: string;
+    };
+
+const INVITE_RESOLUTION_ACTOR_LABEL = "system/invite-resolution";
+
+export function normalizeInviteEmail(email: string): string {
+  const normalized = email.trim().toLowerCase();
+  if (
+    !normalized ||
+    normalized.includes("/") ||
+    /\s/.test(normalized) ||
+    !normalized.includes("@")
+  ) {
+    throw new Error("invite email is invalid");
+  }
+  return normalized;
+}
+
+export function inviteLookupKey(provider: string | null, email: string): string {
+  const providerKey = normalizeProviderHint(provider) ?? "*";
+  return `${providerKey}:${normalizeInviteEmail(email)}`;
+}
+
+export function normalizeProviderHint(provider: string | null): string | null {
+  const normalized = provider?.trim().toLowerCase() ?? "";
+  if (!normalized) {
+    return null;
+  }
+  if (normalized.includes("/") || /\s/.test(normalized)) {
+    throw new Error("invite provider hint is invalid");
+  }
+  return normalized;
+}
+
+export function resolvePendingInvitesForLogin({
+  invites,
+  login,
+  now = new Date().toISOString(),
+}: {
+  invites: PendingNotebookInvite[];
+  login: AuthenticatedLoginProfile;
+  now?: string;
+}): InviteResolution {
+  const profile: PrincipalProfile = {
+    principal: login.principal,
+    provider: normalizeProvider(login.provider),
+    email: login.email ? normalizeInviteEmail(login.email) : null,
+    displayName: login.displayName?.trim() || null,
+    firstSeenAt: now,
+    lastSeenAt: now,
+  };
+
+  if (!login.email || !login.emailVerified) {
+    return { profile, acceptedInvites: [], aclGrants: [] };
+  }
+
+  const loginEmail = normalizeInviteEmail(login.email);
+  const loginProvider = normalizeProvider(login.provider);
+  const acceptedInvites = invites
+    .filter((invite) => inviteMatchesLogin(invite, loginEmail, loginProvider, now))
+    .map((invite) => ({
+      ...invite,
+      status: "accepted" as const,
+      acceptedByPrincipal: login.principal,
+      acceptedAt: now,
+    }));
+
+  const aclGrants = acceptedInvites.map((invite) => ({
+    notebookId: invite.notebookId,
+    subjectKind: "principal" as const,
+    subject: login.principal,
+    scope: invite.scope,
+    actorLabel: INVITE_RESOLUTION_ACTOR_LABEL,
+    inviteId: invite.id,
+  }));
+
+  return { profile, acceptedInvites, aclGrants };
+}
+
+export function publicViewerAclGrant(
+  notebookId: string,
+  actorLabel: string,
+): {
+  notebookId: string;
+  subjectKind: "public";
+  subject: "anonymous";
+  scope: "viewer";
+  actorLabel: string;
+} {
+  return {
+    notebookId,
+    subjectKind: "public",
+    subject: "anonymous",
+    scope: "viewer",
+    actorLabel,
+  };
+}
+
+export function shareTargetDisplay(input: {
+  profile?: PrincipalProfile | null;
+  pendingInvite?: Pick<PendingNotebookInvite, "email"> | null;
+  publicViewer?: boolean;
+}): ShareTargetDisplay {
+  if (input.publicViewer) {
+    return { kind: "public_viewer", label: "Anyone with the link" };
+  }
+  if (input.profile) {
+    return {
+      kind: "principal",
+      label: input.profile.displayName || input.profile.email || input.profile.principal,
+      principal: input.profile.principal,
+      email: input.profile.email,
+    };
+  }
+  if (input.pendingInvite) {
+    return {
+      kind: "pending_invite",
+      label: normalizeInviteEmail(input.pendingInvite.email),
+      email: normalizeInviteEmail(input.pendingInvite.email),
+    };
+  }
+  throw new Error("share target display requires a profile, pending invite, or public viewer flag");
+}
+
+function inviteMatchesLogin(
+  invite: PendingNotebookInvite,
+  loginEmail: string,
+  loginProvider: string,
+  now: string,
+): boolean {
+  if (invite.status !== "pending") {
+    return false;
+  }
+  if (invite.expiresAt && invite.expiresAt <= now) {
+    return false;
+  }
+  if (normalizeInviteEmail(invite.email) !== loginEmail) {
+    return false;
+  }
+  const providerHint = normalizeProviderHint(invite.providerHint);
+  return !providerHint || providerHint === loginProvider;
+}
+
+function normalizeProvider(provider: string): string {
+  const normalized = normalizeProviderHint(provider);
+  if (!normalized) {
+    throw new Error("login provider is invalid");
+  }
+  return normalized;
+}

--- a/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
@@ -7,7 +7,9 @@ import {
   accessEmailFromJwt,
   accessPrincipalFromJwt,
   assertHostedAccessSmokeEnv,
+  webSocketUpgradeRequestHeaders,
 } from "../scripts/hosted-access-smoke-env.mjs";
+import { authenticateRequestWithProviders } from "../src/identity.ts";
 
 describe("hosted Access smoke environment helpers", () => {
   it("maps Access subjects to principal rows without using email as the principal", () => {
@@ -17,11 +19,10 @@ describe("hosted Access smoke environment helpers", () => {
     assert.equal(accessEmailFromJwt(token), "alice@example.com");
   });
 
-  it("builds Access HTTP headers and WebSocket subprotocol auth without URL tokens", () => {
+  it("builds Access HTTP headers and WebSocket subprotocol auth without URL tokens", async () => {
     const token = jwt({ sub: "access-user-123" });
 
     assert.deepEqual(accessAuthHeaders(token, { operator: "smoke:owner", scope: "owner" }), {
-      Authorization: `Bearer ${token}`,
       "CF-Access-Token": token,
       "X-Operator": "smoke:owner",
       "X-Scope": "owner",
@@ -29,6 +30,33 @@ describe("hosted Access smoke environment helpers", () => {
     assert.deepEqual(accessAuthProtocols(token), [
       `nteract-access-token.${Buffer.from(token, "utf8").toString("base64url")}`,
     ]);
+    await assert.doesNotReject(() =>
+      authenticateRequestWithProviders(
+        new Request("https://cloud.test/n/demo/sync", {
+          headers: accessAuthHeaders(token),
+        }),
+      ),
+    );
+  });
+
+  it("builds raw WebSocket Access upgrade headers with one Worker-visible credential", () => {
+    const token = jwt({ sub: "access-user-123" });
+    const headers = webSocketUpgradeRequestHeaders(
+      new URL("wss://cloud.test/n/access-demo/sync?operator=smoke%3Aowner&scope=owner"),
+      {
+        key: "test-key",
+        origin: "https://cloud.test",
+        accessToken: token,
+      },
+    );
+
+    assert.ok(headers.includes(`CF-Access-Token: ${token}`));
+    assert.ok(!headers.some((header) => header.startsWith("Authorization:")));
+    assert.equal(
+      headers.filter((header) => /^CF-Access-Token:|^Authorization:|^Cookie:/i.test(header)).length,
+      1,
+    );
+    assert.ok(!headers.some((header) => header.includes("nteract-access-token.")));
   });
 
   it("requires an owner Access token", () => {

--- a/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  accessAuthHeaders,
+  accessAuthProtocols,
+  accessEmailFromJwt,
+  accessPrincipalFromJwt,
+  assertHostedAccessSmokeEnv,
+} from "../scripts/hosted-access-smoke-env.mjs";
+
+describe("hosted Access smoke environment helpers", () => {
+  it("maps Access subjects to principal rows without using email as the principal", () => {
+    const token = jwt({ sub: "access-user-123", email: "alice@example.com" });
+
+    assert.equal(accessPrincipalFromJwt(token), "user:cloudflare-access:access-user-123");
+    assert.equal(accessEmailFromJwt(token), "alice@example.com");
+  });
+
+  it("builds Access HTTP headers and WebSocket subprotocol auth without URL tokens", () => {
+    const token = jwt({ sub: "access-user-123" });
+
+    assert.deepEqual(accessAuthHeaders(token, { operator: "smoke:owner", scope: "owner" }), {
+      Authorization: `Bearer ${token}`,
+      "CF-Access-Token": token,
+      "X-Operator": "smoke:owner",
+      "X-Scope": "owner",
+    });
+    assert.deepEqual(accessAuthProtocols(token), [
+      `nteract-access-token.${Buffer.from(token, "utf8").toString("base64url")}`,
+    ]);
+  });
+
+  it("requires an owner Access token", () => {
+    assert.throws(
+      () => assertHostedAccessSmokeEnv({ ownerToken: "" }),
+      /NOTEBOOK_CLOUD_ACCESS_JWT is required/,
+    );
+  });
+});
+
+function jwt(payload) {
+  return [base64UrlJson({ alg: "RS256", typ: "JWT" }), base64UrlJson(payload), "signature"].join(
+    ".",
+  );
+}
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -447,6 +447,7 @@ describe("Cloudflare Access identity", () => {
 
     assert.equal(identity.actorLabel, "user:cloudflare-access:alice/smoke:owner");
     assert.equal(identity.scope, "owner");
+    assert.equal(identity.metadata.transport, "access-token-header");
   });
 
   it("rejects Access tokens with the wrong audience", async () => {

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -355,7 +355,7 @@ describe("Cloudflare Access identity", () => {
     });
   });
 
-  it("accepts browser WebSocket Access tokens through subprotocols", async () => {
+  it("accepts browser WebSocket Access tokens through subprotocols without echoing credentials", async () => {
     const { env, token } = await accessTokenFixture({ subject: "alice" });
     const protocol = `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`;
 
@@ -431,6 +431,22 @@ describe("Cloudflare Access identity", () => {
 
     assert.equal(identity.actorLabel, "user:cloudflare-access:alice/browser:tab");
     assert.equal(identity.scope, "viewer");
+  });
+
+  it("accepts Cloudflare Access CLI tokens from the cf-access-token header", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=smoke:owner&scope=owner", {
+        headers: {
+          "CF-Access-Token": token,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/smoke:owner");
+    assert.equal(identity.scope, "owner");
   });
 
   it("rejects Access tokens with the wrong audience", async () => {

--- a/apps/notebook-cloud/test/sharing.test.ts
+++ b/apps/notebook-cloud/test/sharing.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  inviteLookupKey,
+  normalizeInviteEmail,
+  normalizeProviderHint,
+  publicViewerAclGrant,
+  resolvePendingInvitesForLogin,
+  shareTargetDisplay,
+  type AuthenticatedLoginProfile,
+  type PendingNotebookInvite,
+} from "../src/sharing.ts";
+
+describe("hosted notebook sharing prototype", () => {
+  it("resolves a pending email invite to a principal ACL grant on first verified login", () => {
+    const invite = pendingInvite({ email: " Alice@Example.COM " });
+    const login = accessLogin({
+      principal: "user:cloudflare-access:access-sub-1",
+      email: "alice@example.com",
+      displayName: "Alice Example",
+    });
+
+    const resolution = resolvePendingInvitesForLogin({
+      invites: [invite],
+      login,
+      now: "2026-05-24T12:00:00.000Z",
+    });
+
+    assert.deepEqual(resolution.aclGrants, [
+      {
+        notebookId: "notebook-1",
+        subjectKind: "principal",
+        subject: "user:cloudflare-access:access-sub-1",
+        scope: "editor",
+        actorLabel: "system/invite-resolution",
+        inviteId: "invite-1",
+      },
+    ]);
+    assert.equal(resolution.acceptedInvites[0]?.acceptedByPrincipal, login.principal);
+    assert.doesNotMatch(resolution.aclGrants[0]?.subject ?? "", /alice@example.com/);
+  });
+
+  it("does not resolve invites from unverified emails or the wrong provider", () => {
+    const invite = pendingInvite({ providerHint: "cloudflare-access" });
+
+    assert.equal(
+      resolvePendingInvitesForLogin({
+        invites: [invite],
+        login: accessLogin({ emailVerified: false }),
+      }).aclGrants.length,
+      0,
+    );
+    assert.equal(
+      resolvePendingInvitesForLogin({
+        invites: [invite],
+        login: accessLogin({ provider: "dev" }),
+      }).aclGrants.length,
+      0,
+    );
+  });
+
+  it("normalizes provider hints before resolving pending invites", () => {
+    const invite = pendingInvite({ providerHint: " Cloudflare-Access " });
+
+    const resolution = resolvePendingInvitesForLogin({
+      invites: [invite],
+      login: accessLogin({ provider: "cloudflare-access" }),
+    });
+
+    assert.equal(resolution.aclGrants.length, 1);
+    assert.equal(resolution.profile.provider, "cloudflare-access");
+  });
+
+  it("keeps pending invite lookup keyed by normalized email plus provider hint", () => {
+    assert.equal(normalizeInviteEmail(" Alice@Example.COM "), "alice@example.com");
+    assert.equal(normalizeProviderHint(" Cloudflare-Access "), "cloudflare-access");
+    assert.equal(
+      inviteLookupKey(" Cloudflare-Access ", " Alice@Example.COM "),
+      "cloudflare-access:alice@example.com",
+    );
+    assert.equal(inviteLookupKey(null, "alice@example.com"), "*:alice@example.com");
+  });
+
+  it("represents public viewers as explicit public ACL rows", () => {
+    assert.deepEqual(publicViewerAclGrant("notebook-1", "user:dev:alice/desktop:test"), {
+      notebookId: "notebook-1",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+      actorLabel: "user:dev:alice/desktop:test",
+    });
+  });
+
+  it("builds display labels for resolved principals, pending invites, and public viewers", () => {
+    const principal = shareTargetDisplay({
+      profile: {
+        principal: "user:cloudflare-access:access-sub-1",
+        provider: "cloudflare-access",
+        email: "alice@example.com",
+        displayName: "Alice Example",
+        firstSeenAt: "2026-05-24T12:00:00.000Z",
+        lastSeenAt: "2026-05-24T12:00:00.000Z",
+      },
+    });
+    const pending = shareTargetDisplay({ pendingInvite: { email: "Bob@Example.com" } });
+    const publicViewer = shareTargetDisplay({ publicViewer: true });
+
+    assert.equal(principal.label, "Alice Example");
+    assert.equal(pending.label, "bob@example.com");
+    assert.deepEqual(publicViewer, { kind: "public_viewer", label: "Anyone with the link" });
+  });
+});
+
+function pendingInvite(overrides: Partial<PendingNotebookInvite> = {}): PendingNotebookInvite {
+  return {
+    id: "invite-1",
+    notebookId: "notebook-1",
+    email: "alice@example.com",
+    providerHint: "cloudflare-access",
+    scope: "editor",
+    status: "pending",
+    createdByActorLabel: "user:cloudflare-access:owner/smoke:owner",
+    createdAt: "2026-05-24T11:00:00.000Z",
+    expiresAt: "2026-06-24T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function accessLogin(
+  overrides: Partial<AuthenticatedLoginProfile> = {},
+): AuthenticatedLoginProfile {
+  return {
+    principal: "user:cloudflare-access:access-sub-1",
+    provider: "cloudflare-access",
+    email: "alice@example.com",
+    emailVerified: true,
+    displayName: "Alice Example",
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -796,6 +796,44 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("allows same-origin cookie-backed Access WebSocket upgrades by default", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "cookie-origin-demo");
+    seedAcl(env, {
+      notebookId: "cookie-origin-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-origin-demo/sync?operator=browser:tab&scope=owner", {
+        headers: {
+          Cookie: `CF_Authorization=${token}`,
+          Origin: "https://cloud.test",
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(roomFetches, 1);
+  });
+
   it("allows configured browser WebSocket origins", async () => {
     let roomFetches = 0;
     const env = fakeEnv({
@@ -850,6 +888,71 @@ describe("Worker artifact routes", () => {
     const response = await worker.fetch(
       new Request("https://cloud.test/n/acl-demo/sync?viewer_session=blocked", {
         headers: {
+          Origin: "https://evil.example",
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), { error: "websocket origin is not allowed" });
+    assert.equal(roomFetches, 0);
+  });
+
+  it("rejects cookie-backed WebSocket upgrades with no Origin before room dispatch", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-origin-demo/sync?operator=browser:tab&scope=owner", {
+        headers: {
+          Cookie: `CF_Authorization=${token}`,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), { error: "websocket origin is required" });
+    assert.equal(roomFetches, 0);
+  });
+
+  it("rejects cookie-backed WebSocket upgrades from untrusted origins by default", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-origin-demo/sync?operator=browser:tab&scope=owner", {
+        headers: {
+          Cookie: `CF_Authorization=${token}`,
           Origin: "https://evil.example",
           Upgrade: "websocket",
         },

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -832,9 +832,10 @@ describe("Worker artifact routes", () => {
     assert.equal(roomFetches, 1);
   });
 
-  it("rejects untrusted browser WebSocket origins before room dispatch", async () => {
+  it("rejects WebSocket upgrades from origins outside the configured allowlist", async () => {
     let roomFetches = 0;
     const env = fakeEnv({
+      NOTEBOOK_CLOUD_ALLOWED_ORIGINS: "https://notebooks.example.com",
       NOTEBOOK_ROOMS: {
         idFromName: (name: string) => ({ toString: () => name }),
         get: () => ({
@@ -847,10 +848,10 @@ describe("Worker artifact routes", () => {
     });
 
     const response = await worker.fetch(
-      new Request("http://localhost/n/origin-demo/sync?user=alice&scope=owner", {
+      new Request("https://cloud.test/n/acl-demo/sync?viewer_session=blocked", {
         headers: {
+          Origin: "https://evil.example",
           Upgrade: "websocket",
-          Origin: "https://evil.example.test",
         },
       }),
       env,
@@ -858,28 +859,18 @@ describe("Worker artifact routes", () => {
     );
 
     assert.equal(response.status, 403);
-    assert.deepEqual(await response.json(), { error: "WebSocket Origin is not allowed" });
+    assert.deepEqual(await response.json(), { error: "websocket origin is not allowed" });
     assert.equal(roomFetches, 0);
   });
 
-  it("rejects cookie-backed WebSocket upgrades that omit Origin", async () => {
-    let roomFetches = 0;
+  it("rejects allowlisted WebSocket upgrades when the browser sends no Origin", async () => {
     const env = fakeEnv({
-      NOTEBOOK_ROOMS: {
-        idFromName: (name: string) => ({ toString: () => name }),
-        get: () => ({
-          fetch: async () => {
-            roomFetches += 1;
-            return new Response("unexpected room fetch", { status: 500 });
-          },
-        }),
-      } satisfies DurableObjectNamespace,
+      NOTEBOOK_CLOUD_ALLOWED_ORIGINS: "https://notebooks.example.com",
     });
 
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/origin-demo/sync", {
+      new Request("https://cloud.test/n/acl-demo/sync?viewer_session=missing", {
         headers: {
-          Cookie: "CF_Authorization=access-token",
           Upgrade: "websocket",
         },
       }),
@@ -888,8 +879,7 @@ describe("Worker artifact routes", () => {
     );
 
     assert.equal(response.status, 403);
-    assert.deepEqual(await response.json(), { error: "WebSocket Origin is required" });
-    assert.equal(roomFetches, 0);
+    assert.deepEqual(await response.json(), { error: "websocket origin is required" });
   });
 
   it("does not create notebook rows from unauthorized WebSocket opens", async () => {

--- a/docs/architecture/frontend-sync-bridge.md
+++ b/docs/architecture/frontend-sync-bridge.md
@@ -31,7 +31,7 @@ Three constraints shape every decision below:
 
 Two projects shaped the design:
 
-- **`automerge-repo`'s `DocHandle` / `RepoContext`**. The upstream pattern wires React directly to handle changes via `useDocument`. We learned from intheloop that this works fine for a single doc but pulls every consumer through one re-render path: a runtime-state tick competes with a cell edit competes with a presence frame. We split those into independent stores.
+- **`automerge-repo`'s `DocHandle` / `RepoContext`**. The upstream pattern wires React directly to handle changes via `useDocument`. We learned from [intheloop](https://github.com/runtimed/intheloop) that this works fine for a single doc but pulls every consumer through one re-render path: a runtime-state tick competes with a cell edit competes with a presence frame. We split those into independent stores.
 - **Zustand and Jotai's external-store ergonomics**. The split-store pattern in `notebook-cells.ts` is shaped to match how Zustand exposes per-slice selectors. We didn't pull in a library because the WASM peer already produces typed diffs; the store is a one-call wrapper around `useSyncExternalStore`.
 
 ## Decision 1: Bridge engine streams into stores; do not bind React to Automerge

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -1,0 +1,412 @@
+# Hosted Cloudflare Access + Anaconda Demo Runbook
+
+**Status:** Draft, verified against provider metadata on 2026-05-24.
+
+This is the operational path for the Anaconda-hosted notebook-cloud demo:
+Cloudflare Access owns the browser login session, Anaconda is the Access OIDC
+identity provider, and the notebook-cloud Worker independently validates the
+Access JWT before consulting the per-notebook D1 ACL.
+
+Related design docs:
+
+- `docs/architecture/hosted-credential-transport.md`
+- `docs/architecture/hosted-room-authorization.md`
+- `docs/architecture/hosted-notebook-artifacts.md`
+- `docs/architecture/identity-and-trust.md`
+
+## Target Topology
+
+Use one notebook application hostname for the demo:
+
+```text
+https://<notebook-host>
+```
+
+Examples:
+
+```text
+https://notebooks.example.com
+https://nteract-notebook-cloud.rgbkrk.workers.dev
+```
+
+The Access application protects that host. Browser users authenticate through
+Anaconda OIDC in Cloudflare Access. Cloudflare forwards Access assertions to the
+Worker, and the Worker maps the Access subject to:
+
+```text
+user:cloudflare-access:<encoded-access-sub>
+```
+
+Email and display name are profile metadata. They are not ACL subjects.
+
+Renderer sidecar assets may stay on a separate public asset origin:
+
+```text
+https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/
+```
+
+Do not add the renderer asset origin to the notebook WebSocket origin allowlist.
+It serves public build artifacts only; notebook room traffic belongs to the
+notebook application origin.
+
+## Cloudflare Access Application
+
+Create a Cloudflare Access self-hosted application for the notebook host.
+
+1. In Cloudflare Zero Trust, go to `Access controls > Applications`.
+2. Add an application and choose `Self-hosted`.
+3. Name it, for example `nteract notebook cloud`.
+4. Set the public hostname:
+
+   ```text
+   https://<notebook-host>
+   ```
+
+5. Use a session duration suitable for a live demo, for example `8 hours`.
+6. Add an `Allow` policy for the demo cohort:
+   - Identity provider: the Anaconda OIDC provider configured below.
+   - Include: exact demo emails, an Anaconda-backed email domain, or an Access
+     group used only for the demo.
+   - Require: optional device posture or MFA if the account policy demands it.
+7. Copy the application's `Audience Tag`. This is the Worker value:
+
+   ```text
+   NOTEBOOK_CLOUD_ACCESS_AUD=<Access application Audience Tag>
+   ```
+
+8. Record the Cloudflare One team domain:
+
+   ```text
+   NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN=<team-name>.cloudflareaccess.com
+   ```
+
+Cloudflare's Access docs describe self-hosted apps, Access cookies, and Access
+JWT validation here:
+
+- `https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/`
+- `https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/`
+- `https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/`
+
+## Anaconda OIDC Provider In Access
+
+Add Anaconda as a generic OIDC identity provider in Cloudflare Access.
+
+1. In Cloudflare Zero Trust, go to `Settings > Authentication` or
+   `Integrations > Identity providers`.
+2. Add an identity provider and choose `OpenID Connect`.
+3. In the Anaconda OIDC client, register this redirect URI:
+
+   ```text
+   https://<team-name>.cloudflareaccess.com/cdn-cgi/access/callback
+   ```
+
+4. Configure Cloudflare Access with the Anaconda client ID and client secret.
+   These stay in Cloudflare Access. They are not Worker secrets.
+5. Use these production endpoints:
+
+   ```text
+   Issuer:        https://auth.anaconda.com/api/auth
+   Auth URL:      https://auth.anaconda.com/api/auth/oauth2/authorize
+   Token URL:     https://auth.anaconda.com/api/auth/oauth2/token
+   Certificate:   https://auth.anaconda.com/api/auth/.well-known/jwks.json
+   Userinfo:      https://auth.anaconda.com/api/auth/oauth2/userinfo
+   Scopes:        openid email profile
+   Client auth:   client_secret_basic or client_secret_post
+   Discovery:     https://auth.anaconda.com/api/auth/.well-known/openid-configuration
+   ```
+
+6. For staging, use the same paths under `https://auth.stage.anaconda.com`:
+
+   ```text
+   Issuer:        https://auth.stage.anaconda.com/api/auth
+   Discovery:     https://auth.stage.anaconda.com/api/auth/.well-known/openid-configuration
+   ```
+
+Cloudflare's generic OIDC setup requires the IdP redirect URI above and the
+authorization, token, and JWKS endpoints from the provider discovery document:
+
+```text
+https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/generic-oidc/
+```
+
+## Worker Environment
+
+Set these Worker variables for an Access-backed deployment:
+
+```toml
+[vars]
+DEPLOYMENT_ENV = "prototype"
+NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN = "<team-name>.cloudflareaccess.com"
+NOTEBOOK_CLOUD_ACCESS_AUD = "<Access application Audience Tag>"
+NOTEBOOK_CLOUD_ALLOWED_ORIGINS = "https://<notebook-host>"
+RENDERER_ASSETS_BASE_URL = "https://<asset-host>/renderer-assets/"
+RUNTIMED_WASM_BASE_URL = "https://<asset-host>/renderer-assets/"
+```
+
+`NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` and `NOTEBOOK_CLOUD_ACCESS_AUD` are not
+secrets. They tell the Worker which Access issuer and audience to accept.
+
+Do not set `NOTEBOOK_CLOUD_ACCESS_JWKS_JSON` in normal production operation.
+When unset, the Worker fetches:
+
+```text
+https://<team-name>.cloudflareaccess.com/cdn-cgi/access/certs
+```
+
+Use `NOTEBOOK_CLOUD_ACCESS_JWKS_JSON` only for pinned/offline tests or an
+emergency where fetching the Access JWKS is intentionally disabled.
+
+`NOTEBOOK_CLOUD_DEV_TOKEN` is for the old deployed prototype and local smoke
+scripts. It is not part of the Access + Anaconda demo auth path. Keep it only
+if you still need the dev-token prototype scripts:
+
+```bash
+printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
+  | pnpm --workspace-root exec wrangler secret put NOTEBOOK_CLOUD_DEV_TOKEN \
+      --config apps/notebook-cloud/wrangler.toml
+```
+
+## Allowed Origins
+
+For an Access-backed browser deployment, set:
+
+```text
+NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://<notebook-host>
+```
+
+Use a comma-separated list only when the same Worker must accept browser
+WebSockets from more than one notebook application origin:
+
+```text
+NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com,https://preview-notebooks.example.com
+```
+
+Rules:
+
+- Include the notebook application origin that renders `/n/:id`.
+- Include loopback origins only for local Wrangler development.
+- Do not include the renderer asset Worker origin.
+- Do not include sandboxed output iframe origins.
+- Do not use `*`.
+- Leaving the variable unset disables the origin gate and should be limited to
+  local development or throwaway prototype hosts.
+
+The Worker checks `Origin` before WebSocket auth when the allowlist is set. In
+that mode every WebSocket client, including CLI smoke and future native clients,
+must send an `Origin` that normalizes to one of these values. Browser
+Access-cookie sessions must come from an allowed origin so a malicious site
+cannot use an ambient Access cookie to open a private room socket.
+
+## Deploy
+
+From the repository root:
+
+```bash
+pnpm --dir apps/notebook-cloud build
+pnpm --workspace-root exec wrangler d1 migrations apply nteract-notebook-cloud-prototype-db \
+  --config apps/notebook-cloud/wrangler.toml \
+  --remote
+pnpm --workspace-root exec wrangler deploy \
+  --config apps/notebook-cloud/wrangler.renderer-assets.toml
+pnpm --workspace-root exec wrangler deploy \
+  --config apps/notebook-cloud/wrangler.toml
+```
+
+Use the deployment's actual D1 database name, Worker config, and asset Worker
+config if they differ from the prototype names above.
+
+## ACL Bootstrap Model
+
+The Worker does not grant notebook roles from Anaconda groups or Access
+policies. Access authenticates the user. D1 grants the notebook role.
+
+For a demo notebook:
+
+1. Create or publish the notebook with an owner ACL row.
+2. Grant collaborators by principal:
+
+   ```json
+   {
+     "subject_kind": "principal",
+     "subject": "user:cloudflare-access:<encoded-access-sub>",
+     "scope": "editor"
+   }
+   ```
+
+3. Grant a viewer by principal:
+
+   ```json
+   {
+     "subject_kind": "principal",
+     "subject": "user:cloudflare-access:<encoded-access-sub>",
+     "scope": "viewer"
+   }
+   ```
+
+4. Public viewer is a separate explicit row, and only applies when the request
+   can reach the Worker without being blocked by Access:
+
+   ```json
+   {
+     "subject_kind": "public",
+     "subject": "anonymous",
+     "scope": "viewer"
+   }
+   ```
+
+A hostname protected entirely by Access will not admit anonymous public viewers
+at the Cloudflare edge. For public published notebooks, use an unprotected
+public viewer hostname, a bypass policy for the public viewer route, or a
+separate public deployment that still relies on the Worker ACL row before
+serving room state.
+
+## Hosted Access Smoke
+
+The Access smoke proves that:
+
+- the Worker accepts a Cloudflare Access application JWT;
+- the Access JWT maps to `user:cloudflare-access:<sub>`, not email;
+- owner, editor, and viewer ACL rows are honored;
+- owner and editor can write real `NotebookDoc` Automerge frames;
+- the granted Access viewer receives the live edit stream;
+- no token is put in the WebSocket URL.
+
+Install `cloudflared` and authenticate to the Access application:
+
+```bash
+cloudflared access login https://<notebook-host>
+export NOTEBOOK_CLOUD_ACCESS_JWT="$(cloudflared access token -app=https://<notebook-host>)"
+```
+
+For a single-user smoke, the owner token is reused as editor and viewer. For a
+multi-user demo, run the token command under each user session:
+
+```bash
+export NOTEBOOK_CLOUD_ACCESS_EDITOR_JWT="<second user's Access token>"
+export NOTEBOOK_CLOUD_ACCESS_VIEWER_JWT="<third user's Access token>"
+```
+
+Build the volatile WASM package and run the smoke:
+
+```bash
+cargo xtask wasm runtimed --skip-renderer-plugins
+
+NOTEBOOK_CLOUD_URL=https://<notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_ORIGIN=https://<notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_NOTEBOOK_ID=access-demo-$(date +%Y%m%d%H%M%S) \
+NOTEBOOK_CLOUD_ACCESS_JWT="$NOTEBOOK_CLOUD_ACCESS_JWT" \
+pnpm --dir apps/notebook-cloud smoke:hosted:access
+```
+
+The script sends:
+
+- `CF-Access-Token: <jwt>` so Cloudflare Access can admit the HTTP and
+  WebSocket requests;
+- `Authorization: Bearer <jwt>` as a direct-Worker fallback;
+- `Origin: https://<notebook-host>` for the WebSocket origin allowlist;
+- `nteract-access-token.<base64url-jwt>` as the Worker-level WebSocket bearer
+  fallback when the hostname is not fronted by Access.
+
+Expected JSON shape:
+
+```json
+{
+  "ok": true,
+  "auth_mode": "cloudflare_access",
+  "viewerUrl": "https://<notebook-host>/n/<id>",
+  "checks": [
+    "cloudflare_access_jwt_validated_by_worker",
+    "owner_acl_room_seeded",
+    "editor_principal_acl_granted",
+    "viewer_principal_acl_granted",
+    "real_automerge_sync_payload",
+    "access_owner_seeded_markdown",
+    "access_editor_edited_markdown",
+    "access_viewer_live_convergence",
+    "actor_principals_match_access_subjects"
+  ]
+}
+```
+
+To also prove anonymous public viewer convergence on a host that permits
+unauthenticated public room access, add:
+
+```bash
+NOTEBOOK_CLOUD_ACCESS_PUBLIC_SMOKE=1
+```
+
+Do not enable that flag against a hostname fully protected by Access; the
+anonymous WebSocket should be blocked before it reaches the Worker.
+
+## Browser Cookie Smoke
+
+The CLI smoke proves token validation and ACL behavior. The browser cookie path
+should also be checked manually for the demo host:
+
+1. Open `https://<notebook-host>/n/<id>` in a normal browser profile.
+2. Complete the Cloudflare Access login through Anaconda.
+3. Confirm the WebSocket connects without putting tokens in the URL.
+4. Confirm a granted editor can edit an existing markdown cell.
+5. Confirm a granted viewer sees the edit but cannot edit.
+
+For the browser path, Cloudflare Access should forward
+`Cf-Access-Jwt-Assertion` to the Worker. The Worker validates that assertion
+against `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` and `NOTEBOOK_CLOUD_ACCESS_AUD`,
+then D1 decides the requested notebook scope.
+
+## Troubleshooting
+
+`401 missing/invalid Cloudflare Access token`
+
+- Confirm `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` is the Cloudflare One team domain,
+  not the notebook hostname.
+- Confirm `NOTEBOOK_CLOUD_ACCESS_AUD` is the Access application's Audience Tag.
+- Confirm the Access token was minted for the same app:
+
+  ```bash
+  cloudflared access token -app=https://<notebook-host>
+  ```
+
+`403 websocket origin is not allowed`
+
+- Confirm `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` contains exactly the notebook app
+  origin, including scheme.
+- Confirm `NOTEBOOK_CLOUD_ACCESS_ORIGIN` matches that origin in the smoke.
+- Do not use the renderer asset origin as the smoke origin.
+
+`403 notebook access denied`
+
+- Authentication succeeded, but D1 has no ACL row for the requested principal
+  and scope.
+- Decode the smoke output `principals` field and grant that exact principal.
+- Do not grant email strings as `notebook_acl.subject`.
+
+`404 or failed render for public viewers`
+
+- A public viewer needs both network reachability and the explicit ACL row:
+  `subject_kind = public`, `subject = anonymous`, `scope = viewer`.
+- A fully Access-protected hostname blocks anonymous requests at the edge before
+  Worker ACLs run.
+
+`Missing apps/notebook/src/wasm/runtimed-wasm output`
+
+- Run:
+
+  ```bash
+  cargo xtask wasm runtimed --skip-renderer-plugins
+  ```
+
+## References
+
+- Cloudflare self-hosted Access apps:
+  `https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/`
+- Cloudflare generic OIDC IdP:
+  `https://developers.cloudflare.com/cloudflare-one/identity/idp-integration/generic-oidc/`
+- Cloudflare Access JWT validation:
+  `https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/`
+- Cloudflare CLI Access tokens:
+  `https://developers.cloudflare.com/cloudflare-one/tutorials/cli/`
+- Anaconda production OIDC discovery:
+  `https://auth.anaconda.com/api/auth/.well-known/openid-configuration`
+- Anaconda stage OIDC discovery:
+  `https://auth.stage.anaconda.com/api/auth/.well-known/openid-configuration`

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -184,18 +184,22 @@ NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com,https://preview-not
 Rules:
 
 - Include the notebook application origin that renders `/n/:id`.
+- The Worker treats same-origin notebook pages as allowed by default and uses
+  this variable only to add more notebook application origins.
 - Include loopback origins only for local Wrangler development.
 - Do not include the renderer asset Worker origin.
 - Do not include sandboxed output iframe origins.
 - Do not use `*`.
-- Leaving the variable unset disables the origin gate and should be limited to
-  local development or throwaway prototype hosts.
+- Leaving the variable unset keeps the same-origin default only. Cookie-backed
+  Access WebSockets still reject missing or untrusted `Origin`.
 
-The Worker checks `Origin` before WebSocket auth when the allowlist is set. In
-that mode every WebSocket client, including CLI smoke and future native clients,
-must send an `Origin` that normalizes to one of these values. Browser
-Access-cookie sessions must come from an allowed origin so a malicious site
-cannot use an ambient Access cookie to open a private room socket.
+The Worker checks `Origin` before WebSocket auth when a browser sends one, when
+the allowlist is set, or when an ambient `CF_Authorization` cookie is present.
+When the allowlist is set, every WebSocket client, including CLI smoke and
+future native clients, must send an `Origin` that normalizes to the notebook
+application origin or one of the configured values. Browser Access-cookie
+sessions must come from an allowed origin so a malicious site cannot use an
+ambient Access cookie to open a private room socket.
 
 ## Deploy
 
@@ -302,10 +306,12 @@ The script sends:
 
 - `CF-Access-Token: <jwt>` so Cloudflare Access can admit the HTTP and
   WebSocket requests;
-- `Authorization: Bearer <jwt>` as a direct-Worker fallback;
 - `Origin: https://<notebook-host>` for the WebSocket origin allowlist;
-- `nteract-access-token.<base64url-jwt>` as the Worker-level WebSocket bearer
-  fallback when the hostname is not fronted by Access.
+
+It intentionally sends only one Worker-visible Access credential transport per
+request. The Worker also supports `Authorization: Bearer <jwt>` and
+`nteract-access-token.<base64url-jwt>` as separate deployment/client modes, but
+they must not be combined with `CF-Access-Token` on the same request.
 
 Expected JSON shape:
 

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -43,6 +43,7 @@ answers "what may this principal do in this notebook room?"
 The listener normalizes transport-specific inputs into a credential:
 
 - Access assertion header from Cloudflare Access.
+- Access token header from `cloudflared access token` / CLI clients.
 - Bearer token from `Authorization` for native clients.
 - Bearer token from a WebSocket subprotocol for browser clients that already
   hold a token.

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -306,6 +306,10 @@ checks, but they do not rely on ambient cookies and therefore reduce CSRF risk.
 
 ## Operational path for the Anaconda demo
 
+The exact deployment steps, Anaconda endpoints, Worker variables, origin
+allowlist, and hosted Access smoke command live in
+`docs/architecture/hosted-access-anaconda-demo-runbook.md`.
+
 1. Configure Cloudflare Access for the notebook-cloud Worker.
 2. Add Anaconda OIDC as the Access identity provider.
 3. Configure Worker Access validation:
@@ -343,8 +347,8 @@ configuration.
    Anaconda subject claim, define the exact claim name and migration strategy
    before using it as the principal id.
 3. **Invite-by-email.** D1 ACLs key by principal, but people share by email.
-   A pending-invite table or provider lookup can bridge email to principal
-   without making email the principal.
+   `docs/architecture/hosted-sharing-invites.md` sketches the pending-invite
+   table, first-login resolution, display metadata, and public viewer UX.
 4. **Provider maximum capabilities.** The hosted prototype currently treats
    dev credentials as effectively owner-bounded and relies on ACL rows. Real
    OIDC/JupyterHub providers should expose provider maximum capabilities
@@ -362,6 +366,10 @@ configuration.
   actor validation, and base credential vocabulary.
 - `docs/architecture/hosted-room-authorization.md` - room ACLs and scope
   derivation.
+- `docs/architecture/hosted-access-anaconda-demo-runbook.md` - exact
+  Cloudflare Access + Anaconda demo deployment and smoke steps.
+- `docs/architecture/hosted-sharing-invites.md` - email invite to principal ACL
+  resolution.
 - `apps/notebook-cloud/src/identity.ts` - current Cloudflare Access JWT and
   dev-token credential extraction.
 - Cloudflare WebSockets docs:
@@ -369,7 +377,7 @@ configuration.
 - Cloudflare Access authorization cookie docs:
   `https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/`
 - Cloudflare Access JWT validation docs:
-  `https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/`
+  `https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/`
 - JupyterHub services auth implementation:
   `jupyterhub/services/auth.py`
 - PR #2801 review discussion:

--- a/docs/architecture/hosted-sharing-invites.md
+++ b/docs/architecture/hosted-sharing-invites.md
@@ -1,0 +1,336 @@
+# Hosted Notebook Sharing And Invites
+
+**Status:** Draft, 2026-05-24.
+
+This note designs the product and data path from "share with email" to
+principal-backed `notebook_acl` rows. The important rule is unchanged from the
+identity docs: email is useful for lookup and display, but it is not the room
+principal.
+
+Related docs:
+
+- `docs/architecture/identity-and-trust.md`
+- `docs/architecture/hosted-room-authorization.md`
+- `docs/architecture/hosted-credential-transport.md`
+- `docs/architecture/hosted-access-anaconda-demo-runbook.md`
+
+Prototype code:
+
+- `apps/notebook-cloud/src/sharing.ts`
+- `apps/notebook-cloud/test/sharing.test.ts`
+
+## What The Older Prototype Already Proved
+
+The older [`runtimed/intheloop`](https://github.com/runtimed/intheloop)
+prototype has useful shape:
+
+- `users` stores provider/user profile fields including email and names.
+- `notebook_permissions` grants notebook access by internal `user_id`.
+- `shareNotebook` grants a `writer` relation to an existing user.
+- `userByEmail` lets the UI find an existing user before sharing.
+- The Anaconda Projects permission provider grants `writer` by Anaconda
+  `user_id`.
+- Public user data intentionally omits email in collaborator responses.
+
+That prototype did not need pending invites because sharing targeted an
+existing user record. For nteract cloud, we need an owner to type an email
+before the recipient has ever logged in, and we need the eventual ACL row to
+use the recipient's stable provider principal instead of the typed email.
+
+## Canonical Objects
+
+### Principal Profile
+
+`principal_profiles` is display and lookup metadata for authenticated
+principals.
+
+```sql
+CREATE TABLE principal_profiles (
+  principal TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  provider_subject TEXT,
+  email_normalized TEXT,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  display_name TEXT,
+  avatar_url TEXT,
+  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  raw_claims_json TEXT
+);
+
+CREATE INDEX principal_profiles_email_idx
+  ON principal_profiles(provider, email_normalized)
+  WHERE email_verified = 1;
+```
+
+`principal` is the key used in `notebook_acl.subject`, for example:
+
+```text
+user:cloudflare-access:<encoded-access-sub>
+```
+
+Email and display name are not authorization keys. They can change without
+rewriting ACL rows.
+
+### Pending Invite
+
+`notebook_invites` stores email-addressed invitations that have not yet
+resolved to a principal.
+
+```sql
+CREATE TABLE notebook_invites (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  email_normalized TEXT NOT NULL,
+  provider_hint TEXT,
+  scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+  invited_by_actor_label TEXT NOT NULL,
+  accepted_by_principal TEXT,
+  token_hash TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  expires_at TEXT,
+  accepted_at TEXT,
+  revoked_at TEXT,
+  revoked_by_actor_label TEXT,
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE INDEX notebook_invites_pending_lookup_idx
+  ON notebook_invites(provider_hint, email_normalized, status);
+
+CREATE INDEX notebook_invites_notebook_idx
+  ON notebook_invites(notebook_id, status);
+```
+
+`provider_hint` is normalized to lowercase provider ids. It should be
+`cloudflare-access` for the Access + Anaconda demo. It may be `NULL` only when
+the invite intentionally allows resolution by any trusted login provider that
+proves the same verified email.
+
+`scope` is limited to `viewer` and `editor` for invite UX. `owner` transfer and
+`runtime_peer` grants need explicit owner/admin flows, not email invites.
+
+The existing `notebook_acl` table remains the authorization source of truth:
+
+```text
+notebook_acl(notebook_id, subject_kind, subject, scope)
+```
+
+Pending invites are not ACL rows and cannot authorize a socket.
+
+## Share Flow
+
+1. Owner opens the share dialog for a notebook.
+2. Owner enters `recipient@example.com` and chooses `Viewer` or `Editor`.
+3. The API normalizes the email:
+
+   ```text
+   trim + lowercase
+   ```
+
+4. The API looks for a verified `principal_profiles` row with the same
+   provider hint and normalized email.
+5. If a matching profile exists, the API inserts the principal ACL row
+   immediately:
+
+   ```json
+   {
+     "subject_kind": "principal",
+     "subject": "user:cloudflare-access:<encoded-access-sub>",
+     "scope": "editor"
+   }
+   ```
+
+6. If no matching profile exists, the API creates a `pending` invite row and
+   sends or exposes an invite link.
+7. The share dialog shows:
+   - resolved collaborators by display name;
+   - pending invites by email;
+   - public viewer as a separate "Anyone with the link" row.
+
+The API may create an accepted invite audit row even for immediate grants, but
+the ACL subject is still the resolved principal.
+
+## First Login Resolution
+
+When a user authenticates:
+
+1. Validate the provider credential.
+2. Produce a stable principal, provider name, optional provider subject,
+   verified email, and display name.
+3. Upsert `principal_profiles`.
+4. If the login has no verified email, do not resolve email invites.
+5. Find pending invites whose:
+   - `email_normalized` equals the login email;
+   - `provider_hint` is either the login provider or `NULL`;
+   - `status = 'pending'`;
+   - `expires_at` is null or in the future.
+6. In one transaction, for each matching invite:
+   - insert the `notebook_acl` principal row for `login.principal`;
+   - mark the invite `accepted`;
+   - set `accepted_by_principal = login.principal`;
+   - set `accepted_at`.
+
+The invite resolution actor should be an explicit system actor:
+
+```text
+system/invite-resolution
+```
+
+The resulting ACL row should never contain the email:
+
+```text
+subject_kind = principal
+subject      = user:cloudflare-access:<encoded-access-sub>
+scope        = editor
+```
+
+This keeps authorization stable even if the user later changes email.
+
+## Public Viewer Flow
+
+Public viewing is not an email invite. It is an explicit room ACL row:
+
+```json
+{
+  "subject_kind": "public",
+  "subject": "anonymous",
+  "scope": "viewer"
+}
+```
+
+UX:
+
+- Show a toggle labeled "Anyone with the link can view".
+- Enabling the toggle inserts the public ACL row.
+- Disabling the toggle deletes the public ACL row.
+- Anonymous public viewers appear as aggregate/local viewer state, not as named
+  collaborators.
+- Anonymous public viewers cannot edit, upload blobs, mutate runtime state, or
+  publish revisions.
+
+Network topology still matters. A hostname fully protected by Cloudflare Access
+will block anonymous public viewers before the Worker sees the request. Public
+published notebooks need either a public hostname, an Access bypass policy for
+public viewer routes, or a separate public deployment that still checks the
+Worker ACL row.
+
+## Display Names And Privacy
+
+Collaborator list rendering should prefer:
+
+1. `principal_profiles.display_name`
+2. verified profile email
+3. principal string
+
+Pending invites render the normalized invited email because no principal exists
+yet. That email should be visible to notebook owners and collaborators with ACL
+management rights, but it should not leak to anonymous public viewers.
+
+Public viewer displays as:
+
+```text
+Anyone with the link
+```
+
+The room presence layer should not promote anonymous public sessions to named
+collaborators. If product later wants public cursor presence, define whether it
+is aggregate-only or full per-session presence before enabling it.
+
+## Revocation And Expiry
+
+Revoking a resolved collaborator deletes or replaces the principal ACL row. It
+does not delete `principal_profiles`.
+
+Revoking a pending invite marks the invite `revoked`; it does not need an ACL
+mutation because pending invites are not authorization rows.
+
+Expired invites should either be marked by a scheduled cleanup job or treated as
+expired at query time. Resolution must ignore expired rows.
+
+Owner protection stays in the ACL helper. Neither invite acceptance nor revoke
+flows may leave a notebook without an `owner` ACL row.
+
+## API Sketch
+
+Owner-only APIs:
+
+```text
+GET    /api/n/{notebookId}/shares
+POST   /api/n/{notebookId}/shares
+DELETE /api/n/{notebookId}/shares/{shareId}
+POST   /api/n/{notebookId}/public-viewer
+DELETE /api/n/{notebookId}/public-viewer
+```
+
+`POST /shares` request:
+
+```json
+{
+  "email": "alice@example.com",
+  "scope": "editor",
+  "provider_hint": "cloudflare-access"
+}
+```
+
+Possible responses:
+
+Existing verified profile:
+
+```json
+{
+  "kind": "principal",
+  "principal": "user:cloudflare-access:access-sub",
+  "display_name": "Alice Example",
+  "scope": "editor"
+}
+```
+
+New pending invite:
+
+```json
+{
+  "kind": "pending_invite",
+  "invite_id": "inv_...",
+  "email": "alice@example.com",
+  "scope": "editor",
+  "status": "pending"
+}
+```
+
+First-login resolution can happen inside the auth/session endpoint or the first
+room/API request after authentication. It should be idempotent: rerunning it for
+the same login must not create duplicate ACL rows.
+
+## Implementation Notes
+
+The checked-in TypeScript prototype models the core transition:
+
+- `normalizeInviteEmail(email)` trims and lowercases invite lookup email.
+- `inviteLookupKey(provider, email)` shows the provider-plus-email lookup key.
+- `resolvePendingInvitesForLogin(...)` accepts only pending, non-expired invites
+  matching a verified login email and provider.
+- The generated `aclGrants` use `login.principal`, not email.
+- `publicViewerAclGrant(...)` returns the explicit public ACL row.
+- `shareTargetDisplay(...)` maps principal profiles, pending invites, and
+  public viewer rows into UI labels.
+
+The prototype is intentionally pure TypeScript for now. The D1 transaction and
+HTTP routes should come after the Access demo proves principal shape and after
+we choose the final share API names.
+
+## Open Decisions
+
+1. **Provider subject source.** For the first Access demo, the principal is
+   Access-scoped. If Access can pass a stable Anaconda subject claim, decide the
+   claim and migration before switching to `user:anaconda:*`.
+2. **Invite delivery.** Email delivery, invite-token links, and resend behavior
+   are product work. ACL resolution does not depend on delivery mechanism.
+3. **Organization policy.** Some deployments may restrict invites to an
+   Anaconda org, email domain, or Access group. That should be a share API
+   validation rule, not a different ACL subject type.
+4. **Owner transfer.** Owner transfer needs confirmation and orphan protection.
+   It should not be hidden inside invite-by-email.
+5. **Public hostname.** Decide whether public viewers use the same hostname
+   with an Access bypass rule or a separate public viewer host.

--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -9,8 +9,8 @@
 
 The identity design is highly guided by these projects:
 
-- **runtimed/intheloop** validates an OIDC bearer JWT via JWKS at WebSocket open. The validated `sub` claim becomes the actor identifier. No per-message re-validation.
-- **runtimed/anaconda** validates bearer tokens against Anaconda's userinfo endpoint and maps Anaconda scopes to runtimed scopes.
+- **[`runtimed/intheloop`](https://github.com/runtimed/intheloop)** validates an OIDC bearer JWT via JWKS at WebSocket open. The validated `sub` claim becomes the actor identifier. No per-message re-validation.
+- **[`runtimed/anaconda`](https://github.com/runtimed/anaconda)** validates bearer tokens against Anaconda's userinfo endpoint and maps Anaconda scopes to runtimed scopes.
 - **JupyterHub** stamps spawned single-user servers via environment variables at launch, and the spawned server validates user identity by calling back to `/hub/api/user`. No `X-Forwarded-User` header is trusted.
 
 As a result, our rule is to never trust a locally-stamped identity claim. We validate against the upstream authority that issued the credential. The other modern concern is that nteract is very agent centric. A human user has many operators acting on their behalf: the desktop app, a TUI, Agents enabled via MCP, the runtimed bindings for bespoke agent usage, and scheduled notebook jobs. All of those actors are legitimately authoring edits "on behalf of" the user. Since, token wise, they operate "as" the user, attribution must distinguish operators while the trust gate enforces the user.
@@ -398,8 +398,8 @@ This section records the audit against Automerge and automerge-repo so the trust
 - `crates/notebook-doc/src/diff.rs:439` - `extract_change_actors`, the post-apply attribution primitive used by both `TextAttribution` and the v1 clone-preview actor validator.
 - `automerge::sync::Message` (rust/automerge/src/sync.rs:516-588) - the `ChunkList` wire shape backing per-frame validation.
 - `crates/notebook-doc/src/presence.rs` - presence frame shape.
-- intheloop `backend/auth.ts`, `backend/sync.ts` - bearer-JWT validation + connection-time auth model.
-- runtimed/anaconda `api_key.ts` - Anaconda userinfo validation + scope mapping.
+- [`runtimed/intheloop`](https://github.com/runtimed/intheloop) `backend/auth.ts`, `backend/sync.ts` - bearer-JWT validation + connection-time auth model.
+- [`runtimed/anaconda`](https://github.com/runtimed/anaconda) `api_key.ts` - Anaconda userinfo validation + scope mapping.
 - JupyterHub `jupyterhub/services/auth.py` - Hub cookie/token validation, no `X-Forwarded-User`.
 - Automerge `filters` branch (`origin/filters` on `automerge/automerge`), specifically `rust/automerge/src/filter.rs` - the subduction primitive that complements (but does not replace) our pre-apply gate, and the natural home for runtime revocation.
 - automerge-repo `DocSynchronizer.receiveSyncMessage` and `NetworkAdapterInterface` - confirms there is no built-in per-message authorization hook; any gate has to sit above the synchronizer.


### PR DESCRIPTION
## Summary

- Add the Cloudflare Access + Anaconda hosted demo runbook, including Access app setup, Anaconda OIDC provider endpoints, Worker env vars, allowed origins, deploy steps, ACL bootstrap, and hosted Access smoke instructions.
- Add a hosted Access smoke script that uses Access JWTs, grants owner/editor/viewer ACL rows by principal, sends real `runtimed-wasm` Automerge frames, and verifies live viewer convergence without putting tokens in URLs.
- Add a sharing/invite prototype and design doc for resolving "share with email" into principal ACL rows, with pending invites, first-login resolution, display labels, and explicit public viewer rows.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- The notebook-cloud fixture failures in this worktree were Git LFS pointer checkouts, not code failures. Pulling the relevant LFS objects made the full notebook-cloud suite pass.
- I did an adversarial docs pass before committing and patched the concrete findings: GitHub links for `runtimed/anaconda` and `runtimed/intheloop`, provider-hint normalization for invites, and the non-browser `Origin` requirement when `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` is set.
