### PR TITLE
feat(sift): replace table data in place

### DIFF
--- a/packages/sift/src/index.ts
+++ b/packages/sift/src/index.ts
@@ -61,6 +61,7 @@ export type {
   ColumnType,
   NumericColumnSummary,
   RangeFilter,
+  ReplaceDataOptions,
   SetFilter,
   TableData,
   TableEngine,

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -159,6 +159,28 @@ describe("SiftTable", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("reuses the mounted engine when table data props change", async () => {
+    const firstData = makeTableData([[1, "Alice", 95]]);
+    const firstDispose = vi.fn();
+    firstData.dispose = firstDispose;
+    const secondData = makeTableData([
+      [2, "Bob", 88],
+      [3, "Carol", 91],
+    ]);
+    const onChange = vi.fn();
+
+    const { container, rerender } = render(<SiftTable data={firstData} onChange={onChange} />);
+    await vi.advanceTimersByTimeAsync(0);
+    const viewport = container.querySelector(".sift-viewport");
+
+    rerender(<SiftTable data={secondData} onChange={onChange} />);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(container.querySelector(".sift-viewport")).toBe(viewport);
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ totalCount: 2 });
+  });
+
   it("renders container for url prop without loading flash", async () => {
     // Mock fetch to never resolve (simulating slow load)
     vi.stubGlobal("fetch", () => new Promise(() => {}));

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -30,6 +30,7 @@ import {
   type ColumnFilter,
   type ColumnType,
   createTable,
+  type ReplaceDataOptions,
   type TableData,
   type TableEngine,
   type TableEngineState,
@@ -278,6 +279,7 @@ export function SiftTable({
 }: SiftTableProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const engineRef = useRef<TableEngine | null>(null);
+  const engineDivRef = useRef<HTMLDivElement | null>(null);
   const footerControlRef = useRef<HTMLDivElement | null>(null);
   const footerControlRootRef = useRef<Root | null>(null);
   const [status, setStatus] = useState<"idle" | "loading" | "ready" | "error">("idle");
@@ -301,6 +303,18 @@ export function SiftTable({
     return footerControlRef.current;
   }, [hasFooterControl]);
 
+  const getEngineElement = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return null;
+    if (!engineDivRef.current) {
+      const engineDiv = document.createElement("div");
+      engineDiv.style.height = "100%";
+      container.appendChild(engineDiv);
+      engineDivRef.current = engineDiv;
+    }
+    return engineDivRef.current;
+  }, []);
+
   useEffect(() => {
     if (hasFooterControl) {
       getFooterControlElement();
@@ -310,6 +324,10 @@ export function SiftTable({
 
   useEffect(() => {
     return () => {
+      engineRef.current?.destroy();
+      engineRef.current = null;
+      engineDivRef.current?.remove();
+      engineDivRef.current = null;
       footerControlRootRef.current?.unmount();
       footerControlRootRef.current = null;
       footerControlRef.current = null;
@@ -325,29 +343,21 @@ export function SiftTable({
   useEffect(() => {
     if (!dataSource || !containerRef.current) return;
 
-    // Clean up previous engine
     if (engineRef.current) {
-      engineRef.current.destroy();
-      engineRef.current = null;
+      engineRef.current.replaceData(dataSource);
+      setStatus("ready");
+      return;
     }
 
-    // Create a dedicated div for the engine so it doesn't conflict with React's DOM
-    const engineDiv = document.createElement("div");
-    engineDiv.style.height = "100%";
-    containerRef.current.appendChild(engineDiv);
+    const engineDiv = getEngineElement();
+    if (!engineDiv) return;
 
     engineRef.current = createTable(engineDiv, dataSource, {
       onChange: stableOnChange,
       footerControl: getFooterControlElement(),
     });
     setStatus("ready");
-
-    return () => {
-      engineRef.current?.destroy();
-      engineRef.current = null;
-      engineDiv.remove();
-    };
-  }, [dataSource, stableOnChange, getFooterControlElement]);
+  }, [dataSource, stableOnChange, getFooterControlElement, getEngineElement]);
 
   // Load Arrow stream manifest chunks through the appendable WASM store.
   useEffect(() => {
@@ -355,24 +365,21 @@ export function SiftTable({
 
     const manifest = manifestSource;
     let cancelled = false;
-    const container = containerRef.current;
-    let engineDiv: HTMLDivElement | null = null;
     let disposePendingStore: (() => void) | null = null;
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
-        engineRef.current.destroy();
-        engineRef.current = null;
+        engineRef.current.replaceData(tableData);
+        disposePendingStore = null;
+        return;
       }
-      engineDiv?.remove();
-      engineDiv = document.createElement("div");
-      engineDiv.style.height = "100%";
-      container.appendChild(engineDiv);
-      disposePendingStore = null;
+      const engineDiv = getEngineElement();
+      if (!engineDiv) return;
       engineRef.current = createTable(engineDiv, tableData, {
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
       });
+      disposePendingStore = null;
     }
 
     async function fetchChunkBytes(chunk: ArrowStreamManifestChunk, index: number) {
@@ -458,11 +465,8 @@ export function SiftTable({
       cancelled = true;
       disposePendingStore?.();
       disposePendingStore = null;
-      engineRef.current?.destroy();
-      engineRef.current = null;
-      engineDiv?.remove();
     };
-  }, [manifestKey, columnOverrides, stableOnChange, getFooterControlElement]);
+  }, [manifestKey, columnOverrides, stableOnChange, getFooterControlElement, getEngineElement]);
 
   // Load from URL when `url` prop is provided.
   // Detects format via Content-Type header + magic byte fallback:
@@ -473,24 +477,21 @@ export function SiftTable({
 
     const sourceUrl = urlSource;
     let cancelled = false;
-    const container = containerRef.current;
-    let engineDiv: HTMLDivElement | null = null;
     let disposePendingStore: (() => void) | null = null;
 
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
-        engineRef.current.destroy();
-        engineRef.current = null;
+        engineRef.current.replaceData(tableData);
+        disposePendingStore = null;
+        return;
       }
-      engineDiv?.remove();
-      engineDiv = document.createElement("div");
-      engineDiv.style.height = "100%";
-      container.appendChild(engineDiv);
-      disposePendingStore = null;
+      const engineDiv = getEngineElement();
+      if (!engineDiv) return;
       engineRef.current = createTable(engineDiv, tableData, {
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
       });
+      disposePendingStore = null;
     }
 
     async function loadParquet(parquetBytes: Uint8Array) {
@@ -628,11 +629,15 @@ export function SiftTable({
       cancelled = true;
       disposePendingStore?.();
       disposePendingStore = null;
-      engineRef.current?.destroy();
-      engineRef.current = null;
-      engineDiv?.remove();
     };
-  }, [urlSource, typeOverrides, columnOverrides, stableOnChange, getFooterControlElement]);
+  }, [
+    urlSource,
+    typeOverrides,
+    columnOverrides,
+    stableOnChange,
+    getFooterControlElement,
+    getEngineElement,
+  ]);
 
   return (
     <div ref={containerRef} className={className} style={{ height: "100%", ...style }}>
@@ -673,4 +678,12 @@ export {
   predicateToSQL,
 } from "./filter-schema";
 // Re-export key types and utilities for consumer convenience
-export type { Column, ColumnFilter, ColumnType, TableData, TableEngine, TableEngineState };
+export type {
+  Column,
+  ColumnFilter,
+  ColumnType,
+  ReplaceDataOptions,
+  TableData,
+  TableEngine,
+  TableEngineState,
+};

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -43,6 +43,10 @@ function makeColumns(): Column[] {
 
 function makeTableData(rows: unknown[][]): TableData {
   const columns = makeColumns();
+  return makeTableDataWithColumns(rows, columns);
+}
+
+function makeTableDataWithColumns(rows: unknown[][], columns: Column[]): TableData {
   return {
     columns,
     rowCount: rows.length,
@@ -481,6 +485,115 @@ describe("createTable", () => {
       expect(onChange).toHaveBeenCalled();
       const state = onChange.mock.calls.at(-1)?.[0];
       expect(state.filters).toHaveLength(1);
+    });
+
+    it("replaceData swaps same-schema rows without remounting chrome", async () => {
+      const oldDispose = vi.fn();
+      data.dispose = oldDispose;
+      await flushRAF();
+      const viewport = container.querySelector(".sift-viewport");
+
+      engine.setSort("score", "desc");
+      engine.setFilter(1, { kind: "set", values: new Set(["Person 1"]) });
+      await flushRAF();
+
+      const nextData = makeTableData([
+        [101, "Person 1", 12, true],
+        [102, "Other", 98, false],
+      ]);
+      engine.replaceData(nextData);
+      await flushRAF();
+
+      expect(container.querySelector(".sift-viewport")).toBe(viewport);
+      expect(oldDispose).toHaveBeenCalledTimes(1);
+      expect(engine.getSort()).toEqual({ column: "score", direction: "desc" });
+      expect(engine.getFilters()).toHaveLength(1);
+      expect(engine.getState()).toMatchObject({ filteredCount: 1, totalCount: 2 });
+      expect(container.textContent).toContain("Person 1");
+      expect(container.textContent).not.toContain("Person 0");
+    });
+
+    it("replaceData keeps only sort and filters whose key and type survive", async () => {
+      await flushRAF();
+      engine.setSort("score", "desc");
+      engine.setFilter(1, { kind: "set", values: new Set(["Person 1"]) });
+      engine.setFilter(2, { kind: "range", min: 0, max: 50 });
+      await flushRAF();
+
+      const [idColumn, nameColumn, , activeColumn] = makeColumns();
+      const nextData = makeTableDataWithColumns(
+        [
+          [1, "Person 1", true],
+          [2, "Other", false],
+        ],
+        [idColumn, nameColumn, activeColumn],
+      );
+      engine.replaceData(nextData);
+      await flushRAF();
+
+      expect(engine.getSort()).toBeNull();
+      expect(engine.getFilters()).toEqual([
+        { column: "name", filter: { kind: "set", values: new Set(["Person 1"]) } },
+      ]);
+      expect(engine.getState()).toMatchObject({ filteredCount: 1, totalCount: 2 });
+      const labels = Array.from(container.querySelectorAll(".sift-th-label")).map(
+        (label) => label.textContent,
+      );
+      expect(labels).toEqual(["ID", "Name", "Active"]);
+    });
+
+    it("replaceData drops sort and filters for columns whose type changes", async () => {
+      await flushRAF();
+      engine.setSort("score", "desc");
+      engine.setFilter(2, { kind: "range", min: 0, max: 50 });
+      await flushRAF();
+
+      const [idColumn, nameColumn, scoreColumn, activeColumn] = makeColumns();
+      const categoricalScore = {
+        ...scoreColumn,
+        numeric: false,
+        columnType: "categorical" as const,
+      };
+      const nextData = makeTableDataWithColumns(
+        [
+          [1, "Person 1", "low", true],
+          [2, "Person 2", "high", false],
+        ],
+        [idColumn, nameColumn, categoricalScore, activeColumn],
+      );
+      engine.replaceData(nextData);
+      await flushRAF();
+
+      expect(engine.getSort()).toBeNull();
+      expect(engine.getFilters()).toEqual([]);
+      expect(engine.getState()).toMatchObject({ filteredCount: 2, totalCount: 2 });
+    });
+
+    it("replaceData clears cached cells and renders values from the new data", async () => {
+      const firstRows = [
+        [1, "Alice", 10, true],
+        [2, "Bob", 20, false],
+      ];
+      const secondRows = [
+        [1, "Carol", 30, true],
+        [2, "Dave", 40, false],
+      ];
+      const cacheContainer = document.createElement("div");
+      document.body.appendChild(cacheContainer);
+      const cacheEngine = createTable(cacheContainer, makeTableData(firstRows));
+      const viewport = cacheContainer.querySelector<HTMLElement>(".sift-viewport")!;
+      Object.defineProperty(viewport, "clientHeight", { value: 400, configurable: true });
+      viewport.dispatchEvent(new Event("scroll"));
+      await vi.advanceTimersByTimeAsync(20);
+      expect(cacheContainer.textContent).toContain("Alice");
+
+      cacheEngine.replaceData(makeTableData(secondRows));
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(cacheContainer.textContent).toContain("Carol");
+      expect(cacheContainer.textContent).not.toContain("Alice");
+      cacheEngine.destroy();
+      cacheContainer.remove();
     });
   });
 

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -124,10 +124,18 @@ export type TableEngineOptions = {
   footerControl?: HTMLElement;
 };
 
+export type ReplaceDataOptions = {
+  /** Drop sort state even when the sorted column survives in the new data. */
+  resetSort?: boolean;
+  /** Drop filters even when filtered columns survive in the new data. */
+  resetFilters?: boolean;
+};
+
 export type TableEngine = {
   onBatchAppended(): void;
   /** Signal that all batches have been loaded and streaming is complete. */
   setStreamingDone(): void;
+  replaceData(newData: TableData, options?: ReplaceDataOptions): void;
   destroy(): void;
   setFilter(colIndex: number, filter: ColumnFilter): void;
   clearFilter(colIndex: number): void;
@@ -222,16 +230,17 @@ function measureMaxElementHeight(): number {
 
 export function createTable(
   container: HTMLElement,
-  data: TableData,
+  initialData: TableData,
   options?: TableEngineOptions,
 ): TableEngine {
-  const { columns } = data;
+  let data = initialData;
+  let columns = data.columns;
 
   // Mutable row count — grows as batches arrive
   let rowCount = data.rowCount;
 
   // Filter state — one per column, null = no filter
-  const filters: ColumnFilter[] = columns.map(() => null);
+  let filters: ColumnFilter[] = columns.map(() => null);
   let filteredCount = rowCount;
 
   // Unfiltered summaries (saved so we can restore when filters are cleared)
@@ -2034,7 +2043,7 @@ export function createTable(
     unfilteredSummaries = [...data.columnSummaries];
 
     // If filters are active, recompute from filtered rows
-    if (hasActiveFilters()) {
+    if (hasActiveFilters() && data.recomputeFilteredSummaries) {
       recomputeFilteredSummaries();
     }
 
@@ -2081,6 +2090,142 @@ export function createTable(
     // Notify consumers — totalCount may have grown across row groups, and
     // host UIs that size their container based on row count want to settle
     // on the final value rather than the first batch.
+    notifyChange();
+  }
+
+  function findSurvivingColumnIndices(newColumns: Column[]): Map<number, number> {
+    const unusedNewIndices = new Set(newColumns.map((_, index) => index));
+    const survivors = new Map<number, number>();
+    for (let oldIndex = 0; oldIndex < columns.length; oldIndex++) {
+      const oldColumn = columns[oldIndex];
+      for (const newIndex of unusedNewIndices) {
+        const newColumn = newColumns[newIndex];
+        if (oldColumn.key === newColumn.key && oldColumn.columnType === newColumn.columnType) {
+          survivors.set(oldIndex, newIndex);
+          unusedNewIndices.delete(newIndex);
+          break;
+        }
+      }
+    }
+    return survivors;
+  }
+
+  function preserveStateFor(
+    newColumns: Column[],
+    replaceOptions: ReplaceDataOptions | undefined,
+  ): {
+    sort: TableEngineState["sort"];
+    filters: TableEngineState["filters"];
+  } {
+    const survivors = findSurvivingColumnIndices(newColumns);
+    const preservedFilters: TableEngineState["filters"] = [];
+    if (!replaceOptions?.resetFilters) {
+      for (let oldIndex = 0; oldIndex < filters.length; oldIndex++) {
+        const newIndex = survivors.get(oldIndex);
+        if (newIndex === undefined || !filters[oldIndex]) continue;
+        preservedFilters.push({
+          column: newColumns[newIndex].key,
+          filter: filters[oldIndex],
+        });
+      }
+    }
+
+    let preservedSort: TableEngineState["sort"] = null;
+    if (!replaceOptions?.resetSort && sortState) {
+      const newSortIndex = survivors.get(sortState.col);
+      if (newSortIndex !== undefined) {
+        preservedSort = {
+          column: newColumns[newSortIndex].key,
+          direction: sortState.dir,
+        };
+      }
+    }
+
+    return { sort: preservedSort, filters: preservedFilters };
+  }
+
+  function sameColumnShape(newColumns: Column[]): boolean {
+    return (
+      columns.length === newColumns.length &&
+      columns.every(
+        (column, index) =>
+          column.key === newColumns[index].key &&
+          column.columnType === newColumns[index].columnType,
+      )
+    );
+  }
+
+  function hidePooledRows() {
+    for (const pr of pool) {
+      pr.assignedRow = -1;
+      pr.el.style.display = "none";
+    }
+  }
+
+  function replaceData(newData: TableData, replaceOptions?: ReplaceDataOptions) {
+    const preserved = preserveStateFor(newData.columns, replaceOptions);
+
+    if (!sameColumnShape(newData.columns)) {
+      destroy();
+      const replacement = createTable(container, newData, options);
+      Object.assign(api, replacement);
+      if (preserved.sort) {
+        replacement.setSort(preserved.sort.column, preserved.sort.direction);
+      }
+      for (const preservedFilter of preserved.filters) {
+        const newIndex = newData.columns.findIndex(
+          (column) => column.key === preservedFilter.column,
+        );
+        if (newIndex !== -1) replacement.setFilter(newIndex, preservedFilter.filter);
+      }
+      return;
+    }
+
+    const oldData = data;
+    data = newData;
+    columns = newData.columns;
+    rowCount = newData.rowCount;
+    growBuffers(rowCount);
+    filteredCount = rowCount;
+    unfilteredSummaries = [...newData.columnSummaries];
+
+    if (replaceOptions?.resetSort) {
+      sortState = null;
+    }
+    if (replaceOptions?.resetFilters) {
+      filters = columns.map(() => null);
+    }
+
+    cellCaches.length = 0;
+    focusedDataRow = null;
+    lastVisFirst = -1;
+    lastVisLast = -1;
+    pendingScrollAnchor = null;
+
+    for (let c = 0; c < columns.length; c++) {
+      const label = headerCells[c].querySelector(".sift-th-label");
+      if (label) label.textContent = columns[c].label;
+      const typeIcon = headerCells[c].querySelector(".sift-type-icon");
+      if (typeIcon) {
+        typeIcon.textContent = typeIconChar(columns[c].columnType);
+        typeIcon.setAttribute("title", columns[c].columnType);
+      }
+    }
+
+    applyFilterAndSort();
+    if (hasActiveFilters() && data.recomputeFilteredSummaries) {
+      recomputeFilteredSummaries();
+    }
+    updateSortUI();
+    updateRowCountDisplay();
+    rebuildFilterPills();
+    renderAllSummaries();
+    updateFilteredLabels();
+    hidePooledRows();
+    viewport.scrollTop = 0;
+    heightsDirty = true;
+    scheduleRender();
+    if (oldData !== newData) oldData.dispose?.();
     notifyChange();
   }
 
@@ -2680,9 +2825,10 @@ export function createTable(
   // notifyChange on sort / filter / append.
   options?.onChange?.(getState());
 
-  return {
+  const api: TableEngine = {
     onBatchAppended,
     setStreamingDone,
+    replaceData,
     destroy,
     setFilter,
     clearFilter,
@@ -2694,4 +2840,5 @@ export function createTable(
     getFocusedDataRow: () => focusedDataRow,
     setFocusedDataRow,
   };
+  return api;
 }


### PR DESCRIPTION
## Summary

- add `TableEngine.replaceData(newData, options)` for in-place Sift data swaps
- preserve sort/filter state for surviving columns by `key + columnType`, with reset options
- reuse the mounted React table engine for direct table-data, manifest, and URL reload paths
- cover same-schema swaps, schema shrink/survival rules, and React wrapper reuse

## Verification

- `pnpm --dir packages/sift test`
- `pnpm --dir packages/sift build:lib`
- `cargo xtask lint --fix`
- `cargo xtask wasm sift`
- `cargo xtask verify-plugins`
- `git diff --check`

Stacked on #2901. Continues #2622.
