### PR TITLE
[ipy-opt] Add Output widget replay measurements

### DIFF
--- a/crates/notebook/fixtures/audit-test/17-output-widget-replay-stress.ipynb
+++ b/crates/notebook/fixtures/audit-test/17-output-widget-replay-stress.ipynb
@@ -1,0 +1,52 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "output-widget-replay-stress",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from IPython.display import display\n",
+        "import ipywidgets as widgets\n",
+        "\n",
+        "out = widgets.Output()\n",
+        "display(out)\n",
+        "\n",
+        "with out:\n",
+        "    for index in range(200):\n",
+        "        print(f\"captured-{index:03d}-\" + \"x\" * 64)\n",
+        "\n",
+        "print(\"output-widget-replay-stress-done\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "post-widget-replay-health-check",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(\"kernel-responsive-after-output-widget-replay\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "runt": {
+      "env_id": "fixture-output-widget-replay-stress",
+      "uv": {
+        "dependencies": [
+          "ipywidgets>=8,<9"
+        ],
+        "requires-python": ">=3.10"
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/crates/runtimed/examples/output_widget_replay_measure.rs
+++ b/crates/runtimed/examples/output_widget_replay_measure.rs
@@ -1,0 +1,34 @@
+use runtimed::output_widget_replay_measure::{
+    measure_current_replay_loop, ReplayMeasurementConfig,
+};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let counts = parse_counts(
+        std::env::var("NTERACT_OUTPUT_WIDGET_REPLAY_COUNTS")
+            .unwrap_or_else(|_| "10,100,500".to_string())
+            .as_str(),
+    );
+    let payload_bytes = std::env::var("NTERACT_OUTPUT_WIDGET_REPLAY_PAYLOAD_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(256);
+
+    for output_count in counts {
+        let metrics = measure_current_replay_loop(ReplayMeasurementConfig {
+            output_count,
+            payload_bytes,
+        })
+        .await?;
+        println!("{}", serde_json::to_string(&metrics)?);
+    }
+
+    Ok(())
+}
+
+fn parse_counts(raw: &str) -> Vec<usize> {
+    raw.split(',')
+        .filter_map(|part| part.trim().parse::<usize>().ok())
+        .filter(|count| *count > 0)
+        .collect()
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -44,6 +44,7 @@ pub mod notebook_sync_server;
 pub mod output_prep;
 pub(crate) mod output_redaction;
 pub mod output_store;
+pub mod output_widget_replay_measure;
 pub mod paths;
 pub(crate) mod pixi_project;
 pub mod process_groups;

--- a/crates/runtimed/src/output_widget_replay_measure.rs
+++ b/crates/runtimed/src/output_widget_replay_measure.rs
@@ -1,0 +1,171 @@
+//! Reproducible measurements for the current Output widget replay loop.
+//!
+//! This module intentionally models the shape of the current IOPub OutputModel
+//! replay path without changing production behavior: append a captured output
+//! manifest to `RuntimeStateDoc.comms[*].outputs`, mirror the full outputs list
+//! into comm state, resolve every manifest, then enqueue one kernel-facing
+//! replay update.
+
+use std::time::Instant;
+
+use anyhow::Context;
+use runtime_doc::RuntimeStateDoc;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::blob_store::BlobStore;
+use crate::output_store::{self, OutputManifest, DEFAULT_INLINE_THRESHOLD};
+
+const COMM_ID: &str = "comm-output-replay-measure";
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReplayMeasurementConfig {
+    pub output_count: usize,
+    pub payload_bytes: usize,
+}
+
+impl Default for ReplayMeasurementConfig {
+    fn default() -> Self {
+        Self {
+            output_count: 100,
+            payload_bytes: 256,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplayMeasurement {
+    pub output_count: usize,
+    pub payload_bytes: usize,
+    pub comm_output_appends: usize,
+    pub comm_state_mirrors: usize,
+    pub replay_updates: usize,
+    pub manifest_resolutions: usize,
+    pub resolved_outputs_sent: usize,
+    pub append_nanos: u128,
+    pub mirror_nanos: u128,
+    pub resolve_nanos: u128,
+    pub total_nanos: u128,
+}
+
+impl ReplayMeasurement {
+    fn new(config: ReplayMeasurementConfig) -> Self {
+        Self {
+            output_count: config.output_count,
+            payload_bytes: config.payload_bytes,
+            comm_output_appends: 0,
+            comm_state_mirrors: 0,
+            replay_updates: 0,
+            manifest_resolutions: 0,
+            resolved_outputs_sent: 0,
+            append_nanos: 0,
+            mirror_nanos: 0,
+            resolve_nanos: 0,
+            total_nanos: 0,
+        }
+    }
+}
+
+pub async fn measure_current_replay_loop(
+    config: ReplayMeasurementConfig,
+) -> anyhow::Result<ReplayMeasurement> {
+    let blob_root = std::env::temp_dir().join(format!(
+        "runtimed-output-widget-replay-measure-{}",
+        Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&blob_root)
+        .await
+        .with_context(|| format!("create blob root {}", blob_root.display()))?;
+    let blob_store = BlobStore::new(blob_root.clone());
+
+    let started = Instant::now();
+    let mut metrics = ReplayMeasurement::new(config);
+    let mut doc = RuntimeStateDoc::new();
+    doc.put_comm(
+        COMM_ID,
+        "jupyter.widget",
+        "@jupyter-widgets/output",
+        "OutputModel",
+        &serde_json::json!({ "outputs": [] }),
+        0,
+    )?;
+
+    for index in 0..config.output_count {
+        let output = captured_stream_output(index, config.payload_bytes);
+        let manifest =
+            output_store::create_manifest(&output, &blob_store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .context("create output manifest")?;
+        let manifest_json = manifest.to_json();
+
+        let append_started = Instant::now();
+        doc.append_comm_output(COMM_ID, &manifest_json)?;
+        metrics.append_nanos += append_started.elapsed().as_nanos();
+        metrics.comm_output_appends += 1;
+
+        let mirror_started = Instant::now();
+        let output_manifests = doc
+            .get_comm(COMM_ID)
+            .map(|entry| entry.outputs)
+            .unwrap_or_default();
+        doc.set_comm_state_property(
+            COMM_ID,
+            "outputs",
+            &serde_json::Value::Array(output_manifests.clone()),
+        )?;
+        metrics.mirror_nanos += mirror_started.elapsed().as_nanos();
+        metrics.comm_state_mirrors += 1;
+
+        let resolve_started = Instant::now();
+        let mut resolved_outputs = Vec::with_capacity(output_manifests.len());
+        for output_manifest in output_manifests {
+            let manifest: OutputManifest =
+                serde_json::from_value(output_manifest).context("parse output manifest")?;
+            let resolved = output_store::resolve_manifest(&manifest, &blob_store)
+                .await
+                .context("resolve output manifest")?;
+            resolved_outputs.push(resolved);
+            metrics.manifest_resolutions += 1;
+        }
+        metrics.resolve_nanos += resolve_started.elapsed().as_nanos();
+        metrics.resolved_outputs_sent += resolved_outputs.len();
+        metrics.replay_updates += 1;
+    }
+
+    metrics.total_nanos = started.elapsed().as_nanos();
+    let _ = tokio::fs::remove_dir_all(&blob_root).await;
+    Ok(metrics)
+}
+
+fn captured_stream_output(index: usize, payload_bytes: usize) -> serde_json::Value {
+    let prefix = format!("captured-{index:06}:");
+    let padding_len = payload_bytes.saturating_sub(prefix.len() + 1);
+    let text = format!("{prefix}{}\n", "x".repeat(padding_len));
+    serde_json::json!({
+        "output_type": "stream",
+        "name": "stdout",
+        "text": text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn measurement_records_triangular_resolve_work_for_current_replay_loop() {
+        let metrics = measure_current_replay_loop(ReplayMeasurementConfig {
+            output_count: 4,
+            payload_bytes: 16,
+        })
+        .await
+        .expect("measurement should run");
+
+        assert_eq!(metrics.output_count, 4);
+        assert_eq!(metrics.comm_output_appends, 4);
+        assert_eq!(metrics.comm_state_mirrors, 4);
+        assert_eq!(metrics.replay_updates, 4);
+        assert_eq!(metrics.manifest_resolutions, 10);
+        assert_eq!(metrics.resolved_outputs_sent, 10);
+    }
+}

--- a/docs/architecture/output-widget-replay-measurements.md
+++ b/docs/architecture/output-widget-replay-measurements.md
@@ -1,0 +1,66 @@
+# Output Widget Replay Measurements
+
+**Status:** Draft, 2026-05-24.
+
+This note records the reproducible measurement surface for the current
+runtime-agent to IPython Output widget replay path. It is intentionally a
+measurement baseline, not an optimization.
+
+## What Is Measured
+
+When a Jupyter Output widget captures output, the IOPub task currently:
+
+1. appends one output manifest to `RuntimeStateDoc.comms[*].outputs`;
+2. mirrors the full outputs list into the comm state `outputs` property;
+3. resolves every manifest in that full list back to nbformat JSON;
+4. sends one best-effort `SendCommUpdate` replay to the kernel.
+
+The durable record remains `RuntimeStateDoc`. The kernel-facing replay is
+best-effort convenience for the Python-side Output widget object.
+
+## Rust Measurement
+
+Run the measurement helper from the repository root:
+
+```bash
+NTERACT_OUTPUT_WIDGET_REPLAY_COUNTS=10,50,100 \
+NTERACT_OUTPUT_WIDGET_REPLAY_PAYLOAD_BYTES=256 \
+cargo run -p runtimed --example output_widget_replay_measure
+```
+
+Each output line is JSON. The key field is `manifest_resolutions`: with the
+current replay loop, `N` captured outputs resolve `N * (N + 1) / 2` manifests
+because every replay update resolves the full output list.
+
+Example shape:
+
+```json
+{"output_count":100,"manifest_resolutions":5050,"resolved_outputs_sent":5050}
+```
+
+The unit test
+`output_widget_replay_measure::tests::measurement_records_triangular_resolve_work_for_current_replay_loop`
+pins that deterministic triangular work count. Wall-clock fields are included
+for local comparison between branches, but they should not be used as strict CI
+assertions.
+
+## Notebook Fixtures
+
+Two audit fixtures cover the widget pressure that motivated the stack:
+
+- `crates/notebook/fixtures/audit-test/16-widget-slider.ipynb` exercises rapid
+  frontend-to-kernel widget state changes and kernel responsiveness.
+- `crates/notebook/fixtures/audit-test/17-output-widget-replay-stress.ipynb`
+  creates one Output widget and captures 200 stream outputs into it. This is
+  the representative high-output replay fixture for future local or E2E checks.
+
+## Optimization Target
+
+The first optimization PR should reduce kernel-facing replay work without
+changing these invariants:
+
+- `RuntimeStateDoc.comms[*].outputs` remains the durable source of truth.
+- Output widget `clear_output(wait=...)` semantics are preserved.
+- IOPub must not await bounded replay backpressure.
+- `KernelIdle`, `CellError`, `ExecutionDone`, and `KernelDied` remain on the
+  reliable lifecycle path, not on best-effort output work transport.


### PR DESCRIPTION
## Summary

- Add a reproducible Rust measurement helper for the current Output widget replay loop.
- Add `cargo run -p runtimed --example output_widget_replay_measure` for local branch-to-branch measurements.
- Add an audit fixture notebook with one Output widget capturing 200 stream outputs.
- Document the measurement command, current triangular work shape, and invariants for the next optimization PR.

## Evidence

Post-rebase sample:

```json
{"output_count":10,"payload_bytes":256,"comm_output_appends":10,"comm_state_mirrors":10,"replay_updates":10,"manifest_resolutions":55,"resolved_outputs_sent":55}
{"output_count":50,"payload_bytes":256,"comm_output_appends":50,"comm_state_mirrors":50,"replay_updates":50,"manifest_resolutions":1275,"resolved_outputs_sent":1275}
{"output_count":100,"payload_bytes":256,"comm_output_appends":100,"comm_state_mirrors":100,"replay_updates":100,"manifest_resolutions":5050,"resolved_outputs_sent":5050}
```

The deterministic count is `N * (N + 1) / 2`, matching the current full-list replay behavior.

## Verification

- `cargo test -p runtimed output_widget_replay_measure::tests::measurement_records_triangular_resolve_work_for_current_replay_loop`
- `NTERACT_OUTPUT_WIDGET_REPLAY_COUNTS=10,50,100 NTERACT_OUTPUT_WIDGET_REPLAY_PAYLOAD_BYTES=256 cargo run -p runtimed --example output_widget_replay_measure`
- `cargo test -p runtimed`
- `cargo xtask lint --fix`
- `jq empty crates/notebook/fixtures/audit-test/17-output-widget-replay-stress.ipynb`
