### PR TITLE
fix(kernel-launcher): preserve polars object date columns

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import hashlib
+import sys
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -75,6 +76,9 @@ def has_arrow_stream_protocol(obj: Any) -> bool:
 
 
 def _normalize_polars_object_dates(df: Any) -> Any:
+    if not type(df).__module__.startswith("polars"):
+        return df
+
     schema = getattr(df, "schema", None)
     if not schema or not hasattr(schema, "items"):
         return df
@@ -103,18 +107,16 @@ def _normalize_polars_object_dates(df: Any) -> Any:
     if not date_columns:
         return df
 
-    try:
-        import polars as pl
-    except Exception:
+    pl = sys.modules.get("polars")
+    if pl is None:
         return df
 
-    date_exprs = [
-        pl.col(name).map_elements(lambda value: value, return_dtype=pl.Date)
-        for name in date_columns
+    date_series = [
+        pl.Series(name, get_column(name).to_list(), dtype=pl.Date) for name in date_columns
     ]
 
     try:
-        return with_columns(date_exprs)
+        return with_columns(date_series)
     except Exception:
         return df
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -75,39 +75,46 @@ def has_arrow_stream_protocol(obj: Any) -> bool:
 
 
 def _normalize_polars_object_dates(df: Any) -> Any:
-    try:
-        import polars as pl
-    except Exception:
-        return df
-
-    if not isinstance(df, pl.DataFrame):
-        return df
-
     schema = getattr(df, "schema", None)
-    if not schema:
+    if not schema or not hasattr(schema, "items"):
         return df
 
-    object_columns = [name for name, dtype in schema.items() if dtype == pl.Object]
+    get_column = getattr(df, "get_column", None)
+    with_columns = getattr(df, "with_columns", None)
+    if not callable(get_column) or not callable(with_columns):
+        return df
+
+    object_columns = [name for name, dtype in schema.items() if str(dtype) == "Object"]
     if not object_columns:
         return df
 
-    date_exprs = []
+    date_columns = []
     for name in object_columns:
         try:
-            values = df.get_column(name).drop_nulls().to_list()
+            values = get_column(name).drop_nulls().to_list()
         except Exception:
             continue
 
         if values and all(
             isinstance(value, _dt.date) and not isinstance(value, _dt.datetime) for value in values
         ):
-            date_exprs.append(pl.col(name).map_elements(lambda value: value, return_dtype=pl.Date))
+            date_columns.append(name)
 
-    if not date_exprs:
+    if not date_columns:
         return df
 
     try:
-        return df.with_columns(date_exprs)
+        import polars as pl
+    except Exception:
+        return df
+
+    date_exprs = [
+        pl.col(name).map_elements(lambda value: value, return_dtype=pl.Date)
+        for name in date_columns
+    ]
+
+    try:
+        return with_columns(date_exprs)
     except Exception:
         return df
 

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -8,6 +8,7 @@ Arrow manifest with multiple independently decodable stream chunks.
 
 from __future__ import annotations
 
+import datetime as _dt
 import hashlib
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -71,6 +72,41 @@ def has_arrow_stream_protocol(obj: Any) -> bool:
         return isinstance(obj, pa.RecordBatchReader)
     except Exception:
         return False
+
+
+def _normalize_polars_object_dates(df: Any) -> Any:
+    try:
+        import polars as pl
+    except Exception:
+        return df
+
+    schema = getattr(df, "schema", None)
+    if not schema:
+        return df
+
+    object_columns = [name for name, dtype in schema.items() if dtype == pl.Object]
+    if not object_columns:
+        return df
+
+    date_exprs = []
+    for name in object_columns:
+        try:
+            values = df.get_column(name).drop_nulls().to_list()
+        except Exception:
+            continue
+
+        if values and all(
+            isinstance(value, _dt.date) and not isinstance(value, _dt.datetime) for value in values
+        ):
+            date_exprs.append(pl.col(name).map_elements(lambda value: value, return_dtype=pl.Date))
+
+    if not date_exprs:
+        return df
+
+    try:
+        return df.with_columns(date_exprs)
+    except Exception:
+        return df
 
 
 def _record_batch_reader_from_stream(source: Any) -> Any:
@@ -324,6 +360,7 @@ def serialize_dataframe(df: Any, *, max_bytes: int) -> tuple[bytes, str, int]:
     objects that do not expose the Arrow stream protocol or that need a chunked
     manifest.
     """
+    df = _normalize_polars_object_dates(df)
     if not has_arrow_stream_protocol(df):
         raise ValueError(f"unsupported DataFrame type: {type(df).__module__}.{type(df).__name__}")
     data, content_type, included_rows, _record_batch_count = serialize_arrow_stream(

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -80,6 +80,9 @@ def _normalize_polars_object_dates(df: Any) -> Any:
     except Exception:
         return df
 
+    if not isinstance(df, pl.DataFrame):
+        return df
+
     schema = getattr(df, "schema", None)
     if not schema:
         return df

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -20,4 +20,11 @@ build-backend = "hatchling.build"
 packages = ["nteract_kernel_launcher"]
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = [
+    "pytest>=8.0",
+    "pyarrow>=14",
+    "pandas",
+    "polars",
+    "numpy>=2.2.6",
+    "narwhals>=1.0",
+]

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -116,6 +116,31 @@ def test_serialize_dataframe_polars_emits_arrow_stream():
     assert table.num_rows == 3
 
 
+def test_serialize_dataframe_polars_object_dates_emit_arrow_date32():
+    import datetime as dt
+
+    np = pytest.importorskip("numpy")
+    pa = pytest.importorskip("pyarrow")
+    pl = pytest.importorskip("polars")
+    from nteract_kernel_launcher._format import serialize_dataframe
+
+    date_options = [
+        dt.date(1997, 1, 10),
+        dt.date(1985, 2, 15),
+        dt.date(1983, 3, 22),
+        dt.date(1981, 4, 30),
+    ]
+    birthdates = np.random.default_rng(0).choice(date_options, size=8)
+    df = pl.DataFrame({"birthdate": birthdates})
+    assert df.schema["birthdate"] == pl.Object
+
+    data, _, _ = serialize_dataframe(df, max_bytes=10_000_000)
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert table.schema.field("birthdate").type == pa.date32()
+    assert table.to_pydict()["birthdate"] == list(birthdates)
+
+
 def test_serialize_dataframe_polars_uses_arrow_stream_protocol(monkeypatch):
     pl = pytest.importorskip("polars")
     import nteract_kernel_launcher._format as fmt

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -193,6 +193,18 @@ def test_serialize_dataframe_accepts_arrow_pycapsule_stream_protocol():
     assert table.num_rows == 10
 
 
+def test_serialize_dataframe_accepts_pyarrow_table_when_polars_is_importable():
+    pa = pytest.importorskip("pyarrow")
+    pytest.importorskip("polars")
+    from nteract_kernel_launcher._format import serialize_dataframe
+
+    data, _, included_rows = serialize_dataframe(pa.table({"a": [1, 2, 3]}), max_bytes=10_000_000)
+
+    table = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert included_rows == 3
+    assert table.to_pydict() == {"a": [1, 2, 3]}
+
+
 def test_serialize_dataframe_rejects_oversized_generic_pycapsule_stream():
     pa = pytest.importorskip("pyarrow")
     from nteract_kernel_launcher._format import serialize_dataframe

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -141,6 +141,71 @@ def test_serialize_dataframe_polars_object_dates_emit_arrow_date32():
     assert table.to_pydict()["birthdate"] == list(birthdates)
 
 
+def test_normalize_polars_object_dates_uses_loaded_polars_module(monkeypatch):
+    import builtins
+    import datetime as dt
+    import sys
+    from types import SimpleNamespace
+
+    import nteract_kernel_launcher._format as fmt
+
+    class FakeColumn:
+        def __init__(self, values):
+            self._values = values
+
+        def drop_nulls(self):
+            return self
+
+        def to_list(self):
+            return self._values
+
+    class FakePolarsDataFrame:
+        __module__ = "polars.dataframe.frame"
+
+        schema = {"birthdate": "Object"}
+
+        def __init__(self):
+            self.series = None
+
+        def get_column(self, name):
+            assert name == "birthdate"
+            return FakeColumn([dt.date(1997, 1, 10)])
+
+        def with_columns(self, series):
+            self.series = series
+            return self
+
+    def make_series(name, values, dtype):
+        return {"name": name, "values": values, "dtype": dtype}
+
+    fake_pl = SimpleNamespace(Date=object(), Series=make_series)
+    monkeypatch.setitem(sys.modules, "polars", fake_pl)
+
+    polars_imports = 0
+    original_import = builtins.__import__
+
+    def import_spy(name, *args, **kwargs):
+        nonlocal polars_imports
+        if name == "polars" or name.startswith("polars."):
+            polars_imports += 1
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_spy)
+
+    df = FakePolarsDataFrame()
+    normalized = fmt._normalize_polars_object_dates(df)
+
+    assert normalized is df
+    assert df.series == [
+        {
+            "name": "birthdate",
+            "values": [dt.date(1997, 1, 10)],
+            "dtype": fake_pl.Date,
+        }
+    ]
+    assert polars_imports == 0
+
+
 def test_serialize_dataframe_polars_uses_arrow_stream_protocol(monkeypatch):
     pl = pytest.importorskip("polars")
     import nteract_kernel_launcher._format as fmt

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -205,6 +205,29 @@ def test_serialize_dataframe_accepts_pyarrow_table_when_polars_is_importable():
     assert table.to_pydict() == {"a": [1, 2, 3]}
 
 
+def test_serialize_dataframe_pyarrow_table_does_not_import_polars(monkeypatch):
+    import builtins
+
+    pa = pytest.importorskip("pyarrow")
+    pytest.importorskip("polars")
+    from nteract_kernel_launcher._format import serialize_dataframe
+
+    polars_imports = 0
+    original_import = builtins.__import__
+
+    def import_spy(name, *args, **kwargs):
+        nonlocal polars_imports
+        if name == "polars" or name.startswith("polars."):
+            polars_imports += 1
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_spy)
+
+    serialize_dataframe(pa.table({"a": [1, 2, 3]}), max_bytes=10_000_000)
+
+    assert polars_imports == 0
+
+
 def test_serialize_dataframe_rejects_oversized_generic_pycapsule_stream():
     pa = pytest.importorskip("pyarrow")
     from nteract_kernel_launcher._format import serialize_dataframe


### PR DESCRIPTION
## Summary

- Normalize recoverable Polars `Object` columns containing Python `datetime.date` values to `pl.Date` before Arrow stream serialization.
- Add a regression for the `np.random.choice([... datetime.date ...])` path that otherwise exports as `fixed_size_binary[8]`.

## Verification

- `uv run --with pyarrow --with pandas --with polars --with narwhals --with numpy pytest python/nteract-kernel-launcher/tests/test_bootstrap.py python/nteract-kernel-launcher/tests/test_format.py -q`
- `cargo xtask lint --fix`

## Notes

- The stable MCP server reproduced the released behavior, but did not validate this local patch because it was not connected to the local dev daemon.
