### PR TITLE
fix(mcp-app): log host container dimensions

### DIFF
--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -112,7 +112,7 @@ function McpApp() {
           loggingAdvertised: capabilities?.logging !== undefined,
           sandboxCsp: capabilities?.sandbox?.csp,
           displayMode: ctx?.displayMode,
-          containerSize: ctx?.containerSize,
+          containerDimensions: ctx?.containerDimensions,
         });
         if (ctx?.theme) applyDocumentTheme(ctx.theme);
         if (ctx?.styles?.variables) applyHostStyleVariables(ctx.styles.variables);


### PR DESCRIPTION
## Summary

- Log MCP Apps `hostContext.containerDimensions` instead of the non-spec `containerSize` field.
- Keep the `app-connected` diagnostic aligned with the field name hosts actually send.

## Verification

- `cargo xtask lint --fix`
- `pnpm exec vp run nteract-mcp-app#build`
- `git diff --check`
