### PR TITLE
fix(notebook-cloud): allow Access token preflights

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1316,7 +1316,7 @@ function withCors(response: Response): Response {
   response.headers.set("Access-Control-Allow-Methods", "DELETE, GET, HEAD, POST, PUT, OPTIONS");
   response.headers.set(
     "Access-Control-Allow-Headers",
-    `Authorization, Cf-Access-Jwt-Assertion, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
+    `Authorization, Cf-Access-Jwt-Assertion, CF-Access-Token, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
   );
   return response;
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -139,6 +139,26 @@ describe("Worker artifact routes", () => {
     assert.equal(await response.text(), "wasm");
   });
 
+  it("allows Cloudflare Access token headers during API preflight", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n/preflight-demo/acl", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://notebooks.example.com",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "CF-Access-Token, Content-Type",
+        },
+      }),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    const allowedHeaders = response.headers.get("Access-Control-Allow-Headers") ?? "";
+    assert.equal(response.status, 204);
+    assert.match(allowedHeaders, /\bCF-Access-Token\b/);
+    assert.match(allowedHeaders, /\bContent-Type\b/);
+  });
+
   it("serves renderer sidecar assets through a Worker-owned route", async () => {
     const seenPaths: string[] = [];
     const env = fakeEnv({


### PR DESCRIPTION
## Summary

- Allow `CF-Access-Token` through notebook-cloud API CORS preflights.
- Add a Worker route regression test for Access token + `Content-Type` preflight headers.

## Why

`CF-Access-Token` is now a supported Cloudflare Access transport for CLI/API requests, but the generic Worker CORS header allow-list did not include it. Browser/API clients using that header could fail before auth reached the Worker.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/identity.test.ts`
- `vp check`
- `git diff --check`
- `cargo xtask lint --fix`
