### PR TITLE
feat(notebook-cloud): add owner invite routes

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -42,8 +42,12 @@ import {
 import { collectBlobRefs } from "./blob-refs.ts";
 import { cloudLog, durationMs } from "./observability.ts";
 import {
+  createPendingNotebookInvite,
   getPendingNotebookInvitesForLogin,
+  listNotebookInvites,
   resolveNotebookInvitesForLogin,
+  revokePendingNotebookInvite,
+  type PendingNotebookInviteRow,
 } from "./sharing-storage.ts";
 
 export { NotebookRoom };
@@ -148,6 +152,21 @@ const worker: ExportedHandler<Env> = {
     const aclMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/acl\/?$/);
     if (aclMatch) {
       return routeNotebookAcl(request, env, decodeURIComponent(aclMatch[1]));
+    }
+
+    const inviteMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/invites\/?$/);
+    if (inviteMatch) {
+      return routeNotebookInvites(request, env, decodeURIComponent(inviteMatch[1]));
+    }
+
+    const inviteItemMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/invites\/([^/]+)\/?$/);
+    if (inviteItemMatch) {
+      return routeNotebookInvite(
+        request,
+        env,
+        decodeURIComponent(inviteItemMatch[1]),
+        decodeURIComponent(inviteItemMatch[2]),
+      );
     }
 
     const renderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/renders\/([^/]+)$/);
@@ -599,6 +618,217 @@ async function routeRuntimeSnapshot(
   });
 
   return json({ ok: true, key, size: body.byteLength }, 201);
+}
+
+interface PendingInvitePayload {
+  email?: unknown;
+  provider_hint?: unknown;
+  providerHint?: unknown;
+  scope?: unknown;
+  expires_at?: unknown;
+  expiresAt?: unknown;
+}
+
+interface ParsedPendingInviteInput {
+  email: string;
+  provider_hint: string | null;
+  scope: "viewer" | "editor";
+  expires_at: string | null;
+}
+
+async function routeNotebookInvites(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    return json({
+      notebook_id: notebookId,
+      invites: (await listNotebookInvites(env, notebookId)).map(inviteResponse),
+    });
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const inviteInput = await parsePendingInviteInput(request);
+  if (inviteInput instanceof Response) {
+    return inviteInput;
+  }
+
+  let invite: PendingNotebookInviteRow | null;
+  try {
+    invite = await createPendingNotebookInvite(env, {
+      notebookId,
+      email: inviteInput.email,
+      providerHint: inviteInput.provider_hint,
+      scope: inviteInput.scope,
+      expiresAt: inviteInput.expires_at,
+      actorLabel: identity.actorLabel,
+    });
+  } catch (error) {
+    if (isInviteInputError(error)) {
+      return json({ error: errorMessage(error) }, 400);
+    }
+    throw error;
+  }
+
+  if (!invite) {
+    return json({ error: "invite was not created" }, 500);
+  }
+
+  cloudLog("info", "invite.create.completed", {
+    notebook_id: notebookId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    invite_id: invite.id,
+    invite_scope: invite.scope,
+    provider_hint: invite.provider_hint,
+    counter: "invite_creates",
+    counter_delta: 1,
+  });
+
+  return json(
+    {
+      ok: true,
+      notebook_id: notebookId,
+      invite: inviteResponse(invite),
+    },
+    201,
+  );
+}
+
+async function routeNotebookInvite(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  inviteId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "DELETE") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method !== "DELETE") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const revoked = await revokePendingNotebookInvite(env, {
+    notebookId,
+    inviteId,
+    actorLabel: identity.actorLabel,
+  });
+  if (!revoked) {
+    return json({ error: "pending invite not found" }, 404);
+  }
+
+  cloudLog("info", "invite.revoke.completed", {
+    notebook_id: notebookId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    invite_id: inviteId,
+    counter: "invite_revocations",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    notebook_id: notebookId,
+    invites: (await listNotebookInvites(env, notebookId)).map(inviteResponse),
+  });
+}
+
+async function parsePendingInviteInput(
+  request: Request,
+): Promise<ParsedPendingInviteInput | Response> {
+  let payload: PendingInvitePayload;
+  try {
+    payload = (await request.json()) as PendingInvitePayload;
+  } catch {
+    return json({ error: "invite body must be JSON" }, 400);
+  }
+
+  const email = stringField(payload.email, "email");
+  if (email instanceof Response) {
+    return email;
+  }
+
+  const scopeValue = stringField(payload.scope, "scope");
+  if (scopeValue instanceof Response) {
+    return scopeValue;
+  }
+  if (scopeValue !== "viewer" && scopeValue !== "editor") {
+    return json({ error: "invite scope must be viewer or editor" }, 400);
+  }
+
+  const providerHint = optionalStringField(
+    payload.provider_hint ?? payload.providerHint,
+    "provider_hint",
+  );
+  if (providerHint instanceof Response) {
+    return providerHint;
+  }
+
+  const expiresAt = optionalStringField(payload.expires_at ?? payload.expiresAt, "expires_at");
+  if (expiresAt instanceof Response) {
+    return expiresAt;
+  }
+  if (expiresAt && !Number.isFinite(Date.parse(expiresAt))) {
+    return json({ error: "invite expiry is invalid" }, 400);
+  }
+
+  return {
+    email,
+    provider_hint: providerHint,
+    scope: scopeValue,
+    expires_at: expiresAt,
+  };
+}
+
+function inviteResponse(row: PendingNotebookInviteRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    notebook_id: row.notebook_id,
+    email: row.email_normalized,
+    provider_hint: row.provider_hint,
+    scope: row.scope,
+    status: row.status,
+    invited_by_actor_label: row.invited_by_actor_label,
+    accepted_by_principal: row.accepted_by_principal,
+    created_at: row.created_at,
+    expires_at: row.expires_at,
+    accepted_at: row.accepted_at,
+    revoked_at: row.revoked_at,
+    revoked_by_actor_label: row.revoked_by_actor_label,
+  };
 }
 
 async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
@@ -1206,6 +1436,17 @@ function stringField(value: unknown, fieldName: string): string | Response {
   return value.trim();
 }
 
+function optionalStringField(value: unknown, fieldName: string): string | null | Response {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    return json({ error: `${fieldName} must be a string` }, 400);
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
 function isOwnerAclInput(row: ParsedNotebookAclInput): boolean {
   return row.subject_kind === "principal" && row.scope === "owner";
 }
@@ -1403,6 +1644,10 @@ function json(value: unknown, status = 200): Response {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isInviteInputError(error: unknown): boolean {
+  return errorMessage(error).startsWith("invite ");
 }
 
 async function sha256Hex(body: ArrayBuffer): Promise<string> {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -50,6 +50,7 @@ import {
   type ListedPendingNotebookInviteRow,
   type PendingNotebookInviteRow,
 } from "./sharing-storage.ts";
+import { normalizeInviteEmail, normalizeProviderHint } from "./sharing.ts";
 
 export { NotebookRoom };
 
@@ -674,22 +675,14 @@ async function routeNotebookInvites(
     return inviteInput;
   }
 
-  let invite: PendingNotebookInviteRow | null;
-  try {
-    invite = await createPendingNotebookInvite(env, {
-      notebookId,
-      email: inviteInput.email,
-      providerHint: inviteInput.provider_hint,
-      scope: inviteInput.scope,
-      expiresAt: inviteInput.expires_at,
-      actorLabel: identity.actorLabel,
-    });
-  } catch (error) {
-    if (isInviteInputError(error)) {
-      return json({ error: errorMessage(error) }, 400);
-    }
-    throw error;
-  }
+  const invite = await createPendingNotebookInvite(env, {
+    notebookId,
+    email: inviteInput.email,
+    providerHint: inviteInput.provider_hint,
+    scope: inviteInput.scope,
+    expiresAt: inviteInput.expires_at,
+    actorLabel: identity.actorLabel,
+  });
 
   if (!invite) {
     return json({ error: "invite was not created" }, 500);
@@ -781,6 +774,12 @@ async function parsePendingInviteInput(
   if (email instanceof Response) {
     return email;
   }
+  let normalizedEmail: string;
+  try {
+    normalizedEmail = normalizeInviteEmail(email);
+  } catch (error) {
+    return json({ error: errorMessage(error) }, 400);
+  }
 
   const scopeValue = stringField(payload.scope, "scope");
   if (scopeValue instanceof Response) {
@@ -797,6 +796,12 @@ async function parsePendingInviteInput(
   if (providerHint instanceof Response) {
     return providerHint;
   }
+  let normalizedProviderHint: string | null;
+  try {
+    normalizedProviderHint = normalizeProviderHint(providerHint);
+  } catch (error) {
+    return json({ error: errorMessage(error) }, 400);
+  }
 
   const expiresAt = optionalStringField(payload.expires_at ?? payload.expiresAt, "expires_at");
   if (expiresAt instanceof Response) {
@@ -807,8 +812,8 @@ async function parsePendingInviteInput(
   }
 
   return {
-    email,
-    provider_hint: providerHint,
+    email: normalizedEmail,
+    provider_hint: normalizedProviderHint,
     scope: scopeValue,
     expires_at: expiresAt,
   };
@@ -1647,10 +1652,6 @@ function json(value: unknown, status = 200): Response {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function isInviteInputError(error: unknown): boolean {
-  return errorMessage(error).startsWith("invite ");
 }
 
 async function sha256Hex(body: ArrayBuffer): Promise<string> {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -807,8 +807,14 @@ async function parsePendingInviteInput(
   if (expiresAt instanceof Response) {
     return expiresAt;
   }
-  if (expiresAt && !Number.isFinite(Date.parse(expiresAt))) {
-    return json({ error: "invite expiry is invalid" }, 400);
+  if (expiresAt) {
+    const expiresAtMs = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      return json({ error: "invite expiry is invalid" }, 400);
+    }
+    if (expiresAtMs <= Date.now()) {
+      return json({ error: "invite expiry must be in the future" }, 400);
+    }
   }
 
   return {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -47,6 +47,7 @@ import {
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
   revokePendingNotebookInvite,
+  type ListedPendingNotebookInviteRow,
   type PendingNotebookInviteRow,
 } from "./sharing-storage.ts";
 
@@ -813,7 +814,9 @@ async function parsePendingInviteInput(
   };
 }
 
-function inviteResponse(row: PendingNotebookInviteRow): Record<string, unknown> {
+function inviteResponse(
+  row: PendingNotebookInviteRow | ListedPendingNotebookInviteRow,
+): Record<string, unknown> {
   return {
     id: row.id,
     notebook_id: row.notebook_id,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -51,6 +51,8 @@ export interface PendingNotebookInviteRow {
   revoked_by_actor_label: string | null;
 }
 
+export type ListedPendingNotebookInviteRow = Omit<PendingNotebookInviteRow, "token_hash">;
+
 export interface PendingNotebookInviteInput {
   id?: string;
   notebookId: string;
@@ -62,6 +64,8 @@ export interface PendingNotebookInviteInput {
   tokenHash?: string | null;
   timestamp?: string;
 }
+
+const NOTEBOOK_INVITE_LIST_LIMIT = 200;
 
 export async function upsertPrincipalProfile(
   env: Env,
@@ -246,7 +250,7 @@ export async function getPendingNotebookInvite(
 export async function listNotebookInvites(
   env: Env,
   notebookId: string,
-): Promise<PendingNotebookInviteRow[]> {
+): Promise<ListedPendingNotebookInviteRow[]> {
   if (!env.DB) {
     return [];
   }
@@ -261,7 +265,6 @@ export async function listNotebookInvites(
             status,
             invited_by_actor_label,
             accepted_by_principal,
-            token_hash,
             created_at,
             expires_at,
             accepted_at,
@@ -269,10 +272,11 @@ export async function listNotebookInvites(
             revoked_by_actor_label
        FROM notebook_invites
        WHERE notebook_id = ?
-       ORDER BY created_at`,
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
   )
-    .bind(notebookId)
-    .all<PendingNotebookInviteRow>();
+    .bind(notebookId, NOTEBOOK_INVITE_LIST_LIMIT)
+    .all<ListedPendingNotebookInviteRow>();
   return rows.results ?? [];
 }
 

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -243,6 +243,68 @@ export async function getPendingNotebookInvite(
     .first<PendingNotebookInviteRow>();
 }
 
+export async function listNotebookInvites(
+  env: Env,
+  notebookId: string,
+): Promise<PendingNotebookInviteRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            token_hash,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM notebook_invites
+       WHERE notebook_id = ?
+       ORDER BY created_at`,
+  )
+    .bind(notebookId)
+    .all<PendingNotebookInviteRow>();
+  return rows.results ?? [];
+}
+
+export async function revokePendingNotebookInvite(
+  env: Env,
+  input: {
+    notebookId: string;
+    inviteId: string;
+    actorLabel: string;
+    timestamp?: string;
+  },
+): Promise<boolean> {
+  if (!env.DB) {
+    return false;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const result = await env.DB.prepare(
+    `UPDATE notebook_invites
+        SET status = 'revoked',
+            revoked_at = ?,
+            revoked_by_actor_label = ?
+      WHERE notebook_id = ?
+        AND id = ?
+        AND status = 'pending'`,
+  )
+    .bind(timestamp, input.actorLabel, input.notebookId, input.inviteId)
+    .run();
+  return d1Changes(result) > 0;
+}
+
 async function getExistingPendingNotebookInvite(
   env: Env,
   input: {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2740,7 +2740,10 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
-    if (this.query.includes("FROM notebook_invites")) {
+    if (
+      this.query.includes("FROM notebook_invites") &&
+      this.query.includes("WHERE notebook_id = ?")
+    ) {
       const notebookId = this.values[0] as string;
       const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;
       return okResult(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1069,6 +1069,171 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  it("lets owners create, list, and revoke pending notebook invites", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "invite-demo");
+    seedAcl(env, {
+      notebookId: "invite-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const create = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: " Bob@Example.COM ",
+        provider_hint: " Cloudflare-Access ",
+        scope: "editor",
+        expires_at: "2026-06-24T00:00:00.000Z",
+      },
+      "invite-demo",
+    );
+    assert.equal(create.status, 201);
+    const createBody = (await create.json()) as {
+      invite: Record<string, unknown>;
+      notebook_id: string;
+    };
+    assert.equal(createBody.notebook_id, "invite-demo");
+    assert.equal(createBody.invite.email, "bob@example.com");
+    assert.equal(createBody.invite.provider_hint, "cloudflare-access");
+    assert.equal(createBody.invite.scope, "editor");
+    assert.equal(createBody.invite.status, "pending");
+    assert.equal(Object.hasOwn(createBody.invite, "token_hash"), false);
+
+    const inviteId = createBody.invite.id as string;
+    assert.equal(env.DB.invites.get(inviteId)?.token_hash, null);
+
+    const list = await inviteRequest(env, "GET", undefined, "invite-demo");
+    assert.equal(list.status, 200);
+    const listBody = (await list.json()) as { invites: Array<Record<string, unknown>> };
+    assert.deepEqual(
+      listBody.invites.map((invite) => [invite.id, invite.email, invite.status]),
+      [[inviteId, "bob@example.com", "pending"]],
+    );
+    assert.equal(Object.hasOwn(listBody.invites[0] ?? {}, "token_hash"), false);
+
+    const revoke = await inviteItemRequest(env, "DELETE", inviteId, "invite-demo");
+    assert.equal(revoke.status, 200);
+    const revokeBody = (await revoke.json()) as { invites: Array<Record<string, unknown>> };
+    assert.deepEqual(
+      revokeBody.invites.map((invite) => [invite.id, invite.email, invite.status]),
+      [[inviteId, "bob@example.com", "revoked"]],
+    );
+    assert.equal(
+      env.DB.invites.get(inviteId)?.revoked_by_actor_label,
+      "user:dev:alice/desktop:test",
+    );
+  });
+
+  it("keeps invite management owner-only and scope-limited", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "invite-private-demo");
+    seedAcl(env, {
+      notebookId: "invite-private-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "invite-private-demo",
+      subject: "user:dev:bob",
+      scope: "editor",
+    });
+
+    const bobCreate = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: "mallory@example.com",
+        scope: "viewer",
+      },
+      "invite-private-demo",
+      {
+        "X-User": "bob",
+        "X-Scope": "editor",
+      },
+    );
+    assert.equal(bobCreate.status, 403);
+
+    const ownerInvite = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: "new-owner@example.com",
+        scope: "owner",
+      },
+      "invite-private-demo",
+    );
+    assert.equal(ownerInvite.status, 400);
+    assert.deepEqual(await ownerInvite.json(), {
+      error: "invite scope must be viewer or editor",
+    });
+  });
+
+  it("requires trusted origins for cookie-backed invite mutations", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv(accessEnv);
+    seedNotebook(env, "access-invite-demo");
+    seedAcl(env, {
+      notebookId: "access-invite-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+
+    const body = JSON.stringify({
+      email: "bob@example.com",
+      provider_hint: "cloudflare-access",
+      scope: "editor",
+    });
+    const headers = {
+      "Content-Type": "application/json",
+      Cookie: `CF_Authorization=${token}`,
+      "X-Operator": "browser:tab",
+      "X-Scope": "owner",
+    };
+
+    const missingOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-invite-demo/invites", {
+        method: "POST",
+        headers,
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(missingOrigin.status, 403);
+    assert.deepEqual(await missingOrigin.json(), { error: "request origin is required" });
+
+    const untrustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-invite-demo/invites", {
+        method: "POST",
+        headers: {
+          ...headers,
+          Origin: "https://evil.example",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(untrustedOrigin.status, 403);
+    assert.deepEqual(await untrustedOrigin.json(), { error: "request origin is not allowed" });
+
+    const trustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-invite-demo/invites", {
+        method: "POST",
+        headers: {
+          ...headers,
+          Origin: "https://cloud.test",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(trustedOrigin.status, 201);
+  });
+
   it("rejects deleting the last owner ACL row", async () => {
     const env = fakeEnv();
     seedNotebook(env, "last-owner-demo");
@@ -1904,6 +2069,57 @@ async function aclRequest(
   );
 }
 
+async function inviteRequest(
+  env: FakeEnv,
+  method: "GET" | "POST",
+  body: Record<string, unknown> | undefined,
+  notebookId = "invite-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/n/${notebookId}/invites`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
+async function inviteItemRequest(
+  env: FakeEnv,
+  method: "DELETE",
+  inviteId: string,
+  notebookId = "invite-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(`/api/n/${notebookId}/invites/${inviteId}`, "http://localhost"), {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "owner",
+        ...headers,
+      },
+    }),
+    env,
+    fakeContext(),
+  );
+}
+
 async function scopedPut(
   env: FakeEnv,
   pathname: string,
@@ -2243,6 +2459,73 @@ class FakeD1Statement implements D1PreparedStatement {
       );
       this.db.acl.splice(0, this.db.acl.length, ...retained);
       return okResult(undefined, { changes: countBefore - retained.length });
+    } else if (this.query.includes("INSERT INTO notebook_invites")) {
+      const [
+        id,
+        notebookId,
+        emailNormalized,
+        providerHint,
+        scope,
+        actorLabel,
+        tokenHash,
+        createdAt,
+        expiresAt,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string | null,
+        PendingNotebookInviteRow["scope"],
+        string,
+        string | null,
+        string,
+        string | null,
+      ];
+      const duplicate = [...this.db.invites.values()].find(
+        (invite) =>
+          invite.notebook_id === notebookId &&
+          invite.email_normalized === emailNormalized &&
+          invite.provider_hint === providerHint &&
+          invite.scope === scope &&
+          invite.status === "pending",
+      );
+      if (duplicate) {
+        throw new Error("D1_ERROR: UNIQUE constraint failed: notebook_invites pending invite");
+      }
+      this.db.invites.set(id, {
+        id,
+        notebook_id: notebookId,
+        email_normalized: emailNormalized,
+        provider_hint: providerHint,
+        scope,
+        status: "pending",
+        invited_by_actor_label: actorLabel,
+        accepted_by_principal: null,
+        token_hash: tokenHash,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        accepted_at: null,
+        revoked_at: null,
+        revoked_by_actor_label: null,
+      });
+    } else if (
+      this.query.includes("UPDATE notebook_invites") &&
+      this.query.includes("revoked_by_actor_label")
+    ) {
+      const [revokedAt, revokedByActorLabel, notebookId, inviteId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const invite = this.db.invites.get(inviteId);
+      if (invite && invite.notebook_id === notebookId && invite.status === "pending") {
+        invite.status = "revoked";
+        invite.revoked_at = revokedAt;
+        invite.revoked_by_actor_label = revokedByActorLabel;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, createdAtOrUpdatedAt, maybeUpdatedAt] = this.values as [
         string,
@@ -2397,6 +2680,28 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM notebook_invites")) {
+      if (this.query.includes("WHERE notebook_id = ?")) {
+        const [notebookId, email, scope, providerHint] = this.values as [
+          string,
+          string,
+          PendingNotebookInviteRow["scope"],
+          string | null,
+          string | null,
+        ];
+        return (
+          ([...this.db.invites.values()].find(
+            (invite) =>
+              invite.notebook_id === notebookId &&
+              invite.email_normalized === email &&
+              invite.scope === scope &&
+              invite.status === "pending" &&
+              invite.provider_hint === providerHint,
+          ) as T | undefined) ?? null
+        );
+      }
+      return (this.db.invites.get(this.values[0] as string) as T | undefined) ?? null;
+    }
     if (this.query.includes("FROM notebooks")) {
       return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;
     }
@@ -2410,6 +2715,12 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("FROM notebook_invites")) {
+      const notebookId = this.values[0] as string;
+      return okResult(
+        [...this.db.invites.values()].filter((invite) => invite.notebook_id === notebookId) as T[],
+      );
+    }
     if (this.query.includes("FROM notebook_acl")) {
       const notebookId = this.values[0] as string;
       if (

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1077,6 +1077,7 @@ describe("Worker artifact routes", () => {
       subject: "user:dev:alice",
       scope: "owner",
     });
+    const futureInviteExpiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
 
     const create = await inviteRequest(
       env,
@@ -1085,7 +1086,7 @@ describe("Worker artifact routes", () => {
         email: " Bob@Example.COM ",
         provider_hint: " Cloudflare-Access ",
         scope: "editor",
-        expires_at: "2026-06-24T00:00:00.000Z",
+        expires_at: futureInviteExpiry,
       },
       "invite-demo",
     );
@@ -1124,6 +1125,35 @@ describe("Worker artifact routes", () => {
       env.DB.invites.get(inviteId)?.revoked_by_actor_label,
       "user:dev:alice/desktop:test",
     );
+  });
+
+  it("does not revoke pending invites through another notebook route", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "invite-demo-a");
+    seedNotebook(env, "invite-demo-b");
+    seedAcl(env, {
+      notebookId: "invite-demo-a",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "invite-demo-b",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedPendingInvite(env, {
+      id: "invite-b",
+      notebookId: "invite-demo-b",
+      email: "bob@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+    });
+
+    const revoke = await inviteItemRequest(env, "DELETE", "invite-b", "invite-demo-a");
+
+    assert.equal(revoke.status, 404);
+    assert.deepEqual(await revoke.json(), { error: "pending invite not found" });
+    assert.equal(env.DB.invites.get("invite-b")?.status, "pending");
   });
 
   it("keeps invite management owner-only and scope-limited", async () => {
@@ -1193,6 +1223,21 @@ describe("Worker artifact routes", () => {
     );
     assert.equal(invalidProvider.status, 400);
     assert.deepEqual(await invalidProvider.json(), { error: "invite provider hint is invalid" });
+
+    const expiredInvite = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: "expired@example.com",
+        scope: "viewer",
+        expires_at: "2000-01-01T00:00:00.000Z",
+      },
+      "invite-private-demo",
+    );
+    assert.equal(expiredInvite.status, 400);
+    assert.deepEqual(await expiredInvite.json(), {
+      error: "invite expiry must be in the future",
+    });
   });
 
   it("requires trusted origins for cookie-backed invite mutations", async () => {
@@ -2732,9 +2777,6 @@ class FakeD1Statement implements D1PreparedStatement {
     }
     if (this.query.includes("FROM principal_profiles")) {
       return (this.db.profiles.get(this.values[0] as string) as T | undefined) ?? null;
-    }
-    if (this.query.includes("FROM notebook_invites")) {
-      return (this.db.invites.get(this.values[0] as string) as T | undefined) ?? null;
     }
     return null;
   }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1168,6 +1168,31 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await ownerInvite.json(), {
       error: "invite scope must be viewer or editor",
     });
+
+    const invalidEmail = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: "not an email",
+        scope: "viewer",
+      },
+      "invite-private-demo",
+    );
+    assert.equal(invalidEmail.status, 400);
+    assert.deepEqual(await invalidEmail.json(), { error: "invite email is invalid" });
+
+    const invalidProvider = await inviteRequest(
+      env,
+      "POST",
+      {
+        email: "viewer@example.com",
+        provider_hint: "bad/provider",
+        scope: "viewer",
+      },
+      "invite-private-demo",
+    );
+    assert.equal(invalidProvider.status, 400);
+    assert.deepEqual(await invalidProvider.json(), { error: "invite provider hint is invalid" });
   });
 
   it("requires trusted origins for cookie-backed invite mutations", async () => {
@@ -2717,8 +2742,15 @@ class FakeD1Statement implements D1PreparedStatement {
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (this.query.includes("FROM notebook_invites")) {
       const notebookId = this.values[0] as string;
+      const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;
       return okResult(
-        [...this.db.invites.values()].filter((invite) => invite.notebook_id === notebookId) as T[],
+        [...this.db.invites.values()]
+          .filter((invite) => invite.notebook_id === notebookId)
+          .sort(
+            (left, right) =>
+              right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+          )
+          .slice(0, limit) as T[],
       );
     }
     if (this.query.includes("FROM notebook_acl")) {

--- a/docs/architecture/hosted-access-anaconda-demo-runbook.md
+++ b/docs/architecture/hosted-access-anaconda-demo-runbook.md
@@ -272,7 +272,27 @@ For a demo notebook:
    }
    ```
 
-3. Grant a known viewer by principal:
+3. Or create a pending invite for a user who has not logged in yet:
+
+   ```http
+   POST /api/n/<notebook-id>/invites
+   ```
+
+   ```json
+   {
+     "email": "recipient@example.com",
+     "provider_hint": "cloudflare-access",
+     "scope": "editor"
+   }
+   ```
+
+   The invite is email-addressed only until first login. Once the recipient
+   authenticates with a verified matching email, the Worker resolves the invite
+   to a principal-backed ACL row, upserts `principal_profiles`, and marks the
+   invite accepted. The email remains lookup and display metadata; it is never
+   the ACL subject.
+
+4. Grant a viewer by principal:
 
    ```json
    {
@@ -281,14 +301,6 @@ For a demo notebook:
      "scope": "viewer"
    }
    ```
-
-4. For share-by-email bootstrapping, create a pending invite row with the
-   normalized email and optional provider hint. On the invited user's first
-   Cloudflare Access login, the Worker resolves the invite before notebook ACL
-   authorization, upserts `principal_profiles`, marks the invite accepted, and
-   inserts a `notebook_acl` row whose subject is the resolved
-   `user:cloudflare-access:<encoded-access-sub>` principal. The email remains
-   lookup and display metadata; it is never the ACL subject.
 
 5. Public viewer is a separate explicit row, and only applies when the request
    can reach the Worker without being blocked by Access:
@@ -434,11 +446,11 @@ and product decisions:
    or Access forwards a deployment-approved stable Anaconda subject claim, ACL
    rows should use `user:cloudflare-access:<encoded-access-sub>`. Do not switch
    to `user:anaconda:*` based on email.
-3. **Collaborator bootstrap.** The current owner/editor/viewer smoke can derive
-   principals from local Access JWT subjects, seed D1 ACL rows, or resolve
-   pre-created pending invite rows on first Access login. The browser product
-   still needs share-by-email creation routes before non-operators can grant
-   collaborators by email.
+3. **Collaborator bootstrap UI.** The Worker has owner-scoped invite routes for
+   creating, listing, and revoking pending email invites, plus first-login
+   invite resolution into principal-backed ACL rows. The browser product still
+   needs share-dialog wiring and email delivery before non-operators can manage
+   invites without HTTP tooling.
 4. **Public viewers.** A fully Access-protected hostname blocks anonymous
    viewers at the edge. Public published notebooks need an Access bypass rule,
    a separate public viewer hostname, or another route that still reaches the

--- a/docs/architecture/hosted-sharing-invites.md
+++ b/docs/architecture/hosted-sharing-invites.md
@@ -18,8 +18,10 @@ Prototype code:
 
 - `apps/notebook-cloud/src/sharing.ts`
 - `apps/notebook-cloud/src/sharing-storage.ts`
+- `apps/notebook-cloud/src/index.ts`
 - `apps/notebook-cloud/test/sharing.test.ts`
 - `apps/notebook-cloud/test/sharing-storage.test.ts`
+- `apps/notebook-cloud/test/worker-routes.test.ts`
 
 ## What The Older Prototype Already Proved
 
@@ -153,6 +155,18 @@ Pending invites are not ACL rows and cannot authorize a socket.
 
 The API may create an accepted invite audit row even for immediate grants, but
 the ACL subject is still the resolved principal.
+
+The initial Worker surface is deliberately small and owner-scoped:
+
+- `GET /api/n/:id/invites` lists pending, accepted, and revoked invite rows for
+  owners.
+- `POST /api/n/:id/invites` creates or returns an existing pending invite for a
+  normalized email, optional provider hint, and `viewer` or `editor` scope.
+- `DELETE /api/n/:id/invites/:inviteId` revokes a pending invite.
+
+These routes require owner authorization and use the same mutation-origin
+checks as ACL changes. They do not send email, expose `token_hash`, or insert
+email strings into `notebook_acl`.
 
 ## First Login Resolution
 

--- a/docs/architecture/hosted-sharing-invites.md
+++ b/docs/architecture/hosted-sharing-invites.md
@@ -158,8 +158,8 @@ the ACL subject is still the resolved principal.
 
 The initial Worker surface is deliberately small and owner-scoped:
 
-- `GET /api/n/:id/invites` lists pending, accepted, and revoked invite rows for
-  owners.
+- `GET /api/n/:id/invites` lists the most recent pending, accepted, and revoked
+  invite rows for owners.
 - `POST /api/n/:id/invites` creates or returns an existing pending invite for a
   normalized email, optional provider hint, and `viewer` or `editor` scope.
 - `DELETE /api/n/:id/invites/:inviteId` revokes a pending invite.


### PR DESCRIPTION
## Summary

- add owner-scoped notebook invite routes for create/list/revoke
- keep pending invite responses free of `token_hash` and email out of ACL subjects
- document the hosted invite route surface in the sharing ADR and Anaconda Access runbook

## Tests

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/sharing-storage.test.ts test/sharing.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
