### PR TITLE
fix(notebook-cloud): harden Access edge cases

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-access-preflight.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-preflight.mjs
@@ -2,6 +2,7 @@ import {
   accessAuthHeaders,
   accessPrincipalFromJwt,
   assertAccessHealthConfigured,
+  safePublicBaseUrl,
 } from "./hosted-access-smoke-env.mjs";
 import { fingerprintPrincipal } from "./hosted-access-smoke-ws.mjs";
 
@@ -62,15 +63,6 @@ async function fetchAccessHealth() {
   }
 
   return assertAccessHealthConfigured(payload, { baseUrl });
-}
-
-function safePublicBaseUrl(value) {
-  try {
-    const url = new URL(value);
-    return url.origin;
-  } catch {
-    return "<invalid>";
-  }
 }
 
 function roundMs(value) {

--- a/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke-env.mjs
@@ -16,7 +16,7 @@ export function assertAccessHealthConfigured(payload, { baseUrl } = {}) {
     return health;
   }
 
-  const target = baseUrl ? ` for ${baseUrl}` : "";
+  const target = baseUrl ? ` for ${safePublicBaseUrl(baseUrl)}` : "";
   const detail =
     health.status === "partial"
       ? "exactly one of NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN or NOTEBOOK_CLOUD_ACCESS_AUD is missing"
@@ -24,6 +24,23 @@ export function assertAccessHealthConfigured(payload, { baseUrl } = {}) {
   throw new Error(
     `Cloudflare Access auth is ${health.status}${target}; expected configured before running the hosted Access smoke (${detail}; jwks=${health.jwks}).`,
   );
+}
+
+export function safePublicBaseUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.origin;
+  } catch {
+    return "<invalid>";
+  }
+}
+
+export function safePublicViewerUrl(baseUrl, roomId) {
+  const base = safePublicBaseUrl(baseUrl);
+  if (base === "<invalid>") {
+    return base;
+  }
+  return new URL(`/n/${encodeURIComponent(roomId)}`, base).href;
 }
 
 export function accessHealthFromPayload(payload) {

--- a/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-access-smoke.mjs
@@ -8,6 +8,8 @@ import {
   accessAuthHeaders,
   accessPrincipalFromJwt,
   assertHostedAccessSmokeEnv,
+  safePublicBaseUrl,
+  safePublicViewerUrl,
 } from "./hosted-access-smoke-env.mjs";
 import {
   clientForSocket,
@@ -146,11 +148,11 @@ console.log(
     {
       ok: true,
       auth_mode: "cloudflare_access",
-      baseUrl,
+      baseUrl: safePublicBaseUrl(baseUrl),
       origin: smokeOrigin,
       access_health: accessHealth,
       roomId,
-      viewerUrl: new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href,
+      viewerUrl: safePublicViewerUrl(baseUrl, roomId),
       principal_fingerprints: {
         owner: fingerprintPrincipal(ownerPrincipal),
         editor: fingerprintPrincipal(editorPrincipal),

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -762,6 +762,8 @@ function selectAccessJwks(jwks: JsonWebKeySet, header: JwtHeader): JsonWebKey[] 
   const candidates = keys.filter((key) => {
     if (key.kty !== "RSA") return false;
     if (key.alg && key.alg !== "RS256") return false;
+    if (key.use && key.use !== "sig") return false;
+    if (key.key_ops && !key.key_ops.includes("verify")) return false;
     if (header.kid && (key as JsonWebKey & { kid?: string }).kid !== header.kid) return false;
     return true;
   });

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -430,20 +430,17 @@ function cloudflareAccessHealth(env: Env): {
 } {
   const hasTeamDomain = Boolean(env.NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN?.trim());
   const hasAudience = Boolean(env.NOTEBOOK_CLOUD_ACCESS_AUD?.trim());
+  const hasPinnedJwks = Boolean(env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?.trim());
   const status =
     hasTeamDomain && hasAudience
       ? "configured"
-      : hasTeamDomain || hasAudience
+      : hasTeamDomain || hasAudience || hasPinnedJwks
         ? "partial"
         : "disabled";
 
   return {
     status,
-    jwks: env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON?.trim()
-      ? "pinned"
-      : status === "configured"
-        ? "remote"
-        : "none",
+    jwks: hasPinnedJwks ? "pinned" : status === "configured" ? "remote" : "none",
   };
 }
 

--- a/apps/notebook-cloud/test/access-jwt-fixture.ts
+++ b/apps/notebook-cloud/test/access-jwt-fixture.ts
@@ -13,6 +13,8 @@ export async function accessTokenFixture(options: {
   includeKid?: boolean;
   includeMalformedKey?: boolean;
   includeUnmatchedKey?: boolean;
+  matchingKeyOps?: JsonWebKey["key_ops"];
+  matchingKeyUse?: JsonWebKey["use"] | null;
   name?: string;
   subject: string;
 }): Promise<AccessTokenFixture> {
@@ -77,7 +79,13 @@ export async function accessTokenFixture(options: {
           ...(unmatchedPublicJwk
             ? [{ ...unmatchedPublicJwk, alg: "RS256", kid: "unmatched", use: "sig" }]
             : []),
-          { ...publicJwk, alg: "RS256", kid, use: "sig" },
+          {
+            ...publicJwk,
+            alg: "RS256",
+            kid,
+            ...(options.matchingKeyUse === null ? {} : { use: options.matchingKeyUse ?? "sig" }),
+            ...(options.matchingKeyOps ? { key_ops: options.matchingKeyOps } : {}),
+          },
         ],
       }),
       NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN: issuer,

--- a/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-access-smoke-env.test.mjs
@@ -9,6 +9,8 @@ import {
   accessPrincipalFromJwt,
   assertAccessHealthConfigured,
   assertHostedAccessSmokeEnv,
+  safePublicBaseUrl,
+  safePublicViewerUrl,
   webSocketUpgradeRequestHeaders,
 } from "../scripts/hosted-access-smoke-env.mjs";
 import { authenticateRequestWithProviders } from "../src/identity.ts";
@@ -138,6 +140,37 @@ describe("hosted Access smoke environment helpers", () => {
           },
         }),
       /Cloudflare Access auth is disabled; expected configured.*NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN and NOTEBOOK_CLOUD_ACCESS_AUD are not set.*jwks=none/,
+    );
+  });
+
+  it("redacts credential material from Access health diagnostics", () => {
+    assert.equal(
+      safePublicBaseUrl("https://user:secret@notebooks.example.com/path?token=abc"),
+      "https://notebooks.example.com",
+    );
+    assert.equal(
+      safePublicViewerUrl("https://user:secret@notebooks.example.com/path?token=abc", "room/slash"),
+      "https://notebooks.example.com/n/room%2Fslash",
+    );
+    assert.equal(safePublicViewerUrl("not a url", "room/slash"), "<invalid>");
+
+    assert.throws(
+      () =>
+        assertAccessHealthConfigured(
+          {
+            auth: {
+              cloudflare_access: {
+                status: "partial",
+                jwks: "pinned",
+              },
+            },
+          },
+          { baseUrl: "https://user:secret@notebooks.example.com/path?token=abc" },
+        ),
+      (error) =>
+        error instanceof Error &&
+        /for https:\/\/notebooks\.example\.com/.test(error.message) &&
+        !/secret|token=abc|\/path/.test(error.message),
     );
   });
 

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -518,6 +518,66 @@ describe("Cloudflare Access identity", () => {
     assert.equal(identity.metadata.transport, "access-token-header");
   });
 
+  it("prefers bearer Access tokens over ambient Access cookies", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?operator=cli:smoke&scope=owner", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Cookie: `CF_Authorization=${token}`,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.actorLabel, "user:cloudflare-access:alice/cli:smoke");
+    assert.equal(identity.metadata.transport, "access-bearer");
+  });
+
+  it("rejects multiple explicit Access token credentials", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync?operator=cli:smoke&scope=owner", {
+            headers: {
+              "CF-Access-Token": token,
+              Authorization: `Bearer ${token}`,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 400 &&
+        /multiple identity credentials/.test(error.message),
+    );
+  });
+
+  it("rejects Access token headers mixed with Access subprotocol credentials", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+    const protocol = `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}`;
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync?operator=cli:smoke&scope=owner", {
+            headers: {
+              "CF-Access-Token": token,
+              "Sec-WebSocket-Protocol": protocol,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 400 &&
+        /multiple identity credentials/.test(error.message),
+    );
+  });
+
   it("rejects Access tokens with the wrong audience", async () => {
     const { env, token } = await accessTokenFixture({
       audience: "wrong-audience",
@@ -575,6 +635,26 @@ describe("Cloudflare Access identity", () => {
     );
   });
 
+  it("rejects Access credentials when only a pinned JWKS is configured", async () => {
+    const { env, token } = await accessTokenFixture({ subject: "alice" });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync", {
+            headers: {
+              "Cf-Access-Jwt-Assertion": token,
+            },
+          }),
+          { NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: env.NOTEBOOK_CLOUD_ACCESS_JWKS_JSON },
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 503 &&
+        /not fully configured/.test(error.message),
+    );
+  });
+
   it("tries matching RSA keys when a rotating Access JWT omits kid", async () => {
     const { env, token } = await accessTokenFixture({
       includeKid: false,
@@ -592,6 +672,52 @@ describe("Cloudflare Access identity", () => {
     );
 
     assert.equal(identity.actorLabel, "user:cloudflare-access:alice/desktop:a");
+  });
+
+  it("rejects Access JWKS candidates marked for encryption use", async () => {
+    const { env, token } = await accessTokenFixture({
+      matchingKeyUse: "enc",
+      subject: "alice",
+    });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync?operator=desktop:a", {
+            headers: {
+              "Cf-Access-Jwt-Assertion": token,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 401 &&
+        /signing key was not found/.test(error.message),
+    );
+  });
+
+  it("rejects Access JWKS candidates without verify key operations", async () => {
+    const { env, token } = await accessTokenFixture({
+      matchingKeyOps: ["encrypt"],
+      subject: "alice",
+    });
+
+    await assert.rejects(
+      () =>
+        authenticateRequestWithProviders(
+          new Request("https://cloud.test/n/demo/sync?operator=desktop:a", {
+            headers: {
+              "Cf-Access-Jwt-Assertion": token,
+            },
+          }),
+          env,
+        ),
+      (error) =>
+        error instanceof AuthError &&
+        error.status === 401 &&
+        /signing key was not found/.test(error.message),
+    );
   });
 
   it("skips malformed Access JWKS candidates and tries the next matching key", async () => {

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -442,6 +442,31 @@ describe("hosted sharing storage", () => {
     assert.equal(env.DB.invites.get("invite-expired")?.status, "pending");
   });
 
+  it("expires storage invites with numeric time comparisons instead of string ordering", async () => {
+    const env = fakeEnv();
+    await createPendingNotebookInvite(env, {
+      id: "invite-expired-no-fraction",
+      notebookId: "notebook-1",
+      email: "alice@example.com",
+      providerHint: "cloudflare-access",
+      scope: "editor",
+      actorLabel: "user:cloudflare-access:owner/desktop:owner",
+      expiresAt: "2026-05-24T00:00:00Z",
+      timestamp: "2026-05-23T23:00:00.000Z",
+    });
+
+    const resolution = await resolveNotebookInvitesForLogin(
+      env,
+      accessLogin(),
+      "2026-05-24T00:00:00.000Z",
+    );
+
+    assert.equal(resolution.acceptedInvites.length, 0);
+    assert.equal(resolution.aclGrants.length, 0);
+    assert.equal(env.DB.acl.length, 0);
+    assert.equal(env.DB.invites.get("invite-expired-no-fraction")?.status, "pending");
+  });
+
   it("does not re-accept revoked invites from storage resolution", async () => {
     const env = fakeEnv();
     await createPendingNotebookInvite(env, {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -88,6 +88,27 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  it("reports partial Cloudflare Access readiness for pinned JWKS without issuer config", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_CLOUD_ACCESS_JWKS_JSON: '{"keys":[]}',
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/health"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      auth: { cloudflare_access: { status: string; jwks: string } };
+    };
+    assert.deepEqual(body.auth.cloudflare_access, {
+      status: "partial",
+      jwks: "pinned",
+    });
+  });
+
   it("serves viewer bundle assets through the Worker assets binding", async () => {
     const env = fakeEnv({
       ASSETS: {
@@ -968,6 +989,162 @@ describe("Worker artifact routes", () => {
     assert.equal(cliNoOrigin.status, 201);
   });
 
+  it("requires trusted origins for Access-backed ACL deletes", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv(accessEnv);
+    seedNotebook(env, "access-acl-delete-demo");
+    seedAcl(env, {
+      notebookId: "access-acl-delete-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "access-acl-delete-demo",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+
+    const body = JSON.stringify({
+      subject_kind: "principal",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+    const headers = {
+      "Content-Type": "application/json",
+      Cookie: `CF_Authorization=${token}`,
+      "X-Operator": "browser:tab",
+      "X-Scope": "owner",
+    };
+
+    const missingOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-delete-demo/acl", {
+        method: "DELETE",
+        headers,
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(missingOrigin.status, 403);
+    assert.deepEqual(await missingOrigin.json(), { error: "request origin is required" });
+    assert.equal(
+      (
+        await getNotebookAclRowsForPrincipal(
+          env,
+          "access-acl-delete-demo",
+          "user:cloudflare-access:bob",
+        )
+      ).length,
+      1,
+    );
+
+    const untrustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-delete-demo/acl", {
+        method: "DELETE",
+        headers: {
+          ...headers,
+          Origin: "https://evil.example",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(untrustedOrigin.status, 403);
+    assert.deepEqual(await untrustedOrigin.json(), { error: "request origin is not allowed" });
+
+    const trustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-acl-delete-demo/acl", {
+        method: "DELETE",
+        headers: {
+          ...headers,
+          Origin: "https://cloud.test",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(trustedOrigin.status, 200);
+    assert.equal(
+      (
+        await getNotebookAclRowsForPrincipal(
+          env,
+          "access-acl-delete-demo",
+          "user:cloudflare-access:bob",
+        )
+      ).length,
+      0,
+    );
+  });
+
+  it("allows no-Origin CLI Access-token ACL deletes but rejects browser origins", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    const env = fakeEnv({
+      ...accessEnv,
+      NOTEBOOK_CLOUD_ALLOWED_ORIGINS: "https://notebooks.example.com",
+    });
+    seedNotebook(env, "access-token-acl-delete-demo");
+    seedAcl(env, {
+      notebookId: "access-token-acl-delete-demo",
+      subject: "user:cloudflare-access:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "access-token-acl-delete-demo",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+
+    const body = JSON.stringify({
+      subject_kind: "principal",
+      subject: "user:cloudflare-access:bob",
+      scope: "editor",
+    });
+    const headers = {
+      "CF-Access-Token": token,
+      "Content-Type": "application/json",
+      "X-Operator": "cli:smoke",
+      "X-Scope": "owner",
+    };
+
+    const untrustedOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-token-acl-delete-demo/acl", {
+        method: "DELETE",
+        headers: {
+          ...headers,
+          Origin: "https://evil.example",
+        },
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(untrustedOrigin.status, 403);
+    assert.deepEqual(await untrustedOrigin.json(), { error: "request origin is not allowed" });
+
+    const cliNoOrigin = await worker.fetch(
+      new Request("https://cloud.test/api/n/access-token-acl-delete-demo/acl", {
+        method: "DELETE",
+        headers,
+        body,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(cliNoOrigin.status, 200);
+    assert.equal(
+      (
+        await getNotebookAclRowsForPrincipal(
+          env,
+          "access-token-acl-delete-demo",
+          "user:cloudflare-access:bob",
+        )
+      ).length,
+      0,
+    );
+  });
+
   it("lets owners grant and revoke explicit public viewer ACL rows", async () => {
     const env = fakeEnv();
     seedNotebook(env, "public-acl-demo");
@@ -1753,6 +1930,47 @@ describe("Worker artifact routes", () => {
     assert.equal(roomFetches, 1);
   });
 
+  it("rejects untrusted browser origins for Access-token and bearer WebSocket upgrades", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    for (const [label, credentialHeaders] of [
+      ["token", { "CF-Access-Token": token }],
+      ["bearer", { Authorization: `Bearer ${token}` }],
+    ] as const) {
+      let roomFetches = 0;
+      const env = fakeEnv({
+        ...accessEnv,
+        NOTEBOOK_ROOMS: {
+          idFromName: (name: string) => ({ toString: () => name }),
+          get: () => ({
+            fetch: async () => {
+              roomFetches += 1;
+              return new Response("unexpected room fetch", { status: 500 });
+            },
+          }),
+        } satisfies DurableObjectNamespace,
+      });
+
+      const response = await worker.fetch(
+        new Request(
+          `https://cloud.test/n/untrusted-${label}-origin-demo/sync?operator=browser:tab&scope=owner`,
+          {
+            headers: {
+              ...credentialHeaders,
+              Origin: "https://evil.example",
+              Upgrade: "websocket",
+            },
+          },
+        ),
+        env,
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 403, label);
+      assert.deepEqual(await response.json(), { error: "websocket origin is not allowed" }, label);
+      assert.equal(roomFetches, 0, label);
+    }
+  });
+
   it("requires Origin for Access-token WebSocket subprotocol credentials", async () => {
     const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
     let roomFetches = 0;
@@ -1784,6 +2002,55 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 403);
     assert.deepEqual(await response.json(), { error: "websocket origin is required" });
     assert.equal(roomFetches, 0);
+  });
+
+  it("allows same-origin Access assertion and subprotocol WebSocket upgrades", async () => {
+    const { env: accessEnv, token } = await accessTokenFixture({ subject: "alice" });
+    for (const [label, credentialHeaders] of [
+      ["assertion", { "Cf-Access-Jwt-Assertion": token }],
+      [
+        "subprotocol",
+        { "Sec-WebSocket-Protocol": `${ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}` },
+      ],
+    ] as const) {
+      let roomFetches = 0;
+      const env = fakeEnv({
+        ...accessEnv,
+        NOTEBOOK_ROOMS: {
+          idFromName: (name: string) => ({ toString: () => name }),
+          get: () => ({
+            fetch: async () => {
+              roomFetches += 1;
+              return new Response("room ok");
+            },
+          }),
+        } satisfies DurableObjectNamespace,
+      });
+      seedNotebook(env, `same-origin-${label}-demo`);
+      seedAcl(env, {
+        notebookId: `same-origin-${label}-demo`,
+        subject: "user:cloudflare-access:alice",
+        scope: "owner",
+      });
+
+      const response = await worker.fetch(
+        new Request(
+          `https://cloud.test/n/same-origin-${label}-demo/sync?operator=browser:tab&scope=owner`,
+          {
+            headers: {
+              ...credentialHeaders,
+              Origin: "https://cloud.test",
+              Upgrade: "websocket",
+            },
+          },
+        ),
+        env,
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 200, label);
+      assert.equal(roomFetches, 1, label);
+    }
   });
 
   it("does not create notebook rows from unauthorized WebSocket opens", async () => {


### PR DESCRIPTION
## Summary
- report pinned-JWKS-only Cloudflare Access config as partial instead of disabled
- filter Access JWKS candidates to signing/verify-capable RSA keys
- redact credential-bearing base URLs from hosted Access smoke diagnostics
- add focused coverage for Access credential precedence, WebSocket/ACL origin gates, JWKS intent, and invite expiry time comparisons

## Verification
- pnpm --dir apps/notebook-cloud run typecheck
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/worker-routes.test.ts test/sharing.test.ts test/sharing-storage.test.ts test/hosted-access-smoke-env.test.mjs test/hosted-access-smoke-ws.test.mjs
- cargo xtask lint --fix
