### PR TITLE
docs(protocol): add output protocol ADRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -997,6 +997,7 @@ jobs:
             --package dx \
             --package prewarm \
             --package nteract \
+            --package nteract-kernel-launcher \
             --group dev
 
       - name: Run runtimed-py unit tests
@@ -1005,6 +1006,9 @@ jobs:
 
       - name: Run dx unit tests
         run: uv run --no-sync pytest python/dx/tests/ -v --tb=short
+
+      - name: Run nteract-kernel-launcher unit tests
+        run: uv run --no-sync pytest python/nteract-kernel-launcher/tests/ -v --tb=short
 
       - name: Install and run prewarm unit tests
         run: |

--- a/docs/architecture/arrow-c-stream-output-protocol.md
+++ b/docs/architecture/arrow-c-stream-output-protocol.md
@@ -1,0 +1,138 @@
+# Arrow C Stream Output Protocol
+
+**Status:** Draft, 2026-05-24.
+
+## Context
+
+DataFrame display used to require producer-specific formatter registrations:
+pandas here, polars there, pyarrow elsewhere, narwhals as another wrapper, and
+Hugging Face datasets as a special case. That makes startup slower, imports
+optional libraries before user code asks for them, and leaves every new
+Arrow-compatible producer needing a new formatter hook.
+
+Modern dataframe libraries are converging on the Arrow PyCapsule interface:
+objects expose `__arrow_c_stream__()` and consumers import that as an Arrow C
+stream. The C stream is an in-process pointer protocol, not a notebook wire
+format, but it is the right producer-neutral way to obtain record batches.
+
+This ADR records the protocol boundary we want to upstream: kernels should
+look for the Arrow C stream producer contract first, then serialize that stream
+into ordinary notebook MIME outputs.
+
+Neighbors:
+
+- `docs/architecture/blob-ref-and-chunk-manifest-protocol.md` - how serialized
+  Arrow bytes are referenced and chunked.
+- `python/nteract-kernel-launcher/docs/arrow-native-outputs.md` - current
+  launcher implementation plan and merged behavior.
+- `docs/architecture/blob-storage-and-content-addressing.md` - where the
+  resulting bytes live after the daemon receives them.
+
+## Decision 1: `__arrow_c_stream__` is the primary table producer contract
+
+The launcher should consider any object with callable `__arrow_c_stream__` to
+be a table-like rich output candidate.
+
+The default path is:
+
+```python
+reader = pyarrow.RecordBatchReader.from_stream(obj)
+```
+
+or, on pyarrow versions without that public helper, the narrow PyCapsule import
+fallback. pandas, polars, pyarrow tables/readers, narwhals wrappers, DuckDB,
+DataFusion, cuDF, and future producers can then share one formatter path.
+
+Producer-specific type registrations are not the default table path. They are
+allowed only when the output needs domain semantics beyond generic Arrow, such
+as Hugging Face dataset feature summaries.
+
+## Decision 2: The imported stream is single-pass
+
+Consumers must assume an Arrow C stream can be consumed once. Formatting cannot
+probe the stream once for metadata and then consume it again for bytes unless a
+specific producer documents replay support.
+
+The launcher therefore drains one imported `RecordBatchReader` and derives all
+transport facts from that drain:
+
+- schema and schema metadata;
+- row counts and record batch counts;
+- chunk hashes and byte sizes;
+- the final LLM/plain summary hints.
+
+If a total row count is available cheaply from `num_rows`, `height`, `shape`,
+or `len`, it may be reported. Otherwise the included row count is the truthful
+count.
+
+## Decision 3: Notebook transport is Arrow IPC stream bytes
+
+The Arrow C stream pointer is never written into a notebook output. The
+transport/storage bytes are Arrow IPC stream format:
+
+```text
+application/vnd.apache.arrow.stream
+```
+
+Small outputs can be one IPC stream blob. Large or progressive outputs use an
+Arrow stream manifest whose chunks are each self-contained IPC stream
+mini-streams. Chunk boundaries prefer record batch boundaries; if one batch is
+too large, it may be sliced into smaller Arrow batches before IPC encoding.
+
+Schema metadata must survive this conversion. pandas index metadata,
+Hugging Face feature metadata, and future schema key/value hints belong in the
+Arrow schema rather than in TypeScript-specific side channels.
+
+## Decision 4: Startup must not import optional dataframe libraries
+
+The bootstrap installs generic per-MIME formatters and import hooks. It should
+not import pandas, polars, pyarrow, narwhals, altair, plotly, or datasets on the
+kernel startup path just to decide whether they are present.
+
+The cost of importing pyarrow is paid only when an Arrow-capable object is
+actually formatted. The cost of third-party renderer activation is paid when
+the user imports the renderer package.
+
+This is important for upstreaming because IPython and ipykernel cannot assume a
+notebook kernel wants every dataframe or visualization package imported before
+the first prompt.
+
+## Decision 5: Summaries are advisory siblings, not the table payload
+
+The structured table payload is the Arrow IPC stream plus manifest/ref
+metadata. Text summaries are sibling MIME values such as `text/llm+plain` or
+plain fallbacks. They help LLM tools and non-table renderers, but they are not
+the source of truth for schema, rows, or bytes.
+
+Summary hints in manifests should be cheap and explicit:
+
+```json
+{
+  "total_rows": 1000,
+  "included_rows": 1000,
+  "sampled": false,
+  "sample_strategy": "none"
+}
+```
+
+If a future first-paint path emits only a head sample, the manifest must say
+that honestly rather than pretending the table is complete.
+
+## Consequences
+
+- New Arrow-capable libraries can display rich tables without launcher changes.
+- The startup path gets smaller because optional library imports move to first
+  actual use.
+- The protocol cleanly separates producer interchange (`__arrow_c_stream__`)
+  from notebook transport (`application/vnd.apache.arrow.stream`).
+- Any formatter bug must fail soft and let normal IPython representation keep
+  working.
+
+## Open Questions
+
+1. Whether IPython should expose a first-class display formatter helper for
+   `__arrow_c_stream__` producers.
+2. How a standardized Jupyter form should advertise partial/progressive table
+   state without requiring a nteract-specific manifest MIME.
+3. Whether producer libraries should expose cheap total-row metadata as part
+   of the Arrow PyCapsule protocol or leave it as library-specific attributes.

--- a/docs/architecture/blob-ref-and-chunk-manifest-protocol.md
+++ b/docs/architecture/blob-ref-and-chunk-manifest-protocol.md
@@ -1,0 +1,216 @@
+# Blob Ref and Chunk Manifest Output Protocol
+
+**Status:** Draft, 2026-05-24.
+
+## Context
+
+Notebook outputs need to carry large binary payloads without making every
+runtime document, `.ipynb` save, and sync frame contain the bytes inline.
+Jupyter already lets IOPub messages attach binary buffers, but the JSON MIME
+bundle still needs a durable, host-neutral way to say what those buffers are
+and how to resolve them after the original message has passed.
+
+nteract currently uses `application/vnd.nteract.blob-ref+json` for this
+envelope. Arrow/Sift table outputs add a second shape:
+`application/vnd.nteract.arrow-stream-manifest+json`, where one selected output
+names many content-addressed Arrow stream chunks.
+
+This ADR separates the protocol contract from the current desktop daemon
+implementation so the same shape can be discussed with IPython, ipykernel, and
+Jupyter clients.
+
+Neighbors:
+
+- `docs/architecture/blob-storage-and-content-addressing.md` - daemon-side blob
+  store, hash validation, HTTP serving, and multipart upload.
+- `docs/architecture/hosted-notebook-artifacts.md` - hosted snapshot and blob
+  artifact materialization.
+- `docs/superpowers/specs/2026-05-11-arrow-manifest-durable-storage-design.md`
+  - save/load durability details for nested Arrow manifest refs.
+- `python/nteract-kernel-launcher/docs/arrow-native-outputs.md` - Python
+  producer behavior.
+
+## Decision 1: Output bundles carry host-neutral blob refs, not URLs
+
+A blob ref is a JSON value whose identity is the content hash of the bytes:
+
+```json
+{
+  "hash": "<sha256-hex>",
+  "content_type": "application/vnd.apache.arrow.stream",
+  "size": 12345,
+  "buffer_index": 0,
+  "summary": {
+    "total_rows": 1000,
+    "included_rows": 1000,
+    "sampled": false,
+    "sample_strategy": "none"
+  },
+  "query": null
+}
+```
+
+The current desktop implementation uses lowercase SHA-256 hex. The ref does
+not include a localhost URL, cloud URL, file path, or room id. The host owns
+resolution:
+
+- Desktop maps the hash to the local daemon blob server.
+- Hosted viewers map the hash to notebook artifact storage.
+- Headless tools can resolve the hash through a blob store API or leave it as
+  a ref.
+
+`buffer_index` is a transport hint for the current IOPub message only. It says
+which attached binary buffer carries the bytes. It is not part of durable
+identity and can be recomputed when a message is republished.
+
+## Decision 2: Multiple chunks use one multi-ref envelope
+
+When one logical output needs multiple binary payloads, the same MIME carries a
+multi-ref value:
+
+```json
+{
+  "content_type": "application/vnd.apache.arrow.stream",
+  "size": 24690,
+  "refs": [
+    {
+      "hash": "<sha256-hex>",
+      "content_type": "application/vnd.apache.arrow.stream",
+      "size": 12345,
+      "buffer_index": 0
+    },
+    {
+      "hash": "<sha256-hex>",
+      "content_type": "application/vnd.apache.arrow.stream",
+      "size": 12345,
+      "buffer_index": 1
+    }
+  ],
+  "summary": {
+    "total_rows": 1000,
+    "included_rows": 1000,
+    "sampled": false,
+    "sample_strategy": "none"
+  },
+  "query": null
+}
+```
+
+The buffer hook treats single-ref and multi-ref envelopes the same way: look up
+pending bytes by hash, attach buffers in ref order, stamp `buffer_index`, and
+let the daemon verify hash and size before committing bytes to the blob store.
+
+If no pending bytes exist for a hash, the message passes through unchanged.
+That permits replay of historical outputs whose bytes are already in a blob
+store.
+
+## Decision 3: Chunk manifests describe the logical stream
+
+The blob-ref MIME answers "where are the bytes?" The chunk manifest answers
+"how do these bytes form one renderable value?"
+
+For Arrow stream tables, the selected MIME is:
+
+```text
+application/vnd.nteract.arrow-stream-manifest+json
+```
+
+The manifest has this core shape:
+
+```json
+{
+  "version": 1,
+  "content_type": "application/vnd.apache.arrow.stream",
+  "schema": {
+    "hash": "<schema-fingerprint>",
+    "content_type": "application/vnd.apache.arrow.schema",
+    "fields": 2,
+    "columns": [
+      { "name": "a", "type": "int64", "nullable": true },
+      { "name": "b", "type": "large_string", "nullable": true }
+    ],
+    "metadata": {
+      "pandas": true,
+      "huggingface": false
+    }
+  },
+  "chunks": [
+    {
+      "index": 0,
+      "hash": "<sha256-hex>",
+      "size": 12345,
+      "row_count": 4096,
+      "record_batch_count": 4,
+      "encoding": "arrow-ipc-stream"
+    }
+  ],
+  "complete": true,
+  "summary": {
+    "total_rows": 4096,
+    "included_rows": 4096,
+    "sampled": false,
+    "sample_strategy": "none"
+  }
+}
+```
+
+Each `chunks[]` entry names a blob ref by hash. Each chunk is independently
+decodable as an Arrow IPC stream mini-stream. Consumers concatenate logical
+rows in ascending `index` order, not by reassembling raw bytes.
+
+The manifest may later grow `coalesced` entries for derived artifacts. Unknown
+fields must be preserved at save/load boundaries.
+
+## Decision 4: Durable save rewrites nested refs to ContentRef shape
+
+Live runtime/render state keeps chunk entries as `hash` strings because that is
+what renderers consume. Saved `.ipynb` JSON should make nested manifest-owned
+blobs explicit:
+
+```json
+{
+  "blob": "<sha256-hex>",
+  "size": 12345,
+  "content_type": "application/vnd.apache.arrow.stream"
+}
+```
+
+The transform applies only to known blob-bearing manifest slots such as
+`chunks[].hash`, `coalesced.hash`, and `coalesced.segments[].hash`. A schema
+fingerprint like `schema.hash` remains a string until schema bytes are stored
+as an actual blob.
+
+Save must fail rather than writing a complete-looking manifest when a chunk
+blob is missing. Load may drop the manifest MIME and preserve fallback siblings
+when a referenced blob is absent locally.
+
+## Decision 5: Vendor MIME is the incubation boundary
+
+The current MIME names are nteract vendor names on purpose. They let the
+launcher, daemon, frontend, MCP tools, and hosted viewer converge before asking
+IPython or Jupyter to standardize anything.
+
+The upstreamable part is not the nteract name. It is the split:
+
+1. A MIME-bundle JSON envelope describes content-addressed binary refs.
+2. IOPub buffers opportunistically carry bytes for those refs.
+3. A manifest MIME describes logical multi-blob values.
+4. Hosts resolve hashes to URLs or bytes without rewriting notebook outputs.
+
+## Consequences
+
+- Outputs survive daemon port changes because refs contain hashes, not URLs.
+- Replay and saved notebooks can refer to blobs without reattaching bytes.
+- Renderers can reason about multi-chunk tables without daemon-specific APIs.
+- GC, save, and publish code must understand nested manifest refs, not only
+  top-level blob refs.
+
+## Open Questions
+
+1. Whether an upstream Jupyter form should use a vendor-neutral MIME, a
+   top-level `attachments`-like message field, or metadata alongside existing
+   MIME entries.
+2. Whether hashes should be represented as bare SHA-256 hex, `sha256:<hex>`,
+   or an algorithm-tagged JSON object before standardization.
+3. How much of `summary` and `query` belongs in the generic blob-ref protocol
+   versus MIME-specific metadata.

--- a/docs/architecture/traceback-output-protocol.md
+++ b/docs/architecture/traceback-output-protocol.md
@@ -1,0 +1,162 @@
+# Structured Kernel Traceback Output Protocol
+
+**Status:** Draft, 2026-05-24.
+
+## Context
+
+Classic Jupyter tracebacks are primarily strings: an exception name, value, and
+ANSI traceback lines. That is portable, but it forces every richer client to
+reparse text to find frames, source locations, syntax offsets, library frames,
+or the notebook cell that defined a function.
+
+nteract's launcher now emits a structured traceback MIME payload:
+
+```text
+application/vnd.nteract.traceback+json
+```
+
+This ADR records the payload contract and the safety rules separately from the
+current implementation so it can be discussed with IPython and ipykernel.
+
+Neighbors:
+
+- `python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py` -
+  current producer.
+- `docs/architecture/execution-pipeline.md` - output ordering and runtime
+  manifest durability.
+- `docs/architecture/frontend-sync-bridge.md` - output rendering boundaries.
+
+## Decision 1: The payload is structured data plus plain text fallback
+
+The rich payload has these top-level fields:
+
+```json
+{
+  "ename": "ValueError",
+  "evalue": "bad input",
+  "language": "python",
+  "frames": [],
+  "syntax": null,
+  "execution": {
+    "execution_id": "exec-123",
+    "execution_count": 7
+  },
+  "text": "Traceback (most recent call last):\n...",
+  "raw_text": "Traceback (most recent call last):\n..."
+}
+```
+
+`text` is the client-friendly plain rendering of the structured payload.
+`raw_text` is Python's original traceback text. Renderers should prefer the
+structured fields, fall back to `text`, and use `raw_text` for diagnostics or
+copy/export of the original interpreter output.
+
+The payload is additive. It must not remove the ability to show a traceback if
+the rich renderer is absent or broken.
+
+## Decision 2: Frames are source-aware records
+
+Each frame is a JSON object:
+
+```json
+{
+  "filename": "/tmp/ipykernel_123/abc.py",
+  "lineno": 12,
+  "name": "transform",
+  "library": false,
+  "lines": [
+    { "lineno": 10, "source": "def transform(x):" },
+    { "lineno": 11, "source": "    y = x + 1" },
+    { "lineno": 12, "source": "    raise ValueError(y)", "highlight": true }
+  ],
+  "execution_id": "exec-def",
+  "execution_count": 5,
+  "source_hash": "sha256:<source-hash>",
+  "source_ref": {
+    "kind": "notebook_execution",
+    "execution_id": "exec-def",
+    "execution_count": 5,
+    "source_hash": "sha256:<source-hash>",
+    "compiled_filename": "/tmp/ipykernel_123/abc.py"
+  }
+}
+```
+
+`library` is a hint for UI grouping and dimming, not an authorization boundary.
+`lines` is a bounded source window around the failing line. `source_ref`
+connects compiled filenames back to notebook cell execution provenance when
+the kernel can supply it.
+
+## Decision 3: Syntax errors use a dedicated `syntax` record
+
+Parser errors often have no useful user-code stack frame. The payload should
+carry syntax information directly from the exception object:
+
+```json
+{
+  "filename": "/tmp/ipykernel_123/syntax.py",
+  "lineno": 1,
+  "offset": 8,
+  "end_lineno": 1,
+  "end_offset": 9,
+  "text": "def bad(",
+  "msg": "invalid syntax",
+  "source_ref": {
+    "kind": "notebook_execution",
+    "execution_id": "exec-123"
+  }
+}
+```
+
+Clients can then render a caret range without reverse-engineering CPython's
+formatted traceback lines.
+
+## Decision 4: Rich traceback emission must be fail-open
+
+Traceback rendering is an error path. The protocol implementation must never
+make a user lose the underlying traceback.
+
+The current launcher follows these rules:
+
+- install a wrapper around IPython's traceback hook only once;
+- build and publish the rich payload inside a broad safety boundary;
+- propagate intentional control flow such as `SystemExit` and
+  `KeyboardInterrupt`;
+- on any other failure, call the original traceback implementation;
+- if even the original traceback path fails, do not raise a secondary exception
+  that obscures the user's original error.
+
+The upstreamable invariant is stronger than the current transport choice:
+structured tracebacks can be carried as a MIME output, as error-message
+metadata, or as a future Jupyter message field, but construction failure must
+fall back to the classic traceback.
+
+## Decision 5: Payloads are bounded and redacted by default
+
+The producer should avoid turning exceptional states into unbounded or
+sensitive output:
+
+- deep stacks are clipped to head frames, a sentinel, and tail frames;
+- leading library frames above the first user frame may be stripped;
+- source windows are small;
+- environment values that look secret are redacted by default;
+- redaction can be disabled explicitly for debugging.
+
+Redaction is best-effort output hygiene, not a security boundary. Kernel code
+already has access to the user's process environment.
+
+## Consequences
+
+- Frontends can render tracebacks without parsing ANSI strings.
+- LLM tools can reason about exception structure and source provenance.
+- A future IPython/ipykernel proposal can focus on the payload and fail-open
+  invariant before choosing the final Jupyter transport.
+- Existing plain traceback behavior remains the fallback.
+
+## Open Questions
+
+1. Whether upstream Jupyter should attach this to `error` messages, emit it as
+   a rich MIME bundle, or standardize a new structured traceback field.
+2. Whether `source_ref.kind = "notebook_execution"` is general enough for
+   scripts, magics, generated code, and non-Python kernels.
+3. Which redaction controls belong in IPython, ipykernel, or frontend policy.

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -173,6 +173,32 @@ def test_buffer_hook_routes_display_data_via_display_pub(monkeypatch):
     assert sent[0]["buffers"] == [data]
 
 
+def test_buffer_hook_routes_update_display_data_via_display_pub(monkeypatch):
+    from nteract_kernel_launcher import _buffer_hook
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    ip, sent, pub, dh = _fake_ip_with_pubs()
+    monkeypatch.setattr(_buffer_hook, "_get_ipython", lambda: ip)
+
+    data = b"updated-arrow"
+    h = hashlib.sha256(data).hexdigest()
+    _buffer_hook.pending_buffers()[h] = data
+
+    msg = {
+        "header": {"msg_type": "update_display_data"},
+        "content": {
+            "data": {BLOB_REF_MIME: {"hash": h, "size": len(data)}},
+            "transient": {"display_id": "table-1"},
+        },
+    }
+    result = _buffer_hook.buffer_hook(msg)
+    assert result is None
+    assert sent[0]["socket"] == "PUB"
+    assert sent[0]["buffers"] == [data]
+    assert sent[0]["msg"]["content"]["transient"] == {"display_id": "table-1"}
+    assert h not in _buffer_hook.pending_buffers()
+
+
 def test_buffer_hook_attaches_multiple_ref_buffers(monkeypatch):
     from nteract_kernel_launcher import _buffer_hook
     from nteract_kernel_launcher._refs import BLOB_REF_MIME
@@ -350,9 +376,10 @@ def test_load_extension_invokes_the_install_steps(monkeypatch):
     monkeypatch.setattr(
         _bootstrap, "_enable_third_party_renderers", lambda: calls.append("renderers")
     )
+    monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: calls.append("traceback"))
 
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert calls == ["llm", "formatters", "hooks", "renderers"]
+    assert calls == ["llm", "formatters", "hooks", "renderers", "traceback"]
 
 
 def test_load_extension_swallows_per_step_failures(monkeypatch):
@@ -368,10 +395,11 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     monkeypatch.setattr(_bootstrap, "_install_dataframe_formatters", boom)
     monkeypatch.setattr(_bootstrap, "_install_buffer_hooks", lambda ip: called.append("hooks"))
     monkeypatch.setattr(_bootstrap, "_enable_third_party_renderers", lambda: called.append("r"))
+    monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: called.append("traceback"))
 
     # Must not raise.
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert called == ["hooks", "r"]
+    assert called == ["hooks", "r", "traceback"]
 
 
 def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):
@@ -548,6 +576,58 @@ def test_install_registers_iterable_dataset_formatter():
     )
     deferred = display_formatter.mimebundle_formatter.deferred_printers
     assert ("datasets.iterable_dataset", "IterableDataset") in deferred
+
+
+def test_generic_arrow_formatters_emit_pycapsule_bundle_once():
+    """Bare Arrow-capable objects should use the generic per-MIME formatters.
+
+    This is the launcher replacement for the old dx per-type formatter path:
+    the object only exposes ``__arrow_c_stream__`` and should still produce the
+    blob ref, Arrow manifest, and LLM summary through one shared serialization.
+    """
+    import io
+
+    pa = pytest.importorskip("pyarrow")
+    from IPython.core.formatters import DisplayFormatter
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    class StreamOnlyTable:
+        def __init__(self):
+            self._table = pa.table({"a": [1, 2, 3]})
+            self.exports = 0
+
+        def __arrow_c_stream__(self, requested_schema=None):
+            if self.exports:
+                raise RuntimeError("stream already consumed")
+            self.exports += 1
+            return self._table.__arrow_c_stream__(requested_schema)
+
+        def __len__(self):
+            return self._table.num_rows
+
+    display_formatter = DisplayFormatter()
+    ip = SimpleNamespace(display_formatter=display_formatter)
+    _bootstrap._install_llm_formatter(ip)
+    _bootstrap._install_dataframe_formatters(ip)
+    _buffer_hook.pending_buffers().clear()
+
+    source = StreamOnlyTable()
+    data, _metadata = display_formatter.format(source)
+
+    assert source.exports == 1
+    assert BLOB_REF_MIME in data
+    assert ARROW_STREAM_MANIFEST_MIME in data
+    assert "text/llm+plain" in data
+
+    h = data[BLOB_REF_MIME]["hash"]
+    assert data[ARROW_STREAM_MANIFEST_MIME]["chunks"][0]["hash"] == h
+    assert h in _buffer_hook.pending_buffers()
+
+    table = pa.ipc.open_stream(io.BytesIO(_buffer_hook.pending_buffers()[h])).read_all()
+    assert table.column_names == ["a"]
+    assert table.num_rows == 3
 
 
 # ─── emit path — only runs if pandas + pyarrow are importable ────────────

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -540,10 +540,10 @@ def test_plotly_entrypoint_imports_lazily_configure_plotly_io(monkeypatch, entry
 
 
 def test_real_plotly_express_import_lazily_configures_plotly_io(monkeypatch):
-    pytest.importorskip("plotly.express")
-
     from nteract_kernel_launcher import _bootstrap
 
+    _isolate_renderer_import_hook(monkeypatch, _bootstrap)
+    pytest.importorskip("plotly.express")
     _isolate_renderer_import_hook(monkeypatch, _bootstrap)
     _bootstrap._enable_third_party_renderers()
 

--- a/python/nteract-kernel-launcher/tests/test_progressive.py
+++ b/python/nteract-kernel-launcher/tests/test_progressive.py
@@ -26,12 +26,14 @@ def test_display_arrow_stream_publishes_manifest_revisions():
 
     _buffer_hook.pending_buffers().clear()
     table = pa.table({"a": list(range(6))})
-    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=2))
+    batches = table.to_batches(max_chunksize=2)
+    reader = pa.RecordBatchReader.from_batches(table.schema, batches)
+    max_chunk_bytes = max(batch.nbytes for batch in batches)
 
     handle = display_arrow_stream(
         reader,
         display_fn=fake_display,
-        max_chunk_bytes=1,
+        max_chunk_bytes=max_chunk_bytes,
         total_rows=table.num_rows,
     )
 
@@ -81,9 +83,16 @@ def test_display_arrow_stream_single_chunk_publishes_complete_once():
         return Handle()
 
     table = pa.table({"a": list(range(3))})
-    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches())
+    batches = table.to_batches()
+    reader = pa.RecordBatchReader.from_batches(table.schema, batches)
+    max_chunk_bytes = max(batch.nbytes for batch in batches)
 
-    display_arrow_stream(reader, display_fn=fake_display, max_chunk_bytes=1, total_rows=3)
+    display_arrow_stream(
+        reader,
+        display_fn=fake_display,
+        max_chunk_bytes=max_chunk_bytes,
+        total_rows=3,
+    )
 
     assert [kind for kind, _, _ in messages] == ["display"]
     assert BLOB_REF_MIME in messages[0][1]


### PR DESCRIPTION
## Summary

- add three draft protocol ADRs for blob refs/chunk manifests, Arrow C stream table outputs, and structured traceback payloads
- expand launcher tests around `update_display_data` buffer attachment, full bootstrap step ordering including tracebacks, and generic `__arrow_c_stream__` per-MIME formatting
- run `python/nteract-kernel-launcher/tests/` in the Python CI job and make progressive Arrow tests stable across pyarrow batch-size estimates

## Verification

- `uv run --no-sync pytest python/nteract-kernel-launcher/tests/ -v --tb=short`
- `uv run --no-sync ruff format --check python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_progressive.py`
- `uv run --no-sync ruff check python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_progressive.py`
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`

## Notes

- The first `cargo xtask lint --fix` run failed because this worktree did not have JS dependencies installed and `vite-plus` could not resolve. After `pnpm install --frozen-lockfile`, the same lint command passed.
