### PR TITLE
[ipy-opt] Batch high-volume display output commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7447,6 +7447,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "windows-sys 0.52.0",
+ "zeromq",
 ]
 
 [[package]]

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -1537,6 +1537,72 @@ impl RuntimeStateDoc {
         Ok(output_id)
     }
 
+    /// Append or replace multiple output manifests for one execution.
+    ///
+    /// This is the hot path for display bursts. It computes the next sequence
+    /// number once, then assigns sequence numbers as new output entries are
+    /// created. Calling [`append_output`] repeatedly would rescan and sort all
+    /// existing outputs for every item in the batch.
+    pub fn append_outputs(
+        &mut self,
+        execution_id: &str,
+        manifests: &[serde_json::Value],
+    ) -> Result<Vec<String>, RuntimeStateError> {
+        let output_ids = manifests
+            .iter()
+            .map(|manifest| extract_output_id(manifest).ok_or(RuntimeStateError::MissingOutputId))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let Some(outputs) = self.ensure_output_map(execution_id) else {
+            return Ok(output_ids);
+        };
+
+        let mut next_seq = self.next_output_seq(&outputs);
+        let mut first_error = None;
+        for (manifest, output_id) in manifests.iter().zip(output_ids.iter()) {
+            let output_entry = match self.doc.get(&outputs, output_id).ok().flatten() {
+                Some((Value::Object(ObjType::Map), id)) => id,
+                _ => {
+                    let id = match self.doc.put_object(&outputs, output_id, ObjType::Map) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            first_error.get_or_insert_with(|| e.into());
+                            continue;
+                        }
+                    };
+                    if let Err(e) = self.doc.put(&id, "seq", ScalarValue::Uint(next_seq)) {
+                        first_error.get_or_insert_with(|| e.into());
+                        let _ = self.doc.delete(&outputs, output_id);
+                        continue;
+                    }
+                    next_seq = next_seq.saturating_add(1);
+                    id
+                }
+            };
+
+            if let Some(old_manifest) = self.read_output_manifest(&output_entry) {
+                if let Some(display_id) = Self::display_id_for_manifest(&old_manifest) {
+                    self.remove_display_index_entry(display_id, execution_id, output_id);
+                }
+            }
+
+            if let Err(e) = self.write_output_manifest(&output_entry, manifest) {
+                first_error.get_or_insert_with(|| e.into());
+                continue;
+            }
+
+            if let Some(display_id) = Self::display_id_for_manifest(manifest) {
+                self.add_display_index_entry(display_id, execution_id, output_id);
+            }
+        }
+
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+
+        Ok(output_ids)
+    }
+
     /// Replace all outputs for an execution.
     ///
     /// Used during notebook load to populate outputs for synthetic execution_ids.
@@ -4329,6 +4395,22 @@ mod tests {
         assert_eq!(id1, "stream-hash-b");
 
         assert_eq!(doc.get_outputs("exec-1"), vec![m_a, m_b]);
+    }
+
+    #[test]
+    fn append_outputs_preserves_batch_order() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1").unwrap();
+        let m_a = test_stream("hash-a");
+        let m_b = test_stream("hash-b");
+        let m_c = test_stream("hash-c");
+
+        let ids = doc
+            .append_outputs("exec-1", &[m_a.clone(), m_b.clone(), m_c.clone()])
+            .unwrap();
+
+        assert_eq!(ids, vec!["stream-hash-a", "stream-hash-b", "stream-hash-c"]);
+        assert_eq!(doc.get_outputs("exec-1"), vec![m_a, m_b, m_c]);
     }
 
     #[test]

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -130,3 +130,4 @@ serial_test = "3"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }
 notebook-sync = { path = "../notebook-sync" }
 async-rust-lsp = "0.3"
+zeromq = "0.6"

--- a/crates/runtimed/examples/raw_iopub_display_stress.rs
+++ b/crates/runtimed/examples/raw_iopub_display_stress.rs
@@ -1,0 +1,442 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::PathBuf,
+    process::Stdio,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use jupyter_protocol::{
+    connection_info::Transport, ConnectionInfo, ExecuteRequest, ExecutionState, JupyterMessage,
+    JupyterMessageContent, MediaType, Status, Stdio as JupyterStdio,
+};
+use jupyter_zmq_client::{
+    create_client_iopub_connection, create_client_shell_connection_with_identity,
+    find_kernelspec_with_jupyter_paths, peek_ports_with_listeners, peer_identity_for_session,
+    runtime_dir,
+};
+use petname::petname;
+use serde::Serialize;
+use tokio::{process::Child, time::Instant};
+use uuid::Uuid;
+
+#[derive(Parser, Debug)]
+#[command(about = "Stress raw Jupyter IOPub display traffic without runtimed or the notebook UI")]
+struct Args {
+    /// Comma-separated display counts to execute in order.
+    #[arg(long, default_value = "100,500,1000")]
+    counts: String,
+
+    /// Kernel name from Jupyter kernelspec discovery.
+    #[arg(long, default_value = "python3")]
+    kernel: String,
+
+    /// Raw command to launch the kernel. Use {connection_file} as the placeholder.
+    #[arg(long)]
+    cmd: Option<String>,
+
+    /// Per-execution timeout.
+    #[arg(long, default_value_t = 180)]
+    timeout_secs: u64,
+
+    /// Extra delay after connecting IOPub before sending the first execute request.
+    #[arg(long, default_value_t = 500)]
+    subscribe_delay_ms: u64,
+}
+
+struct LaunchedKernel {
+    kernel_name: String,
+    session_id: String,
+    connection_info: ConnectionInfo,
+    connection_file: PathBuf,
+    child: Child,
+}
+
+#[derive(Serialize)]
+struct StressResult {
+    kernel: String,
+    count: usize,
+    success: bool,
+    timed_out: bool,
+    ordered: bool,
+    display_count: usize,
+    stream_count: usize,
+    stdout_bytes: usize,
+    sentinel_seen: bool,
+    shell_execute_reply_seen: bool,
+    shell_reply_status: Option<String>,
+    status_busy_seen: bool,
+    status_idle_seen: bool,
+    iopub_messages: usize,
+    foreign_iopub_messages: usize,
+    shell_messages: usize,
+    foreign_shell_messages: usize,
+    message_counts: BTreeMap<String, usize>,
+    first_display_ms: Option<u128>,
+    last_display_ms: Option<u128>,
+    shell_reply_ms: Option<u128>,
+    idle_ms: Option<u128>,
+    elapsed_ms: u128,
+    missing: Vec<usize>,
+    duplicates: Vec<usize>,
+    first_labels: Vec<usize>,
+    last_labels: Vec<usize>,
+    errors: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let counts = parse_counts(&args.counts)?;
+
+    let mut kernel = launch_kernel(&args).await?;
+    let identity = peer_identity_for_session(&kernel.session_id)?;
+    let shell = create_client_shell_connection_with_identity(
+        &kernel.connection_info,
+        &kernel.session_id,
+        identity,
+    )
+    .await?;
+    let (mut shell_writer, mut shell_reader) = shell.split();
+    let mut iopub =
+        create_client_iopub_connection(&kernel.connection_info, "", &kernel.session_id).await?;
+
+    tokio::time::sleep(Duration::from_millis(args.subscribe_delay_ms)).await;
+
+    for count in counts {
+        let result = run_once(
+            &kernel.kernel_name,
+            count,
+            Duration::from_secs(args.timeout_secs),
+            &mut shell_writer,
+            &mut shell_reader,
+            &mut iopub,
+        )
+        .await?;
+        let timed_out = result.timed_out;
+        println!("{}", serde_json::to_string(&result)?);
+        if timed_out {
+            break;
+        }
+    }
+
+    let _ = tokio::fs::remove_file(&kernel.connection_file).await;
+    let _ = kernel.child.kill().await;
+    Ok(())
+}
+
+async fn launch_kernel(args: &Args) -> Result<LaunchedKernel> {
+    let kernel_id = petname(2, "-").context("failed to generate kernel id")?;
+    let session_id = Uuid::new_v4().to_string();
+    let key = Uuid::new_v4().to_string();
+    let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
+    let (ports, listeners) = peek_ports_with_listeners(ip, 5).await?;
+    let kernel_name = args
+        .cmd
+        .as_ref()
+        .map_or(args.kernel.clone(), |_| "cmd".to_string());
+    let connection_info = ConnectionInfo {
+        transport: Transport::TCP,
+        ip: ip.to_string(),
+        stdin_port: ports[0],
+        control_port: ports[1],
+        hb_port: ports[2],
+        shell_port: ports[3],
+        iopub_port: ports[4],
+        signature_scheme: "hmac-sha256".to_string(),
+        key,
+        kernel_name: Some(kernel_name.clone()),
+    };
+
+    let runtime_dir = runtime_dir();
+    tokio::fs::create_dir_all(&runtime_dir).await?;
+    let connection_file = runtime_dir.join(format!("raw-iopub-stress-{kernel_id}.json"));
+    tokio::fs::write(&connection_file, serde_json::to_string(&connection_info)?).await?;
+
+    let mut command = if let Some(cmd) = &args.cmd {
+        let command_line = cmd.replace(
+            "{connection_file}",
+            connection_file
+                .to_str()
+                .context("connection file path is not valid UTF-8")?,
+        );
+        shell_command(&command_line)
+    } else {
+        let kernelspec = find_kernelspec_with_jupyter_paths(&args.kernel).await?;
+        kernelspec.command(&connection_file, None, None)?
+    };
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Ok(cwd) = std::env::current_dir() {
+        command.current_dir(cwd);
+    }
+
+    let child = command.spawn().context("failed to spawn kernel")?;
+    drop(listeners);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    Ok(LaunchedKernel {
+        kernel_name,
+        session_id,
+        connection_info,
+        connection_file,
+        child,
+    })
+}
+
+fn shell_command(command_line: &str) -> tokio::process::Command {
+    if cfg!(windows) {
+        let mut command = tokio::process::Command::new("cmd");
+        command.args(["/C", command_line]);
+        command
+    } else {
+        let mut command = tokio::process::Command::new("sh");
+        command.args(["-c", command_line]);
+        command
+    }
+}
+
+async fn run_once<ShellSend, ShellRecv, IoPubRecv>(
+    kernel_name: &str,
+    count: usize,
+    timeout: Duration,
+    shell_writer: &mut jupyter_zmq_client::Connection<ShellSend>,
+    shell_reader: &mut jupyter_zmq_client::Connection<ShellRecv>,
+    iopub: &mut jupyter_zmq_client::Connection<IoPubRecv>,
+) -> Result<StressResult>
+where
+    ShellSend: zeromq::SocketSend,
+    ShellRecv: zeromq::SocketRecv,
+    IoPubRecv: zeromq::SocketRecv,
+{
+    let code = display_stress_code(count);
+    let message: JupyterMessage = ExecuteRequest::new(code).into();
+    let message_id = message.header.msg_id.clone();
+
+    let start = Instant::now();
+    let deadline = start + timeout;
+    let mut timeout_sleep = Box::pin(tokio::time::sleep_until(deadline));
+
+    let mut labels = Vec::with_capacity(count);
+    let mut display_count = 0;
+    let mut stream_count = 0;
+    let mut stdout_bytes = 0;
+    let mut sentinel_seen = false;
+    let mut shell_execute_reply_seen = false;
+    let mut shell_reply_status = None;
+    let mut status_busy_seen = false;
+    let mut status_idle_seen = false;
+    let mut iopub_messages = 0;
+    let mut foreign_iopub_messages = 0;
+    let mut shell_messages = 0;
+    let mut foreign_shell_messages = 0;
+    let mut message_counts = BTreeMap::new();
+    let mut first_display_ms = None;
+    let mut last_display_ms = None;
+    let mut shell_reply_ms = None;
+    let mut idle_ms = None;
+    let mut errors = Vec::new();
+    let mut timed_out = false;
+
+    shell_writer.send(message).await?;
+
+    while !(status_idle_seen && shell_execute_reply_seen) {
+        tokio::select! {
+            _ = &mut timeout_sleep => {
+                timed_out = true;
+                break;
+            }
+            result = iopub.read() => {
+                let msg = result?;
+                let is_ours = parent_matches(&msg, &message_id);
+                if !is_ours {
+                    foreign_iopub_messages += 1;
+                    continue;
+                }
+
+                iopub_messages += 1;
+                *message_counts.entry(msg.header.msg_type.clone()).or_insert(0) += 1;
+
+                match msg.content {
+                    JupyterMessageContent::DisplayData(data) => {
+                        display_count += 1;
+                        let elapsed = start.elapsed().as_millis();
+                        first_display_ms.get_or_insert(elapsed);
+                        last_display_ms = Some(elapsed);
+                        if let Some(label) = data.data.content.iter().find_map(plain_text_label) {
+                            labels.push(label);
+                        }
+                    }
+                    JupyterMessageContent::StreamContent(stream) => {
+                        stream_count += 1;
+                        match stream.name {
+                            JupyterStdio::Stdout => {
+                                stdout_bytes += stream.text.len();
+                                if stream.text.contains(&sentinel(count)) {
+                                    sentinel_seen = true;
+                                }
+                            }
+                            JupyterStdio::Stderr => {
+                                if !stream.text.trim().is_empty() {
+                                    errors.push(format!("stderr: {}", stream.text.trim()));
+                                }
+                            }
+                        }
+                    }
+                    JupyterMessageContent::Status(Status { execution_state }) => match execution_state {
+                        ExecutionState::Busy => status_busy_seen = true,
+                        ExecutionState::Idle => {
+                            status_idle_seen = true;
+                            idle_ms = Some(start.elapsed().as_millis());
+                        }
+                        other => {
+                            errors.push(format!("status: {}", other.as_str()));
+                        }
+                    },
+                    JupyterMessageContent::ErrorOutput(error) => {
+                        errors.push(format!("{}: {}", error.ename, error.evalue));
+                    }
+                    _ => {}
+                }
+            }
+            result = shell_reader.read() => {
+                let msg = result?;
+                let is_ours = parent_matches(&msg, &message_id);
+                if !is_ours {
+                    foreign_shell_messages += 1;
+                    continue;
+                }
+
+                shell_messages += 1;
+                if let JupyterMessageContent::ExecuteReply(reply) = msg.content {
+                    shell_execute_reply_seen = true;
+                    shell_reply_status = Some(format!("{:?}", reply.status));
+                    shell_reply_ms = Some(start.elapsed().as_millis());
+                }
+            }
+        }
+    }
+
+    let (ordered, missing, duplicates) = sequence_diagnostics(&labels, count);
+    let success = !timed_out
+        && ordered
+        && display_count == count
+        && labels.len() == count
+        && sentinel_seen
+        && shell_execute_reply_seen
+        && status_idle_seen
+        && errors.is_empty();
+
+    Ok(StressResult {
+        kernel: kernel_name.to_string(),
+        count,
+        success,
+        timed_out,
+        ordered,
+        display_count,
+        stream_count,
+        stdout_bytes,
+        sentinel_seen,
+        shell_execute_reply_seen,
+        shell_reply_status,
+        status_busy_seen,
+        status_idle_seen,
+        iopub_messages,
+        foreign_iopub_messages,
+        shell_messages,
+        foreign_shell_messages,
+        message_counts,
+        first_display_ms,
+        last_display_ms,
+        shell_reply_ms,
+        idle_ms,
+        elapsed_ms: start.elapsed().as_millis(),
+        missing,
+        duplicates,
+        first_labels: labels.iter().copied().take(10).collect(),
+        last_labels: labels
+            .iter()
+            .copied()
+            .rev()
+            .take(10)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect(),
+        errors,
+    })
+}
+
+fn parent_matches(msg: &JupyterMessage, message_id: &str) -> bool {
+    msg.parent_header
+        .as_ref()
+        .map(|header| header.msg_id.as_str())
+        == Some(message_id)
+}
+
+fn plain_text_label(media: &MediaType) -> Option<usize> {
+    let MediaType::Plain(text) = media else {
+        return None;
+    };
+    text.trim().strip_prefix("display ")?.parse().ok()
+}
+
+fn sentinel(count: usize) -> String {
+    format!("RAW_IOPUB_SENTINEL count={count}")
+}
+
+fn display_stress_code(count: usize) -> String {
+    format!(
+        r#"
+from IPython.display import display
+import time
+
+N = {count}
+start = time.perf_counter()
+for i in range(N):
+    display({{"text/plain": f"display {{i:06d}}"}}, raw=True)
+elapsed = time.perf_counter() - start
+print("{sentinel} elapsed={{:.6f}}".format(elapsed))
+"#,
+        count = count,
+        sentinel = sentinel(count),
+    )
+}
+
+fn parse_counts(counts: &str) -> Result<Vec<usize>> {
+    let parsed = counts
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::parse::<usize>)
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    anyhow::ensure!(!parsed.is_empty(), "at least one count is required");
+    Ok(parsed)
+}
+
+fn sequence_diagnostics(labels: &[usize], expected: usize) -> (bool, Vec<usize>, Vec<usize>) {
+    let ordered = labels.iter().copied().eq(0..expected);
+    let seen: HashSet<usize> = labels.iter().copied().collect();
+    let missing = (0..expected)
+        .filter(|index| !seen.contains(index))
+        .take(20)
+        .collect();
+
+    let mut seen_once = HashSet::new();
+    let mut duplicate_set = HashSet::new();
+    let mut duplicates = Vec::new();
+    for label in labels {
+        if !seen_once.insert(*label) && duplicate_set.insert(*label) {
+            duplicates.push(*label);
+            if duplicates.len() == 20 {
+                break;
+            }
+        }
+    }
+
+    (ordered, missing, duplicates)
+}

--- a/crates/runtimed/src/output_committer.rs
+++ b/crates/runtimed/src/output_committer.rs
@@ -18,7 +18,12 @@ use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 use crate::task_supervisor::spawn_supervised;
 
-const OUTPUT_COMMITTER_QUEUE_CAPACITY: usize = 64;
+// Keep the IOPub reader hot during rich-output bursts. A Python loop can emit
+// 1000 display_data messages in a few hundred milliseconds; if this queue is
+// too small, the reader backpressures while the kernel is still publishing and
+// tail messages can be lost before status=idle arrives.
+const OUTPUT_COMMITTER_QUEUE_CAPACITY: usize = 2048;
+const OUTPUT_COMMIT_BATCH_SIZE: usize = 128;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum OrdinaryOutputKind {
@@ -33,13 +38,6 @@ impl OrdinaryOutputKind {
             Self::DisplayData => "output",
             Self::ExecuteResult => "output",
             Self::Error => "error",
-        }
-    }
-
-    fn transaction_label(self) -> &'static str {
-        match self {
-            Self::DisplayData | Self::ExecuteResult => "runtime-state-iopub-output-transaction",
-            Self::Error => "runtime-state-iopub-error-transaction",
         }
     }
 
@@ -82,15 +80,18 @@ impl OutputCommitterHandle {
     /// Queue an ordinary output commit.
     ///
     /// The bounded queue protects memory under sustained rich-output bursts.
-    /// When it fills, the IOPub reader waits for the worker to drain earlier
-    /// queued outputs and commit this output in order. That preserves durable
-    /// output ordering without allowing unbounded queue growth.
+    /// When it fills, the IOPub reader waits only for a queue slot and then
+    /// enqueues the output behind earlier outputs. That preserves durable
+    /// output ordering without allowing unbounded queue growth or forcing the
+    /// IOPub reader to synchronously drain all pending output work mid-burst.
     pub(crate) async fn enqueue_output(&self, output: OrdinaryOutputCommit) {
         match self.output_tx.try_send(output) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(output)) => {
-                debug!("[output-committer] Queue full; committing output through priority path");
-                self.commit_for_ordering(output).await;
+                debug!("[output-committer] Queue full; waiting for output queue capacity");
+                if self.output_tx.send(output).await.is_err() {
+                    warn!("[output-committer] Dropping output: committer closed");
+                }
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 warn!("[output-committer] Dropping output: committer closed");
@@ -129,20 +130,6 @@ impl OutputCommitterHandle {
             }
         }
     }
-
-    async fn commit_for_ordering(&self, output: OrdinaryOutputCommit) {
-        let (ack_tx, ack_rx) = oneshot::channel();
-        let request = PriorityOutputRequest {
-            output: Some(output),
-            signal: None,
-            ack: Some(ack_tx),
-        };
-        if self.priority_tx.send(request).is_err() {
-            warn!("[output-committer] Failed to commit output: committer closed");
-            return;
-        }
-        let _ = ack_rx.await;
-    }
 }
 
 async fn commit_priority_request(
@@ -152,7 +139,7 @@ async fn commit_priority_request(
 ) {
     drain_queued_outputs(output_rx, context).await;
     if let Some(output) = request.output {
-        commit_output(output, context).await;
+        commit_output_batch(vec![output], context).await;
     }
     if let Some(signal) = request.signal {
         let _ = context.lifecycle_tx.send(signal);
@@ -166,8 +153,18 @@ async fn drain_queued_outputs(
     output_rx: &mut mpsc::Receiver<OrdinaryOutputCommit>,
     context: &OutputCommitterContext,
 ) {
-    while let Ok(output) = output_rx.try_recv() {
-        commit_output(output, context).await;
+    loop {
+        let mut batch = Vec::with_capacity(OUTPUT_COMMIT_BATCH_SIZE);
+        while batch.len() < OUTPUT_COMMIT_BATCH_SIZE {
+            match output_rx.try_recv() {
+                Ok(output) => batch.push(output),
+                Err(_) => break,
+            }
+        }
+        if batch.is_empty() {
+            break;
+        }
+        commit_output_batch(batch, context).await;
     }
 }
 
@@ -193,7 +190,15 @@ async fn run_output_committer(
             }
 
             Some(output) = output_rx.recv() => {
-                commit_output(output, &context).await;
+                let mut batch = Vec::with_capacity(OUTPUT_COMMIT_BATCH_SIZE);
+                batch.push(output);
+                while batch.len() < OUTPUT_COMMIT_BATCH_SIZE {
+                    match output_rx.try_recv() {
+                        Ok(output) => batch.push(output),
+                        Err(_) => break,
+                    }
+                }
+                commit_output_batch(batch, &context).await;
             }
 
             else => break,
@@ -250,7 +255,42 @@ fn start_output_committer_with_capacity(
     }
 }
 
-async fn commit_output(output: OrdinaryOutputCommit, context: &OutputCommitterContext) {
+async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &OutputCommitterContext) {
+    if outputs.is_empty() {
+        return;
+    }
+
+    let mut manifests = Vec::with_capacity(outputs.len());
+    for output in &outputs {
+        manifests.push(create_manifest_json(output, context).await);
+    }
+
+    if let Err(e) = context.state.transact_at_current_heads(
+        Some(&context.kernel_actor_id),
+        "runtime-state-iopub-output-batch-transaction",
+        |sd| {
+            let mut index = 0;
+            while index < outputs.len() {
+                let execution_id = outputs[index].execution_id.as_str();
+                let start = index;
+                while index < outputs.len() && outputs[index].execution_id == execution_id {
+                    index += 1;
+                }
+                if let Err(e) = sd.append_outputs(execution_id, &manifests[start..index]) {
+                    warn!("[output-committer] Failed to append output batch to state doc: {e}");
+                }
+            }
+            Ok(())
+        },
+    ) {
+        warn!("[runtime-state] {}", e);
+    }
+}
+
+async fn create_manifest_json(
+    output: &OrdinaryOutputCommit,
+    context: &OutputCommitterContext,
+) -> serde_json::Value {
     if output.kind.uses_buffer_preflight() {
         output_store::preflight_ref_buffers(
             &output.nbformat_value,
@@ -260,7 +300,7 @@ async fn commit_output(output: OrdinaryOutputCommit, context: &OutputCommitterCo
         .await;
     }
 
-    let manifest_json = match output_store::create_manifest_with_redactor(
+    match output_store::create_manifest_with_redactor(
         &output.nbformat_value,
         &context.blob_store,
         DEFAULT_INLINE_THRESHOLD,
@@ -280,23 +320,6 @@ async fn commit_output(output: OrdinaryOutputCommit, context: &OutputCommitterCo
                 .redact_output_value(&output.nbformat_value);
             crate::notebook_sync_server::fallback_output_with_id(&redacted)
         }
-    };
-
-    if let Err(e) = context.state.transact_at_current_heads(
-        Some(&context.kernel_actor_id),
-        output.kind.transaction_label(),
-        |sd| {
-            if let Err(e) = sd.append_output(&output.execution_id, &manifest_json) {
-                warn!(
-                    "[output-committer] Failed to append {} output to state doc: {}",
-                    output.kind.label(),
-                    e
-                );
-            }
-            Ok(())
-        },
-    ) {
-        warn!("[runtime-state] {}", e);
     }
 }
 


### PR DESCRIPTION
## Summary
- adds a raw Jupyter IOPub display stress harness for isolating ZMQ/kernel transport from runtimed
- keeps the ordinary output committer bounded but raises burst capacity from 64 to 2048 so the IOPub reader stays hot for display storms
- batches ordinary output commits and adds `RuntimeStateDoc::append_outputs` to avoid rescanning/sorting output sequence state for every output

## Evidence
Raw ZMQ/kernel layer, one kernel, direct shell/IOPub sockets:
- `ipykernel_launcher`, N=1000: 1000/1000 ordered display outputs, sentinel, idle, execute_reply in ~348 ms
- `nteract_kernel_launcher`, N=1000: 1000/1000 ordered display outputs, sentinel, idle, execute_reply in ~276 ms

Full runtimed daemon path:
- before this branch: N=1000 stuck/timeout with 887 display outputs and no sentinel in one repro
- queue-capacity-only experiment: N=1000 completed in ~102s
- queue + committer batching + RuntimeStateDoc batch append, final 2048 queue: N=1000 completed in ~23s with 1000/1000 ordered display outputs and sentinel

## Verification
- `cargo xtask lint --fix`
- `cargo test -p runtime-doc append_outputs_preserves_batch_order`
- `cargo test -p runtimed output_committer --lib`
- `cargo check -p runtimed --example raw_iopub_display_stress`
- `cargo run -p runtimed --example raw_iopub_display_stress -- --counts 100,500,1000 --timeout-secs 180 --cmd 'uv run --with ipykernel python -m ipykernel_launcher -f {connection_file}'`
- dev-daemon Python stress via `runtimed.Client`, one Python kernel, `display(...)` loop for N=1000 on final code
