### PR TITLE
fix(sift): dispose wasm table data

### DIFF
--- a/packages/sift/src/main.ts
+++ b/packages/sift/src/main.ts
@@ -230,6 +230,7 @@ function loadLocalArrow$(dataset: DatasetEntry, tableRoot: HTMLElement): Observa
     () =>
       new Observable<void>((subscriber) => {
         let cancelled = false;
+        let disposePendingStore: (() => void) | null = null;
 
         (async () => {
           const response = await fetch(`${import.meta.env.BASE_URL}${dataset.path}`);
@@ -248,8 +249,13 @@ function loadLocalArrow$(dataset: DatasetEntry, tableRoot: HTMLElement): Observa
 
           renderLoadingSkeleton(tableRoot, "Loading into WASM…");
           const handle = await loadIpc(arrowBytes);
+          if (cancelled) {
+            getModuleSync().free(handle);
+            return;
+          }
 
           const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+          disposePendingStore = () => tableData.dispose?.();
           tableData.prefetchViewport = prefetchViewport;
           const mod = getModuleSync();
           const columnHints = mod.arrow_ipc_column_hints_with_row_count(
@@ -267,6 +273,7 @@ function loadLocalArrow$(dataset: DatasetEntry, tableRoot: HTMLElement): Observa
           if (cancelled) return;
           tableRoot.innerHTML = "";
           currentEngine = createTable(tableRoot, tableData);
+          disposePendingStore = null;
           currentEngine.setStreamingDone();
           subscriber.next();
           subscriber.complete();
@@ -276,6 +283,8 @@ function loadLocalArrow$(dataset: DatasetEntry, tableRoot: HTMLElement): Observa
 
         return () => {
           cancelled = true;
+          disposePendingStore?.();
+          disposePendingStore = null;
         };
       }),
   );
@@ -291,6 +300,7 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
     () =>
       new Observable<void>((subscriber) => {
         let cancelled = false;
+        let disposePendingStore: (() => void) | null = null;
 
         (async () => {
           renderLoadingSkeleton(tableRoot, "Loading dataset…");
@@ -351,8 +361,10 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
 
           // Load first row group → mount table immediately
           const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
+          disposePendingStore = () => mod.free(handle);
 
           const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+          disposePendingStore = () => tableData.dispose?.();
           tableData.prefetchViewport = prefetchViewport;
           tableData.recomputeSummaries = () =>
             updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
@@ -365,6 +377,7 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
           if (cancelled) return;
           tableRoot.innerHTML = "";
           currentEngine = createTable(tableRoot, tableData);
+          disposePendingStore = null;
           subscriber.next();
 
           // Stream remaining row groups progressively
@@ -388,6 +401,8 @@ function loadHuggingFaceWasm$(dataset: DatasetEntry, tableRoot: HTMLElement): Ob
 
         return () => {
           cancelled = true;
+          disposePendingStore?.();
+          disposePendingStore = null;
         };
       }),
   );

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -200,7 +200,7 @@ describe("SiftTable", () => {
       }),
     );
 
-    const { container } = render(
+    const { container, unmount } = render(
       <SiftTable
         source={{
           kind: "arrow-stream-manifest",
@@ -223,6 +223,10 @@ describe("SiftTable", () => {
     expect(Array.from(predicateModule.append_arrow_stream_chunk.mock.calls[0][1])).toEqual([
       1, 2, 3, 4,
     ]);
+
+    unmount();
+    expect(predicateModule.free).toHaveBeenCalledTimes(1);
+    expect(predicateModule.free).toHaveBeenCalledWith(9);
 
     vi.unstubAllGlobals();
     vi.useFakeTimers();

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -353,10 +353,11 @@ export function SiftTable({
   useEffect(() => {
     if (!manifestSource || !containerRef.current) return;
 
+    const manifest = manifestSource;
     let cancelled = false;
     const container = containerRef.current;
-    let wasmHandle: number | null = null;
     let engineDiv: HTMLDivElement | null = null;
+    let disposePendingStore: (() => void) | null = null;
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
@@ -367,6 +368,7 @@ export function SiftTable({
       engineDiv = document.createElement("div");
       engineDiv.style.height = "100%";
       container.appendChild(engineDiv);
+      disposePendingStore = null;
       engineRef.current = createTable(engineDiv, tableData, {
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
@@ -390,7 +392,7 @@ export function SiftTable({
       setStatus("loading");
       setError(null);
 
-      const chunks = manifestSource.chunks;
+      const chunks = manifest.chunks;
       if (chunks.length === 0) {
         throw new Error("Arrow stream manifest has no chunks");
       }
@@ -400,7 +402,7 @@ export function SiftTable({
 
       const mod = getModuleSync();
       const handle = mod.create_arrow_stream_store();
-      wasmHandle = handle;
+      disposePendingStore = () => mod.free(handle);
 
       const firstBytes = await fetchChunkBytes(chunks[0], 0);
       if (cancelled) return;
@@ -412,6 +414,7 @@ export function SiftTable({
       );
       const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
       const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+      disposePendingStore = () => tableData.dispose?.();
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () =>
         updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
@@ -437,7 +440,7 @@ export function SiftTable({
         engineRef.current?.onBatchAppended();
       }
 
-      if (manifestSource.complete !== false) {
+      if (manifest.complete !== false) {
         mod.finish_arrow_stream_store(handle);
         engineRef.current?.setStreamingDone();
       }
@@ -453,13 +456,8 @@ export function SiftTable({
 
     return () => {
       cancelled = true;
-      if (wasmHandle !== null) {
-        try {
-          getModuleSync().free(wasmHandle);
-        } catch {
-          /* module may not be loaded */
-        }
-      }
+      disposePendingStore?.();
+      disposePendingStore = null;
       engineRef.current?.destroy();
       engineRef.current = null;
       engineDiv?.remove();
@@ -473,10 +471,11 @@ export function SiftTable({
   useEffect(() => {
     if (!urlSource || !containerRef.current) return;
 
+    const sourceUrl = urlSource;
     let cancelled = false;
     const container = containerRef.current;
-    let wasmHandle: number | null = null;
     let engineDiv: HTMLDivElement | null = null;
+    let disposePendingStore: (() => void) | null = null;
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
@@ -487,6 +486,7 @@ export function SiftTable({
       engineDiv = document.createElement("div");
       engineDiv.style.height = "100%";
       container.appendChild(engineDiv);
+      disposePendingStore = null;
       engineRef.current = createTable(engineDiv, tableData, {
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
@@ -512,9 +512,10 @@ export function SiftTable({
 
       // Load first row group → mount table immediately
       const handle = mod.load_parquet_row_group(parquetBytes, 0, 0);
-      wasmHandle = handle;
+      disposePendingStore = () => mod.free(handle);
 
       const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+      disposePendingStore = () => tableData.dispose?.();
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () =>
         updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
@@ -553,12 +554,16 @@ export function SiftTable({
       if (cancelled) return;
 
       const handle = await loadIpc(bytes);
-      wasmHandle = handle;
+      if (cancelled) {
+        getModuleSync().free(handle);
+        return;
+      }
 
       const mod = getModuleSync();
       const columnHints = mod.arrow_ipc_column_hints_with_row_count(bytes, mod.num_rows(handle));
       const pandasIndexCols = pandasIndexColumnsFromHints(columnHints);
       const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+      disposePendingStore = () => tableData.dispose?.();
       tableData.prefetchViewport = prefetchViewport;
       tableData.recomputeSummaries = () =>
         updateWasmSummaries(mod, handle, tableData, columns, pandasIndexCols);
@@ -596,7 +601,7 @@ export function SiftTable({
       setStatus("loading");
       setError(null);
 
-      const response = await fetch(urlSource);
+      const response = await fetch(sourceUrl);
       if (!response.ok) {
         throw new Error(`Failed to fetch: ${response.status} ${response.statusText}`);
       }
@@ -621,13 +626,8 @@ export function SiftTable({
 
     return () => {
       cancelled = true;
-      if (wasmHandle !== null) {
-        try {
-          getModuleSync().free(wasmHandle);
-        } catch {
-          /* module may not be loaded */
-        }
-      }
+      disposePendingStore?.();
+      disposePendingStore = null;
       engineRef.current?.destroy();
       engineRef.current = null;
       engineDiv?.remove();

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -128,6 +128,37 @@ describe("createTable", () => {
       expect(container.querySelector(".sift-stats")).not.toBeNull();
     });
 
+    it("disposes backing table data when destroyed", () => {
+      const localContainer = document.createElement("div");
+      document.body.appendChild(localContainer);
+      const dispose = vi.fn();
+      const localEngine = createTable(localContainer, {
+        ...makeTableData(rows),
+        dispose,
+      });
+
+      localEngine.destroy();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      localContainer.remove();
+    });
+
+    it("disposes backing table data only once across repeated destroy calls", () => {
+      const localContainer = document.createElement("div");
+      document.body.appendChild(localContainer);
+      const dispose = vi.fn();
+      const localEngine = createTable(localContainer, {
+        ...makeTableData(rows),
+        dispose,
+      });
+
+      localEngine.destroy();
+      localEngine.destroy();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      localContainer.remove();
+    });
+
     it("renders correct header labels", async () => {
       await flushRAF();
       const labels = container.querySelectorAll(".sift-th-label");

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -98,6 +98,8 @@ export type TableData = {
   recomputeFilteredSummaries?: (mask: Uint8Array, filteredCount: number) => void;
   /** Optional: apply filters in WASM and return matching row indices. */
   filterRows?: (filters: (ColumnFilter | null)[]) => Uint32Array;
+  /** Optional: release backing resources when the table engine is destroyed. */
+  dispose?: () => void;
 };
 
 // --- Filter types ---
@@ -2178,7 +2180,12 @@ export function createTable(
 
   // --- Destroy ---
 
+  let destroyed = false;
+
   function destroy() {
+    if (destroyed) return;
+    destroyed = true;
+
     // Cancel pending render + FPS observable
     if (scheduledRaf !== null) {
       cancelAnimationFrame(scheduledRaf);
@@ -2215,6 +2222,7 @@ export function createTable(
     // Clear DOM
     container.innerHTML = "";
     container.classList.remove("sift-table-container");
+    data.dispose?.();
   }
 
   // --- Filter API ---

--- a/packages/sift/src/wasm-table-data.test.ts
+++ b/packages/sift/src/wasm-table-data.test.ts
@@ -28,6 +28,7 @@ const predicateModule = vi.hoisted(() => ({
   get_cell_f64: vi.fn(() => {
     throw new Error("get_cell_f64 should not be called during batched prefetch");
   }),
+  free: vi.fn(),
 }));
 
 vi.mock("./predicate", () => ({
@@ -61,5 +62,15 @@ describe("createWasmTableData", () => {
     expect(predicateModule.is_null).not.toHaveBeenCalled();
     expect(predicateModule.get_cell_string).not.toHaveBeenCalled();
     expect(predicateModule.get_cell_f64).not.toHaveBeenCalled();
+  });
+
+  it("disposes the backing WASM store once", () => {
+    const { tableData } = createWasmTableData(7);
+
+    tableData.dispose?.();
+    tableData.dispose?.();
+
+    expect(predicateModule.free).toHaveBeenCalledTimes(1);
+    expect(predicateModule.free).toHaveBeenCalledWith(7);
   });
 });

--- a/packages/sift/src/wasm-table-data.ts
+++ b/packages/sift/src/wasm-table-data.ts
@@ -41,6 +41,7 @@ export function createWasmTableData(
   columnOverrides?: Record<string, Partial<Column>>,
 ): WasmTableHandle {
   const mod = getModuleSync();
+  let disposed = false;
 
   const numRows = mod.num_rows(handle);
   const numCols = mod.num_cols(handle);
@@ -256,6 +257,12 @@ export function createWasmTableData(
         }
       }
       return mod.store_filter_rows(handle, specs);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      mod.free(handle);
+      cache.clear();
     },
   };
 


### PR DESCRIPTION
## Summary

- add `TableData.dispose` so Sift table engines own backing store cleanup
- make WASM-backed table data disposal idempotent and wire engine destruction to release handles
- avoid React/demo double-free and cancellation leaks while loading WASM table data

## Verification

- `pnpm --dir packages/sift test`
- `cargo xtask wasm sift`
- `cargo xtask verify-plugins`
- `pnpm --dir packages/sift build:lib`
- `cargo xtask lint --fix`
- `git diff --check`

Part of #2622. This is the tactical base PR for the follow-up `replaceData()` stack.
