### PR TITLE
docs(notebook-cloud): define hosted output origin isolation

### DIFF
--- a/docs/architecture/deployment-topology.md
+++ b/docs/architecture/deployment-topology.md
@@ -18,6 +18,8 @@ layers:
   JupyterHub, browser WebSockets, and native clients present credentials.
 - `hosted-notebook-artifacts.md` defines the durable snapshot pair and blob
   layout.
+- `hosted-output-origin-isolation.md` defines why authenticated app origins,
+  renderer asset origins, and untrusted output-document origins stay separate.
 - `runtime-peer-and-blob-authority-audit.md` clarifies that `runtime_peer` is
   the room role, `RuntimeAgent` is local daemon machinery, and `PutBlob` is not
   runtime topology.
@@ -260,6 +262,9 @@ Minimum policy:
   third-party origins are never allowed to open authenticated room WebSockets;
 - header-authenticated native, CLI, agent, and runtime-peer clients may omit
   `Origin`, but any supplied `Origin` must still be valid and trusted.
+
+The origin classes and deployment reasons are defined in
+`hosted-output-origin-isolation.md`.
 
 This ADR decides where the origin gate lives: the Worker enforces it before
 credential normalization and before stamping trusted room headers. The detailed

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -12,6 +12,7 @@ Related design docs:
 - `docs/architecture/hosted-credential-transport.md`
 - `docs/architecture/hosted-room-authorization.md`
 - `docs/architecture/hosted-notebook-artifacts.md`
+- `docs/architecture/hosted-output-origin-isolation.md`
 - `docs/architecture/identity-and-trust.md`
 
 ## Target Topology
@@ -48,6 +49,11 @@ https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/
 Do not add the renderer asset origin to the notebook WebSocket origin allowlist.
 It serves public build artifacts only; notebook room traffic belongs to the
 notebook application origin.
+
+Untrusted output documents should use their own output-document origin before
+private hosted notebooks scale beyond the prototype. That origin is separate
+from both the Access-protected notebook host and the renderer asset host; see
+`hosted-output-origin-isolation.md`.
 
 ## Cloudflare Access Application
 

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -304,7 +304,9 @@ Minimum policy:
   `NOTEBOOK_CLOUD_ALLOWED_ORIGINS`.
 - Do not allow sandboxed output iframes or renderer asset origins to open
   authenticated notebook-room WebSockets.
-- Keep renderer asset origins separate from notebook-room origins.
+- Keep renderer asset origins and output-document origins separate from
+  notebook-room origins. `hosted-output-origin-isolation.md` defines that
+  origin split.
 
 Header-authenticated CLI, native, and runtime clients may omit `Origin` even
 when an allowlist is configured. If any client sends `Origin`, malformed or
@@ -377,6 +379,8 @@ configuration.
   Cloudflare Access + Anaconda demo deployment and smoke steps.
 - `docs/architecture/hosted-sharing-invites.md` - email invite to principal ACL
   resolution.
+- `docs/architecture/hosted-output-origin-isolation.md` - hosted output
+  document, renderer asset, and blob-origin separation.
 - `apps/notebook-cloud/src/identity.ts` - current Cloudflare Access JWT and
   dev-token credential extraction.
 - Cloudflare WebSockets docs:

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -23,6 +23,8 @@ The shared runtime work now gives us a cleaner path:
   `{ "blob": "<sha256>" }` until the host maps them to a URL.
 - The Worker can use shared typed-frame size limits and shared CBOR presence
   helpers instead of local protocol copies.
+- Hosted output documents, renderer sidecars, and private blob reads have
+  separate origin boundaries; see `hosted-output-origin-isolation.md`.
 
 ## Decision 1: Durable publish artifacts are snapshot pairs
 
@@ -168,8 +170,10 @@ decision for public viewer presence is settled.
   behavior live in `docs/architecture/hosted-room-authorization.md`.
 - This ADR does not require hosted rooms to run kernels. Runtime snapshots can
   be imported from a local daemon or future remote runtime peer.
-- This ADR does not define the final blob origin. `/api/n/:id/blobs/:hash` is a
-  prototype origin; a separate output-blob origin with signed URLs remains open.
+- This ADR does not define the final blob or output-document origin.
+  `/api/n/:id/blobs/:hash` is a prototype origin; the production origin split
+  and signed/capability URL direction live in
+  `hosted-output-origin-isolation.md`.
 
 ## Open Questions
 

--- a/docs/architecture/hosted-output-origin-isolation.md
+++ b/docs/architecture/hosted-output-origin-isolation.md
@@ -29,9 +29,12 @@ HTML/SVG iframe output was served by a separate Cloudflare Worker on
 `https://runtusercontent.com` (preview: `https://preview.runtusercontent.com`).
 The main app was configured with `VITE_IFRAME_OUTPUT_URI` so the output frame
 boundary was a deploy-time origin decision, not a renderer implementation
-detail. That shape is the right starting point for notebook-cloud as well, but
-the nteract system also has separate renderer plugin sidecars, blob resolvers,
-and live room WebSockets that need sharper names.
+detail. That deployment is useful prior art, not a compatibility contract.
+Notebook-cloud should keep the underlying security property: untrusted output
+must not share ambient application authority. It should still adopt better
+Cloudflare, OIDC, browser-platform, or operational patterns where they improve
+the system instead of copying old domain names, environment variable names,
+Worker layouts, or auth shortcuts wholesale.
 
 Related docs:
 
@@ -183,6 +186,10 @@ The `runtimed/intheloop` precedent maps to notebook-cloud like this:
 | `VITE_IFRAME_OUTPUT_URI` | output-document base URL host config |
 | separate iframe-output deploy script | future output-document Worker deploy |
 | Cloudflare Worker assets for iframe shell | renderer/output shell assets |
+
+This table is a precedent map, not a deployment mandate. It names the boundary
+we want to preserve, while leaving the concrete hosting, CDN, Access/OIDC, and
+capability-token mechanics open to better current practice.
 
 Anaconda is the identity provider for the app origin. It is not a reason for
 output documents to receive app-origin cookies or direct OIDC material.

--- a/docs/architecture/hosted-output-origin-isolation.md
+++ b/docs/architecture/hosted-output-origin-isolation.md
@@ -72,6 +72,15 @@ should be able to point renderer assets and output documents at dedicated
 origins. Shared renderer code must not infer cloud paths from app-specific
 routes such as `/api/n/:id`.
 
+The current `/n/:id` published viewer is also a prototype convenience served
+from the notebook application origin. That keeps the early demo simple, but it
+means the read-only viewer page currently shares an origin with authenticated
+APIs, localStorage, and WebSocket credential bootstrapping. Before broad private
+notebook sharing, the published read-only viewer should move to a less
+privileged preview/viewer origin, or the privileged application shell should be
+split from the unauthenticated output/viewer surface so the app-origin
+definition above is true in practice.
+
 ## Decision 2: A separate output origin does not replace the sandbox
 
 The iframe sandbox remains load-bearing. Output frames must continue to omit
@@ -85,6 +94,9 @@ coordination space. These are complementary controls:
 - output origin: deployment and browser-policy separation from the app;
 - sandbox without `allow-same-origin`: parent DOM, storage, cookies, and
   inter-output isolation.
+- app-origin hardening: future deployments should evaluate
+  `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` once renderer
+  assets, WASM sidecars, and output documents have explicit CORS/CORP behavior.
 
 Do not loosen the sandbox to make plugin loading easier. If a renderer needs a
 new network dependency, add it through the host context, renderer asset origin,
@@ -244,7 +256,10 @@ output documents to receive app-origin cookies or direct OIDC material.
    clearer.
 4. Whether the renderer asset origin and output document origin can share a
    registrable domain without weakening cookie/storage isolation. The safer
-   default is separate hosts with no shared cookie domain.
+   default is separate hosts with no shared cookie domain. Different subdomains
+   on the same registrable domain are not sufficient if any app, asset, or
+   output host can set `Domain=<registrable-domain>` cookies; app and output
+   hosts must never share registrable-domain-scoped cookies.
 
 ## References
 

--- a/docs/architecture/hosted-output-origin-isolation.md
+++ b/docs/architecture/hosted-output-origin-isolation.md
@@ -1,0 +1,252 @@
+# Hosted Output Origin Isolation
+
+**Status:** Draft, 2026-05-24.
+**Addresses:** GitHub issue #2645.
+
+## Context
+
+Notebook outputs are untrusted content. A Python cell can emit arbitrary HTML,
+SVG, JavaScript-backed widgets, Plotly/Vega/Leaflet documents, anywidget
+bundles, or renderer-specific WASM sidecars. Desktop contains that content in
+the shared isolated output frame:
+
+- Tauri serves the frame document from the `nteract-frame://` custom scheme so
+  it can receive a dedicated CSP.
+- Plain browser development can use `srcDoc`.
+- The iframe sandbox deliberately omits `allow-same-origin`, giving output code
+  a sandbox-induced opaque origin.
+
+That model is still the core security boundary, but hosted production adds real
+authenticated browser sessions, notebook ACLs, Cloudflare Access cookies,
+viewer/editor WebSockets, and public CDN-style renderer assets. A hosted
+deployment must not let output JavaScript share cookies, localStorage, ambient
+credentials, room WebSocket privileges, or application-origin APIs with the
+notebook application.
+
+Prior art exists in the older `runtimed/intheloop` deployment. The main
+application and API were served from `https://app.runt.run`, while user-created
+HTML/SVG iframe output was served by a separate Cloudflare Worker on
+`https://runtusercontent.com` (preview: `https://preview.runtusercontent.com`).
+The main app was configured with `VITE_IFRAME_OUTPUT_URI` so the output frame
+boundary was a deploy-time origin decision, not a renderer implementation
+detail. That shape is the right starting point for notebook-cloud as well, but
+the nteract system also has separate renderer plugin sidecars, blob resolvers,
+and live room WebSockets that need sharper names.
+
+Related docs:
+
+- `src/components/isolated/AGENTS.md`
+- `docs/architecture/deployment-topology.md`
+- `docs/architecture/hosted-credential-transport.md`
+- `docs/architecture/hosted-room-authorization.md`
+- `docs/architecture/hosted-notebook-artifacts.md`
+- `docs/architecture/blob-storage-and-content-addressing.md`
+
+## Decision 1: Hosted deployments have three origin classes
+
+A production hosted notebook deployment should separate at least these origin
+classes:
+
+1. **Notebook application origin.** Serves the authenticated UI, HTTP APIs, and
+   typed-frame room WebSockets. This origin is protected by Cloudflare Access or
+   another configured identity provider, owns cookies/session material, enforces
+   WebSocket `Origin` policy, and stamps trusted room identity headers.
+2. **Renderer asset origin.** Serves public build-time renderer sidecars such
+   as Sift WASM, plugin CSS, and future renderer chunk assets. It has no
+   notebook identity, no room APIs, no authenticated WebSockets, and no
+   user-generated notebook blobs. It may use `Access-Control-Allow-Origin: *`
+   because sandboxed `srcDoc`/opaque-origin frames and parent viewers must be
+   able to fetch these immutable sidecars.
+3. **Output document origin.** Serves the document shell used to execute
+   untrusted output JavaScript. It is a separate host from the notebook
+   application and should ideally be on a separate registrable domain, such as
+   `*.nteractusercontent.com`, so no cookie scope or localStorage namespace can
+   overlap with the authenticated app origin.
+
+The current notebook-cloud Worker may keep a prototype route like
+`/renderer-assets/` for local/demo convenience, but production configuration
+should be able to point renderer assets and output documents at dedicated
+origins. Shared renderer code must not infer cloud paths from app-specific
+routes such as `/api/n/:id`.
+
+## Decision 2: A separate output origin does not replace the sandbox
+
+The iframe sandbox remains load-bearing. Output frames must continue to omit
+`allow-same-origin`, even when served from a separate output host.
+
+The separate host gives the frame its own response headers, CSP, caching,
+observability, and deploy lifecycle. The sandbox-induced opaque origin prevents
+output JavaScript from using that host as a shared storage or same-origin
+coordination space. These are complementary controls:
+
+- output origin: deployment and browser-policy separation from the app;
+- sandbox without `allow-same-origin`: parent DOM, storage, cookies, and
+  inter-output isolation.
+
+Do not loosen the sandbox to make plugin loading easier. If a renderer needs a
+new network dependency, add it through the host context, renderer asset origin,
+or blob resolver, not by giving the output frame application-origin powers.
+
+## Decision 3: Output documents never hold room credentials
+
+Output document JavaScript must not receive:
+
+- Cloudflare Access cookies or Access JWTs;
+- notebook room bearer tokens, one-time tickets, or dev tokens;
+- `Authorization` material;
+- trusted identity headers;
+- URLs that imply editor/owner authority.
+
+Output documents communicate with the parent through the existing explicit
+`postMessage` bridge. The parent validates message source, expected frame
+session, and renderer protocol shape before accepting messages. The output
+frame may ask the parent to resolve a blob or send a widget message through the
+existing renderer bridge; it must not open `/n/:id/sync` or any authenticated
+notebook-room WebSocket itself.
+
+`hosted-credential-transport.md` and `deployment-topology.md` already require
+the Worker to reject renderer asset origins, sandboxed output origins, and
+arbitrary third-party origins at the notebook WebSocket `Origin` gate. This ADR
+adds the deployment reason: those origins are intentionally untrusted output
+surfaces, not notebook application origins.
+
+## Decision 4: Renderer assets are public sidecars, not notebook APIs
+
+Renderer sidecars are static, build-time artifacts. The dedicated renderer asset
+Worker/origin should serve only files needed by the isolated renderers, for
+example:
+
+```text
+/renderer-assets/sift_wasm.wasm
+/renderer-assets/*
+```
+
+It must not serve the notebook application bundle, authenticated API responses,
+notebook snapshots, room event streams, or user-generated blobs. Existing
+notebook-cloud tests already assert that the renderer asset Worker does not
+expose the app bundle and rejects traversal-shaped asset paths; those tests
+should remain part of this boundary.
+
+The renderer asset origin can be configured independently for:
+
+- parent viewer preloads and dynamic imports;
+- isolated output frames whose origin is `null`;
+- cloud-hosted Sift/Arrow sidecars;
+- future CDN deployment of renderer chunks.
+
+This keeps plugin hosting scalable without teaching renderers about notebook
+route structure.
+
+## Decision 5: Blob resolution stays host-owned
+
+`RuntimeStateDoc` and `NotebookDoc` should continue to store host-neutral
+content references such as:
+
+```json
+{ "blob": "sha256-...", "size": 1234, "media_type": "image/png" }
+```
+
+WASM and renderer plugins should not rewrite these into daemon-local or
+Cloudflare-local URLs. The host provides a `BlobResolver`:
+
+- desktop maps blob refs to the local daemon blob server;
+- notebook-cloud maps blob refs to `/api/n/:id/blobs/:hash` for the prototype;
+- production can map blob refs to a signed, cookie-free blob/output origin.
+
+The output document origin may fetch only the blob URLs the parent gives it.
+For private notebooks, those URLs should be short-lived capabilities scoped to
+the notebook, revision/render batch, hash, and viewer. For public published
+notebooks, content-addressed public URLs are acceptable only when the notebook
+is deliberately public. In both cases, attribution and ACL decisions stay
+server-side; output JavaScript does not get to self-identify authors or
+principals.
+
+## Decision 6: The Anaconda demo uses Access for the app origin only
+
+The first Anaconda-friendly hosted demo uses Cloudflare Access with Anaconda
+configured as the OIDC provider. That Access application should protect the
+notebook application host only.
+
+Do not put the output document origin or renderer asset origin behind the same
+Access application cookie. If those origins need access control, use
+capability URLs or an output-specific validation layer that does not share the
+notebook app's ambient browser credential. This avoids the main failure mode
+from issue #2645: untrusted output code becoming same-site with the
+authenticated notebook app.
+
+The `runtimed/intheloop` precedent maps to notebook-cloud like this:
+
+| In the Loop | Notebook-cloud equivalent |
+|-------------|---------------------------|
+| `app.runt.run` unified app/API Worker | notebook application origin |
+| `runtusercontent.com` iframe output Worker | output document origin |
+| `VITE_IFRAME_OUTPUT_URI` | output-document base URL host config |
+| separate iframe-output deploy script | future output-document Worker deploy |
+| Cloudflare Worker assets for iframe shell | renderer/output shell assets |
+
+Anaconda is the identity provider for the app origin. It is not a reason for
+output documents to receive app-origin cookies or direct OIDC material.
+
+## Implementation Sequence
+
+1. **Document and cross-reference the boundary.** Land this ADR and point
+   hosted auth/artifact docs at it wherever they mention future output origins.
+2. **Keep the current sandbox invariant.** Preserve the `allow-same-origin`
+   absence tests and treat any change to output iframe sandbox flags as a
+   security review.
+3. **Separate renderer sidecars operationally.** Keep `RENDERER_ASSETS_BASE_URL`
+   / equivalent config working so the deployed demo can move Sift WASM and
+   other sidecars to a dedicated Worker/CDN without code changes.
+4. **Introduce an output-document host config.** Add a host-configured
+   output-document base URL, analogous to `VITE_IFRAME_OUTPUT_URI`, for hosted
+   production. Browser-local development may continue using `srcDoc`.
+5. **Build an output-document Worker.** Serve only the output document shell,
+   with CSP tailored for renderers and no app APIs, room WebSockets, or
+   credentials.
+6. **Capability-scope private blob reads.** Move private hosted blob reads from
+   app-origin API routes to short-lived capability URLs or another equivalent
+   cookie-free mechanism before broad private notebook sharing.
+7. **Add boundary tests.** Cover:
+   - renderer asset origin cannot serve app bundle or notebook data;
+   - output origin is never accepted by the room WebSocket origin gate;
+   - output frames cannot access parent storage/cookies under the sandbox;
+   - cloud viewer config can place renderer assets, runtimed WASM assets, and
+     output documents on distinct origins.
+
+## Non-Goals
+
+- This ADR does not choose the final public domain name. Names like
+  `nteractusercontent.com` describe the security shape, not a committed domain.
+- This ADR does not replace `hosted-credential-transport.md`; it relies on that
+  ADR for credential transport and WebSocket origin policy.
+- This ADR does not define invite or ACL semantics; those remain in
+  `hosted-room-authorization.md` and `hosted-sharing-invites.md`.
+- This ADR does not make output frames trusted. They remain untrusted even when
+  served from a first-party controlled output domain.
+
+## Open Questions
+
+1. Whether the first production output-document host should be a Cloudflare
+   Worker with static assets, a Worker plus R2-backed documents, or a pure
+   static CDN origin.
+2. Whether private blob capability URLs should be path tokens, signed query
+   parameters, signed cookies on an output-only host, or a Worker-mediated
+   authorization check. Query parameters are easy but can leak into logs.
+3. Whether output documents need per-render-batch session ids beyond the
+   existing frame bridge ids to make parent validation and observability
+   clearer.
+4. Whether the renderer asset origin and output document origin can share a
+   registrable domain without weakening cookie/storage isolation. The safer
+   default is separate hosts with no shared cookie domain.
+
+## References
+
+- GitHub issue #2645, "Design hosted web output-origin isolation."
+- `runtimed/intheloop/DEPLOYMENT.md`, "Iframe Outputs Service."
+- `runtimed/intheloop/iframe-outputs/worker/wrangler.toml`, which routes the
+  iframe output Worker to `runtusercontent.com` and
+  `preview.runtusercontent.com`.
+- `runtimed/intheloop/iframe-outputs/worker/worker.ts`, which serves the output
+  frame shell with output-specific response headers.
+- `src/components/isolated/AGENTS.md`, which documents the current desktop and
+  browser output-frame security invariants.


### PR DESCRIPTION
## Summary

- adds an ADR for hosted output-origin isolation, addressing #2645
- grounds the security boundary in the prior `runtimed/intheloop` deployment while making clear that it is prior art, not a compatibility contract or hosting mandate
- names the three hosted origin classes: notebook application, renderer assets, and output documents
- cross-references the ADR from hosted credential transport, artifact, runbook, and deployment-topology docs

## Verification

- `cargo xtask lint --fix`
- `git diff --check`

## Review

- Opus 4.6 adversarial review via `uv run pr-review ... --out .context/reviews/pr-2941-r3.json`: clear, no findings
- Pullfrog ADR-focused adversarial pass commented with three doc-level observations
- Follow-up commit `035abf68` addresses the Pullfrog notes about the app-origin `/n/:id` prototype exception, COOP/COEP hardening, and registrable-domain cookie scope
- Pullfrog follow-up pass: no new issues found
- GitHub checks: passing
