### PR TITLE
fix(kernel-launcher): redact output text before send

### DIFF
--- a/crates/kernel-env/src/launcher.rs
+++ b/crates/kernel-env/src/launcher.rs
@@ -60,10 +60,20 @@ pub const LAUNCHER_FILES: &[(&str, &str)] = &[
         include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py"),
     ),
     (
+        "_output_redaction.py",
+        include_str!(
+            "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_output_redaction.py"
+        ),
+    ),
+    (
         "_progressive.py",
         include_str!(
             "../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_progressive.py"
         ),
+    ),
+    (
+        "_redact.py",
+        include_str!("../../../python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py"),
     ),
     (
         "_refs.py",
@@ -224,6 +234,14 @@ mod tests {
             .find(|(n, _)| *n == "_bootstrap.py")
             .expect("_bootstrap.py must be included");
         assert!(boot.1.contains("def load_ipython_extension"));
+    }
+
+    #[test]
+    fn launcher_ships_output_redaction_modules() {
+        let names: std::collections::HashSet<&str> =
+            LAUNCHER_FILES.iter().map(|(name, _)| *name).collect();
+        assert!(names.contains("_redact.py"));
+        assert!(names.contains("_output_redaction.py"));
     }
 
     #[tokio::test]

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -46,7 +46,9 @@ from typing import Any
 from IPython.core.formatters import BaseFormatter
 from traitlets import ObjectName, Unicode
 
-from nteract_kernel_launcher import _buffer_hook, _output_redaction, _traceback
+import nteract_kernel_launcher._buffer_hook as _buffer_hook
+import nteract_kernel_launcher._output_redaction as _output_redaction
+import nteract_kernel_launcher._traceback as _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import (
     ARROW_STREAM_MANIFEST_MIME,

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -46,7 +46,7 @@ from typing import Any
 from IPython.core.formatters import BaseFormatter
 from traitlets import ObjectName, Unicode
 
-from nteract_kernel_launcher import _buffer_hook, _traceback
+from nteract_kernel_launcher import _buffer_hook, _output_redaction, _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import (
     ARROW_STREAM_MANIFEST_MIME,
@@ -678,6 +678,7 @@ def load_ipython_extension(ip: Any) -> None:
     _run_bootstrap_step("LLM formatter install", lambda: _install_llm_formatter(ip))
     _run_bootstrap_step("dataframe formatter install", lambda: _install_dataframe_formatters(ip))
     _run_bootstrap_step("buffer hook install", lambda: _install_buffer_hooks(ip))
+    _run_bootstrap_step("output redaction install", lambda: _output_redaction.install(ip))
     _run_bootstrap_step("third-party renderer enable", _enable_third_party_renderers)
 
     # Traceback install goes last so earlier failures can't prevent it.

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_output_redaction.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_output_redaction.py
@@ -1,0 +1,80 @@
+"""Install producer-side text redaction on Jupyter output sessions."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Iterable
+from typing import Any
+
+from nteract_kernel_launcher._redact import redact_message_content
+
+log = logging.getLogger("nteract_kernel_launcher")
+
+_INSTALLED_ATTR = "_nteract_output_redaction_installed"
+
+
+def _candidate_sessions(ip: Any) -> Iterable[Any]:
+    owners = [
+        getattr(ip, "display_pub", None),
+        getattr(ip, "displayhook", None),
+        getattr(ip, "kernel", None),
+        sys.stdout,
+        sys.stderr,
+    ]
+    seen: set[int] = set()
+    for owner in owners:
+        session = getattr(owner, "session", None)
+        if session is None:
+            continue
+        marker = id(session)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        if callable(getattr(session, "send", None)):
+            yield session
+
+
+def _redact_msg_or_content(msg_or_type: Any, content: Any) -> tuple[Any, Any]:
+    if isinstance(msg_or_type, dict):
+        header = msg_or_type.get("header")
+        msg_type = header.get("msg_type") if isinstance(header, dict) else None
+        if not isinstance(msg_type, str):
+            return msg_or_type, content
+        message_content = msg_or_type.get("content")
+        redacted_content = redact_message_content(msg_type, message_content)
+        if redacted_content is message_content:
+            return msg_or_type, content
+        redacted_msg = dict(msg_or_type)
+        redacted_msg["content"] = redacted_content
+        return redacted_msg, content
+
+    if isinstance(msg_or_type, str):
+        return msg_or_type, redact_message_content(msg_or_type, content)
+
+    return msg_or_type, content
+
+
+def _wrap_session(session: Any) -> None:
+    if getattr(session, _INSTALLED_ATTR, False):
+        return
+
+    original_send = session.send
+
+    def send(stream: Any, msg_or_type: Any, content: Any = None, *args: Any, **kwargs: Any) -> Any:
+        try:
+            msg_or_type, content = _redact_msg_or_content(msg_or_type, content)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("output redaction failed: %s", exc)
+        return original_send(stream, msg_or_type, content, *args, **kwargs)
+
+    send._nteract_installed = True
+    send._nteract_original_send = original_send
+    session.send = send
+    setattr(session, _INSTALLED_ATTR, True)
+
+
+def install(ip: Any) -> None:
+    """Patch known Jupyter output sessions to scrub text before send."""
+    for session in _candidate_sessions(ip):
+        _wrap_session(session)

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py
@@ -1,0 +1,159 @@
+"""Best-effort output text redaction shared by launcher output paths."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+REDACT_ENV_VALUES_FLAG = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS"
+REDACTION_MARKER = "[redacted env]"
+MIN_REDACTION_VALUE_LEN = 8
+COMMON_ENV_VALUES = {
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "disabled",
+    "enabled",
+}
+
+KNOWN_NON_SECRET_ENV_KEYS = {
+    "_",
+    "__CF_USER_TEXT_ENCODING",
+    "CARGO_HOME",
+    "COLORFGBG",
+    "COLORTERM",
+    "CONDA_DEFAULT_ENV",
+    "CONDA_EXE",
+    "CONDA_PREFIX",
+    "CONDA_PYTHON_EXE",
+    "DISPLAY",
+    "GOPATH",
+    "GOROOT",
+    "HOME",
+    "LANG",
+    "LANGUAGE",
+    "LOGNAME",
+    "OLDPWD",
+    "PATH",
+    "PWD",
+    "PYENV_ROOT",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "RUSTUP_HOME",
+    "SHELL",
+    "SHLVL",
+    "SSH_AUTH_SOCK",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERNAME",
+    "VIRTUAL_ENV",
+    "XPC_FLAGS",
+    "XPC_SERVICE_NAME",
+}
+
+
+def redaction_enabled() -> bool:
+    raw = os.environ.get(REDACT_ENV_VALUES_FLAG)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def is_known_non_secret_env_key(key: str) -> bool:
+    key = key.upper()
+    return (
+        key in KNOWN_NON_SECRET_ENV_KEYS
+        or key.startswith("LC_")
+        or key.startswith("TERM_PROGRAM")
+        or key.startswith("XDG_")
+    )
+
+
+def eligible_env_values() -> list[str]:
+    if not redaction_enabled():
+        return []
+
+    values = set()
+    for key, raw in os.environ.items():
+        if is_known_non_secret_env_key(key):
+            continue
+        value = raw
+        if len(value) < MIN_REDACTION_VALUE_LEN:
+            continue
+        if value.strip() != value:
+            continue
+        if value.lower() in COMMON_ENV_VALUES:
+            continue
+        values.add(value)
+
+    return sorted(values, key=lambda value: (-len(value), value))
+
+
+def redact_text(text: str, values: list[str] | None = None) -> str:
+    if values is None:
+        values = eligible_env_values()
+    for value in values:
+        text = text.replace(value, REDACTION_MARKER)
+    return text
+
+
+def redact_payload_value(value: Any, values: list[str] | None = None) -> Any:
+    if values is None:
+        values = eligible_env_values()
+    if not values:
+        return value
+    if isinstance(value, str):
+        return redact_text(value, values)
+    if isinstance(value, list):
+        return [redact_payload_value(item, values) for item in value]
+    if isinstance(value, dict):
+        return {key: redact_payload_value(item, values) for key, item in value.items()}
+    return value
+
+
+def redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    values = eligible_env_values()
+    if not values:
+        return payload
+    return redact_payload_value(payload, values)
+
+
+def _redact_mime_data(data: Any, values: list[str]) -> Any:
+    if not isinstance(data, dict):
+        return data
+    redacted = dict(data)
+    for mime, value in data.items():
+        if isinstance(value, str):
+            redacted[mime] = redact_text(value, values)
+    return redacted
+
+
+def redact_message_content(msg_type: str, content: Any) -> Any:
+    """Redact text-bearing Jupyter output message content.
+
+    Binary buffers and non-string MIME values are intentionally left untouched.
+    """
+    values = eligible_env_values()
+    if not values or not isinstance(content, dict):
+        return content
+
+    redacted = dict(content)
+    if msg_type == "stream":
+        text = content.get("text")
+        if isinstance(text, str):
+            redacted["text"] = redact_text(text, values)
+    elif msg_type in {"display_data", "execute_result", "update_display_data"}:
+        redacted["data"] = _redact_mime_data(content.get("data"), values)
+    elif msg_type == "error":
+        evalue = content.get("evalue")
+        traceback = content.get("traceback")
+        if isinstance(evalue, str):
+            redacted["evalue"] = redact_text(evalue, values)
+        if isinstance(traceback, list):
+            redacted["traceback"] = [
+                redact_text(line, values) if isinstance(line, str) else line for line in traceback
+            ]
+    return redacted

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -28,7 +28,7 @@ import traceback as _pytraceback
 import types
 from typing import Any
 
-from nteract_kernel_launcher import _redact
+import nteract_kernel_launcher._redact as _redact
 
 log = logging.getLogger("nteract_kernel_launcher")
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -28,6 +28,8 @@ import traceback as _pytraceback
 import types
 from typing import Any
 
+from nteract_kernel_launcher import _redact
+
 log = logging.getLogger("nteract_kernel_launcher")
 
 TRACEBACK_MIME = "application/vnd.nteract.traceback+json"
@@ -58,118 +60,17 @@ _CELL_REGISTRY_ATTR = "_nteract_traceback_cell_registry"
 _CELL_REGISTRY_HOOK_ATTR = "_nteract_traceback_cell_registry_hook"
 _NOTEBOOK_EXECUTION_SOURCE_KIND = "notebook_execution"
 
-_REDACT_ENV_VALUES_FLAG = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS"
-_REDACTION_MARKER = "[redacted env]"
-_MIN_REDACTION_VALUE_LEN = 8
-_COMMON_ENV_VALUES = {
-    "localhost",
-    "127.0.0.1",
-    "0.0.0.0",
-    "disabled",
-    "enabled",
-}
-
-_KNOWN_NON_SECRET_ENV_KEYS = {
-    "_",
-    "__CF_USER_TEXT_ENCODING",
-    "CARGO_HOME",
-    "COLORFGBG",
-    "COLORTERM",
-    "CONDA_DEFAULT_ENV",
-    "CONDA_EXE",
-    "CONDA_PREFIX",
-    "CONDA_PYTHON_EXE",
-    "DISPLAY",
-    "GOPATH",
-    "GOROOT",
-    "HOME",
-    "LANG",
-    "LANGUAGE",
-    "LOGNAME",
-    "OLDPWD",
-    "PATH",
-    "PWD",
-    "PYENV_ROOT",
-    "PYTHONHOME",
-    "PYTHONPATH",
-    "RUSTUP_HOME",
-    "SHELL",
-    "SHLVL",
-    "SSH_AUTH_SOCK",
-    "TEMP",
-    "TERM",
-    "TMP",
-    "TMPDIR",
-    "USER",
-    "USERNAME",
-    "VIRTUAL_ENV",
-    "XPC_FLAGS",
-    "XPC_SERVICE_NAME",
-}
-
-
-# ─── Environment value redaction ───────────────────────────────────────────
-
-
-def _redaction_enabled() -> bool:
-    raw = os.environ.get(_REDACT_ENV_VALUES_FLAG)
-    if raw is None:
-        return True
-    return raw.strip().lower() not in {"0", "false", "no", "off"}
-
-
-def _is_known_non_secret_env_key(key: str) -> bool:
-    key = key.upper()
-    return (
-        key in _KNOWN_NON_SECRET_ENV_KEYS
-        or key.startswith("LC_")
-        or key.startswith("TERM_PROGRAM")
-        or key.startswith("XDG_")
-    )
-
-
-def _eligible_env_values() -> list[str]:
-    if not _redaction_enabled():
-        return []
-
-    values = set()
-    for key, raw in os.environ.items():
-        if _is_known_non_secret_env_key(key):
-            continue
-        value = raw
-        if len(value) < _MIN_REDACTION_VALUE_LEN:
-            continue
-        if value.strip() != value:
-            continue
-        if value.lower() in _COMMON_ENV_VALUES:
-            continue
-        values.add(value)
-
-    return sorted(values, key=lambda value: (-len(value), value))
-
-
-def _redact_text(text: str, values: list[str]) -> str:
-    for value in values:
-        text = text.replace(value, _REDACTION_MARKER)
-    return text
-
-
-def _redact_payload_value(value: Any, values: list[str]) -> Any:
-    if isinstance(value, str):
-        return _redact_text(value, values)
-    if isinstance(value, list):
-        return [_redact_payload_value(item, values) for item in value]
-    if isinstance(value, dict):
-        return {key: _redact_payload_value(item, values) for key, item in value.items()}
-    return value
-
-
-def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    values = _eligible_env_values()
-    if not values:
-        return payload
-    return _redact_payload_value(payload, values)
-
+_REDACT_ENV_VALUES_FLAG = _redact.REDACT_ENV_VALUES_FLAG
+_REDACTION_MARKER = _redact.REDACTION_MARKER
+_MIN_REDACTION_VALUE_LEN = _redact.MIN_REDACTION_VALUE_LEN
+_COMMON_ENV_VALUES = _redact.COMMON_ENV_VALUES
+_KNOWN_NON_SECRET_ENV_KEYS = _redact.KNOWN_NON_SECRET_ENV_KEYS
+_redaction_enabled = _redact.redaction_enabled
+_is_known_non_secret_env_key = _redact.is_known_non_secret_env_key
+_eligible_env_values = _redact.eligible_env_values
+_redact_text = _redact.redact_text
+_redact_payload_value = _redact.redact_payload_value
+_redact_payload = _redact.redact_payload
 
 # ─── Payload construction ───────────────────────────────────────────────────
 

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -373,13 +373,14 @@ def test_load_extension_invokes_the_install_steps(monkeypatch):
         _bootstrap, "_install_dataframe_formatters", lambda ip: calls.append("formatters")
     )
     monkeypatch.setattr(_bootstrap, "_install_buffer_hooks", lambda ip: calls.append("hooks"))
+    monkeypatch.setattr(_bootstrap._output_redaction, "install", lambda ip: calls.append("redact"))
     monkeypatch.setattr(
         _bootstrap, "_enable_third_party_renderers", lambda: calls.append("renderers")
     )
     monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: calls.append("traceback"))
 
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert calls == ["llm", "formatters", "hooks", "renderers", "traceback"]
+    assert calls == ["llm", "formatters", "hooks", "redact", "renderers", "traceback"]
 
 
 def test_load_extension_swallows_per_step_failures(monkeypatch):
@@ -394,12 +395,13 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     monkeypatch.setattr(_bootstrap, "_install_llm_formatter", boom)
     monkeypatch.setattr(_bootstrap, "_install_dataframe_formatters", boom)
     monkeypatch.setattr(_bootstrap, "_install_buffer_hooks", lambda ip: called.append("hooks"))
+    monkeypatch.setattr(_bootstrap._output_redaction, "install", lambda ip: called.append("redact"))
     monkeypatch.setattr(_bootstrap, "_enable_third_party_renderers", lambda: called.append("r"))
     monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: called.append("traceback"))
 
     # Must not raise.
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert called == ["hooks", "r", "traceback"]
+    assert called == ["hooks", "redact", "r", "traceback"]
 
 
 def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):

--- a/python/nteract-kernel-launcher/tests/test_output_redaction.py
+++ b/python/nteract-kernel-launcher/tests/test_output_redaction.py
@@ -1,0 +1,100 @@
+"""Tests for producer-side output text redaction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from nteract_kernel_launcher import _output_redaction
+
+
+class _FakeSession:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, stream, msg_or_type, content=None, *args, **kwargs):
+        self.sent.append(
+            {
+                "stream": stream,
+                "msg_or_type": msg_or_type,
+                "content": content,
+                "args": args,
+                "kwargs": kwargs,
+            }
+        )
+
+
+def _fake_ip(session):
+    return SimpleNamespace(
+        display_pub=SimpleNamespace(session=session),
+        displayhook=SimpleNamespace(session=session),
+    )
+
+
+def test_stream_output_redacts_environment_values(monkeypatch):
+    secret = "launcher-stream-secret-12345"
+    monkeypatch.setenv("STREAM_REDACTION_SECRET", secret)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    session = _FakeSession()
+    _output_redaction.install(_fake_ip(session))
+
+    session.send(
+        "socket",
+        "stream",
+        content={"name": "stdout", "text": f"token={secret}"},
+        parent={"msg_id": "parent"},
+    )
+
+    sent = session.sent[0]
+    assert sent["content"]["text"] == "token=[redacted env]"
+    assert sent["kwargs"]["parent"] == {"msg_id": "parent"}
+
+
+def test_display_and_error_text_redacts_environment_values(monkeypatch):
+    secret = "launcher-display-secret-12345"
+    monkeypatch.setenv("DISPLAY_REDACTION_SECRET", secret)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    session = _FakeSession()
+    _output_redaction.install(_fake_ip(session))
+
+    display_msg = {
+        "header": {"msg_type": "display_data"},
+        "content": {
+            "data": {
+                "text/plain": f"value {secret}",
+                "application/json": {"token": secret},
+            }
+        },
+    }
+    session.send("socket", display_msg)
+    session.send(
+        "socket",
+        "error",
+        content={"evalue": secret, "traceback": [f"line {secret}"]},
+    )
+
+    redacted_display = session.sent[0]["msg_or_type"]
+    assert redacted_display["content"]["data"]["text/plain"] == "value [redacted env]"
+    assert redacted_display["content"]["data"]["application/json"] == {"token": secret}
+    assert display_msg["content"]["data"]["text/plain"] == f"value {secret}"
+
+    redacted_error = session.sent[1]["content"]
+    assert redacted_error["evalue"] == "[redacted env]"
+    assert redacted_error["traceback"] == ["line [redacted env]"]
+
+
+def test_output_redaction_install_is_idempotent(monkeypatch):
+    secret = "launcher-idempotent-secret-12345"
+    monkeypatch.setenv("IDEMPOTENT_REDACTION_SECRET", secret)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    session = _FakeSession()
+    ip = _fake_ip(session)
+    _output_redaction.install(ip)
+    first_send = session.send
+    _output_redaction.install(ip)
+
+    assert session.send is first_send
+    session.send("socket", "stream", content={"name": "stdout", "text": secret})
+    assert session.sent[0]["content"]["text"] == "[redacted env]"

--- a/python/nteract-kernel-launcher/tests/test_progressive.py
+++ b/python/nteract-kernel-launcher/tests/test_progressive.py
@@ -109,6 +109,47 @@ def test_display_arrow_stream_single_chunk_publishes_complete_once():
     assert "llm" not in manifest
 
 
+def test_display_arrow_stream_splits_oversized_batches():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher import _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._progressive import display_arrow_stream
+
+    messages = []
+
+    class Handle:
+        def update(self, obj, **kwargs):
+            messages.append(("update", obj, kwargs))
+
+    def fake_display(obj, **kwargs):
+        messages.append(("display", obj, kwargs))
+        return Handle()
+
+    _buffer_hook.pending_buffers().clear()
+    table = pa.table({"text": ["x" * 64 for _ in range(5)]})
+    batches = table.to_batches(max_chunksize=table.num_rows)
+    assert len(batches) == 1
+
+    reader = pa.RecordBatchReader.from_batches(table.schema, batches)
+    display_arrow_stream(
+        reader,
+        display_fn=fake_display,
+        max_chunk_bytes=max(1, batches[0].nbytes // 2),
+        total_rows=table.num_rows,
+    )
+
+    manifest = messages[-1][1][ARROW_STREAM_MANIFEST_MIME]
+    assert manifest["complete"] is True
+    assert len(manifest["chunks"]) > 1
+
+    decoded = [
+        pa.ipc.open_stream(io.BytesIO(_buffer_hook.pending_buffers()[chunk["hash"]])).read_all()
+        for chunk in manifest["chunks"]
+    ]
+    assert sum(table.num_rows for table in decoded) == 5
+    assert all(table.num_rows < 5 for table in decoded)
+
+
 def test_display_arrow_stream_is_exported_from_package():
     import nteract_kernel_launcher
 


### PR DESCRIPTION
## Summary

- move environment-value redaction into a shared launcher utility
- install producer-side output redaction on Jupyter output sessions so stream, display text, and error text are scrubbed before send
- include the redaction modules in the daemon-vendored launcher package
- add focused tests for output redaction and progressive Arrow oversized-batch splitting

## Verification

- `uv run --no-sync pytest python/nteract-kernel-launcher/tests/ -v --tb=short`
- `uv run --no-sync ruff check python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py python/nteract-kernel-launcher/nteract_kernel_launcher/_output_redaction.py python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py python/nteract-kernel-launcher/tests/test_output_redaction.py python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_progressive.py`
- `cargo test -p kernel-env launcher`
- `cargo fmt --check`
- `git diff --check`
- `cargo xtask lint --fix` *(blocked by existing `apps/notebook-cloud/src/identity.ts` duplicate `accessToken` declaration on `origin/main`)*
