### PR TITLE
refactor(runt): remove deprecated console command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7252,17 +7252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpassword"
-version = "7.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7280,16 +7269,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7313,7 +7292,6 @@ dependencies = [
  "nteract-telemetry",
  "petname",
  "rmcp",
- "rpassword",
  "runt-mcp",
  "runt-workspace",
  "runtimed-client",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -29,7 +29,6 @@ clap = { version = "4.5.1", features = ["derive", "color"] }
 colored = "3"
 tokio = { version = "1", features = ["full"] }
 petname = "2"
-rpassword = "7"
 dirs = "6"
 tabled = "0.20"
 futures = "0.3"

--- a/crates/runt/src/kernel_client.rs
+++ b/crates/runt/src/kernel_client.rs
@@ -101,62 +101,6 @@ impl KernelClient {
         })
     }
 
-    /// Start a kernel from a raw command string.
-    ///
-    /// The command is split on whitespace and `{connection_file}` is replaced
-    /// with the path to the generated connection file.
-    #[allow(clippy::expect_used)] // petname only returns None when word count is 0
-    pub async fn start_from_command(cmd: &str) -> Result<Self> {
-        let kernel_id = petname(2, "-").expect("failed to generate petname");
-        let session_id = Uuid::new_v4().to_string();
-        let key = Uuid::new_v4().to_string();
-
-        let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
-        let (ports, listeners) = peek_ports_with_listeners(ip, 5).await?;
-        let connection_info = ConnectionInfo {
-            transport: jupyter_protocol::connection_info::Transport::TCP,
-            ip: ip.to_string(),
-            stdin_port: ports[0],
-            control_port: ports[1],
-            hb_port: ports[2],
-            shell_port: ports[3],
-            iopub_port: ports[4],
-            signature_scheme: "hmac-sha256".to_string(),
-            key,
-            kernel_name: None,
-        };
-
-        let runtime_dir = runtime_dir();
-        tokio::fs::create_dir_all(&runtime_dir).await?;
-
-        let connection_file = runtime_dir.join(format!("runt-kernel-{}.json", kernel_id));
-        let content = serde_json::to_string(&connection_info)?;
-        tokio::fs::write(&connection_file, &content).await?;
-
-        let cf_str = connection_file.to_string_lossy();
-        let args: Vec<String> = cmd
-            .split_whitespace()
-            .map(|arg| arg.replace("{connection_file}", &cf_str))
-            .collect();
-
-        let mut command = tokio::process::Command::new(&args[0]);
-        command.args(&args[1..]);
-        command.current_dir(default_kernel_cwd());
-        let child = command.spawn().map_err(|e| RuntimeError::CommandFailed {
-            command: "kernel",
-            source: e,
-        })?;
-        drop(listeners);
-
-        Ok(Self {
-            kernel_id,
-            session_id,
-            connection_info,
-            connection_file,
-            child: Some(child),
-        })
-    }
-
     pub async fn from_connection_file(path: impl AsRef<Path>) -> Result<Self> {
         let connection_file = path.as_ref().to_path_buf();
         let content = tokio::fs::read_to_string(&connection_file).await?;
@@ -183,14 +127,6 @@ impl KernelClient {
 
     pub fn connection_file(&self) -> &Path {
         &self.connection_file
-    }
-
-    pub fn connection_info(&self) -> &ConnectionInfo {
-        &self.connection_info
-    }
-
-    pub fn session_id(&self) -> &str {
-        &self.session_id
     }
 
     pub async fn interrupt(&mut self) -> Result<()> {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -320,15 +320,6 @@ enum Commands {
     /// [DEPRECATED] Use 'runt jupyter exec' instead
     #[command(hide = true)]
     Exec { id: String, code: Option<String> },
-    /// [DEPRECATED] Use 'runt jupyter console' instead
-    #[command(hide = true)]
-    Console {
-        kernel: Option<String>,
-        #[arg(long)]
-        cmd: Option<String>,
-        #[arg(short, long)]
-        verbose: bool,
-    },
     /// [DEPRECATED] Use 'runt jupyter clean' instead
     #[command(hide = true)]
     Clean {
@@ -387,17 +378,6 @@ enum JupyterCommands {
         id: String,
         /// The code to execute (reads from stdin if not provided)
         code: Option<String>,
-    },
-    /// Launch a kernel and open an interactive console
-    Console {
-        /// The kernel to launch (e.g., python3, julia)
-        kernel: Option<String>,
-        /// Custom command to launch the kernel (use {connection_file} as placeholder)
-        #[arg(long)]
-        cmd: Option<String>,
-        /// Print all Jupyter messages for debugging
-        #[arg(short, long)]
-        verbose: bool,
     },
     /// Remove stale kernel connection files for kernels that are no longer running
     Clean {
@@ -771,15 +751,6 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             eprintln!("         Use the daemon (notebook app or `runt mcp`) instead.");
             execute_code(&id, code.as_deref()).await?
         }
-        Some(Commands::Console {
-            kernel,
-            cmd,
-            verbose,
-        }) => {
-            eprintln!("Warning: 'runt console' is deprecated and will be removed in v2.5.");
-            eprintln!("         Use the daemon (notebook app or `runt mcp`) instead.");
-            console(kernel.as_deref(), cmd.as_deref(), verbose).await?
-        }
         Some(Commands::Clean { timeout, dry_run }) => {
             eprintln!("Warning: 'runt clean' is deprecated and will be removed in v2.5.");
             eprintln!("         Use the daemon (notebook app or `runt mcp`) instead.");
@@ -1111,11 +1082,6 @@ async fn jupyter_command(command: JupyterCommands) -> Result<()> {
         JupyterCommands::Stop { id, all } => stop_kernels(id.as_deref(), all).await,
         JupyterCommands::Interrupt { id } => interrupt_kernel(&id).await,
         JupyterCommands::Exec { id, code } => execute_code(&id, code.as_deref()).await,
-        JupyterCommands::Console {
-            kernel,
-            cmd,
-            verbose,
-        } => console(kernel.as_deref(), cmd.as_deref(), verbose).await,
         JupyterCommands::Clean { timeout, dry_run } => clean_kernels(timeout, dry_run).await,
     }
 }
@@ -1517,193 +1483,6 @@ async fn check_kernel_alive(connection_info: &ConnectionInfo, timeout: Duration)
     .await;
 
     matches!(heartbeat_result, Ok(Ok(())))
-}
-
-async fn console(kernel_name: Option<&str>, cmd: Option<&str>, verbose: bool) -> Result<()> {
-    use jupyter_protocol::{
-        ExecuteRequest, ExecutionState, InputReply, JupyterMessage, JupyterMessageContent,
-        MediaType, ReplyStatus, Status, Stdio,
-    };
-    use std::io::{self, Write};
-
-    let mut client = match (kernel_name, cmd) {
-        (_, Some(cmd)) => KernelClient::start_from_command(cmd).await?,
-        (Some(name), None) => {
-            let kernelspec = find_kernelspec(name).await?;
-            KernelClient::start_from_kernelspec(kernelspec).await?
-        }
-        (None, None) => anyhow::bail!("Provide a kernel name or --cmd"),
-    };
-
-    // Give the kernel a moment to bind its sockets
-    tokio::time::sleep(Duration::from_millis(500)).await;
-
-    let connection_info = client.connection_info();
-    let session_id = client.session_id();
-
-    let identity = jupyter_zmq_client::peer_identity_for_session(session_id)?;
-    let shell = jupyter_zmq_client::create_client_shell_connection_with_identity(
-        connection_info,
-        session_id,
-        identity.clone(),
-    )
-    .await?;
-    let mut stdin_conn = jupyter_zmq_client::create_client_stdin_connection_with_identity(
-        connection_info,
-        session_id,
-        identity,
-    )
-    .await?;
-    let (mut shell_writer, mut shell_reader) = shell.split();
-
-    let mut iopub =
-        jupyter_zmq_client::create_client_iopub_connection(connection_info, "", session_id).await?;
-
-    let kernel_name = connection_info
-        .kernel_name
-        .clone()
-        .unwrap_or_else(|| "kernel".to_string());
-    println!("{} console", kernel_name);
-    println!("Use Ctrl+D to exit.\n");
-
-    let mut execution_count: u32 = 0;
-
-    loop {
-        execution_count += 1;
-        print!("In [{}]: ", execution_count);
-        io::stdout().flush()?;
-
-        // Read one line without holding a persistent StdinLock, so that
-        // the kernel stdin handler can also read from terminal stdin.
-        let mut line = String::new();
-        if io::stdin().read_line(&mut line)? == 0 {
-            break; // EOF
-        }
-
-        let code = line.trim();
-        if code.is_empty() {
-            execution_count -= 1;
-            continue;
-        }
-
-        let mut execute_request = ExecuteRequest::new(code.to_string());
-        execute_request.allow_stdin = true;
-        let message: JupyterMessage = execute_request.into();
-        let message_id = message.header.msg_id.clone();
-        shell_writer.send(message).await?;
-
-        // Wait for idle status on iopub (signals all output is done).
-        // Some kernels send ExecuteReply before streaming output, so we
-        // can't use the reply alone as the completion signal.
-        let mut got_idle = false;
-        while !got_idle {
-            tokio::select! {
-                result = iopub.read() => {
-                    let msg = result?;
-                    let is_ours = msg
-                        .parent_header
-                        .as_ref()
-                        .map(|h| h.msg_id.as_str())
-                        == Some(message_id.as_str());
-                    if verbose {
-                        eprintln!("[iopub] {} (ours={})", msg.header.msg_type, is_ours);
-                    }
-                    if !is_ours {
-                        continue;
-                    }
-                    match &msg.content {
-                        JupyterMessageContent::StreamContent(stream) => {
-                            match stream.name {
-                                Stdio::Stdout => print!("{}", stream.text),
-                                Stdio::Stderr => eprint!("{}", stream.text),
-                            }
-                            let _ = io::stdout().flush();
-                        }
-                        JupyterMessageContent::ExecuteResult(result) => {
-                            for media in &result.data.content {
-                                if let MediaType::Plain(text) = media {
-                                    println!("Out[{}]: {}", execution_count, text);
-                                    break;
-                                }
-                            }
-                        }
-                        JupyterMessageContent::DisplayData(data) => {
-                            for media in &data.data.content {
-                                if let MediaType::Plain(text) = media {
-                                    println!("{}", text);
-                                    break;
-                                }
-                            }
-                        }
-                        JupyterMessageContent::ErrorOutput(error) => {
-                            eprintln!("{}: {}", error.ename, error.evalue);
-                            for line in &error.traceback {
-                                eprintln!("{}", line);
-                            }
-                        }
-                        JupyterMessageContent::Status(Status { execution_state }) => {
-                            if *execution_state == ExecutionState::Idle {
-                                got_idle = true;
-                            }
-                        }
-                        JupyterMessageContent::UpdateDisplayData(data) => {
-                            for media in &data.data.content {
-                                if let MediaType::Plain(text) = media {
-                                    println!("{}", text);
-                                    break;
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                result = shell_reader.read() => {
-                    let msg = result?;
-                    if verbose {
-                        let is_ours = msg
-                            .parent_header
-                            .as_ref()
-                            .map(|h| h.msg_id.as_str())
-                            == Some(message_id.as_str());
-                        eprintln!("[shell] {} (ours={})", msg.header.msg_type, is_ours);
-                    }
-                }
-                result = stdin_conn.read() => {
-                    let msg = result?;
-                    if verbose {
-                        eprintln!("[stdin] {}", msg.header.msg_type);
-                    }
-                    if let JupyterMessageContent::InputRequest(ref request) = msg.content {
-                        let value = if request.password {
-                            eprint!("{}", request.prompt);
-                            let _ = io::stderr().flush();
-                            rpassword::read_password().unwrap_or_default()
-                        } else {
-                            eprint!("{}", request.prompt);
-                            let _ = io::stderr().flush();
-                            let mut input = String::new();
-                            io::stdin().read_line(&mut input)?;
-                            input.trim_end_matches('\n').to_string()
-                        };
-                        let reply = InputReply {
-                            value,
-                            status: ReplyStatus::Ok,
-                            error: None,
-                        };
-                        stdin_conn.send(reply.as_child_of(&msg)).await?;
-                    }
-                }
-            }
-        }
-        // Blank line between output and the next prompt
-        println!();
-    }
-
-    println!("\nShutting down kernel...");
-    client.shutdown(false).await?;
-    println!("Done.");
-
-    Ok(())
 }
 
 async fn execute_code(id: &str, code: Option<&str>) -> Result<()> {


### PR DESCRIPTION
## Summary
- removes the deprecated interactive `runt console` alias
- removes `runt jupyter console` and its interactive console implementation
- drops the now-unused `rpassword` dependency and lockfile entries

## Verification
- `cargo check -p runt`
- `cargo test -p runt`
- `cargo xtask lint --fix`
- `target/debug/runt console` exits with unrecognized subcommand
- `target/debug/runt jupyter console` exits with unrecognized subcommand
- `target/debug/runt jupyter --help` no longer lists `console`
