### PR TITLE
feat(notebook-cloud): add sharing invite storage

### DIFF
--- a/apps/notebook-cloud/migrations/0005_sharing_invites.sql
+++ b/apps/notebook-cloud/migrations/0005_sharing_invites.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS principal_profiles (
+  principal TEXT PRIMARY KEY,
+  provider TEXT NOT NULL,
+  provider_subject TEXT,
+  email_normalized TEXT,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  display_name TEXT,
+  avatar_url TEXT,
+  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  raw_claims_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS principal_profiles_email_idx
+  ON principal_profiles(provider, email_normalized)
+  WHERE email_verified = 1;
+
+CREATE TABLE IF NOT EXISTS notebook_invites (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  email_normalized TEXT NOT NULL,
+  provider_hint TEXT,
+  scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+  invited_by_actor_label TEXT NOT NULL,
+  accepted_by_principal TEXT,
+  token_hash TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  expires_at TEXT,
+  accepted_at TEXT,
+  revoked_at TEXT,
+  revoked_by_actor_label TEXT,
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE INDEX IF NOT EXISTS notebook_invites_pending_lookup_idx
+  ON notebook_invites(provider_hint, email_normalized, status);
+
+CREATE INDEX IF NOT EXISTS notebook_invites_notebook_idx
+  ON notebook_invites(notebook_id, status);

--- a/apps/notebook-cloud/migrations/0005_sharing_invites.sql
+++ b/apps/notebook-cloud/migrations/0005_sharing_invites.sql
@@ -34,7 +34,15 @@ CREATE TABLE IF NOT EXISTS notebook_invites (
 );
 
 CREATE INDEX IF NOT EXISTS notebook_invites_pending_lookup_idx
-  ON notebook_invites(provider_hint, email_normalized, status);
+  ON notebook_invites(email_normalized, status, provider_hint);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notebook_invites_pending_provider_unique_idx
+  ON notebook_invites(notebook_id, email_normalized, provider_hint, scope)
+  WHERE status = 'pending' AND provider_hint IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS notebook_invites_pending_wildcard_unique_idx
+  ON notebook_invites(notebook_id, email_normalized, scope)
+  WHERE status = 'pending' AND provider_hint IS NULL;
 
 CREATE INDEX IF NOT EXISTS notebook_invites_notebook_idx
   ON notebook_invites(notebook_id, status);

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -102,7 +102,7 @@ export async function upsertPrincipalProfile(
       provider,
       input.providerSubject ?? null,
       email,
-      email ? 1 : 0,
+      input.emailVerified && email ? 1 : 0,
       input.displayName?.trim() || null,
       input.avatarUrl ?? null,
       timestamp,
@@ -379,7 +379,13 @@ export async function resolveNotebookInvitesForLogin(
   const aclGrants: InviteResolution["aclGrants"] = [];
   for (let index = 0; index < operations.length; index += 1) {
     const acceptInviteResult = results[index * 2];
-    if (!acceptInviteResult || d1Changes(acceptInviteResult) === 0) {
+    const insertAclResult = results[index * 2 + 1];
+    if (
+      !acceptInviteResult ||
+      !insertAclResult ||
+      d1Changes(acceptInviteResult) === 0 ||
+      d1Changes(insertAclResult) === 0
+    ) {
       continue;
     }
     acceptedInvites.push({
@@ -419,6 +425,9 @@ function inviteAclInsert(
         AND email_normalized = ?
         AND (provider_hint = ? OR provider_hint IS NULL)
         AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+        AND EXISTS (
+          SELECT 1 FROM notebooks WHERE notebooks.id = notebook_invites.notebook_id
+        )
      ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
        updated_at = excluded.updated_at`,
     )
@@ -452,7 +461,10 @@ function inviteAcceptedUpdate(
           AND status = 'pending'
           AND email_normalized = ?
           AND (provider_hint = ? OR provider_hint IS NULL)
-          AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))`,
+          AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+          AND EXISTS (
+            SELECT 1 FROM notebooks WHERE notebooks.id = notebook_invites.notebook_id
+          )`,
     )
     .bind(
       grant.subject,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -331,7 +331,7 @@ export async function resolveNotebookInvitesForLogin(
 ): Promise<InviteResolution> {
   // Trust boundary: callers must pass identity-provider verified claims.
   // Invite acceptance is derived from login.email plus login.emailVerified.
-  await upsertPrincipalProfile(env, {
+  const profile = await upsertPrincipalProfile(env, {
     principal: login.principal,
     provider: login.provider,
     email: login.email,
@@ -342,8 +342,12 @@ export async function resolveNotebookInvitesForLogin(
 
   const invites = await getPendingNotebookInvitesForLogin(env, login, now);
   const resolution = resolvePendingInvitesForLogin({ invites, login, now });
+  const resolutionWithProfile = {
+    ...resolution,
+    profile: profileFromRow(profile) ?? resolution.profile,
+  };
   if (!env.DB || resolution.aclGrants.length === 0) {
-    return resolution;
+    return resolutionWithProfile;
   }
 
   const operations: {
@@ -365,16 +369,16 @@ export async function resolveNotebookInvitesForLogin(
     });
   }
   if (operations.length === 0) {
-    return resolution;
+    return resolutionWithProfile;
   }
 
   const results = await env.DB.batch(
-    operations.flatMap((operation) => [operation.insertAcl, operation.acceptInvite]),
+    operations.flatMap((operation) => [operation.acceptInvite, operation.insertAcl]),
   );
   const acceptedInvites: PendingNotebookInvite[] = [];
   const aclGrants: InviteResolution["aclGrants"] = [];
   for (let index = 0; index < operations.length; index += 1) {
-    const acceptInviteResult = results[index * 2 + 1];
+    const acceptInviteResult = results[index * 2];
     if (!acceptInviteResult || d1Changes(acceptInviteResult) === 0) {
       continue;
     }
@@ -386,7 +390,7 @@ export async function resolveNotebookInvitesForLogin(
     });
     aclGrants.push(operations[index].grant);
   }
-  return { ...resolution, acceptedInvites, aclGrants };
+  return { ...resolutionWithProfile, acceptedInvites, aclGrants };
 }
 
 function inviteAclInsert(
@@ -409,7 +413,9 @@ function inviteAclInsert(
      SELECT notebook_id, 'principal', ?, scope, ?, ?, ?
        FROM notebook_invites
       WHERE id = ?
-        AND status = 'pending'
+        AND status = 'accepted'
+        AND accepted_by_principal = ?
+        AND accepted_at = ?
         AND email_normalized = ?
         AND (provider_hint = ? OR provider_hint IS NULL)
         AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
@@ -422,6 +428,8 @@ function inviteAclInsert(
       timestamp,
       grant.actorLabel,
       invite.id,
+      grant.subject,
+      timestamp,
       normalizeInviteEmail(invite.email),
       normalizeProviderHint(invite.providerHint),
       timestamp,
@@ -520,6 +528,20 @@ function normalizeInviteExpiresAt(expiresAt: string | null): string | null {
 function d1Changes(result: { meta: Record<string, unknown> }): number {
   const changes = result.meta.changes;
   return typeof changes === "number" ? changes : 0;
+}
+
+function profileFromRow(row: PrincipalProfileRow | null): InviteResolution["profile"] | null {
+  if (!row) {
+    return null;
+  }
+  return {
+    principal: row.principal,
+    provider: row.provider,
+    email: row.email_normalized,
+    displayName: row.display_name,
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+  };
 }
 
 function isUniqueConstraintError(error: unknown): boolean {

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -1,0 +1,423 @@
+import type { D1PreparedStatement, Env } from "./cloudflare-types.ts";
+import { ensureCatalogSchema } from "./storage.ts";
+import {
+  normalizeInviteEmail,
+  normalizeProviderHint,
+  resolvePendingInvitesForLogin,
+  type AuthenticatedLoginProfile,
+  type InviteResolution,
+  type PendingNotebookInvite,
+} from "./sharing.ts";
+
+export interface PrincipalProfileRow {
+  principal: string;
+  provider: string;
+  provider_subject: string | null;
+  email_normalized: string | null;
+  email_verified: number;
+  display_name: string | null;
+  avatar_url: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+  raw_claims_json: string | null;
+}
+
+export interface PrincipalProfileInput {
+  principal: string;
+  provider: string;
+  providerSubject?: string | null;
+  email?: string | null;
+  emailVerified?: boolean;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  rawClaimsJson?: string | null;
+  timestamp?: string;
+}
+
+export interface PendingNotebookInviteRow {
+  id: string;
+  notebook_id: string;
+  email_normalized: string;
+  provider_hint: string | null;
+  scope: PendingNotebookInvite["scope"];
+  status: PendingNotebookInvite["status"];
+  invited_by_actor_label: string;
+  accepted_by_principal: string | null;
+  token_hash: string | null;
+  created_at: string;
+  expires_at: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  revoked_by_actor_label: string | null;
+}
+
+export interface PendingNotebookInviteInput {
+  id?: string;
+  notebookId: string;
+  email: string;
+  providerHint?: string | null;
+  scope: PendingNotebookInvite["scope"];
+  actorLabel: string;
+  expiresAt?: string | null;
+  tokenHash?: string | null;
+  timestamp?: string;
+}
+
+export async function upsertPrincipalProfile(
+  env: Env,
+  input: PrincipalProfileInput,
+): Promise<PrincipalProfileRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const provider = normalizeRequiredProvider(input.provider);
+  const email = normalizeVerifiedProfileEmail(input.email ?? null, input.emailVerified ?? false);
+  await env.DB.prepare(
+    `INSERT INTO principal_profiles (
+       principal,
+       provider,
+       provider_subject,
+       email_normalized,
+       email_verified,
+       display_name,
+       avatar_url,
+       first_seen_at,
+       last_seen_at,
+       raw_claims_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(principal) DO UPDATE SET
+       provider = excluded.provider,
+       provider_subject = excluded.provider_subject,
+       email_normalized = excluded.email_normalized,
+       email_verified = excluded.email_verified,
+       display_name = excluded.display_name,
+       avatar_url = excluded.avatar_url,
+       last_seen_at = excluded.last_seen_at,
+       raw_claims_json = excluded.raw_claims_json`,
+  )
+    .bind(
+      input.principal,
+      provider,
+      input.providerSubject ?? null,
+      email,
+      email ? 1 : 0,
+      input.displayName?.trim() || null,
+      input.avatarUrl ?? null,
+      timestamp,
+      timestamp,
+      input.rawClaimsJson ?? null,
+    )
+    .run();
+
+  return await getPrincipalProfile(env, input.principal);
+}
+
+export async function getPrincipalProfile(
+  env: Env,
+  principal: string,
+): Promise<PrincipalProfileRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT principal,
+            provider,
+            provider_subject,
+            email_normalized,
+            email_verified,
+            display_name,
+            avatar_url,
+            first_seen_at,
+            last_seen_at,
+            raw_claims_json
+       FROM principal_profiles
+       WHERE principal = ?`,
+  )
+    .bind(principal)
+    .first<PrincipalProfileRow>();
+}
+
+export async function createPendingNotebookInvite(
+  env: Env,
+  input: PendingNotebookInviteInput,
+): Promise<PendingNotebookInviteRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const inviteId = input.id ?? crypto.randomUUID();
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const providerHint = normalizeProviderHint(input.providerHint ?? null);
+  const scope = normalizeInviteScope(input.scope);
+  const email = normalizeInviteEmail(input.email);
+  const expiresAt = normalizeInviteExpiresAt(input.expiresAt ?? null);
+  await env.DB.prepare(
+    `INSERT INTO notebook_invites (
+       id,
+       notebook_id,
+       email_normalized,
+       provider_hint,
+       scope,
+       status,
+       invited_by_actor_label,
+       token_hash,
+       created_at,
+       expires_at
+     ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
+  )
+    .bind(
+      inviteId,
+      input.notebookId,
+      email,
+      providerHint,
+      scope,
+      input.actorLabel,
+      input.tokenHash ?? null,
+      timestamp,
+      expiresAt,
+    )
+    .run();
+
+  return await getPendingNotebookInvite(env, inviteId);
+}
+
+export async function getPendingNotebookInvite(
+  env: Env,
+  inviteId: string,
+): Promise<PendingNotebookInviteRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            token_hash,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM notebook_invites
+       WHERE id = ?`,
+  )
+    .bind(inviteId)
+    .first<PendingNotebookInviteRow>();
+}
+
+export async function getPendingNotebookInvitesForLogin(
+  env: Env,
+  login: Pick<AuthenticatedLoginProfile, "provider" | "email" | "emailVerified">,
+): Promise<PendingNotebookInvite[]> {
+  if (!env.DB || !login.emailVerified) {
+    return [];
+  }
+
+  const email = normalizeMaybeInviteEmail(login.email);
+  if (!email) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const provider = normalizeRequiredProvider(login.provider);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            token_hash,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM notebook_invites
+       WHERE email_normalized = ?
+         AND status = 'pending'
+         AND (provider_hint = ? OR provider_hint IS NULL)
+       ORDER BY created_at`,
+  )
+    .bind(email, provider)
+    .all<PendingNotebookInviteRow>();
+  return (rows.results ?? []).map(pendingInviteFromRow);
+}
+
+export async function resolveNotebookInvitesForLogin(
+  env: Env,
+  login: AuthenticatedLoginProfile,
+  now = new Date().toISOString(),
+): Promise<InviteResolution> {
+  await upsertPrincipalProfile(env, {
+    principal: login.principal,
+    provider: login.provider,
+    email: login.email,
+    emailVerified: login.emailVerified,
+    displayName: login.displayName,
+    timestamp: now,
+  });
+
+  const invites = await getPendingNotebookInvitesForLogin(env, login);
+  const resolution = resolvePendingInvitesForLogin({ invites, login, now });
+  if (!env.DB || resolution.aclGrants.length === 0) {
+    return resolution;
+  }
+
+  const statements: D1PreparedStatement[] = [];
+  for (const grant of resolution.aclGrants) {
+    const invite = resolution.acceptedInvites.find((candidate) => candidate.id === grant.inviteId);
+    if (!invite) {
+      continue;
+    }
+    statements.push(inviteAclInsert(env, grant, invite, now));
+    statements.push(inviteAcceptedUpdate(env, grant, invite, now));
+  }
+  if (statements.length > 0) {
+    await env.DB.batch(statements);
+  }
+  return resolution;
+}
+
+function inviteAclInsert(
+  env: Env,
+  grant: InviteResolution["aclGrants"][number],
+  invite: PendingNotebookInvite,
+  timestamp: string,
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO notebook_acl (
+       notebook_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT notebook_id, 'principal', ?, scope, ?, ?, ?
+       FROM notebook_invites
+      WHERE id = ?
+        AND status = 'pending'
+        AND email_normalized = ?
+        AND (provider_hint = ? OR provider_hint IS NULL)
+        AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+     ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(
+      grant.subject,
+      timestamp,
+      timestamp,
+      grant.actorLabel,
+      invite.id,
+      normalizeInviteEmail(invite.email),
+      normalizeProviderHint(invite.providerHint),
+      timestamp,
+    );
+}
+
+function inviteAcceptedUpdate(
+  env: Env,
+  grant: InviteResolution["aclGrants"][number],
+  invite: PendingNotebookInvite,
+  timestamp: string,
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `UPDATE notebook_invites
+          SET status = 'accepted',
+              accepted_by_principal = ?,
+              accepted_at = ?
+        WHERE id = ?
+          AND status = 'pending'
+          AND email_normalized = ?
+          AND (provider_hint = ? OR provider_hint IS NULL)
+          AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))`,
+    )
+    .bind(
+      grant.subject,
+      timestamp,
+      invite.id,
+      normalizeInviteEmail(invite.email),
+      normalizeProviderHint(invite.providerHint),
+      timestamp,
+    );
+}
+
+function pendingInviteFromRow(row: PendingNotebookInviteRow): PendingNotebookInvite {
+  return {
+    id: row.id,
+    notebookId: row.notebook_id,
+    email: row.email_normalized,
+    providerHint: row.provider_hint,
+    scope: row.scope,
+    status: row.status,
+    createdByActorLabel: row.invited_by_actor_label,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    acceptedByPrincipal: row.accepted_by_principal,
+    acceptedAt: row.accepted_at,
+  };
+}
+
+function normalizeRequiredProvider(provider: string): string {
+  const normalized = normalizeProviderHint(provider);
+  if (!normalized) {
+    throw new Error("login provider is invalid");
+  }
+  return normalized;
+}
+
+function normalizeVerifiedProfileEmail(email: string | null, verified: boolean): string | null {
+  if (!verified) {
+    return null;
+  }
+  return normalizeMaybeInviteEmail(email);
+}
+
+function normalizeMaybeInviteEmail(email: string | null): string | null {
+  if (!email) {
+    return null;
+  }
+  try {
+    return normalizeInviteEmail(email);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeInviteScope(
+  scope: PendingNotebookInvite["scope"],
+): PendingNotebookInvite["scope"] {
+  if (scope !== "viewer" && scope !== "editor") {
+    throw new Error("invite scope must be viewer or editor");
+  }
+  return scope;
+}
+
+function normalizeInviteExpiresAt(expiresAt: string | null): string | null {
+  if (!expiresAt) {
+    return null;
+  }
+  if (!Number.isFinite(Date.parse(expiresAt))) {
+    throw new Error("invite expiry is invalid");
+  }
+  return expiresAt;
+}

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -221,6 +221,7 @@ export async function getPendingNotebookInvite(
 export async function getPendingNotebookInvitesForLogin(
   env: Env,
   login: Pick<AuthenticatedLoginProfile, "provider" | "email" | "emailVerified">,
+  now = new Date().toISOString(),
 ): Promise<PendingNotebookInvite[]> {
   if (!env.DB || !login.emailVerified) {
     return [];
@@ -252,9 +253,10 @@ export async function getPendingNotebookInvitesForLogin(
        WHERE email_normalized = ?
          AND status = 'pending'
          AND (provider_hint = ? OR provider_hint IS NULL)
+         AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
        ORDER BY created_at`,
   )
-    .bind(email, provider)
+    .bind(email, provider, now)
     .all<PendingNotebookInviteRow>();
   return (rows.results ?? []).map(pendingInviteFromRow);
 }
@@ -273,25 +275,53 @@ export async function resolveNotebookInvitesForLogin(
     timestamp: now,
   });
 
-  const invites = await getPendingNotebookInvitesForLogin(env, login);
+  const invites = await getPendingNotebookInvitesForLogin(env, login, now);
   const resolution = resolvePendingInvitesForLogin({ invites, login, now });
   if (!env.DB || resolution.aclGrants.length === 0) {
     return resolution;
   }
 
-  const statements: D1PreparedStatement[] = [];
+  const operations: {
+    invite: PendingNotebookInvite;
+    grant: InviteResolution["aclGrants"][number];
+    insertAcl: D1PreparedStatement;
+    acceptInvite: D1PreparedStatement;
+  }[] = [];
   for (const grant of resolution.aclGrants) {
     const invite = resolution.acceptedInvites.find((candidate) => candidate.id === grant.inviteId);
     if (!invite) {
       continue;
     }
-    statements.push(inviteAclInsert(env, grant, invite, now));
-    statements.push(inviteAcceptedUpdate(env, grant, invite, now));
+    operations.push({
+      invite,
+      grant,
+      insertAcl: inviteAclInsert(env, grant, invite, now),
+      acceptInvite: inviteAcceptedUpdate(env, grant, invite, now),
+    });
   }
-  if (statements.length > 0) {
-    await env.DB.batch(statements);
+  if (operations.length === 0) {
+    return resolution;
   }
-  return resolution;
+
+  const results = await env.DB.batch(
+    operations.flatMap((operation) => [operation.insertAcl, operation.acceptInvite]),
+  );
+  const acceptedInvites: PendingNotebookInvite[] = [];
+  const aclGrants: InviteResolution["aclGrants"] = [];
+  for (let index = 0; index < operations.length; index += 1) {
+    const acceptInviteResult = results[index * 2 + 1];
+    if (!acceptInviteResult || d1Changes(acceptInviteResult) === 0) {
+      continue;
+    }
+    acceptedInvites.push({
+      ...operations[index].invite,
+      status: "accepted",
+      acceptedByPrincipal: login.principal,
+      acceptedAt: now,
+    });
+    aclGrants.push(operations[index].grant);
+  }
+  return { ...resolution, acceptedInvites, aclGrants };
 }
 
 function inviteAclInsert(
@@ -420,4 +450,9 @@ function normalizeInviteExpiresAt(expiresAt: string | null): string | null {
     throw new Error("invite expiry is invalid");
   }
   return expiresAt;
+}
+
+function d1Changes(result: { meta: Record<string, unknown> }): number {
+  const changes = result.meta.changes;
+  return typeof changes === "number" ? changes : 0;
 }

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -89,8 +89,6 @@ export async function upsertPrincipalProfile(
        raw_claims_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(principal) DO UPDATE SET
-       provider = excluded.provider,
-       provider_subject = excluded.provider_subject,
        email_normalized = excluded.email_normalized,
        email_verified = excluded.email_verified,
        display_name = excluded.display_name,
@@ -157,6 +155,16 @@ export async function createPendingNotebookInvite(
   const scope = normalizeInviteScope(input.scope);
   const email = normalizeInviteEmail(input.email);
   const expiresAt = normalizeInviteExpiresAt(input.expiresAt ?? null);
+  const existing = await getExistingPendingNotebookInvite(env, {
+    notebookId: input.notebookId,
+    email,
+    providerHint,
+    scope,
+  });
+  if (existing) {
+    return existing;
+  }
+
   await env.DB.prepare(
     `INSERT INTO notebook_invites (
        id,
@@ -215,6 +223,44 @@ export async function getPendingNotebookInvite(
        WHERE id = ?`,
   )
     .bind(inviteId)
+    .first<PendingNotebookInviteRow>();
+}
+
+async function getExistingPendingNotebookInvite(
+  env: Env,
+  input: {
+    notebookId: string;
+    email: string;
+    providerHint: string | null;
+    scope: PendingNotebookInvite["scope"];
+  },
+): Promise<PendingNotebookInviteRow | null> {
+  return await env
+    .DB!.prepare(
+      `SELECT id,
+              notebook_id,
+              email_normalized,
+              provider_hint,
+              scope,
+              status,
+              invited_by_actor_label,
+              accepted_by_principal,
+              token_hash,
+              created_at,
+              expires_at,
+              accepted_at,
+              revoked_at,
+              revoked_by_actor_label
+         FROM notebook_invites
+        WHERE notebook_id = ?
+          AND email_normalized = ?
+          AND scope = ?
+          AND status = 'pending'
+          AND ((provider_hint IS NULL AND ? IS NULL) OR provider_hint = ?)
+        ORDER BY created_at
+        LIMIT 1`,
+    )
+    .bind(input.notebookId, input.email, input.scope, input.providerHint, input.providerHint)
     .first<PendingNotebookInviteRow>();
 }
 

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -89,6 +89,7 @@ export async function upsertPrincipalProfile(
        raw_claims_json
      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(principal) DO UPDATE SET
+       provider_subject = COALESCE(principal_profiles.provider_subject, excluded.provider_subject),
        email_normalized = excluded.email_normalized,
        email_verified = excluded.email_verified,
        display_name = excluded.display_name,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -165,8 +165,9 @@ export async function createPendingNotebookInvite(
     return existing;
   }
 
-  await env.DB.prepare(
-    `INSERT INTO notebook_invites (
+  try {
+    await env.DB.prepare(
+      `INSERT INTO notebook_invites (
        id,
        notebook_id,
        email_normalized,
@@ -178,19 +179,34 @@ export async function createPendingNotebookInvite(
        created_at,
        expires_at
      ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
-  )
-    .bind(
-      inviteId,
-      input.notebookId,
+    )
+      .bind(
+        inviteId,
+        input.notebookId,
+        email,
+        providerHint,
+        scope,
+        input.actorLabel,
+        input.tokenHash ?? null,
+        timestamp,
+        expiresAt,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) {
+      throw error;
+    }
+    const raced = await getExistingPendingNotebookInvite(env, {
+      notebookId: input.notebookId,
       email,
       providerHint,
       scope,
-      input.actorLabel,
-      input.tokenHash ?? null,
-      timestamp,
-      expiresAt,
-    )
-    .run();
+    });
+    if (raced) {
+      return raced;
+    }
+    throw error;
+  }
 
   return await getPendingNotebookInvite(env, inviteId);
 }
@@ -312,6 +328,8 @@ export async function resolveNotebookInvitesForLogin(
   login: AuthenticatedLoginProfile,
   now = new Date().toISOString(),
 ): Promise<InviteResolution> {
+  // Trust boundary: callers must pass identity-provider verified claims.
+  // Invite acceptance is derived from login.email plus login.emailVerified.
   await upsertPrincipalProfile(env, {
     principal: login.principal,
     provider: login.provider,
@@ -501,4 +519,9 @@ function normalizeInviteExpiresAt(expiresAt: string | null): string | null {
 function d1Changes(result: { meta: Record<string, unknown> }): number {
   const changes = result.meta.changes;
   return typeof changes === "number" ? changes : 0;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unique|constraint/i.test(message);
 }

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -558,5 +558,5 @@ function profileFromRow(row: PrincipalProfileRow | null): InviteResolution["prof
 
 function isUniqueConstraintError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /unique|constraint/i.test(message);
+  return /unique constraint failed/i.test(message);
 }

--- a/apps/notebook-cloud/src/sharing.ts
+++ b/apps/notebook-cloud/src/sharing.ts
@@ -69,11 +69,14 @@ const INVITE_RESOLUTION_ACTOR_LABEL = "system/invite-resolution";
 
 export function normalizeInviteEmail(email: string): string {
   const normalized = email.trim().toLowerCase();
+  const parts = normalized.split("@");
   if (
     !normalized ||
     normalized.includes("/") ||
     /\s/.test(normalized) ||
-    !normalized.includes("@")
+    parts.length !== 2 ||
+    !parts[0] ||
+    !parts[1]
   ) {
     throw new Error("invite email is invalid");
   }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -98,6 +98,42 @@ const SCHEMA_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS notebook_acl_subject_idx
     ON notebook_acl (subject_kind, subject, notebook_id)`,
+  `CREATE TABLE IF NOT EXISTS principal_profiles (
+    principal TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    provider_subject TEXT,
+    email_normalized TEXT,
+    email_verified INTEGER NOT NULL DEFAULT 0,
+    display_name TEXT,
+    avatar_url TEXT,
+    first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    raw_claims_json TEXT
+  )`,
+  `CREATE INDEX IF NOT EXISTS principal_profiles_email_idx
+    ON principal_profiles(provider, email_normalized)
+    WHERE email_verified = 1`,
+  `CREATE TABLE IF NOT EXISTS notebook_invites (
+    id TEXT PRIMARY KEY,
+    notebook_id TEXT NOT NULL,
+    email_normalized TEXT NOT NULL,
+    provider_hint TEXT,
+    scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+    invited_by_actor_label TEXT NOT NULL,
+    accepted_by_principal TEXT,
+    token_hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_at TEXT,
+    accepted_at TEXT,
+    revoked_at TEXT,
+    revoked_by_actor_label TEXT,
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS notebook_invites_pending_lookup_idx
+    ON notebook_invites(provider_hint, email_normalized, status)`,
+  `CREATE INDEX IF NOT EXISTS notebook_invites_notebook_idx
+    ON notebook_invites(notebook_id, status)`,
 ];
 
 const SCHEMA_MIGRATIONS = [

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -131,7 +131,13 @@ const SCHEMA_STATEMENTS = [
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
   `CREATE INDEX IF NOT EXISTS notebook_invites_pending_lookup_idx
-    ON notebook_invites(provider_hint, email_normalized, status)`,
+    ON notebook_invites(email_normalized, status, provider_hint)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS notebook_invites_pending_provider_unique_idx
+    ON notebook_invites(notebook_id, email_normalized, provider_hint, scope)
+    WHERE status = 'pending' AND provider_hint IS NOT NULL`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS notebook_invites_pending_wildcard_unique_idx
+    ON notebook_invites(notebook_id, email_normalized, scope)
+    WHERE status = 'pending' AND provider_hint IS NULL`,
   `CREATE INDEX IF NOT EXISTS notebook_invites_notebook_idx
     ON notebook_invites(notebook_id, status)`,
 ];

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -402,6 +402,32 @@ describe("hosted sharing storage", () => {
     assert.equal(env.DB.invites.get("invite-expired")?.status, "pending");
   });
 
+  it("does not re-accept revoked invites from storage resolution", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-revoked",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+    env.DB.invites.get("invite-revoked")!.status = "revoked";
+    env.DB.invites.get("invite-revoked")!.revoked_at = "2026-05-24T11:30:00.000Z";
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.equal(resolution.acceptedInvites.length, 0);
+    assert.equal(resolution.aclGrants.length, 0);
+    assert.equal(env.DB.acl.length, 0);
+    assert.equal(env.DB.invites.get("invite-revoked")?.status, "revoked");
+  });
+
   it("reports only invites whose row actually transitioned to accepted", async () => {
     const env = fakeEnv();
     await createPendingNotebookInvite(env, {

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -49,6 +49,26 @@ describe("hosted sharing storage", () => {
     assert.equal(profile?.last_seen_at, "2026-05-24T12:05:00.000Z");
   });
 
+  it("backfills provider subject when a profile was first seen without one", async () => {
+    const env = fakeEnv();
+    await resolveNotebookInvitesForLogin(env, accessLogin(), "2026-05-24T12:00:00.000Z");
+
+    const profile = await upsertPrincipalProfile(env, {
+      principal: "user:cloudflare-access:access-sub-1",
+      provider: "cloudflare-access",
+      providerSubject: "access-sub-1",
+      email: "alice@example.com",
+      emailVerified: true,
+      displayName: "Alice Example",
+      timestamp: "2026-05-24T12:05:00.000Z",
+    });
+
+    assert.equal(profile?.provider, "cloudflare-access");
+    assert.equal(profile?.provider_subject, "access-sub-1");
+    assert.equal(profile?.first_seen_at, "2026-05-24T12:00:00.000Z");
+    assert.equal(profile?.last_seen_at, "2026-05-24T12:05:00.000Z");
+  });
+
   it("resolves verified email invites into principal ACL rows", async () => {
     const env = fakeEnv();
     await createPendingNotebookInvite(env, {
@@ -127,6 +147,55 @@ describe("hosted sharing storage", () => {
     assert.equal(
       env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.last_seen_at,
       "2026-05-24T12:05:00.000Z",
+    );
+  });
+
+  it("accepts multiple pending invites in one resolution batch", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-1",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+    await createPendingNotebookInvite(env, {
+      id: "invite-2",
+      notebookId: "notebook-2",
+      email: "alice@example.com",
+      providerHint: null,
+      scope: "viewer",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:01:00.000Z",
+    });
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-1", "invite-2"],
+    );
+    assert.deepEqual(
+      resolution.aclGrants.map((grant) => [grant.notebookId, grant.scope]),
+      [
+        ["notebook-1", "editor"],
+        ["notebook-2", "viewer"],
+      ],
+    );
+    assert.equal(env.DB.invites.get("invite-1")?.status, "accepted");
+    assert.equal(env.DB.invites.get("invite-2")?.status, "accepted");
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.notebook_id, row.scope]),
+      [
+        ["notebook-1", "editor"],
+        ["notebook-2", "viewer"],
+      ],
     );
   });
 

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -1,0 +1,434 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type {
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  D1Value,
+  Env,
+} from "../src/cloudflare-types.ts";
+import {
+  createPendingNotebookInvite,
+  resolveNotebookInvitesForLogin,
+  type PendingNotebookInviteRow,
+  type PrincipalProfileRow,
+} from "../src/sharing-storage.ts";
+import type { NotebookAclRow } from "../src/storage.ts";
+import type { AuthenticatedLoginProfile } from "../src/sharing.ts";
+
+describe("hosted sharing storage", () => {
+  it("resolves verified email invites into principal ACL rows", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-1",
+      notebookId: "notebook-1",
+      email: " Alice@Example.COM ",
+      providerHint: " Cloudflare-Access ",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      expiresAt: "2026-06-24T11:00:00.000Z",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-1"],
+    );
+    assert.equal(
+      env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.email_normalized,
+      "alice@example.com",
+    );
+    assert.equal(env.DB.invites.get("invite-1")?.status, "accepted");
+    assert.equal(
+      env.DB.invites.get("invite-1")?.accepted_by_principal,
+      "user:cloudflare-access:access-sub-1",
+    );
+    assert.deepEqual(env.DB.acl, [
+      {
+        notebook_id: "notebook-1",
+        subject_kind: "principal",
+        subject: "user:cloudflare-access:access-sub-1",
+        scope: "editor",
+        created_at: "2026-05-24T12:00:00.000Z",
+        updated_at: "2026-05-24T12:00:00.000Z",
+        created_by_actor_label: "system/invite-resolution",
+      },
+    ]);
+    assert.doesNotMatch(env.DB.acl[0]?.subject ?? "", /alice@example.com/);
+  });
+
+  it("does not duplicate ACL rows when invite resolution reruns", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-1",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: null,
+      scope: "viewer",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+
+    await resolveNotebookInvitesForLogin(env, accessLogin(), "2026-05-24T12:00:00.000Z");
+    const second = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin({ displayName: "Alice Updated" }),
+      "2026-05-24T12:05:00.000Z",
+    );
+
+    assert.equal(second.aclGrants.length, 0);
+    assert.equal(env.DB.acl.length, 1);
+    assert.equal(
+      env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.display_name,
+      "Alice Updated",
+    );
+    assert.equal(
+      env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.first_seen_at,
+      "2026-05-24T12:00:00.000Z",
+    );
+    assert.equal(
+      env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.last_seen_at,
+      "2026-05-24T12:05:00.000Z",
+    );
+  });
+
+  it("stores a profile but skips malformed or unverified email invite lookup", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-1",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+    });
+
+    const malformed = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin({ email: "noatsign" }),
+      "2026-05-24T12:00:00.000Z",
+    );
+    const unverified = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin({ emailVerified: false }),
+      "2026-05-24T12:01:00.000Z",
+    );
+
+    assert.equal(malformed.aclGrants.length, 0);
+    assert.equal(unverified.aclGrants.length, 0);
+    assert.equal(env.DB.invites.get("invite-1")?.status, "pending");
+    assert.equal(
+      env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.email_normalized,
+      null,
+    );
+    assert.equal(env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.email_verified, 0);
+  });
+
+  it("honors provider hints while allowing explicit provider-wildcard invites", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-wildcard",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: null,
+      scope: "viewer",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+    });
+    await createPendingNotebookInvite(env, {
+      id: "invite-github",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "github",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+    });
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin({ provider: "cloudflare-access" }),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-wildcard"],
+    );
+    assert.equal(env.DB.invites.get("invite-github")?.status, "pending");
+  });
+
+  it("rejects invalid pending invite inputs before they become ACL material", async () => {
+    const env = fakeEnv();
+    await assert.rejects(
+      () =>
+        createPendingNotebookInvite(env, {
+          notebookId: "notebook-1",
+          email: "not an email",
+          scope: "viewer",
+          actorLabel: "user:cloudflare-access:owner/desktop:owner",
+        }),
+      /invite email is invalid/,
+    );
+    await assert.rejects(
+      () =>
+        createPendingNotebookInvite(env, {
+          notebookId: "notebook-1",
+          email: "alice@example.com",
+          scope: "owner" as never,
+          actorLabel: "user:cloudflare-access:owner/desktop:owner",
+        }),
+      /invite scope must be viewer or editor/,
+    );
+    await assert.rejects(
+      () =>
+        createPendingNotebookInvite(env, {
+          notebookId: "notebook-1",
+          email: "alice@example.com",
+          scope: "editor",
+          actorLabel: "user:cloudflare-access:owner/desktop:owner",
+          expiresAt: "not a date",
+        }),
+      /invite expiry is invalid/,
+    );
+  });
+});
+
+function fakeEnv(): Env & { DB: FakeD1 } {
+  return { DB: new FakeD1() } as Env & { DB: FakeD1 };
+}
+
+function accessLogin(
+  overrides: Partial<AuthenticatedLoginProfile> = {},
+): AuthenticatedLoginProfile {
+  return {
+    principal: "user:cloudflare-access:access-sub-1",
+    provider: "cloudflare-access",
+    email: "alice@example.com",
+    emailVerified: true,
+    displayName: "Alice Example",
+    ...overrides,
+  };
+}
+
+class FakeD1 implements D1Database {
+  readonly profiles = new Map<string, PrincipalProfileRow>();
+  readonly invites = new Map<string, PendingNotebookInviteRow>();
+  readonly acl: NotebookAclRow[] = [];
+
+  prepare(query: string): D1PreparedStatement {
+    return new FakeD1Statement(this, query);
+  }
+
+  async exec(): Promise<D1Result> {
+    return okResult();
+  }
+
+  async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    const results: D1Result<T>[] = [];
+    for (const statement of statements) {
+      results.push(await statement.run<T>());
+    }
+    return results;
+  }
+}
+
+class FakeD1Statement implements D1PreparedStatement {
+  private values: D1Value[] = [];
+
+  constructor(
+    private readonly db: FakeD1,
+    private readonly query: string,
+  ) {}
+
+  bind(...values: D1Value[]): D1PreparedStatement {
+    this.values = values;
+    return this;
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM principal_profiles")) {
+      return (this.db.profiles.get(this.values[0] as string) as T | undefined) ?? null;
+    }
+    if (this.query.includes("FROM notebook_invites")) {
+      return (this.db.invites.get(this.values[0] as string) as T | undefined) ?? null;
+    }
+    return null;
+  }
+
+  async run<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("INSERT INTO principal_profiles")) {
+      const [
+        principal,
+        provider,
+        providerSubject,
+        emailNormalized,
+        emailVerified,
+        displayName,
+        avatarUrl,
+        firstSeenAt,
+        lastSeenAt,
+        rawClaimsJson,
+      ] = this.values as [
+        string,
+        string,
+        string | null,
+        string | null,
+        number,
+        string | null,
+        string | null,
+        string,
+        string,
+        string | null,
+      ];
+      const existing = this.db.profiles.get(principal);
+      this.db.profiles.set(principal, {
+        principal,
+        provider,
+        provider_subject: providerSubject,
+        email_normalized: emailNormalized,
+        email_verified: emailVerified,
+        display_name: displayName,
+        avatar_url: avatarUrl,
+        first_seen_at: existing?.first_seen_at ?? firstSeenAt,
+        last_seen_at: lastSeenAt,
+        raw_claims_json: rawClaimsJson,
+      });
+    } else if (this.query.includes("INSERT INTO notebook_invites")) {
+      const [
+        id,
+        notebookId,
+        emailNormalized,
+        providerHint,
+        scope,
+        actorLabel,
+        tokenHash,
+        createdAt,
+        expiresAt,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string | null,
+        PendingNotebookInviteRow["scope"],
+        string,
+        string | null,
+        string,
+        string | null,
+      ];
+      this.db.invites.set(id, {
+        id,
+        notebook_id: notebookId,
+        email_normalized: emailNormalized,
+        provider_hint: providerHint,
+        scope,
+        status: "pending",
+        invited_by_actor_label: actorLabel,
+        accepted_by_principal: null,
+        token_hash: tokenHash,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        accepted_at: null,
+        revoked_at: null,
+        revoked_by_actor_label: null,
+      });
+    } else if (
+      this.query.includes("INSERT INTO notebook_acl") &&
+      this.query.includes("FROM notebook_invites")
+    ) {
+      const [subject, createdAt, updatedAt, actorLabel, inviteId, email, providerHint, now] = this
+        .values as [string, string, string, string, string, string, string | null, string];
+      const invite = this.db.invites.get(inviteId);
+      if (invite && inviteCanResolve(invite, email, providerHint, now)) {
+        this.insertAclIfMissing({
+          notebook_id: invite.notebook_id,
+          subject_kind: "principal",
+          subject,
+          scope: invite.scope,
+          created_at: createdAt,
+          updated_at: updatedAt,
+          created_by_actor_label: actorLabel,
+        });
+      }
+    } else if (this.query.includes("UPDATE notebook_invites")) {
+      const [principal, acceptedAt, inviteId, email, providerHint, now] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string,
+      ];
+      const invite = this.db.invites.get(inviteId);
+      if (invite && inviteCanResolve(invite, email, providerHint, now)) {
+        invite.status = "accepted";
+        invite.accepted_by_principal = principal;
+        invite.accepted_at = acceptedAt;
+      }
+    }
+    return okResult();
+  }
+
+  async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.startsWith("PRAGMA table_info")) {
+      return okResult([{ name: "runtime_snapshot_key" }] as T[]);
+    }
+    if (this.query.includes("FROM notebook_invites")) {
+      const [email, provider] = this.values as [string, string];
+      return okResult(
+        [...this.db.invites.values()].filter(
+          (invite) =>
+            invite.status === "pending" &&
+            invite.email_normalized === email &&
+            (invite.provider_hint === provider || invite.provider_hint === null),
+        ) as T[],
+      );
+    }
+    return okResult([]);
+  }
+
+  private insertAclIfMissing(row: NotebookAclRow): void {
+    const existing = this.db.acl.find(
+      (candidate) =>
+        candidate.notebook_id === row.notebook_id &&
+        candidate.subject_kind === row.subject_kind &&
+        candidate.subject === row.subject &&
+        candidate.scope === row.scope,
+    );
+    if (existing) {
+      existing.updated_at = row.updated_at;
+      return;
+    }
+    this.db.acl.push(row);
+  }
+}
+
+function inviteCanResolve(
+  invite: PendingNotebookInviteRow,
+  email: string,
+  providerHint: string | null,
+  now: string,
+): boolean {
+  if (
+    invite.status !== "pending" ||
+    invite.email_normalized !== email ||
+    (invite.provider_hint !== null && invite.provider_hint !== providerHint)
+  ) {
+    return false;
+  }
+  if (!invite.expires_at) {
+    return true;
+  }
+  const expiresAtMs = Date.parse(invite.expires_at);
+  const nowMs = Date.parse(now);
+  return Number.isFinite(expiresAtMs) && Number.isFinite(nowMs) && expiresAtMs > nowMs;
+}
+
+function okResult<T = unknown>(results: T[] = []): D1Result<T> {
+  return { success: true, results, meta: { changes: results.length } };
+}

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -156,6 +156,42 @@ describe("hosted sharing storage", () => {
     assert.equal(env.DB.invites.size, 1);
   });
 
+  it("recovers when a concurrent duplicate pending invite wins the insert race", async () => {
+    const env = fakeEnv();
+    env.DB.beforeInviteInsert = ({ notebookId, emailNormalized, providerHint, scope }) => {
+      env.DB.invites.set("invite-raced", {
+        id: "invite-raced",
+        notebook_id: notebookId,
+        email_normalized: emailNormalized,
+        provider_hint: providerHint,
+        scope,
+        status: "pending",
+        invited_by_actor_label: "user:cloudflare-access:owner/desktop:owner",
+        accepted_by_principal: null,
+        token_hash: null,
+        created_at: "2026-05-24T11:00:00.000Z",
+        expires_at: null,
+        accepted_at: null,
+        revoked_at: null,
+        revoked_by_actor_label: null,
+      });
+      env.DB.beforeInviteInsert = undefined;
+    };
+
+    const invite = await createPendingNotebookInvite(env, {
+      id: "invite-loser",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:01:00.000Z",
+    });
+
+    assert.equal(invite?.id, "invite-raced");
+    assert.equal(env.DB.invites.size, 1);
+  });
+
   it("stores a profile but skips malformed or unverified email invite lookup", async () => {
     const env = fakeEnv();
     await createPendingNotebookInvite(env, {
@@ -327,6 +363,12 @@ class FakeD1 implements D1Database {
   readonly profiles = new Map<string, PrincipalProfileRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly acl: NotebookAclRow[] = [];
+  beforeInviteInsert?: (input: {
+    notebookId: string;
+    emailNormalized: string;
+    providerHint: string | null;
+    scope: PendingNotebookInviteRow["scope"];
+  }) => void;
   beforeInviteAccept?: (inviteId: string) => void;
 
   prepare(query: string): D1PreparedStatement {
@@ -450,6 +492,23 @@ class FakeD1Statement implements D1PreparedStatement {
         string,
         string | null,
       ];
+      this.db.beforeInviteInsert?.({
+        notebookId,
+        emailNormalized,
+        providerHint,
+        scope,
+      });
+      const duplicate = [...this.db.invites.values()].find(
+        (invite) =>
+          invite.notebook_id === notebookId &&
+          invite.email_normalized === emailNormalized &&
+          invite.provider_hint === providerHint &&
+          invite.scope === scope &&
+          invite.status === "pending",
+      );
+      if (duplicate) {
+        throw new Error("D1_ERROR: UNIQUE constraint failed: notebook_invites pending invite");
+      }
       this.db.invites.set(id, {
         id,
         notebook_id: notebookId,

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -11,6 +11,7 @@ import type {
 import {
   createPendingNotebookInvite,
   resolveNotebookInvitesForLogin,
+  upsertPrincipalProfile,
   type PendingNotebookInviteRow,
   type PrincipalProfileRow,
 } from "../src/sharing-storage.ts";
@@ -18,6 +19,36 @@ import type { NotebookAclRow } from "../src/storage.ts";
 import type { AuthenticatedLoginProfile } from "../src/sharing.ts";
 
 describe("hosted sharing storage", () => {
+  it("keeps principal provider identity stable while refreshing profile metadata", async () => {
+    const env = fakeEnv();
+    await upsertPrincipalProfile(env, {
+      principal: "user:cloudflare-access:access-sub-1",
+      provider: "cloudflare-access",
+      providerSubject: "access-sub-1",
+      email: "alice@example.com",
+      emailVerified: true,
+      displayName: "Alice Example",
+      timestamp: "2026-05-24T12:00:00.000Z",
+    });
+
+    const profile = await upsertPrincipalProfile(env, {
+      principal: "user:cloudflare-access:access-sub-1",
+      provider: "github",
+      providerSubject: "github-sub-1",
+      email: "alice-updated@example.com",
+      emailVerified: true,
+      displayName: "Alice Updated",
+      timestamp: "2026-05-24T12:05:00.000Z",
+    });
+
+    assert.equal(profile?.provider, "cloudflare-access");
+    assert.equal(profile?.provider_subject, "access-sub-1");
+    assert.equal(profile?.email_normalized, "alice-updated@example.com");
+    assert.equal(profile?.display_name, "Alice Updated");
+    assert.equal(profile?.first_seen_at, "2026-05-24T12:00:00.000Z");
+    assert.equal(profile?.last_seen_at, "2026-05-24T12:05:00.000Z");
+  });
+
   it("resolves verified email invites into principal ACL rows", async () => {
     const env = fakeEnv();
     await createPendingNotebookInvite(env, {
@@ -97,6 +128,32 @@ describe("hosted sharing storage", () => {
       env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.last_seen_at,
       "2026-05-24T12:05:00.000Z",
     );
+  });
+
+  it("returns an existing pending invite instead of creating a duplicate", async () => {
+    const env = fakeEnv();
+    const first = await createPendingNotebookInvite(env, {
+      id: "invite-1",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+    const second = await createPendingNotebookInvite(env, {
+      id: "invite-2",
+      notebookId: "notebook-1",
+      email: " Alice@Example.com ",
+      providerHint: " Cloudflare-Access ",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:05:00.000Z",
+    });
+
+    assert.equal(first?.id, "invite-1");
+    assert.equal(second?.id, "invite-1");
+    assert.equal(env.DB.invites.size, 1);
   });
 
   it("stores a profile but skips malformed or unverified email invite lookup", async () => {
@@ -281,6 +338,8 @@ class FakeD1 implements D1Database {
   }
 
   async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    // This test fake intentionally does not model D1's transaction rollback.
+    // The sharing-storage tests only assert successful guarded batches.
     const results: D1Result<T>[] = [];
     for (const statement of statements) {
       results.push(await statement.run<T>());
@@ -307,6 +366,25 @@ class FakeD1Statement implements D1PreparedStatement {
       return (this.db.profiles.get(this.values[0] as string) as T | undefined) ?? null;
     }
     if (this.query.includes("FROM notebook_invites")) {
+      if (this.query.includes("WHERE notebook_id = ?")) {
+        const [notebookId, email, scope, providerHint] = this.values as [
+          string,
+          string,
+          PendingNotebookInviteRow["scope"],
+          string | null,
+          string | null,
+        ];
+        return (
+          ([...this.db.invites.values()].find(
+            (invite) =>
+              invite.notebook_id === notebookId &&
+              invite.email_normalized === email &&
+              invite.scope === scope &&
+              invite.status === "pending" &&
+              invite.provider_hint === providerHint,
+          ) as T | undefined) ?? null
+        );
+      }
       return (this.db.invites.get(this.values[0] as string) as T | undefined) ?? null;
     }
     return null;
@@ -340,8 +418,8 @@ class FakeD1Statement implements D1PreparedStatement {
       const existing = this.db.profiles.get(principal);
       this.db.profiles.set(principal, {
         principal,
-        provider,
-        provider_subject: providerSubject,
+        provider: existing?.provider ?? provider,
+        provider_subject: existing?.provider_subject ?? providerSubject,
         email_normalized: emailNormalized,
         email_verified: emailVerified,
         display_name: displayName,

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -148,6 +148,8 @@ describe("hosted sharing storage", () => {
       env.DB.profiles.get("user:cloudflare-access:access-sub-1")?.last_seen_at,
       "2026-05-24T12:05:00.000Z",
     );
+    assert.equal(second.profile.firstSeenAt, "2026-05-24T12:00:00.000Z");
+    assert.equal(second.profile.lastSeenAt, "2026-05-24T12:05:00.000Z");
   });
 
   it("accepts multiple pending invites in one resolution batch", async () => {
@@ -196,6 +198,56 @@ describe("hosted sharing storage", () => {
         ["notebook-1", "editor"],
         ["notebook-2", "viewer"],
       ],
+    );
+  });
+
+  it("reports only successful accepts from a partial multi-invite batch", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-stolen",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+    await createPendingNotebookInvite(env, {
+      id: "invite-kept",
+      notebookId: "notebook-2",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "viewer",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:01:00.000Z",
+    });
+    env.DB.beforeInviteAccept = (inviteId) => {
+      if (inviteId !== "invite-stolen") {
+        return;
+      }
+      const invite = env.DB.invites.get(inviteId)!;
+      invite.status = "accepted";
+      invite.accepted_by_principal = "user:cloudflare-access:other";
+      invite.accepted_at = "2026-05-24T11:59:00.000Z";
+    };
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-kept"],
+    );
+    assert.deepEqual(
+      resolution.aclGrants.map((grant) => grant.inviteId),
+      ["invite-kept"],
+    );
+    assert.deepEqual(
+      env.DB.acl.map((row) => row.notebook_id),
+      ["notebook-2"],
     );
   });
 
@@ -598,10 +650,34 @@ class FakeD1Statement implements D1PreparedStatement {
       this.query.includes("INSERT INTO notebook_acl") &&
       this.query.includes("FROM notebook_invites")
     ) {
-      const [subject, createdAt, updatedAt, actorLabel, inviteId, email, providerHint, now] = this
-        .values as [string, string, string, string, string, string, string | null, string];
+      const [
+        subject,
+        createdAt,
+        updatedAt,
+        actorLabel,
+        inviteId,
+        acceptedByPrincipal,
+        acceptedAt,
+        email,
+        providerHint,
+        now,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string,
+      ];
       const invite = this.db.invites.get(inviteId);
-      if (invite && inviteCanResolve(invite, email, providerHint, now)) {
+      if (
+        invite &&
+        inviteCanGrantAcl(invite, acceptedByPrincipal, acceptedAt, email, providerHint, now)
+      ) {
         this.insertAclIfMissing({
           notebook_id: invite.notebook_id,
           subject_kind: "principal",
@@ -677,6 +753,31 @@ function inviteCanResolve(
 ): boolean {
   if (
     invite.status !== "pending" ||
+    invite.email_normalized !== email ||
+    (invite.provider_hint !== null && invite.provider_hint !== providerHint)
+  ) {
+    return false;
+  }
+  if (!invite.expires_at) {
+    return true;
+  }
+  const expiresAtMs = Date.parse(invite.expires_at);
+  const nowMs = Date.parse(now);
+  return Number.isFinite(expiresAtMs) && Number.isFinite(nowMs) && expiresAtMs > nowMs;
+}
+
+function inviteCanGrantAcl(
+  invite: PendingNotebookInviteRow,
+  acceptedByPrincipal: string,
+  acceptedAt: string,
+  email: string,
+  providerHint: string | null,
+  now: string,
+): boolean {
+  if (
+    invite.status !== "accepted" ||
+    invite.accepted_by_principal !== acceptedByPrincipal ||
+    invite.accepted_at !== acceptedAt ||
     invite.email_normalized !== email ||
     (invite.provider_hint !== null && invite.provider_hint !== providerHint)
   ) {

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -251,6 +251,46 @@ describe("hosted sharing storage", () => {
     );
   });
 
+  it("skips stale invites whose notebook parent disappeared", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-stale",
+      notebookId: "notebook-deleted",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+    await createPendingNotebookInvite(env, {
+      id: "invite-live",
+      notebookId: "notebook-live",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "viewer",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      timestamp: "2026-05-24T11:01:00.000Z",
+    });
+    env.DB.deletedNotebookIds.add("notebook-deleted");
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.deepEqual(
+      resolution.acceptedInvites.map((invite) => invite.id),
+      ["invite-live"],
+    );
+    assert.equal(env.DB.invites.get("invite-stale")?.status, "pending");
+    assert.equal(env.DB.invites.get("invite-live")?.status, "accepted");
+    assert.deepEqual(
+      env.DB.acl.map((row) => row.notebook_id),
+      ["notebook-live"],
+    );
+  });
+
   it("returns an existing pending invite instead of creating a duplicate", async () => {
     const env = fakeEnv();
     const first = await createPendingNotebookInvite(env, {
@@ -510,6 +550,7 @@ class FakeD1 implements D1Database {
   readonly profiles = new Map<string, PrincipalProfileRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly acl: NotebookAclRow[] = [];
+  readonly deletedNotebookIds = new Set<string>();
   beforeInviteInsert?: (input: {
     notebookId: string;
     emailNormalized: string;
@@ -702,6 +743,7 @@ class FakeD1Statement implements D1PreparedStatement {
       const invite = this.db.invites.get(inviteId);
       if (
         invite &&
+        !this.db.deletedNotebookIds.has(invite.notebook_id) &&
         inviteCanGrantAcl(invite, acceptedByPrincipal, acceptedAt, email, providerHint, now)
       ) {
         this.insertAclIfMissing({
@@ -726,7 +768,11 @@ class FakeD1Statement implements D1PreparedStatement {
       ];
       this.db.beforeInviteAccept?.(inviteId);
       const invite = this.db.invites.get(inviteId);
-      if (invite && inviteCanResolve(invite, email, providerHint, now)) {
+      if (
+        invite &&
+        !this.db.deletedNotebookIds.has(invite.notebook_id) &&
+        inviteCanResolve(invite, email, providerHint, now)
+      ) {
         invite.status = "accepted";
         invite.accepted_by_principal = principal;
         invite.accepted_at = acceptedAt;

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -163,6 +163,56 @@ describe("hosted sharing storage", () => {
     assert.equal(env.DB.invites.get("invite-github")?.status, "pending");
   });
 
+  it("does not return or accept expired pending invites from storage resolution", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-expired",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      expiresAt: "2026-05-24T11:59:59.000Z",
+      timestamp: "2026-05-24T11:00:00.000Z",
+    });
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.equal(resolution.acceptedInvites.length, 0);
+    assert.equal(resolution.aclGrants.length, 0);
+    assert.equal(env.DB.acl.length, 0);
+    assert.equal(env.DB.invites.get("invite-expired")?.status, "pending");
+  });
+
+  it("reports only invites whose row actually transitioned to accepted", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-raced",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+    });
+    env.DB.beforeInviteAccept = (inviteId) => {
+      env.DB.invites.get(inviteId)!.status = "accepted";
+      env.DB.beforeInviteAccept = undefined;
+    };
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T12:00:00.000Z",
+    );
+
+    assert.equal(resolution.acceptedInvites.length, 0);
+    assert.equal(resolution.aclGrants.length, 0);
+  });
+
   it("rejects invalid pending invite inputs before they become ACL material", async () => {
     const env = fakeEnv();
     await assert.rejects(
@@ -220,6 +270,7 @@ class FakeD1 implements D1Database {
   readonly profiles = new Map<string, PrincipalProfileRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly acl: NotebookAclRow[] = [];
+  beforeInviteAccept?: (inviteId: string) => void;
 
   prepare(query: string): D1PreparedStatement {
     return new FakeD1Statement(this, query);
@@ -354,6 +405,7 @@ class FakeD1Statement implements D1PreparedStatement {
           updated_at: updatedAt,
           created_by_actor_label: actorLabel,
         });
+        return okResult([], { changes: 1 });
       }
     } else if (this.query.includes("UPDATE notebook_invites")) {
       const [principal, acceptedAt, inviteId, email, providerHint, now] = this.values as [
@@ -364,11 +416,13 @@ class FakeD1Statement implements D1PreparedStatement {
         string | null,
         string,
       ];
+      this.db.beforeInviteAccept?.(inviteId);
       const invite = this.db.invites.get(inviteId);
       if (invite && inviteCanResolve(invite, email, providerHint, now)) {
         invite.status = "accepted";
         invite.accepted_by_principal = principal;
         invite.accepted_at = acceptedAt;
+        return okResult([], { changes: 1 });
       }
     }
     return okResult();
@@ -379,13 +433,14 @@ class FakeD1Statement implements D1PreparedStatement {
       return okResult([{ name: "runtime_snapshot_key" }] as T[]);
     }
     if (this.query.includes("FROM notebook_invites")) {
-      const [email, provider] = this.values as [string, string];
+      const [email, provider, now] = this.values as [string, string, string];
       return okResult(
         [...this.db.invites.values()].filter(
           (invite) =>
             invite.status === "pending" &&
             invite.email_normalized === email &&
-            (invite.provider_hint === provider || invite.provider_hint === null),
+            (invite.provider_hint === provider || invite.provider_hint === null) &&
+            inviteCanResolveAt(invite, now),
         ) as T[],
       );
     }
@@ -429,6 +484,18 @@ function inviteCanResolve(
   return Number.isFinite(expiresAtMs) && Number.isFinite(nowMs) && expiresAtMs > nowMs;
 }
 
-function okResult<T = unknown>(results: T[] = []): D1Result<T> {
-  return { success: true, results, meta: { changes: results.length } };
+function inviteCanResolveAt(invite: PendingNotebookInviteRow, now: string): boolean {
+  if (!invite.expires_at) {
+    return true;
+  }
+  const expiresAtMs = Date.parse(invite.expires_at);
+  const nowMs = Date.parse(now);
+  return Number.isFinite(expiresAtMs) && Number.isFinite(nowMs) && expiresAtMs > nowMs;
+}
+
+function okResult<T = unknown>(
+  results: T[] = [],
+  meta: Record<string, unknown> = { changes: results.length },
+): D1Result<T> {
+  return { success: true, results, meta };
 }

--- a/apps/notebook-cloud/test/sharing.test.ts
+++ b/apps/notebook-cloud/test/sharing.test.ts
@@ -119,6 +119,13 @@ describe("hosted notebook sharing prototype", () => {
     assert.equal(inviteLookupKey(null, "alice@example.com"), "*:alice@example.com");
   });
 
+  it("rejects structurally invalid invite emails", () => {
+    assert.throws(() => normalizeInviteEmail("@@"), /invite email is invalid/);
+    assert.throws(() => normalizeInviteEmail("a@b@c"), /invite email is invalid/);
+    assert.throws(() => normalizeInviteEmail("@example.com"), /invite email is invalid/);
+    assert.throws(() => normalizeInviteEmail("alice@"), /invite email is invalid/);
+  });
+
   it("represents public viewers as explicit public ACL rows", () => {
     assert.deepEqual(publicViewerAclGrant("notebook-1", "user:dev:alice/desktop:test"), {
       notebookId: "notebook-1",

--- a/docs/architecture/hosted-sharing-invites.md
+++ b/docs/architecture/hosted-sharing-invites.md
@@ -17,7 +17,9 @@ Related docs:
 Prototype code:
 
 - `apps/notebook-cloud/src/sharing.ts`
+- `apps/notebook-cloud/src/sharing-storage.ts`
 - `apps/notebook-cloud/test/sharing.test.ts`
+- `apps/notebook-cloud/test/sharing-storage.test.ts`
 
 ## What The Older Prototype Already Proved
 
@@ -316,9 +318,11 @@ The checked-in TypeScript prototype models the core transition:
 - `shareTargetDisplay(...)` maps principal profiles, pending invites, and
   public viewer rows into UI labels.
 
-The prototype is intentionally pure TypeScript for now. The D1 transaction and
-HTTP routes should come after the Access demo proves principal shape and after
-we choose the final share API names.
+The checked-in storage foundation now creates the `principal_profiles` and
+`notebook_invites` D1 tables and exposes helpers that upsert profiles, create
+pending invites, and resolve first-login invites into principal ACL rows. HTTP
+routes should come after the Access demo proves principal shape and after we
+choose the final share API names.
 
 ## Open Decisions
 


### PR DESCRIPTION
## Summary

- add D1 schema and local bootstrap statements for hosted `principal_profiles` and `notebook_invites`
- add a `sharing-storage` helper layer that stores profile metadata, creates pending email invites, and resolves verified first-login invites into principal ACL rows
- cover idempotent invite resolution, provider hints, malformed/unverified email handling, and invalid invite input rejection

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/sharing.test.ts test/sharing-storage.test.ts test/worker-routes.test.ts test/identity.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `cargo xtask lint --fix`
- `git diff --check`
