### PR TITLE
fix(notebook-cloud): harden Access auth edges

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
@@ -8,7 +8,6 @@ import { FrameType } from "runtimed";
 
 import {
   accessAuthHeaders,
-  accessEmailFromJwt,
   accessPrincipalFromJwt,
   assertHostedAccessSmokeEnv,
   webSocketUpgradeRequestHeaders,
@@ -145,15 +144,10 @@ console.log(
       origin: smokeOrigin,
       roomId,
       viewerUrl: new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href,
-      principals: {
-        owner: ownerPrincipal,
-        editor: editorPrincipal,
-        viewer: viewerPrincipal,
-      },
-      emails: {
-        owner: accessEmailFromJwt(ownerToken),
-        editor: accessEmailFromJwt(editorToken),
-        viewer: accessEmailFromJwt(viewerToken),
+      principal_fingerprints: {
+        owner: fingerprintPrincipal(ownerPrincipal),
+        editor: fingerprintPrincipal(editorPrincipal),
+        viewer: fingerprintPrincipal(viewerPrincipal),
       },
       checks: [
         "cloudflare_access_jwt_validated_by_worker",
@@ -328,17 +322,34 @@ async function connectAnonymous(notebookId, viewerSession) {
 async function clientForSocket(socket, safeUrl) {
   const queue = [];
   const waiters = [];
-  socket.addEventListener("message", async (event) => {
-    const frame = await decodeFrame(event.data);
-    const index = waiters.findIndex((waiter) => waiter.predicate(frame));
-    if (index === -1) {
-      queue.push(frame);
-      return;
+  let fatalError = null;
+  const failWaiters = (error) => {
+    fatalError = error;
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      clearTimeout(waiter.timer);
+      waiter.reject(error);
     }
+  };
+  socket.addEventListener("message", async (event) => {
+    try {
+      const frame = await decodeFrame(event.data);
+      const index = waiters.findIndex((waiter) => waiter.predicate(frame));
+      if (index === -1) {
+        queue.push(frame);
+        return;
+      }
 
-    const [waiter] = waiters.splice(index, 1);
-    clearTimeout(waiter.timer);
-    waiter.resolve(frame);
+      const [waiter] = waiters.splice(index, 1);
+      clearTimeout(waiter.timer);
+      waiter.resolve(frame);
+    } catch (error) {
+      failWaiters(error);
+      socket.close();
+    }
+  });
+  socket.addEventListener("error", (event) => {
+    failWaiters(event.error ?? new Error(`WebSocket error from ${safeUrl}`));
   });
 
   if (socket.readyState !== RawWebSocketClient.OPEN) {
@@ -353,6 +364,9 @@ async function clientForSocket(socket, safeUrl) {
   return {
     socket,
     nextFrame(predicate, timeoutMs = 5_000) {
+      if (fatalError) {
+        return Promise.reject(fatalError);
+      }
       const queued = queue.findIndex(predicate);
       if (queued !== -1) {
         const [frame] = queue.splice(queued, 1);
@@ -367,7 +381,7 @@ async function clientForSocket(socket, safeUrl) {
           }
           reject(new Error(`timed out waiting for frame from ${safeUrl}`));
         }, timeoutMs);
-        waiters.push({ predicate, resolve, timer });
+        waiters.push({ predicate, resolve, reject, timer });
       });
     },
   };
@@ -393,6 +407,9 @@ async function decodeFrame(data) {
   }
 
   const bytes = new Uint8Array(buffer);
+  if (bytes.byteLength === 0) {
+    throw new Error("empty WebSocket message");
+  }
   const type = bytes[0];
   const payload = bytes.slice(1);
   let json;
@@ -427,7 +444,7 @@ async function closeClient(client) {
 
 function safeWebSocketUrl(url) {
   const safe = new URL(url.href);
-  for (const [key, value] of safe.searchParams) {
+  for (const [key, value] of Array.from(safe.searchParams.entries())) {
     if (key.toLowerCase().includes("token") || value.startsWith("eyJ")) {
       safe.searchParams.set(key, "<redacted>");
     }
@@ -535,6 +552,7 @@ class RawWebSocketClient {
     this.readyState = RawWebSocketClient.OPEN;
     this.listeners = new Map();
     this.buffer = initialBuffer ?? Buffer.alloc(0);
+    this.fragmentedMessage = null;
     this.socket.on("data", (chunk) => this.receive(chunk));
     this.socket.on("close", () => {
       this.readyState = RawWebSocketClient.CLOSED;
@@ -586,6 +604,7 @@ class RawWebSocketClient {
     while (this.buffer.length >= 2) {
       const first = this.buffer[0];
       const second = this.buffer[1];
+      const fin = Boolean(first & 0x80);
       const opcode = first & 0x0f;
       const masked = Boolean(second & 0x80);
       let length = second & 0x7f;
@@ -626,14 +645,38 @@ class RawWebSocketClient {
         this.socket.end();
         this.dispatch("close", {});
       } else if (opcode === 0x9) {
+        assert(fin, "fragmented WebSocket ping is invalid");
         this.socket.write(encodeClientFrame(0x0a, payload));
-      } else if (opcode === 0x2) {
-        this.dispatch("message", { data: new Uint8Array(payload) });
-      } else if (opcode === 0x1) {
-        this.dispatch("message", { data: payload.toString("utf8") });
+      } else if (opcode === 0x0) {
+        assert(this.fragmentedMessage, "unexpected WebSocket continuation frame");
+        this.fragmentedMessage.chunks.push(payload);
+        if (fin) {
+          const message = this.fragmentedMessage;
+          this.fragmentedMessage = null;
+          this.dispatchMessage(message.opcode, Buffer.concat(message.chunks));
+        }
+      } else if (opcode === 0x2 || opcode === 0x1) {
+        assert(!this.fragmentedMessage, "new WebSocket message started before continuation ended");
+        if (fin) {
+          this.dispatchMessage(opcode, payload);
+        } else {
+          this.fragmentedMessage = { opcode, chunks: [payload] };
+        }
       }
     }
   }
+
+  dispatchMessage(opcode, payload) {
+    if (opcode === 0x2) {
+      this.dispatch("message", { data: new Uint8Array(payload) });
+    } else if (opcode === 0x1) {
+      this.dispatch("message", { data: payload.toString("utf8") });
+    }
+  }
+}
+
+function fingerprintPrincipal(principal) {
+  return createHash("sha256").update(principal).digest("hex").slice(0, 16);
 }
 
 function encodeClientFrame(opcode, payload) {

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -154,7 +154,11 @@ export async function authenticateRequestWithProviders(
   env: IdentityEnvironment = {},
 ): Promise<AuthenticatedConnection> {
   const accessCredential = accessCredentialFromRequest(request);
-  if (accessCredential && accessConfigFromEnv(env)) {
+  const accessConfig = accessConfigFromEnv(env);
+  if (accessCredential && !accessConfig && hasPartialAccessConfig(env)) {
+    throw new AuthError("Cloudflare Access auth is not fully configured", 503);
+  }
+  if (accessCredential && accessConfig) {
     if (hasDevIdentityCredential(request) || hasDevCredentialTransport(request)) {
       throw new AuthError("multiple identity credentials presented", 400);
     }
@@ -600,13 +604,12 @@ function validDevTokenCredential(
 
 function accessCredentialFromRequest(request: Request): AccessCredential | undefined {
   const candidates: AccessCredential[] = [];
+  const cookieToken = cookieValue(request.headers.get("cookie"), "CF_Authorization");
   const assertionToken = request.headers.get(CLOUDFLARE_ACCESS_JWT_HEADER)?.trim() || undefined;
   if (assertionToken) {
     candidates.push({
       token: assertionToken,
-      transport: cookieValue(request.headers.get("cookie"), "CF_Authorization")
-        ? "access-cookie-assertion"
-        : "access-assertion",
+      transport: cookieToken ? "access-cookie-assertion" : "access-assertion",
     });
   }
 
@@ -620,13 +623,7 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
     candidates.push({ token: bearerToken, transport: "access-bearer" });
   }
 
-  const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
-  if (accessToken) {
-    candidates.push({ token: accessToken, transport: "access-token-header" });
-  }
-
-  const cookieToken = cookieValue(request.headers.get("cookie"), "CF_Authorization");
-  if (cookieToken && !assertionToken) {
+  if (cookieToken && candidates.length === 0) {
     candidates.push({ token: cookieToken, transport: "access-cookie" });
   }
 
@@ -647,6 +644,16 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
   }
 
   return candidates[0];
+}
+
+function hasPartialAccessConfig(env: IdentityEnvironment): boolean {
+  const audience = env.NOTEBOOK_CLOUD_ACCESS_AUD?.trim();
+  const rawTeamDomain = env.NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?.trim();
+  const jwksJson = env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?.trim();
+  if (!audience && !rawTeamDomain && !jwksJson) {
+    return false;
+  }
+  return !audience || !rawTeamDomain;
 }
 
 function accessConfigFromEnv(env: IdentityEnvironment): AccessConfig | undefined {
@@ -771,22 +778,26 @@ async function verifyWithAnyAccessKey(
   signature: Uint8Array,
 ): Promise<boolean> {
   for (const key of keys) {
-    const cryptoKey = await crypto.subtle.importKey(
-      "jwk",
-      key,
-      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-      false,
-      ["verify"],
-    );
-    if (
-      await crypto.subtle.verify(
-        "RSASSA-PKCS1-v1_5",
-        cryptoKey,
-        signature,
-        new TextEncoder().encode(signingInput),
-      )
-    ) {
-      return true;
+    try {
+      const cryptoKey = await crypto.subtle.importKey(
+        "jwk",
+        key,
+        { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+        false,
+        ["verify"],
+      );
+      if (
+        await crypto.subtle.verify(
+          "RSASSA-PKCS1-v1_5",
+          cryptoKey,
+          signature,
+          new TextEncoder().encode(signingInput),
+        )
+      ) {
+        return true;
+      }
+    } catch {
+      continue;
     }
   }
   return false;

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,11 +1,13 @@
 import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
+  ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
   AuthError,
   allowsBlobUpload,
   allowsPublish,
   authenticateRequestWithProviders,
   DEV_AUTH_TOKEN_HEADER,
+  DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   parseScope,
   stampTrustedIdentity,
   type AuthenticatedConnection,
@@ -289,10 +291,14 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
 }
 
 function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | null {
-  const allowedOrigins = allowedWebSocketOrigins(request, env);
-  const origin = normalizedOrigin(request.headers.get("Origin"));
+  const rawOrigin = request.headers.get("Origin");
+  const allowedOrigins = allowedTrustedOrigins(request, env);
+  const origin = normalizedOrigin(rawOrigin);
+  if (hasOriginHeader(rawOrigin) && !origin) {
+    return json({ error: "websocket origin is not allowed" }, 403);
+  }
   if (!origin) {
-    if (!requiresWebSocketOrigin(request, env)) {
+    if (!requiresWebSocketOrigin(request)) {
       return null;
     }
     return json({ error: "websocket origin is required" }, 403);
@@ -303,11 +309,30 @@ function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | 
   return null;
 }
 
-function requiresWebSocketOrigin(request: Request, env: Env): boolean {
-  return Boolean(env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS?.trim()) || hasCloudflareAccessCookie(request);
+function requiresWebSocketOrigin(request: Request): boolean {
+  return hasCloudflareAccessCookie(request) || hasCredentialWebSocketSubprotocol(request);
 }
 
-function allowedWebSocketOrigins(request: Request, env: Env): Set<string> {
+function rejectUntrustedMutationOrigin(request: Request, env: Env): Response | null {
+  const rawOrigin = request.headers.get("Origin");
+  const allowedOrigins = allowedTrustedOrigins(request, env);
+  const origin = normalizedOrigin(rawOrigin);
+  if (hasOriginHeader(rawOrigin) && !origin) {
+    return json({ error: "request origin is not allowed" }, 403);
+  }
+  if (!origin) {
+    if (hasCloudflareAccessCookie(request)) {
+      return json({ error: "request origin is required" }, 403);
+    }
+    return null;
+  }
+  if (!allowedOrigins.has(origin)) {
+    return json({ error: "request origin is not allowed" }, 403);
+  }
+  return null;
+}
+
+function allowedTrustedOrigins(request: Request, env: Env): Set<string> {
   const origins = new Set<string>([new URL(request.url).origin]);
   const raw = env.NOTEBOOK_CLOUD_ALLOWED_ORIGINS?.trim();
   if (!raw) {
@@ -334,6 +359,10 @@ function normalizedOrigin(value: string | null): string | null {
   }
 }
 
+function hasOriginHeader(value: string | null): boolean {
+  return Boolean(value?.trim());
+}
+
 function hasCloudflareAccessCookie(request: Request): boolean {
   const cookie = request.headers.get("Cookie");
   if (!cookie) {
@@ -341,6 +370,20 @@ function hasCloudflareAccessCookie(request: Request): boolean {
   }
 
   return cookie.split(";").some((part) => part.trim().split("=")[0] === "CF_Authorization");
+}
+
+function hasCredentialWebSocketSubprotocol(request: Request): boolean {
+  const protocol = request.headers.get("Sec-WebSocket-Protocol");
+  if (!protocol) {
+    return false;
+  }
+  return protocol
+    .split(",")
+    .some((part) =>
+      [ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX, DEV_AUTH_TOKEN_PROTOCOL_PREFIX].some((prefix) =>
+        part.trim().startsWith(prefix),
+      ),
+    );
 }
 
 async function routeSnapshot(
@@ -511,6 +554,13 @@ async function routeRuntimeSnapshot(
 async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST" || request.method === "DELETE") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
   }
 
   const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");

--- a/apps/notebook-cloud/src/sharing.ts
+++ b/apps/notebook-cloud/src/sharing.ts
@@ -105,23 +105,23 @@ export function resolvePendingInvitesForLogin({
   login: AuthenticatedLoginProfile;
   now?: string;
 }): InviteResolution {
+  const normalizedEmail = safeNormalizeInviteEmail(login.email);
+  const loginProvider = normalizeProvider(login.provider);
   const profile: PrincipalProfile = {
     principal: login.principal,
-    provider: normalizeProvider(login.provider),
-    email: login.email ? normalizeInviteEmail(login.email) : null,
+    provider: loginProvider,
+    email: normalizedEmail,
     displayName: login.displayName?.trim() || null,
     firstSeenAt: now,
     lastSeenAt: now,
   };
 
-  if (!login.email || !login.emailVerified) {
+  if (!normalizedEmail || !login.emailVerified) {
     return { profile, acceptedInvites: [], aclGrants: [] };
   }
 
-  const loginEmail = normalizeInviteEmail(login.email);
-  const loginProvider = normalizeProvider(login.provider);
   const acceptedInvites = invites
-    .filter((invite) => inviteMatchesLogin(invite, loginEmail, loginProvider, now))
+    .filter((invite) => inviteMatchesLogin(invite, normalizedEmail, loginProvider, now))
     .map((invite) => ({
       ...invite,
       status: "accepted" as const,
@@ -177,10 +177,11 @@ export function shareTargetDisplay(input: {
     };
   }
   if (input.pendingInvite) {
+    const email = safeNormalizeInviteEmail(input.pendingInvite.email);
     return {
       kind: "pending_invite",
-      label: normalizeInviteEmail(input.pendingInvite.email),
-      email: normalizeInviteEmail(input.pendingInvite.email),
+      label: email ?? "Unknown invitee",
+      email: email ?? "",
     };
   }
   throw new Error("share target display requires a profile, pending invite, or public viewer flag");
@@ -195,14 +196,25 @@ function inviteMatchesLogin(
   if (invite.status !== "pending") {
     return false;
   }
-  if (invite.expiresAt && invite.expiresAt <= now) {
+  const nowMs = Date.parse(now);
+  if (!Number.isFinite(nowMs)) {
     return false;
   }
-  if (normalizeInviteEmail(invite.email) !== loginEmail) {
+  if (invite.expiresAt) {
+    const expiresAtMs = Date.parse(invite.expiresAt);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= nowMs) {
+      return false;
+    }
+  }
+  const inviteEmail = safeNormalizeInviteEmail(invite.email);
+  if (inviteEmail !== loginEmail) {
     return false;
   }
-  const providerHint = normalizeProviderHint(invite.providerHint);
-  return !providerHint || providerHint === loginProvider;
+  const providerHint = safeNormalizeProviderHint(invite.providerHint);
+  if (!providerHint.ok) {
+    return false;
+  }
+  return !providerHint.value || providerHint.value === loginProvider;
 }
 
 function normalizeProvider(provider: string): string {
@@ -211,4 +223,25 @@ function normalizeProvider(provider: string): string {
     throw new Error("login provider is invalid");
   }
   return normalized;
+}
+
+function safeNormalizeInviteEmail(email: string | null | undefined): string | null {
+  if (!email) {
+    return null;
+  }
+  try {
+    return normalizeInviteEmail(email);
+  } catch {
+    return null;
+  }
+}
+
+function safeNormalizeProviderHint(
+  provider: string | null,
+): { ok: true; value: string | null } | { ok: false; value: null } {
+  try {
+    return { ok: true, value: normalizeProviderHint(provider) };
+  } catch {
+    return { ok: false, value: null };
+  }
 }

--- a/apps/notebook-cloud/test/access-jwt-fixture.ts
+++ b/apps/notebook-cloud/test/access-jwt-fixture.ts
@@ -11,6 +11,7 @@ export async function accessTokenFixture(options: {
   audience?: string;
   email?: string;
   includeKid?: boolean;
+  includeMalformedKey?: boolean;
   includeUnmatchedKey?: boolean;
   name?: string;
   subject: string;
@@ -72,6 +73,7 @@ export async function accessTokenFixture(options: {
       NOTEBOOK_CLOUD_ACCESS_AUD: audience,
       NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: JSON.stringify({
         keys: [
+          ...(options.includeMalformedKey ? [{ alg: "RS256", kty: "RSA", use: "sig" }] : []),
           ...(unmatchedPublicJwk
             ? [{ ...unmatchedPublicJwk, alg: "RS256", kid: "unmatched", use: "sig" }]
             : []),

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -450,6 +450,23 @@ describe("Cloudflare Access identity", () => {
     assert.equal(identity.metadata.transport, "access-token-header");
   });
 
+  it("prefers explicit Access token headers over ambient Access cookies", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=smoke:owner&scope=owner", {
+        headers: {
+          "CF-Access-Token": token,
+          Cookie: `CF_Authorization=${token}`,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/smoke:owner");
+    assert.equal(identity.metadata.transport, "access-token-header");
+  });
+
   it("rejects Access tokens with the wrong audience", async () => {
     const { env, token } = await accessTokenFixture({
       audience: "wrong-audience",
@@ -487,10 +504,49 @@ describe("Cloudflare Access identity", () => {
     assert.equal(identity.scope, "viewer");
   });
 
+  it("rejects Access credentials when Access env is only partially configured", async () => {
+    const { token } = await accessTokenFixture({ subject: "alice" });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync", {
+            headers: {
+              "Cf-Access-Jwt-Assertion": token,
+            },
+          }),
+          { NOTEBOOK_CLOUD_ACCESS_AUD: "notebook-cloud-aud" },
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 503 &&
+        /not fully configured/.test(error.message),
+    );
+  });
+
   it("tries matching RSA keys when a rotating Access JWT omits kid", async () => {
     const { env, token } = await accessTokenFixture({
       includeKid: false,
       includeUnmatchedKey: true,
+      subject: "alice",
+    });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=desktop:a", {
+        headers: {
+          "Cf-Access-Jwt-Assertion": token,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/desktop:a");
+  });
+
+  it("skips malformed Access JWKS candidates and tries the next matching key", async () => {
+    const { env, token } = await accessTokenFixture({
+      includeKid: false,
+      includeMalformedKey: true,
       subject: "alice",
     });
 

--- a/apps/notebook-cloud/test/sharing.test.ts
+++ b/apps/notebook-cloud/test/sharing.test.ts
@@ -60,6 +60,43 @@ describe("hosted notebook sharing prototype", () => {
     );
   });
 
+  it("does not throw when an unverified login has a malformed email claim", () => {
+    const resolution = resolvePendingInvitesForLogin({
+      invites: [pendingInvite()],
+      login: accessLogin({ email: "noatsign", emailVerified: false }),
+    });
+
+    assert.equal(resolution.profile.email, null);
+    assert.equal(resolution.aclGrants.length, 0);
+  });
+
+  it("skips malformed stored invites while resolving other valid invites", () => {
+    const validInvite = pendingInvite({ id: "invite-valid" });
+    const resolution = resolvePendingInvitesForLogin({
+      invites: [
+        pendingInvite({ id: "invite-bad-provider", providerHint: "okta/sso" }),
+        pendingInvite({ id: "invite-bad-email", email: "bad invite" }),
+        validInvite,
+      ],
+      login: accessLogin(),
+    });
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-valid"],
+    );
+  });
+
+  it("expires invites with numeric time comparisons instead of ISO string ordering", () => {
+    const resolution = resolvePendingInvitesForLogin({
+      invites: [pendingInvite({ expiresAt: "2026-05-24T00:00:00Z" })],
+      login: accessLogin(),
+      now: "2026-05-24T00:00:00.000Z",
+    });
+
+    assert.equal(resolution.aclGrants.length, 0);
+  });
+
   it("normalizes provider hints before resolving pending invites", () => {
     const invite = pendingInvite({ providerHint: " Cloudflare-Access " });
 
@@ -109,6 +146,14 @@ describe("hosted notebook sharing prototype", () => {
     assert.equal(principal.label, "Alice Example");
     assert.equal(pending.label, "bob@example.com");
     assert.deepEqual(publicViewer, { kind: "public_viewer", label: "Anyone with the link" });
+  });
+
+  it("uses a placeholder display label for malformed pending invite rows", () => {
+    assert.deepEqual(shareTargetDisplay({ pendingInvite: { email: "" } }), {
+      kind: "pending_invite",
+      label: "Unknown invitee",
+      email: "",
+    });
   });
 });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import worker from "../src/index.ts";
 import {
+  ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
   TRUSTED_WEBSOCKET_PROTOCOL_HEADER,
@@ -519,6 +520,70 @@ describe("Worker artifact routes", () => {
     assert.equal(bobCatalog.status, 200);
   });
 
+  it("requires trusted origins for cookie-backed ACL mutations", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv(accessEnv);
+    seedNotebook(env, "access-acl-demo");
+    seedAcl(env, {
+      notebookId: "access-acl-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+
+    const body = JSON.stringify({
+      subject_kind: "principal",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+    const headers = {
+      "Content-Type": "application/json",
+      Cookie: `CF_Authorization=${token}`,
+      "X-Operator": "browser:tab",
+      "X-Scope": "owner",
+    };
+
+    const missingOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-demo/acl", {
+        method: "POST",
+        headers,
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(missingOrigin.status, 403);
+    assert.deepEqual(await missingOrigin.json(), { error: "request origin is required" });
+
+    const untrustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-demo/acl", {
+        method: "POST",
+        headers: {
+          ...headers,
+          Origin: "https://evil.example",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(untrustedOrigin.status, 403);
+    assert.deepEqual(await untrustedOrigin.json(), { error: "request origin is not allowed" });
+
+    const trustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-demo/acl", {
+        method: "POST",
+        headers: {
+          ...headers,
+          Origin: "https://cloud.test",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(trustedOrigin.status, 201);
+  });
+
   it("lets owners grant and revoke explicit public viewer ACL rows", async () => {
     const env = fakeEnv();
     seedNotebook(env, "public-acl-demo");
@@ -901,6 +966,36 @@ describe("Worker artifact routes", () => {
     assert.equal(roomFetches, 0);
   });
 
+  it("rejects malformed WebSocket Origin headers even without an allowlist", async () => {
+    let roomFetches = 0;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/acl-demo/sync?viewer_session=malformed", {
+        headers: {
+          Origin: "not-a-url",
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), { error: "websocket origin is not allowed" });
+    assert.equal(roomFetches, 0);
+  });
+
   it("rejects cookie-backed WebSocket upgrades with no Origin before room dispatch", async () => {
     const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
     let roomFetches = 0;
@@ -966,14 +1061,65 @@ describe("Worker artifact routes", () => {
     assert.equal(roomFetches, 0);
   });
 
-  it("rejects allowlisted WebSocket upgrades when the browser sends no Origin", async () => {
+  it("allows no-Origin CLI Access-token WebSocket upgrades even with an allowlist", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
     const env = fakeEnv({
+      ...accessEnv,
       NOTEBOOK_CLOUD_ALLOWED_ORIGINS: "https://notebooks.example.com",
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "cli-origin-demo");
+    seedAcl(env, {
+      notebookId: "cli-origin-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
     });
 
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/acl-demo/sync?viewer_session=missing", {
+      new Request("https://cloud.test/n/cli-origin-demo/sync?operator=cli:smoke&scope=owner", {
         headers: {
+          "CF-Access-Token": token,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(roomFetches, 1);
+  });
+
+  it("requires Origin for Access-token WebSocket subprotocol credentials", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    const accessProtocol = `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`;
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cli-origin-demo/sync?operator=browser:tab&scope=owner", {
+        headers: {
+          "Sec-WebSocket-Protocol": accessProtocol,
           Upgrade: "websocket",
         },
       }),
@@ -983,6 +1129,7 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 403);
     assert.deepEqual(await response.json(), { error: "websocket origin is required" });
+    assert.equal(roomFetches, 0);
   });
 
   it("does not create notebook rows from unauthorized WebSocket opens", async () => {
@@ -1036,6 +1183,7 @@ describe("Worker artifact routes", () => {
         new Request("https://cloud.test/n/unclaimed-demo/sync?user=alice&scope=editor", {
           headers: {
             Upgrade: "websocket",
+            Origin: "https://cloud.test",
             "Sec-WebSocket-Protocol": `${DEV_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
               "<NOTEBOOK_CLOUD_DEV_TOKEN>",
             )}`,


### PR DESCRIPTION
## Summary

- Harden Cloudflare Access credential selection and partial configuration handling.
- Make WebSocket and ACL mutation Origin enforcement transport-aware.
- Make pending invite resolution resilient to malformed stored rows and date formatting drift.
- Keep hosted Access smoke diagnostics usable without logging emails, principals, or credential-looking URL params.

## Verification

- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/sharing.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `vp check`
- `node --check apps/notebook-cloud/scripts/hosted-access-smoke.mjs`
- `cargo xtask lint --fix`
- `git diff --check`
