### PR TITLE
feat(agent-repl): add persistent REPL prototype

### DIFF
--- a/docs/architecture/agent-repl-prototype.md
+++ b/docs/architecture/agent-repl-prototype.md
@@ -1,0 +1,167 @@
+# Agent REPL Prototype
+
+**Status:** Draft, 2026-05-25.
+
+**Prototype:** `examples/agent-repl/`
+
+## Context
+
+Sometimes an agent does not need a notebook. It just needs a Python process
+that remembers `x = 3` on the next tool call.
+
+That is not a criticism of notebooks. It is the boundary between two products:
+
+- A **persistent agent REPL** is process state plus an execution API.
+- A **notebook runtime** is durable, visual, restartable, shareable execution
+  state connected to a document that humans edit and inspect.
+
+nteract is intentionally built for the second thing. It owns room lifecycle,
+Automerge sync, RuntimeStateDoc, kernel launch, output blob storage, renderer
+plugins, dependency metadata, trust, save/load, and multi-peer reconnects. That
+is useful machinery when the artifact is a notebook. It is a lot of machinery
+if the only requirement is "run this next Python snippet in the same namespace."
+
+Said another way: if all we need is `x = 3` to still exist on the next turn,
+Automerge is a very impressive way to remember a dictionary entry.
+
+## Shape
+
+The prototype keeps the architecture deliberately small:
+
+```text
+MCP client or inline caller
+    |
+    v
+ReplManager
+    |
+    v
+named session -> worker Python process
+                    |
+                    v
+                 IPython InteractiveShell.run_cell_async()
+                 or stdlib eval/exec namespace
+```
+
+The important bit is the process boundary. The tool server should not execute
+agent code in its own process. If the agent runs `while True: pass`, the session
+can be killed and recreated without killing the MCP server.
+
+## Tool Surface
+
+The MCP server exposes four tools:
+
+| Tool | Purpose |
+|------|---------|
+| `run_python` | Run code in a named persistent session. |
+| `reset_python` | Kill and forget a named session. |
+| `python_status` | Inspect one named session. |
+| `list_python_sessions` | List sessions owned by the current MCP process. |
+
+That is enough surface for an agent to build workflows:
+
+```python
+run_python("import pandas as pd")
+run_python("df = pd.read_csv('data.csv')")
+run_python("df.head()")
+```
+
+No cell IDs. No document heads. No output lookup tool. No separate active
+notebook. The session name is the routing key.
+
+## Backends
+
+`backend="ipython"` is the useful default because IPython already solved the
+interactive parts:
+
+- complete-cell execution via `InteractiveShell.run_cell_async()`;
+- top-level await;
+- better tracebacks;
+- magics;
+- display capture and MIME bundles.
+
+`backend="python"` is the stdlib fallback. It keeps a namespace and handles
+expression-only snippets, but it does not pretend to be a rich notebook kernel.
+That is fine for smoke tests and constrained environments.
+
+`backend="auto"` tries IPython and falls back to stdlib Python.
+
+## What This Avoids
+
+This prototype intentionally has none of the following:
+
+- Jupyter kernel protocol or ZMQ channels;
+- Automerge documents;
+- notebook cell order;
+- durable execution IDs;
+- output blob manifests;
+- iframe renderer plugins;
+- save/load;
+- multi-window sync;
+- dependency synchronization;
+- trust gates;
+- daemon upgrade/rejoin logic.
+
+Those omissions are the point. A REPL tool should have a tiny surface area until
+the product needs notebook properties.
+
+## Where It Stops Being Enough
+
+The simple REPL becomes the wrong abstraction when any of these become product
+requirements:
+
+1. **The user needs a durable artifact.** A process namespace is not a document.
+   Once outputs must survive restart or be reviewed later, use a notebook-shaped
+   runtime record.
+2. **Humans need rich visuals.** MIME bundles can be returned through MCP, but
+   rendering Plotly, Vega, widgets, iframes, and binary assets is exactly where
+   nteract earns its complexity.
+3. **Multiple peers need to watch or edit.** A worker process has no convergence
+   story. nteract's room and document model exists because multi-peer state is
+   not a REPL problem.
+4. **Execution needs auditability.** If the consumer needs stable execution IDs,
+   output ordering boundaries, causal terminal status, or post-hoc result lookup,
+   the RuntimeStateDoc model is the right shape.
+5. **Environment state matters.** Dependency metadata, trust, and reproducible
+   environments are bigger than a persistent namespace.
+
+## Presentation Framing
+
+The clean distinction:
+
+> A persistent REPL is "keep a Python process alive and send it code."
+>
+> A notebook is "make that execution durable, inspectable, replayable,
+> shareable, visual, restartable, dependency-aware, and safe enough for humans
+> to trust."
+>
+> nteract is overcomplicated for the first thing because it is built for the
+> second thing.
+
+The self-deprecating version:
+
+> We built an excellent system for remembering execution as a collaborative
+> document. Sometimes the right answer is a process with a dictionary and a kill
+> switch.
+
+## Run It
+
+```bash
+uv run --project examples/agent-repl agent-repl-mcp
+```
+
+Inline usage:
+
+```python
+from agent_repl import ReplManager
+
+manager = ReplManager()
+try:
+    print(manager.run("x = 41"))
+    print(manager.run("x + 1"))
+finally:
+    manager.close()
+```
+
+This is intentionally small enough to throw away. Its value is as a comparison
+point: it shows which pieces are essential for a REPL and which pieces only
+become essential once the artifact is a notebook.

--- a/examples/agent-repl/README.md
+++ b/examples/agent-repl/README.md
@@ -1,0 +1,61 @@
+# Agent REPL Prototype
+
+This is a deliberately small persistent Python REPL for agents. It is not part
+of the nteract runtime stack; it is a reference prototype for the case where an
+agent only needs process-local Python state across tool calls.
+
+## Run As An MCP Server
+
+```bash
+uv run --project examples/agent-repl agent-repl-mcp
+```
+
+Example MCP client config:
+
+```json
+{
+  "command": "uv",
+  "args": ["run", "--project", "examples/agent-repl", "agent-repl-mcp"],
+  "working_directory": "/path/to/nteract"
+}
+```
+
+The MCP server exposes four tools:
+
+- `run_python(code, session, timeout_s, backend)`
+- `reset_python(session)`
+- `python_status(session)`
+- `list_python_sessions()`
+
+## Use Inline
+
+```python
+from agent_repl import ReplManager
+
+manager = ReplManager()
+try:
+    print(manager.run("x = 41"))
+    print(manager.run("x + 1"))
+finally:
+    manager.close()
+```
+
+## Backends
+
+- `ipython` uses `InteractiveShell.run_cell_async()` and captures stdout,
+  stderr, and rich display payloads.
+- `python` uses only the standard library. It preserves a session namespace and
+  reports a value for expression-only cells, but it intentionally does not try
+  to recreate IPython's display machinery.
+
+`backend="auto"` tries IPython first and falls back to standard Python.
+
+## Prototype Boundaries
+
+Each named session is one worker process. If a run times out, the worker is
+killed and that session state is lost. That is the point: this keeps the MCP
+server recoverable when code hangs.
+
+This does not provide notebook persistence, multi-client document sync,
+dependency management, output blob storage, renderer plugins, or durable cell
+history. Those are nteract-shaped problems. This prototype is just a REPL.

--- a/examples/agent-repl/pyproject.toml
+++ b/examples/agent-repl/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "agent-repl"
+version = "0.1.0"
+description = "Prototype persistent Python REPL tool for agents"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "ipython>=8.0",
+    "mcp>=1.2.0",
+]
+
+[project.scripts]
+agent-repl-mcp = "agent_repl.mcp_server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_repl"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.9",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP", "B", "SIM"]

--- a/examples/agent-repl/src/agent_repl/__init__.py
+++ b/examples/agent-repl/src/agent_repl/__init__.py
@@ -1,0 +1,6 @@
+"""Prototype persistent Python REPL for agents."""
+
+from agent_repl.manager import ReplManager, ReplTimeout
+from agent_repl.types import RunResult, SessionInfo
+
+__all__ = ["ReplManager", "ReplTimeout", "RunResult", "SessionInfo"]

--- a/examples/agent-repl/src/agent_repl/_worker.py
+++ b/examples/agent-repl/src/agent_repl/_worker.py
@@ -1,0 +1,228 @@
+"""Worker process for one persistent Python session.
+
+The parent owns MCP/inline tool state. This child owns the Python namespace.
+JSON lines are used for the prototype RPC. Normal Python stdout/stderr is
+captured during execution so ordinary ``print()`` calls do not corrupt the
+transport.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import asyncio
+import base64
+import contextlib
+import inspect
+import io
+import json
+import sys
+import traceback
+import warnings
+from typing import Any
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, bytes):
+        return {"encoding": "base64", "data": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return repr(value)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+class PlainPythonBackend:
+    """Small stdlib-only backend.
+
+    This is intentionally modest. It keeps a namespace and returns a value for
+    expression-only snippets. It does not recreate IPython's display hook,
+    magics, rich formatters, or full top-level await behavior for statement
+    blocks.
+    """
+
+    name = "python"
+
+    def __init__(self) -> None:
+        self.namespace: dict[str, Any] = {"__name__": "__console__", "__doc__": None}
+        self.execution_count = 0
+
+    async def run(self, code: str) -> dict[str, Any]:
+        self.execution_count += 1
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                value = await self._eval_or_exec(code)
+        except BaseException as exc:
+            return {
+                "backend": self.name,
+                "ok": False,
+                "stdout": stdout.getvalue(),
+                "stderr": stderr.getvalue(),
+                "error_name": type(exc).__name__,
+                "traceback": traceback.format_exc(),
+                "execution_count": self.execution_count,
+            }
+
+        return {
+            "backend": self.name,
+            "ok": True,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+            "result_repr": repr(value) if value is not None else None,
+            "displays": [],
+            "execution_count": self.execution_count,
+        }
+
+    async def _eval_or_exec(self, code: str) -> Any:
+        flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        try:
+            compiled = compile(code, "<agent-repl>", "eval", flags=flags)
+        except SyntaxError:
+            tree = ast.parse(code, mode="exec")
+            if tree.body and isinstance(tree.body[-1], ast.Expr):
+                prefix = ast.Module(body=tree.body[:-1], type_ignores=tree.type_ignores)
+                ast.fix_missing_locations(prefix)
+                if prefix.body:
+                    prefix_code = compile(prefix, "<agent-repl>", "exec", flags=flags)
+                    await _maybe_await(eval(prefix_code, self.namespace, self.namespace))
+
+                expression = ast.Expression(body=tree.body[-1].value)
+                ast.fix_missing_locations(expression)
+                expression_code = compile(expression, "<agent-repl>", "eval", flags=flags)
+                value = eval(expression_code, self.namespace, self.namespace)
+                return await _maybe_await(value)
+
+            compiled = compile(tree, "<agent-repl>", "exec", flags=flags)
+            value = eval(compiled, self.namespace, self.namespace)
+            return await _maybe_await(value)
+
+        value = eval(compiled, self.namespace, self.namespace)
+        return await _maybe_await(value)
+
+
+class IPythonBackend:
+    """IPython backend using InteractiveShell.run_cell_async."""
+
+    name = "ipython"
+
+    def __init__(self) -> None:
+        from IPython.core.interactiveshell import InteractiveShell
+
+        self.shell = InteractiveShell.instance()
+        self.shell.user_ns.setdefault("__name__", "__console__")
+        self.shell.user_ns.setdefault("__doc__", None)
+
+    async def run(self, code: str) -> dict[str, Any]:
+        from IPython.utils.capture import capture_output
+
+        with (
+            capture_output(stdout=True, stderr=True, display=True) as captured,
+            warnings.catch_warnings(),
+        ):
+            warnings.filterwarnings(
+                "ignore",
+                message="`run_cell_async` will not call `transform_cell` automatically.*",
+                category=DeprecationWarning,
+            )
+            result = await self.shell.run_cell_async(code, store_history=True, silent=False)
+
+        error = result.error_before_exec or result.error_in_exec
+        return {
+            "backend": self.name,
+            "ok": error is None,
+            "stdout": captured.stdout,
+            "stderr": captured.stderr,
+            "result_repr": repr(result.result) if result.result is not None else None,
+            "displays": [self._serialize_display(output) for output in captured.outputs],
+            "error_name": type(error).__name__ if error else None,
+            "traceback": "".join(traceback.format_exception(error)) if error else None,
+            "execution_count": getattr(result, "execution_count", None),
+        }
+
+    @staticmethod
+    def _serialize_display(output: Any) -> dict[str, Any]:
+        return {
+            "data": _jsonable(getattr(output, "data", {})),
+            "metadata": _jsonable(getattr(output, "metadata", {})),
+            "transient": _jsonable(getattr(output, "transient", {})),
+            "update": bool(getattr(output, "update", False)),
+        }
+
+
+def _create_backend(kind: str) -> PlainPythonBackend | IPythonBackend:
+    if kind == "python":
+        return PlainPythonBackend()
+    if kind == "ipython":
+        return IPythonBackend()
+    if kind == "auto":
+        try:
+            return IPythonBackend()
+        except Exception:
+            return PlainPythonBackend()
+    raise ValueError(f"unknown backend: {kind}")
+
+
+async def _handle_request(backend: PlainPythonBackend | IPythonBackend, request: dict[str, Any]):
+    op = request.get("op")
+    if op == "run":
+        payload = await backend.run(str(request.get("code", "")))
+    elif op == "status":
+        payload = {
+            "backend": backend.name,
+            "ok": True,
+            "execution_count": getattr(backend, "execution_count", None),
+        }
+    else:
+        payload = {
+            "backend": backend.name,
+            "ok": False,
+            "error_name": "UnknownOperation",
+            "traceback": f"unknown operation: {op!r}",
+        }
+
+    payload["id"] = request.get("id")
+    return payload
+
+
+async def _run_loop(backend_kind: str) -> None:
+    backend = _create_backend(backend_kind)
+    while True:
+        line = await asyncio.to_thread(sys.stdin.readline)
+        if line == "":
+            return
+
+        try:
+            request = json.loads(line)
+            response = await _handle_request(backend, request)
+        except BaseException as exc:
+            response = {
+                "id": None,
+                "backend": getattr(backend, "name", backend_kind),
+                "ok": False,
+                "error_name": type(exc).__name__,
+                "traceback": traceback.format_exc(),
+            }
+
+        print(json.dumps(response, ensure_ascii=False), flush=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="agent-repl worker process")
+    parser.add_argument("--backend", choices=["auto", "ipython", "python"], default="auto")
+    args = parser.parse_args(argv)
+    asyncio.run(_run_loop(args.backend))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agent-repl/src/agent_repl/_worker.py
+++ b/examples/agent-repl/src/agent_repl/_worker.py
@@ -19,7 +19,28 @@ import json
 import sys
 import traceback
 import warnings
+from threading import Lock
 from typing import Any
+
+
+class _BackgroundStream(io.TextIOBase):
+    """Absorb writes that happen outside the active execution capture."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._lines: list[str] = []
+
+    def writable(self) -> bool:
+        return True
+
+    def write(self, text: str) -> int:
+        with self._lock:
+            self._lines.append(text)
+            del self._lines[:-80]
+        return len(text)
+
+    def flush(self) -> None:
+        pass
 
 
 def _jsonable(value: Any) -> Any:
@@ -63,7 +84,7 @@ class PlainPythonBackend:
         try:
             with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
                 value = await self._eval_or_exec(code)
-        except BaseException as exc:
+        except Exception as exc:
             return {
                 "backend": self.name,
                 "ok": False,
@@ -197,6 +218,10 @@ async def _handle_request(backend: PlainPythonBackend | IPythonBackend, request:
 
 async def _run_loop(backend_kind: str) -> None:
     backend = _create_backend(backend_kind)
+    transport = sys.stdout
+    sys.stdout = _BackgroundStream()
+    sys.stderr = _BackgroundStream()
+
     while True:
         line = await asyncio.to_thread(sys.stdin.readline)
         if line == "":
@@ -205,7 +230,7 @@ async def _run_loop(backend_kind: str) -> None:
         try:
             request = json.loads(line)
             response = await _handle_request(backend, request)
-        except BaseException as exc:
+        except Exception as exc:
             response = {
                 "id": None,
                 "backend": getattr(backend, "name", backend_kind),
@@ -214,7 +239,8 @@ async def _run_loop(backend_kind: str) -> None:
                 "traceback": traceback.format_exc(),
             }
 
-        print(json.dumps(response, ensure_ascii=False), flush=True)
+        transport.write(json.dumps(response, ensure_ascii=False) + "\n")
+        transport.flush()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -127,7 +127,16 @@ class _WorkerSession:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise queue.Empty
-                response = self._responses.get(timeout=remaining)
+                try:
+                    response = self._responses.get(timeout=min(remaining, 0.05))
+                except queue.Empty:
+                    if not self.alive:
+                        message = f"session {self.name!r} worker exited before responding"
+                        stderr_tail = self.stderr_tail()
+                        if stderr_tail:
+                            message = f"{message}\n\nworker stderr:\n{stderr_tail}"
+                        raise RuntimeError(message) from None
+                    continue
                 if response.get("id") == request_id:
                     return response
                 if response.get("id") is None and response.get("ok") is False:

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -8,6 +8,7 @@ import queue
 import subprocess
 import sys
 import threading
+import time
 from dataclasses import asdict
 from itertools import count
 from pathlib import Path
@@ -104,10 +105,14 @@ class _WorkerSession:
         assert self._process.stdin is not None
         self._process.stdin.write(json.dumps(request) + "\n")
         self._process.stdin.flush()
+        deadline = time.monotonic() + timeout_s
 
         try:
             while True:
-                response = self._responses.get(timeout=timeout_s)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise queue.Empty
+                response = self._responses.get(timeout=remaining)
                 if response.get("id") == request_id:
                     return response
         except queue.Empty as exc:

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -36,11 +36,15 @@ class _WorkerSession:
         self._ids = count(1)
         self._request_lock = threading.Lock()
         self._responses: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._stderr_lock = threading.Lock()
         self._executions = 0
         self._closed = False
         self._process = self._start()
         self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._stderr_reader = threading.Thread(target=self._read_stderr, daemon=True)
         self._reader.start()
+        self._stderr_reader.start()
 
     @property
     def pid(self) -> int:
@@ -98,7 +102,11 @@ class _WorkerSession:
 
     def _request(self, request: dict[str, Any], timeout_s: float) -> dict[str, Any]:
         if not self.alive:
-            raise RuntimeError(f"session {self.name!r} worker is not running")
+            message = f"session {self.name!r} worker is not running"
+            stderr_tail = self.stderr_tail()
+            if stderr_tail:
+                message = f"{message}\n\nworker stderr:\n{stderr_tail}"
+            raise RuntimeError(message)
 
         request_id = next(self._ids)
         request["id"] = request_id
@@ -140,7 +148,7 @@ class _WorkerSession:
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
             env=env,
@@ -163,6 +171,17 @@ class _WorkerSession:
                         "traceback": f"worker wrote non-JSON stdout: {line!r}",
                     }
                 )
+
+    def _read_stderr(self) -> None:
+        assert self._process.stderr is not None
+        for line in self._process.stderr:
+            with self._stderr_lock:
+                self._stderr_lines.append(line)
+                del self._stderr_lines[:-40]
+
+    def stderr_tail(self) -> str:
+        with self._stderr_lock:
+            return "".join(self._stderr_lines).strip()
 
 
 class ReplManager:
@@ -204,6 +223,18 @@ class ReplManager:
                 error_name="Timeout",
                 traceback=f"execution timed out after {timeout_s:g}s; session was killed",
                 timed_out=True,
+                restarted=True,
+            )
+        except RuntimeError as exc:
+            with self._lock:
+                if self._sessions.get(session) is worker:
+                    self._sessions.pop(session, None)
+            return RunResult(
+                session=session,
+                backend=worker.backend,
+                ok=False,
+                error_name="SessionUnavailable",
+                traceback=str(exc),
                 restarted=True,
             )
 

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -1,0 +1,253 @@
+"""Inline manager for persistent Python worker sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+from dataclasses import asdict
+from itertools import count
+from pathlib import Path
+from typing import Any
+
+from agent_repl.types import RunResult, SessionInfo
+
+
+class ReplTimeout(TimeoutError):
+    """Raised when a worker does not return before the requested timeout."""
+
+
+class _WorkerSession:
+    def __init__(
+        self,
+        name: str,
+        backend: str,
+        python_executable: str,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.name = name
+        self.backend = backend
+        self.python_executable = python_executable
+        self.extra_env = extra_env or {}
+        self._ids = count(1)
+        self._request_lock = threading.Lock()
+        self._responses: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._executions = 0
+        self._closed = False
+        self._process = self._start()
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+
+    @property
+    def pid(self) -> int:
+        return self._process.pid
+
+    @property
+    def alive(self) -> bool:
+        return self._process.poll() is None
+
+    @property
+    def executions(self) -> int:
+        return self._executions
+
+    def run(self, code: str, timeout_s: float) -> RunResult:
+        with self._request_lock:
+            response = self._request({"op": "run", "code": code}, timeout_s=timeout_s)
+        self._executions += 1
+        return RunResult(
+            session=self.name,
+            backend=str(response.get("backend", self.backend)),
+            ok=bool(response.get("ok")),
+            stdout=str(response.get("stdout", "")),
+            stderr=str(response.get("stderr", "")),
+            result_repr=response.get("result_repr"),
+            displays=list(response.get("displays") or []),
+            error_name=response.get("error_name"),
+            traceback=response.get("traceback"),
+            execution_count=response.get("execution_count"),
+        )
+
+    def status(self) -> SessionInfo:
+        return SessionInfo(
+            session=self.name,
+            backend=self.backend,
+            pid=self.pid,
+            alive=self.alive,
+            executions=self.executions,
+        )
+
+    def close(self) -> None:
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=2)
+
+    def kill(self) -> None:
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.kill()
+            self._process.wait(timeout=2)
+
+    def _request(self, request: dict[str, Any], timeout_s: float) -> dict[str, Any]:
+        if not self.alive:
+            raise RuntimeError(f"session {self.name!r} worker is not running")
+
+        request_id = next(self._ids)
+        request["id"] = request_id
+        assert self._process.stdin is not None
+        self._process.stdin.write(json.dumps(request) + "\n")
+        self._process.stdin.flush()
+
+        try:
+            while True:
+                response = self._responses.get(timeout=timeout_s)
+                if response.get("id") == request_id:
+                    return response
+        except queue.Empty as exc:
+            self.kill()
+            raise ReplTimeout(f"session {self.name!r} timed out after {timeout_s:g}s") from exc
+
+    def _start(self) -> subprocess.Popen[str]:
+        env = os.environ.copy()
+        env.update(self.extra_env)
+        env["PYTHONUNBUFFERED"] = "1"
+
+        src_root = Path(__file__).resolve().parents[1]
+        pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            str(src_root) if not pythonpath else os.pathsep.join([str(src_root), pythonpath])
+        )
+
+        return subprocess.Popen(
+            [
+                self.python_executable,
+                "-m",
+                "agent_repl._worker",
+                "--backend",
+                self.backend,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            bufsize=1,
+            env=env,
+        )
+
+    def _read_stdout(self) -> None:
+        assert self._process.stdout is not None
+        for line in self._process.stdout:
+            if self._closed:
+                return
+            try:
+                self._responses.put(json.loads(line))
+            except json.JSONDecodeError:
+                self._responses.put(
+                    {
+                        "id": None,
+                        "backend": self.backend,
+                        "ok": False,
+                        "error_name": "WorkerProtocolError",
+                        "traceback": f"worker wrote non-JSON stdout: {line!r}",
+                    }
+                )
+
+
+class ReplManager:
+    """Owns named persistent Python sessions."""
+
+    def __init__(
+        self,
+        *,
+        backend: str = "auto",
+        python_executable: str | None = None,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.backend = backend
+        self.python_executable = python_executable or sys.executable
+        self.extra_env = extra_env
+        self._sessions: dict[str, _WorkerSession] = {}
+        self._lock = threading.Lock()
+
+    def run(
+        self,
+        code: str,
+        *,
+        session: str = "default",
+        timeout_s: float = 30,
+        backend: str | None = None,
+    ) -> RunResult:
+        with self._lock:
+            worker = self._session(session, backend or self.backend)
+
+        try:
+            return worker.run(code, timeout_s=timeout_s)
+        except ReplTimeout:
+            with self._lock:
+                self._sessions.pop(session, None)
+            return RunResult(
+                session=session,
+                backend=worker.backend,
+                ok=False,
+                error_name="Timeout",
+                traceback=f"execution timed out after {timeout_s:g}s; session was killed",
+                timed_out=True,
+                restarted=True,
+            )
+
+    def reset(self, session: str = "default") -> bool:
+        with self._lock:
+            worker = self._sessions.pop(session, None)
+        if worker is None:
+            return False
+        worker.close()
+        return True
+
+    def status(self, session: str = "default") -> SessionInfo | None:
+        with self._lock:
+            worker = self._sessions.get(session)
+        return worker.status() if worker is not None else None
+
+    def list_sessions(self) -> list[SessionInfo]:
+        with self._lock:
+            workers = list(self._sessions.values())
+        return [worker.status() for worker in workers]
+
+    def close(self) -> None:
+        with self._lock:
+            workers = list(self._sessions.values())
+            self._sessions.clear()
+        for worker in workers:
+            worker.close()
+
+    def _session(self, name: str, backend: str) -> _WorkerSession:
+        worker = self._sessions.get(name)
+        if worker is not None and worker.alive and worker.backend == backend:
+            return worker
+
+        if worker is not None:
+            worker.close()
+
+        worker = _WorkerSession(
+            name=name,
+            backend=backend,
+            python_executable=self.python_executable,
+            extra_env=self.extra_env,
+        )
+        self._sessions[name] = worker
+        return worker
+
+
+def as_jsonable(value: RunResult | SessionInfo | list[SessionInfo] | None) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [asdict(item) for item in value]
+    return asdict(value)

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import queue
@@ -15,6 +16,23 @@ from pathlib import Path
 from typing import Any
 
 from agent_repl.types import RunResult, SessionInfo
+
+SAFE_WORKER_ENV_KEYS = {
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LOGNAME",
+    "PATH",
+    "PYTHONPATH",
+    "SHELL",
+    "TEMP",
+    "TERM",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "VIRTUAL_ENV",
+}
+SAFE_WORKER_ENV_PREFIXES = ("LC_",)
 
 
 class ReplTimeout(TimeoutError):
@@ -92,7 +110,8 @@ class _WorkerSession:
                 self._process.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 self._process.kill()
-                self._process.wait(timeout=2)
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    self._process.wait(timeout=2)
         self._reader.join(timeout=1)
         self._stderr_reader.join(timeout=1)
 
@@ -100,7 +119,8 @@ class _WorkerSession:
         self._closed = True
         if self._process.poll() is None:
             self._process.kill()
-            self._process.wait(timeout=2)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                self._process.wait(timeout=2)
 
     def _request(self, request: dict[str, Any], timeout_s: float) -> dict[str, Any]:
         if not self.alive:
@@ -148,7 +168,12 @@ class _WorkerSession:
             raise ReplTimeout(f"session {self.name!r} timed out after {timeout_s:g}s") from exc
 
     def _start(self) -> subprocess.Popen[str]:
-        env = os.environ.copy()
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key in SAFE_WORKER_ENV_KEYS
+            or any(key.startswith(prefix) for prefix in SAFE_WORKER_ENV_PREFIXES)
+        }
         env.update(self.extra_env)
         env["PYTHONUNBUFFERED"] = "1"
 

--- a/examples/agent-repl/src/agent_repl/manager.py
+++ b/examples/agent-repl/src/agent_repl/manager.py
@@ -93,6 +93,8 @@ class _WorkerSession:
             except subprocess.TimeoutExpired:
                 self._process.kill()
                 self._process.wait(timeout=2)
+        self._reader.join(timeout=1)
+        self._stderr_reader.join(timeout=1)
 
     def kill(self) -> None:
         self._closed = True
@@ -111,8 +113,13 @@ class _WorkerSession:
         request_id = next(self._ids)
         request["id"] = request_id
         assert self._process.stdin is not None
-        self._process.stdin.write(json.dumps(request) + "\n")
-        self._process.stdin.flush()
+        try:
+            self._process.stdin.write(json.dumps(request) + "\n")
+            self._process.stdin.flush()
+        except OSError as exc:
+            raise RuntimeError(
+                f"session {self.name!r} worker died while accepting a request"
+            ) from exc
         deadline = time.monotonic() + timeout_s
 
         try:
@@ -123,6 +130,10 @@ class _WorkerSession:
                 response = self._responses.get(timeout=remaining)
                 if response.get("id") == request_id:
                     return response
+                if response.get("id") is None and response.get("ok") is False:
+                    error_name = response.get("error_name") or "WorkerProtocolError"
+                    traceback_text = response.get("traceback") or "worker protocol error"
+                    raise RuntimeError(f"{error_name}: {traceback_text}")
         except queue.Empty as exc:
             self.kill()
             raise ReplTimeout(f"session {self.name!r} timed out after {timeout_s:g}s") from exc

--- a/examples/agent-repl/src/agent_repl/mcp_server.py
+++ b/examples/agent-repl/src/agent_repl/mcp_server.py
@@ -48,13 +48,15 @@ async def reset_python(session: str = "default") -> dict[str, Any]:
 @mcp.tool()
 async def python_status(session: str = "default") -> dict[str, Any]:
     """Return status for a named Python session."""
-    return {"session": session, "status": as_jsonable(manager.status(session))}
+    status = await asyncio.to_thread(manager.status, session)
+    return {"session": session, "status": as_jsonable(status)}
 
 
 @mcp.tool()
 async def list_python_sessions() -> dict[str, Any]:
     """List active Python sessions for this MCP server process."""
-    return {"sessions": as_jsonable(manager.list_sessions())}
+    sessions = await asyncio.to_thread(manager.list_sessions)
+    return {"sessions": as_jsonable(sessions)}
 
 
 def main() -> None:

--- a/examples/agent-repl/src/agent_repl/mcp_server.py
+++ b/examples/agent-repl/src/agent_repl/mcp_server.py
@@ -1,0 +1,68 @@
+"""MCP server exposing the prototype REPL as tools."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Literal
+
+from agent_repl.manager import ReplManager, as_jsonable
+
+Backend = Literal["auto", "ipython", "python"]
+manager = ReplManager()
+
+
+def _mcp():
+    from mcp.server.fastmcp import FastMCP
+
+    return FastMCP("agent-repl")
+
+
+mcp = _mcp()
+
+
+@mcp.tool()
+async def run_python(
+    code: str,
+    session: str = "default",
+    timeout_s: float = 30,
+    backend: Backend = "auto",
+) -> dict[str, Any]:
+    """Run Python code in a persistent named session."""
+    result = await asyncio.to_thread(
+        manager.run,
+        code,
+        session=session,
+        timeout_s=timeout_s,
+        backend=backend,
+    )
+    return as_jsonable(result)
+
+
+@mcp.tool()
+async def reset_python(session: str = "default") -> dict[str, Any]:
+    """Reset a named Python session, killing its worker process if needed."""
+    reset = await asyncio.to_thread(manager.reset, session)
+    return {"session": session, "reset": reset}
+
+
+@mcp.tool()
+async def python_status(session: str = "default") -> dict[str, Any]:
+    """Return status for a named Python session."""
+    return {"session": session, "status": as_jsonable(manager.status(session))}
+
+
+@mcp.tool()
+async def list_python_sessions() -> dict[str, Any]:
+    """List active Python sessions for this MCP server process."""
+    return {"sessions": as_jsonable(manager.list_sessions())}
+
+
+def main() -> None:
+    try:
+        mcp.run()
+    finally:
+        manager.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agent-repl/src/agent_repl/mcp_server.py
+++ b/examples/agent-repl/src/agent_repl/mcp_server.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 from typing import Any, Literal
 
 from agent_repl.manager import ReplManager, as_jsonable
 
 Backend = Literal["auto", "ipython", "python"]
 manager = ReplManager()
+atexit.register(manager.close)
 
 
 def _mcp():

--- a/examples/agent-repl/src/agent_repl/mcp_server.py
+++ b/examples/agent-repl/src/agent_repl/mcp_server.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from agent_repl.manager import ReplManager, as_jsonable
 
 Backend = Literal["auto", "ipython", "python"]
+MAX_TIMEOUT_S = 300.0
 manager = ReplManager()
 atexit.register(manager.close)
 
@@ -30,11 +31,12 @@ async def run_python(
     backend: Backend = "auto",
 ) -> dict[str, Any]:
     """Run Python code in a persistent named session."""
+    clamped_timeout_s = min(max(timeout_s, 0.1), MAX_TIMEOUT_S)
     result = await asyncio.to_thread(
         manager.run,
         code,
         session=session,
-        timeout_s=timeout_s,
+        timeout_s=clamped_timeout_s,
         backend=backend,
     )
     return as_jsonable(result)

--- a/examples/agent-repl/src/agent_repl/types.py
+++ b/examples/agent-repl/src/agent_repl/types.py
@@ -1,0 +1,37 @@
+"""Shared result types for the prototype REPL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+JsonObject = dict[str, Any]
+
+
+@dataclass
+class RunResult:
+    """Execution result returned by the worker."""
+
+    session: str
+    backend: str
+    ok: bool
+    stdout: str = ""
+    stderr: str = ""
+    result_repr: str | None = None
+    displays: list[JsonObject] = field(default_factory=list)
+    error_name: str | None = None
+    traceback: str | None = None
+    execution_count: int | None = None
+    timed_out: bool = False
+    restarted: bool = False
+
+
+@dataclass
+class SessionInfo:
+    """Lightweight status for a named session."""
+
+    session: str
+    backend: str
+    pid: int
+    alive: bool
+    executions: int

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from agent_repl import ReplManager
+
+
+def test_plain_python_session_persists_state() -> None:
+    manager = ReplManager(backend="python")
+    try:
+        first = manager.run("x = 41")
+        second = manager.run("y = x + 1\ny")
+    finally:
+        manager.close()
+
+    assert first.ok
+    assert second.ok
+    assert second.result_repr == "42"
+
+
+def test_plain_python_captures_stdout_and_errors() -> None:
+    manager = ReplManager(backend="python")
+    try:
+        printed = manager.run("print('hello')")
+        failed = manager.run("1 / 0")
+    finally:
+        manager.close()
+
+    assert printed.ok
+    assert printed.stdout == "hello\n"
+    assert not failed.ok
+    assert failed.error_name == "ZeroDivisionError"
+    assert failed.traceback
+
+
+def test_timeout_kills_only_that_session() -> None:
+    manager = ReplManager(backend="python")
+    try:
+        manager.run("x = 7", session="keep")
+        timed_out = manager.run("import time; time.sleep(5)", session="drop", timeout_s=0.2)
+        still_alive = manager.run("x", session="keep")
+        restarted = manager.run("99", session="drop")
+    finally:
+        manager.close()
+
+    assert not timed_out.ok
+    assert timed_out.timed_out
+    assert still_alive.result_repr == "7"
+    assert restarted.ok
+    assert restarted.result_repr == "99"
+
+
+def test_ipython_backend_captures_rich_display() -> None:
+    manager = ReplManager(backend="ipython")
+    try:
+        result = manager.run(
+            "from IPython.display import display\n"
+            "display({'text/plain': 'hi', 'application/json': {'answer': 42}}, raw=True)"
+        )
+    finally:
+        manager.close()
+
+    assert result.ok
+    assert result.displays
+    assert result.displays[0]["data"]["application/json"] == {"answer": 42}

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -69,6 +69,50 @@ def test_timeout_budget_is_not_reset_by_discarded_responses() -> None:
     assert elapsed < 0.35
 
 
+def test_manager_returns_structured_error_if_worker_dies_before_run() -> None:
+    class BrokenWorker:
+        backend = "python"
+        alive = True
+
+        def run(self, code: str, timeout_s: float):  # noqa: ARG002
+            raise RuntimeError("worker disappeared")
+
+        def close(self) -> None:
+            pass
+
+    manager = ReplManager(backend="python")
+    manager._sessions["default"] = BrokenWorker()
+
+    result = manager.run("1")
+
+    assert not result.ok
+    assert result.error_name == "SessionUnavailable"
+    assert result.restarted
+    assert "worker disappeared" in (result.traceback or "")
+    assert "default" not in manager._sessions
+
+
+def test_dead_worker_error_includes_stderr_tail() -> None:
+    worker = _WorkerSession("bad", "bogus", sys.executable)
+    try:
+        for _ in range(20):
+            if not worker.alive:
+                break
+            time.sleep(0.05)
+
+        try:
+            worker._request({"op": "run", "code": "1"}, timeout_s=0.2)
+        except RuntimeError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("expected worker startup failure")
+    finally:
+        worker.close()
+
+    assert "worker stderr:" in message
+    assert "invalid choice" in message
+
+
 def test_ipython_backend_captures_rich_display() -> None:
     manager = ReplManager(backend="ipython")
     try:

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 import time
 
@@ -151,6 +152,83 @@ def test_background_thread_print_does_not_corrupt_transport() -> None:
     assert started.result_repr == "'started'"
     assert after.ok
     assert after.result_repr == "42"
+
+
+def test_worker_does_not_inherit_unlisted_parent_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_REPL_TEST_SECRET", "secret")
+    manager = ReplManager(backend="python")
+    try:
+        result = manager.run("import os\nos.environ.get('AGENT_REPL_TEST_SECRET')")
+    finally:
+        manager.close()
+
+    assert result.ok
+    assert result.result_repr is None
+
+
+def test_worker_receives_explicit_extra_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_REPL_PARENT_ONLY", "secret")
+    manager = ReplManager(
+        backend="python",
+        extra_env={"AGENT_REPL_EXPLICIT": "present"},
+    )
+    try:
+        parent_only = manager.run("import os\nos.environ.get('AGENT_REPL_PARENT_ONLY')")
+        explicit = manager.run("import os\nos.environ.get('AGENT_REPL_EXPLICIT')")
+    finally:
+        manager.close()
+
+    assert parent_only.result_repr is None
+    assert explicit.result_repr == "'present'"
+
+
+def test_kill_ignores_timeout_expired() -> None:
+    class StubbornProcess:
+        def poll(self):
+            return None
+
+        def kill(self) -> None:
+            pass
+
+        def wait(self, timeout: float) -> None:
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    worker = object.__new__(_WorkerSession)
+    worker._closed = False
+    worker._process = StubbornProcess()
+
+    worker.kill()
+
+    assert worker._closed
+
+
+def test_close_ignores_timeout_expired_after_kill() -> None:
+    class StubbornProcess:
+        def poll(self):
+            return None
+
+        def terminate(self) -> None:
+            pass
+
+        def kill(self) -> None:
+            pass
+
+        def wait(self, timeout: float) -> None:
+            raise subprocess.TimeoutExpired("worker", timeout)
+
+    class DummyThread:
+        def join(self, timeout: float) -> None:
+            pass
+
+    worker = object.__new__(_WorkerSession)
+    worker._closed = False
+    worker._process = StubbornProcess()
+    worker._reader = DummyThread()
+    worker._stderr_reader = DummyThread()
+
+    worker.close()
+
+    assert worker._closed
 
 
 def test_manager_returns_structured_error_if_worker_dies_before_run() -> None:

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -55,7 +55,7 @@ def test_timeout_kills_only_that_session() -> None:
 def test_timeout_budget_is_not_reset_by_discarded_responses() -> None:
     worker = _WorkerSession("test", "python", sys.executable)
     try:
-        worker._responses.put({"id": None, "ok": False})
+        worker._responses.put({"id": 999, "ok": True})
         started = time.monotonic()
         try:
             worker._request({"op": "run", "code": "import time; time.sleep(5)"}, timeout_s=0.2)
@@ -67,6 +67,53 @@ def test_timeout_budget_is_not_reset_by_discarded_responses() -> None:
         worker.close()
 
     assert elapsed < 0.35
+
+
+def test_broken_pipe_during_request_is_structured_error() -> None:
+    class BrokenStdin:
+        def write(self, text: str) -> None:
+            raise BrokenPipeError("closed pipe")
+
+        def flush(self) -> None:
+            pass
+
+    worker = _WorkerSession("test", "python", sys.executable)
+    try:
+        worker._process.stdin = BrokenStdin()
+        try:
+            worker._request({"op": "run", "code": "1"}, timeout_s=0.2)
+        except RuntimeError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("expected broken pipe")
+    finally:
+        worker.close()
+
+    assert "worker died while accepting a request" in message
+
+
+def test_protocol_error_response_is_not_discarded() -> None:
+    worker = _WorkerSession("test", "python", sys.executable)
+    try:
+        worker._responses.put(
+            {
+                "id": None,
+                "ok": False,
+                "error_name": "WorkerProtocolError",
+                "traceback": "bad stdout",
+            }
+        )
+        try:
+            worker._request({"op": "run", "code": "import time; time.sleep(5)"}, timeout_s=1)
+        except RuntimeError as exc:
+            message = str(exc)
+        else:
+            raise AssertionError("expected protocol error")
+    finally:
+        worker.close()
+
+    assert "WorkerProtocolError" in message
+    assert "bad stdout" in message
 
 
 def test_manager_returns_structured_error_if_worker_dies_before_run() -> None:

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import sys
+import time
+
 from agent_repl import ReplManager
+from agent_repl.manager import ReplTimeout, _WorkerSession
 
 
 def test_plain_python_session_persists_state() -> None:
@@ -46,6 +50,23 @@ def test_timeout_kills_only_that_session() -> None:
     assert still_alive.result_repr == "7"
     assert restarted.ok
     assert restarted.result_repr == "99"
+
+
+def test_timeout_budget_is_not_reset_by_discarded_responses() -> None:
+    worker = _WorkerSession("test", "python", sys.executable)
+    try:
+        worker._responses.put({"id": None, "ok": False})
+        started = time.monotonic()
+        try:
+            worker._request({"op": "run", "code": "import time; time.sleep(5)"}, timeout_s=0.2)
+        except ReplTimeout:
+            elapsed = time.monotonic() - started
+        else:
+            raise AssertionError("expected timeout")
+    finally:
+        worker.close()
+
+    assert elapsed < 0.35
 
 
 def test_ipython_backend_captures_rich_display() -> None:

--- a/examples/agent-repl/tests/test_manager.py
+++ b/examples/agent-repl/tests/test_manager.py
@@ -116,6 +116,43 @@ def test_protocol_error_response_is_not_discarded() -> None:
     assert "bad stdout" in message
 
 
+def test_user_exit_becomes_structured_session_error() -> None:
+    manager = ReplManager(backend="python")
+    try:
+        exited = manager.run("import sys; sys.exit(3)", timeout_s=1)
+        restarted = manager.run("42")
+    finally:
+        manager.close()
+
+    assert not exited.ok
+    assert exited.error_name == "SessionUnavailable"
+    assert "worker exited before responding" in (exited.traceback or "")
+    assert restarted.ok
+    assert restarted.result_repr == "42"
+
+
+def test_background_thread_print_does_not_corrupt_transport() -> None:
+    manager = ReplManager(backend="python")
+    try:
+        started = manager.run(
+            "import threading, time\n"
+            "def later():\n"
+            "    time.sleep(0.1)\n"
+            "    print('late background output')\n"
+            "threading.Thread(target=later).start()\n"
+            "'started'"
+        )
+        time.sleep(0.2)
+        after = manager.run("21 + 21")
+    finally:
+        manager.close()
+
+    assert started.ok
+    assert started.result_repr == "'started'"
+    assert after.ok
+    assert after.result_repr == "42"
+
+
 def test_manager_returns_structured_error_if_worker_dies_before_run() -> None:
     class BrokenWorker:
         backend = "python"


### PR DESCRIPTION
## Summary

- Add `examples/agent-repl`, a standalone prototype package for a persistent Python REPL tool that can run as an MCP server or be imported inline.
- Implement named sessions backed by separate worker processes, with IPython and stdlib Python backends, result capture, reset/status tools, timeout-kill behavior, and focused tests.
- Add `docs/architecture/agent-repl-prototype.md` as the reference write-up for the presentation framing and where this simpler shape stops being enough.

## Why

This gives us a concrete comparison point for the presentation: persistent REPL usage does not require the full nteract notebook/runtime stack. The prototype isolates the small version of the problem while the doc explains when the notebook machinery becomes justified.

## Validation

- `uv run --project examples/agent-repl pytest -q`
- `uv run --project examples/agent-repl ruff check .`
- `uv run --project examples/agent-repl ruff format --check .`
- `uv run --project examples/agent-repl python -c "from agent_repl.mcp_server import mcp; print(mcp.name if hasattr(mcp, 'name') else 'ok')"`
- inline smoke with `ReplManager`
- `cargo xtask lint --fix`

## Adversarial Review

- `uv run pr-review https://github.com/nteract/nteract/pull/2957 --max-turns 120 --out .context/reviews/pr-2957-round6.json`
- Final verdict: `clear`
- Terminal reason: `review_complete`
