### PR TITLE
docs(architecture): clarify room authority boundaries

### DIFF
--- a/docs/architecture/blob-storage-and-content-addressing.md
+++ b/docs/architecture/blob-storage-and-content-addressing.md
@@ -368,6 +368,14 @@ it should never reconstruct a cloud route shape from `notebookId` or any
 other doc-level value. On the desktop, both default to the daemon's local
 HTTP origin and the same port, but the contracts can move independently.
 
+The resolver boundary is also an authority boundary. `BlobBackend` stores bytes;
+`BlobResolver` decides how an authorized viewer obtains them. `PutBlob` and
+multipart upload only transfer bytes into the backend. They do not grant read
+access, mutate room state, or prove that a peer may reference the hash from a
+particular document path. Hosted room hosts must authorize both the upload
+surface and the later `NotebookDoc` / `RuntimeStateDoc` reference that makes the
+blob reachable.
+
 1. **Port-change tolerance.** Daemon restart with a new port is one refresh
    on the resolver, not a doc rewrite.
 2. **Cloud transport reuse.** The hosted notebook path

--- a/docs/architecture/deployment-topology.md
+++ b/docs/architecture/deployment-topology.md
@@ -38,6 +38,22 @@ placement as the same concept. The current model has sharper nouns:
 - **file binding**: an optional local `.ipynb` persistence surface, not the
   identity of the room.
 
+Authority boundaries:
+
+- A **room locator** is an address for reaching a room host. It is not an ACL
+  grant, runtime attachment, owner claim, blob credential, or file lock.
+- The **room host** is document authority. It owns live document materialization,
+  scope enforcement, sync fanout, and snapshot persistence for the room.
+- The **room ACL** is access authority. Credentials authenticate principals;
+  ACL rows and provider bounds decide the connection scope.
+- A **runtime peer** is compute authority only for the room surfaces its scope
+  grants: runtime state, output, lifecycle, and referenced blobs. It does not
+  own the room and does not move the document authority to JupyterHub.
+- A **blob upload** is byte transfer. It becomes reachable room state only when
+  an authorized `NotebookDoc` or `RuntimeStateDoc` mutation references it.
+- A **file binding** is local persistence metadata. It is not the room identity
+  and should not decide who owns a hosted room.
+
 The desired product direction is:
 
 ```text
@@ -49,7 +65,7 @@ Cloudflare Worker + Durable Object room host
         |
         | scoped runtime_peer WebSocket
         v
-JupyterHub-spawned compute / kernel sidecar
+JupyterHub runtime sidecar / compute
 ```
 
 Cloudflare is the document engine and collaboration surface. Anaconda OIDC,
@@ -269,6 +285,11 @@ hosted room, or refuse to autosave if another daemon owns the same file binding.
 The same-path autosave collision remains tracked by #2285 and should be fixed
 with a local lock/heartbeat or dirty-disk refusal independent of this hosted
 topology.
+
+Do not encode runtime provider, identity provider, owner principal, or blob
+backend into a locator unless that component is actually the room host. A
+JupyterHub-backed kernel for an Anaconda-hosted room remains runtime attachment
+metadata and an ACL grant, not part of the room address.
 
 ## Decision 6: Durable state is split by responsibility
 

--- a/docs/architecture/hosted-room-authorization.md
+++ b/docs/architecture/hosted-room-authorization.md
@@ -56,6 +56,18 @@ The existing `notebooks.owner_principal` column becomes catalog metadata. It is
 useful for listing and provenance, but it is not the authorization source of
 truth. The owner permission is an ACL row with `scope = 'owner'`.
 
+This keeps the hosted authority split explicit:
+
+- The room URL addresses a room host; it does not grant access.
+- The Durable Object is document authority; it materializes and validates live
+  `NotebookDoc` and `RuntimeStateDoc` state for the room.
+- The ACL is access authority; it decides whether a validated principal may
+  connect as `viewer`, `editor`, `runtime_peer`, or `owner`.
+- JupyterHub and other compute providers authorize their own compute resources,
+  then attach as scoped runtime peers when the room ACL permits it.
+- Blob uploads are subordinate to the connection scope and the later document
+  path that references the uploaded hash.
+
 ## Decision 2: ACL rows are explicit D1 records
 
 The next schema migration adds `notebook_acl`:
@@ -275,6 +287,9 @@ bridge, or JupyterHub sidecar. A runtime peer:
 
 This keeps kernel attachment separate from document editing. A hosted room can
 exist without a runtime peer and still render/persist notebook state.
+It also keeps JupyterHub out of the document-authority path for the preferred
+Anaconda-hosted topology: Hub grants access to compute, while the room ACL
+grants `runtime_peer` access to the room.
 
 ## Decision 9: Blob and plugin origins stay separate
 

--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -5,7 +5,11 @@
 
 ## Context
 
-`NotebookDoc` and `RuntimeStateDoc` sync between peers via typed-frame v4 over a Unix socket today, with same-UID trust covering attribution. We want to extend the same protocol to hosted multi-user rooms (Anaconda hosted, JupyterHub-spawned, future deployments) without forking the wire format, and we want every change in the document to carry verifiable authorship.
+`NotebookDoc` and `RuntimeStateDoc` sync between peers via typed-frame v4 over
+a Unix socket today, with same-UID trust covering attribution. We want to
+extend the same protocol to hosted multi-user rooms (Anaconda hosted,
+JupyterHub-backed compute, future deployments) without forking the wire format,
+and we want every change in the document to carry verifiable authorship.
 
 The identity design is highly guided by these projects:
 
@@ -42,13 +46,19 @@ This also lends us to better audit logging.
 
 ## Decision 2: Rooms are entities; access is a per-room ACL
 
-A notebook room is an entity in its own right, identified by a host-derived URI:
+A notebook room is an entity in its own right, addressed by a room locator:
 
-- `local-daemon:<uuid>` or `local-daemon:<path>` for rooms served by the local daemon.
+- `local-daemon:<uuid>` or `local-daemon:<path>` for rooms served by the local
+  daemon.
 - `runtimed.com/n/<uuid>` (or similar) for Anaconda-hosted rooms.
-- `hub.example.com/<user>/n/<uuid>` for JupyterHub-spawned rooms.
+- `hub.example.com/<user>/n/<uuid>` only when that Hub deployment explicitly
+  runs the room host. A JupyterHub runtime sidecar attached to an
+  Anaconda-hosted room is not encoded in the room locator.
 
-The URI says *where the room lives*, not *who can access it*. Access is governed by a **per-room ACL** that maps principals to scopes.
+The locator says *where to reach the room host*, not *who can access it*, where
+compute runs, or which blob store backs output bytes. The room host is the live
+document authority for `NotebookDoc` and `RuntimeStateDoc`. Access is governed
+by a **per-room ACL** that maps principals to scopes.
 
 ```
 room: runtimed.com/n/9f3a...
@@ -62,7 +72,8 @@ The ACL can reference principals from any identity provider the host is configur
 
 Three properties fall out:
 
-1. **Room URIs are stable across ownership changes.** Changing the owner principal mutates the ACL, not the URI. Existing links keep working.
+1. **Room locators are stable across ownership changes.** Changing the owner
+   principal mutates the ACL, not the locator. Existing links keep working.
 2. **Rooms can mix principals from multiple IdPs** when the host is configured to validate more than one. Cross-IdP collaboration (e.g., an Anaconda-hosted room shared with a JupyterHub user) is a deployment decision, not a protocol invention.
 3. **Future organizational principals** (`org:acme:engineering`, group memberships, etc.) slot into the ACL as additional principal kinds without changing the wire or the validator.
 


### PR DESCRIPTION
## Summary

- Clarifies that room locators are addresses, not authority grants or runtime placement.
- Records the authority split across room hosts, room ACLs, runtime peers, blob uploads, and file bindings.
- Updates identity, hosted-room authorization, deployment topology, and blob storage ADR language so JupyterHub-backed compute stays a runtime attachment rather than document authority.

## Verification

- `cargo xtask lint --fix`

## Review Plan

- Keep as draft until repo-local `pr-review` is clear and CI passes.
