### PR TITLE
feat(notebook-cloud): expose hosted session metadata

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -231,9 +231,21 @@ principal is `user:cloudflare-access:<sub>`, and the requested `scope` is still
 only a request: the room ACL decides whether that principal may enter as
 `viewer`, `editor`, `runtime_peer`, or `owner`.
 
+The Access principal namespace names the authority validated by the Worker:
+`user:cloudflare-access:<encoded-sub>`. Access `email` and `name` claims are
+stamped as display/audit metadata on the trusted room connection; they are not
+used as ACL subjects. The Durable Object receives provider, transport,
+principal namespace, display name, and email only through Worker-stamped
+trusted headers, and the `cloud_room_ready` control frame may expose that
+non-secret metadata to clients.
+
 Browser WebSocket upgrades must come from the Worker origin or an origin listed
 in `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` as a comma-separated list. Cookie-backed
 WebSocket upgrades without an `Origin` header are rejected.
+
+The viewer auth menu has a "Use browser session" mode for Cloudflare Access
+trials. It stores only the requested room scope in localStorage; the credential
+remains the browser's Access session and is validated by the Worker.
 
 Requests with no dev credential become anonymous public viewers. The Worker derives:
 

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -24,6 +24,7 @@ export interface AuthenticatedConnection {
   operator: string;
   actorLabel: string;
   scope: ConnectionScope;
+  metadata: AuthenticatedConnectionMetadata;
   webSocketProtocol?: string;
 }
 
@@ -35,17 +36,40 @@ export interface IdentityEnvironment {
   NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?: string;
 }
 
+export interface AuthenticatedConnectionMetadata {
+  provider: "anonymous" | "dev" | "cloudflare-access";
+  transport:
+    | "anonymous"
+    | "loopback-dev"
+    | "dev-token-header"
+    | "dev-token-subprotocol"
+    | "access-assertion"
+    | "access-bearer"
+    | "access-cookie"
+    | "access-cookie-assertion"
+    | "access-subprotocol";
+  principalNamespace: string;
+  displayName?: string;
+  email?: string;
+}
+
 const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
 
 export const TRUSTED_PRINCIPAL_HEADER = "x-nteract-principal";
 export const TRUSTED_OPERATOR_HEADER = "x-nteract-operator";
 export const TRUSTED_SCOPE_HEADER = "x-nteract-scope";
 export const TRUSTED_WEBSOCKET_PROTOCOL_HEADER = "x-nteract-websocket-protocol";
+export const TRUSTED_IDENTITY_PROVIDER_HEADER = "x-nteract-identity-provider";
+export const TRUSTED_CREDENTIAL_TRANSPORT_HEADER = "x-nteract-credential-transport";
+export const TRUSTED_PRINCIPAL_NAMESPACE_HEADER = "x-nteract-principal-namespace";
+export const TRUSTED_DISPLAY_NAME_HEADER = "x-nteract-display-name";
+export const TRUSTED_EMAIL_HEADER = "x-nteract-email";
 export const CLOUDFLARE_ACCESS_JWT_HEADER = "cf-access-jwt-assertion";
 export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";
 
 interface AccessCredential {
   token: string;
+  transport: AuthenticatedConnectionMetadata["transport"];
   webSocketProtocol?: string;
 }
 
@@ -70,6 +94,7 @@ interface AccessJwtPayload {
   email?: string;
   exp?: number;
   iss?: string;
+  name?: string;
   nbf?: number;
   sub?: string;
 }
@@ -111,9 +136,16 @@ export function authenticateRequest(
   }
 
   const identity = authenticateDevRequest(request);
+  const authenticated = {
+    ...identity,
+    metadata: {
+      ...identity.metadata,
+      transport: devCredential.transport,
+    },
+  };
   return devCredential.webSocketProtocol
-    ? { ...identity, webSocketProtocol: devCredential.webSocketProtocol }
-    : identity;
+    ? { ...authenticated, webSocketProtocol: devCredential.webSocketProtocol }
+    : authenticated;
 }
 
 export async function authenticateRequestWithProviders(
@@ -164,6 +196,15 @@ export async function authenticateCloudflareAccessRequest(
     operator,
     actorLabel: `${principal}/${operator}`,
     scope,
+    metadata: {
+      provider: "cloudflare-access" as const,
+      transport: credential.transport,
+      principalNamespace: "user:cloudflare-access",
+      ...(payload.name?.trim() || payload.email?.trim()
+        ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
+        : {}),
+      ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
+    },
   };
   return credential.webSocketProtocol
     ? { ...identity, webSocketProtocol: credential.webSocketProtocol }
@@ -186,6 +227,12 @@ export function authenticateDevRequest(request: Request): AuthenticatedConnectio
     operator,
     actorLabel: `${principal}/${operator}`,
     scope,
+    metadata: {
+      provider: "dev",
+      transport: "loopback-dev",
+      principalNamespace: "user:dev",
+      displayName: user,
+    },
   };
 }
 
@@ -207,6 +254,12 @@ export function authenticateAnonymousViewer(request: Request): AuthenticatedConn
     operator,
     actorLabel: `${principal}/${operator}`,
     scope: "viewer",
+    metadata: {
+      provider: "anonymous",
+      transport: "anonymous",
+      principalNamespace: "anonymous",
+      displayName: "Anonymous",
+    },
   };
 }
 
@@ -219,6 +272,11 @@ export function stampTrustedIdentity(request: Request, identity: AuthenticatedCo
   headers.set(TRUSTED_PRINCIPAL_HEADER, identity.principal);
   headers.set(TRUSTED_OPERATOR_HEADER, identity.operator);
   headers.set(TRUSTED_SCOPE_HEADER, identity.scope);
+  headers.set(TRUSTED_IDENTITY_PROVIDER_HEADER, identity.metadata.provider);
+  headers.set(TRUSTED_CREDENTIAL_TRANSPORT_HEADER, identity.metadata.transport);
+  headers.set(TRUSTED_PRINCIPAL_NAMESPACE_HEADER, identity.metadata.principalNamespace);
+  setOptionalTrustedHeader(headers, TRUSTED_DISPLAY_NAME_HEADER, identity.metadata.displayName);
+  setOptionalTrustedHeader(headers, TRUSTED_EMAIL_HEADER, identity.metadata.email);
   if (identity.webSocketProtocol) {
     headers.set(TRUSTED_WEBSOCKET_PROTOCOL_HEADER, identity.webSocketProtocol);
     headers.set("Sec-WebSocket-Protocol", identity.webSocketProtocol);
@@ -234,8 +292,13 @@ export function readTrustedIdentity(request: Request): AuthenticatedConnection {
   const operator = request.headers.get(TRUSTED_OPERATOR_HEADER);
   const scope = request.headers.get(TRUSTED_SCOPE_HEADER);
   const webSocketProtocol = request.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER) ?? undefined;
+  const provider = request.headers.get(TRUSTED_IDENTITY_PROVIDER_HEADER);
+  const transport = request.headers.get(TRUSTED_CREDENTIAL_TRANSPORT_HEADER);
+  const principalNamespace = request.headers.get(TRUSTED_PRINCIPAL_NAMESPACE_HEADER);
+  const displayName = request.headers.get(TRUSTED_DISPLAY_NAME_HEADER) ?? undefined;
+  const email = request.headers.get(TRUSTED_EMAIL_HEADER) ?? undefined;
 
-  if (!principal || !operator || !scope) {
+  if (!principal || !operator || !scope || !provider || !transport || !principalNamespace) {
     throw new Error("missing trusted identity headers");
   }
 
@@ -248,6 +311,7 @@ export function readTrustedIdentity(request: Request): AuthenticatedConnection {
     operator,
     actorLabel: `${principal}/${operator}`,
     scope: parsedScope,
+    metadata: parseTrustedMetadata(provider, transport, principalNamespace, displayName, email),
   };
   return webSocketProtocol ? { ...identity, webSocketProtocol } : identity;
 }
@@ -368,6 +432,75 @@ function headerOrQuery(
   return request.headers.get(headerName) ?? url.searchParams.get(queryName) ?? undefined;
 }
 
+function setOptionalTrustedHeader(headers: Headers, name: string, value: string | undefined): void {
+  const headerValue = sanitizeTrustedMetadataHeader(value);
+  if (headerValue) {
+    headers.set(name, headerValue);
+  } else {
+    headers.delete(name);
+  }
+}
+
+function sanitizeTrustedMetadataHeader(value: string | undefined): string | undefined {
+  let sanitized = "";
+  for (const char of value ?? "") {
+    const code = char.charCodeAt(0);
+    if (code === 0 || code === 10 || code === 13) {
+      if (!sanitized.endsWith(" ")) {
+        sanitized += " ";
+      }
+      continue;
+    }
+    sanitized += char;
+  }
+  sanitized = sanitized.trim();
+  if (!sanitized) {
+    return undefined;
+  }
+  return sanitized.slice(0, 512);
+}
+
+function parseTrustedMetadata(
+  provider: string,
+  transport: string,
+  principalNamespace: string,
+  displayName: string | undefined,
+  email: string | undefined,
+): AuthenticatedConnectionMetadata {
+  if (!isMetadataProvider(provider)) {
+    throw new Error(`unknown trusted identity provider: ${provider}`);
+  }
+  if (!isMetadataTransport(transport)) {
+    throw new Error(`unknown trusted credential transport: ${transport}`);
+  }
+
+  return {
+    provider,
+    transport,
+    principalNamespace,
+    ...(displayName ? { displayName } : {}),
+    ...(email ? { email } : {}),
+  };
+}
+
+function isMetadataProvider(value: string): value is AuthenticatedConnectionMetadata["provider"] {
+  return value === "anonymous" || value === "dev" || value === "cloudflare-access";
+}
+
+function isMetadataTransport(value: string): value is AuthenticatedConnectionMetadata["transport"] {
+  return (
+    value === "anonymous" ||
+    value === "loopback-dev" ||
+    value === "dev-token-header" ||
+    value === "dev-token-subprotocol" ||
+    value === "access-assertion" ||
+    value === "access-bearer" ||
+    value === "access-cookie" ||
+    value === "access-cookie-assertion" ||
+    value === "access-subprotocol"
+  );
+}
+
 function hasDevCredential(request: Request): boolean {
   const url = new URL(request.url);
   return [
@@ -402,12 +535,22 @@ function hasDevCredentialTransport(request: Request): boolean {
 function authenticateDevCredential(
   request: Request,
   env: IdentityEnvironment,
-): { webSocketProtocol?: string } | undefined {
+):
+  | {
+      transport: Extract<
+        AuthenticatedConnectionMetadata["transport"],
+        "loopback-dev" | "dev-token-header" | "dev-token-subprotocol"
+      >;
+      webSocketProtocol?: string;
+    }
+  | undefined {
   if (isLocalDevRequest(request)) {
     const webSocketProtocol = tokenFromWebSocketProtocol(
       request.headers.get("sec-websocket-protocol"),
     );
-    return webSocketProtocol ? { webSocketProtocol: webSocketProtocol.webSocketProtocol } : {};
+    return webSocketProtocol
+      ? { transport: "loopback-dev", webSocketProtocol: webSocketProtocol.webSocketProtocol }
+      : { transport: "loopback-dev" };
   }
 
   return validDevTokenCredential(request, env);
@@ -421,7 +564,15 @@ function isLocalDevRequest(request: Request): boolean {
 function validDevTokenCredential(
   request: Request,
   env: IdentityEnvironment,
-): { webSocketProtocol?: string } | undefined {
+):
+  | {
+      transport: Extract<
+        AuthenticatedConnectionMetadata["transport"],
+        "dev-token-header" | "dev-token-subprotocol"
+      >;
+      webSocketProtocol?: string;
+    }
+  | undefined {
   const expected = env.NOTEBOOK_CLOUD_DEV_TOKEN?.trim();
   if (!expected) {
     return undefined;
@@ -429,14 +580,17 @@ function validDevTokenCredential(
 
   const headerToken = request.headers.get(DEV_AUTH_TOKEN_HEADER) ?? undefined;
   if (timingSafeStringEqual(headerToken, expected)) {
-    return {};
+    return { transport: "dev-token-header" };
   }
 
   const webSocketProtocol = tokenFromWebSocketProtocol(
     request.headers.get("sec-websocket-protocol"),
   );
   if (webSocketProtocol && timingSafeStringEqual(webSocketProtocol.token, expected)) {
-    return { webSocketProtocol: webSocketProtocol.webSocketProtocol };
+    return {
+      transport: "dev-token-subprotocol",
+      webSocketProtocol: webSocketProtocol.webSocketProtocol,
+    };
   }
 
   return undefined;
@@ -446,17 +600,22 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
   const candidates: AccessCredential[] = [];
   const assertionToken = request.headers.get(CLOUDFLARE_ACCESS_JWT_HEADER)?.trim() || undefined;
   if (assertionToken) {
-    candidates.push({ token: assertionToken });
+    candidates.push({
+      token: assertionToken,
+      transport: cookieValue(request.headers.get("cookie"), "CF_Authorization")
+        ? "access-cookie-assertion"
+        : "access-assertion",
+    });
   }
 
   const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));
   if (bearerToken) {
-    candidates.push({ token: bearerToken });
+    candidates.push({ token: bearerToken, transport: "access-bearer" });
   }
 
   const cookieToken = cookieValue(request.headers.get("cookie"), "CF_Authorization");
   if (cookieToken && !assertionToken) {
-    candidates.push({ token: cookieToken });
+    candidates.push({ token: cookieToken, transport: "access-cookie" });
   }
 
   const webSocketProtocol = tokenFromWebSocketProtocol(
@@ -466,6 +625,7 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
   if (webSocketProtocol) {
     candidates.push({
       token: webSocketProtocol.token,
+      transport: "access-subprotocol",
       webSocketProtocol: webSocketProtocol.webSocketProtocol,
     });
   }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -115,6 +115,10 @@ export class NotebookRoom {
       peer_id: peer.id,
       actor_label: identity.actorLabel,
       connection_scope: identity.scope,
+      identity_provider: identity.metadata.provider,
+      principal_namespace: identity.metadata.principalNamespace,
+      display_name: identity.metadata.displayName,
+      email: identity.metadata.email,
       room_peer_count: this.peers.size,
       timestamp: peer.connectedAt,
     });

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -24,6 +24,10 @@ export type SessionControlMessage =
       peer_id: string;
       actor_label: string;
       connection_scope: string;
+      identity_provider?: string;
+      principal_namespace?: string;
+      display_name?: string;
+      email?: string;
       room_peer_count: number;
       timestamp: string;
     }

--- a/apps/notebook-cloud/test/access-jwt-fixture.ts
+++ b/apps/notebook-cloud/test/access-jwt-fixture.ts
@@ -9,8 +9,10 @@ export interface AccessTokenFixture {
 
 export async function accessTokenFixture(options: {
   audience?: string;
+  email?: string;
   includeKid?: boolean;
   includeUnmatchedKey?: boolean;
+  name?: string;
   subject: string;
 }): Promise<AccessTokenFixture> {
   const issuer = "https://team.cloudflareaccess.com";
@@ -52,8 +54,10 @@ export async function accessTokenFixture(options: {
   };
   const payload = {
     aud: options.audience ?? audience,
+    ...(options.email ? { email: options.email } : {}),
     exp: now + 300,
     iss: issuer,
+    ...(options.name ? { name: options.name } : {}),
     sub: options.subject,
   };
   const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(payload))}`;

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -9,6 +9,7 @@ import {
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
   readCloudPrototypeAuth,
+  storeCloudAccessAuth,
   storeCloudPrototypeDevAuth,
   validatePrototypeToken,
   type CloudPrototypeAuthStorage,
@@ -42,6 +43,23 @@ describe("cloud collaborator auth", () => {
     assert.equal(auth.user, "alice");
     assert.equal(auth.requestedScope, "editor");
     assert.deepEqual(auth.protocols, ["nteract-dev-token.c2VjcmV0", "nteract.v4"]);
+  });
+
+  it("can request an editor role from a browser Access session without JS token material", () => {
+    const storage = new MemoryStorage();
+    storeCloudAccessAuth(storage, { scope: "editor" });
+
+    const state = readCloudPrototypeAuth(storage);
+    const auth = cloudSyncAuthFromPrototypeAuthState(state);
+
+    assert.equal(state.mode, "access");
+    assert.equal(state.token, null);
+    assert.equal(state.user, null);
+    assert.equal(auth.requestedScope, "editor");
+    assert.deepEqual(auth.protocols, []);
+    assert.match(prototypeAuthSummary(state), /Browser session requesting editor/);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
   });
 
   it("preserves every explicit connection scope supported by the protocol", () => {

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -32,6 +32,12 @@ describe("dev identity", () => {
       operator: "browser:session%2Fa",
       actorLabel: "anonymous:session%2Fa/browser:session%2Fa",
       scope: "viewer",
+      metadata: {
+        provider: "anonymous",
+        transport: "anonymous",
+        principalNamespace: "anonymous",
+        displayName: "Anonymous",
+      },
     });
     assert.equal(isAnonymousViewer(identity), true);
   });
@@ -76,6 +82,12 @@ describe("dev identity", () => {
       operator: "desktop:test-session",
       actorLabel: "user:dev:kyle%40example.com/desktop:test-session",
       scope: "editor",
+      metadata: {
+        provider: "dev",
+        transport: "loopback-dev",
+        principalNamespace: "user:dev",
+        displayName: "kyle@example.com",
+      },
     });
   });
 
@@ -255,6 +267,17 @@ describe("dev identity", () => {
     assert.deepEqual(readTrustedIdentity(stamped), identity);
   });
 
+  it("sanitizes optional trusted metadata headers", () => {
+    const request = new Request(
+      "https://cloud.test/n/demo/sync?user=Alice%0D%0ASet-Cookie&operator=desktop:a",
+    );
+    const identity = authenticateDevRequest(request);
+    const stamped = stampTrustedIdentity(request, identity);
+
+    assert.equal(stamped.headers.get("x-nteract-display-name"), "Alice Set-Cookie");
+    assert.equal(readTrustedIdentity(stamped).metadata.displayName, "Alice Set-Cookie");
+  });
+
   it("rewrites presence actor principal while preserving the operator suffix", () => {
     const identity = authenticateDevRequest(
       new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a"),
@@ -302,7 +325,11 @@ describe("dev identity", () => {
 
 describe("Cloudflare Access identity", () => {
   it("validates Access JWT assertions and maps sub to a room principal", async () => {
-    const { env, token } = await accessTokenFixture({ subject: "user/123" });
+    const { env, token } = await accessTokenFixture({
+      subject: "user/123",
+      email: "alice@example.com",
+      name: "Alice Demo",
+    });
 
     const identity = await authenticateRequestWithProviders(
       new Request("https://cloud.test/n/demo/sync?operator=desktop:a&scope=editor", {
@@ -318,6 +345,13 @@ describe("Cloudflare Access identity", () => {
       operator: "desktop:a",
       actorLabel: "user:cloudflare-access:user%2F123/desktop:a",
       scope: "editor",
+      metadata: {
+        provider: "cloudflare-access",
+        transport: "access-assertion",
+        principalNamespace: "user:cloudflare-access",
+        displayName: "Alice Demo",
+        email: "alice@example.com",
+      },
     });
   });
 
@@ -335,6 +369,7 @@ describe("Cloudflare Access identity", () => {
     );
 
     assert.equal(identity.actorLabel, "user:cloudflare-access:alice/browser:tab");
+    assert.equal(identity.metadata.transport, "access-subprotocol");
     assert.equal(identity.webSocketProtocol, NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL);
   });
 

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -17,7 +17,7 @@ export interface CloudSyncAuth {
 }
 
 export interface CloudPrototypeAuthState {
-  mode: "anonymous" | "dev" | "invalid";
+  mode: "anonymous" | "access" | "dev" | "invalid";
   token: string | null;
   user: string | null;
   requestedScope: ConnectionScope | null;
@@ -71,11 +71,20 @@ export function readCloudPrototypeAuth(
   storage: Pick<CloudPrototypeAuthStorage, "getItem">,
 ): CloudPrototypeAuthState {
   const token = storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY)?.trim() ?? "";
+  const requestedScope = parseStoredScope(storage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY));
   if (!token) {
+    if (requestedScope) {
+      return {
+        mode: "access",
+        token: null,
+        user: null,
+        requestedScope,
+        problem: null,
+      };
+    }
     return anonymousAuthState();
   }
 
-  const requestedScope = parseStoredScope(storage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY));
   const user = storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY)?.trim() || "browser-editor";
   const problem = validatePrototypeToken(token);
   if (problem) {
@@ -98,6 +107,14 @@ export function readCloudPrototypeAuth(
 }
 
 export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthState): CloudSyncAuth {
+  if (state.mode === "access") {
+    return {
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: state.requestedScope ?? "editor",
+    };
+  }
   if (state.mode !== "dev" || !state.token) {
     return { protocols: [], user: null, operator: null, requestedScope: null };
   }
@@ -119,6 +136,15 @@ export function storeCloudPrototypeDevAuth(
 ): void {
   storage.setItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY, input.token.trim());
   storage.setItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY, input.user.trim() || "browser-editor");
+  storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
+}
+
+export function storeCloudAccessAuth(
+  storage: Pick<CloudPrototypeAuthStorage, "removeItem" | "setItem">,
+  input: { scope: ConnectionScope },
+): void {
+  storage.removeItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY);
+  storage.removeItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY);
   storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
 }
 
@@ -148,6 +174,9 @@ export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
   if (state.mode === "dev") {
     return `${state.user ?? "browser-editor"} requesting ${state.requestedScope ?? "editor"}`;
   }
+  if (state.mode === "access") {
+    return `Browser session requesting ${state.requestedScope ?? "editor"}`;
+  }
   if (state.mode === "invalid") {
     return `${state.problem ?? "Stored collaborator token is invalid"} Connected anonymously.`;
   }
@@ -172,6 +201,21 @@ export function prototypeAuthDiagnostics(
       {
         label: "Dev token",
         value: "Stored locally; sent as a WebSocket subprotocol, never in the URL.",
+      },
+    );
+  } else if (state.mode === "access") {
+    rows.push(
+      {
+        label: "Requested identity",
+        value: "Browser session credential, validated by the Worker.",
+      },
+      {
+        label: "Requested scope",
+        value: state.requestedScope ?? "editor",
+      },
+      {
+        label: "Credential",
+        value: "No token in JavaScript; Cloudflare Access supplies the assertion.",
       },
     );
   } else if (state.mode === "invalid") {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -21,6 +21,7 @@ import {
   cloudSyncAuthFromPrototypeAuthState,
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
+  storeCloudAccessAuth,
   storeCloudPrototypeDevAuth,
   validatePrototypeToken,
   type CloudPrototypeAuthState,
@@ -594,9 +595,11 @@ function CloudAuthControls({
   const summary =
     authState.mode === "dev"
       ? `Dev ${authState.user ?? "browser-editor"}`
-      : authState.mode === "invalid"
-        ? "Auth needs attention"
-        : "Anonymous";
+      : authState.mode === "access"
+        ? "Browser session"
+        : authState.mode === "invalid"
+          ? "Auth needs attention"
+          : "Anonymous";
   const diagnostics = prototypeAuthDiagnostics(authState, {
     actorLabel: connectionActorLabel,
     connectionError,
@@ -621,6 +624,13 @@ function CloudAuthControls({
 
   const resetAuth = () => {
     clearCloudPrototypeDevAuth(window.localStorage);
+    setToken("");
+    setFormError(null);
+    onAuthStateChange();
+  };
+
+  const applyAccessAuth = () => {
+    storeCloudAccessAuth(window.localStorage, { scope });
     setToken("");
     setFormError(null);
     onAuthStateChange();
@@ -691,6 +701,10 @@ function CloudAuthControls({
           <button type="submit">
             <KeyRound aria-hidden="true" />
             Use dev identity
+          </button>
+          <button type="button" onClick={applyAccessAuth}>
+            <KeyRound aria-hidden="true" />
+            Use browser session
           </button>
           <button type="button" onClick={() => void copyDiagnostics()}>
             <Copy aria-hidden="true" />


### PR DESCRIPTION
## Summary

Stacked on #2889.

- carries provider/transport/namespace/display/email metadata through the trusted Worker -> Durable Object identity handoff
- includes the non-secret identity metadata in `cloud_room_ready` so the viewer can distinguish anonymous, dev, and Cloudflare Access sessions
- adds a browser-session auth mode for Cloudflare Access deployments that stores only the requested scope in localStorage
- documents the Access principal namespace and the fact that email/name are display/audit metadata, not ACL subjects

## Verification

- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/collaborator-auth.test.ts test/notebook-room.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
