### PR TITLE
chore(notebook-cloud): expose Access health readiness

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -239,6 +239,11 @@ identity selection on that request. Browser-visible Access token subprotocols
 remain mutually exclusive with forwarded assertions and are rejected if both are
 present.
 
+`GET /api/health` includes a non-secret
+`auth.cloudflare_access.status` readiness field. Expect `configured` for an
+Access-backed deployment; `partial` means exactly one of
+`NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` or `NOTEBOOK_CLOUD_ACCESS_AUD` is missing.
+
 The Access principal namespace names the authority validated by the Worker:
 `user:cloudflare-access:<encoded-sub>`. Access `email` and `name` claims are
 stamped as display/audit metadata on the trusted room connection; they are not

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -90,6 +90,9 @@ const worker: ExportedHandler<Env> = {
         status: "ok",
         service: "nteract-notebook-cloud",
         deployment_env: env.DEPLOYMENT_ENV ?? "development",
+        auth: {
+          cloudflare_access: cloudflareAccessHealth(env),
+        },
       });
     }
 
@@ -394,6 +397,29 @@ function hasCredentialWebSocketSubprotocol(request: Request): boolean {
         part.trim().startsWith(prefix),
       ),
     );
+}
+
+function cloudflareAccessHealth(env: Env): {
+  status: "configured" | "partial" | "disabled";
+  jwks: "remote" | "pinned" | "none";
+} {
+  const hasTeamDomain = Boolean(env.NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?.trim());
+  const hasAudience = Boolean(env.NOTEBOOK_CLOUD_ACCESS_AUD?.trim());
+  const status =
+    hasTeamDomain && hasAudience
+      ? "configured"
+      : hasTeamDomain || hasAudience
+        ? "partial"
+        : "disabled";
+
+  return {
+    status,
+    jwks: env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?.trim()
+      ? "pinned"
+      : status === "configured"
+        ? "remote"
+        : "none",
+  };
 }
 
 async function routeSnapshot(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -42,6 +42,51 @@ before(async () => {
 });
 
 describe("Worker artifact routes", () => {
+  it("reports Cloudflare Access readiness without exposing configured values", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN: "team.cloudflareaccess.com",
+      NOTEBOOK_CLOUD_ACCESS_AUD: "aud-secret-ish-value",
+      NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: '{"keys":[]}',
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/health"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      auth: { cloudflare_access: { status: string; jwks: string } };
+    };
+    assert.deepEqual(body.auth.cloudflare_access, {
+      status: "configured",
+      jwks: "pinned",
+    });
+    assert.doesNotMatch(JSON.stringify(body), /team\.cloudflareaccess\.com|aud-secret-ish-value/);
+  });
+
+  it("reports partial Cloudflare Access readiness for incomplete deployments", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_CLOUD_ACCESS_AUD: "aud-only",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/health"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      auth: { cloudflare_access: { status: string; jwks: string } };
+    };
+    assert.deepEqual(body.auth.cloudflare_access, {
+      status: "partial",
+      jwks: "none",
+    });
+  });
+
   it("serves viewer bundle assets through the Worker assets binding", async () => {
     const env = fakeEnv({
       ASSETS: {

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -166,6 +166,25 @@ printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
       --config apps/notebook-cloud/wrangler.toml
 ```
 
+After deploying the variables, `GET /api/health` reports a non-secret Access
+readiness summary:
+
+```json
+{
+  "auth": {
+    "cloudflare_access": {
+      "status": "configured",
+      "jwks": "remote"
+    }
+  }
+}
+```
+
+`status: "partial"` means exactly one of `NOTEBOOK_CLOUD_ACCESS_AUD` or
+`NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` is present. Fix that before running browser
+or WebSocket smoke tests; otherwise Access-authenticated requests will fail
+with `Cloudflare Access auth is not fully configured`.
+
 ## Allowed Origins
 
 For an Access-backed browser deployment, set:


### PR DESCRIPTION
## Summary

- adds a non-secret Cloudflare Access readiness summary to `GET /api/health`
- documents the `configured` / `partial` signal in the notebook-cloud README and Anaconda Access runbook
- adds Worker route coverage for configured and partial Access health states without exposing team domain or audience values

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run typecheck`
