### PR TITLE
test(notebook-cloud): add hosted access preflight

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -281,6 +281,10 @@ viewer sees owner/editor markdown edits:
 cloudflared access login https://<notebook-host>
 export NOTEBOOK_CLOUD_ACCESS_JWT="$(cloudflared access token -app=https://<notebook-host>)"
 
+NOTEBOOK_CLOUD_URL=https://<notebook-host> \
+NOTEBOOK_CLOUD_ACCESS_JWT="$NOTEBOOK_CLOUD_ACCESS_JWT" \
+pnpm --dir apps/notebook-cloud smoke:hosted:access:preflight
+
 cargo xtask wasm runtimed --skip-renderer-plugins
 NOTEBOOK_CLOUD_URL=https://<notebook-host> \
 NOTEBOOK_CLOUD_ACCESS_ORIGIN=https://<notebook-host> \

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
+    "smoke:hosted:access:preflight": "node --import tsx scripts/hosted-access-preflight.mjs",
     "smoke:hosted:access": "node --import tsx scripts/hosted-access-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-access-preflight.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-preflight.mjs
@@ -1,0 +1,78 @@
+import {
+  accessAuthHeaders,
+  accessPrincipalFromJwt,
+  assertAccessHealthConfigured,
+} from "./hosted-access-smoke-env.mjs";
+import { fingerprintPrincipal } from "./hosted-access-smoke-ws.mjs";
+
+const DEFAULT_BASE_URL = "https://nteract-notebook-cloud.rgbkrk.workers.dev";
+const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? DEFAULT_BASE_URL;
+const accessToken = process.env.NOTEBOOK_CLOUD_ACCESS_JWT;
+const startedAt = performance.now();
+
+try {
+  const accessHealth = await fetchAccessHealth();
+  const result = {
+    ok: true,
+    auth_mode: "cloudflare_access",
+    base_url: safePublicBaseUrl(baseUrl),
+    access_health: accessHealth,
+    access_jwt: accessToken
+      ? {
+          present: true,
+          principal_fingerprint: fingerprintPrincipal(accessPrincipalFromJwt(accessToken)),
+        }
+      : {
+          present: false,
+        },
+    checks: ["cloudflare_access_worker_configured"],
+    timings_ms: {
+      total: roundMs(performance.now() - startedAt),
+    },
+  };
+  console.log(JSON.stringify(result, null, 2));
+} catch (error) {
+  const result = {
+    ok: false,
+    auth_mode: "cloudflare_access",
+    base_url: safePublicBaseUrl(baseUrl),
+    error: error instanceof Error ? error.message : String(error),
+    timings_ms: {
+      total: roundMs(performance.now() - startedAt),
+    },
+  };
+  console.error(JSON.stringify(result, null, 2));
+  process.exitCode = 1;
+}
+
+async function fetchAccessHealth() {
+  const response = await fetch(new URL("/api/health", baseUrl), {
+    headers: accessToken ? accessAuthHeaders(accessToken) : undefined,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Access health preflight failed: ${response.status}`);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new Error("Access health preflight did not return JSON");
+  }
+
+  return assertAccessHealthConfigured(payload, { baseUrl });
+}
+
+function safePublicBaseUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return "<invalid>";
+  }
+}
+
+function roundMs(value) {
+  return Math.round(value * 100) / 100;
+}

--- a/apps/notebook-cloud/test/hosted-access-preflight.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-preflight.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const appDir = fileURLToPath(new URL("..", import.meta.url));
+
+describe("hosted Access preflight script", () => {
+  it("reports configured Access health without requiring a JWT", async () => {
+    const { result } = await runPreflight({
+      auth: {
+        cloudflare_access: {
+          status: "configured",
+          jwks: "remote",
+        },
+      },
+    });
+
+    assert.equal(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.deepEqual(payload.access_health, { status: "configured", jwks: "remote" });
+    assert.deepEqual(payload.access_jwt, { present: false });
+  });
+
+  it("fails disabled Access health without leaking the JWT", async () => {
+    const token = jwt({ sub: "access-user-123", email: "alice@example.com" });
+    const { result, requestHeaders } = await runPreflight(
+      {
+        auth: {
+          cloudflare_access: {
+            status: "disabled",
+            jwks: "none",
+          },
+        },
+      },
+      { token },
+    );
+
+    assert.equal(result.status, 1);
+    assert.equal(requestHeaders["cf-access-token"], token);
+    assert.ok(!result.stderr.includes(token));
+    assert.ok(!result.stderr.includes("alice@example.com"));
+    assert.match(result.stderr, /Cloudflare Access auth is disabled/);
+  });
+
+  it("fingerprints the Access principal without printing raw identity claims", async () => {
+    const token = jwt({ sub: "access-user-123", email: "alice@example.com" });
+    const { result } = await runPreflight(
+      {
+        auth: {
+          cloudflare_access: {
+            status: "configured",
+            jwks: "pinned",
+          },
+        },
+      },
+      { token },
+    );
+
+    assert.equal(result.status, 0);
+    assert.ok(!result.stdout.includes(token));
+    assert.ok(!result.stdout.includes("access-user-123"));
+    assert.ok(!result.stdout.includes("alice@example.com"));
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.access_jwt.present, true);
+    assert.match(payload.access_jwt.principal_fingerprint, /^[a-f0-9]{16}$/);
+  });
+
+  it("reports invalid base URLs without dumping the Access token", async () => {
+    const token = jwt({ sub: "access-user-123" });
+    const result = await runNodeScript({
+      NOTEBOOK_CLOUD_URL: "not a url",
+      NOTEBOOK_CLOUD_ACCESS_JWT: token,
+    });
+
+    assert.equal(result.status, 1);
+    assert.ok(!result.stderr.includes(token));
+    const payload = JSON.parse(result.stderr);
+    assert.equal(payload.base_url, "<invalid>");
+  });
+});
+
+async function runPreflight(healthPayload, { token } = {}) {
+  const requestHeaders = {};
+  const server = createServer((request, response) => {
+    Object.assign(requestHeaders, request.headers);
+    assert.equal(request.url, "/api/health");
+    response.setHeader("Content-Type", "application/json");
+    response.end(JSON.stringify(healthPayload));
+  });
+
+  try {
+    await listen(server);
+    const address = server.address();
+    assert(address && typeof address === "object");
+    const result = await runNodeScript({
+      NOTEBOOK_CLOUD_URL: `http://127.0.0.1:${address.port}`,
+      ...(token ? { NOTEBOOK_CLOUD_ACCESS_JWT: token } : {}),
+    });
+    return { result, requestHeaders };
+  } finally {
+    await close(server);
+  }
+}
+
+function runNodeScript(env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "scripts/hosted-access-preflight.mjs"],
+      {
+        cwd: appDir,
+        env: {
+          ...process.env,
+          ...env,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function jwt(payload) {
+  return [base64UrlJson({ alg: "RS256", typ: "JWT" }), base64UrlJson(payload), "signature"].join(
+    ".",
+  );
+}
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}


### PR DESCRIPTION
## Summary

- add a non-mutating hosted Access preflight smoke command
- report configured/disabled/partial Access health before the full mutating Access smoke
- redact Access JWTs and identity claims while still showing a principal fingerprint when a JWT is supplied

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-access-preflight.test.mjs test/hosted-access-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
- deployed preflight against `https://nteract-notebook-cloud.rgbkrk.workers.dev` reports Access disabled as expected
