### PR TITLE
fix(mcp-app): dedupe shared renderer plugin installs

### DIFF
--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -58,6 +58,9 @@ export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCell
   useEffect(() => {
     if (failed || !targetRef.current || outputs.length === 0) return;
 
+    // The embed lifetime is tied to the output container, not output identity.
+    // Content changes with the same output count are delivered by the render
+    // effect below so the iframe is not torn down between equivalent cells.
     const handle = createNteractOutputEmbed({
       target: targetRef.current,
       rendererBundle: SHARED_RENDERER_BUNDLE,

--- a/apps/mcp-app/src/lib/__tests__/shared-renderer-plugin-loader.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/shared-renderer-plugin-loader.test.ts
@@ -22,6 +22,7 @@ describe("createDaemonRendererPluginLoader", () => {
     const plugin = await loader?.("text/markdown");
 
     expect(plugin).toEqual({
+      id: "markdown",
       code: "module.exports = { install() {} }",
       css: ".markdown-output{}",
     });

--- a/apps/mcp-app/src/lib/shared-renderer-plugin-loader.ts
+++ b/apps/mcp-app/src/lib/shared-renderer-plugin-loader.ts
@@ -43,7 +43,7 @@ export function createDaemonRendererPluginLoader(
       ? rendererPluginAssetUrl(blobBaseUrl, `${info.name}.css`)
       : undefined;
     const promise = Promise.all([fetchText(codeUrl), cssUrl ? fetchText(cssUrl) : undefined])
-      .then(([code, css]) => ({ code, css }))
+      .then(([code, css]) => ({ id: info.name, code, css }))
       .catch((error) => {
         cache.delete(info.name);
         throw error;

--- a/src/components/isolated/__tests__/output-embed.test.ts
+++ b/src/components/isolated/__tests__/output-embed.test.ts
@@ -188,6 +188,49 @@ describe("createNteractOutputEmbed", () => {
     );
   });
 
+  it("installs one shared renderer plugin for multiple MIME aliases", async () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const rendererPluginLoader = vi.fn(async (mime: string) =>
+      mime === "text/markdown" || mime === "text/latex"
+        ? { id: "markdown", code: "markdown plugin", css: ".markdown{}" }
+        : undefined,
+    );
+
+    const handle = createNteractOutputEmbed({
+      target,
+      rendererBundle: { rendererCode: "", rendererCss: "" },
+      rendererPluginLoader,
+    });
+    const frameWindow = handle.iframe.contentWindow!;
+    bootstrapFrame(frameWindow);
+    const transport = MockJsonRpcTransport.instances[0];
+    transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+
+    await handle.renderBatch([
+      {
+        mimeType: "text/markdown",
+        data: "**hello**",
+        outputId: "markdown-output",
+      },
+      {
+        mimeType: "text/latex",
+        data: "$x$",
+        outputId: "latex-output",
+      },
+    ]);
+
+    expect(rendererPluginLoader).toHaveBeenCalledWith("text/markdown");
+    expect(rendererPluginLoader).not.toHaveBeenCalledWith("text/latex");
+    expect(transport.notify).toHaveBeenCalledWith(NTERACT_INSTALL_RENDERER, {
+      code: "markdown plugin",
+      css: ".markdown{}",
+    });
+    expect(
+      transport.notify.mock.calls.filter(([method]) => method === NTERACT_INSTALL_RENDERER),
+    ).toHaveLength(1);
+  });
+
   it("reports renderer bundle provider failures", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -23,6 +23,7 @@ import {
 } from "./renderer-plugin-info";
 
 interface PluginModule {
+  id?: string;
   code: string;
   css?: string;
 }
@@ -67,12 +68,14 @@ export function loadPluginForMime(mime: string): Promise<PluginModule | undefine
   if (cached) return cached;
 
   const loader = PLUGIN_LOADERS[pluginName];
-  const promise = loader().catch((error) => {
-    if (pluginCache.get(pluginName) === promise) {
-      pluginCache.delete(pluginName);
-    }
-    throw error;
-  });
+  const promise = loader()
+    .then((plugin) => ({ ...plugin, id: pluginName }))
+    .catch((error) => {
+      if (pluginCache.get(pluginName) === promise) {
+        pluginCache.delete(pluginName);
+      }
+      throw error;
+    });
   pluginCache.set(pluginName, promise);
   return promise;
 }
@@ -99,7 +102,8 @@ export async function injectPluginsForMimes(
   injectedSet: Set<string>,
 ): Promise<void> {
   for (const mime of mimes) {
-    if (injectedSet.has(mime)) continue;
+    const installKey = rendererPluginNameForMime(mime) ?? mime;
+    if (injectedSet.has(installKey)) continue;
     const plugin = await loadPluginForMime(mime);
     if (!plugin) continue;
     logIsolatedDiagnostic({
@@ -113,6 +117,6 @@ export async function injectPluginsForMimes(
       },
     });
     frame.installRenderer(plugin.code, plugin.css);
-    injectedSet.add(mime);
+    injectedSet.add(installKey);
   }
 }

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -22,12 +22,18 @@ import {
   type ResolveEmbeddableOutputsOptions,
 } from "./embeddable-output";
 import type { OutputBlobResolver } from "./output-manifest";
+import { rendererPluginNameForMime } from "./renderer-plugin-info";
 
 export type NteractOutputRendererBundleProvider =
   | IsolatedFrameRendererBundle
   | (() => Promise<IsolatedFrameRendererBundle>);
 
 export interface NteractOutputRendererPlugin {
+  /**
+   * Stable plugin identity used to avoid reinstalling one plugin for multiple
+   * MIME aliases, such as text/markdown and text/latex.
+   */
+  id?: string;
   code: string;
   css?: string;
 }
@@ -240,11 +246,19 @@ export function createNteractOutputEmbed(
     }
 
     for (const mime of payloads.map((payload) => payload.mimeType)) {
-      if (injectedPlugins.has(mime)) continue;
+      const expectedInstallKey = rendererPluginNameForMime(mime) ?? mime;
+      if (injectedPlugins.has(expectedInstallKey)) continue;
+
       const plugin = await options.rendererPluginLoader(mime);
       if (!plugin) continue;
+      const installKey = plugin.id ?? expectedInstallKey;
+      if (injectedPlugins.has(installKey)) {
+        injectedPlugins.add(expectedInstallKey);
+        continue;
+      }
       runtime.installRenderer(plugin.code, plugin.css);
-      injectedPlugins.add(mime);
+      injectedPlugins.add(installKey);
+      injectedPlugins.add(expectedInstallKey);
     }
   }
 


### PR DESCRIPTION
## Summary

- key shared renderer plugin installation by stable plugin identity instead of MIME alias
- return daemon plugin IDs from the MCP App plugin loader and shared virtual plugin loader
- document the MCP App shared-output embed lifetime split and cover markdown/latex alias dedupe in tests

## Verification

- `pnpm --dir apps/mcp-app exec tsc --noEmit`
- `pnpm --dir apps/renderer-test exec tsc --noEmit`
- `pnpm test:run apps/mcp-app/src/lib/__tests__/host-log.test.ts apps/mcp-app/src/lib/__tests__/shared-renderer-plugin-loader.test.ts src/components/isolated/__tests__/renderer-plugin-info.test.ts src/components/isolated/__tests__/mcp-app-structured-content.test.ts src/components/isolated/__tests__/output-embed.test.ts`
- `pnpm --dir apps/mcp-app exec vp run build`
- `cargo test -p runt-mcp resources --lib`
- `cargo test -p runtimed blob_server --lib`
- `git diff --check`
- `cargo xtask lint --fix`
