### PR TITLE
refactor(pr-reviewer): run reviews through opencode

### DIFF
--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr-reviewer
-description: Use the repository-local pr-review CLI for Bedrock-authenticated Claude Agent SDK reviews of GitHub pull requests, branch diffs, or review loops. Use when a task asks for an external/Claude/Bedrock review, a second-model PR review, structured review findings, or validation of an implementation PR.
+description: Use the repository-local pr-review CLI for opencode-backed Bedrock reviews of GitHub pull requests, branch diffs, or review loops. Use when a task asks for an external/Claude/Bedrock review, a second-model PR review, structured review findings, or validation of an implementation PR.
 ---
 
 # PR Reviewer
 
-Use `pr-review` instead of shelling out to raw `claude` for PR reviews in this repository. It creates an isolated disposable git worktree, authenticates Claude through Bedrock, gives the reviewer the PR diff plus repo access, and writes structured JSON reports.
+Use `pr-review` instead of shelling out to raw `claude` for PR reviews in this repository. It creates an isolated disposable git worktree, runs opencode against a Bedrock model, gives the reviewer the PR diff plus repo access, and writes structured JSON reports.
 
 ## When To Use
 
@@ -29,7 +29,7 @@ uv run pr-review https://github.com/nteract/nteract/pull/<number> \
   --out .context/reviews/pr-<number>.json
 ```
 
-For large diffs, raise `--max-turns`. If omitted, `pr-review` estimates a turn budget from changed files and diff size.
+`--max-turns` is retained as advisory metadata for review sizing. opencode does not enforce it as a hard turn limit.
 
 ## Read The Report
 
@@ -45,7 +45,7 @@ Meanings:
 - `verdict: clear` with `terminal_reason: review_complete` means the reviewer completed and found no actionable issues.
 - `verdict: findings` means triage each finding locally before reporting or patching.
 - `verdict: needs_human` means a product, design, or scoping decision is needed.
-- `terminal_reason: budget_exhausted` means rerun with a higher `--max-turns`.
+- `terminal_reason: budget_exhausted` means the model reported it could not finish within the advisory budget.
 - `verdict: infra_uncertain` or `terminal_reason: infra_uncertain` means do not trust the review as a quality signal until the infrastructure issue is resolved.
 
 ## Review Loop
@@ -65,7 +65,7 @@ Meanings:
 ## Guardrails
 
 - Do not use `claude ultrareview`; it consumes limited Claude reviews.
-- Do not substitute regular Claude/Max auth if Bedrock fails. Report the blocking Bedrock failure.
+- Do not substitute regular Claude/Max auth if opencode/Bedrock fails. Report the blocking failure.
 - Treat reviewer output as advisory until locally verified.
 - Preserve review-only mode: if the user asked only for review, do not edit files.
 - The CLI may create review worktrees and reports under `.context/`; that path is intentionally untracked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Use `.agents/skills/` when the task matches:
 - `execution-pipeline` — end-to-end cell execution: required_heads → ExecuteCell → CellQueued → RuntimeStateDoc polling → output-sync grace → output resolution
 - `frontend-dev` — frontend development, TypeScript bindings (ts-rs), UI iteration workflows
 - `mcp-session-lifecycle` — MCP proxy supervision, daemon watch loop, session state, rejoin/reconnect races, room eviction
-- `pr-reviewer` — Bedrock-authenticated Claude Agent SDK PR reviews with isolated worktrees and structured findings
+- `pr-reviewer` — opencode-backed Bedrock PR reviews with isolated worktrees and structured findings
 - `releasing` — version bumps, tag conventions, release procedures
 - `testing` — choosing test strategies, running verification, E2E, diagnostics collection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ invalid-assignment = "ignore"
 
 # Gremlin depends on claude-agent-sdk which is macOS-only (not in CI)
 [[tool.ty.overrides]]
-include = ["python/gremlin/**", "python/pr-reviewer/**"]
+include = ["python/gremlin/**"]
 [tool.ty.overrides.rules]
 unresolved-import = "ignore"
 

--- a/python/pr-reviewer/README.md
+++ b/python/pr-reviewer/README.md
@@ -1,16 +1,15 @@
 # pr-reviewer
 
-Internal PR review harness that runs Claude through the Agent SDK with Amazon
-Bedrock authentication.
+Internal PR review harness that runs opencode with an Amazon Bedrock model.
 
-The reviewer creates a disposable git worktree for a GitHub PR, asks Claude to
+The reviewer creates a disposable git worktree for a GitHub PR, asks opencode to
 inspect the checked-out PR head and base diff, and writes normalized review
 artifacts under `.context/reviews/`.
 
-The Agent SDK session runs in the disposable worktree with Read, Glob, Grep, and
-Bash available. Source-editing tools remain disabled. Review prompts include the
-full diff up front so Bash can be used for deeper inspection instead of basic
-diff reconstruction.
+The opencode session runs in the disposable worktree with a generated
+read-only reviewer config that denies `edit` permissions while allowing shell
+inspection. Review prompts include the full diff up front so shell inspection
+can be used for deeper review instead of basic diff reconstruction.
 
 ## Usage
 
@@ -22,18 +21,19 @@ uv run pr-review https://github.com/nteract/nteract/pull/2508 \
   --out .context/reviews/pr-2508.json
 ```
 
-Review turn budgets scale from the PR diff size and can be overridden:
+The legacy `--max-turns` option is retained as advisory report metadata for
+review sizing, but opencode does not enforce it as a hard turn limit:
 
 ```bash
 uv run pr-review https://github.com/nteract/nteract/pull/2508 --max-turns 120
 ```
 
-## Bedrock authentication
+## opencode authentication
 
-The harness sets `CLAUDE_CODE_USE_BEDROCK=1` for SDK calls and requires
-`AWS_REGION` either in the environment or through `--aws-region`. Credentials
-come from the AWS SDK credential chain, such as `AWS_PROFILE`,
-`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, SSO, or
-`AWS_BEARER_TOKEN_BEDROCK`.
+The harness shells out to `opencode run --format json`. Install and configure
+opencode normally, then select a model using opencode's provider/model format.
+`AWS_REGION` can come from the environment or `--aws-region`, and credentials
+come from the AWS SDK credential chain used by opencode's Bedrock provider.
 
-The default model is `global.anthropic.claude-opus-4-6-v1`.
+The default model is `amazon-bedrock/global.anthropic.claude-opus-4-6-v1`.
+Set `PR_REVIEWER_OPENCODE=/path/to/opencode` to use a non-default binary.

--- a/python/pr-reviewer/pyproject.toml
+++ b/python/pr-reviewer/pyproject.toml
@@ -1,16 +1,14 @@
 [project]
 name = "pr-reviewer"
 version = "0.0.0"
-description = "Internal Bedrock-backed Claude Agent SDK PR reviewer"
+description = "Internal opencode-backed PR reviewer"
 readme = "README.md"
 license = "BSD-3-Clause"
 authors = [
     { name = "Kyle Kelley", email = "rgbkrk@gmail.com" }
 ]
 requires-python = ">=3.10"
-dependencies = [
-    "claude-agent-sdk>=0.1.80",
-]
+dependencies = []
 
 [project.scripts]
 pr-review = "pr_reviewer.cli:main"

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -27,6 +27,8 @@ PASSTHROUGH_ENV_KEYS = {
     "USER",
 }
 
+REVIEW_OUTPUT_KEYS = {"verdict", "terminal_reason", "summary", "findings"}
+
 
 @dataclass(frozen=True)
 class OpencodeRunResult:
@@ -116,15 +118,34 @@ def parse_structured_review_json(text: str) -> dict[str, Any]:
     try:
         parsed = json.loads(stripped)
     except json.JSONDecodeError:
-        start = stripped.find("{")
-        end = stripped.rfind("}")
-        if start == -1 or end == -1 or end < start:
-            raise
-        parsed = json.loads(stripped[start : end + 1])
+        parsed = parse_last_review_json_object(stripped)
 
     if not isinstance(parsed, dict):
         raise ValueError("review output JSON was not an object")
     return parsed
+
+
+def parse_last_review_json_object(text: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    candidates: list[dict[str, Any]] = []
+    last_error: JSONDecodeError | None = None
+
+    for start, character in enumerate(text):
+        if character != "{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(text[start:])
+        except JSONDecodeError as exc:
+            last_error = exc
+            continue
+        if isinstance(value, dict) and REVIEW_OUTPUT_KEYS.issubset(value):
+            candidates.append(value)
+
+    if candidates:
+        return candidates[-1]
+    if last_error is not None:
+        raise last_error
+    raise JSONDecodeError("no JSON object found", text, 0)
 
 
 def build_infra_uncertain_report(

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -30,6 +30,16 @@ PASSTHROUGH_ENV_KEYS = {
 REVIEW_OUTPUT_KEYS = {"verdict", "terminal_reason", "summary", "findings"}
 
 
+def build_read_only_opencode_config() -> dict[str, Any]:
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "permission": {
+            "bash": "allow",
+            "edit": "deny",
+        },
+    }
+
+
 @dataclass(frozen=True)
 class OpencodeRunResult:
     text: str
@@ -42,28 +52,20 @@ def build_opencode_env(config: ReviewerConfig, config_dir: Path) -> dict[str, st
     config_path = config_dir / "opencode-reviewer.json"
     # Keep opencode's normal provider/auth config, but block file edits while
     # still allowing shell inspection in the disposable review workspace.
-    config_path.write_text(
-        json.dumps(
-            {
-                "$schema": "https://opencode.ai/config.json",
-                "permission": {
-                    "bash": "allow",
-                    "edit": "deny",
-                },
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n"
-    )
+    reviewer_config = build_read_only_opencode_config()
+    config_path.write_text(json.dumps(reviewer_config, indent=2, sort_keys=True) + "\n")
 
     env = {
         key: value
         for key, value in os.environ.items()
         if key in PASSTHROUGH_ENV_KEYS
         or key.startswith("AWS_")
-        or (key.startswith("OPENCODE_") and key != "OPENCODE_CONFIG")
+        or (
+            key.startswith("OPENCODE_")
+            and key not in {"OPENCODE_CONFIG", "OPENCODE_CONFIG_CONTENT"}
+        )
     }
+    env["OPENCODE_CONFIG_CONTENT"] = json.dumps(reviewer_config, sort_keys=True)
     env["OPENCODE_CONFIG"] = str(config_path)
     if config.aws_region:
         env["AWS_REGION"] = config.aws_region
@@ -201,7 +203,7 @@ async def run_opencode(
                 proc.communicate(prompt.encode("utf-8")),
                 timeout=config.effective_timeout_seconds(),
             )
-        except TimeoutError as exc:
+        except (TimeoutError, asyncio.TimeoutError) as exc:
             proc.kill()
             await proc.wait()
             raise RuntimeError(

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -1,27 +1,143 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
 from pr_reviewer.config import ReviewerConfig
-from pr_reviewer.prompt import SYSTEM_PROMPT, build_review_prompt
-from pr_reviewer.schema import REVIEW_SCHEMA, ReviewReport, normalize_structured_output
+from pr_reviewer.prompt import build_review_prompt
+from pr_reviewer.schema import ReviewReport, normalize_structured_output
 from pr_reviewer.workspace import ReviewWorkspace
 
-ALLOWED_TOOLS = ["Read", "Glob", "Grep", "Bash"]
-DISALLOWED_TOOLS = [
-    "Write",
-    "Edit",
-    "MultiEdit",
-    "NotebookEdit",
-    "TodoWrite",
-    "WebSearch",
-    "WebFetch",
-]
+
+@dataclass(frozen=True)
+class OpencodeRunResult:
+    text: str
+    session_id: str | None
+    cost_usd: float | None
 
 
-async def _single_prompt_stream(prompt: str):
-    yield {
-        "type": "user",
-        "message": {"role": "user", "content": prompt},
-    }
+def build_opencode_env(config: ReviewerConfig, config_dir: Path) -> dict[str, str]:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "opencode-reviewer.json"
+    # Keep opencode's normal provider/auth config, but block file edits while
+    # still allowing shell inspection in the disposable review workspace.
+    config_path.write_text(
+        json.dumps(
+            {
+                "$schema": "https://opencode.ai/config.json",
+                "permission": {
+                    "bash": "allow",
+                    "edit": "deny",
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+
+    env = os.environ.copy()
+    env["OPENCODE_CONFIG"] = str(config_path)
+    if config.aws_region:
+        env["AWS_REGION"] = config.aws_region
+    return env
+
+
+def parse_opencode_events(stdout: str) -> OpencodeRunResult:
+    text_parts: list[str] = []
+    session_id: str | None = None
+    cost_usd: float | None = None
+
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"opencode emitted non-JSON output on line {line_number}") from exc
+
+        if not isinstance(event, dict):
+            continue
+        session_id = event.get("sessionID") or session_id
+        part = event.get("part")
+        if isinstance(part, dict) and part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+        if isinstance(part, dict) and part.get("type") == "step-finish":
+            cost = part.get("cost")
+            if isinstance(cost, int | float):
+                cost_usd = float(cost)
+
+    return OpencodeRunResult(
+        text="".join(text_parts).strip(), session_id=session_id, cost_usd=cost_usd
+    )
+
+
+def parse_structured_review_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        start = stripped.find("{")
+        end = stripped.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            raise
+        parsed = json.loads(stripped[start : end + 1])
+
+    if not isinstance(parsed, dict):
+        raise ValueError("review output JSON was not an object")
+    return parsed
+
+
+async def run_opencode(
+    prompt: str,
+    *,
+    cwd: Path | None,
+    config: ReviewerConfig,
+) -> OpencodeRunResult:
+    with tempfile.TemporaryDirectory(prefix="pr-review-opencode-") as temp_dir:
+        env = build_opencode_env(config, Path(temp_dir))
+        command = [
+            config.opencode_path,
+            "run",
+            "--model",
+            config.model,
+            "--format",
+            "json",
+        ]
+        if cwd is not None:
+            command.extend(["--dir", str(cwd)])
+        command.append(prompt)
+
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=str(cwd) if cwd is not None else None,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"opencode exited with status {proc.returncode}: {stderr.strip() or stdout.strip()}"
+            )
+        return parse_opencode_events(stdout)
 
 
 async def run_review(
@@ -30,44 +146,10 @@ async def run_review(
     config: ReviewerConfig,
     extra_prompt: str | None = None,
 ) -> ReviewReport:
-    from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, SystemMessage, query
-
-    session_id: str | None = None
-    model: str | None = config.model
-    final: ResultMessage | None = None
-
-    options = ClaudeAgentOptions(
-        system_prompt=SYSTEM_PROMPT,
-        cwd=workspace.path,
-        model=config.model,
-        effort=config.effort,
-        max_turns=config.max_turns,
-        env=config.sdk_env(),
-        permission_mode="bypassPermissions",
-        allowed_tools=ALLOWED_TOOLS,
-        disallowed_tools=DISALLOWED_TOOLS,
-        output_format={"type": "json_schema", "schema": REVIEW_SCHEMA},
-        setting_sources=config.setting_sources,
-        strict_mcp_config=True,
-        mcp_servers={},
-    )
-
     prompt = build_review_prompt(workspace, extra_prompt=extra_prompt)
-    async for message in query(prompt=_single_prompt_stream(prompt), options=options):
-        if isinstance(message, SystemMessage) and message.subtype == "init":
-            session_id = message.data.get("session_id")
-            model = message.data.get("model") or model
-        elif isinstance(message, ResultMessage):
-            final = message
-
-    if final is None:
-        raise RuntimeError("Claude Agent SDK stream ended without a result message")
-
-    if final.structured_output is None:
-        raise RuntimeError(f"review did not return structured output: {final.result!r}")
-
+    run = await run_opencode(prompt, cwd=workspace.path, config=config)
     verdict, terminal_reason, summary, findings = normalize_structured_output(
-        final.structured_output
+        parse_structured_review_json(run.text)
     )
     return ReviewReport(
         verdict=verdict,
@@ -75,35 +157,14 @@ async def run_review(
         summary=summary,
         findings=findings,
         reviewed_diff=workspace.reviewed_diff,
-        model=model,
-        session_id=session_id or final.session_id,
+        model=config.model,
+        session_id=run.session_id,
         workspace=str(workspace.path),
-        cost_usd=final.total_cost_usd,
-        raw_result=final.result,
+        cost_usd=run.cost_usd,
+        raw_result=run.text,
     )
 
 
 async def run_doctor(config: ReviewerConfig) -> str:
-    from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
-
-    options = ClaudeAgentOptions(
-        cwd=None,
-        model=config.model,
-        effort="low",
-        max_turns=1,
-        env=config.sdk_env(),
-        allowed_tools=[],
-        disallowed_tools=["Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebSearch", "WebFetch"],
-        setting_sources=[],
-        strict_mcp_config=True,
-        mcp_servers={},
-    )
-    final: ResultMessage | None = None
-    async for message in query(prompt=_single_prompt_stream("Reply exactly OK."), options=options):
-        if isinstance(message, ResultMessage):
-            final = message
-    if final is None:
-        raise RuntimeError("doctor stream ended without a result message")
-    if final.is_error:
-        raise RuntimeError(final.result or "doctor request failed")
-    return final.result or ""
+    run = await run_opencode("Reply exactly OK.", cwd=None, config=config)
+    return run.text

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -5,6 +5,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass
+from json import JSONDecodeError
 from pathlib import Path
 from typing import Any
 
@@ -126,6 +127,27 @@ def parse_structured_review_json(text: str) -> dict[str, Any]:
     return parsed
 
 
+def build_infra_uncertain_report(
+    *,
+    workspace: ReviewWorkspace,
+    config: ReviewerConfig,
+    run: OpencodeRunResult,
+    error: Exception,
+) -> ReviewReport:
+    return ReviewReport(
+        verdict="infra_uncertain",
+        terminal_reason="infra_uncertain",
+        summary=f"Reviewer returned malformed structured output: {error}",
+        findings=[],
+        reviewed_diff=workspace.reviewed_diff,
+        model=config.model,
+        session_id=run.session_id,
+        workspace=str(workspace.path),
+        cost_usd=run.cost_usd,
+        raw_result=run.text,
+    )
+
+
 async def run_opencode(
     prompt: str,
     *,
@@ -171,9 +193,17 @@ async def run_review(
 ) -> ReviewReport:
     prompt = f"{SYSTEM_PROMPT}\n\n{build_review_prompt(workspace, extra_prompt=extra_prompt)}"
     run = await run_opencode(prompt, cwd=workspace.path, config=config)
-    verdict, terminal_reason, summary, findings = normalize_structured_output(
-        parse_structured_review_json(run.text)
-    )
+    try:
+        verdict, terminal_reason, summary, findings = normalize_structured_output(
+            parse_structured_review_json(run.text)
+        )
+    except (JSONDecodeError, ValueError) as exc:
+        return build_infra_uncertain_report(
+            workspace=workspace,
+            config=config,
+            run=run,
+            error=exc,
+        )
     return ReviewReport(
         verdict=verdict,
         terminal_reason=terminal_reason,

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -196,7 +196,17 @@ async def run_opencode(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout_bytes, stderr_bytes = await proc.communicate(prompt.encode("utf-8"))
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(prompt.encode("utf-8")),
+                timeout=config.effective_timeout_seconds(),
+            )
+        except TimeoutError as exc:
+            proc.kill()
+            await proc.wait()
+            raise RuntimeError(
+                f"opencode timed out after {config.effective_timeout_seconds():.1f} seconds"
+            ) from exc
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
         if proc.returncode != 0:
@@ -213,10 +223,17 @@ async def run_review(
     extra_prompt: str | None = None,
 ) -> ReviewReport:
     prompt = f"{SYSTEM_PROMPT}\n\n{build_review_prompt(workspace, extra_prompt=extra_prompt)}"
-    run = await run_opencode(prompt, cwd=workspace.path, config=config)
     try:
+        run = await run_opencode(prompt, cwd=workspace.path, config=config)
         verdict, terminal_reason, summary, findings = normalize_structured_output(
             parse_structured_review_json(run.text)
+        )
+    except RuntimeError as exc:
+        return build_infra_uncertain_report(
+            workspace=workspace,
+            config=config,
+            run=OpencodeRunResult(text="", session_id=None, cost_usd=None),
+            error=exc,
         )
     except (JSONDecodeError, ValueError) as exc:
         return build_infra_uncertain_report(

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -9,9 +9,22 @@ from pathlib import Path
 from typing import Any
 
 from pr_reviewer.config import ReviewerConfig
-from pr_reviewer.prompt import build_review_prompt
+from pr_reviewer.prompt import SYSTEM_PROMPT, build_review_prompt
 from pr_reviewer.schema import ReviewReport, normalize_structured_output
 from pr_reviewer.workspace import ReviewWorkspace
+
+PASSTHROUGH_ENV_KEYS = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "SHELL",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USER",
+}
 
 
 @dataclass(frozen=True)
@@ -41,7 +54,13 @@ def build_opencode_env(config: ReviewerConfig, config_dir: Path) -> dict[str, st
         + "\n"
     )
 
-    env = os.environ.copy()
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key in PASSTHROUGH_ENV_KEYS
+        or key.startswith("AWS_")
+        or (key.startswith("OPENCODE_") and key != "OPENCODE_CONFIG")
+    }
     env["OPENCODE_CONFIG"] = str(config_path)
     if config.aws_region:
         env["AWS_REGION"] = config.aws_region
@@ -51,7 +70,8 @@ def build_opencode_env(config: ReviewerConfig, config_dir: Path) -> dict[str, st
 def parse_opencode_events(stdout: str) -> OpencodeRunResult:
     text_parts: list[str] = []
     session_id: str | None = None
-    cost_usd: float | None = None
+    cost_usd = 0.0
+    saw_cost = False
 
     for line_number, line in enumerate(stdout.splitlines(), start=1):
         if not line.strip():
@@ -72,10 +92,13 @@ def parse_opencode_events(stdout: str) -> OpencodeRunResult:
         if isinstance(part, dict) and part.get("type") == "step-finish":
             cost = part.get("cost")
             if isinstance(cost, int | float):
-                cost_usd = float(cost)
+                cost_usd += float(cost)
+                saw_cost = True
 
     return OpencodeRunResult(
-        text="".join(text_parts).strip(), session_id=session_id, cost_usd=cost_usd
+        text="".join(text_parts).strip(),
+        session_id=session_id,
+        cost_usd=cost_usd if saw_cost else None,
     )
 
 
@@ -121,16 +144,16 @@ async def run_opencode(
         ]
         if cwd is not None:
             command.extend(["--dir", str(cwd)])
-        command.append(prompt)
 
         proc = await asyncio.create_subprocess_exec(
             *command,
             cwd=str(cwd) if cwd is not None else None,
             env=env,
+            stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout_bytes, stderr_bytes = await proc.communicate(prompt.encode("utf-8"))
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
         if proc.returncode != 0:
@@ -146,7 +169,7 @@ async def run_review(
     config: ReviewerConfig,
     extra_prompt: str | None = None,
 ) -> ReviewReport:
-    prompt = build_review_prompt(workspace, extra_prompt=extra_prompt)
+    prompt = f"{SYSTEM_PROMPT}\n\n{build_review_prompt(workspace, extra_prompt=extra_prompt)}"
     run = await run_opencode(prompt, cwd=workspace.path, config=config)
     verdict, terminal_reason, summary, findings = normalize_structured_output(
         parse_structured_review_json(run.text)

--- a/python/pr-reviewer/src/pr_reviewer/cli.py
+++ b/python/pr-reviewer/src/pr_reviewer/cli.py
@@ -22,7 +22,7 @@ INFRA_ERROR = 2
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pr-review",
-        description="Run an isolated Bedrock-backed Claude Agent SDK PR review.",
+        description="Run an isolated opencode-backed PR review.",
     )
     add_review_args(parser)
     return parser
@@ -31,7 +31,7 @@ def build_parser() -> argparse.ArgumentParser:
 def build_doctor_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pr-review doctor",
-        description="Smoke-test Bedrock authentication and model access.",
+        description="Smoke-test opencode model access.",
     )
     add_common_args(parser, default_max_turns=DEFAULT_DOCTOR_MAX_TURNS)
     return parser
@@ -40,7 +40,12 @@ def build_doctor_parser() -> argparse.ArgumentParser:
 def add_common_args(parser: argparse.ArgumentParser, *, default_max_turns: int | None) -> None:
     parser.add_argument("--model", default=None)
     parser.add_argument("--aws-region", default=None)
-    parser.add_argument("--max-turns", type=int, default=default_max_turns)
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=default_max_turns,
+        help="Advisory review budget recorded in report metadata.",
+    )
 
 
 def add_review_args(parser: argparse.ArgumentParser) -> None:
@@ -145,7 +150,7 @@ def run_doctor_command(args: argparse.Namespace) -> int:
     if result.strip().rstrip(".") != "OK":
         print(f"doctor returned unexpected response: {result!r}", file=sys.stderr)
         return INFRA_ERROR
-    print(f"Bedrock SDK smoke test OK: model={config.model} region={config.aws_region}")
+    print(f"opencode smoke test OK: model={config.model} region={config.aws_region}")
     return CLEAR
 
 

--- a/python/pr-reviewer/src/pr_reviewer/cli.py
+++ b/python/pr-reviewer/src/pr_reviewer/cli.py
@@ -46,6 +46,12 @@ def add_common_args(parser: argparse.ArgumentParser, *, default_max_turns: int |
         default=default_max_turns,
         help="Advisory review budget recorded in report metadata.",
     )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=None,
+        help="Hard wall-clock timeout for the opencode subprocess.",
+    )
 
 
 def add_review_args(parser: argparse.ArgumentParser) -> None:
@@ -75,6 +81,7 @@ def config_from_args(args: argparse.Namespace, *, max_turns: int | None = None) 
         model=args.model,
         aws_region=args.aws_region,
         max_turns=max_turns if max_turns is not None else args.max_turns,
+        timeout_seconds=args.timeout_seconds,
     )
 
 

--- a/python/pr-reviewer/src/pr_reviewer/config.py
+++ b/python/pr-reviewer/src/pr_reviewer/config.py
@@ -9,6 +9,8 @@ DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_DOCTOR_MAX_TURNS = 1
 DEFAULT_REVIEW_MIN_TURNS = 64
 DEFAULT_REVIEW_MAX_TURNS = 200
+DEFAULT_MIN_TIMEOUT_SECONDS = 60.0
+DEFAULT_SECONDS_PER_TURN = 30.0
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,7 @@ class ReviewerConfig:
     aws_region: str = DEFAULT_AWS_REGION
     max_turns: int = DEFAULT_REVIEW_MIN_TURNS
     opencode_path: str = DEFAULT_OPENCODE_PATH
+    timeout_seconds: float | None = None
 
     @classmethod
     def from_env(
@@ -25,7 +28,9 @@ class ReviewerConfig:
         model: str | None = None,
         aws_region: str | None = None,
         max_turns: int | None = DEFAULT_REVIEW_MIN_TURNS,
+        timeout_seconds: float | None = None,
     ) -> ReviewerConfig:
+        env_timeout = os.environ.get("PR_REVIEWER_TIMEOUT_SECONDS")
         return cls(
             model=model
             if model is not None
@@ -37,7 +42,19 @@ class ReviewerConfig:
             ),
             max_turns=max_turns if max_turns is not None else DEFAULT_REVIEW_MIN_TURNS,
             opencode_path=os.environ.get("PR_REVIEWER_OPENCODE", DEFAULT_OPENCODE_PATH),
+            timeout_seconds=(
+                timeout_seconds
+                if timeout_seconds is not None
+                else float(env_timeout)
+                if env_timeout
+                else None
+            ),
         )
+
+    def effective_timeout_seconds(self) -> float:
+        if self.timeout_seconds is not None:
+            return self.timeout_seconds
+        return max(DEFAULT_MIN_TIMEOUT_SECONDS, self.max_turns * DEFAULT_SECONDS_PER_TURN)
 
 
 def estimate_review_turns(

--- a/python/pr-reviewer/src/pr_reviewer/config.py
+++ b/python/pr-reviewer/src/pr_reviewer/config.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
-from typing import Literal
+from dataclasses import dataclass
 
 DEFAULT_MODEL = "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
 DEFAULT_OPENCODE_PATH = "opencode"
@@ -10,10 +9,6 @@ DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_DOCTOR_MAX_TURNS = 1
 DEFAULT_REVIEW_MIN_TURNS = 64
 DEFAULT_REVIEW_MAX_TURNS = 200
-DEFAULT_EFFORT = "xhigh"
-
-Effort = Literal["low", "medium", "high", "xhigh", "max"]
-SettingSource = Literal["user", "project", "local"]
 
 
 @dataclass(frozen=True)
@@ -21,8 +16,6 @@ class ReviewerConfig:
     model: str = DEFAULT_MODEL
     aws_region: str = DEFAULT_AWS_REGION
     max_turns: int = DEFAULT_REVIEW_MIN_TURNS
-    effort: Effort = DEFAULT_EFFORT
-    setting_sources: list[SettingSource] = field(default_factory=lambda: ["project"])
     opencode_path: str = DEFAULT_OPENCODE_PATH
 
     @classmethod

--- a/python/pr-reviewer/src/pr_reviewer/config.py
+++ b/python/pr-reviewer/src/pr_reviewer/config.py
@@ -4,7 +4,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Literal
 
-DEFAULT_MODEL = "global.anthropic.claude-opus-4-6-v1"
+DEFAULT_MODEL = "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
+DEFAULT_OPENCODE_PATH = "opencode"
 DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_DOCTOR_MAX_TURNS = 1
 DEFAULT_REVIEW_MIN_TURNS = 64
@@ -22,6 +23,7 @@ class ReviewerConfig:
     max_turns: int = DEFAULT_REVIEW_MIN_TURNS
     effort: Effort = DEFAULT_EFFORT
     setting_sources: list[SettingSource] = field(default_factory=lambda: ["project"])
+    opencode_path: str = DEFAULT_OPENCODE_PATH
 
     @classmethod
     def from_env(
@@ -41,13 +43,8 @@ class ReviewerConfig:
                 else os.environ.get("AWS_REGION", DEFAULT_AWS_REGION)
             ),
             max_turns=max_turns if max_turns is not None else DEFAULT_REVIEW_MIN_TURNS,
+            opencode_path=os.environ.get("PR_REVIEWER_OPENCODE", DEFAULT_OPENCODE_PATH),
         )
-
-    def sdk_env(self) -> dict[str, str]:
-        return {
-            "CLAUDE_CODE_USE_BEDROCK": "1",
-            "AWS_REGION": self.aws_region,
-        }
 
 
 def estimate_review_turns(

--- a/python/pr-reviewer/src/pr_reviewer/prompt.py
+++ b/python/pr-reviewer/src/pr_reviewer/prompt.py
@@ -19,8 +19,8 @@ Set terminal_reason to explain how the review ended:
 - budget_exhausted: you could not finish before the turn/context budget.
 - infra_uncertain: review could not be trusted because of tooling or environment uncertainty.
 
-You may use Read, Glob, Grep, and Bash inside this isolated disposable review
-workspace. Prefer read-only inspection, but use Bash freely when it helps you
+You are running through opencode inside an isolated disposable review workspace.
+Prefer read-only inspection, but use shell inspection when it helps you
 understand the diff. Do not intentionally edit source files; this review should
 produce findings, not patches.
 """
@@ -46,8 +46,25 @@ Diff stat:
 {workspace.reviewed_diff.diff_stat or "(empty)"}
 
 You are in the PR workspace. Inspect files as needed and compare the PR against
-the full diff below. Return only the structured review result requested by the
-host.
+the full diff below. Return exactly one JSON object and no prose, markdown, or
+code fence. The JSON shape is:
+{{
+  "verdict": "clear" | "findings" | "needs_human" | "infra_uncertain",
+  "terminal_reason": "review_complete" | "actionable_findings" |
+    "needs_human" | "budget_exhausted" | "infra_uncertain",
+  "summary": "short review summary",
+  "findings": [
+    {{
+      "severity": "blocker" | "high" | "medium" | "low",
+      "file": "path/to/file",
+      "line": 123,
+      "title": "short issue title",
+      "evidence": "why this is a real bug or risk",
+      "suggested_fix": "concrete fix, or null",
+      "confidence": "high" | "medium" | "low"
+    }}
+  ]
+}}
 
 Full diff:
 {workspace.diff_patch or "(empty)"}

--- a/python/pr-reviewer/src/pr_reviewer/schema.py
+++ b/python/pr-reviewer/src/pr_reviewer/schema.py
@@ -15,58 +15,6 @@ Severity = Literal["blocker", "high", "medium", "low"]
 Confidence = Literal["high", "medium", "low"]
 
 
-REVIEW_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "additionalProperties": False,
-    "required": ["verdict", "terminal_reason", "findings", "summary"],
-    "properties": {
-        "verdict": {
-            "type": "string",
-            "enum": ["clear", "findings", "needs_human", "infra_uncertain"],
-        },
-        "terminal_reason": {
-            "type": "string",
-            "enum": [
-                "review_complete",
-                "actionable_findings",
-                "needs_human",
-                "budget_exhausted",
-                "infra_uncertain",
-            ],
-        },
-        "summary": {"type": "string"},
-        "findings": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "additionalProperties": False,
-                "required": [
-                    "severity",
-                    "file",
-                    "line",
-                    "title",
-                    "evidence",
-                    "suggested_fix",
-                    "confidence",
-                ],
-                "properties": {
-                    "severity": {
-                        "type": "string",
-                        "enum": ["blocker", "high", "medium", "low"],
-                    },
-                    "file": {"type": "string"},
-                    "line": {"type": ["integer", "null"]},
-                    "title": {"type": "string"},
-                    "evidence": {"type": "string"},
-                    "suggested_fix": {"type": ["string", "null"]},
-                    "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
-                },
-            },
-        },
-    },
-}
-
-
 @dataclass(frozen=True)
 class Finding:
     severity: Severity

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -1,63 +1,12 @@
 import asyncio
-import sys
-import types
 from pathlib import Path
 
-from pr_reviewer.agent import run_doctor, run_review
+from pr_reviewer import agent
+from pr_reviewer.agent import OpencodeRunResult, run_doctor, run_review
 from pr_reviewer.config import ReviewerConfig
 from pr_reviewer.git import PullRequestInfo
 from pr_reviewer.schema import ReviewedDiff
 from pr_reviewer.workspace import ReviewWorkspace
-
-
-class FakeSystemMessage:
-    def __init__(self) -> None:
-        self.subtype = "init"
-        self.data = {"session_id": "session-1", "model": "model-from-sdk"}
-
-
-class FakeResultMessage:
-    def __init__(self) -> None:
-        self.structured_output = {
-            "verdict": "clear",
-            "terminal_reason": "review_complete",
-            "summary": "Looks good.",
-            "findings": [],
-        }
-        self.session_id = "result-session"
-        self.total_cost_usd = 1.25
-        self.result = '{"verdict":"clear"}'
-        self.is_error = False
-
-
-class FakeClaudeAgentOptions:
-    captured: dict | None = None
-
-    def __init__(self, **kwargs) -> None:
-        FakeClaudeAgentOptions.captured = kwargs
-
-
-async def fake_query(prompt, options):
-    chunks = []
-    async for chunk in prompt:
-        chunks.append(chunk)
-    fake_query.chunks = chunks
-    fake_query.options = options
-    yield FakeSystemMessage()
-    yield FakeResultMessage()
-
-
-fake_query.chunks = []
-fake_query.options = None
-
-
-def install_fake_sdk(monkeypatch) -> None:
-    fake_sdk = types.ModuleType("claude_agent_sdk")
-    fake_sdk.ClaudeAgentOptions = FakeClaudeAgentOptions
-    fake_sdk.ResultMessage = FakeResultMessage
-    fake_sdk.SystemMessage = FakeSystemMessage
-    fake_sdk.query = fake_query
-    monkeypatch.setitem(sys.modules, "claude_agent_sdk", fake_sdk)
 
 
 def make_workspace(tmp_path: Path) -> ReviewWorkspace:
@@ -85,52 +34,93 @@ def make_workspace(tmp_path: Path) -> ReviewWorkspace:
     )
 
 
-def test_run_review_constructs_sdk_options_and_report(monkeypatch, tmp_path: Path) -> None:
-    install_fake_sdk(monkeypatch)
-    config = ReviewerConfig(model="model", aws_region="us-west-2", max_turns=77)
+def test_parse_opencode_events_collects_text_session_and_cost() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"step_start","sessionID":"ses-1","part":{"type":"step-start"}}',
+            '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"{\\"verdict\\": "}}',
+            '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"\\"clear\\"}"}}',
+            '{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","cost":0.12}}',
+        ]
+    )
+
+    result = agent.parse_opencode_events(stdout)
+
+    assert result == OpencodeRunResult(
+        text='{"verdict": "clear"}', session_id="ses-1", cost_usd=0.12
+    )
+
+
+def test_parse_structured_review_json_accepts_fenced_json() -> None:
+    data = agent.parse_structured_review_json(
+        """```json
+{"verdict":"clear","terminal_reason":"review_complete","summary":"ok","findings":[]}
+```"""
+    )
+
+    assert data["verdict"] == "clear"
+    assert data["terminal_reason"] == "review_complete"
+
+
+def test_run_review_uses_opencode_output(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    async def fake_run_opencode(
+        prompt: str, *, cwd: Path, config: ReviewerConfig
+    ) -> OpencodeRunResult:
+        calls.append((prompt, cwd, config))
+        return OpencodeRunResult(
+            text=(
+                '{"verdict":"clear","terminal_reason":"review_complete",'
+                '"summary":"Looks good.","findings":[]}'
+            ),
+            session_id="ses-review",
+            cost_usd=0.34,
+        )
+
+    monkeypatch.setattr(agent, "run_opencode", fake_run_opencode)
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2", max_turns=77)
 
     report = asyncio.run(run_review(make_workspace(tmp_path), config=config))
 
     assert report.verdict == "clear"
     assert report.terminal_reason == "review_complete"
     assert report.summary == "Looks good."
-    assert report.session_id == "session-1"
-    assert report.model == "model-from-sdk"
-    assert report.cost_usd == 1.25
-
-    options = FakeClaudeAgentOptions.captured
-    assert options is not None
-    assert options["cwd"] == tmp_path
-    assert options["model"] == "model"
-    assert options["max_turns"] == 77
-    assert options["permission_mode"] == "bypassPermissions"
-    assert "Bash" in options["allowed_tools"]
-    assert "Write" in options["disallowed_tools"]
-    assert options["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
-    assert options["env"]["AWS_REGION"] == "us-west-2"
-
-    assert fake_query.chunks == [
-        {
-            "type": "user",
-            "message": {
-                "role": "user",
-                "content": fake_query.chunks[0]["message"]["content"],
-            },
-        }
-    ]
-    assert "diff --git a/src/a.py b/src/a.py" in fake_query.chunks[0]["message"]["content"]
+    assert report.session_id == "ses-review"
+    assert report.model == "amazon-bedrock/model"
+    assert report.cost_usd == 0.34
+    assert report.raw_result is not None
+    assert "diff --git a/src/a.py b/src/a.py" in calls[0][0]
+    assert calls[0][1] == tmp_path
+    assert calls[0][2] == config
 
 
-def test_run_doctor_uses_streaming_prompt(monkeypatch) -> None:
-    install_fake_sdk(monkeypatch)
-    config = ReviewerConfig(model="model", aws_region="us-west-2", max_turns=1)
+def test_run_doctor_uses_opencode(monkeypatch) -> None:
+    calls = []
+
+    async def fake_run_opencode(
+        prompt: str, *, cwd: Path | None, config: ReviewerConfig
+    ) -> OpencodeRunResult:
+        calls.append((prompt, cwd, config))
+        return OpencodeRunResult(text="OK.", session_id="ses-doctor", cost_usd=0.01)
+
+    monkeypatch.setattr(agent, "run_opencode", fake_run_opencode)
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2", max_turns=1)
 
     result = asyncio.run(run_doctor(config))
 
-    assert result == '{"verdict":"clear"}'
-    assert fake_query.chunks == [
-        {
-            "type": "user",
-            "message": {"role": "user", "content": "Reply exactly OK."},
-        }
-    ]
+    assert result == "OK."
+    assert calls == [("Reply exactly OK.", None, config)]
+
+
+def test_build_opencode_env_writes_read_only_config(tmp_path: Path) -> None:
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
+
+    env = agent.build_opencode_env(config, tmp_path)
+
+    config_path = Path(env["OPENCODE_CONFIG"])
+    assert config_path.exists()
+    contents = config_path.read_text()
+    assert '"edit": "deny"' in contents
+    assert '"bash": "allow"' in contents
+    assert env["AWS_REGION"] == "us-west-2"

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 from pathlib import Path
 
+import pytest
+
 from pr_reviewer import agent
 from pr_reviewer.agent import OpencodeRunResult, run_doctor, run_review
 from pr_reviewer.config import ReviewerConfig
@@ -137,6 +139,28 @@ def test_run_review_preserves_malformed_output_as_infra_uncertain(
     assert report.raw_result == '{"verdict" "clear"}'
 
 
+def test_run_review_preserves_opencode_runtime_error_as_infra_uncertain(
+    monkeypatch, tmp_path: Path
+) -> None:
+    async def fake_run_opencode(
+        prompt: str, *, cwd: Path, config: ReviewerConfig
+    ) -> OpencodeRunResult:
+        raise RuntimeError("opencode failed")
+
+    monkeypatch.setattr(agent, "run_opencode", fake_run_opencode)
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
+
+    report = asyncio.run(run_review(make_workspace(tmp_path), config=config))
+
+    assert report.verdict == "infra_uncertain"
+    assert report.terminal_reason == "infra_uncertain"
+    assert report.summary == "Reviewer returned malformed structured output: opencode failed"
+    assert report.findings == []
+    assert report.session_id is None
+    assert report.cost_usd is None
+    assert report.raw_result == ""
+
+
 def test_run_doctor_uses_opencode(monkeypatch) -> None:
     calls = []
 
@@ -217,3 +241,36 @@ def test_run_opencode_passes_prompt_on_stdin(monkeypatch, tmp_path: Path) -> Non
     assert "large prompt" not in command
     assert kwargs["stdin"] == asyncio.subprocess.PIPE
     assert calls[1] == ("stdin", b"large prompt")
+
+
+def test_run_opencode_times_out_and_kills_process(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    class FakeProcess:
+        returncode = None
+
+        async def communicate(self, stdin: bytes) -> tuple[bytes, bytes]:
+            await asyncio.sleep(10)
+            return b"", b""
+
+        def kill(self) -> None:
+            calls.append("kill")
+
+        async def wait(self) -> None:
+            calls.append("wait")
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(os, "environ", {"PATH": "/usr/bin", "HOME": "/tmp/home"})
+    config = ReviewerConfig(
+        model="amazon-bedrock/model",
+        aws_region="us-west-2",
+        timeout_seconds=0.01,
+    )
+
+    with pytest.raises(RuntimeError, match="opencode timed out after 0.0 seconds"):
+        asyncio.run(agent.run_opencode("large prompt", cwd=tmp_path, config=config))
+
+    assert calls == ["kill", "wait"]

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 
 from pr_reviewer import agent
@@ -41,13 +42,14 @@ def test_parse_opencode_events_collects_text_session_and_cost() -> None:
             '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"{\\"verdict\\": "}}',
             '{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"\\"clear\\"}"}}',
             '{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","cost":0.12}}',
+            '{"type":"step_finish","sessionID":"ses-1","part":{"type":"step-finish","cost":0.08}}',
         ]
     )
 
     result = agent.parse_opencode_events(stdout)
 
     assert result == OpencodeRunResult(
-        text='{"verdict": "clear"}', session_id="ses-1", cost_usd=0.12
+        text='{"verdict": "clear"}', session_id="ses-1", cost_usd=0.2
     )
 
 
@@ -91,6 +93,7 @@ def test_run_review_uses_opencode_output(monkeypatch, tmp_path: Path) -> None:
     assert report.cost_usd == 0.34
     assert report.raw_result is not None
     assert "diff --git a/src/a.py b/src/a.py" in calls[0][0]
+    assert "Do not report style-only comments." in calls[0][0]
     assert calls[0][1] == tmp_path
     assert calls[0][2] == config
 
@@ -113,7 +116,12 @@ def test_run_doctor_uses_opencode(monkeypatch) -> None:
     assert calls == [("Reply exactly OK.", None, config)]
 
 
-def test_build_opencode_env_writes_read_only_config(tmp_path: Path) -> None:
+def test_build_opencode_env_writes_read_only_config(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("UNRELATED_SECRET", "do-not-copy")
+    monkeypatch.setenv("AWS_PROFILE", "reviewer")
+    monkeypatch.setenv("OPENCODE_TOKEN", "token")
+    monkeypatch.setenv("OPENCODE_CONFIG", "/tmp/caller-config.json")
     config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
 
     env = agent.build_opencode_env(config, tmp_path)
@@ -124,3 +132,49 @@ def test_build_opencode_env_writes_read_only_config(tmp_path: Path) -> None:
     assert '"edit": "deny"' in contents
     assert '"bash": "allow"' in contents
     assert env["AWS_REGION"] == "us-west-2"
+    assert env["AWS_PROFILE"] == "reviewer"
+    assert env["OPENCODE_TOKEN"] == "token"
+    assert env["OPENCODE_CONFIG"] == str(config_path)
+    assert env["PATH"] == "/usr/bin"
+    assert "UNRELATED_SECRET" not in env
+
+
+def test_run_opencode_passes_prompt_on_stdin(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self, stdin: bytes) -> tuple[bytes, bytes]:
+            calls.append(("stdin", stdin))
+            return (
+                b'{"type":"text","sessionID":"ses-1","part":{"type":"text","text":"OK"}}\n',
+                b"",
+            )
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        calls.append(("command", command, kwargs))
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(os, "environ", {"PATH": "/usr/bin", "HOME": "/tmp/home"})
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
+
+    result = asyncio.run(agent.run_opencode("large prompt", cwd=tmp_path, config=config))
+
+    assert result.text == "OK"
+    command = calls[0][1]
+    kwargs = calls[0][2]
+    assert command == (
+        "opencode",
+        "run",
+        "--model",
+        "amazon-bedrock/model",
+        "--format",
+        "json",
+        "--dir",
+        str(tmp_path),
+    )
+    assert "large prompt" not in command
+    assert kwargs["stdin"] == asyncio.subprocess.PIPE
+    assert calls[1] == ("stdin", b"large prompt")

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from pathlib import Path
 
@@ -185,6 +186,7 @@ def test_build_opencode_env_writes_read_only_config(monkeypatch, tmp_path: Path)
     monkeypatch.setenv("AWS_PROFILE", "reviewer")
     monkeypatch.setenv("OPENCODE_TOKEN", "token")
     monkeypatch.setenv("OPENCODE_CONFIG", "/tmp/caller-config.json")
+    monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", '{"permission":"allow"}')
     config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
 
     env = agent.build_opencode_env(config, tmp_path)
@@ -198,6 +200,13 @@ def test_build_opencode_env_writes_read_only_config(monkeypatch, tmp_path: Path)
     assert env["AWS_PROFILE"] == "reviewer"
     assert env["OPENCODE_TOKEN"] == "token"
     assert env["OPENCODE_CONFIG"] == str(config_path)
+    assert json.loads(env["OPENCODE_CONFIG_CONTENT"]) == {
+        "$schema": "https://opencode.ai/config.json",
+        "permission": {
+            "bash": "allow",
+            "edit": "deny",
+        },
+    }
     assert env["PATH"] == "/usr/bin"
     assert "UNRELATED_SECRET" not in env
 

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -64,6 +64,19 @@ def test_parse_structured_review_json_accepts_fenced_json() -> None:
     assert data["terminal_reason"] == "review_complete"
 
 
+def test_parse_structured_review_json_uses_last_review_shaped_object() -> None:
+    data = agent.parse_structured_review_json(
+        """I inspected {"unrelated": true}.
+{"verdict":"findings","terminal_reason":"actionable_findings","summary":"old","findings":[]}
+More notes with {"not":"the report"}.
+{"verdict":"clear","terminal_reason":"review_complete","summary":"final","findings":[]}
+"""
+    )
+
+    assert data["verdict"] == "clear"
+    assert data["summary"] == "final"
+
+
 def test_run_review_uses_opencode_output(monkeypatch, tmp_path: Path) -> None:
     calls = []
 

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -98,6 +98,32 @@ def test_run_review_uses_opencode_output(monkeypatch, tmp_path: Path) -> None:
     assert calls[0][2] == config
 
 
+def test_run_review_preserves_malformed_output_as_infra_uncertain(
+    monkeypatch, tmp_path: Path
+) -> None:
+    async def fake_run_opencode(
+        prompt: str, *, cwd: Path, config: ReviewerConfig
+    ) -> OpencodeRunResult:
+        return OpencodeRunResult(
+            text='{"verdict" "clear"}',
+            session_id="ses-review",
+            cost_usd=0.34,
+        )
+
+    monkeypatch.setattr(agent, "run_opencode", fake_run_opencode)
+    config = ReviewerConfig(model="amazon-bedrock/model", aws_region="us-west-2")
+
+    report = asyncio.run(run_review(make_workspace(tmp_path), config=config))
+
+    assert report.verdict == "infra_uncertain"
+    assert report.terminal_reason == "infra_uncertain"
+    assert "Reviewer returned malformed structured output:" in report.summary
+    assert report.findings == []
+    assert report.session_id == "ses-review"
+    assert report.cost_usd == 0.34
+    assert report.raw_result == '{"verdict" "clear"}'
+
+
 def test_run_doctor_uses_opencode(monkeypatch) -> None:
     calls = []
 

--- a/python/pr-reviewer/tests/test_config.py
+++ b/python/pr-reviewer/tests/test_config.py
@@ -6,6 +6,8 @@ def test_config_sets_default_opencode_model() -> None:
 
     assert config.model == "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
     assert config.aws_region == "us-west-2"
+    assert not hasattr(config, "effort")
+    assert not hasattr(config, "setting_sources")
 
 
 def test_config_from_env_prefers_explicit_values(monkeypatch) -> None:

--- a/python/pr-reviewer/tests/test_config.py
+++ b/python/pr-reviewer/tests/test_config.py
@@ -49,6 +49,21 @@ def test_config_from_env_reads_opencode_binary(monkeypatch) -> None:
     assert config.opencode_path == "/opt/opencode"
 
 
+def test_config_from_env_reads_timeout_seconds(monkeypatch) -> None:
+    monkeypatch.setenv("PR_REVIEWER_TIMEOUT_SECONDS", "12.5")
+
+    config = ReviewerConfig.from_env()
+
+    assert config.timeout_seconds == 12.5
+    assert config.effective_timeout_seconds() == 12.5
+
+
+def test_config_derives_timeout_from_turn_budget() -> None:
+    config = ReviewerConfig(max_turns=2)
+
+    assert config.effective_timeout_seconds() == 60.0
+
+
 def test_estimate_review_turns_scales_with_diff_size() -> None:
     small = estimate_review_turns(diff_patch="one\nline\n", changed_files=["a.py"])
     larger = estimate_review_turns(

--- a/python/pr-reviewer/tests/test_config.py
+++ b/python/pr-reviewer/tests/test_config.py
@@ -1,13 +1,11 @@
 from pr_reviewer.config import DEFAULT_MODEL, ReviewerConfig, estimate_review_turns
 
 
-def test_config_sets_bedrock_env() -> None:
+def test_config_sets_default_opencode_model() -> None:
     config = ReviewerConfig(model=DEFAULT_MODEL, aws_region="us-west-2")
 
-    assert config.sdk_env() == {
-        "CLAUDE_CODE_USE_BEDROCK": "1",
-        "AWS_REGION": "us-west-2",
-    }
+    assert config.model == "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
+    assert config.aws_region == "us-west-2"
 
 
 def test_config_from_env_prefers_explicit_values(monkeypatch) -> None:
@@ -39,6 +37,14 @@ def test_config_from_env_preserves_empty_aws_region() -> None:
     config = ReviewerConfig.from_env(aws_region="")
 
     assert config.aws_region == ""
+
+
+def test_config_from_env_reads_opencode_binary(monkeypatch) -> None:
+    monkeypatch.setenv("PR_REVIEWER_OPENCODE", "/opt/opencode")
+
+    config = ReviewerConfig.from_env()
+
+    assert config.opencode_path == "/opt/opencode"
 
 
 def test_estimate_review_turns_scales_with_diff_size() -> None:


### PR DESCRIPTION
## Summary

- replace the Claude Agent SDK review runner with an `opencode run --format json` subprocess runner
- apply read-only reviewer permissions through opencode inline config, with a temp config file fallback, so project config cannot re-enable edit tools
- feed large review prompts over stdin, parse noisy JSONL event streams, preserve malformed model output as `infra_uncertain`, and bound subprocess runs with `--timeout-seconds`
- keep the existing `pr-review` CLI, disposable PR worktree flow, report schema, exit codes, and `--extra-prompt` support
- update repo skill/docs to describe the opencode-backed reviewer

## Verification

- `uv run pytest python/pr-reviewer/tests -q`
- `uv run ruff check python/pr-reviewer pyproject.toml`
- `uv run ruff format --check python/pr-reviewer`
- `uv run pr-review doctor --timeout-seconds 60`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/2905 --max-turns 120 --timeout-seconds 1200 --extra-prompt "..." --out .context/reviews/pr-2905-opencode-final.json`

## Notes

- `--max-turns` is retained as review-budget metadata for compatibility; `--timeout-seconds` is the hard opencode subprocess ceiling.
- The workspace-level `claude-agent-sdk` dependency remains for Gremlin, but `python/pr-reviewer` no longer depends on it.
- The final dogfood review found two issues after the previous patch set; this branch now addresses both with `asyncio.TimeoutError` handling and `OPENCODE_CONFIG_CONTENT` permission overrides.
