### PR TITLE
docs(protocol): tighten output ADR wording

### DIFF
--- a/docs/architecture/arrow-c-stream-output-protocol.md
+++ b/docs/architecture/arrow-c-stream-output-protocol.md
@@ -33,15 +33,17 @@ Neighbors:
 The launcher should consider any object with callable `__arrow_c_stream__` to
 be a table-like rich output candidate.
 
-The default path is:
+The preferred public pyarrow path is:
 
 ```python
 reader = pyarrow.RecordBatchReader.from_stream(obj)
 ```
 
 or, on pyarrow versions without that public helper, the narrow PyCapsule import
-fallback. pandas, polars, pyarrow tables/readers, narwhals wrappers, DuckDB,
-DataFusion, cuDF, and future producers can then share one formatter path.
+fallback. Both paths are part of the v1 launcher behavior; the fallback is an
+implementation compatibility bridge, not a separate producer contract. pandas,
+polars, pyarrow tables/readers, narwhals wrappers, DuckDB, DataFusion, cuDF,
+and future producers can then share one formatter path.
 
 Producer-specific type registrations are not the default table path. They are
 allowed only when the output needs domain semantics beyond generic Arrow, such
@@ -117,6 +119,20 @@ Summary hints in manifests should be cheap and explicit:
 
 If a future first-paint path emits only a head sample, the manifest must say
 that honestly rather than pretending the table is complete.
+
+## Decision 6: Vendor MIME is the incubation boundary
+
+The upstreamable part of this ADR is the producer contract and transport split:
+
+1. Producers expose `__arrow_c_stream__`.
+2. The kernel imports that stream once.
+3. Notebook transport stores Arrow IPC stream bytes plus manifest/ref metadata.
+4. Text summaries remain advisory sibling MIME values.
+
+The current nteract MIME names and manifest fields are an incubation vehicle.
+The manifest itself is versioned by the blob-ref/chunk-manifest protocol; the
+Arrow producer contract should evolve additively unless an upstream proposal
+chooses a new transport shape.
 
 ## Consequences
 

--- a/docs/architecture/blob-ref-and-chunk-manifest-protocol.md
+++ b/docs/architecture/blob-ref-and-chunk-manifest-protocol.md
@@ -39,7 +39,6 @@ A blob ref is a JSON value whose identity is the content hash of the bytes:
   "hash": "<sha256-hex>",
   "content_type": "application/vnd.apache.arrow.stream",
   "size": 12345,
-  "buffer_index": 0,
   "summary": {
     "total_rows": 1000,
     "included_rows": 1000,
@@ -50,9 +49,9 @@ A blob ref is a JSON value whose identity is the content hash of the bytes:
 }
 ```
 
-The current desktop implementation uses lowercase SHA-256 hex. The ref does
-not include a localhost URL, cloud URL, file path, or room id. The host owns
-resolution:
+The current desktop implementation uses lowercase SHA-256 hex without an
+algorithm prefix. The ref does not include a localhost URL, cloud URL, file
+path, or room id. The host owns resolution:
 
 - Desktop maps the hash to the local daemon blob server.
 - Hosted viewers map the hash to notebook artifact storage.
@@ -60,8 +59,12 @@ resolution:
   a ref.
 
 `buffer_index` is a transport hint for the current IOPub message only. It says
-which attached binary buffer carries the bytes. It is not part of durable
-identity and can be recomputed when a message is republished.
+which attached binary buffer carries the bytes. Producers do not need to put it
+in single-ref bundles; the buffer hook stamps it before the message is sent.
+It is explicit in the transmitted JSON because Jupyter buffers are positional
+and consumers may inspect a ref after envelope normalization without replaying
+the hook's JSON traversal. It is not part of durable identity and can be
+recomputed when a message is republished.
 
 ## Decision 2: Multiple chunks use one multi-ref envelope
 

--- a/docs/architecture/traceback-output-protocol.md
+++ b/docs/architecture/traceback-output-protocol.md
@@ -51,8 +51,9 @@ The rich payload has these top-level fields:
 structured fields, fall back to `text`, and use `raw_text` for diagnostics or
 copy/export of the original interpreter output.
 
-The payload is additive. It must not remove the ability to show a traceback if
-the rich renderer is absent or broken.
+The payload is additive-only in v1: new fields must be optional, and existing
+field meanings must remain stable. It must not remove the ability to show a
+traceback if the rich renderer is absent or broken.
 
 ## Decision 2: Frames are source-aware records
 
@@ -85,7 +86,8 @@ Each frame is a JSON object:
 `library` is a hint for UI grouping and dimming, not an authorization boundary.
 `lines` is a bounded source window around the failing line. `source_ref`
 connects compiled filenames back to notebook cell execution provenance when
-the kernel can supply it.
+the kernel can supply it. `source_ref.kind` is an open-ended string; the current
+well-known value is `"notebook_execution"`, not a closed enum.
 
 ## Decision 3: Syntax errors use a dedicated `syntax` record
 
@@ -139,11 +141,27 @@ sensitive output:
 - deep stacks are clipped to head frames, a sentinel, and tail frames;
 - leading library frames above the first user frame may be stripped;
 - source windows are small;
-- environment values that look secret are redacted by default;
+- environment variable values are redacted by default, except for values from
+  keys known to be non-secret and values that are too short or common to be
+  useful secrets;
 - redaction can be disabled explicitly for debugging.
 
-Redaction is best-effort output hygiene, not a security boundary. Kernel code
-already has access to the user's process environment.
+Redaction is best-effort traceback output hygiene, not a security boundary.
+Kernel code already has access to the user's process environment. Other output
+channels need their own producer-side policy if they should get the same
+scrubbing before entering runtime state or blob storage.
+
+## Decision 6: Vendor MIME is the incubation boundary
+
+The current MIME name is a nteract vendor name on purpose. The upstreamable
+part is the payload contract and failure behavior:
+
+1. A structured traceback payload carries frames, syntax information, source
+   provenance, and plain-text fallbacks.
+2. Payload evolution is additive-only in v1.
+3. Rich traceback construction must fail open to classic traceback output.
+4. The final transport may be a MIME bundle, `error` message metadata, or a
+   future Jupyter message field.
 
 ## Consequences
 
@@ -157,6 +175,8 @@ already has access to the user's process environment.
 
 1. Whether upstream Jupyter should attach this to `error` messages, emit it as
    a rich MIME bundle, or standardize a new structured traceback field.
-2. Whether `source_ref.kind = "notebook_execution"` is general enough for
+2. Which `source_ref.kind` values should be treated as well-known across
    scripts, magics, generated code, and non-Python kernels.
-3. Which redaction controls belong in IPython, ipykernel, or frontend policy.
+3. Which redaction controls belong in IPython, ipykernel, or frontend policy,
+   and whether the same environment-value scrubbing should apply to stream
+   outputs before they enter runtime state.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py
@@ -12,7 +12,7 @@ BLOB_REF_MIME = "application/vnd.nteract.blob-ref+json"
 class BlobRef:
     """A content-addressed reference to a blob in the daemon's blob store.
 
-    ``hash`` is the persistent identity (e.g. ``"sha256:abc123..."``).
+    ``hash`` is the persistent identity as lowercase SHA-256 hex.
     ``size`` is the blob's byte length as reported by the runtime agent.
 
     No URL is stored. The frontend derives the blob-server URL from the hash


### PR DESCRIPTION
## Summary

- align blob-ref ADR examples and `_refs.py` hash docs with the current bare SHA-256 producer shape
- clarify Arrow C stream fallback behavior for older pyarrow versions
- tighten traceback ADR wording around additive evolution, source provenance, vendor MIME incubation, and environment-value redaction scope

## Verification

- `uv run --no-sync ruff check python/nteract-kernel-launcher/nteract_kernel_launcher/_refs.py`
- `git diff --check`
- `cargo xtask lint --fix` *(blocked by existing `apps/notebook-cloud/src/identity.ts` duplicate `accessToken` declaration on `origin/main`)*
