### PR TITLE
fix(notebook-cloud): accept Access token headers

### DIFF
--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -44,6 +44,7 @@ export interface AuthenticatedConnectionMetadata {
     | "dev-token-header"
     | "dev-token-subprotocol"
     | "access-assertion"
+    | "access-token-header"
     | "access-bearer"
     | "access-cookie"
     | "access-cookie-assertion"
@@ -494,6 +495,7 @@ function isMetadataTransport(value: string): value is AuthenticatedConnectionMet
     value === "dev-token-header" ||
     value === "dev-token-subprotocol" ||
     value === "access-assertion" ||
+    value === "access-token-header" ||
     value === "access-bearer" ||
     value === "access-cookie" ||
     value === "access-cookie-assertion" ||
@@ -611,6 +613,11 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
   const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));
   if (bearerToken) {
     candidates.push({ token: bearerToken, transport: "access-bearer" });
+  }
+
+  const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
+  if (accessToken) {
+    candidates.push({ token: accessToken, transport: "access-token-header" });
   }
 
   const cookieToken = cookieValue(request.headers.get("cookie"), "CF_Authorization");

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -433,6 +433,23 @@ describe("Cloudflare Access identity", () => {
     assert.equal(identity.scope, "viewer");
   });
 
+  it("accepts Cloudflare Access CLI tokens from the cf-access-token header", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=smoke:owner&scope=owner", {
+        headers: {
+          "CF-Access-Token": token,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/smoke:owner");
+    assert.equal(identity.scope, "owner");
+    assert.equal(identity.metadata.transport, "access-token-header");
+  });
+
   it("rejects Access tokens with the wrong audience", async () => {
     const { env, token } = await accessTokenFixture({
       audience: "wrong-audience",

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -43,6 +43,7 @@ answers "what may this principal do in this notebook room?"
 The listener normalizes transport-specific inputs into a credential:
 
 - Access assertion header from Cloudflare Access.
+- Access token header from `cloudflared access token` / CLI clients.
 - Bearer token from `Authorization` for native clients.
 - Bearer token from a WebSocket subprotocol for browser clients that already
   hold a token.


### PR DESCRIPTION
## Summary

- accept `CF-Access-Token` as an explicit Cloudflare Access credential transport for CLI/API clients
- stamp that path as `access-token-header` metadata instead of conflating it with `Authorization: Bearer`
- cover the header path in the Access identity unit tests and document it in the credential transport ADR

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `git diff --check`
