### PR TITLE
fix(notebook-sync): settle terminal stream outputs

### DIFF
--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -21,7 +21,8 @@
 //! 1. **Terminal wait.** Poll until `executions[eid].status` is `"done"` or
 //!    `"error"`.
 //! 2. **Output-sync grace.** If the terminal status is reached but the
-//!    output list is still empty on our replica, poll briefly (capped at
+//!    output list is still empty, or the terminal output includes a stream
+//!    manifest that may still be updating in place, poll briefly (capped at
 //!    `output_sync_grace`) for the last sync frames to land.
 
 use std::time::{Duration, Instant};
@@ -64,6 +65,8 @@ pub const DEFAULT_OUTPUT_SYNC_GRACE: Duration = Duration::from_millis(500);
 const TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// Poll frequency during the output-sync grace window.
 const OUTPUT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Quiet period after the last observed terminal stream-output mutation.
+const STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(100);
 
 /// Wait for a specific execution to reach terminal status in the
 /// `RuntimeStateDoc` and return the final outputs, execution count, and
@@ -133,22 +136,44 @@ pub async fn await_execution_terminal(
     // ── Phase 2: output-sync grace ──────────────────────────────────────
     //
     // The daemon commits outputs before `set_execution_done`, but sync
-    // frames can arrive in separate batches; our local replica may be a
-    // tick behind. Poll briefly for outputs to appear.
-    if final_state.output_manifests.is_empty() {
+    // frames can arrive in separate batches; our local replica may be a tick
+    // behind. Stream outputs are also updated in place, so a non-empty output
+    // list can still contain the penultimate stream blob. Poll briefly until
+    // stream outputs are quiet.
+    if final_state.output_manifests.is_empty() || has_stream_output(&final_state.output_manifests) {
         let grace = output_sync_grace.unwrap_or(DEFAULT_OUTPUT_SYNC_GRACE);
         let remaining_until_deadline = deadline.saturating_duration_since(Instant::now());
         let output_deadline = Instant::now() + grace.min(remaining_until_deadline);
+        let mut stream_quiet_since = if has_stream_output(&final_state.output_manifests) {
+            Some(Instant::now())
+        } else {
+            None
+        };
 
         while Instant::now() < output_deadline {
+            if stream_quiet_since.is_some_and(|since| since.elapsed() >= STREAM_OUTPUT_QUIET_PERIOD)
+            {
+                break;
+            }
+
             if let Ok(state) = handle.get_runtime_state() {
                 if let Some(exec) = state.executions.get(execution_id) {
-                    if !exec.outputs.is_empty() {
+                    if exec.outputs != final_state.output_manifests {
                         final_state.output_manifests = exec.outputs.clone();
                         if final_state.execution_count.is_none() {
                             final_state.execution_count = exec.execution_count;
                         }
-                        break;
+                        stream_quiet_since = if has_stream_output(&final_state.output_manifests) {
+                            Some(Instant::now())
+                        } else {
+                            None
+                        };
+
+                        if !final_state.output_manifests.is_empty()
+                            && !has_stream_output(&final_state.output_manifests)
+                        {
+                            break;
+                        }
                     }
                 }
             }
@@ -157,4 +182,10 @@ pub async fn await_execution_terminal(
     }
 
     Ok(final_state)
+}
+
+fn has_stream_output(outputs: &[serde_json::Value]) -> bool {
+    outputs
+        .iter()
+        .any(|output| output.get("output_type").and_then(|t| t.as_str()) == Some("stream"))
 }

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -5,8 +5,12 @@
 
 use runtime_doc::{ExecutionState, RuntimeLifecycle, RuntimeState};
 use tokio::sync::watch;
+use tokio::time::{Duration, Instant};
 
 use crate::handle::DocHandle;
+
+const TERMINAL_STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(100);
+const TERMINAL_STREAM_OUTPUT_MAX_GRACE: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionTerminalReason {
@@ -75,7 +79,9 @@ impl ExecutionWatcher {
             let state = self.rx.borrow_and_update().clone();
             if let Some(progress) = self.progress_from_state(&state) {
                 if progress.terminal {
+                    let progress = self.settle_terminal_stream_output(progress).await;
                     self.finished = true;
+                    return Some(progress);
                 }
                 return Some(progress);
             }
@@ -173,6 +179,42 @@ impl ExecutionWatcher {
             terminal_reason: Some(reason),
         }
     }
+
+    async fn settle_terminal_stream_output(
+        &mut self,
+        mut progress: ExecutionProgressState,
+    ) -> ExecutionProgressState {
+        if !has_stream_output(&progress.output_manifests) {
+            return progress;
+        }
+
+        let max_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_MAX_GRACE;
+        let mut quiet_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_QUIET_PERIOD;
+
+        loop {
+            let now = Instant::now();
+            let next_deadline = quiet_deadline.min(max_deadline);
+            if now >= next_deadline {
+                return progress;
+            }
+
+            match tokio::time::timeout_at(next_deadline, self.rx.changed()).await {
+                Ok(Ok(())) => {
+                    let state = self.rx.borrow_and_update().clone();
+                    if let Some(next) = self.progress_from_state(&state) {
+                        if next.terminal {
+                            progress = next;
+                            if !has_stream_output(&progress.output_manifests) {
+                                return progress;
+                            }
+                            quiet_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_QUIET_PERIOD;
+                        }
+                    }
+                }
+                Ok(Err(_)) | Err(_) => return progress,
+            }
+        }
+    }
 }
 
 fn terminal_reason_for(entry: &ExecutionState) -> Option<ExecutionTerminalReason> {
@@ -182,6 +224,12 @@ fn terminal_reason_for(entry: &ExecutionState) -> Option<ExecutionTerminalReason
         "error" => Some(ExecutionTerminalReason::Error),
         _ => None,
     }
+}
+
+fn has_stream_output(outputs: &[serde_json::Value]) -> bool {
+    outputs
+        .iter()
+        .any(|output| output.get("output_type").and_then(|t| t.as_str()) == Some("stream"))
 }
 
 #[cfg(test)]
@@ -283,6 +331,50 @@ mod tests {
         let progress = watcher.next().await.expect("output progress");
         assert_eq!(progress.output_manifests.len(), 1);
         assert!(!progress.terminal);
+    }
+
+    #[tokio::test]
+    async fn watcher_waits_for_terminal_stream_output_to_settle() {
+        let (handle, tx) = make_handle();
+        let mut watcher = ExecutionWatcher::new(&handle, "cell-1", "exec-1");
+
+        set_execution(&tx, "exec-1", "cell-1", "running", Vec::new());
+        let _ = watcher.next().await.expect("first progress");
+
+        set_execution(
+            &tx,
+            "exec-1",
+            "cell-1",
+            "done",
+            vec![serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": {"inline": "partial"},
+            })],
+        );
+
+        let tx_for_task = tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            set_execution(
+                &tx_for_task,
+                "exec-1",
+                "cell-1",
+                "done",
+                vec![serde_json::json!({
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": {"inline": "final"},
+                })],
+            );
+        });
+
+        let terminal = watcher.next().await.expect("terminal progress");
+        assert_eq!(
+            terminal.terminal_reason,
+            Some(ExecutionTerminalReason::Done)
+        );
+        assert_eq!(terminal.output_manifests[0]["text"]["inline"], "final");
     }
 
     #[tokio::test]

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -1107,6 +1107,54 @@ mod tests {
             .unwrap();
         assert_eq!(text, "late-arriving");
     }
+
+    #[tokio::test]
+    async fn await_execution_terminal_grace_waits_for_stream_output_to_settle() {
+        // A noisy stream output is updated in place. A client can observe
+        // terminal status with the penultimate stream manifest before the final
+        // in-place update syncs through, so terminal waiters need a short quiet
+        // window for stream outputs, not just "outputs are non-empty".
+        use crate::execution_wait::await_execution_terminal;
+
+        let (handle, shared, _rx, _cmd_rx) = test_handle_with_shared();
+        set_execution(
+            &shared,
+            "exec-1",
+            "cell-1",
+            "done",
+            &[stream_output("await-stream-output", "partial")],
+            Some(8),
+        );
+
+        let shared_for_task = shared.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            let mut st = shared_for_task.lock().unwrap();
+            st.state_doc
+                .replace_output(
+                    "exec-1",
+                    "await-stream-output",
+                    &stream_output("await-stream-output", "final"),
+                )
+                .unwrap();
+        });
+
+        let state = await_execution_terminal(
+            &handle,
+            "exec-1",
+            std::time::Duration::from_secs(5),
+            Some(std::time::Duration::from_millis(500)),
+        )
+        .await
+        .expect("terminal state");
+
+        assert_eq!(state.status, "done");
+        assert_eq!(state.output_manifests.len(), 1);
+        let text = state.output_manifests[0]["text"]["inline"]
+            .as_str()
+            .unwrap();
+        assert_eq!(text, "final");
+    }
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- wait for terminal stream output manifests to settle before returning final execution results
- apply the same quiet-window behavior to `ExecutionWatcher`, which backs Python `Execution.result()`
- add regressions for non-empty stream manifests that update after terminal status

## Verification

- `cargo test -p notebook-sync execution_ -- --nocapture`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kylekelley/.codex/worktrees/bb49/desktop/target/debug/runtimed RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_TEST_UV_POOL_SIZE=1 .venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py::TestTerminalEmulation::test_noisy_stdout_final_output_reconciles -q --tb=short --timeout=120 --durations=15`
- `cargo xtask lint --fix`
