### PR TITLE
test(renderer): harden output identity policy

### DIFF
--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af4edc9ecd366d1116a32920bf1bb02b704b073fef98690101aa4a99cefcff6f
-size 1486266
+oid sha256:399aab2710b774c1a1e3e76410090a39fa677edbe5c42c68eedc5a7828a464b7
+size 1486385

--- a/src/isolated-renderer/__tests__/output-identity.test.ts
+++ b/src/isolated-renderer/__tests__/output-identity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { outputEntryIdForPayload } from "../output-identity";
+
+describe("isolated renderer output identity", () => {
+  it("uses outputId as the stable renderer key across display updates", () => {
+    const first = outputEntryIdForPayload({
+      outputId: "display-output-1",
+      cellId: "cell-a",
+      outputIndex: 0,
+    });
+    const update = outputEntryIdForPayload({
+      outputId: "display-output-1",
+      cellId: "cell-a",
+      outputIndex: 0,
+    });
+
+    expect(update).toBe(first);
+  });
+
+  it("uses different outputIds as different renderer keys for fresh outputs", () => {
+    const first = outputEntryIdForPayload({
+      outputId: "execution-1-output",
+      cellId: "cell-a",
+      outputIndex: 0,
+    });
+    const fresh = outputEntryIdForPayload({
+      outputId: "execution-2-output",
+      cellId: "cell-a",
+      outputIndex: 0,
+    });
+
+    expect(fresh).not.toBe(first);
+  });
+
+  it("falls back to cell id and output index for legacy payloads without outputId", () => {
+    expect(outputEntryIdForPayload({ cellId: "cell-a", outputIndex: 2 })).toBe("cell-a-2");
+    expect(outputEntryIdForPayload({ cellId: "cell-a" }, { fallbackIndex: 3 })).toBe("cell-a-3");
+  });
+
+  it("keeps no-id single renders transient while no-id batch renders are positional", () => {
+    expect(
+      outputEntryIdForPayload(
+        {},
+        {
+          transientFallback: true,
+          createTransientId: () => "output-transient",
+        },
+      ),
+    ).toBe("output-transient");
+    expect(outputEntryIdForPayload({}, { fallbackIndex: 4 })).toBe("output-4");
+  });
+});

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -58,6 +58,7 @@ import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { measureDocumentHeight } from "./layout-measure";
+import { outputEntryIdForPayload } from "./output-identity";
 // Import widget support
 import { IframeWidgetStoreProvider } from "./widget-provider";
 
@@ -498,16 +499,7 @@ function IsolatedRendererApp() {
       case "render": {
         const renderPayload = payload as RenderPayload;
 
-        // Prefer the daemon-stamped output_id when available — it is stable
-        // across display_update, stream appends, and cell reorders, so
-        // React reconciliation won't re-mount sibling outputs. Fall back
-        // to cellId+outputIndex for render paths that don't carry one
-        // (e.g. the markdown cell renders a single payload with no id).
-        const id = renderPayload.outputId
-          ? renderPayload.outputId
-          : renderPayload.cellId
-            ? `${renderPayload.cellId}-${renderPayload.outputIndex ?? 0}`
-            : `output-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const id = outputEntryIdForPayload(renderPayload, { transientFallback: true });
 
         setState((prev) => {
           if (renderPayload.replace) {
@@ -532,14 +524,7 @@ function IsolatedRendererApp() {
       case "renderBatch": {
         const batchPayload = payload as { outputs: RenderPayload[] };
         const entries: OutputEntry[] = (batchPayload.outputs ?? []).map((p, i) => ({
-          // Prefer daemon-stamped output_id (stable across stream append /
-          // display_update / reorder). Fall back to positional key only for
-          // payloads without an id (legacy render paths).
-          id: p.outputId
-            ? p.outputId
-            : p.cellId
-              ? `${p.cellId}-${p.outputIndex ?? i}`
-              : `output-${i}`,
+          id: outputEntryIdForPayload(p, { fallbackIndex: i }),
           payload: p,
         }));
         setState((prev) => ({ ...prev, outputs: entries }));

--- a/src/isolated-renderer/output-identity.ts
+++ b/src/isolated-renderer/output-identity.ts
@@ -1,0 +1,35 @@
+interface OutputIdentityPayload {
+  outputId?: string;
+  cellId?: string;
+  outputIndex?: number;
+}
+
+interface OutputEntryIdOptions {
+  fallbackIndex?: number;
+  transientFallback?: boolean;
+  createTransientId?: () => string;
+}
+
+function defaultTransientOutputId(): string {
+  return `output-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function outputEntryIdForPayload(
+  payload: OutputIdentityPayload,
+  options: OutputEntryIdOptions = {},
+): string {
+  // Daemon-stamped output_id is the identity boundary: display_update keeps
+  // the same key, while fresh execution outputs get fresh ids and remount.
+  if (payload.outputId) return payload.outputId;
+
+  const fallbackIndex = options.fallbackIndex ?? 0;
+  if (payload.cellId) {
+    return `${payload.cellId}-${payload.outputIndex ?? fallbackIndex}`;
+  }
+
+  if (options.transientFallback) {
+    return (options.createTransientId ?? defaultTransientOutputId)();
+  }
+
+  return `output-${fallbackIndex}`;
+}


### PR DESCRIPTION
## Summary

- Extract isolated renderer output key selection into a small tested helper
- Document the identity boundary: daemon-stamped `outputId` is reused for `display_update`, while fresh outputs get fresh ids and remount
- Preserve legacy fallback behavior for payloads that do not carry `outputId`

## Verification

- `pnpm test:run src/isolated-renderer/__tests__/output-identity.test.ts`
- `cargo xtask renderer-plugins`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
