### PR TITLE
fix(mcp-app): fill raster image outputs

### DIFF
--- a/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx
@@ -29,6 +29,25 @@ describe("MimeRenderer", () => {
     vi.restoreAllMocks();
   });
 
+  it("renders raster images directly", () => {
+    render(
+      <MimeRenderer
+        blobBaseUrl="http://localhost:47830"
+        data={{
+          "image/png": "http://localhost:47830/blob/f00f3d991a8191036",
+          "text/plain": "<Figure size 1100x520 with 1 Axes>",
+        }}
+      />,
+    );
+
+    const image = screen.getByRole("img", {
+      name: "<Figure size 1100x520 with 1 Axes>",
+    });
+    expect(image.getAttribute("src")).toBe("http://localhost:47830/blob/f00f3d991a8191036");
+    expect(image.classList.contains("image-output")).toBe(true);
+    expect(loadPluginForMime).not.toHaveBeenCalled();
+  });
+
   it("sends host-facing logs when plugin rendering fails", async () => {
     vi.mocked(loadPluginForMime).mockReturnValue(Promise.reject(new Error("blocked by CSP")));
 

--- a/apps/mcp-app/src/style.css
+++ b/apps/mcp-app/src/style.css
@@ -334,7 +334,11 @@ body {
 /* ── Image output ────────────────────────────────────────── */
 
 .image-output {
+  display: block;
+  width: 100%;
   max-width: 100%;
+  height: auto;
+  object-fit: contain;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## Summary

- Render raster MCP app image outputs as block-level, full-width output content with preserved aspect ratio.
- Add coverage for the direct raster image rendering path so raster images bypass plugin loading.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx`
- `pnpm exec vp run nteract-mcp-app#build`
- `cargo test -p runt-mcp output_resource_meta`
- `git diff --check`
