### PR TITLE
fix(renderer): require explicit output identity

### DIFF
--- a/apps/notebook-cloud/test/mime-policy.test.ts
+++ b/apps/notebook-cloud/test/mime-policy.test.ts
@@ -19,6 +19,7 @@ describe("cloud viewer MIME policy", () => {
 
     const payload = jupyterOutputToRenderPayload(
       {
+        output_id: "test-widget-output",
         output_type: "display_data",
         data,
         metadata: {},

--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -8,11 +8,13 @@ describe("cloud viewer render resolution", () => {
     const outputs = await resolveOutputs(
       [
         {
+          output_id: "healthy-stdout",
           output_type: "stream",
           name: "stdout",
           text: "healthy stdout\n",
         },
         {
+          output_id: "missing-display",
           output_type: "display_data",
           data: {
             "text/plain": {
@@ -27,6 +29,7 @@ describe("cloud viewer render resolution", () => {
 
     assert.equal(outputs.length, 2);
     assert.deepEqual(outputs[0], {
+      output_id: "healthy-stdout",
       output_type: "stream",
       name: "stdout",
       text: "healthy stdout\n",
@@ -47,7 +50,14 @@ describe("cloud viewer render resolution", () => {
           cell_type: "code",
           source: "print('ok')",
           execution_count: 1,
-          outputs: [{ output_type: "stream", name: "stdout", text: "ok\n" }],
+          outputs: [
+            {
+              output_id: "healthy-cell-stdout",
+              output_type: "stream",
+              name: "stdout",
+              text: "ok\n",
+            },
+          ],
         },
         rejectingBlobResolver(),
         0,
@@ -60,6 +70,7 @@ describe("cloud viewer render resolution", () => {
           execution_count: 2,
           outputs: [
             {
+              output_id: "broken-result",
               output_type: "execute_result",
               execution_count: 2,
               data: {
@@ -151,11 +162,13 @@ describe("cloud viewer render resolution", () => {
         execution_count: "null",
         outputs: [
           {
+            output_id: "runtime-count-stream",
             output_type: "stream",
             name: "stdout",
             text: "loaded\n",
           },
           {
+            output_id: "runtime-count-result",
             output_type: "execute_result",
             execution_count: 7,
             data: { "text/plain": "shape: (25, 8)" },
@@ -171,6 +184,76 @@ describe("cloud viewer render resolution", () => {
     assert.equal(cell.executionId, "exec-runtime-count");
   });
 
+  it("stamps direct outputs without output_id before isolated rendering", async () => {
+    const cell = await resolveCell(
+      {
+        id: "raw-output-cell",
+        cell_type: "code",
+        source: "print('legacy')",
+        outputs: [
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "legacy\n",
+          },
+        ],
+      },
+      rejectingBlobResolver(),
+      0,
+    );
+
+    assert.equal(cell.outputs.length, 1);
+    assert.equal(cell.outputs[0].output_id, "cloud-output:raw-output-cell:0");
+  });
+
+  it("reports manifest-shaped outputs without output_id instead of rendering ContentRefs", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_type: "display_data",
+          data: {
+            "text/plain": { inline: "legacy manifest text" },
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+      "legacy-manifest-cell",
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_type, "error");
+    assert.equal(outputs[0].output_id, "resolution-error:cloud-output:legacy-manifest-cell:0");
+    if (outputs[0].output_type === "error") {
+      assert.match(outputs[0].evalue, /without output_id/);
+    }
+  });
+
+  it("does not mistake JSON MIME objects with url fields for ContentRefs", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_type: "display_data",
+          data: {
+            "application/json": { url: "https://example.test/value" },
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+      "json-url-cell",
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_id, "cloud-output:json-url-cell:0");
+    assert.equal(outputs[0].output_type, "display_data");
+    if (outputs[0].output_type === "display_data") {
+      assert.deepEqual(outputs[0].data["application/json"], {
+        url: "https://example.test/value",
+      });
+    }
+  });
+
   it("uses the first finite execute_result count as the output fallback", async () => {
     const cell = await resolveCell(
       {
@@ -180,12 +263,14 @@ describe("cloud viewer render resolution", () => {
         execution_count: "null",
         outputs: [
           {
+            output_id: "multiple-results-a",
             output_type: "execute_result",
             execution_count: 7,
             data: { "text/plain": "a" },
             metadata: {},
           },
           {
+            output_id: "multiple-results-b",
             output_type: "execute_result",
             execution_count: 8,
             data: { "text/plain": "b" },
@@ -209,11 +294,13 @@ describe("cloud viewer render resolution", () => {
         execution_count: "null",
         outputs: [
           {
+            output_id: "no-result-count-stream",
             output_type: "stream",
             name: "stdout",
             text: "loaded\n",
           },
           {
+            output_id: "no-result-count-display",
             output_type: "display_data",
             execution_count: 99,
             data: { "text/plain": "display only" },
@@ -232,6 +319,7 @@ describe("cloud viewer render resolution", () => {
     const outputs = await resolveOutputs(
       [
         {
+          output_id: "direct-columnar-refs",
           output_type: "execute_result",
           execution_count: 1,
           data: {
@@ -277,6 +365,7 @@ describe("cloud viewer render resolution", () => {
         execution_count: 3,
         outputs: [
           {
+            output_id: "cell-count-result",
             output_type: "execute_result",
             execution_count: 7,
             data: { "text/plain": "shape: (25, 8)" },

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -35,13 +35,14 @@ export async function resolveCell(
 ): Promise<ResolvedCell> {
   const cellType = normalizeCellType(cell.cell_type);
   const metadata = normalizeMetadata(cell.metadata);
+  const cellId = typeof cell.id === "string" ? cell.id : `cell-${index + 1}`;
   const outputs = Array.isArray(cell.outputs)
-    ? await resolveOutputs(cell.outputs, blobResolver)
+    ? await resolveOutputs(cell.outputs, blobResolver, cellId)
     : [];
   const executionCount =
     normalizeExecutionCount(cell.execution_count) ?? executionCountFromOutputs(outputs);
   return {
-    id: typeof cell.id === "string" ? cell.id : `cell-${index + 1}`,
+    id: cellId,
     cellType,
     source: typeof cell.source === "string" ? cell.source : "",
     language: cellType === "code" ? (normalizeCellLanguage(metadata) ?? defaultLanguage) : null,
@@ -55,13 +56,15 @@ export async function resolveCell(
 export async function resolveOutputs(
   outputs: unknown[],
   blobResolver: BlobResolver,
+  cellId: string = "output",
 ): Promise<JupyterOutput[]> {
   const resolved = await Promise.all(
-    outputs.map(async (output) => {
+    outputs.map(async (output, index) => {
+      const syntheticOutputId = `cloud-output:${cellId}:${index}`;
       try {
-        return await resolveOutput(output, blobResolver);
+        return await resolveOutput(output, blobResolver, syntheticOutputId);
       } catch (error) {
-        return outputResolutionError(error);
+        return outputResolutionError(error, output, syntheticOutputId);
       }
     }),
   );
@@ -71,10 +74,11 @@ export async function resolveOutputs(
 async function resolveOutput(
   output: unknown,
   blobResolver: BlobResolver,
+  syntheticOutputId: string,
 ): Promise<JupyterOutput | null> {
   if (typeof output === "string") {
     try {
-      return resolveOutput(JSON.parse(output) as unknown, blobResolver);
+      return resolveOutput(JSON.parse(output) as unknown, blobResolver, syntheticOutputId);
     } catch {
       return null;
     }
@@ -84,16 +88,30 @@ async function resolveOutput(
     return resolveManifest(output as OutputManifest, blobResolver) as Promise<JupyterOutput>;
   }
 
+  if (isManifestWithMissingOutputId(output)) {
+    throw new Error("Cannot resolve output manifest without output_id");
+  }
+
   if (isJupyterOutput(output)) {
-    return output;
+    return identifyJupyterOutput(output, syntheticOutputId);
   }
 
   return null;
 }
 
-function outputResolutionError(error: unknown): JupyterOutput {
+function identifyJupyterOutput(output: JupyterOutput, outputId: string): JupyterOutput {
+  if (output.output_id) return output;
+  return { ...output, output_id: outputId };
+}
+
+function outputResolutionError(
+  error: unknown,
+  output: unknown,
+  syntheticOutputId: string,
+): JupyterOutput {
   const message = error instanceof Error ? error.message : String(error);
   return {
+    output_id: resolutionErrorOutputId(output, syntheticOutputId),
     output_type: "error",
     ename: "OutputResolutionError",
     evalue: `Unable to resolve output: ${message}`,
@@ -101,8 +119,61 @@ function outputResolutionError(error: unknown): JupyterOutput {
   };
 }
 
+function resolutionErrorOutputId(output: unknown, syntheticOutputId: string): string {
+  if (typeof output === "object" && output !== null) {
+    const outputId = (output as { output_id?: unknown }).output_id;
+    if (typeof outputId === "string" && outputId.length > 0) {
+      return `resolution-error:${outputId}`;
+    }
+  }
+  return `resolution-error:${syntheticOutputId}`;
+}
+
 function isJupyterOutput(value: unknown): value is JupyterOutput {
   return typeof value === "object" && value !== null && "output_type" in value;
+}
+
+function isManifestWithMissingOutputId(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const output = value as Record<string, unknown>;
+  if (typeof output.output_id === "string" && output.output_id.length > 0) return false;
+
+  if (output.output_type === "stream") {
+    return isContentRefLike(output.text);
+  }
+
+  if (output.output_type === "display_data" || output.output_type === "execute_result") {
+    const dataEntries = Object.entries(asRecord(output.data));
+    return (
+      dataEntries.length > 0 &&
+      dataEntries.every(([mimeType, ref]) => isContentRefLike(ref, mimeType))
+    );
+  }
+
+  if (output.output_type === "error") {
+    return isContentRefLike(output.traceback) || isContentRefLike(output.rich);
+  }
+
+  return false;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function isContentRefLike(value: unknown, mimeType?: string): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const ref = value as Record<string, unknown>;
+  if ("inline" in ref) return typeof ref.inline === "string";
+  if ("blob" in ref) return typeof ref.blob === "string";
+  if ("url" in ref) {
+    return typeof ref.url === "string" && !isJsonMimeType(mimeType);
+  }
+  return false;
+}
+
+function isJsonMimeType(mimeType: string | undefined): boolean {
+  return mimeType === "application/json" || mimeType?.endsWith("+json") === true;
 }
 
 function normalizeCellType(value: unknown): ResolvedCell["cellType"] {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -264,6 +264,7 @@ export const MarkdownCell = memo(function MarkdownCell({
       frameRef.current.render({
         mimeType: "text/plain",
         data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
+        outputId: `markdown-error:${cell.id}`,
         cellId: cell.id,
         replace: true,
       });
@@ -277,6 +278,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     frameRef.current.render({
       mimeType: "text/markdown",
       data: processedSource,
+      outputId: `markdown:${cell.id}`,
       cellId: cell.id,
       replace: true,
     });
@@ -297,6 +299,7 @@ export const MarkdownCell = memo(function MarkdownCell({
           frame.render({
             mimeType: "text/markdown",
             data: processedSource,
+            outputId: `markdown:${cell.id}`,
             cellId: cell.id,
             replace: true,
           });
@@ -306,6 +309,7 @@ export const MarkdownCell = memo(function MarkdownCell({
           frame.render({
             mimeType: "text/plain",
             data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
+            outputId: `markdown-error:${cell.id}`,
             cellId: cell.id,
             replace: true,
           });

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -200,6 +200,7 @@ describe("MarkdownCell theme sync", () => {
       expect(mockFrameHandle.render).toHaveBeenCalledWith({
         mimeType: "text/markdown",
         data: "```python\nprint('hello')\n```",
+        outputId: "markdown:md-1",
         cellId: "md-1",
         replace: true,
       });
@@ -215,6 +216,7 @@ describe("MarkdownCell theme sync", () => {
       expect(mockFrameHandle.render).toHaveBeenCalledWith({
         mimeType: "text/plain",
         data: "Failed to load markdown renderer: chunk failed",
+        outputId: "markdown-error:md-1",
         cellId: "md-1",
         replace: true,
       });

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -35,6 +35,7 @@ describe("isOutputManifest", () => {
   it("returns true for a stream manifest with inline ContentRef", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-stream-inline",
         output_type: "stream",
         name: "stdout",
         text: { inline: "hello\n" },
@@ -45,6 +46,7 @@ describe("isOutputManifest", () => {
   it("returns true for a stream manifest with blob ContentRef", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-stream-blob",
         output_type: "stream",
         name: "stdout",
         text: { blob: "abc123", size: 100 },
@@ -55,6 +57,7 @@ describe("isOutputManifest", () => {
   it("returns true for a display_data manifest", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-display-inline",
         output_type: "display_data",
         data: { "text/plain": { inline: "hi" } },
       }),
@@ -64,6 +67,7 @@ describe("isOutputManifest", () => {
   it("returns true for a display_data manifest with url ContentRef", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-display-url",
         output_type: "display_data",
         data: {
           "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
@@ -75,6 +79,7 @@ describe("isOutputManifest", () => {
   it("returns true for an execute_result manifest", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-execute-inline",
         output_type: "execute_result",
         data: { "text/plain": { inline: "42" } },
         execution_count: 1,
@@ -85,6 +90,7 @@ describe("isOutputManifest", () => {
   it("returns true for an error manifest with inline traceback", () => {
     expect(
       isOutputManifest({
+        output_id: "manifest-error-inline",
         output_type: "error",
         ename: "ValueError",
         evalue: "bad",
@@ -117,6 +123,16 @@ describe("isOutputManifest", () => {
     expect(isOutputManifest(null)).toBe(false);
   });
 
+  it("returns false for manifests without output_id", () => {
+    expect(
+      isOutputManifest({
+        output_type: "stream",
+        name: "stdout",
+        text: { inline: "hello\n" },
+      }),
+    ).toBe(false);
+  });
+
   it("returns false for a string", () => {
     expect(isOutputManifest("hello")).toBe(false);
   });
@@ -128,15 +144,23 @@ describe("isOutputManifest", () => {
   });
 
   it("returns false for display_data with empty data", () => {
-    expect(isOutputManifest({ output_type: "display_data", data: {} })).toBe(
-      false,
-    );
+    expect(
+      isOutputManifest({
+        output_id: "manifest-empty-display",
+        output_type: "display_data",
+        data: {},
+      }),
+    ).toBe(false);
   });
 
   it("returns false for unknown output_type", () => {
-    expect(isOutputManifest({ output_type: "unknown_type", data: {} })).toBe(
-      false,
-    );
+    expect(
+      isOutputManifest({
+        output_id: "manifest-unknown-type",
+        output_type: "unknown_type",
+        data: {},
+      }),
+    ).toBe(false);
   });
 });
 
@@ -149,12 +173,14 @@ describe("resolveManifestSync", () => {
 
   it("resolves stream manifest with inline text", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-stream-inline",
       output_type: "stream",
       name: "stdout",
       text: { inline: "hello\n" },
     };
     const output = resolveManifestSync(manifest, blobPort);
     expect(output).toEqual({
+      output_id: "sync-stream-inline",
       output_type: "stream",
       name: "stdout",
       text: "hello\n",
@@ -163,6 +189,7 @@ describe("resolveManifestSync", () => {
 
   it("returns null for stream manifest with blob text ref", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-stream-blob",
       output_type: "stream",
       name: "stdout",
       text: { blob: "abc123", size: 100 },
@@ -172,6 +199,7 @@ describe("resolveManifestSync", () => {
 
   it("resolves display_data with all inline refs", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-display-inline",
       output_type: "display_data",
       data: {
         "text/plain": { inline: "hi" },
@@ -182,6 +210,7 @@ describe("resolveManifestSync", () => {
     };
     const output = resolveManifestSync(manifest, blobPort);
     expect(output).toEqual({
+      output_id: "sync-display-inline",
       output_type: "display_data",
       data: { "text/plain": "hi", "text/html": "<b>hi</b>" },
       metadata: { isolated: true },
@@ -191,6 +220,7 @@ describe("resolveManifestSync", () => {
 
   it("resolves display_data with url ref", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-display-url",
       output_type: "display_data",
       data: {
         "image/png": { url: `http://127.0.0.1:${blobPort}/blob/imgblob` },
@@ -198,6 +228,7 @@ describe("resolveManifestSync", () => {
     };
     const output = resolveManifestSync(manifest, blobPort);
     expect(output).toEqual({
+      output_id: "sync-display-url",
       output_type: "display_data",
       data: { "image/png": `http://127.0.0.1:${blobPort}/blob/imgblob` },
       metadata: {},
@@ -207,6 +238,7 @@ describe("resolveManifestSync", () => {
 
   it("returns null for display_data with text blob ref", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-display-blob",
       output_type: "display_data",
       data: {
         "text/plain": { blob: "textblob", size: 5000 },
@@ -218,6 +250,7 @@ describe("resolveManifestSync", () => {
   it("resolves error manifest with inline traceback", () => {
     const traceback = ["line1", "line2"];
     const manifest: OutputManifest = {
+      output_id: "sync-error-inline",
       output_type: "error",
       ename: "ValueError",
       evalue: "bad",
@@ -225,6 +258,7 @@ describe("resolveManifestSync", () => {
     };
     const output = resolveManifestSync(manifest, blobPort);
     expect(output).toEqual({
+      output_id: "sync-error-inline",
       output_type: "error",
       ename: "ValueError",
       evalue: "bad",
@@ -234,6 +268,7 @@ describe("resolveManifestSync", () => {
 
   it("returns null for error manifest with blob traceback", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-error-blob",
       output_type: "error",
       ename: "ValueError",
       evalue: "bad",
@@ -247,6 +282,7 @@ describe("resolveManifestSync", () => {
     // manifest. Sync resolve should attach the parsed payload to the output.
     const richPayload = { ename: "KeyError", evalue: "'x'", frames: [], text: "KeyError: 'x'" };
     const manifest: OutputManifest = {
+      output_id: "sync-error-rich-inline",
       output_type: "error",
       ename: "KeyError",
       evalue: "'x'",
@@ -267,6 +303,7 @@ describe("resolveManifestSync", () => {
     // and the rich payload would never be fetched — rich tracebacks of
     // any size would downgrade to ANSI rendering.
     const manifest: OutputManifest = {
+      output_id: "sync-error-rich-blob",
       output_type: "error",
       ename: "ZeroDivisionError",
       evalue: "division by zero",
@@ -281,6 +318,7 @@ describe("resolveManifestSync", () => {
     // whose ANSI traceback didn't parse into frames). rich stays
     // undefined so OutputArea falls through to AnsiErrorOutput.
     const manifest: OutputManifest = {
+      output_id: "sync-error-no-rich",
       output_type: "error",
       ename: "ValueError",
       evalue: "bad",
@@ -295,6 +333,7 @@ describe("resolveManifestSync", () => {
 
   it("auto-parses JSON MIME types in sync resolution", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-json",
       output_type: "execute_result",
       data: {
         "application/json": { inline: '{"key":"value"}' },
@@ -312,6 +351,7 @@ describe("resolveManifestSync", () => {
 
   it("adds blob URLs to Arrow stream manifest chunks in sync resolution", () => {
     const manifest: OutputManifest = {
+      output_id: "sync-arrow-display",
       output_type: "display_data",
       data: {
         [ARROW_STREAM_MANIFEST_MIME]: {
@@ -600,6 +640,7 @@ describe("resolveManifest", () => {
   describe("display_data manifests", () => {
     it("resolves inline data refs", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-display-inline",
         output_type: "display_data",
         data: {
           "text/plain": { inline: "hello" },
@@ -611,6 +652,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-display-inline",
         output_type: "display_data",
         data: {
           "text/plain": "hello",
@@ -623,12 +665,14 @@ describe("resolveManifest", () => {
 
     it("defaults metadata to empty object when omitted", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-display-metadata-default",
         output_type: "display_data",
         data: { "text/plain": { inline: "hi" } },
       };
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-display-metadata-default",
         output_type: "display_data",
         data: { "text/plain": "hi" },
         metadata: {},
@@ -638,6 +682,7 @@ describe("resolveManifest", () => {
 
     it("resolves url refs directly", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-display-url",
         output_type: "display_data",
         data: {
           "image/png": { url: "http://127.0.0.1:9876/blob/pnghash" },
@@ -646,6 +691,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-display-url",
         output_type: "display_data",
         data: { "image/png": "http://127.0.0.1:9876/blob/pnghash" },
         metadata: {},
@@ -658,6 +704,7 @@ describe("resolveManifest", () => {
   describe("execute_result manifests", () => {
     it("resolves with execution_count", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-execute-count",
         output_type: "execute_result",
         data: { "text/plain": { inline: "42" } },
         execution_count: 5,
@@ -665,6 +712,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-execute-count",
         output_type: "execute_result",
         data: { "text/plain": "42" },
         metadata: {},
@@ -675,6 +723,7 @@ describe("resolveManifest", () => {
 
     it("defaults execution_count to null when omitted", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-execute-count-default",
         output_type: "execute_result",
         data: { "text/plain": { inline: "result" } },
       };
@@ -687,6 +736,7 @@ describe("resolveManifest", () => {
 
     it("preserves transient display_id", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-execute-display-id",
         output_type: "execute_result",
         data: { "text/plain": { inline: "x" } },
         transient: { display_id: "exec-d1" },
@@ -703,6 +753,7 @@ describe("resolveManifest", () => {
 
     it("auto-parses JSON MIME types in data", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-execute-json",
         output_type: "execute_result",
         data: {
           "application/json": { inline: '{"answer":42}' },
@@ -722,6 +773,7 @@ describe("resolveManifest", () => {
   describe("stream manifests", () => {
     it("resolves inline text", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-stream-inline",
         output_type: "stream",
         name: "stdout",
         text: { inline: "hello world\n" },
@@ -729,6 +781,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-stream-inline",
         output_type: "stream",
         name: "stdout",
         text: "hello world\n",
@@ -737,6 +790,7 @@ describe("resolveManifest", () => {
 
     it("resolves blob text", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-stream-blob",
         output_type: "stream",
         name: "stderr",
         text: { blob: "errhash", size: 100 },
@@ -748,6 +802,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-stream-blob",
         output_type: "stream",
         name: "stderr",
         text: "error output text",
@@ -759,6 +814,7 @@ describe("resolveManifest", () => {
     it("resolves traceback from inline ref", async () => {
       const traceback = ["frame1", "frame2", "frame3"];
       const manifest: OutputManifest = {
+        output_id: "async-error-inline",
         output_type: "error",
         ename: "ValueError",
         evalue: "invalid literal",
@@ -767,6 +823,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-error-inline",
         output_type: "error",
         ename: "ValueError",
         evalue: "invalid literal",
@@ -777,6 +834,7 @@ describe("resolveManifest", () => {
     it("resolves traceback from blob ref", async () => {
       const traceback = ["Traceback (most recent call last):", "  File ..."];
       const manifest: OutputManifest = {
+        output_id: "async-error-blob",
         output_type: "error",
         ename: "RuntimeError",
         evalue: "boom",
@@ -789,6 +847,7 @@ describe("resolveManifest", () => {
 
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
+        output_id: "async-error-blob",
         output_type: "error",
         ename: "RuntimeError",
         evalue: "boom",
@@ -798,6 +857,7 @@ describe("resolveManifest", () => {
 
     it("preserves ename and evalue verbatim", async () => {
       const manifest: OutputManifest = {
+        output_id: "async-error-verbatim",
         output_type: "error",
         ename: "Custom.Error.Name",
         evalue: "message with 'quotes' and \"doubles\"",

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -170,6 +170,7 @@ describe("resolveOutput", () => {
     const cached: JupyterOutput = streamOutput("stdout", "cached");
     const cache = new Map<string, JupyterOutput>();
     const manifest = {
+      output_id: "manifest-cached",
       output_type: "stream",
       name: "stdout",
       text: { inline: "cached" },
@@ -183,6 +184,7 @@ describe("resolveOutput", () => {
 
   it("resolves structured manifest object with inline refs", async () => {
     const manifest = {
+      output_id: "manifest-inline-stream",
       output_type: "stream",
       name: "stdout",
       text: { inline: "hello\n" },
@@ -191,6 +193,7 @@ describe("resolveOutput", () => {
 
     const result = await resolveOutput(manifest, 8765, cache);
     expect(result).toEqual({
+      output_id: "manifest-inline-stream",
       output_type: "stream",
       name: "stdout",
       text: "hello\n",
@@ -199,6 +202,7 @@ describe("resolveOutput", () => {
 
   it("resolves display_data manifest with inline data", async () => {
     const manifest = {
+      output_id: "manifest-inline-display",
       output_type: "display_data",
       data: {
         "text/plain": { inline: "hi" },
@@ -210,6 +214,7 @@ describe("resolveOutput", () => {
 
     const result = await resolveOutput(manifest, 8765, cache);
     expect(result).toEqual({
+      output_id: "manifest-inline-display",
       output_type: "display_data",
       data: { "text/plain": "hi", "text/html": "<b>hi</b>" },
       metadata: { isolated: true },
@@ -219,6 +224,7 @@ describe("resolveOutput", () => {
 
   it("resolves manifest with blob ref by fetching from blob server", async () => {
     const manifest = {
+      output_id: "manifest-blob-stream",
       output_type: "stream",
       name: "stdout",
       text: { blob: "abc123hash", size: 5000 },
@@ -232,6 +238,7 @@ describe("resolveOutput", () => {
 
     const result = await resolveOutput(manifest, blobPort, cache);
     expect(result).toEqual({
+      output_id: "manifest-blob-stream",
       output_type: "stream",
       name: "stdout",
       text: "big text output",
@@ -243,6 +250,7 @@ describe("resolveOutput", () => {
 
   it("caches resolved manifest output", async () => {
     const manifest = {
+      output_id: "manifest-cache-stream",
       output_type: "stream",
       name: "stdout",
       text: { inline: "cached manifest" },
@@ -256,6 +264,7 @@ describe("resolveOutput", () => {
     // Second call should hit cache without resolving
     const result = await resolveOutput(manifest, 8765, cache);
     expect(result).toEqual({
+      output_id: "manifest-cache-stream",
       output_type: "stream",
       name: "stdout",
       text: "cached manifest",
@@ -264,6 +273,7 @@ describe("resolveOutput", () => {
 
   it("returns null for manifest object when blobPort is null", async () => {
     const manifest = {
+      output_id: "manifest-missing-blob-resolver",
       output_type: "stream",
       name: "stdout",
       text: { blob: "abc123", size: 100 },
@@ -381,6 +391,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("converts a code cell with structured manifest outputs", async () => {
     const manifest = {
+      output_id: "manifest-code-stream",
       output_type: "stream",
       name: "stdout",
       text: { inline: "hello\n" },
@@ -394,7 +405,14 @@ describe("cellSnapshotsToNotebookCells", () => {
       cell_type: "code",
       source: "print('hello')",
       execution_count: 1,
-      outputs: [{ output_type: "stream", name: "stdout", text: "hello\n" }],
+      outputs: [
+        {
+          output_id: "manifest-code-stream",
+          output_type: "stream",
+          name: "stdout",
+          text: "hello\n",
+        },
+      ],
       metadata: {},
     });
   });
@@ -595,6 +613,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("filters out null (unparseable) outputs", async () => {
     const validManifest = {
+      output_id: "manifest-valid-stream",
       output_type: "stream",
       name: "stdout",
       text: { inline: "ok\n" },
@@ -610,6 +629,7 @@ describe("cellSnapshotsToNotebookCells", () => {
     if (cells[0].cell_type === "code") {
       expect(cells[0].outputs).toHaveLength(1);
       expect(cells[0].outputs[0]).toEqual({
+        output_id: "manifest-valid-stream",
         output_type: "stream",
         name: "stdout",
         text: "ok\n",
@@ -619,11 +639,13 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("passes through consecutive streams without merging (daemon consolidates)", async () => {
     const out1 = {
+      output_id: "manifest-stream-1",
       output_type: "stream",
       name: "stdout",
       text: { inline: "line1\n" },
     };
     const out2 = {
+      output_id: "manifest-stream-2",
       output_type: "stream",
       name: "stdout",
       text: { inline: "line2\n" },
@@ -637,11 +659,13 @@ describe("cellSnapshotsToNotebookCells", () => {
     if (cells[0].cell_type === "code") {
       expect(cells[0].outputs).toHaveLength(2);
       expect(cells[0].outputs[0]).toEqual({
+        output_id: "manifest-stream-1",
         output_type: "stream",
         name: "stdout",
         text: "line1\n",
       });
       expect(cells[0].outputs[1]).toEqual({
+        output_id: "manifest-stream-2",
         output_type: "stream",
         name: "stdout",
         text: "line2\n",
@@ -651,11 +675,13 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("does not merge streams with different names", async () => {
     const stdout = {
+      output_id: "manifest-stdout",
       output_type: "stream",
       name: "stdout",
       text: { inline: "out\n" },
     };
     const stderr = {
+      output_id: "manifest-stderr",
       output_type: "stream",
       name: "stderr",
       text: { inline: "err\n" },
@@ -670,6 +696,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("converts mixed cell types in order", async () => {
     const streamManifest = {
+      output_id: "manifest-ordered-stream",
       output_type: "stream",
       name: "stdout",
       text: { inline: "42\n" },
@@ -705,6 +732,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("uses shared cache across all output resolutions", async () => {
     const manifest = {
+      output_id: "manifest-shared-cache",
       output_type: "execute_result",
       data: { "text/plain": { inline: "same" } },
       execution_count: 1,
@@ -726,11 +754,13 @@ describe("cellSnapshotsToNotebookCells", () => {
   it("handles code cell with multiple output types", async () => {
     const outputs = [
       {
+        output_id: "manifest-multi-stream",
         output_type: "stream",
         name: "stdout",
         text: { inline: "computing...\n" },
       },
       {
+        output_id: "manifest-multi-execute",
         output_type: "execute_result",
         data: {
           "text/plain": { inline: "42" },
@@ -739,6 +769,7 @@ describe("cellSnapshotsToNotebookCells", () => {
         execution_count: 3,
       },
       {
+        output_id: "manifest-multi-display",
         output_type: "display_data",
         data: { "image/png": { url: "http://127.0.0.1:8765/blob/imgblob" } },
       },
@@ -756,6 +787,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("resolves manifest object outputs with blob refs when blobPort is provided", async () => {
     const manifest = {
+      output_id: "manifest-cell-blob-stream",
       output_type: "stream",
       name: "stdout",
       text: { blob: "blobhash123", size: 5000 },
@@ -770,6 +802,7 @@ describe("cellSnapshotsToNotebookCells", () => {
     if (cells[0].cell_type === "code") {
       expect(cells[0].outputs).toHaveLength(1);
       expect(cells[0].outputs[0]).toEqual({
+        output_id: "manifest-cell-blob-stream",
         output_type: "stream",
         name: "stdout",
         text: "from manifest\n",
@@ -782,6 +815,7 @@ describe("cellSnapshotsToNotebookCells", () => {
 
   it("handles manifest object with no blobPort gracefully", async () => {
     const manifest = {
+      output_id: "manifest-cell-missing-blob-resolver",
       output_type: "stream",
       name: "stdout",
       text: { blob: "blobhash", size: 100 },
@@ -828,6 +862,7 @@ describe("cellSnapshotsToNotebookCells", () => {
       "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero",
     ];
     const errManifest = {
+      output_id: "manifest-error-output",
       output_type: "error",
       ename: "ZeroDivisionError",
       evalue: "division by zero",

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:399aab2710b774c1a1e3e76410090a39fa677edbe5c42c68eedc5a7828a464b7
-size 1486385
+oid sha256:0414b8f29f6db757cc240528f9b1331789d2c186b0d0ee70f553964bf22af7e1
+size 1486178

--- a/apps/renderer-test/src/main.tsx
+++ b/apps/renderer-test/src/main.tsx
@@ -60,6 +60,7 @@ function FixtureCard({
         mimeType: output.mimeType,
         data: output.data,
         metadata: output.metadata,
+        outputId: `fixture-${index}-0`,
         cellId: `fixture-${index}`,
         outputIndex: 0,
       });
@@ -69,6 +70,7 @@ function FixtureCard({
           mimeType: output.mimeType,
           data: output.data,
           metadata: output.metadata,
+          outputId: `fixture-${index}-${outputIndex}`,
           cellId: `fixture-${index}`,
           outputIndex,
         })),
@@ -219,6 +221,7 @@ function HostContextScenarioApp() {
     frameRef.current?.render({
       mimeType: "text/html",
       data: '<div id="host-context-probe" style="color: var(--nteract-host-context-probe); font-family: var(--font-sans);">Host context probe</div>',
+      outputId: "host-context-probe",
       cellId: "host-context",
       outputIndex: 0,
     });
@@ -304,11 +307,13 @@ function VanillaEmbedScenarioApp() {
       },
       output: [
         {
+          output_id: "vanilla-embed-stream",
           output_type: "stream",
           name: "stdout",
           text: "vanilla stream before\n",
         },
         {
+          output_id: "vanilla-embed-markdown",
           output_type: "display_data",
           data: {
             "text/markdown":
@@ -316,6 +321,7 @@ function VanillaEmbedScenarioApp() {
           },
         },
         {
+          output_id: "vanilla-embed-html-blob",
           output_type: "display_data",
           data: {
             "text/html": { blob: "pandasHtml", size: 160 },
@@ -376,6 +382,7 @@ function VanillaRemountScenarioApp() {
       target,
       rendererBundle: defaultRendererLoader,
       output: {
+        outputId: `vanilla-remount-${version}`,
         mimeType: "text/html",
         data: `<div id="vanilla-remount-probe">vanilla remount ${version}</div>`,
       },

--- a/decks/talk/data/outputs.ts
+++ b/decks/talk/data/outputs.ts
@@ -75,6 +75,7 @@ export const demoBlobResolver: OutputBlobResolver = {
 
 export const agentReplOutputs: NteractEmbeddableOutput[] = [
   {
+    output_id: "agent-repl-stream",
     output_type: "stream",
     name: "stdout",
     text: [
@@ -84,8 +85,9 @@ export const agentReplOutputs: NteractEmbeddableOutput[] = [
       ">>> ds.features",
       "",
     ].join("\n"),
-  } as NteractEmbeddableOutput,
+  },
   {
+    output_id: "agent-repl-observation",
     output_type: "display_data",
     data: {
       "text/markdown": [
@@ -99,10 +101,11 @@ export const agentReplOutputs: NteractEmbeddableOutput[] = [
       ].join("\n"),
     },
     metadata: {},
-  } as NteractEmbeddableOutput,
+  },
 ];
 
 export const mathnetDataFrameOutput: OutputManifest = {
+  output_id: "mathnet-dataframe",
   output_type: "execute_result",
   execution_count: 12,
   data: {
@@ -129,6 +132,7 @@ export const mathnetDataFrameOutput: OutputManifest = {
 };
 
 export const mathnetProblemManifest: OutputManifest = {
+  output_id: "mathnet-problem-card",
   output_type: "display_data",
   data: {
     "text/html": {

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -20,7 +20,10 @@ import {
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
-import { jupyterOutputsToRenderPayloads } from "@/components/isolated/output-payloads";
+import {
+  jupyterOutputsToRenderPayloads,
+  type IdentifiedJupyterOutput,
+} from "@/components/isolated/output-payloads";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
@@ -84,6 +87,9 @@ export type { JupyterOutput } from "./jupyter-output";
 interface OutputAreaProps {
   /**
    * Array of Jupyter outputs to render.
+   * Isolated rendering requires every output to carry a non-empty `output_id`.
+   * Non-runtime render surfaces must stamp a synthetic id before passing
+   * outputs here.
    */
   outputs: JupyterOutput[];
   /**
@@ -319,6 +325,15 @@ function hasWidgetOutputs(
     }
     return false;
   });
+}
+
+function requireIdentifiedOutputs(outputs: JupyterOutput[]): IdentifiedJupyterOutput[] {
+  for (const output of outputs) {
+    if (!output.output_id) {
+      throw new Error("Cannot render isolated output without output_id");
+    }
+  }
+  return outputs as IdentifiedJupyterOutput[];
 }
 
 /**
@@ -736,6 +751,7 @@ export function OutputArea({
               mimeType: "text/plain",
               data: `Failed to load renderer plugin: ${formatPluginLoadError(error)}`,
               metadata: { isError: true },
+              outputId: `${cellId}:plugin-load-error`,
               cellId,
               outputIndex: 0,
             },
@@ -750,9 +766,29 @@ export function OutputArea({
       // Build batch of render payloads and send atomically.
       // This avoids the clear+re-render cycle that causes DOM thrashing
       // (visible as flickering when interactive widgets update rapidly).
-      const batch = jupyterOutputsToRenderPayloads(outputs, { cellId, priority }).map((payload) =>
-        withTracebackExecutionTargets(payload, resolveTracebackExecutionTarget),
-      );
+      let batch: RenderPayload[];
+      try {
+        batch = jupyterOutputsToRenderPayloads(requireIdentifiedOutputs(outputs), {
+          cellId,
+          priority,
+        }).map((payload) =>
+          withTracebackExecutionTargets(payload, resolveTracebackExecutionTarget),
+        );
+      } catch (error) {
+        if (gen !== renderGenRef.current) return;
+        console.error("[OutputArea] Failed to build isolated render payloads:", error);
+        frameRef.current.renderBatch([
+          {
+            mimeType: "text/plain",
+            data: `Failed to render isolated output: ${formatPluginLoadError(error)}`,
+            metadata: { isError: true },
+            outputId: `${cellId ?? "unknown-cell"}:output-identity-error`,
+            cellId,
+            outputIndex: 0,
+          },
+        ]);
+        return;
+      }
 
       frameRef.current.renderBatch(batch);
 

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -142,7 +142,7 @@ function renderReadOnlyCellSource({
     return (
       <OutputArea
         cellId={cellId}
-        outputs={[markdownSourceOutput(source)]}
+        outputs={[markdownSourceOutput(cellId, source)]}
         isolated="auto"
         priority={priority}
         hostContext={hostContext}
@@ -161,8 +161,9 @@ function renderReadOnlyCellSource({
   );
 }
 
-function markdownSourceOutput(source: string): JupyterOutput {
+function markdownSourceOutput(cellId: string, source: string): JupyterOutput {
   return {
+    output_id: `markdown-source:${cellId}`,
     output_type: "display_data",
     data: { "text/markdown": source },
     metadata: {},

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -84,6 +84,7 @@ vi.mock("@/components/isolated", async () => {
 function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): JupyterOutput[] {
   return [
     {
+      output_id: "markdown-output",
       output_type: "display_data",
       data: { "text/markdown": content },
       metadata: {},
@@ -94,6 +95,7 @@ function makeMarkdownOutput(content = "```python\nprint('hello')\n```"): Jupyter
 function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
   return [
     {
+      output_id: "stream-output",
       output_type: "stream",
       name: "stdout",
       text,
@@ -104,16 +106,19 @@ function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
 function makeMixedIsolatedOutputs(): JupyterOutput[] {
   return [
     {
+      output_id: "mixed-stream-output",
       output_type: "stream",
       name: "stdout",
       text: "stream before\n",
     },
     {
+      output_id: "mixed-html-output",
       output_type: "display_data",
       data: { "text/html": "<b>unsafe html</b>" },
       metadata: {},
     },
     {
+      output_id: "mixed-error-output",
       output_type: "error",
       ename: "RecursionError",
       evalue: "maximum recursion depth exceeded",
@@ -143,6 +148,7 @@ function makeMixedIsolatedOutputs(): JupyterOutput[] {
 function makeParquetOutput(): JupyterOutput[] {
   return [
     {
+      output_id: "parquet-output",
       output_type: "display_data",
       data: { "application/vnd.apache.parquet": { hash: "fake-parquet" } },
       metadata: {},
@@ -318,6 +324,7 @@ describe("OutputArea iframe theme sync", () => {
   it("keeps interactive plugin iframe outputs on the wheel-boundary path", () => {
     const plotlyOutput: JupyterOutput[] = [
       {
+        output_id: "plotly-output",
         output_type: "display_data",
         data: { "application/vnd.plotly.v1+json": { data: [] } },
         metadata: {},

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -91,6 +91,7 @@ describe("ReadOnlyNotebookCell", () => {
         executionCount={7}
         outputs={[
           {
+            output_id: "cell-code-stdout",
             output_type: "stream",
             name: "stdout",
             text: "hello\n",
@@ -136,7 +137,15 @@ describe("ReadOnlyNotebookCell", () => {
         id="traceback-code"
         cellType="code"
         source="raise Exception()"
-        outputs={[{ output_type: "error", ename: "E", evalue: "bad", traceback: [] }]}
+        outputs={[
+          {
+            output_id: "traceback-code-error",
+            output_type: "error",
+            ename: "E",
+            evalue: "bad",
+            traceback: [],
+          },
+        ]}
         resolveTracebackExecutionTarget={() => null}
         onNavigateToTracebackCell={() => undefined}
       />,
@@ -182,7 +191,14 @@ describe("ReadOnlyNotebookCell", () => {
   });
 
   it("keeps code output props stable across unrelated parent rerenders", () => {
-    const outputs: JupyterOutput[] = [{ output_type: "stream", name: "stdout", text: "visible\n" }];
+    const outputs: JupyterOutput[] = [
+      {
+        output_id: "stable-code-stdout",
+        output_type: "stream",
+        name: "stdout",
+        text: "visible\n",
+      },
+    ];
     const { rerender } = render(
       <ReadOnlyNotebookCell
         id="stable-code"
@@ -215,7 +231,14 @@ describe("ReadOnlyNotebookCell", () => {
         showSource={false}
         displayMode="report"
         focusOutputs
-        outputs={[{ output_type: "stream", name: "stdout", text: "visible\n" }]}
+        outputs={[
+          {
+            output_id: "report-code-stdout",
+            output_type: "stream",
+            name: "stdout",
+            text: "visible\n",
+          },
+        ]}
       />,
     );
 

--- a/src/components/isolated/IsolationTest.tsx
+++ b/src/components/isolated/IsolationTest.tsx
@@ -428,6 +428,7 @@ export function IsolationTest() {
     sendToIframe("render", {
       mimeType: "text/html",
       data: "<div style='color: #4ade80; padding: 8px;'>HTML rendered via postMessage!</div>",
+      outputId: "isolation-test-raw-render",
     });
   };
 
@@ -691,6 +692,7 @@ function ProductionFrameDemo() {
   const handleRenderHtml = () => {
     frameRef.current?.render({
       mimeType: "text/html",
+      outputId: "isolation-demo-html",
       data: `
         <h2 style="margin: 0 0 8px 0;">Production IsolatedFrame Test</h2>
         <p>This content was rendered via the <code>IsolatedFrame</code> component.</p>
@@ -709,6 +711,7 @@ function ProductionFrameDemo() {
     // A small test image (1x1 red pixel in base64)
     frameRef.current?.render({
       mimeType: "image/png",
+      outputId: "isolation-demo-image",
       data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
     });
   };

--- a/src/components/isolated/__tests__/embeddable-output.test.ts
+++ b/src/components/isolated/__tests__/embeddable-output.test.ts
@@ -21,11 +21,13 @@ describe("resolveEmbeddableOutputs", () => {
     const [payload] = await resolveEmbeddableOutputs({
       mimeType: "text/plain",
       data: "hello",
+      outputId: "direct-output",
     });
 
     expect(payload).toMatchObject({
       mimeType: "text/plain",
       data: "hello",
+      outputId: "direct-output",
       outputIndex: 0,
     });
   });
@@ -54,6 +56,20 @@ describe("resolveEmbeddableOutputs", () => {
       cellId: "cell-1",
       outputIndex: 0,
     });
+  });
+
+  it("rejects Jupyter outputs without explicit output identity", async () => {
+    await expect(
+      resolveEmbeddableOutputs(
+        JSON.stringify({
+          output_type: "display_data",
+          data: {
+            "text/plain": "plain fallback",
+          },
+          metadata: {},
+        }),
+      ),
+    ).rejects.toThrow("Unsupported embeddable output value");
   });
 
   it("resolves blob-backed manifests through HostBlobResolver", async () => {
@@ -88,6 +104,7 @@ describe("resolveEmbeddableOutputs", () => {
 
   it("requires a blob resolver for manifests", async () => {
     const manifest: OutputManifest = {
+      output_id: "missing-blob-resolver",
       output_type: "stream",
       name: "stdout",
       text: { blob: "stdout", size: 5 },

--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -87,6 +87,7 @@ describe("IsolatedFrameRuntime", () => {
     const payload: RenderPayload = {
       mimeType: "text/plain",
       data: "queued",
+      outputId: "queued-output",
     };
     const { frameWindow, runtime } = createRuntime();
 
@@ -181,6 +182,7 @@ describe("IsolatedFrameRuntime", () => {
     const stalePayload: RenderPayload = {
       mimeType: "text/plain",
       data: "old iframe",
+      outputId: "stale-output",
     };
     const { frameWindow, runtime } = createRuntime();
 
@@ -210,6 +212,7 @@ describe("IsolatedFrameRuntime", () => {
     const initialContent: RenderPayload = {
       mimeType: "text/markdown",
       data: "# Initial content",
+      outputId: "initial-content",
     };
     const { callbacks, frameWindow, runtime } = createRuntime(initialContent);
 
@@ -383,9 +386,12 @@ describe("IsolatedFrameRuntime", () => {
     expect(MockJsonRpcTransport.instances).toHaveLength(1);
     expect(callbacks.onBootstrapReady).toHaveBeenCalledTimes(1);
 
-    runtime.render({ mimeType: "text/plain", data: "after dispose" });
+    runtime.render({ mimeType: "text/plain", data: "after dispose", outputId: "after-dispose" });
     expect(frameWindow.postMessage).not.toHaveBeenCalledWith(
-      { type: "render", payload: { mimeType: "text/plain", data: "after dispose" } },
+      {
+        type: "render",
+        payload: { mimeType: "text/plain", data: "after dispose", outputId: "after-dispose" },
+      },
       "*",
     );
   });

--- a/src/components/isolated/__tests__/output-embed.test.ts
+++ b/src/components/isolated/__tests__/output-embed.test.ts
@@ -113,7 +113,11 @@ describe("createNteractOutputEmbed", () => {
     });
     const frameWindow = handle.iframe.contentWindow!;
 
-    await handle.render({ mimeType: "text/plain", data: "queued output" });
+    await handle.render({
+      mimeType: "text/plain",
+      data: "queued output",
+      outputId: "queued-output",
+    });
     bootstrapFrame(frameWindow);
     const transport = MockJsonRpcTransport.instances[0];
     expect(transport.notify).not.toHaveBeenCalledWith(

--- a/src/components/isolated/embeddable-output.ts
+++ b/src/components/isolated/embeddable-output.ts
@@ -1,4 +1,3 @@
-import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { RenderPayload } from "./frame-bridge";
 import {
   isOutputManifest,
@@ -9,17 +8,26 @@ import {
 import {
   isRenderPayload,
   jupyterOutputToRenderPayload,
+  type IdentifiedJupyterOutput,
   type RenderPayloadOptions,
 } from "./output-payloads";
 
-export type NteractEmbeddableOutput = RenderPayload | JupyterOutput | OutputManifest | string;
+export type NteractEmbeddableOutput =
+  | RenderPayload
+  | IdentifiedJupyterOutput
+  | OutputManifest
+  | string;
 
 export interface ResolveEmbeddableOutputsOptions extends RenderPayloadOptions {
   blobResolver?: OutputBlobResolver;
 }
 
-function isJupyterOutput(value: unknown): value is JupyterOutput {
-  return typeof value === "object" && value !== null && "output_type" in value;
+function isIdentifiedJupyterOutput(value: unknown): value is IdentifiedJupyterOutput {
+  if (typeof value !== "object" || value === null) return false;
+  const output = value as Record<string, unknown>;
+  return (
+    "output_type" in output && typeof output.output_id === "string" && output.output_id.length > 0
+  );
 }
 
 async function resolveOneEmbeddableOutput(
@@ -49,11 +57,15 @@ async function resolveOneEmbeddableOutput(
       throw new Error("A blobResolver is required to resolve output manifests");
     }
     const resolved = await resolveManifest(output, options.blobResolver);
-    const payload = jupyterOutputToRenderPayload(resolved as JupyterOutput, outputIndex, options);
+    const payload = jupyterOutputToRenderPayload(
+      resolved as IdentifiedJupyterOutput,
+      outputIndex,
+      options,
+    );
     return payload ? [payload] : [];
   }
 
-  if (isJupyterOutput(output)) {
+  if (isIdentifiedJupyterOutput(output)) {
     const payload = jupyterOutputToRenderPayload(output, outputIndex, options);
     return payload ? [payload] : [];
   }

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -24,12 +24,11 @@ export interface RenderPayload {
   /** Optional metadata for the output */
   metadata?: Record<string, unknown>;
   /**
-   * Stable daemon-stamped UUID for this output. When present, the iframe
-   * uses it as the React key so display_update and reorder operations
-   * don't re-mount sibling outputs. Falls back to `cellId`+`outputIndex`
-   * for payloads that don't carry one (e.g. markdown cell render paths).
+   * Stable renderer identity. Runtime output payloads must use the
+   * daemon-stamped output_id; non-runtime render surfaces must provide an
+   * explicit synthetic id instead of relying on positional fallbacks.
    */
-  outputId?: string;
+  outputId: string;
   /** Cell ID this output belongs to (for routing) */
   cellId?: string;
   /** Output index within the cell */
@@ -42,8 +41,8 @@ export interface RenderPayload {
 
 /**
  * Atomically replace all outputs in the iframe with a batch.
- * Uses stable IDs from cellId + outputIndex for React reconciliation,
- * avoiding DOM teardown on updates (e.g., interactive widget slider changes).
+ * Uses each payload's required outputId for React reconciliation, avoiding
+ * DOM teardown on updates (e.g., interactive widget slider changes).
  */
 export interface RenderBatchMessage {
   type: "render_batch";

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -88,5 +88,6 @@ export type {
 } from "./output-manifest";
 export { resolveEmbeddableOutputs } from "./embeddable-output";
 export type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from "./embeddable-output";
+export type { IdentifiedJupyterOutput } from "./output-payloads";
 // Provider and hook for renderer bundle
 export { IsolatedRendererProvider, useIsolatedRenderer } from "./isolated-renderer-context";

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -271,7 +271,8 @@ function sameContainerDimensions(
  *   onReady={() => {
  *     frameRef.current?.render({
  *       mimeType: "text/html",
- *       data: "<h1>Hello from isolated frame!</h1>"
+ *       data: "<h1>Hello from isolated frame!</h1>",
+ *       outputId: "example-output",
  *     });
  *   }}
  *   onResize={(height) => console.log("New height:", height)}

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -16,7 +16,7 @@ export type ContentRef =
   | { blob: string; size?: number; media_type?: string };
 
 interface ManifestCommon {
-  output_id?: string;
+  output_id: string;
 }
 
 export type OutputManifest =
@@ -48,14 +48,14 @@ export type OutputManifest =
 
 export type ResolvedJupyterOutput =
   | {
-      output_id?: string;
+      output_id: string;
       output_type: "display_data";
       data: Record<string, unknown>;
       metadata: Record<string, unknown>;
       display_id?: string;
     }
   | {
-      output_id?: string;
+      output_id: string;
       output_type: "execute_result";
       data: Record<string, unknown>;
       metadata: Record<string, unknown>;
@@ -63,13 +63,13 @@ export type ResolvedJupyterOutput =
       display_id?: string;
     }
   | {
-      output_id?: string;
+      output_id: string;
       output_type: "stream";
       name: "stdout" | "stderr";
       text: string;
     }
   | {
-      output_id?: string;
+      output_id: string;
       output_type: "error";
       ename: string;
       evalue: string;
@@ -104,6 +104,7 @@ export function isOutputManifest(value: unknown): value is OutputManifest {
   if (typeof value !== "object" || value === null) return false;
   const obj = value as Record<string, unknown>;
   if (!("output_type" in obj)) return false;
+  if (typeof obj.output_id !== "string" || obj.output_id.length === 0) return false;
 
   switch (obj.output_type) {
     case "stream":

--- a/src/components/isolated/output-payloads.ts
+++ b/src/components/isolated/output-payloads.ts
@@ -2,6 +2,8 @@ import type { RenderPayload } from "./frame-bridge";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 
+export type IdentifiedJupyterOutput = JupyterOutput & { output_id: string };
+
 export interface RenderPayloadOptions {
   cellId?: string;
   priority?: readonly string[];
@@ -10,20 +12,32 @@ export interface RenderPayloadOptions {
 export function isRenderPayload(value: unknown): value is RenderPayload {
   if (typeof value !== "object" || value === null) return false;
   const payload = value as Record<string, unknown>;
-  return typeof payload.mimeType === "string" && "data" in payload;
+  return (
+    typeof payload.mimeType === "string" &&
+    "data" in payload &&
+    typeof payload.outputId === "string" &&
+    payload.outputId.length > 0
+  );
 }
 
 function normalizeText(text: string | string[]): string {
   return Array.isArray(text) ? text.join("") : text;
 }
 
+function requireOutputId(output: IdentifiedJupyterOutput): string {
+  if (!output.output_id) {
+    throw new Error("Cannot render isolated output without output_id");
+  }
+  return output.output_id;
+}
+
 export function jupyterOutputToRenderPayload(
-  output: JupyterOutput,
+  output: IdentifiedJupyterOutput,
   outputIndex: number,
   options: RenderPayloadOptions = {},
 ): RenderPayload | null {
   const { cellId, priority = DEFAULT_PRIORITY } = options;
-  const outputId = output.output_id;
+  const outputId = requireOutputId(output);
 
   if (output.output_type === "execute_result" || output.output_type === "display_data") {
     const mimeType = selectMimeType(output.data, priority);
@@ -80,7 +94,7 @@ export function jupyterOutputToRenderPayload(
 }
 
 export function jupyterOutputsToRenderPayloads(
-  outputs: readonly JupyterOutput[],
+  outputs: readonly IdentifiedJupyterOutput[],
   options: RenderPayloadOptions = {},
 ): RenderPayload[] {
   return outputs.flatMap((output, index) => {

--- a/src/isolated-renderer/__tests__/output-identity.test.ts
+++ b/src/isolated-renderer/__tests__/output-identity.test.ts
@@ -32,21 +32,8 @@ describe("isolated renderer output identity", () => {
     expect(fresh).not.toBe(first);
   });
 
-  it("falls back to cell id and output index for legacy payloads without outputId", () => {
-    expect(outputEntryIdForPayload({ cellId: "cell-a", outputIndex: 2 })).toBe("cell-a-2");
-    expect(outputEntryIdForPayload({ cellId: "cell-a" }, { fallbackIndex: 3 })).toBe("cell-a-3");
-  });
-
-  it("keeps no-id single renders transient while no-id batch renders are positional", () => {
-    expect(
-      outputEntryIdForPayload(
-        {},
-        {
-          transientFallback: true,
-          createTransientId: () => "output-transient",
-        },
-      ),
-    ).toBe("output-transient");
-    expect(outputEntryIdForPayload({}, { fallbackIndex: 4 })).toBe("output-4");
+  it("rejects payloads without outputId instead of deriving fallback identity", () => {
+    expect(() => outputEntryIdForPayload({} as { outputId: string })).toThrow("missing outputId");
+    expect(() => outputEntryIdForPayload({ outputId: "" })).toThrow("missing outputId");
   });
 });

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -497,46 +497,57 @@ function IsolatedRendererApp() {
   const handleMessage = useCallback((type: string, payload: unknown) => {
     switch (type) {
       case "render": {
-        const renderPayload = payload as RenderPayload;
+        try {
+          const renderPayload = payload as RenderPayload;
+          const id = outputEntryIdForPayload(renderPayload);
 
-        const id = outputEntryIdForPayload(renderPayload, { transientFallback: true });
+          setState((prev) => {
+            if (renderPayload.replace) {
+              // Replace all outputs with this single new output
+              return { ...prev, outputs: [{ id, payload: renderPayload }] };
+            }
+            // Default: append to existing outputs
+            return {
+              ...prev,
+              outputs: [...prev.outputs, { id, payload: renderPayload }],
+            };
+          });
 
-        setState((prev) => {
-          if (renderPayload.replace) {
-            // Replace all outputs with this single new output
-            return { ...prev, outputs: [{ id, payload: renderPayload }] };
-          }
-          // Default: append to existing outputs
-          return {
-            ...prev,
-            outputs: [...prev.outputs, { id, payload: renderPayload }],
-          };
-        });
-
-        // Notify parent of render completion after next paint
-        requestAnimationFrame(() => {
-          postMeasuredHeight("render_complete", 1);
-        });
-        scheduleRendererLayoutPulses();
+          // Notify parent of render completion after next paint
+          requestAnimationFrame(() => {
+            postMeasuredHeight("render_complete", 1);
+          });
+          scheduleRendererLayoutPulses();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error("[isolated-renderer] invalid render payload:", error);
+          emitRendererDiagnostic("invalid-render-payload", { message }, "error");
+        }
         break;
       }
 
       case "renderBatch": {
-        const batchPayload = payload as { outputs: RenderPayload[] };
-        const entries: OutputEntry[] = (batchPayload.outputs ?? []).map((p, i) => ({
-          id: outputEntryIdForPayload(p, { fallbackIndex: i }),
-          payload: p,
-        }));
-        setState((prev) => ({ ...prev, outputs: entries }));
-        emitRendererDiagnostic("render-batch-received", {
-          outputCount: entries.length,
-          mimes: entries.map((entry) => entry.payload.mimeType),
-        });
+        try {
+          const batchPayload = payload as { outputs: RenderPayload[] };
+          const entries: OutputEntry[] = (batchPayload.outputs ?? []).map((p) => ({
+            id: outputEntryIdForPayload(p),
+            payload: p,
+          }));
+          setState((prev) => ({ ...prev, outputs: entries }));
+          emitRendererDiagnostic("render-batch-received", {
+            outputCount: entries.length,
+            mimes: entries.map((entry) => entry.payload.mimeType),
+          });
 
-        requestAnimationFrame(() => {
-          postMeasuredHeight("render_complete", entries.length);
-        });
-        scheduleRendererLayoutPulses();
+          requestAnimationFrame(() => {
+            postMeasuredHeight("render_complete", entries.length);
+          });
+          scheduleRendererLayoutPulses();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error("[isolated-renderer] invalid render batch payload:", error);
+          emitRendererDiagnostic("invalid-render-batch-payload", { message }, "error");
+        }
         break;
       }
 

--- a/src/isolated-renderer/output-identity.ts
+++ b/src/isolated-renderer/output-identity.ts
@@ -1,35 +1,12 @@
 interface OutputIdentityPayload {
-  outputId?: string;
-  cellId?: string;
-  outputIndex?: number;
+  outputId: string;
 }
 
-interface OutputEntryIdOptions {
-  fallbackIndex?: number;
-  transientFallback?: boolean;
-  createTransientId?: () => string;
-}
-
-function defaultTransientOutputId(): string {
-  return `output-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
-export function outputEntryIdForPayload(
-  payload: OutputIdentityPayload,
-  options: OutputEntryIdOptions = {},
-): string {
+export function outputEntryIdForPayload(payload: OutputIdentityPayload): string {
   // Daemon-stamped output_id is the identity boundary: display_update keeps
   // the same key, while fresh execution outputs get fresh ids and remount.
-  if (payload.outputId) return payload.outputId;
-
-  const fallbackIndex = options.fallbackIndex ?? 0;
-  if (payload.cellId) {
-    return `${payload.cellId}-${payload.outputIndex ?? fallbackIndex}`;
+  if (!payload.outputId) {
+    throw new Error("Isolated renderer payload is missing outputId");
   }
-
-  if (options.transientFallback) {
-    return (options.createTransientId ?? defaultTransientOutputId)();
-  }
-
-  return `output-${fallbackIndex}`;
+  return payload.outputId;
 }


### PR DESCRIPTION
## Summary

- Remove the isolated renderer's positional/transient fallback identity paths
- Require `outputId` on render payloads and output manifests used by the isolated renderer bridge
- Give markdown previews, renderer-test fixtures, and demo renders explicit synthetic ids instead of relying on hidden fallback keys

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx apps/notebook/src/lib/__tests__/manifest-resolution.test.ts apps/notebook/src/lib/__tests__/materialize-cells.test.ts src/isolated-renderer/__tests__/output-identity.test.ts src/components/isolated/__tests__/embeddable-output.test.ts src/components/isolated/__tests__/output-embed.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `cd apps/notebook-cloud && node --import tsx --test test/render-resolution.test.ts test/mime-policy.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/renderer-test build`
- `cargo xtask renderer-plugins`
- `cargo xtask verify-plugins`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
