### PR TITLE
fix(notebook-cloud): gate editor runtime state writes

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -2,11 +2,7 @@ import type { DurableObjectState, Env } from "./cloudflare-types.ts";
 import { FrameType, encodeTypedFrame, type FrameTypeValue, type TypedFrame } from "./protocol.ts";
 import { createEmptyRoomHost, loadRoomHostSnapshot, type RoomHostHandle } from "./runtimed-wasm.ts";
 import { getNotebookCatalog } from "./storage.ts";
-import {
-  allowsNotebookWrite,
-  allowsRuntimeStateWrite,
-  type AuthenticatedConnection,
-} from "./identity.ts";
+import { allowsNotebookWrite, type AuthenticatedConnection } from "./identity.ts";
 import { cloudLog, durationMs, errorMessage } from "./observability.ts";
 
 const ROOM_HOST_ACTOR_LABEL = "system/schema:notebook-cloud-room";
@@ -56,7 +52,7 @@ export class RoomMaterializer {
         host.sync_peer(
           peer.id,
           allowsNotebookWrite(peer.identity.scope),
-          allowsRuntimeStateWrite(peer.identity.scope),
+          allowsHostedRuntimeStateWrite(peer.identity),
         ),
       ),
     );
@@ -72,7 +68,7 @@ export class RoomMaterializer {
     const canWrite =
       frame.type === FrameType.AUTOMERGE_SYNC
         ? allowsNotebookWrite(peer.identity.scope)
-        : allowsRuntimeStateWrite(peer.identity.scope);
+        : allowsHostedRuntimeStateWrite(peer.identity);
     const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);
     return this.withHost((host) =>
@@ -253,6 +249,11 @@ export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {
 
 export function typedFrameFromRoomHostOutbound(frame: RoomHostOutboundFrame): Uint8Array {
   return encodeTypedFrame(frame.frame_type, toUint8Array(frame.payload));
+}
+
+function allowsHostedRuntimeStateWrite(identity: AuthenticatedConnection): boolean {
+  // Hosted editors are markdown-only until RuntimeStateDoc path validation lands.
+  return identity.scope === "owner" || identity.scope === "runtime_peer";
 }
 
 function normalizeResult(value: unknown): RoomHostFrameResult {

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -427,6 +427,51 @@ describe("RoomMaterializer", () => {
 
     assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
   });
+
+  it("allows runtime peers, not editors, to author runtime state changes", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const runtimePeerConnection = { id: "peer-runtime", identity: runtimeIdentity };
+    const runtimePeer = new RuntimeStatePeerHandle(runtimeIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, runtimePeerConnection, runtimePeer);
+    runtimePeer.create_execution_with_source("exec-runtime", "print('runtime')", 0);
+    const runtimeMessage = runtimePeer.flush_runtime_state_sync();
+    assert.ok(runtimeMessage);
+
+    const accepted = await materializer.receiveFrame(runtimePeerConnection, {
+      type: FrameType.RUNTIME_STATE_SYNC,
+      payload: runtimeMessage,
+    });
+    assert.equal(accepted.changed, true);
+    assert.equal(accepted.runtime_state_changed, true);
+
+    const editorIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=editor"),
+    );
+    const editorPeerConnection = { id: "peer-editor", identity: editorIdentity };
+    const editorPeer = NotebookHandle.create_bootstrap(editorIdentity.actorLabel);
+    await syncMaterializerRuntimeStateWithClient(materializer, editorPeerConnection, editorPeer);
+    assert.deepEqual(editorPeer.get_execution_by_id("exec-runtime"), {
+      status: "queued",
+      success: null,
+      execution_count: null,
+      output_ids: [],
+    });
+
+    await assert.rejects(
+      () =>
+        materializer.receiveFrame(editorPeerConnection, {
+          type: FrameType.RUNTIME_STATE_SYNC,
+          payload: runtimeMessage,
+        }),
+      /cannot write RuntimeStateDoc changes/,
+    );
+  });
 });
 
 function syncHostWithClient(
@@ -496,6 +541,74 @@ async function syncMaterializerWithClient(
     for (const reply of replies) {
       const next = await materializer.receiveFrame(peer, {
         type: FrameType.AUTOMERGE_SYNC,
+        payload: reply.slice(1),
+      });
+      outbound.push(...next.outbound);
+    }
+    result = {
+      changed: false,
+      notebook_changed: false,
+      runtime_state_changed: false,
+      outbound,
+    };
+  }
+}
+
+async function syncMaterializerWithRuntimePeer(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  runtime: RuntimeStatePeerHandle,
+): Promise<void> {
+  let result = await materializer.syncPeer(peer);
+  for (let round = 0; round < 8; round += 1) {
+    const replies = applyRuntimeOutboundToRuntimePeer(result.outbound, peer.id, runtime);
+    if (replies.length === 0) {
+      return;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.RUNTIME_STATE_SYNC,
+        payload: reply.slice(1),
+      });
+      outbound.push(...next.outbound);
+    }
+    result = {
+      changed: false,
+      notebook_changed: false,
+      runtime_state_changed: false,
+      outbound,
+    };
+  }
+}
+
+async function syncMaterializerRuntimeStateWithClient(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  client: NotebookHandle,
+): Promise<void> {
+  const outbound = [];
+  const initial = client.flush_runtime_state_sync();
+  if (initial) {
+    const reply = await materializer.receiveFrame(peer, {
+      type: FrameType.RUNTIME_STATE_SYNC,
+      payload: initial,
+    });
+    outbound.push(...reply.outbound);
+  }
+
+  const hostSync = await materializer.syncPeer(peer);
+  outbound.push(...hostSync.outbound);
+  let result = { ...hostSync, outbound };
+  for (let round = 0; round < 8; round += 1) {
+    const replies = applyRuntimeOutboundToClient(result.outbound, peer.id, client);
+    if (replies.length === 0) {
+      return;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.RUNTIME_STATE_SYNC,
         payload: reply.slice(1),
       });
       outbound.push(...next.outbound);


### PR DESCRIPTION
## Summary

- Restrict hosted room RuntimeStateDoc authorship to owner/runtime_peer scopes.
- Keep editors able to sync/read runtime state while preserving their existing markdown NotebookDoc edit path.
- Add a RoomMaterializer regression test proving runtime_peer writes pass and editor RuntimeStateDoc writes are rejected.

## Why

RuntimeStateDoc carries execution and output state. Hosted markdown editors should not be able to forge runtime records while the fuller comm-state path validator remains a follow-up.

This follows the authority language in `docs/architecture/runtime-peer-and-blob-authority-audit.md` and the draft room-authority ADR: the DO room host remains document authority, the room ACL grants connection scope, and `runtime_peer` is the scoped compute/runtime-state author.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts test/notebook-room.test.ts test/worker-routes.test.ts`
- `vp check`
- `git diff --check`
- `cargo xtask lint --fix`
