### PR TITLE
[redact-opt] Cache launcher redaction candidates

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_redact.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 REDACT_ENV_VALUES_FLAG = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS"
 REDACTION_MARKER = "[redacted env]"
 MIN_REDACTION_VALUE_LEN = 8
+REDACTION_CACHE_TTL_SECONDS = 0.25
 COMMON_ENV_VALUES = {
     "localhost",
     "127.0.0.1",
@@ -54,6 +56,11 @@ KNOWN_NON_SECRET_ENV_KEYS = {
     "XPC_SERVICE_NAME",
 }
 
+_cached_values: list[str] | None = None
+_cached_at = 0.0
+_cached_env_size = -1
+_cached_flag: str | None = None
+
 
 def redaction_enabled() -> bool:
     raw = os.environ.get(REDACT_ENV_VALUES_FLAG)
@@ -72,7 +79,15 @@ def is_known_non_secret_env_key(key: str) -> bool:
     )
 
 
-def eligible_env_values() -> list[str]:
+def clear_redaction_cache() -> None:
+    global _cached_at, _cached_env_size, _cached_flag, _cached_values
+    _cached_values = None
+    _cached_at = 0.0
+    _cached_env_size = -1
+    _cached_flag = None
+
+
+def _compute_eligible_env_values() -> list[str]:
     if not redaction_enabled():
         return []
 
@@ -90,6 +105,26 @@ def eligible_env_values() -> list[str]:
         values.add(value)
 
     return sorted(values, key=lambda value: (-len(value), value))
+
+
+def eligible_env_values() -> list[str]:
+    global _cached_at, _cached_env_size, _cached_flag, _cached_values
+    now = time.monotonic()
+    env_size = len(os.environ)
+    flag = os.environ.get(REDACT_ENV_VALUES_FLAG)
+    if (
+        _cached_values is not None
+        and env_size == _cached_env_size
+        and flag == _cached_flag
+        and now - _cached_at < REDACTION_CACHE_TTL_SECONDS
+    ):
+        return _cached_values
+
+    _cached_values = _compute_eligible_env_values()
+    _cached_at = now
+    _cached_env_size = env_size
+    _cached_flag = flag
+    return _cached_values
 
 
 def redact_text(text: str, values: list[str] | None = None) -> str:

--- a/python/nteract-kernel-launcher/tests/test_output_redaction.py
+++ b/python/nteract-kernel-launcher/tests/test_output_redaction.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from nteract_kernel_launcher import _output_redaction
+import pytest
+from nteract_kernel_launcher import _output_redaction, _redact
+
+
+@pytest.fixture(autouse=True)
+def clear_redaction_cache():
+    _redact.clear_redaction_cache()
 
 
 class _FakeSession:
@@ -98,3 +104,22 @@ def test_output_redaction_install_is_idempotent(monkeypatch):
     assert session.send is first_send
     session.send("socket", "stream", content={"name": "stdout", "text": secret})
     assert session.sent[0]["content"]["text"] == "[redacted env]"
+
+
+def test_redaction_candidates_refresh_after_cache_window(monkeypatch):
+    now = 1000.0
+    monkeypatch.setattr(_redact.time, "monotonic", lambda: now)
+    _redact.clear_redaction_cache()
+
+    first_secret = "launcher-cache-secret-12345"
+    second_secret = "launcher-cache-secret-67890"
+    monkeypatch.setenv("CACHE_REDACTION_SECRET", first_secret)
+    monkeypatch.delenv("NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS", raising=False)
+
+    assert first_secret in _redact.eligible_env_values()
+
+    monkeypatch.setenv("CACHE_REDACTION_SECRET", second_secret)
+    assert second_secret not in _redact.eligible_env_values()
+
+    now += _redact.REDACTION_CACHE_TTL_SECONDS + 0.001
+    assert second_secret in _redact.eligible_env_values()

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -15,6 +15,12 @@ import pytest
 from nteract_kernel_launcher import _traceback
 from nteract_kernel_launcher._traceback import TRACEBACK_MIME, build_rich_payload, install
 
+
+@pytest.fixture(autouse=True)
+def clear_redaction_cache():
+    _traceback._redact.clear_redaction_cache()
+
+
 # ─── build_rich_payload ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Cache Python launcher redaction candidates for a short refresh window.
- Refresh immediately when the redaction flag or environment size changes.
- Keep dotenv-style same-key value changes bounded by a 250ms refresh window instead of freezing candidates forever.
- Reset the cache in tests so each case preserves its previous environment assumptions.

## Measurement

Ad hoc 200-secret environment, 5000 calls:

- Before: `eligible_env_values`: 0.9184s total, 183.7 us/call
- Before: stream no-match redaction: 1.1634s total, 232.7 us/call
- Before: stream with-match redaction: 0.9874s total, 197.5 us/call
- After: cached `eligible_env_values`: 0.0031s total, 0.6 us/call
- After: cached stream no-match redaction: 0.2423s total, 48.5 us/call
- After: cached stream with-match redaction: 0.0607s total, 12.1 us/call

## Verification

- `uv run --directory python/nteract-kernel-launcher pytest tests/test_output_redaction.py tests/test_traceback.py -q`
- `cargo xtask lint --fix`

## Stack

- Depends on #2906.
