### PR TITLE
[ipy-opt] Cache Output widget replay resolution

### DIFF
--- a/crates/runtimed/examples/output_widget_replay_measure.rs
+++ b/crates/runtimed/examples/output_widget_replay_measure.rs
@@ -1,5 +1,5 @@
 use runtimed::output_widget_replay_measure::{
-    measure_current_replay_loop, ReplayMeasurementConfig,
+    measure_cached_replay_loop, measure_current_replay_loop, ReplayMeasurementConfig,
 };
 
 #[tokio::main]
@@ -15,12 +15,27 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(256);
 
     for output_count in counts {
-        let metrics = measure_current_replay_loop(ReplayMeasurementConfig {
+        let config = ReplayMeasurementConfig {
             output_count,
             payload_bytes,
-        })
-        .await?;
-        println!("{}", serde_json::to_string(&metrics)?);
+        };
+        let current = measure_current_replay_loop(config).await?;
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({
+                "strategy": "current",
+                "metrics": current,
+            }))?
+        );
+
+        let cached = measure_cached_replay_loop(config).await?;
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({
+                "strategy": "cached",
+                "metrics": cached,
+            }))?
+        );
     }
 
     Ok(())

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -220,6 +220,49 @@ fn try_send_comm_update(
     }
 }
 
+async fn resolve_output_widget_replay_state(
+    replay_cache: &mut HashMap<String, Vec<serde_json::Value>>,
+    comm_id: &str,
+    output_manifests: &[serde_json::Value],
+    appended_manifest: &OutputManifest,
+    cleared_before_append: bool,
+    blob_store: &crate::blob_store::BlobStore,
+) -> Vec<serde_json::Value> {
+    if cleared_before_append {
+        replay_cache.remove(comm_id);
+    }
+
+    let cached_outputs = replay_cache.entry(comm_id.to_string()).or_default();
+    if cached_outputs.len() + 1 == output_manifests.len() {
+        match output_store::resolve_manifest(appended_manifest, blob_store).await {
+            Ok(resolved) => cached_outputs.push(resolved),
+            Err(e) => warn!(
+                "[jupyter-kernel] Failed to resolve appended Output widget manifest for comm_id={}: {}",
+                comm_id, e
+            ),
+        }
+    } else {
+        cached_outputs.clear();
+        for output_manifest in output_manifests {
+            match serde_json::from_value::<OutputManifest>(output_manifest.clone()) {
+                Ok(manifest) => match output_store::resolve_manifest(&manifest, blob_store).await {
+                    Ok(resolved) => cached_outputs.push(resolved),
+                    Err(e) => warn!(
+                        "[jupyter-kernel] Failed to resolve Output widget manifest for comm_id={}: {}",
+                        comm_id, e
+                    ),
+                },
+                Err(e) => warn!(
+                    "[jupyter-kernel] Failed to parse Output widget manifest for comm_id={}: {}",
+                    comm_id, e
+                ),
+            }
+        }
+    }
+
+    cached_outputs.clone()
+}
+
 /// Created at kernel launch time, captures connection_info and session_id.
 /// Can be used concurrently with other kernel operations since interrupt
 /// creates its own ZMQ control connection.
@@ -1297,6 +1340,8 @@ impl KernelConnection for JupyterKernel {
                 // Track Output widgets with pending clear_output(wait=true).
                 let mut pending_clear_widgets: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
+                let mut output_widget_replay_cache: HashMap<String, Vec<serde_json::Value>> =
+                    HashMap::new();
 
                 // Capture routing cache: msg_id -> comm_id.
                 let mut capture_cache: std::collections::HashMap<String, String> =
@@ -1528,24 +1573,16 @@ impl KernelConnection for JupyterKernel {
                                                 .ok()
                                                 .flatten();
                                             if let Some(output_manifests) = output_manifests {
-                                                let mut resolved_outputs = Vec::new();
-                                                for m in &output_manifests {
-                                                    if let Ok(manifest) =
-                                                        serde_json::from_value::<OutputManifest>(
-                                                            m.clone(),
-                                                        )
-                                                    {
-                                                        if let Ok(resolved) =
-                                                            output_store::resolve_manifest(
-                                                                &manifest,
-                                                                &blob_store,
-                                                            )
-                                                            .await
-                                                        {
-                                                            resolved_outputs.push(resolved);
-                                                        }
-                                                    }
-                                                }
+                                                let resolved_outputs =
+                                                    resolve_output_widget_replay_state(
+                                                        &mut output_widget_replay_cache,
+                                                        &widget_comm_id,
+                                                        &output_manifests,
+                                                        &manifest,
+                                                        need_clear,
+                                                        &blob_store,
+                                                    )
+                                                    .await;
                                                 try_send_comm_update(
                                                     &iopub_work_tx,
                                                     widget_comm_id.clone(),
@@ -1664,24 +1701,16 @@ impl KernelConnection for JupyterKernel {
                                                     .ok()
                                                     .flatten();
                                                 if let Some(output_manifests) = output_manifests {
-                                                    let mut resolved_outputs = Vec::new();
-                                                    for m in &output_manifests {
-                                                        if let Ok(manifest) = serde_json::from_value::<
-                                                            OutputManifest,
-                                                        >(
-                                                            m.clone()
-                                                        ) {
-                                                            if let Ok(r) =
-                                                                output_store::resolve_manifest(
-                                                                    &manifest,
-                                                                    &blob_store,
-                                                                )
-                                                                .await
-                                                            {
-                                                                resolved_outputs.push(r);
-                                                            }
-                                                        }
-                                                    }
+                                                    let resolved_outputs =
+                                                        resolve_output_widget_replay_state(
+                                                            &mut output_widget_replay_cache,
+                                                            &widget_comm_id,
+                                                            &output_manifests,
+                                                            &manifest,
+                                                            need_clear,
+                                                            &blob_store,
+                                                        )
+                                                        .await;
                                                     try_send_comm_update(
                                                         &iopub_work_tx,
                                                         widget_comm_id.clone(),
@@ -1883,24 +1912,16 @@ impl KernelConnection for JupyterKernel {
                                                     .ok()
                                                     .flatten();
                                                 if let Some(output_manifests) = output_manifests {
-                                                    let mut resolved_outputs = Vec::new();
-                                                    for m in &output_manifests {
-                                                        if let Ok(manifest) = serde_json::from_value::<
-                                                            OutputManifest,
-                                                        >(
-                                                            m.clone()
-                                                        ) {
-                                                            if let Ok(r) =
-                                                                output_store::resolve_manifest(
-                                                                    &manifest,
-                                                                    &blob_store,
-                                                                )
-                                                                .await
-                                                            {
-                                                                resolved_outputs.push(r);
-                                                            }
-                                                        }
-                                                    }
+                                                    let resolved_outputs =
+                                                        resolve_output_widget_replay_state(
+                                                            &mut output_widget_replay_cache,
+                                                            &widget_comm_id,
+                                                            &output_manifests,
+                                                            &manifest,
+                                                            need_clear,
+                                                            &blob_store,
+                                                        )
+                                                        .await;
                                                     try_send_comm_update(
                                                         &iopub_work_tx,
                                                         widget_comm_id.clone(),
@@ -2004,6 +2025,7 @@ impl KernelConnection for JupyterKernel {
                                             pending_clear_widgets.insert(widget_comm_id.clone());
                                         } else {
                                             pending_clear_widgets.remove(&widget_comm_id);
+                                            output_widget_replay_cache.remove(&widget_comm_id);
                                             if let Err(e) = state_for_iopub.with_doc(|sd| {
                                                 sd.clear_comm_outputs(&widget_comm_id)?;
                                                 sd.set_comm_state_property(
@@ -2278,6 +2300,7 @@ impl KernelConnection for JupyterKernel {
                                     }
 
                                     capture_cache.retain(|_, cid| cid != &close.comm_id.0);
+                                    output_widget_replay_cache.remove(&close.comm_id.0);
 
                                     if let Err(e) = state_for_iopub
                                         .with_doc(|sd| sd.remove_comm(&close.comm_id.0))
@@ -3359,6 +3382,64 @@ mod tests {
             rx.try_recv().is_err(),
             "full work queue should drop comm output replay"
         );
+    }
+
+    #[tokio::test]
+    async fn output_widget_replay_cache_rebuilds_on_drift_and_clear() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let blob_store = crate::blob_store::BlobStore::new(tmp.path().to_path_buf());
+        let first = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "first\n",
+        });
+        let second = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "second\n",
+        });
+        let first_manifest =
+            output_store::create_manifest(&first, &blob_store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .expect("first manifest");
+        let second_manifest =
+            output_store::create_manifest(&second, &blob_store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .expect("second manifest");
+
+        let mut replay_cache = HashMap::new();
+        let rebuilt = resolve_output_widget_replay_state(
+            &mut replay_cache,
+            "comm-a",
+            &[first_manifest.to_json(), second_manifest.to_json()],
+            &second_manifest,
+            false,
+            &blob_store,
+        )
+        .await;
+        assert_eq!(
+            rebuilt.len(),
+            2,
+            "cache drift should rebuild from manifests"
+        );
+        assert_eq!(rebuilt[0]["text"], "first\n");
+        assert_eq!(rebuilt[1]["text"], "second\n");
+
+        let cleared = resolve_output_widget_replay_state(
+            &mut replay_cache,
+            "comm-a",
+            &[second_manifest.to_json()],
+            &second_manifest,
+            true,
+            &blob_store,
+        )
+        .await;
+        assert_eq!(
+            cleared.len(),
+            1,
+            "clear_output(wait=true) should discard stale replay cache"
+        );
+        assert_eq!(cleared[0]["text"], "second\n");
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/output_widget_replay_measure.rs
+++ b/crates/runtimed/src/output_widget_replay_measure.rs
@@ -6,6 +6,7 @@
 //! into comm state, resolve every manifest, then enqueue one kernel-facing
 //! replay update.
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 use anyhow::Context;
@@ -137,6 +138,89 @@ pub async fn measure_current_replay_loop(
     Ok(metrics)
 }
 
+pub async fn measure_cached_replay_loop(
+    config: ReplayMeasurementConfig,
+) -> anyhow::Result<ReplayMeasurement> {
+    let blob_root = std::env::temp_dir().join(format!(
+        "runtimed-output-widget-replay-measure-{}",
+        Uuid::new_v4()
+    ));
+    tokio::fs::create_dir_all(&blob_root)
+        .await
+        .with_context(|| format!("create blob root {}", blob_root.display()))?;
+    let blob_store = BlobStore::new(blob_root.clone());
+
+    let started = Instant::now();
+    let mut metrics = ReplayMeasurement::new(config);
+    let mut doc = RuntimeStateDoc::new();
+    let mut resolved_output_cache: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
+    doc.put_comm(
+        COMM_ID,
+        "jupyter.widget",
+        "@jupyter-widgets/output",
+        "OutputModel",
+        &serde_json::json!({ "outputs": [] }),
+        0,
+    )?;
+
+    for index in 0..config.output_count {
+        let output = captured_stream_output(index, config.payload_bytes);
+        let manifest =
+            output_store::create_manifest(&output, &blob_store, DEFAULT_INLINE_THRESHOLD)
+                .await
+                .context("create output manifest")?;
+        let manifest_json = manifest.to_json();
+
+        let append_started = Instant::now();
+        doc.append_comm_output(COMM_ID, &manifest_json)?;
+        metrics.append_nanos += append_started.elapsed().as_nanos();
+        metrics.comm_output_appends += 1;
+
+        let mirror_started = Instant::now();
+        let output_manifests = doc
+            .get_comm(COMM_ID)
+            .map(|entry| entry.outputs)
+            .unwrap_or_default();
+        doc.set_comm_state_property(
+            COMM_ID,
+            "outputs",
+            &serde_json::Value::Array(output_manifests.clone()),
+        )?;
+        metrics.mirror_nanos += mirror_started.elapsed().as_nanos();
+        metrics.comm_state_mirrors += 1;
+
+        let resolve_started = Instant::now();
+        let cached_outputs = resolved_output_cache
+            .entry(COMM_ID.to_string())
+            .or_default();
+        if cached_outputs.len() + 1 == output_manifests.len() {
+            let resolved = output_store::resolve_manifest(&manifest, &blob_store)
+                .await
+                .context("resolve appended output manifest")?;
+            cached_outputs.push(resolved);
+            metrics.manifest_resolutions += 1;
+        } else {
+            cached_outputs.clear();
+            for output_manifest in &output_manifests {
+                let manifest: OutputManifest = serde_json::from_value(output_manifest.clone())
+                    .context("parse output manifest")?;
+                let resolved = output_store::resolve_manifest(&manifest, &blob_store)
+                    .await
+                    .context("resolve output manifest")?;
+                cached_outputs.push(resolved);
+                metrics.manifest_resolutions += 1;
+            }
+        }
+        metrics.resolve_nanos += resolve_started.elapsed().as_nanos();
+        metrics.resolved_outputs_sent += cached_outputs.len();
+        metrics.replay_updates += 1;
+    }
+
+    metrics.total_nanos = started.elapsed().as_nanos();
+    let _ = tokio::fs::remove_dir_all(&blob_root).await;
+    Ok(metrics)
+}
+
 fn captured_stream_output(index: usize, payload_bytes: usize) -> serde_json::Value {
     let prefix = format!("captured-{index:06}:");
     let padding_len = payload_bytes.saturating_sub(prefix.len() + 1);
@@ -166,6 +250,23 @@ mod tests {
         assert_eq!(metrics.comm_state_mirrors, 4);
         assert_eq!(metrics.replay_updates, 4);
         assert_eq!(metrics.manifest_resolutions, 10);
+        assert_eq!(metrics.resolved_outputs_sent, 10);
+    }
+
+    #[tokio::test]
+    async fn cached_replay_resolves_each_manifest_once() {
+        let metrics = measure_cached_replay_loop(ReplayMeasurementConfig {
+            output_count: 4,
+            payload_bytes: 16,
+        })
+        .await
+        .expect("measurement should run");
+
+        assert_eq!(metrics.output_count, 4);
+        assert_eq!(metrics.comm_output_appends, 4);
+        assert_eq!(metrics.comm_state_mirrors, 4);
+        assert_eq!(metrics.replay_updates, 4);
+        assert_eq!(metrics.manifest_resolutions, 4);
         assert_eq!(metrics.resolved_outputs_sent, 10);
     }
 }

--- a/docs/architecture/output-widget-replay-measurements.md
+++ b/docs/architecture/output-widget-replay-measurements.md
@@ -28,20 +28,25 @@ NTERACT_OUTPUT_WIDGET_REPLAY_PAYLOAD_BYTES=256 \
 cargo run -p runtimed --example output_widget_replay_measure
 ```
 
-Each output line is JSON. The key field is `manifest_resolutions`: with the
-current replay loop, `N` captured outputs resolve `N * (N + 1) / 2` manifests
-because every replay update resolves the full output list.
+Each output line is JSON with a `strategy` and nested `metrics`. The key field
+is `metrics.manifest_resolutions`: with the current replay loop, `N` captured
+outputs resolve `N * (N + 1) / 2` manifests because every replay update
+resolves the full output list. The cached strategy resolves only the newly
+appended manifest when its local cache matches the durable output list.
 
 Example shape:
 
 ```json
-{"output_count":100,"manifest_resolutions":5050,"resolved_outputs_sent":5050}
+{"strategy":"current","metrics":{"output_count":100,"manifest_resolutions":5050,"resolved_outputs_sent":5050}}
+{"strategy":"cached","metrics":{"output_count":100,"manifest_resolutions":100,"resolved_outputs_sent":5050}}
 ```
 
 The unit test
 `output_widget_replay_measure::tests::measurement_records_triangular_resolve_work_for_current_replay_loop`
-pins that deterministic triangular work count. Wall-clock fields are included
-for local comparison between branches, but they should not be used as strict CI
+pins that deterministic triangular work count. The companion
+`cached_replay_resolves_each_manifest_once` test pins the linearized resolution
+target for the Output widget replay cache. Wall-clock fields are included for
+local comparison between branches, but they should not be used as strict CI
 assertions.
 
 ## Notebook Fixtures


### PR DESCRIPTION
## Summary

- Cache resolved Output widget replay outputs per comm so each newly captured manifest is resolved once on the hot path.
- Rebuild the cache from `RuntimeStateDoc` manifests if local cache length drifts, and clear it across `clear_output` and `comm_close`.
- Extend the replay measurement example/docs with `current` vs `cached` strategies.

## Evidence

- Red test first: `cargo test -p runtimed output_widget_replay_measure::tests::cached_replay_resolves_each_manifest_once` failed before implementation with missing `measure_cached_replay_loop`.
- `cargo test -p runtimed output_widget_replay_measure::tests`
- `cargo test -p runtimed output_widget_replay_cache_rebuilds_on_drift_and_clear`
- `NTERACT_OUTPUT_WIDGET_REPLAY_COUNTS=10,50,100 NTERACT_OUTPUT_WIDGET_REPLAY_PAYLOAD_BYTES=256 cargo run -p runtimed --example output_widget_replay_measure`
- `cargo xtask lint --fix`
- `cargo test -p runtimed`

For 100 captured outputs at 256 bytes, the measurement example reported:

- `current`: `manifest_resolutions=5050`, `resolved_outputs_sent=5050`
- `cached`: `manifest_resolutions=100`, `resolved_outputs_sent=5050`

## Stack

- Depends on #2917.
