### PR TITLE
fix(renderer): reuse plotly display updates

### DIFF
--- a/apps/notebook/src/renderer-plugins/plotly.js
+++ b/apps/notebook/src/renderer-plugins/plotly.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2944c28bdf153e846eba63e2b5d374ef668e254effafcfadb2611b1615341f29
-size 4630890
+oid sha256:2c550d0b2e91a4daeea0100463b783423017e9febae6a2b697d8a62cc7617f22
+size 4631336

--- a/src/isolated-renderer/__tests__/plotly-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/plotly-renderer.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, render } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { install } from "../plotly-renderer";
+
+const plotlyMocks = vi.hoisted(() => ({
+  newPlot: vi.fn(),
+  react: vi.fn(),
+  relayout: vi.fn(),
+  purge: vi.fn(),
+}));
+
+vi.mock("plotly.js-dist-min", () => ({
+  default: plotlyMocks,
+}));
+
+function installPlotlyRenderer() {
+  let Renderer: ComponentType<RendererProps> | undefined;
+
+  install({
+    register: (_mimeTypes, component) => {
+      Renderer = component;
+    },
+  });
+
+  expect(Renderer).toBeDefined();
+  return Renderer!;
+}
+
+describe("Plotly renderer plugin", () => {
+  const firstFigure = {
+    data: [{ type: "scatter", x: [1, 2], y: [3, 4] }],
+    layout: { title: "first" },
+    config: { scrollZoom: true },
+  };
+
+  const nextFigure = {
+    data: [{ type: "scatter", x: [1, 2], y: [5, 6] }],
+    layout: { title: "next" },
+    config: { scrollZoom: true },
+  };
+
+  beforeEach(() => {
+    document.documentElement.classList.remove("dark");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("uses Plotly.react for display updates instead of remounting the chart", () => {
+    const Renderer = installPlotlyRenderer();
+
+    const { rerender } = render(
+      <Renderer data={firstFigure} mimeType="application/vnd.plotly.v1+json" />,
+    );
+
+    expect(plotlyMocks.newPlot).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.react).not.toHaveBeenCalled();
+    expect(plotlyMocks.purge).not.toHaveBeenCalled();
+
+    rerender(<Renderer data={nextFigure} mimeType="application/vnd.plotly.v1+json" />);
+
+    expect(plotlyMocks.newPlot).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.react).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.react.mock.calls[0][0]).toBe(plotlyMocks.newPlot.mock.calls[0][0]);
+    expect(plotlyMocks.react.mock.calls[0][1].data).toEqual(nextFigure.data);
+    expect(plotlyMocks.react.mock.calls[0][1].layout.title).toBe("next");
+    expect(plotlyMocks.react.mock.calls[0][1].layout.uirevision).toBe("nteract-display-update");
+    expect(plotlyMocks.purge).not.toHaveBeenCalled();
+  });
+
+  it("honors a user-provided uirevision", () => {
+    const Renderer = installPlotlyRenderer();
+    const figure = {
+      ...firstFigure,
+      layout: { ...firstFigure.layout, uirevision: "user-controlled" },
+    };
+
+    render(<Renderer data={figure} mimeType="application/vnd.plotly.v1+json" />);
+
+    expect(plotlyMocks.newPlot.mock.calls[0][1].layout.uirevision).toBe("user-controlled");
+  });
+
+  it("purges the Plotly chart only when the renderer unmounts", () => {
+    const Renderer = installPlotlyRenderer();
+
+    const { rerender, unmount } = render(
+      <Renderer data={firstFigure} mimeType="application/vnd.plotly.v1+json" />,
+    );
+    rerender(<Renderer data={nextFigure} mimeType="application/vnd.plotly.v1+json" />);
+
+    expect(plotlyMocks.purge).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(plotlyMocks.purge).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.purge.mock.calls[0][0]).toBe(plotlyMocks.newPlot.mock.calls[0][0]);
+  });
+
+  it("initializes a new Plotly chart after the data becomes invalid and valid again", () => {
+    const Renderer = installPlotlyRenderer();
+
+    const { rerender } = render(
+      <Renderer data={firstFigure} mimeType="application/vnd.plotly.v1+json" />,
+    );
+    const firstElement = plotlyMocks.newPlot.mock.calls[0][0];
+
+    rerender(<Renderer data={null} mimeType="application/vnd.plotly.v1+json" />);
+
+    expect(plotlyMocks.purge).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.purge.mock.calls[0][0]).toBe(firstElement);
+
+    rerender(<Renderer data={nextFigure} mimeType="application/vnd.plotly.v1+json" />);
+
+    expect(plotlyMocks.newPlot).toHaveBeenCalledTimes(2);
+    expect(plotlyMocks.react).not.toHaveBeenCalled();
+    expect(plotlyMocks.newPlot.mock.calls[1][0]).not.toBe(firstElement);
+  });
+
+  it("uses Plotly.react when the figure arrives as a JSON string", () => {
+    const Renderer = installPlotlyRenderer();
+
+    const { rerender } = render(
+      <Renderer data={JSON.stringify(firstFigure)} mimeType="application/vnd.plotly.v1+json" />,
+    );
+    rerender(
+      <Renderer data={JSON.stringify(nextFigure)} mimeType="application/vnd.plotly.v1+json" />,
+    );
+
+    expect(plotlyMocks.newPlot).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.react).toHaveBeenCalledTimes(1);
+    expect(plotlyMocks.react.mock.calls[0][1].data).toEqual(nextFigure.data);
+  });
+});

--- a/src/isolated-renderer/plotly-renderer.tsx
+++ b/src/isolated-renderer/plotly-renderer.tsx
@@ -7,7 +7,7 @@
  */
 
 import Plotly from "plotly.js-dist-min";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 // --- Theme helpers ---
@@ -66,13 +66,19 @@ interface RendererProps {
   mimeType: string;
 }
 
+const DEFAULT_UI_REVISION = "nteract-display-update";
+
 // --- PlotlyRenderer component ---
 
 function PlotlyRenderer({ data: rawData }: RendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const plottedElementRef = useRef<HTMLDivElement | null>(null);
 
-  const data =
-    typeof rawData === "string" ? (JSON.parse(rawData) as PlotlyData) : (rawData as PlotlyData);
+  const data = useMemo(
+    () =>
+      typeof rawData === "string" ? (JSON.parse(rawData) as PlotlyData) : (rawData as PlotlyData),
+    [rawData],
+  );
 
   // Pre-size the container to match the user's explicit dimensions (if any).
   // Plotly's `responsive: true` config installs a parent ResizeObserver and
@@ -83,9 +89,29 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
   // the chart. Setting the container's CSS height up front means plotly
   // sees its target dimensions from the first paint and the responsive
   // observer simply confirms what's already there.
-  const userLayout = (data?.layout ?? {}) as Record<string, unknown>;
+  const userLayout = useMemo(() => (data?.layout ?? {}) as Record<string, unknown>, [data]);
   const explicitHeight = typeof userLayout.height === "number" ? userLayout.height : undefined;
   const explicitWidth = typeof userLayout.width === "number" ? userLayout.width : undefined;
+
+  const setContainerRef = useCallback((node: HTMLDivElement | null) => {
+    const previous = containerRef.current;
+    if (!node && previous && plottedElementRef.current === previous) {
+      Plotly.purge(previous);
+      plottedElementRef.current = null;
+    }
+
+    containerRef.current = node;
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      const el = plottedElementRef.current;
+      if (el) {
+        Plotly.purge(el);
+      }
+      plottedElementRef.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current || !data?.data) return;
@@ -102,6 +128,9 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
       ...userLayout,
       ...darkLayoutOverrides(isDark),
     };
+    if (layout.uirevision === undefined) {
+      layout.uirevision = DEFAULT_UI_REVISION;
+    }
 
     const config: Record<string, unknown> = {
       responsive: true,
@@ -110,12 +139,24 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
       ...data.config,
     };
 
-    Plotly.newPlot(el, {
+    const figure = {
       data: data.data as Plotly.Data[],
       layout: layout as Partial<Plotly.Layout>,
       config: config as Partial<Plotly.Config>,
       frames: data.frames as Plotly.Frame[],
-    });
+    };
+
+    if (plottedElementRef.current === el) {
+      Plotly.react(el, figure);
+    } else {
+      Plotly.newPlot(el, figure);
+      plottedElementRef.current = el;
+    }
+  }, [data, userLayout]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !data?.data) return;
 
     const themeObserver = new MutationObserver(() => {
       const nowDark = document.documentElement.classList.contains("dark");
@@ -126,11 +167,8 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
       attributeFilter: ["class"],
     });
 
-    return () => {
-      themeObserver.disconnect();
-      Plotly.purge(el);
-    };
-  }, [data, userLayout]);
+    return () => themeObserver.disconnect();
+  }, [data?.data]);
 
   if (!data?.data) return null;
 
@@ -141,7 +179,7 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
 
   return (
     <div
-      ref={containerRef}
+      ref={setContainerRef}
       data-slot="plotly-output"
       className={cn("not-prose py-2 max-w-full")}
       style={containerStyle}


### PR DESCRIPTION
## Summary

- Use `Plotly.react` for isolated Plotly renderer data updates after the first render.
- Keep the existing Plotly DOM node alive across valid `display_update`-style rerenders and purge when the chart node is removed or unmounted.
- Add a default `layout.uirevision` so Plotly can preserve user interactions such as zoom/pan unless the figure explicitly sets its own revision.
- Regenerate the checked-in Plotly renderer plugin bundle.

## Verification

- `pnpm test:run src/isolated-renderer/__tests__/plotly-renderer.test.tsx src/components/outputs/__tests__/plotly-output.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`

## Goal Entry

Entry 1 of the rich renderer `display_update` reuse work: Plotly renderer updates should avoid `purge`/`newPlot` remount churn while keeping fresh execution remount semantics through output identity.
