### PR TITLE
[ipy-opt] Type inbound SendComm messages

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -432,6 +432,28 @@ pub struct NotebookResponseEnvelope {
     pub response: NotebookResponse,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommRequestMessage {
+    pub header: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_header: Option<serde_json::Value>,
+    #[serde(default = "empty_json_object")]
+    pub metadata: serde_json::Value,
+    pub content: serde_json::Value,
+    #[serde(default)]
+    pub buffers: Vec<Vec<u8>>,
+    #[serde(default = "default_comm_channel")]
+    pub channel: String,
+}
+
+fn empty_json_object() -> serde_json::Value {
+    serde_json::Value::Object(serde_json::Map::new())
+}
+
+fn default_comm_channel() -> String {
+    "shell".to_string()
+}
+
 /// Requests sent from notebook app to daemon for notebook operations.
 ///
 /// These are sent as JSON over the notebook sync connection alongside
@@ -493,7 +515,7 @@ pub enum NotebookRequest {
     SendComm {
         /// The full Jupyter message (header, content, buffers, etc.)
         /// Preserves frontend session/msg_id for proper widget protocol.
-        message: serde_json::Value,
+        message: Box<CommRequestMessage>,
     },
 
     /// Search the kernel's input history.
@@ -828,7 +850,7 @@ pub enum RuntimeAgentRequest {
     },
 
     /// Send a comm message to the kernel (widget interactions).
-    SendComm { message: serde_json::Value },
+    SendComm { message: Box<CommRequestMessage> },
 
     /// Request code completions from the kernel.
     Complete { code: String, cursor_pos: usize },
@@ -1853,7 +1875,14 @@ mod tests {
         // Fire-and-forget commands (no response needed)
         assert!(RuntimeAgentRequest::InterruptExecution.is_command());
         assert!(RuntimeAgentRequest::SendComm {
-            message: serde_json::json!({})
+            message: Box::new(CommRequestMessage {
+                header: serde_json::json!({"msg_type": "comm_msg"}),
+                parent_header: None,
+                metadata: serde_json::json!({}),
+                content: serde_json::json!({}),
+                buffers: vec![vec![1, 2, 3]],
+                channel: "shell".to_string(),
+            }),
         }
         .is_command());
 
@@ -1895,6 +1924,26 @@ mod tests {
             packages: vec!["numpy".into()]
         })
         .is_command());
+    }
+
+    #[test]
+    fn comm_request_message_defaults_optional_legacy_fields() {
+        let request: NotebookRequest = serde_json::from_value(serde_json::json!({
+            "action": "send_comm",
+            "message": {
+                "header": { "msg_type": "comm_msg" },
+                "content": { "comm_id": "comm-a", "data": {} }
+            }
+        }))
+        .expect("legacy SendComm without optional fields should deserialize");
+
+        let NotebookRequest::SendComm { message } = request else {
+            panic!("expected SendComm request");
+        };
+        assert_eq!(message.parent_header, None);
+        assert_eq!(message.metadata, serde_json::json!({}));
+        assert!(message.buffers.is_empty());
+        assert_eq!(message.channel, "shell");
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -45,7 +45,7 @@ use crate::stream_terminal::StreamTerminals;
 use crate::task_supervisor::{spawn_best_effort, spawn_supervised};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::EnvType;
-use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig};
+use notebook_protocol::protocol::{CommRequestMessage, KernelPorts, LaunchedEnvConfig};
 
 const REDACT_ENV_VALUES_IN_OUTPUTS_ENV: &str = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS";
 
@@ -3012,68 +3012,30 @@ impl KernelConnection for JupyterKernel {
 
     // ── Comm messages ────────────────────────────────────────────────────
 
-    async fn send_comm_message(&mut self, raw_message: serde_json::Value) -> Result<()> {
+    async fn send_comm_message(&mut self, raw_message: CommRequestMessage) -> Result<()> {
         let shell = self
             .shell_writer
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("No kernel running"))?;
 
-        let header: jupyter_protocol::Header = serde_json::from_value(
-            raw_message
-                .get("header")
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("Missing header in comm message"))?,
-        )?;
+        let header: jupyter_protocol::Header = serde_json::from_value(raw_message.header)?;
 
         let msg_type = header.msg_type.clone();
 
-        let parent_header: Option<jupyter_protocol::Header> =
-            raw_message.get("parent_header").and_then(|v| {
-                if v.is_null() {
-                    None
-                } else {
-                    serde_json::from_value(v.clone()).ok()
-                }
-            });
-
-        let metadata: serde_json::Value = raw_message
-            .get("metadata")
-            .cloned()
-            .unwrap_or(serde_json::json!({}));
-
-        let content_value = raw_message
-            .get("content")
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("Missing content in comm message"))?;
+        let parent_header: Option<jupyter_protocol::Header> = raw_message
+            .parent_header
+            .and_then(|value| serde_json::from_value(value).ok());
 
         let message_content =
-            JupyterMessageContent::from_type_and_content(&msg_type, content_value)?;
-
-        let buffers: Vec<Bytes> = raw_message
-            .get("buffers")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|buf| {
-                        buf.as_array().map(|bytes| {
-                            let bytes: Vec<u8> = bytes
-                                .iter()
-                                .filter_map(|b| b.as_u64().map(|n| n as u8))
-                                .collect();
-                            Bytes::from(bytes)
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+            JupyterMessageContent::from_type_and_content(&msg_type, raw_message.content)?;
 
         let message = JupyterMessage {
             zmq_identities: Vec::new(),
             header,
             parent_header,
-            metadata,
+            metadata: raw_message.metadata,
             content: message_content,
-            buffers,
+            buffers: raw_message.buffers.into_iter().map(Bytes::from).collect(),
             channel: Some(jupyter_protocol::Channel::Shell),
         };
 

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -22,7 +22,7 @@ use crate::blob_store::BlobStore;
 use crate::output_prep::QueueCommandReceivers;
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::PooledEnv;
-use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig};
+use notebook_protocol::protocol::{CommRequestMessage, KernelPorts, LaunchedEnvConfig};
 
 /// Configuration for launching a kernel.
 ///
@@ -106,7 +106,7 @@ pub trait KernelConnection: Send {
     /// Forward a raw comm_msg envelope to the kernel (widget interactions).
     fn send_comm_message(
         &mut self,
-        raw_message: serde_json::Value,
+        message: CommRequestMessage,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 
     /// Send a comm_msg(update) to sync widget state from frontend to kernel.

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -440,7 +440,10 @@ mod tests {
         async fn shutdown(&mut self) -> Result<()> {
             Ok(())
         }
-        async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
+        async fn send_comm_message(
+            &mut self,
+            _: notebook_protocol::protocol::CommRequestMessage,
+        ) -> Result<()> {
             Ok(())
         }
         async fn send_comm_update(

--- a/crates/runtimed/src/requests/send_comm.rs
+++ b/crates/runtimed/src/requests/send_comm.rs
@@ -2,16 +2,18 @@
 
 use crate::notebook_sync_server::{send_runtime_agent_request, NotebookRoom};
 use crate::protocol::NotebookResponse;
+use notebook_protocol::protocol::CommRequestMessage;
 
-pub(crate) async fn handle(room: &NotebookRoom, message: serde_json::Value) -> NotebookResponse {
+pub(crate) async fn handle(
+    room: &NotebookRoom,
+    message: Box<CommRequestMessage>,
+) -> NotebookResponse {
     // Agent path: forward comm message via RPC
     let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
     if has_runtime_agent {
         match send_runtime_agent_request(
             room,
-            notebook_protocol::protocol::RuntimeAgentRequest::SendComm {
-                message: message.clone(),
-            },
+            notebook_protocol::protocol::RuntimeAgentRequest::SendComm { message },
         )
         .await
         {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1072,7 +1072,7 @@ async fn handle_runtime_agent_request(
 
         RuntimeAgentRequest::SendComm { message } => {
             if let Some(ref mut k) = kernel {
-                match k.send_comm_message(message).await {
+                match k.send_comm_message(*message).await {
                     Ok(()) => (RuntimeAgentResponse::Ok, None),
                     Err(e) => (
                         RuntimeAgentResponse::Error {
@@ -1730,7 +1730,10 @@ mod tests {
         async fn shutdown(&mut self) -> Result<()> {
             Ok(())
         }
-        async fn send_comm_message(&mut self, _: serde_json::Value) -> Result<()> {
+        async fn send_comm_message(
+            &mut self,
+            _: notebook_protocol::protocol::CommRequestMessage,
+        ) -> Result<()> {
             Ok(())
         }
         async fn send_comm_update(

--- a/crates/runtimed/tests/rpc_routing.rs
+++ b/crates/runtimed/tests/rpc_routing.rs
@@ -451,7 +451,14 @@ async fn sendcomm_fires_independently() {
     let result = route_request(
         &tx,
         RuntimeAgentRequest::SendComm {
-            message: serde_json::json!({"target_name": "jupyter.widget", "data": {}}),
+            message: Box::new(notebook_protocol::protocol::CommRequestMessage {
+                header: serde_json::json!({"msg_type": "comm_msg"}),
+                parent_header: None,
+                metadata: serde_json::json!({}),
+                content: serde_json::json!({"target_name": "jupyter.widget", "data": {}}),
+                buffers: vec![],
+                channel: "shell".to_string(),
+            }),
         },
     )
     .await;


### PR DESCRIPTION
## Summary

- Adds a typed `CommRequestMessage` protocol envelope for inbound `send_comm` requests.
- Carries that typed envelope through notebook requests, runtime-agent requests, RPC routing, and kernel delivery.
- Keeps the existing JSON wire shape compatible by defaulting omitted legacy fields such as `parent_header`, `metadata`, `buffers`, and `channel`.

## Notes

This is the next `[ipy-opt]` layer after the Output widget replay measurement/cache PRs. It is intentionally the typed envelope precursor for the later blob/ContentRef-aware SendComm transport work; this PR does not claim to externalize inbound comm buffers yet.

The kernel send path still forces the Jupyter channel to Shell, matching the previous behavior.

## Verification

- `cargo test -p notebook-protocol`
- `cargo test -p runtimed sendcomm_fires_independently`
- `cargo xtask lint --fix`
- `cargo test -p runtimed`
