### PR TITLE
fix(notebook-cloud): fail closed on live sync decode errors

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -173,6 +173,55 @@ describe("cloud live sync", () => {
       fake.restore();
     }
   });
+
+  it("rejects ready when the bootstrap message cannot be decoded", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
+      const socket = fake.socket;
+      socket.open();
+      socket.message("not binary");
+
+      await assert.rejects(
+        transport.ready,
+        /cloud sync socket message failed: unsupported WebSocket message/,
+      );
+      assert.equal(socket.readyState, FakeWebSocket.CLOSED);
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("notifies disconnect when a post-ready message cannot be decoded", async () => {
+    const fake = installFakeWebSocket();
+    const disconnects: string[] = [];
+    try {
+      const transport = new CloudWebSocketTransport(
+        new URL("wss://example.test/n/room/sync"),
+        [],
+        undefined,
+        (reason) => disconnects.push(reason.message),
+      );
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      socket.message("not binary");
+      await nextMicrotask();
+
+      assert.deepEqual(disconnects, [
+        "cloud sync socket message failed: unsupported WebSocket message [object String]",
+      ]);
+      assert.equal(socket.readyState, FakeWebSocket.CLOSED);
+      await assert.rejects(
+        transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
+        /cloud sync socket is closed/,
+      );
+    } finally {
+      fake.restore();
+    }
+  });
 });
 
 function installFakeWebSocket(): {
@@ -243,12 +292,20 @@ class FakeWebSocket extends EventTarget {
     frame.set(payload, 1);
     this.dispatchEvent(messageEvent(frame.buffer));
   }
+
+  message(data: unknown): void {
+    this.dispatchEvent(messageEvent(data));
+  }
 }
 
-function messageEvent(data: ArrayBuffer): Event {
+function messageEvent(data: unknown): Event {
   const event = new Event("message");
   Object.defineProperty(event, "data", { value: data });
   return event;
+}
+
+async function nextMicrotask(): Promise<void> {
+  await Promise.resolve();
 }
 
 function closeEvent(code: number, reason: string): Event {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -216,7 +216,17 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.socket = protocols.length > 0 ? new WebSocket(url, protocols) : new WebSocket(url);
     this.socket.binaryType = "arraybuffer";
     this.socket.addEventListener("message", (event) => {
-      void this.handleMessage(event.data);
+      void this.handleMessage(event.data).catch((error: unknown) => {
+        const reason =
+          error instanceof Error
+            ? new Error(`cloud sync socket message failed: ${error.message}`)
+            : new Error(`cloud sync socket message failed: ${String(error)}`);
+        if (!this.readySettled) {
+          this.readyReject(reason);
+        }
+        this.markClosed(reason);
+        this.socket.close();
+      });
     });
     this.socket.addEventListener("error", () => {
       const reason = new Error(`cloud sync socket failed`);


### PR DESCRIPTION
## Summary

- Fail the cloud viewer WebSocket transport closed when inbound message decoding fails.
- Reject bootstrap readiness if the room sends an invalid ready/control message before the viewer is ready.
- Notify the existing disconnect/reconnect path for post-ready decode failures instead of leaving an unhandled promise rejection and a half-running sync engine.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`

