### PR TITLE
fix(notebook-cloud): require Origin for Access assertions

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -252,13 +252,14 @@ NOTEBOOK_CLOUD_ALLOWED_ORIGINS=https://notebooks.example.com
 Do not include the renderer asset origin in this list. It serves public
 build-time sidecars, not authenticated notebook room traffic.
 
-Cookie-backed Access WebSocket upgrades must always send an allowed `Origin`.
-Browser-visible credential subprotocols also require `Origin`, because those
-credentials are available to page JavaScript. Header-authenticated native and
-CLI clients may omit `Origin`; if they do send one, it must match the Worker
-origin or an entry in `NOTEBOOK_CLOUD_ALLOWED_ORIGINS`. The hosted Access smoke
-sends `NOTEBOOK_CLOUD_ACCESS_ORIGIN` by default so the browser-compatible path
-is exercised even though the raw smoke connection uses `CF-Access-Token`.
+Access assertion-backed and cookie-backed WebSocket upgrades must always send an
+allowed `Origin`. Browser-visible credential subprotocols also require
+`Origin`, because those credentials are available to page JavaScript.
+Header-authenticated native and CLI clients may omit `Origin`; if they do send
+one, it must match the Worker origin or an entry in
+`NOTEBOOK_CLOUD_ALLOWED_ORIGINS`. The hosted Access smoke sends
+`NOTEBOOK_CLOUD_ACCESS_ORIGIN` by default so the browser-compatible path is
+exercised even though the raw smoke connection uses `CF-Access-Token`.
 
 The hosted Access smoke uses a real Access JWT from `cloudflared`, grants
 principal ACL rows, sends real Automerge frames, and verifies that a granted

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3,6 +3,7 @@ import { NotebookRoom } from "./notebook-room.ts";
 import {
   ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
   AuthError,
+  CLOUDFLARE_ACCESS_JWT_HEADER,
   allowsBlobUpload,
   allowsPublish,
   authenticateRequestWithProviders,
@@ -310,7 +311,9 @@ function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | 
 }
 
 function requiresWebSocketOrigin(request: Request): boolean {
-  return hasCloudflareAccessCookie(request) || hasCredentialWebSocketSubprotocol(request);
+  return (
+    hasCloudflareAccessSessionCredential(request) || hasCredentialWebSocketSubprotocol(request)
+  );
 }
 
 function rejectUntrustedMutationOrigin(request: Request, env: Env): Response | null {
@@ -321,7 +324,7 @@ function rejectUntrustedMutationOrigin(request: Request, env: Env): Response | n
     return json({ error: "request origin is not allowed" }, 403);
   }
   if (!origin) {
-    if (hasCloudflareAccessCookie(request)) {
+    if (hasCloudflareAccessSessionCredential(request)) {
       return json({ error: "request origin is required" }, 403);
     }
     return null;
@@ -370,6 +373,13 @@ function hasCloudflareAccessCookie(request: Request): boolean {
   }
 
   return cookie.split(";").some((part) => part.trim().split("=")[0] === "CF_Authorization");
+}
+
+function hasCloudflareAccessSessionCredential(request: Request): boolean {
+  return (
+    hasCloudflareAccessCookie(request) ||
+    Boolean(request.headers.get(CLOUDFLARE_ACCESS_JWT_HEADER)?.trim())
+  );
 }
 
 function hasCredentialWebSocketSubprotocol(request: Request): boolean {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -713,6 +713,55 @@ describe("Worker artifact routes", () => {
     assert.equal(trustedOrigin.status, 201);
   });
 
+  it("requires trusted origins for Access assertion ACL mutations", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv(accessEnv);
+    seedNotebook(env, "access-assertion-acl-demo");
+    seedAcl(env, {
+      notebookId: "access-assertion-acl-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+
+    const body = JSON.stringify({
+      subject_kind: "principal",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+    const headers = {
+      "Cf-Access-Jwt-Assertion": token,
+      "Content-Type": "application/json",
+      "X-Operator": "browser:tab",
+      "X-Scope": "owner",
+    };
+
+    const missingOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-assertion-acl-demo/acl", {
+        method: "POST",
+        headers,
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(missingOrigin.status, 403);
+    assert.deepEqual(await missingOrigin.json(), { error: "request origin is required" });
+
+    const trustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-assertion-acl-demo/acl", {
+        method: "POST",
+        headers: {
+          ...headers,
+          Origin: "https://cloud.test",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(trustedOrigin.status, 201);
+  });
+
   it("lets owners grant and revoke explicit public viewer ACL rows", async () => {
     const env = fakeEnv();
     seedNotebook(env, "public-acl-demo");
@@ -1148,6 +1197,41 @@ describe("Worker artifact routes", () => {
           Upgrade: "websocket",
         },
       }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), { error: "websocket origin is required" });
+    assert.equal(roomFetches, 0);
+  });
+
+  it("rejects Access assertion WebSocket upgrades with no Origin before room dispatch", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    let roomFetches = 0;
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            roomFetches += 1;
+            return new Response("unexpected room fetch", { status: 500 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://cloud.test/n/access-assertion-origin-demo/sync?operator=browser:tab&scope=owner",
+        {
+          headers: {
+            "Cf-Access-Jwt-Assertion": token,
+            Upgrade: "websocket",
+          },
+        },
+      ),
       env,
       fakeContext(),
     );

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -190,14 +190,16 @@ Rules:
 - Do not include the renderer asset Worker origin.
 - Do not include sandboxed output iframe origins.
 - Do not use `*`.
-- Leaving the variable unset keeps the same-origin default only. Cookie-backed
-  Access WebSockets still reject missing or untrusted `Origin`.
+- Leaving the variable unset keeps the same-origin default only. Access
+  assertion-backed and cookie-backed WebSockets still reject missing or
+  untrusted `Origin`.
 
 The Worker checks `Origin` before WebSocket auth whenever a client sends one.
-Malformed or untrusted origins are rejected. Browser Access-cookie sessions
-must always send an allowed `Origin` so a malicious site cannot use an ambient
-Access cookie to open a private room socket. Browser-visible credential
-subprotocols also require `Origin`.
+Malformed or untrusted origins are rejected. Browser Access sessions must
+always send an allowed `Origin` so a malicious site cannot use an ambient
+Access cookie, or the forwarded `Cf-Access-Jwt-Assertion` derived from it, to
+open a private room socket. Browser-visible credential subprotocols also
+require `Origin`.
 
 Header-authenticated CLI, native, and future runtime clients may omit `Origin`,
 even when `NOTEBOOK_CLOUD_ALLOWED_ORIGINS` is configured. If those clients send

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -283,17 +283,19 @@ This answers the central authorization question: the identity provider does not
 need to encode nteract room roles. It may bound global capabilities, but D1 room
 ACL rows grant notebook-specific scopes.
 
-## Decision 8: Origin checks are part of cookie-backed WebSocket auth
+## Decision 8: Origin checks are part of Access session WebSocket auth
 
 Any credential that rides automatically with browser requests requires an
 origin gate for WebSocket upgrades.
 
 Minimum policy:
 
-- Reject cookie-backed WebSocket upgrades with missing or untrusted `Origin`.
-  This applies to viewer and writer connections. A private viewer socket can
-  still leak notebook contents to a malicious page if ambient cookies are
-  enough to authenticate it.
+- Reject cookie-backed and Access assertion-backed WebSocket upgrades with
+  missing or untrusted `Origin`. This applies to viewer and writer
+  connections. A private viewer socket can still leak notebook contents to a
+  malicious page if ambient cookies are enough to authenticate it; the Worker
+  treats `Cf-Access-Jwt-Assertion` as part of the same Access session path
+  because the edge derives it from the browser session.
 - Reject browser-visible credential subprotocol upgrades with missing or
   untrusted `Origin`, because page JavaScript can initiate those connections.
 - Maintain an allowlist of notebook application origins that are allowed to


### PR DESCRIPTION
## Summary

- Treat forwarded `Cf-Access-Jwt-Assertion` credentials as Cloudflare Access session credentials for Origin enforcement.
- Require trusted `Origin` before Access assertion-backed ACL mutations or WebSocket room dispatch.
- Update the hosted credential ADR/runbook and notebook-cloud README so browser Access sessions, whether cookie or edge-forwarded assertion, share the same CSRF/WebSocket policy.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `git diff --check`

