### PR TITLE
docs(notebook-cloud): align Access trial runbook

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -253,9 +253,12 @@ Do not include the renderer asset origin in this list. It serves public
 build-time sidecars, not authenticated notebook room traffic.
 
 Cookie-backed Access WebSocket upgrades must always send an allowed `Origin`.
-When this allowlist is set, every `/n/:id/sync` WebSocket client must send a
-matching `Origin`; the hosted Access smoke does this with
-`NOTEBOOK_CLOUD_ACCESS_ORIGIN`.
+Browser-visible credential subprotocols also require `Origin`, because those
+credentials are available to page JavaScript. Header-authenticated native and
+CLI clients may omit `Origin`; if they do send one, it must match the Worker
+origin or an entry in `NOTEBOOK_CLOUD_ALLOWED_ORIGINS`. The hosted Access smoke
+sends `NOTEBOOK_CLOUD_ACCESS_ORIGIN` by default so the browser-compatible path
+is exercised even though the raw smoke connection uses `CF-Access-Token`.
 
 The hosted Access smoke uses a real Access JWT from `cloudflared`, grants
 principal ACL rows, sends real Automerge frames, and verifies that a granted
@@ -344,7 +347,7 @@ Bindings in `wrangler.toml`:
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 - `RUNTIMED_WASM_BASE_URL` (optional): base URL for `runtimed_wasm.js` and `runtimed_wasm_bg.wasm`. The prototype deployment also points this at the dedicated asset Worker so the large WASM module is loaded as a CDN cacheable file instead of being inlined into the viewer bundle.
-- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` (optional): comma- or whitespace-separated notebook application origins added to the same-origin WebSocket allowlist. Cookie-backed Access WebSocket upgrades always require an allowed `Origin`; setting this variable also requires `Origin` on non-cookie WebSocket clients.
+- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` (optional): comma- or whitespace-separated notebook application origins added to the same-origin WebSocket allowlist. Cookie-backed Access WebSocket upgrades and browser-visible credential subprotocols always require an allowed `Origin`; header-authenticated native/CLI clients may omit `Origin`, but any supplied `Origin` must be allowed.
 
 The dedicated renderer asset Worker serves only public, build-time sidecar files from the plugin asset bundle. It intentionally sends `Access-Control-Allow-Origin: *` so sandboxed `srcdoc` iframes with opaque origins can fetch renderer WASM and so the parent viewer can import runtime WASM from a CDN origin. Do not serve authenticated, notebook-specific, or user-generated blobs from this origin; those belong behind the notebook host's blob resolver or a future signed output origin. Deploy the renderer asset Worker before the main Worker when `RENDERER_ASSETS_BASE_URL` or `RUNTIMED_WASM_BASE_URL` points at the separate origin.
 

--- a/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
@@ -59,6 +59,24 @@ describe("hosted Access smoke environment helpers", () => {
     assert.ok(!headers.some((header) => header.includes("nteract-access-token.")));
   });
 
+  it("can build CLI-style Access WebSocket headers without an Origin", () => {
+    const token = jwt({ sub: "access-user-123" });
+    const headers = webSocketUpgradeRequestHeaders(
+      new URL("wss://cloud.test/n/access-demo/sync?operator=cli%3Asmoke&scope=owner"),
+      {
+        key: "test-key",
+        accessToken: token,
+      },
+    );
+
+    assert.ok(headers.includes(`CF-Access-Token: ${token}`));
+    assert.ok(!headers.some((header) => header.toLowerCase().startsWith("origin:")));
+    assert.equal(
+      headers.filter((header) => /^CF-Access-Token:|^Authorization:|^Cookie:/i.test(header)).length,
+      1,
+    );
+  });
+
   it("requires an owner Access token", () => {
     assert.throws(
       () => assertHostedAccessSmokeEnv({ ownerToken: "" }),

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -366,6 +366,34 @@ For the browser path, Cloudflare Access should forward
 against `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` and `NOTEBOOK_CLOUD_ACCESS_AUD`,
 then D1 decides the requested notebook scope.
 
+## Current Trial Blockers
+
+The Worker-side pieces needed for an Access-authenticated collaboration smoke
+are in place, but an Anaconda-backed trial still depends on these deployment
+and product decisions:
+
+1. **Access application and IdP setup.** The demo host must be protected by a
+   Cloudflare Access self-hosted application whose IdP is Anaconda OIDC. The
+   Worker must receive the matching Access audience and team domain.
+2. **Principal namespace.** Until the Worker validates an Anaconda-issued token
+   or Access forwards a deployment-approved stable Anaconda subject claim, ACL
+   rows should use `user:cloudflare-access:<encoded-access-sub>`. Do not switch
+   to `user:anaconda:*` based on email.
+3. **Collaborator bootstrap.** The current owner/editor/viewer smoke can derive
+   principals from local Access JWT subjects and seed D1 ACL rows. The browser
+   product still needs share-by-email routes before non-operators can grant
+   collaborators by email.
+4. **Public viewers.** A fully Access-protected hostname blocks anonymous
+   viewers at the edge. Public published notebooks need an Access bypass rule,
+   a separate public viewer hostname, or another route that still reaches the
+   Worker ACL check.
+5. **Revocation and provider capability bounds.** ACL changes affect new
+   connections. Immediate live-connection eviction and provider-side maximum
+   capability mapping remain follow-up work before broad production use.
+6. **Runtime peer credentials.** The collaboration demo has no remote runtime
+   sidecar. Runtime peers still need a credential and blob-upload story before
+   hosted execution can join the same room.
+
 ## Troubleshooting
 
 `401 missing/invalid Cloudflare Access token`

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -193,13 +193,18 @@ Rules:
 - Leaving the variable unset keeps the same-origin default only. Cookie-backed
   Access WebSockets still reject missing or untrusted `Origin`.
 
-The Worker checks `Origin` before WebSocket auth when a browser sends one, when
-the allowlist is set, or when an ambient `CF_Authorization` cookie is present.
-When the allowlist is set, every WebSocket client, including CLI smoke and
-future native clients, must send an `Origin` that normalizes to the notebook
-application origin or one of the configured values. Browser Access-cookie
-sessions must come from an allowed origin so a malicious site cannot use an
-ambient Access cookie to open a private room socket.
+The Worker checks `Origin` before WebSocket auth whenever a client sends one.
+Malformed or untrusted origins are rejected. Browser Access-cookie sessions
+must always send an allowed `Origin` so a malicious site cannot use an ambient
+Access cookie to open a private room socket. Browser-visible credential
+subprotocols also require `Origin`.
+
+Header-authenticated CLI, native, and future runtime clients may omit `Origin`,
+even when `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` is configured. If those clients send
+an `Origin`, it must normalize to the notebook application origin or one of the
+configured values. The hosted Access smoke sends `NOTEBOOK_CLOUD_ACCESS_ORIGIN`
+by default to exercise the browser-compatible origin path while still carrying
+only one Worker-visible credential, `CF-Access-Token`.
 
 ## Deploy
 
@@ -306,7 +311,8 @@ The script sends:
 
 - `CF-Access-Token: <jwt>` so Cloudflare Access can admit the HTTP and
   WebSocket requests;
-- `Origin: https://<notebook-host>` for the WebSocket origin allowlist;
+- `Origin: https://<notebook-host>` to exercise the browser-compatible
+  WebSocket origin gate;
 
 It intentionally sends only one Worker-visible Access credential transport per
 request. The Worker also supports `Authorization: Bearer <jwt>` and
@@ -384,7 +390,11 @@ then D1 decides the requested notebook scope.
 
 - Authentication succeeded, but D1 has no ACL row for the requested principal
   and scope.
-- Decode the smoke output `principals` field and grant that exact principal.
+- The smoke output intentionally reports only `principal_fingerprints`, not raw
+  principal strings or emails. For manual ACL bootstrap, derive the principal
+  locally from the Access JWT subject (`user:cloudflare-access:<encoded-sub>`)
+  or use the owner-authenticated ACL API to inspect rows for a seeded smoke
+  notebook.
 - Do not grant email strings as `notebook_acl.subject`.
 
 `404 or failed render for public viewers`

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -294,6 +294,8 @@ Minimum policy:
   This applies to viewer and writer connections. A private viewer socket can
   still leak notebook contents to a malicious page if ambient cookies are
   enough to authenticate it.
+- Reject browser-visible credential subprotocol upgrades with missing or
+  untrusted `Origin`, because page JavaScript can initiate those connections.
 - Maintain an allowlist of notebook application origins that are allowed to
   initiate room WebSockets. The hosted Worker treats same-origin notebook pages
   as allowed by default and extends that set with
@@ -302,7 +304,9 @@ Minimum policy:
   authenticated notebook-room WebSockets.
 - Keep renderer asset origins separate from notebook-room origins.
 
-Bearer-in-subprotocol and one-time ticket flows still benefit from origin
+Header-authenticated CLI, native, and runtime clients may omit `Origin` even
+when an allowlist is configured. If any client sends `Origin`, malformed or
+untrusted values are rejected. One-time ticket flows still benefit from origin
 checks, but they do not rely on ambient cookies and therefore reduce CSRF risk.
 
 ## Operational path for the Anaconda demo


### PR DESCRIPTION
## Summary

- align the Access + Anaconda runbook with the merged #2898 Origin policy
- clarify that hosted Access smoke output redacts raw principals/emails
- add a smoke-env helper test for CLI-style `CF-Access-Token` WebSocket headers without `Origin`
- document what still blocks a real Anaconda-backed Access trial

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-access-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/worker-routes.test.ts test/sharing.test.ts test/hosted-access-smoke-env.test.mjs`
- `vp check`
- `git diff --check`
- `cargo xtask lint --fix`

## Notes

This does not deploy the Worker. It only keeps the operator docs and smoke harness aligned with the merged Access hardening behavior.
