### PR TITLE
test(notebook-cloud): preflight Access smoke readiness

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -288,6 +288,12 @@ NOTEBOOK_CLOUD_ACCESS_NOTEBOOK_ID=access-demo-$(date +%Y%m%d%H%M%S) \
 pnpm --dir apps/notebook-cloud smoke:hosted:access
 ```
 
+Before creating or mutating the smoke notebook, the script preflights
+`/api/health` with `CF-Access-Token` and requires
+`auth.cloudflare_access.status === "configured"`. That catches missing
+`NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` / `NOTEBOOK_CLOUD_ACCESS_AUD` deployment
+vars before ACL writes or WebSocket sync attempts.
+
 Use `NOTEBOOK_CLOUD_ACCESS_EDITOR_JWT` and
 `NOTEBOOK_CLOUD_ACCESS_VIEWER_JWT` to run the same smoke with separate Access
 users. Add `NOTEBOOK_CLOUD_ACCESS_PUBLIC_SMOKE=1` only for a host that allows

--- a/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
@@ -10,6 +10,38 @@ export function assertHostedAccessSmokeEnv({ ownerToken }) {
   );
 }
 
+export function assertAccessHealthConfigured(payload, { baseUrl } = {}) {
+  const health = accessHealthFromPayload(payload);
+  if (health.status === "configured") {
+    return health;
+  }
+
+  const target = baseUrl ? ` for ${baseUrl}` : "";
+  const detail =
+    health.status === "partial"
+      ? "exactly one of NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN or NOTEBOOK_CLOUD_ACCESS_AUD is missing"
+      : "NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN and NOTEBOOK_CLOUD_ACCESS_AUD are not set";
+  throw new Error(
+    `Cloudflare Access auth is ${health.status}${target}; expected configured before running the hosted Access smoke (${detail}; jwks=${health.jwks}).`,
+  );
+}
+
+export function accessHealthFromPayload(payload) {
+  const access = payload?.auth?.cloudflare_access;
+  if (!access || typeof access !== "object") {
+    throw new Error("health response is missing auth.cloudflare_access");
+  }
+
+  const { status, jwks } = access;
+  if (!["configured", "partial", "disabled"].includes(status)) {
+    throw new Error(`health response has invalid Cloudflare Access status: ${String(status)}`);
+  }
+  if (!["remote", "pinned", "none"].includes(jwks)) {
+    throw new Error(`health response has invalid Cloudflare Access JWKS status: ${String(jwks)}`);
+  }
+  return { status, jwks };
+}
+
 export function accessPrincipalFromJwt(token) {
   const payload = decodeJwtPayload(token);
   const subject = typeof payload.sub === "string" ? payload.sub.trim() : "";

--- a/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { FrameType } from "runtimed";
 
 import {
+  assertAccessHealthConfigured,
   accessAuthHeaders,
   accessPrincipalFromJwt,
   assertHostedAccessSmokeEnv,
@@ -37,6 +38,7 @@ const wasmBytesUrl = new URL(
 
 const startedAt = performance.now();
 assertHostedAccessSmokeEnv({ ownerToken });
+const accessHealth = await timed("access_health", () => assertAccessHealthReady());
 await assertWasmBuildExists();
 
 const ownerPrincipal = accessPrincipalFromJwt(ownerToken);
@@ -146,6 +148,7 @@ console.log(
       auth_mode: "cloudflare_access",
       baseUrl,
       origin: smokeOrigin,
+      access_health: accessHealth,
       roomId,
       viewerUrl: new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href,
       principal_fingerprints: {
@@ -154,6 +157,7 @@ console.log(
         viewer: fingerprintPrincipal(viewerPrincipal),
       },
       checks: [
+        "cloudflare_access_worker_configured",
         "cloudflare_access_jwt_validated_by_worker",
         "owner_acl_room_seeded",
         "editor_principal_acl_granted",
@@ -204,6 +208,23 @@ async function assertWasmBuildExists() {
       "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
     );
   }
+}
+
+async function assertAccessHealthReady() {
+  const response = await fetch(new URL("/api/health", baseUrl), {
+    headers: accessAuthHeaders(ownerToken),
+  });
+  const text = await response.text();
+  assert(response.ok, `Access health preflight failed: ${response.status} ${previewText(text)}`);
+
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw new Error(`Access health preflight did not return JSON: ${previewText(text)}`);
+  }
+
+  return assertAccessHealthConfigured(payload, { baseUrl });
 }
 
 async function seedNotebookOwner(notebookId) {
@@ -325,6 +346,13 @@ async function connectAnonymous(notebookId, viewerSession) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function previewText(text, maxLength = 300) {
+  const value = String(text ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
@@ -2,10 +2,12 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  accessHealthFromPayload,
   accessAuthHeaders,
   accessAuthProtocols,
   accessEmailFromJwt,
   accessPrincipalFromJwt,
+  assertAccessHealthConfigured,
   assertHostedAccessSmokeEnv,
   webSocketUpgradeRequestHeaders,
 } from "../scripts/hosted-access-smoke-env.mjs";
@@ -81,6 +83,89 @@ describe("hosted Access smoke environment helpers", () => {
     assert.throws(
       () => assertHostedAccessSmokeEnv({ ownerToken: "" }),
       /NOTEBOOK_CLOUD_ACCESS_JWT is required/,
+    );
+  });
+
+  it("parses configured Access health readiness", () => {
+    assert.deepEqual(
+      accessHealthFromPayload({
+        auth: {
+          cloudflare_access: {
+            status: "configured",
+            jwks: "remote",
+          },
+        },
+      }),
+      { status: "configured", jwks: "remote" },
+    );
+    assert.deepEqual(
+      assertAccessHealthConfigured({
+        auth: {
+          cloudflare_access: {
+            status: "configured",
+            jwks: "pinned",
+          },
+        },
+      }),
+      { status: "configured", jwks: "pinned" },
+    );
+  });
+
+  it("fails hosted Access smoke preflight when Access config is partial or disabled", () => {
+    assert.throws(
+      () =>
+        assertAccessHealthConfigured(
+          {
+            auth: {
+              cloudflare_access: {
+                status: "partial",
+                jwks: "none",
+              },
+            },
+          },
+          { baseUrl: "https://notebooks.example.com" },
+        ),
+      /Cloudflare Access auth is partial for https:\/\/notebooks\.example\.com; expected configured.*exactly one of NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN or NOTEBOOK_CLOUD_ACCESS_AUD is missing.*jwks=none/,
+    );
+    assert.throws(
+      () =>
+        assertAccessHealthConfigured({
+          auth: {
+            cloudflare_access: {
+              status: "disabled",
+              jwks: "none",
+            },
+          },
+        }),
+      /Cloudflare Access auth is disabled; expected configured.*NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN and NOTEBOOK_CLOUD_ACCESS_AUD are not set.*jwks=none/,
+    );
+  });
+
+  it("rejects malformed Access health payloads", () => {
+    assert.throws(() => accessHealthFromPayload({ auth: {} }), /missing auth\.cloudflare_access/);
+    assert.throws(
+      () =>
+        accessHealthFromPayload({
+          auth: {
+            cloudflare_access: {
+              status: "ready",
+              jwks: "remote",
+            },
+          },
+        }),
+      /invalid Cloudflare Access status: ready/,
+    );
+    assert.throws(
+      () =>
+        accessHealthFromPayload({
+          auth: {
+            cloudflare_access: {
+              status: "configured",
+              jwks: "local",
+            },
+          },
+        }),
+      /invalid Cloudflare Access JWKS status: local/,
     );
   });
 });

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -297,6 +297,8 @@ serving room state.
 
 The Access smoke proves that:
 
+- `/api/health` reports Cloudflare Access as fully configured before the script
+  creates or mutates a room;
 - the Worker accepts a Cloudflare Access application JWT;
 - the Access JWT maps to `user:cloudflare-access:<sub>`, not email;
 - owner, editor, and viewer ACL rows are honored;
@@ -338,6 +340,11 @@ The script sends:
 - `Origin: https://<notebook-host>` to exercise the browser-compatible
   WebSocket origin gate;
 
+The first request is a token-authenticated `/api/health` preflight. It requires
+`auth.cloudflare_access.status === "configured"` and fails before ACL writes if
+one of `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` or `NOTEBOOK_CLOUD_ACCESS_AUD` is
+missing.
+
 It intentionally sends one client-carried Access credential transport per
 request. If Access forwards `Cf-Access-Jwt-Assertion` to the origin after
 admitting the request, the Worker validates that forwarded assertion as the
@@ -354,8 +361,13 @@ Expected JSON shape:
 {
   "ok": true,
   "auth_mode": "cloudflare_access",
+  "access_health": {
+    "status": "configured",
+    "jwks": "remote"
+  },
   "viewerUrl": "https://<notebook-host>/n/<id>",
   "checks": [
+    "cloudflare_access_worker_configured",
     "cloudflare_access_jwt_validated_by_worker",
     "owner_acl_room_seeded",
     "editor_principal_acl_granted",


### PR DESCRIPTION
## Summary

- preflight `/api/health` before the hosted Cloudflare Access smoke mutates a notebook room
- require `auth.cloudflare_access.status === "configured"` and surface partial/disabled deployment details
- include the non-secret Access health result in smoke output and document the readiness check

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-access-smoke-env.test.mjs test/hosted-access-smoke-ws.test.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
- `git diff --check`
