### PR TITLE
fix(mcp-app): align shared output frame sizing

### DIFF
--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -24,6 +24,8 @@ const SHARED_RENDERER_BUNDLE: NteractOutputRendererBundleProvider = {
   rendererCss,
 };
 
+const SHARED_OUTPUT_MAX_HEIGHT = 2000;
+
 interface SharedCellOutputsProps {
   cell: CellData;
   blobBaseUrl?: string;
@@ -65,6 +67,8 @@ export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCell
       blobResolver,
       hostContext: hostContextPatchRef.current,
       outputDocumentUrl,
+      autoHeight: false,
+      maxHeight: SHARED_OUTPUT_MAX_HEIGHT,
       onDiagnostic(phase, details, level = "debug", source = "isolated-frame") {
         if (level !== "error" && level !== "warn") return;
         hostLog(level === "warn" ? "warning" : "error", "shared-output-renderer-diagnostic", {

--- a/apps/mcp-app/src/lib/__tests__/shared-host-context.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/shared-host-context.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vite-plus/test";
+import { mcpHostContextToNteractEmbedPatch } from "../shared-host-context";
+
+describe("mcpHostContextToNteractEmbedPatch", () => {
+  it("forwards MCP host theme metadata without reusing outer app dimensions", () => {
+    const patch = mcpHostContextToNteractEmbedPatch(
+      {
+        theme: "dark",
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "fullscreen"],
+        containerDimensions: {
+          width: 614,
+          height: 330,
+        },
+        styles: {
+          variables: {
+            "--color-text-primary": "#fff",
+          },
+          css: {
+            fonts: "@font-face { font-family: Test; src: url(test.woff2); }",
+          },
+        },
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        platform: "desktop",
+      },
+      "http://localhost:47830/",
+    );
+
+    expect(patch).toMatchObject({
+      theme: "dark",
+      displayMode: "inline",
+      availableDisplayModes: ["inline", "fullscreen"],
+      styles: {
+        variables: {
+          "--color-text-primary": "#fff",
+        },
+        css: {
+          fonts: "@font-face { font-family: Test; src: url(test.woff2); }",
+        },
+      },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      platform: "desktop",
+      nteract: {
+        rendererAssetsBaseUrl: "http://localhost:47830/plugins/",
+      },
+    });
+    expect(patch.containerDimensions).toBeUndefined();
+  });
+});

--- a/apps/mcp-app/src/lib/shared-host-context.ts
+++ b/apps/mcp-app/src/lib/shared-host-context.ts
@@ -42,6 +42,8 @@ export function mcpHostContextToNteractEmbedPatch(
     .filter((mode): mode is NteractEmbedDisplayMode => mode !== undefined);
   const rendererAssetsBaseUrl = daemonRendererAssetsBaseUrl(blobBaseUrl);
 
+  // Upstream containerDimensions describe the outer MCP App iframe. The nested
+  // shared output renderer computes its own dimensions from its actual iframe.
   return {
     theme: hostContext?.theme,
     styles:
@@ -53,7 +55,6 @@ export function mcpHostContextToNteractEmbedPatch(
         : undefined,
     displayMode: displayMode(hostContext?.displayMode),
     availableDisplayModes: modes && modes.length > 0 ? modes : undefined,
-    containerDimensions: hostContext?.containerDimensions,
     locale: hostContext?.locale,
     timeZone: hostContext?.timeZone,
     userAgent: hostContext?.userAgent,

--- a/src/components/isolated/__tests__/output-embed.test.ts
+++ b/src/components/isolated/__tests__/output-embed.test.ts
@@ -92,6 +92,35 @@ describe("createNteractOutputEmbed", () => {
     handle.dispose();
   });
 
+  it("advertises and enforces capped height when auto-height is disabled", () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const onSizeChanged = vi.fn();
+
+    const handle = createNteractOutputEmbed({
+      target,
+      rendererBundle: { rendererCode: "", rendererCss: "" },
+      autoHeight: false,
+      maxHeight: 400,
+      onSizeChanged,
+    });
+    const frameWindow = handle.iframe.contentWindow!;
+
+    expect(onSizeChanged).toHaveBeenCalledWith(expect.objectContaining({ maxHeight: 400 }));
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: frameWindow,
+        data: { type: "resize", payload: { height: 900 } },
+      }),
+    );
+
+    expect(handle.iframe.style.height).toBe("400px");
+    expect(onSizeChanged).toHaveBeenCalledWith({ height: 400 });
+
+    handle.dispose();
+  });
+
   it("loads an async renderer bundle after bootstrap", async () => {
     const target = document.createElement("div");
     document.body.appendChild(target);

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -53,7 +53,7 @@ export interface NteractOutputEmbedOptions {
   blobResolver?: OutputBlobResolver;
   autoHeight?: boolean;
   maxHeight?: number;
-  onSizeChanged?: (size: { width?: number; height?: number }) => void;
+  onSizeChanged?: (size: NteractEmbedContainerDimensions) => void;
   onDiagnostic?: NteractOutputEmbedDiagnosticHandler;
   onMessage?: (message: unknown) => void;
   onError?: (error: { message: string; stack?: string }) => void;


### PR DESCRIPTION
## Summary

- make the MCP App shared output frame use the same capped, scrollable sizing mode as the main `IsolatedFrame`
- stop forwarding outer MCP App `containerDimensions` into the nested output renderer context
- type `createNteractOutputEmbed` size callbacks with the full embed container-dimension shape

## Testing

- `pnpm test:run src/components/isolated/__tests__/output-embed.test.ts apps/mcp-app/src/lib/__tests__/shared-host-context.test.ts`
- `cargo xtask lint --fix`
