### PR TITLE
fix(mcp-app): prefer Vega outputs over HTML fallbacks

### DIFF
--- a/apps/mcp-app/src/lib/__tests__/mime-priority.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/mime-priority.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import { selectMimeType } from "../mime-priority";
+
+describe("selectMimeType", () => {
+  it("prefers Vega-Lite over HTML fallbacks", () => {
+    expect(
+      selectMimeType({
+        "text/html": "<div>fallback table</div>",
+        "application/vnd.vegalite.v5+json": JSON.stringify({ mark: "bar" }),
+        "text/plain": "fallback",
+      }),
+    ).toBe("application/vnd.vegalite.v5+json");
+  });
+
+  it("keeps known Vega versions in priority order", () => {
+    expect(
+      selectMimeType({
+        "application/vnd.vegalite.v4+json": JSON.stringify({ mark: "point" }),
+        "application/vnd.vegalite.v5+json": JSON.stringify({ mark: "bar" }),
+      }),
+    ).toBe("application/vnd.vegalite.v5+json");
+  });
+
+  it("prefers future Vega MIME variants over HTML fallbacks", () => {
+    expect(
+      selectMimeType({
+        "text/html": "<div>fallback chart</div>",
+        "application/vnd.vegalite.v7+json": JSON.stringify({ mark: "line" }),
+      }),
+    ).toBe("application/vnd.vegalite.v7+json");
+  });
+});

--- a/apps/mcp-app/src/lib/mime-priority.ts
+++ b/apps/mcp-app/src/lib/mime-priority.ts
@@ -1,10 +1,23 @@
-/**
- * MIME type priority for MCP App output rendering.
- * Higher priority types are preferred when multiple are available.
- */
-export const MIME_PRIORITY: readonly string[] = [
-  // Visualizations (highest priority — rich interactive content)
+const VISUAL_MIME_PRIORITY = [
+  // Visualizations (highest priority - rich interactive content)
   "application/vnd.plotly.v1+json",
+] as const;
+
+const VERSIONED_VEGA_MIME_PRIORITY = [
+  "application/vnd.vegalite.v6+json",
+  "application/vnd.vegalite.v6.json",
+  "application/vnd.vegalite.v5+json",
+  "application/vnd.vegalite.v5.json",
+  "application/vnd.vegalite.v4+json",
+  "application/vnd.vegalite.v3+json",
+  "application/vnd.vega.v6+json",
+  "application/vnd.vega.v6.json",
+  "application/vnd.vega.v5+json",
+  "application/vnd.vega.v5.json",
+  "application/vnd.vega.v4+json",
+] as const;
+
+const MIME_PRIORITY_AFTER_VERSIONED_VEGA = [
   "application/geo+json",
   // Data tables (Arrow IPC/parquet -> Sift renderer)
   "application/vnd.nteract.arrow-stream-manifest+json",
@@ -24,6 +37,16 @@ export const MIME_PRIORITY: readonly string[] = [
   "application/json",
   // Plain text (fallback)
   "text/plain",
+] as const;
+
+/**
+ * MIME type priority for MCP App output rendering.
+ * Higher priority types are preferred when multiple are available.
+ */
+export const MIME_PRIORITY: readonly string[] = [
+  ...VISUAL_MIME_PRIORITY,
+  ...VERSIONED_VEGA_MIME_PRIORITY,
+  ...MIME_PRIORITY_AFTER_VERSIONED_VEGA,
 ];
 
 /**
@@ -42,14 +65,21 @@ export function selectMimeType(data: Record<string, unknown>): string | null {
     (k) => data[k] != null && k !== "text/llm+plain",
   );
 
-  // Check priority list first
-  for (const mime of MIME_PRIORITY) {
+  for (const mime of VISUAL_MIME_PRIORITY) {
     if (available.includes(mime)) return mime;
   }
 
-  // Check for Vega/Vega-Lite variants (version-agnostic pattern match)
+  for (const mime of VERSIONED_VEGA_MIME_PRIORITY) {
+    if (available.includes(mime)) return mime;
+  }
+
+  // Check for future Vega/Vega-Lite variants before falling back to HTML.
   const vegaMime = available.find(isVegaMimeType);
   if (vegaMime) return vegaMime;
+
+  for (const mime of MIME_PRIORITY_AFTER_VERSIONED_VEGA) {
+    if (available.includes(mime)) return mime;
+  }
 
   // Fallback: first available type
   return available[0] ?? null;


### PR DESCRIPTION
## Summary

- Align the MCP app MIME selector with the notebook renderer for Vega/Vega-Lite outputs.
- Prefer known versioned Vega MIME types before HTML fallbacks, and keep future `application/vnd.vega*` variants ahead of HTML.
- Add focused unit coverage for known-version priority and future versioned Vega fallbacks.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp test run apps/mcp-app/src/lib/__tests__/mime-priority.test.ts apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx`
- `pnpm exec vp run nteract-mcp-app#build`
- `git diff --check`
