### PR TITLE
fix(mcp-app): autosize HTML outputs

### DIFF
--- a/apps/mcp-app/src/components/__tests__/html-output.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/html-output.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { setHostLogSink, type HostLogParams } from "../../lib/host-log";
+import { HTML_OUTPUT_HEIGHT_MESSAGE, HtmlOutput } from "../html-output";
+
+describe("HtmlOutput", () => {
+  let logs: HostLogParams[];
+
+  beforeEach(() => {
+    logs = [];
+    setHostLogSink({
+      sendLog: (params) => {
+        logs.push(params);
+      },
+    });
+  });
+
+  afterEach(() => {
+    setHostLogSink(null);
+    vi.restoreAllMocks();
+  });
+
+  it("resizes the iframe from height messages sent by its srcdoc", () => {
+    render(<HtmlOutput html="<div style='height: 420px'>diagram</div>" />);
+
+    const frame = screen.getByTitle("HTML output") as HTMLIFrameElement;
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: frame.contentWindow,
+        data: { type: HTML_OUTPUT_HEIGHT_MESSAGE, height: 420 },
+      }),
+    );
+
+    expect(frame.style.height).toBe("422px");
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        level: "debug",
+        data: expect.objectContaining({
+          event: "html-output-iframe-resized",
+          height: 422,
+        }),
+      }),
+    );
+  });
+
+  it("ignores height messages from unrelated frames", () => {
+    render(<HtmlOutput html="<div>diagram</div>" />);
+
+    const frame = screen.getByTitle("HTML output") as HTMLIFrameElement;
+    const otherFrame = document.createElement("iframe");
+    document.body.appendChild(otherFrame);
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: otherFrame.contentWindow,
+        data: { type: HTML_OUTPUT_HEIGHT_MESSAGE, height: 420 },
+      }),
+    );
+
+    expect(frame.style.height).toBe("");
+  });
+});

--- a/apps/mcp-app/src/components/html-output.tsx
+++ b/apps/mcp-app/src/components/html-output.tsx
@@ -1,36 +1,124 @@
 import { useEffect, useRef } from "react";
-import { errorDetails, hostLog } from "../lib/host-log";
+import { hostLog } from "../lib/host-log";
 
 interface HtmlOutputProps {
   html: string;
 }
 
+export const HTML_OUTPUT_HEIGHT_MESSAGE = "nteract/html-output-height";
+const HTML_OUTPUT_MEASURE_REQUEST = "nteract/html-output-measure";
+const HEIGHT_PADDING_PX = 2;
+const HEIGHT_SENTINEL_ID = "__nteract-html-output-height-sentinel";
+
+const heightReporterScript = `
+<script>
+(() => {
+  const HEIGHT_MESSAGE = ${JSON.stringify(HTML_OUTPUT_HEIGHT_MESSAGE)};
+  const MEASURE_REQUEST = ${JSON.stringify(HTML_OUTPUT_MEASURE_REQUEST)};
+  const SENTINEL_ID = ${JSON.stringify(HEIGHT_SENTINEL_ID)};
+  let animationFrame = 0;
+  let lastHeight = 0;
+  let measurementStarted = false;
+
+  const getHeight = () => {
+    const body = document.body;
+    const bodyRect = body?.getBoundingClientRect();
+    const sentinelRect = document.getElementById(SENTINEL_ID)?.getBoundingClientRect();
+    return Math.ceil(Math.max(
+      body?.scrollHeight || 0,
+      body?.offsetHeight || 0,
+      bodyRect?.height || 0,
+      sentinelRect?.bottom || 0
+    ));
+  };
+
+  const reportHeight = () => {
+    if (!measurementStarted) return;
+    if (animationFrame) cancelAnimationFrame(animationFrame);
+    animationFrame = requestAnimationFrame(() => {
+      animationFrame = 0;
+      const height = getHeight();
+      if (!height || height === lastHeight) return;
+      lastHeight = height;
+      window.parent.postMessage({ type: HEIGHT_MESSAGE, height }, "*");
+    });
+  };
+
+  window.addEventListener("load", reportHeight);
+  window.addEventListener("resize", reportHeight);
+  window.addEventListener("message", (event) => {
+    if (event.data?.type === MEASURE_REQUEST) {
+      measurementStarted = true;
+      reportHeight();
+    }
+  });
+  document.addEventListener("DOMContentLoaded", reportHeight);
+
+  if (window.ResizeObserver) {
+    const resizeObserver = new ResizeObserver(reportHeight);
+    if (document.documentElement) resizeObserver.observe(document.documentElement);
+    if (document.body) resizeObserver.observe(document.body);
+  }
+
+  if (window.MutationObserver && document.documentElement) {
+    const mutationObserver = new MutationObserver(reportHeight);
+    mutationObserver.observe(document.documentElement, {
+      attributes: true,
+      childList: true,
+      characterData: true,
+      subtree: true
+    });
+  }
+
+  reportHeight();
+  setTimeout(reportHeight, 0);
+  setTimeout(reportHeight, 100);
+  setTimeout(reportHeight, 500);
+})();
+</script>`;
+
 export function HtmlOutput({ html }: HtmlOutputProps) {
   const frameRef = useRef<HTMLIFrameElement>(null);
+  const lastHeightRef = useRef(0);
 
   useEffect(() => {
     const frame = frameRef.current;
     if (!frame) return;
-    const handleLoad = () => {
-      try {
-        const h = frame.contentDocument?.documentElement?.scrollHeight;
-        if (h) {
-          frame.style.height = `${h + 2}px`;
-          hostLog("debug", "html-output-iframe-resized", {
-            height: h + 2,
-          });
-        } else {
-          hostLog("warning", "html-output-iframe-missing-height");
-        }
-      } catch (error) {
-        hostLog("warning", "html-output-iframe-resize-failed", {
-          error: errorDetails(error),
-        });
-      }
+
+    const setFrameHeight = (height: number) => {
+      const nextHeight = Math.ceil(height) + HEIGHT_PADDING_PX;
+      if (nextHeight <= 0 || nextHeight === lastHeightRef.current) return;
+      lastHeightRef.current = nextHeight;
+      frame.style.height = `${nextHeight}px`;
+      hostLog("debug", "html-output-iframe-resized", { height: nextHeight });
     };
-    frame.addEventListener("load", handleLoad);
-    return () => frame.removeEventListener("load", handleLoad);
-  }, []);
+
+    const requestMeasure = () => {
+      frame.contentWindow?.postMessage({ type: HTML_OUTPUT_MEASURE_REQUEST }, "*");
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== frame.contentWindow) return;
+      const data = event.data;
+      if (typeof data !== "object" || data === null) return;
+      if ((data as { type?: unknown }).type !== HTML_OUTPUT_HEIGHT_MESSAGE) return;
+      event.stopImmediatePropagation();
+      const height = (data as { height?: unknown }).height;
+      if (typeof height !== "number" || !Number.isFinite(height)) return;
+      setFrameHeight(height);
+    };
+
+    window.addEventListener("message", handleMessage, true);
+    frame.addEventListener("load", requestMeasure);
+    requestMeasure();
+
+    const animationFrame = requestAnimationFrame(requestMeasure);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      window.removeEventListener("message", handleMessage, true);
+      frame.removeEventListener("load", requestMeasure);
+    };
+  }, [html]);
 
   const styles =
     typeof document !== "undefined" ? getComputedStyle(document.documentElement) : null;
@@ -42,12 +130,13 @@ export function HtmlOutput({ html }: HtmlOutputProps) {
 
   const srcdoc = `<!DOCTYPE html><html><head><style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, -apple-system, sans-serif; color: ${fg}; background: ${bg}; }
+    html, body { overflow-y: hidden; }
+    body { font-family: system-ui, -apple-system, sans-serif; color: ${fg}; background: ${bg}; overflow-x: auto; }
     table { border-collapse: collapse; font-family: ui-monospace, SFMono-Regular, monospace; font-size: 13px; }
     th, td { padding: 6px 10px; border: 1px solid ${border}; text-align: left; }
     th { background: ${codeBg}; color: ${fgMuted}; font-weight: 600; }
     tr:hover td { background: ${codeBg}; }
-  </style></head><body>${html}</body></html>`;
+  </style>${heightReporterScript}</head><body>${html}<div id="${HEIGHT_SENTINEL_ID}"></div></body></html>`;
 
   return (
     <iframe


### PR DESCRIPTION
## Summary

- Autosize nested `text/html` / SVG output iframes inside the MCP app from measurements reported by the iframe content.
- Re-measure after dynamic HTML layout changes so the outer MCP app can report updated height through the standard MCP Apps `ui/notifications/size-changed` path.
- Add unit coverage for accepting height messages only from the owned output iframe.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run apps/mcp-app/src/components/__tests__/html-output.test.tsx apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx`
- `pnpm exec vp run nteract-mcp-app#build`
- `git diff --check`
- Browser probe against the MCP app dev entrypoint with delayed HTML height growth
