### PR TITLE
fix(notebook-cloud): prefer Access assertions at origin

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -232,6 +232,13 @@ principal is `user:cloudflare-access:<sub>`, and the requested `scope` is still
 only a request: the room ACL decides whether that principal may enter as
 `viewer`, `editor`, `runtime_peer`, or `owner`.
 
+When Cloudflare Access forwards `Cf-Access-Jwt-Assertion` to the Worker, that
+edge assertion is authoritative at the origin. Client-carried header credentials
+such as `CF-Access-Token` or `Authorization: Bearer` are ignored for Worker
+identity selection on that request. Browser-visible Access token subprotocols
+remain mutually exclusive with forwarded assertions and are rejected if both are
+present.
+
 The Access principal namespace names the authority validated by the Worker:
 `user:cloudflare-access:<encoded-sub>`. Access `email` and `name` claims are
 stamped as display/audit metadata on the trusted room connection; they are not

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -611,20 +611,20 @@ function accessCredentialFromRequest(request: Request): AccessCredential | undef
       token: assertionToken,
       transport: cookieToken ? "access-cookie-assertion" : "access-assertion",
     });
-  }
+  } else {
+    const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
+    if (accessToken) {
+      candidates.push({ token: accessToken, transport: "access-token-header" });
+    }
 
-  const accessToken = request.headers.get("cf-access-token")?.trim() || undefined;
-  if (accessToken) {
-    candidates.push({ token: accessToken, transport: "access-token-header" });
-  }
+    const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));
+    if (bearerToken) {
+      candidates.push({ token: bearerToken, transport: "access-bearer" });
+    }
 
-  const bearerToken = bearerTokenFromAuthorization(request.headers.get("authorization"));
-  if (bearerToken) {
-    candidates.push({ token: bearerToken, transport: "access-bearer" });
-  }
-
-  if (cookieToken && candidates.length === 0) {
-    candidates.push({ token: cookieToken, transport: "access-cookie" });
+    if (cookieToken && candidates.length === 0) {
+      candidates.push({ token: cookieToken, transport: "access-cookie" });
+    }
   }
 
   const webSocketProtocol = tokenFromWebSocketProtocol(

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -433,6 +433,47 @@ describe("Cloudflare Access identity", () => {
     assert.equal(identity.scope, "viewer");
   });
 
+  it("prefers forwarded Access assertions over client-carried header credentials", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=smoke:owner&scope=owner", {
+        headers: {
+          "Cf-Access-Jwt-Assertion": token,
+          "CF-Access-Token": "not-a-jwt",
+          Authorization: "Bearer not-a-jwt",
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/smoke:owner");
+    assert.equal(identity.scope, "owner");
+    assert.equal(identity.metadata.transport, "access-assertion");
+  });
+
+  it("rejects browser Access subprotocols when an Access assertion is already forwarded", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+    const protocol = `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`;
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync", {
+            headers: {
+              "Cf-Access-Jwt-Assertion": token,
+              "Sec-WebSocket-Protocol": protocol,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 400 &&
+        /multiple identity credentials/.test(error.message),
+    );
+  });
+
   it("accepts Cloudflare Access CLI tokens from the cf-access-token header", async () => {
     const { env, token } = await accessTokenFixture({ subject: "alice" });
 

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -205,6 +205,9 @@ an `Origin`, it must normalize to the notebook application origin or one of the
 configured values. The hosted Access smoke sends `NOTEBOOK_CLOUD_ACCESS_ORIGIN`
 by default to exercise the browser-compatible origin path while still carrying
 only one Worker-visible credential, `CF-Access-Token`.
+If the Access edge also forwards `Cf-Access-Jwt-Assertion` to the Worker, the
+Worker treats the forwarded assertion as authoritative for origin identity and
+ignores client-carried `CF-Access-Token` or bearer headers on that request.
 
 ## Deploy
 
@@ -314,10 +317,15 @@ The script sends:
 - `Origin: https://<notebook-host>` to exercise the browser-compatible
   WebSocket origin gate;
 
-It intentionally sends only one Worker-visible Access credential transport per
-request. The Worker also supports `Authorization: Bearer <jwt>` and
+It intentionally sends one client-carried Access credential transport per
+request. If Access forwards `Cf-Access-Jwt-Assertion` to the origin after
+admitting the request, the Worker validates that forwarded assertion as the
+authoritative origin credential. The Worker also supports
+`Authorization: Bearer <jwt>` and
 `nteract-access-token.<base64url-jwt>` as separate deployment/client modes, but
-they must not be combined with `CF-Access-Token` on the same request.
+they must not be combined with `CF-Access-Token` on the same request unless the
+Access edge has replaced client credential selection with a forwarded
+assertion.
 
 Expected JSON shape:
 


### PR DESCRIPTION
## Summary

- Treat Cloudflare's forwarded `Cf-Access-Jwt-Assertion` as the authoritative origin credential when present.
- Keep client-carried `CF-Access-Token`, bearer headers, and ambient cookies as fallback transports only when Access has not forwarded an assertion.
- Preserve the browser WebSocket subprotocol conflict check, and document the Access edge/origin precedence in the README and Anaconda runbook.

## Tests

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/hosted-access-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/worker-routes.test.ts test/sharing.test.ts test/hosted-access-smoke-env.test.mjs`
- `cargo xtask lint --fix`
