### PR TITLE
fix(notebook-cloud): keep report iframes scrollable

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import * as ts from "typescript";
+
+test("cloud report-mode rendering leaves output iframes unfocused for page scrolling", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    sourcePath.pathname,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const offenders: string[] = [];
+
+  const visit = (node: ts.Node) => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tagName = node.tagName.getText(sourceFile);
+      if (tagName === "ReadOnlyNotebook" || tagName === "ReadOnlyNotebookCell") {
+        const attributes = node.attributes.properties;
+        const hasReportMode = attributes.some(
+          (attribute) =>
+            ts.isJsxAttribute(attribute) &&
+            attribute.name.getText(sourceFile) === "displayMode" &&
+            attribute.initializer?.getText(sourceFile) === '"report"',
+        );
+        const focusesOutputs = attributes.some(
+          (attribute) =>
+            ts.isJsxAttribute(attribute) && attribute.name.getText(sourceFile) === "focusOutputs",
+        );
+
+        if (hasReportMode && focusesOutputs) {
+          const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          offenders.push(`${tagName}:${position.line + 1}`);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    "cloud report rendering should not focus output iframes; focused iframes trap page scroll",
+  );
+});

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -561,7 +561,6 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
           hostContext={outputHostContext}
           displayMode="report"
           showCode={showCode}
-          focusOutputs
           className="cloud-report-notebook"
           cellClassName="cloud-cell"
           sourceClassName="cloud-source-block"
@@ -829,7 +828,6 @@ function CloudLiveNotebook({
               hostContext={hostContext}
               displayMode="report"
               showSource={cell.cellType !== "code" || showCode}
-              focusOutputs
               className="cloud-cell"
               sourceClassName="cloud-source-block"
               outputClassName="cloud-output-block"


### PR DESCRIPTION
## Summary

- stop forcing focused output wells for cloud report-mode notebook rendering
- preserve the shared click-to-engage / scroll-passthrough iframe behavior for Sift, HTML, SVG, and markdown outputs
- add a cloud viewer regression test that prevents report-mode `ReadOnlyNotebook` usage from re-adding `focusOutputs`

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
