### PR TITLE
feat(mcp-app): adapt structured output for shared renderer

### DIFF
--- a/docs/superpowers/specs/mcp-app-renderer-unification.md
+++ b/docs/superpowers/specs/mcp-app-renderer-unification.md
@@ -1,0 +1,53 @@
+# MCP App Renderer Unification
+
+The MCP App output view should converge on the same isolated output renderer used
+by the desktop app. The long-term target is a thin MCP App shell that receives
+`ui/notifications/tool-result`, adapts nteract `structuredContent`, and delegates
+all rich output rendering to `createNteractOutputEmbed`.
+
+## Why Not Import Output Components Directly?
+
+The MCP App document is already the spec-level app iframe. Rendering notebook
+HTML directly in that document would put untrusted cell output in the same
+JavaScript realm as the MCP Apps JSON-RPC bridge. That differs from the desktop
+app, where rich HTML runs inside the sandboxed isolated output frame.
+
+The safe shared boundary is therefore:
+
+1. Host renders `ui://nteract/output.html` as an MCP App.
+2. The MCP App receives tool results via MCP Apps JSON-RPC.
+3. The MCP App converts nteract structured content into shared output manifests.
+4. `createNteractOutputEmbed` creates a nested sandboxed nteract output frame.
+5. The nested frame uses the shared renderer bundle and renderer plugins.
+
+This keeps notebook output isolated from both the host page and the MCP App
+control plane.
+
+## Spec Alignment
+
+The MCP Apps spec makes three parts relevant to this migration:
+
+- The nteract UI resource remains `text/html;profile=mcp-app` and is linked from
+  tools through `_meta.ui.resourceUri`.
+- The app view reports body size via `ui/notifications/size-changed` and receives
+  host sizing through `HostContext.containerDimensions`.
+- Nested frames are a declared CSP surface through `ui.csp.frameDomains`, so the
+  final runtime flip needs host-specific validation for the nested isolated
+  frame source before we require it in Claude/Codex.
+
+## Migration Slices
+
+1. Add a structured-content adapter that turns current MCP App `cell.outputs`
+   into shared isolated renderer manifests and proves those manifests resolve
+   through `resolveEmbeddableOutputs`.
+2. Add an MCP App renderer bundle provider. Prefer daemon-served renderer assets
+   or a build-time virtual bundle, but avoid depending on Git LFS pointer files
+   in local source checkouts.
+3. Render one rich-output path through `createNteractOutputEmbed` under the MCP
+   App shell, starting with HTML/SVG where the current app has the most layout
+   drift from the desktop renderer.
+4. Extend the MCP resource CSP metadata for the nested frame source once the
+   source is concrete for each host surface.
+5. Delete the duplicate MCP App MIME components and plugin registry after the
+   shared renderer path covers text, images, HTML/SVG, errors, markdown,
+   Plotly/Vega/Leaflet, and Sift.

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { resolveEmbeddableOutputs } from "../embeddable-output";
+import {
+  createMcpAppBlobResolver,
+  mcpAppCellsToSharedOutputs,
+  mcpAppStructuredContentToSharedOutputInputs,
+  type McpAppCellData,
+  type McpAppStructuredContent,
+} from "../mcp-app-structured-content";
+
+function cellWithOutputs(outputs: McpAppCellData["outputs"]): McpAppCellData {
+  return {
+    cell_id: "cell-1",
+    cell_type: "code",
+    source: "display(value)",
+    outputs,
+    execution_count: 1,
+    status: "done",
+  };
+}
+
+describe("MCP App structured content adapter", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("converts blob-backed HTML into shared manifests resolved by the isolated renderer path", async () => {
+    const fetchImpl = vi.fn(async () => new Response("<strong>from blob</strong>"));
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const content: McpAppStructuredContent = {
+      blob_base_url: "http://localhost:47830",
+      cell: cellWithOutputs([
+        {
+          output_id: "html-output",
+          output_type: "display_data",
+          data: {
+            "text/html": "http://localhost:47830/blob/html-hash",
+            "text/plain": "fallback",
+          },
+        },
+      ]),
+    };
+
+    const { outputs, resolveOptions } = mcpAppStructuredContentToSharedOutputInputs(content);
+    const [payload] = await resolveEmbeddableOutputs(outputs, resolveOptions);
+
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:47830/blob/html-hash");
+    expect(payload).toMatchObject({
+      mimeType: "text/html",
+      data: "<strong>from blob</strong>",
+      outputId: "html-output",
+      outputIndex: 0,
+    });
+  });
+
+  it("keeps raster image blobs as URLs for shared image rendering", async () => {
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "image-output",
+            output_type: "display_data",
+            data: {
+              "image/png": "http://localhost:47830/blob/image-hash",
+              "text/plain": "<Figure size 1100x520 with 1 Axes>",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830"),
+    });
+
+    expect(payload).toMatchObject({
+      mimeType: "image/png",
+      data: "http://localhost:47830/blob/image-hash",
+      outputId: "image-output",
+    });
+  });
+
+  it("synthesizes stable output ids for legacy MCP structured content", () => {
+    const [output] = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "hello",
+          },
+        ]),
+      ],
+      undefined,
+    );
+
+    expect(output).toMatchObject({
+      output_id: "cell-1:output:0",
+      output_type: "stream",
+      text: { inline: "hello" },
+    });
+  });
+
+  it("preserves stream and error payloads as shared manifests", async () => {
+    const { outputs, resolveOptions } = mcpAppStructuredContentToSharedOutputInputs({
+      cell: cellWithOutputs([
+        {
+          output_id: "stream-output",
+          output_type: "stream",
+          name: "stderr",
+          text: "warn\n",
+        },
+        {
+          output_id: "error-output",
+          output_type: "error",
+          ename: "ValueError",
+          evalue: "bad",
+          traceback: ["Traceback line", "ValueError: bad"],
+        },
+      ]),
+    });
+
+    const payloads = await resolveEmbeddableOutputs(outputs, resolveOptions);
+
+    expect(payloads[0]).toMatchObject({
+      mimeType: "text/plain",
+      data: "warn\n",
+      metadata: { streamName: "stderr" },
+      outputId: "stream-output",
+    });
+    expect(payloads[1]).toMatchObject({
+      mimeType: "text/plain",
+      data: "Traceback line\nValueError: bad",
+      metadata: {
+        isError: true,
+        ename: "ValueError",
+        evalue: "bad",
+        traceback: ["Traceback line", "ValueError: bad"],
+      },
+      outputId: "error-output",
+    });
+  });
+});

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -88,6 +88,17 @@ export type {
 } from "./output-manifest";
 export { resolveEmbeddableOutputs } from "./embeddable-output";
 export type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from "./embeddable-output";
+export {
+  createMcpAppBlobResolver,
+  mcpAppCellsToSharedOutputs,
+  mcpAppStructuredContentToSharedOutputInputs,
+} from "./mcp-app-structured-content";
+export type {
+  McpAppCellData,
+  McpAppCellOutput,
+  McpAppStructuredContent,
+  McpSharedOutputInputs,
+} from "./mcp-app-structured-content";
 export type { IdentifiedJupyterOutput } from "./output-payloads";
 // Provider and hook for renderer bundle
 export { IsolatedRendererProvider, useIsolatedRenderer } from "./isolated-renderer-context";

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -1,0 +1,167 @@
+import type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from "./embeddable-output";
+import type { ContentRef, OutputBlobResolver, OutputManifest } from "./output-manifest";
+
+export interface McpAppCellOutput {
+  output_type: "stream" | "error" | "display_data" | "execute_result";
+  output_id?: string;
+  name?: string;
+  text?: string;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[] | string;
+  data?: Record<string, string>;
+  execution_count?: number | null;
+}
+
+export interface McpAppCellData {
+  cell_id: string;
+  cell_type: string;
+  source: string;
+  outputs: McpAppCellOutput[];
+  execution_count: number | null;
+  status: string;
+}
+
+export interface McpAppStructuredContent {
+  cell?: McpAppCellData;
+  cells?: McpAppCellData[];
+  blob_base_url?: string;
+}
+
+export interface McpSharedOutputInputs {
+  outputs: NteractEmbeddableOutput[];
+  resolveOptions: ResolveEmbeddableOutputsOptions;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function blobHashFromUrl(value: string, blobBaseUrl: string | undefined): string | null {
+  if (!blobBaseUrl) return null;
+
+  const prefix = `${trimTrailingSlash(blobBaseUrl)}/blob/`;
+  if (!value.startsWith(prefix)) return null;
+
+  const hash = value.slice(prefix.length).split(/[?#]/, 1)[0];
+  return hash ? decodeURIComponent(hash) : null;
+}
+
+function contentRefFromValue(value: unknown, blobBaseUrl: string | undefined): ContentRef {
+  if (typeof value === "string") {
+    const blob = blobHashFromUrl(value, blobBaseUrl);
+    if (blob) return { blob };
+    return { inline: value };
+  }
+
+  return { inline: JSON.stringify(value) };
+}
+
+function fallbackOutputId(cell: McpAppCellData, outputIndex: number): string {
+  return `${cell.cell_id}:output:${outputIndex}`;
+}
+
+function cellOutputToManifest(
+  cell: McpAppCellData,
+  output: McpAppCellOutput,
+  outputIndex: number,
+  blobBaseUrl: string | undefined,
+): OutputManifest | null {
+  const output_id = output.output_id ?? fallbackOutputId(cell, outputIndex);
+
+  switch (output.output_type) {
+    case "display_data":
+    case "execute_result": {
+      if (!output.data) return null;
+      const data = Object.fromEntries(
+        Object.entries(output.data).map(([mime, value]) => [
+          mime,
+          contentRefFromValue(value, blobBaseUrl),
+        ]),
+      );
+      if (output.output_type === "execute_result") {
+        return {
+          output_id,
+          output_type: "execute_result",
+          data,
+          metadata: {},
+          execution_count: output.execution_count ?? null,
+        };
+      }
+      return {
+        output_id,
+        output_type: "display_data",
+        data,
+        metadata: {},
+      };
+    }
+    case "stream":
+      return {
+        output_id,
+        output_type: "stream",
+        name: output.name ?? "stdout",
+        text: contentRefFromValue(output.text ?? "", blobBaseUrl),
+      };
+    case "error":
+      return {
+        output_id,
+        output_type: "error",
+        ename: output.ename ?? "Error",
+        evalue: output.evalue ?? "",
+        traceback: Array.isArray(output.traceback)
+          ? { inline: JSON.stringify(output.traceback) }
+          : contentRefFromValue(output.traceback ?? "[]", blobBaseUrl),
+      };
+    default:
+      return null;
+  }
+}
+
+export function mcpAppCellsToSharedOutputs(
+  cells: readonly McpAppCellData[],
+  blobBaseUrl: string | undefined,
+): NteractEmbeddableOutput[] {
+  return cells.flatMap((cell) =>
+    (cell.outputs ?? []).flatMap((output, index) => {
+      const manifest = cellOutputToManifest(cell, output, index, blobBaseUrl);
+      return manifest ? [manifest] : [];
+    }),
+  );
+}
+
+export function createMcpAppBlobResolver(blobBaseUrl: string): OutputBlobResolver {
+  const base = trimTrailingSlash(blobBaseUrl);
+  const url = (ref: { blob: string }) => `${base}/blob/${encodeURIComponent(ref.blob)}`;
+  return {
+    url,
+    fetch(ref) {
+      return fetch(url(ref));
+    },
+  };
+}
+
+function createInlineOnlyBlobResolver(): OutputBlobResolver {
+  return {
+    url(ref) {
+      throw new Error(`Cannot construct blob URL without blob_base_url: ${ref.blob}`);
+    },
+    fetch(ref) {
+      return Promise.reject(new Error(`Cannot fetch blob without blob_base_url: ${ref.blob}`));
+    },
+  };
+}
+
+export function mcpAppStructuredContentToSharedOutputInputs(
+  content: McpAppStructuredContent,
+): McpSharedOutputInputs {
+  const cells = content.cells ?? (content.cell ? [content.cell] : []);
+  const outputs = mcpAppCellsToSharedOutputs(cells, content.blob_base_url);
+  return {
+    outputs,
+    resolveOptions: {
+      blobResolver: content.blob_base_url
+        ? createMcpAppBlobResolver(content.blob_base_url)
+        : createInlineOnlyBlobResolver(),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a shared MCP App structured-content adapter for the isolated output renderer
- prove MCP App cell outputs resolve through `resolveEmbeddableOutputs`
- document the renderer unification plan and MCP Apps spec constraints

## Verification

- `pnpm test:run src/components/isolated/__tests__/mcp-app-structured-content.test.ts src/components/isolated/__tests__/embeddable-output.test.ts`
- `pnpm --dir apps/mcp-app exec tsc --noEmit`
- `pnpm --dir apps/mcp-app exec vp build`
- `cargo xtask lint --fix`
- `git diff --check`
