### PR TITLE
fix(renderer): reuse vega display updates

### DIFF
--- a/apps/notebook/src/renderer-plugins/vega.js
+++ b/apps/notebook/src/renderer-plugins/vega.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ded5795ed8e6f1f7dd9a66b403e3a84cf81c7e033e2f5c1f84a0e0bd1863ff2
-size 846877
+oid sha256:e58ad6f5d6c47b96469ee71d1871e17c736c6fca10be3d9dd236840c93955b7a
+size 848505

--- a/src/isolated-renderer/__tests__/vega-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/vega-renderer.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { install } from "../vega-renderer";
+
+const vegaMocks = vi.hoisted(() => ({
+  embed: vi.fn(),
+}));
+
+vi.mock("vega-embed", () => ({
+  default: vegaMocks.embed,
+}));
+
+function installVegaRenderer() {
+  let Renderer: ComponentType<RendererProps> | undefined;
+
+  install({
+    register: vi.fn(),
+    registerPattern: (_test, component) => {
+      Renderer = component;
+    },
+  });
+
+  expect(Renderer).toBeDefined();
+  return Renderer!;
+}
+
+function createView() {
+  const changeset = {
+    remove: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+  };
+  return {
+    changeset: vi.fn(() => changeset),
+    change: vi.fn().mockReturnThis(),
+    finalize: vi.fn(),
+    runAsync: vi.fn().mockResolvedValue(undefined),
+    changesetMock: changeset,
+  };
+}
+
+describe("Vega renderer plugin", () => {
+  const firstSpec = {
+    $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+    data: { values: [{ x: 1, y: 2 }] },
+    mark: "point",
+    encoding: {
+      x: { field: "x", type: "quantitative" },
+      y: { field: "y", type: "quantitative" },
+    },
+  };
+
+  const nextValuesSpec = {
+    ...firstSpec,
+    data: { values: [{ x: 1, y: 4 }] },
+  };
+
+  beforeEach(() => {
+    document.documentElement.classList.remove("dark");
+    vegaMocks.embed.mockImplementation(() => Promise.resolve({ view: createView() }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("updates inline Vega-Lite values without re-embedding the view", async () => {
+    const Renderer = installVegaRenderer();
+    const view = createView();
+    vegaMocks.embed.mockResolvedValueOnce({ view });
+
+    const { rerender } = render(
+      <Renderer data={firstSpec} mimeType="application/vnd.vegalite.v5+json" />,
+    );
+
+    await waitFor(() => expect(vegaMocks.embed).toHaveBeenCalledTimes(1));
+
+    rerender(<Renderer data={nextValuesSpec} mimeType="application/vnd.vegalite.v5+json" />);
+
+    await waitFor(() => expect(view.runAsync).toHaveBeenCalledTimes(1));
+
+    expect(vegaMocks.embed).toHaveBeenCalledTimes(1);
+    expect(view.finalize).not.toHaveBeenCalled();
+    expect(view.change).toHaveBeenCalledWith("source_0", view.changesetMock);
+    expect(view.changesetMock.remove).toHaveBeenCalledWith(expect.any(Function));
+    expect(view.changesetMock.insert).toHaveBeenCalledWith(nextValuesSpec.data.values);
+  });
+
+  it("re-embeds when the Vega-Lite spec structure changes", async () => {
+    const Renderer = installVegaRenderer();
+    const firstView = createView();
+    const secondView = createView();
+    vegaMocks.embed.mockResolvedValueOnce({ view: firstView }).mockResolvedValueOnce({
+      view: secondView,
+    });
+
+    const { rerender } = render(
+      <Renderer data={firstSpec} mimeType="application/vnd.vegalite.v5+json" />,
+    );
+    await waitFor(() => expect(vegaMocks.embed).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <Renderer
+        data={{
+          ...firstSpec,
+          mark: "bar",
+        }}
+        mimeType="application/vnd.vegalite.v5+json"
+      />,
+    );
+
+    await waitFor(() => expect(vegaMocks.embed).toHaveBeenCalledTimes(2));
+
+    expect(firstView.finalize).toHaveBeenCalledTimes(1);
+    expect(firstView.change).not.toHaveBeenCalled();
+  });
+
+  it("updates inline values for a Vega spec with a named dataset", async () => {
+    const Renderer = installVegaRenderer();
+    const view = createView();
+    vegaMocks.embed.mockResolvedValueOnce({ view });
+    const firstVegaSpec = {
+      $schema: "https://vega.github.io/schema/vega/v5.json",
+      data: [{ name: "table", values: [{ x: 1, y: 2 }] }],
+      marks: [{ type: "symbol", from: { data: "table" } }],
+    };
+
+    const { rerender } = render(
+      <Renderer data={firstVegaSpec} mimeType="application/vnd.vega.v5+json" />,
+    );
+    await waitFor(() => expect(vegaMocks.embed).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <Renderer
+        data={{
+          ...firstVegaSpec,
+          data: [{ name: "table", values: [{ x: 1, y: 8 }] }],
+        }}
+        mimeType="application/vnd.vega.v5+json"
+      />,
+    );
+
+    await waitFor(() => expect(view.runAsync).toHaveBeenCalledTimes(1));
+
+    expect(vegaMocks.embed).toHaveBeenCalledTimes(1);
+    expect(view.change).toHaveBeenCalledWith("table", view.changesetMock);
+    expect(view.changesetMock.insert).toHaveBeenCalledWith([{ x: 1, y: 8 }]);
+  });
+
+  it("finalizes the previous view when data becomes invalid", async () => {
+    const Renderer = installVegaRenderer();
+    const view = createView();
+    vegaMocks.embed.mockResolvedValueOnce({ view });
+
+    const { rerender } = render(
+      <Renderer data={firstSpec} mimeType="application/vnd.vegalite.v5+json" />,
+    );
+    await waitFor(() => expect(vegaMocks.embed).toHaveBeenCalledTimes(1));
+
+    rerender(<Renderer data={null} mimeType="application/vnd.vegalite.v5+json" />);
+
+    expect(view.finalize).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/isolated-renderer/vega-renderer.tsx
+++ b/src/isolated-renderer/vega-renderer.tsx
@@ -6,7 +6,7 @@
  * Loaded into the isolated iframe via the renderer plugin API.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import vegaEmbed from "vega-embed";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +23,11 @@ function isVegaMimeType(mime: string): boolean {
 
 interface VegaView {
   finalize: () => void;
+  changeset: () => {
+    remove: (tuples: unknown) => { insert: (tuples: unknown) => unknown };
+  };
+  change: (name: string, changeset: unknown) => VegaView;
+  runAsync: () => Promise<unknown>;
 }
 
 function embedOptions(isDark: boolean) {
@@ -39,42 +44,209 @@ interface RendererProps {
   mimeType: string;
 }
 
+interface InlineDataUpdate {
+  datasetName: string;
+  values: unknown[];
+  structuralKey: string;
+}
+
+interface EmbeddedVegaView {
+  element: HTMLDivElement;
+  view: VegaView;
+  finalize: () => void;
+  inlineUpdate: InlineDataUpdate | null;
+}
+
+interface VegaEmbedResult {
+  view: VegaView;
+  finalize?: () => void;
+}
+
+const INLINE_VALUES_SENTINEL = "__nteract_inline_values__";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSpec(data: unknown): Record<string, unknown> | null {
+  if (typeof data === "string") {
+    try {
+      const parsed = JSON.parse(data) as unknown;
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return isRecord(data) ? data : null;
+}
+
+function withTransparentBackground(spec: Record<string, unknown>): Record<string, unknown> {
+  // Spec-level background has the highest priority in Vega's merge chain,
+  // so this reliably overrides theme and config defaults.
+  return { ...spec, background: "transparent" };
+}
+
+function inlineDataUpdateForSpec(spec: Record<string, unknown>): InlineDataUpdate | null {
+  const data = spec.data;
+
+  if (isRecord(data) && Array.isArray(data.values)) {
+    // Vega-Lite compiles a top-level inline `data.values` source to `source_0`.
+    return {
+      datasetName: "source_0",
+      values: data.values,
+      structuralKey: JSON.stringify(
+        withTransparentBackground({
+          ...spec,
+          data: { ...data, values: INLINE_VALUES_SENTINEL },
+        }),
+      ),
+    };
+  }
+
+  if (!Array.isArray(data)) return null;
+
+  const inlineDataEntries = data.filter(
+    (entry): entry is Record<string, unknown> =>
+      isRecord(entry) && typeof entry.name === "string" && Array.isArray(entry.values),
+  );
+  if (inlineDataEntries.length !== 1) return null;
+
+  // Reuse only the unambiguous Vega case: one named inline dataset whose values changed.
+  const [inlineData] = inlineDataEntries;
+  return {
+    datasetName: inlineData.name as string,
+    values: inlineData.values as unknown[],
+    structuralKey: JSON.stringify(
+      withTransparentBackground({
+        ...spec,
+        data: data.map((entry) =>
+          entry === inlineData ? { ...inlineData, values: INLINE_VALUES_SENTINEL } : entry,
+        ),
+      }),
+    ),
+  };
+}
+
+function embeddedViewForResult(
+  element: HTMLDivElement,
+  result: VegaEmbedResult,
+  inlineUpdate: InlineDataUpdate | null,
+): EmbeddedVegaView {
+  return {
+    element,
+    view: result.view,
+    finalize:
+      typeof result.finalize === "function" ? result.finalize : () => result.view.finalize(),
+    inlineUpdate,
+  };
+}
+
+function finalizeEmbedResult(result: VegaEmbedResult): void {
+  if (typeof result.finalize === "function") {
+    result.finalize();
+  } else {
+    result.view.finalize();
+  }
+}
+
 function VegaRenderer({ data }: RendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const embeddedViewRef = useRef<EmbeddedVegaView | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const spec = useMemo(() => parseSpec(data), [data]);
+  const specForEmbed = useMemo(() => (spec ? withTransparentBackground(spec) : null), [spec]);
+  const inlineUpdate = useMemo(() => (spec ? inlineDataUpdateForSpec(spec) : null), [spec]);
+
+  const finalizeEmbeddedView = useCallback(() => {
+    embeddedViewRef.current?.finalize();
+    embeddedViewRef.current = null;
+  }, []);
+
+  const setContainerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      const previous = containerRef.current;
+      if (!node && previous && embeddedViewRef.current?.element === previous) {
+        finalizeEmbeddedView();
+      }
+      containerRef.current = node;
+    },
+    [finalizeEmbeddedView],
+  );
+
+  useEffect(() => () => finalizeEmbeddedView(), [finalizeEmbeddedView]);
 
   useEffect(() => {
     setError(null);
-    if (!containerRef.current || !data) return;
+    if (!containerRef.current || !specForEmbed) {
+      finalizeEmbeddedView();
+      return;
+    }
 
     const el = containerRef.current;
     const isDark = document.documentElement.classList.contains("dark");
+    let active = true;
 
-    let view: VegaView | null = null;
-
-    // Force transparent background so it blends with the cell.
-    const spec = { ...(data as Record<string, unknown>), background: "transparent" };
-
-    vegaEmbed(el, spec as never, embedOptions(isDark)).then(
-      (result) => {
-        view = result.view as VegaView;
-      },
-      (err: Error) => {
-        console.error("[VegaRenderer] embed failed:", err);
-        setError(err.message || String(err));
-      },
-    );
-
-    // Re-embed on theme changes
-    const themeObserver = new MutationObserver(() => {
-      const nowDark = document.documentElement.classList.contains("dark");
-      view?.finalize();
-      vegaEmbed(el, spec as never, embedOptions(nowDark)).then(
+    const previous = embeddedViewRef.current;
+    if (
+      previous?.element === el &&
+      previous.inlineUpdate &&
+      inlineUpdate &&
+      previous.inlineUpdate.structuralKey === inlineUpdate.structuralKey
+    ) {
+      const changeset = previous.view
+        .changeset()
+        .remove(() => true)
+        .insert(inlineUpdate.values);
+      previous.view
+        .change(inlineUpdate.datasetName, changeset)
+        .runAsync()
+        .catch((err: Error) => {
+          if (!active) return;
+          console.error("[VegaRenderer] data update failed:", err);
+          setError(err.message || String(err));
+        });
+      previous.inlineUpdate = inlineUpdate;
+    } else {
+      finalizeEmbeddedView();
+      vegaEmbed(el, specForEmbed as never, embedOptions(isDark)).then(
         (result) => {
-          view = result.view as VegaView;
+          if (!active) {
+            finalizeEmbedResult(result as VegaEmbedResult);
+            return;
+          }
+          embeddedViewRef.current = embeddedViewForResult(
+            el,
+            result as VegaEmbedResult,
+            inlineUpdate,
+          );
         },
         (err: Error) => {
+          if (!active) return;
+          console.error("[VegaRenderer] embed failed:", err);
+          setError(err.message || String(err));
+        },
+      );
+    }
+
+    const themeObserver = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains("dark");
+      finalizeEmbeddedView();
+      vegaEmbed(el, specForEmbed as never, embedOptions(nowDark)).then(
+        (result) => {
+          if (!active) {
+            finalizeEmbedResult(result as VegaEmbedResult);
+            return;
+          }
+          embeddedViewRef.current = embeddedViewForResult(
+            el,
+            result as VegaEmbedResult,
+            inlineUpdate,
+          );
+        },
+        (err: Error) => {
+          if (!active) return;
           console.error("[VegaRenderer] embed failed on theme change:", err);
+          setError(err.message || String(err));
         },
       );
     });
@@ -84,16 +256,16 @@ function VegaRenderer({ data }: RendererProps) {
     });
 
     return () => {
+      active = false;
       themeObserver.disconnect();
-      view?.finalize();
     };
-  }, [data]);
+  }, [finalizeEmbeddedView, inlineUpdate, specForEmbed]);
 
-  if (!data) return null;
+  if (!specForEmbed) return null;
 
   return (
     <div
-      ref={containerRef}
+      ref={setContainerRef}
       data-slot="vega-output"
       className={cn("not-prose py-2 max-w-full overflow-visible")}
     >


### PR DESCRIPTION
## Summary

- Reuse an existing Vega view for display updates when only inline data values changed.
- Keep structural spec changes and theme changes on the safer re-embed path.
- Add isolated renderer tests for Vega-Lite inline data, Vega named inline datasets, structural re-embed fallback, and invalid-data cleanup.
- Regenerate the checked-in Vega renderer plugin bundle.

## Verification

- `pnpm test:run src/isolated-renderer/__tests__/vega-renderer.test.tsx src/components/outputs/__tests__/vega-output.test.tsx`
- `cargo xtask renderer-plugins`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
