### PR TITLE
fix(mcp-app): reduce host log noise

### DIFF
--- a/apps/mcp-app/src/components/__tests__/html-output.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/html-output.test.tsx
@@ -33,15 +33,7 @@ describe("HtmlOutput", () => {
     );
 
     expect(frame.style.height).toBe("422px");
-    expect(logs).toContainEqual(
-      expect.objectContaining({
-        level: "debug",
-        data: expect.objectContaining({
-          event: "html-output-iframe-resized",
-          height: 422,
-        }),
-      }),
-    );
+    expect(logs).toHaveLength(0);
   });
 
   it("ignores height messages from unrelated frames", () => {

--- a/apps/mcp-app/src/lib/__tests__/host-log.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/host-log.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  hostLog,
+  isHostFacingLevel,
+  setHostLogSink,
+  type HostLogParams,
+} from "../host-log";
+
+describe("hostLog", () => {
+  let logs: HostLogParams[];
+
+  beforeEach(() => {
+    logs = [];
+    setHostLogSink({
+      sendLog: (params) => {
+        logs.push(params);
+      },
+    });
+  });
+
+  afterEach(() => {
+    setHostLogSink(null);
+    vi.restoreAllMocks();
+  });
+
+  it("keeps low-level telemetry off the host logging channel", () => {
+    hostLog("debug", "layout-measured", { height: 120 });
+    hostLog("info", "tool-result-received", { outputCount: 1 });
+    hostLog("notice", "app-connected", { displayMode: "inline" });
+
+    expect(logs).toHaveLength(0);
+  });
+
+  it("forwards warnings and errors to the host", () => {
+    hostLog("warning", "mime-renderer-no-supported-mime", { outputMimes: [] });
+    hostLog("error", "plugin-render-failed", { mime: "text/markdown" });
+
+    expect(logs).toEqual([
+      expect.objectContaining({
+        level: "warning",
+        logger: "nteract.mcp-app",
+        data: expect.objectContaining({
+          event: "mime-renderer-no-supported-mime",
+          outputMimes: [],
+        }),
+      }),
+      expect.objectContaining({
+        level: "error",
+        logger: "nteract.mcp-app",
+        data: expect.objectContaining({
+          event: "plugin-render-failed",
+          mime: "text/markdown",
+        }),
+      }),
+    ]);
+  });
+
+  it("classifies only warning-or-higher severities as host-facing", () => {
+    expect(isHostFacingLevel("debug")).toBe(false);
+    expect(isHostFacingLevel("info")).toBe(false);
+    expect(isHostFacingLevel("notice")).toBe(false);
+    expect(isHostFacingLevel("warning")).toBe(true);
+    expect(isHostFacingLevel("error")).toBe(true);
+    expect(isHostFacingLevel("critical")).toBe(true);
+    expect(isHostFacingLevel("alert")).toBe(true);
+    expect(isHostFacingLevel("emergency")).toBe(true);
+  });
+});

--- a/apps/mcp-app/src/lib/host-log.ts
+++ b/apps/mcp-app/src/lib/host-log.ts
@@ -31,6 +31,10 @@ export function hostLog(
   };
 
   if (sink) {
+    if (!isHostFacingLevel(level)) {
+      return;
+    }
+
     try {
       void Promise.resolve(sink.sendLog(params)).catch((error) => {
         logToConsole("warning", "host-log-send-failed", {
@@ -48,6 +52,16 @@ export function hostLog(
   }
 
   logToConsole(level, event, details);
+}
+
+export function isHostFacingLevel(level: HostLogLevel): boolean {
+  return (
+    level === "warning" ||
+    level === "error" ||
+    level === "critical" ||
+    level === "alert" ||
+    level === "emergency"
+  );
 }
 
 export function errorDetails(error: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- keep MCP app `debug`/`info`/`notice` telemetry off the host logging channel once a host sink is attached
- continue forwarding `warning` and higher severities to the host so real renderer failures remain visible
- update HTML output resize expectations and add direct host-log coverage

## Log evidence

Claude's browser log dump shows every MCP app host log notification appearing as a console `warn @ ...` frame, including repeated `layout-measured`, `tool-result-received`, and `app-connected` debug/info telemetry. This keeps diagnostic logs available for local fallback logging while avoiding warning-looking host console spam for successful renders.

## Verification

- `pnpm exec vp test run apps/mcp-app/src/lib/__tests__/host-log.test.ts apps/mcp-app/src/components/__tests__/html-output.test.tsx apps/mcp-app/src/components/__tests__/mime-renderer.test.tsx`
- `pnpm exec vp run nteract-mcp-app#build`
- `cargo xtask lint --fix`
- `git diff --check`
