### PR TITLE
[ipy-opt] Measure blob-backed output segments

### DIFF
--- a/crates/runtimed/examples/output_commit_measure.rs
+++ b/crates/runtimed/examples/output_commit_measure.rs
@@ -1,6 +1,6 @@
 use runtimed::output_commit_measure::{
-    measure_current_output_commit_loop, measure_ordered_worker_output_commit_model,
-    OutputCommitKind, OutputCommitMeasurementConfig,
+    measure_blob_segment_output_model, measure_current_output_commit_loop,
+    measure_ordered_worker_output_commit_model, OutputCommitKind, OutputCommitMeasurementConfig,
 };
 
 #[tokio::main]
@@ -19,6 +19,10 @@ async fn main() -> anyhow::Result<()> {
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(256);
+    let segment_size = std::env::var("NTERACT_OUTPUT_COMMIT_SEGMENT_SIZE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(128);
 
     for kind in [
         OutputCommitKind::DisplayData,
@@ -30,12 +34,16 @@ async fn main() -> anyhow::Result<()> {
                 output_count,
                 payload_bytes,
                 kind,
+                segment_size,
             };
             let current = measure_current_output_commit_loop(config).await?;
             println!("{}", serde_json::to_string(&current)?);
 
             let worker = measure_ordered_worker_output_commit_model(config).await?;
             println!("{}", serde_json::to_string(&worker)?);
+
+            let segment = measure_blob_segment_output_model(config).await?;
+            println!("{}", serde_json::to_string(&segment)?);
         }
     }
 

--- a/crates/runtimed/src/output_commit_measure.rs
+++ b/crates/runtimed/src/output_commit_measure.rs
@@ -10,6 +10,8 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 use anyhow::{ensure, Context};
+use automerge::sync;
+use notebook_protocol::protocol::BlobDurability;
 use runtime_doc::RuntimeStateDoc;
 use serde::Serialize;
 use uuid::Uuid;
@@ -19,6 +21,8 @@ use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 
 const EXECUTION_ID: &str = "exec-output-commit-measure";
+const OUTPUT_SEGMENT_MIME: &str = "application/vnd.nteract.output-segment+json";
+const DEFAULT_SEGMENT_SIZE: usize = 128;
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -43,6 +47,7 @@ pub struct OutputCommitMeasurementConfig {
     pub output_count: usize,
     pub payload_bytes: usize,
     pub kind: OutputCommitKind,
+    pub segment_size: usize,
 }
 
 impl Default for OutputCommitMeasurementConfig {
@@ -51,6 +56,7 @@ impl Default for OutputCommitMeasurementConfig {
             output_count: 100,
             payload_bytes: 256,
             kind: OutputCommitKind::DisplayData,
+            segment_size: DEFAULT_SEGMENT_SIZE,
         }
     }
 }
@@ -65,12 +71,23 @@ pub struct OutputCommitMeasurement {
     pub buffer_preflights: usize,
     pub manifest_creations: usize,
     pub output_appends: usize,
+    pub doc_append_calls: usize,
     pub enqueued_outputs: usize,
     pub committed_outputs: usize,
+    pub durable_output_entries: usize,
+    pub segment_blobs: usize,
+    pub segment_bytes: usize,
+    pub doc_save_bytes: usize,
+    pub sync_daemon_messages: usize,
+    pub sync_daemon_bytes: usize,
+    pub sync_peer_messages: usize,
+    pub sync_peer_bytes: usize,
     pub iopub_nanos: u128,
     pub preflight_nanos: u128,
     pub manifest_nanos: u128,
     pub append_nanos: u128,
+    pub segment_write_nanos: u128,
+    pub sync_nanos: u128,
     pub worker_nanos: u128,
     pub total_nanos: u128,
 }
@@ -86,16 +103,35 @@ impl OutputCommitMeasurement {
             buffer_preflights: 0,
             manifest_creations: 0,
             output_appends: 0,
+            doc_append_calls: 0,
             enqueued_outputs: 0,
             committed_outputs: 0,
+            durable_output_entries: 0,
+            segment_blobs: 0,
+            segment_bytes: 0,
+            doc_save_bytes: 0,
+            sync_daemon_messages: 0,
+            sync_daemon_bytes: 0,
+            sync_peer_messages: 0,
+            sync_peer_bytes: 0,
             iopub_nanos: 0,
             preflight_nanos: 0,
             manifest_nanos: 0,
             append_nanos: 0,
+            segment_write_nanos: 0,
+            sync_nanos: 0,
             worker_nanos: 0,
             total_nanos: 0,
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct SyncMeasurement {
+    daemon_messages: usize,
+    daemon_bytes: usize,
+    peer_messages: usize,
+    peer_bytes: usize,
 }
 
 #[derive(Debug)]
@@ -115,6 +151,7 @@ pub async fn measure_current_output_commit_loop(
     let mut doc = RuntimeStateDoc::new();
     doc.create_execution_with_source(EXECUTION_ID, "pass", 0)?;
     doc.set_execution_running(EXECUTION_ID)?;
+    let mut sync_peer = SyncPeer::after_initial_sync(&mut doc)?;
 
     let started = Instant::now();
     let mut metrics = OutputCommitMeasurement::new("current", config);
@@ -145,6 +182,7 @@ pub async fn measure_current_output_commit_loop(
         doc.append_output(EXECUTION_ID, &manifest.to_json())?;
         metrics.append_nanos += append_started.elapsed().as_nanos();
         metrics.output_appends += 1;
+        metrics.doc_append_calls += 1;
         metrics.committed_outputs += 1;
         metrics.iopub_nanos += iopub_started.elapsed().as_nanos();
         metrics.iopub_messages_observed += 1;
@@ -154,6 +192,7 @@ pub async fn measure_current_output_commit_loop(
         doc.get_outputs(EXECUTION_ID).len() == config.output_count,
         "current output commit loop committed an unexpected number of outputs"
     );
+    finalize_doc_metrics(&mut metrics, &mut doc, &mut sync_peer)?;
     metrics.total_nanos = started.elapsed().as_nanos();
     let _ = tokio::fs::remove_dir_all(&blob_root).await;
     Ok(metrics)
@@ -171,6 +210,7 @@ pub async fn measure_ordered_worker_output_commit_model(
     let mut doc = RuntimeStateDoc::new();
     doc.create_execution_with_source(EXECUTION_ID, "pass", 0)?;
     doc.set_execution_running(EXECUTION_ID)?;
+    let mut sync_peer = SyncPeer::after_initial_sync(&mut doc)?;
 
     let started = Instant::now();
     let mut metrics = OutputCommitMeasurement::new("ordered_worker_model", config);
@@ -187,6 +227,7 @@ pub async fn measure_ordered_worker_output_commit_model(
     }
 
     let worker_started = Instant::now();
+    let mut manifests = Vec::with_capacity(config.output_count);
     while let Some(output) = queue.pop_front() {
         if uses_iopub_buffer_preflight(config.kind) {
             let preflight_started = Instant::now();
@@ -206,12 +247,16 @@ pub async fn measure_ordered_worker_output_commit_model(
         .context("create output manifest")?;
         metrics.manifest_nanos += manifest_started.elapsed().as_nanos();
         metrics.manifest_creations += 1;
-
-        let append_started = Instant::now();
-        doc.append_output(EXECUTION_ID, &manifest.to_json())?;
-        metrics.append_nanos += append_started.elapsed().as_nanos();
-        metrics.output_appends += 1;
+        manifests.push(manifest.to_json());
         metrics.committed_outputs += 1;
+    }
+
+    for chunk in manifests.chunks(effective_segment_size(config.segment_size)) {
+        let append_started = Instant::now();
+        doc.append_outputs(EXECUTION_ID, chunk)?;
+        metrics.append_nanos += append_started.elapsed().as_nanos();
+        metrics.output_appends += chunk.len();
+        metrics.doc_append_calls += 1;
     }
     metrics.worker_nanos = worker_started.elapsed().as_nanos();
 
@@ -219,6 +264,123 @@ pub async fn measure_ordered_worker_output_commit_model(
         doc.get_outputs(EXECUTION_ID).len() == config.output_count,
         "ordered worker model committed an unexpected number of outputs"
     );
+    finalize_doc_metrics(&mut metrics, &mut doc, &mut sync_peer)?;
+    metrics.total_nanos = started.elapsed().as_nanos();
+    let _ = tokio::fs::remove_dir_all(&blob_root).await;
+    Ok(metrics)
+}
+
+/// Model a blob-backed output segment.
+///
+/// The kernel-facing work is unchanged: every IOPub output still becomes a
+/// normal `OutputManifest`, including blob offload for large MIME values. The
+/// difference is the durable runtime-state shape: each segment stores a compact
+/// ordered child-manifest array in blob storage and appends one segment manifest
+/// to RuntimeStateDoc. A production version would need projection/resolution
+/// support before clients could consume this shape.
+pub async fn measure_blob_segment_output_model(
+    config: OutputCommitMeasurementConfig,
+) -> anyhow::Result<OutputCommitMeasurement> {
+    let blob_root = output_commit_measure_blob_root();
+    tokio::fs::create_dir_all(&blob_root)
+        .await
+        .with_context(|| format!("create blob root {}", blob_root.display()))?;
+    let blob_store = BlobStore::new(blob_root.clone());
+    let redactor = OutputRedactor::disabled();
+    let mut doc = RuntimeStateDoc::new();
+    doc.create_execution_with_source(EXECUTION_ID, "pass", 0)?;
+    doc.set_execution_running(EXECUTION_ID)?;
+    let mut sync_peer = SyncPeer::after_initial_sync(&mut doc)?;
+
+    let started = Instant::now();
+    let mut metrics = OutputCommitMeasurement::new("blob_segment_model", config);
+    let mut queue = VecDeque::with_capacity(config.output_count);
+
+    for index in 0..config.output_count {
+        let iopub_started = Instant::now();
+        queue.push_back(QueuedOutput {
+            value: measured_output(config.kind, index, config.payload_bytes),
+        });
+        metrics.iopub_nanos += iopub_started.elapsed().as_nanos();
+        metrics.iopub_messages_observed += 1;
+        metrics.enqueued_outputs += 1;
+    }
+
+    let worker_started = Instant::now();
+    let mut child_manifests = Vec::with_capacity(config.output_count);
+    while let Some(output) = queue.pop_front() {
+        if uses_iopub_buffer_preflight(config.kind) {
+            let preflight_started = Instant::now();
+            output_store::preflight_ref_buffers(&output.value, &[], &blob_store).await;
+            metrics.preflight_nanos += preflight_started.elapsed().as_nanos();
+            metrics.buffer_preflights += 1;
+        }
+
+        let manifest_started = Instant::now();
+        let manifest = output_store::create_manifest_with_redactor(
+            &output.value,
+            &blob_store,
+            DEFAULT_INLINE_THRESHOLD,
+            &redactor,
+        )
+        .await
+        .context("create output manifest")?;
+        metrics.manifest_nanos += manifest_started.elapsed().as_nanos();
+        metrics.manifest_creations += 1;
+        child_manifests.push(manifest.to_json());
+        metrics.committed_outputs += 1;
+    }
+
+    for segment_children in child_manifests.chunks(effective_segment_size(config.segment_size)) {
+        let segment_started = Instant::now();
+        let segment_payload = serde_json::json!({
+            "version": 1,
+            "outputs": segment_children,
+        });
+        let segment_bytes = serde_json::to_vec(&segment_payload)?;
+        let segment_hash = blob_store
+            .put_with_durability(
+                &segment_bytes,
+                OUTPUT_SEGMENT_MIME,
+                BlobDurability::Ephemeral,
+            )
+            .await?;
+        metrics.segment_write_nanos += segment_started.elapsed().as_nanos();
+        metrics.segment_blobs += 1;
+        metrics.segment_bytes += segment_bytes.len();
+
+        let first_output_id = segment_children
+            .first()
+            .and_then(runtime_doc::extract_output_id);
+        let last_output_id = segment_children
+            .last()
+            .and_then(runtime_doc::extract_output_id);
+        let segment_manifest = serde_json::json!({
+            "output_type": "output_segment",
+            "output_id": Uuid::new_v4().to_string(),
+            "segment": {
+                "blob": segment_hash,
+                "size": segment_bytes.len(),
+                "media_type": OUTPUT_SEGMENT_MIME,
+                "count": segment_children.len(),
+                "first_output_id": first_output_id,
+                "last_output_id": last_output_id,
+            },
+        });
+
+        let append_started = Instant::now();
+        doc.append_output(EXECUTION_ID, &segment_manifest)?;
+        metrics.append_nanos += append_started.elapsed().as_nanos();
+        metrics.output_appends += segment_children.len();
+        metrics.doc_append_calls += 1;
+    }
+    metrics.worker_nanos = worker_started.elapsed().as_nanos();
+
+    ensure!(
+        doc.get_outputs(EXECUTION_ID).len() == metrics.segment_blobs,
+        "blob segment model committed an unexpected number of segment outputs"
+    );
+    finalize_doc_metrics(&mut metrics, &mut doc, &mut sync_peer)?;
     metrics.total_nanos = started.elapsed().as_nanos();
     let _ = tokio::fs::remove_dir_all(&blob_root).await;
     Ok(metrics)
@@ -226,6 +388,82 @@ pub async fn measure_ordered_worker_output_commit_model(
 
 fn output_commit_measure_blob_root() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("runtimed-output-commit-measure-{}", Uuid::new_v4()))
+}
+
+fn effective_segment_size(segment_size: usize) -> usize {
+    segment_size.max(1)
+}
+
+struct SyncPeer {
+    doc: RuntimeStateDoc,
+    daemon_state: sync::State,
+    peer_state: sync::State,
+}
+
+impl SyncPeer {
+    fn after_initial_sync(daemon_doc: &mut RuntimeStateDoc) -> anyhow::Result<Self> {
+        let mut peer = Self {
+            doc: RuntimeStateDoc::new(),
+            daemon_state: sync::State::new(),
+            peer_state: sync::State::new(),
+        };
+        sync_runtime_docs(daemon_doc, &mut peer)?;
+        Ok(peer)
+    }
+}
+
+fn finalize_doc_metrics(
+    metrics: &mut OutputCommitMeasurement,
+    doc: &mut RuntimeStateDoc,
+    sync_peer: &mut SyncPeer,
+) -> anyhow::Result<()> {
+    metrics.durable_output_entries = doc.get_outputs(EXECUTION_ID).len();
+    metrics.doc_save_bytes = doc.doc_mut().save().len();
+
+    let sync_started = Instant::now();
+    let sync = sync_runtime_docs(doc, sync_peer)?;
+    metrics.sync_nanos = sync_started.elapsed().as_nanos();
+    metrics.sync_daemon_messages = sync.daemon_messages;
+    metrics.sync_daemon_bytes = sync.daemon_bytes;
+    metrics.sync_peer_messages = sync.peer_messages;
+    metrics.sync_peer_bytes = sync.peer_bytes;
+    Ok(())
+}
+
+fn sync_runtime_docs(
+    daemon_doc: &mut RuntimeStateDoc,
+    peer: &mut SyncPeer,
+) -> anyhow::Result<SyncMeasurement> {
+    let mut stats = SyncMeasurement::default();
+    for _ in 0..100 {
+        let mut progressed = false;
+
+        if let Some(message) = daemon_doc.generate_sync_message(&mut peer.daemon_state) {
+            let encoded = message.clone().encode();
+            stats.daemon_messages += 1;
+            stats.daemon_bytes += encoded.len();
+            peer.doc
+                .receive_sync_message_with_changes(&mut peer.peer_state, message)
+                .context("peer receive runtime-state sync")?;
+            progressed = true;
+        }
+
+        if let Some(message) = peer.doc.generate_sync_message(&mut peer.peer_state) {
+            let encoded = message.clone().encode();
+            stats.peer_messages += 1;
+            stats.peer_bytes += encoded.len();
+            daemon_doc
+                .receive_sync_message_with_changes(&mut peer.daemon_state, message)
+                .context("daemon receive runtime-state sync")?;
+            progressed = true;
+        }
+
+        if !progressed {
+            return Ok(stats);
+        }
+    }
+
+    anyhow::bail!("runtime-state docs did not converge within 100 sync rounds")
 }
 
 fn measured_output(
@@ -286,6 +524,7 @@ mod tests {
             output_count: 4,
             payload_bytes: 16,
             kind: OutputCommitKind::DisplayData,
+            ..Default::default()
         })
         .await
         .expect("measurement should run");
@@ -294,8 +533,12 @@ mod tests {
         assert_eq!(metrics.buffer_preflights, 4);
         assert_eq!(metrics.manifest_creations, 4);
         assert_eq!(metrics.output_appends, 4);
+        assert_eq!(metrics.doc_append_calls, 4);
         assert_eq!(metrics.committed_outputs, 4);
         assert_eq!(metrics.enqueued_outputs, 0);
+        assert_eq!(metrics.durable_output_entries, 4);
+        assert!(metrics.doc_save_bytes > 0);
+        assert!(metrics.sync_daemon_bytes > 0);
     }
 
     #[tokio::test]
@@ -304,6 +547,7 @@ mod tests {
             output_count: 4,
             payload_bytes: 16,
             kind: OutputCommitKind::ExecuteResult,
+            ..Default::default()
         })
         .await
         .expect("measurement should run");
@@ -313,6 +557,34 @@ mod tests {
         assert_eq!(metrics.buffer_preflights, 4);
         assert_eq!(metrics.manifest_creations, 4);
         assert_eq!(metrics.output_appends, 4);
+        assert_eq!(metrics.doc_append_calls, 1);
         assert_eq!(metrics.committed_outputs, 4);
+        assert_eq!(metrics.durable_output_entries, 4);
+        assert!(metrics.doc_save_bytes > 0);
+        assert!(metrics.sync_daemon_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn blob_segment_model_reduces_durable_output_entries() {
+        let metrics = measure_blob_segment_output_model(OutputCommitMeasurementConfig {
+            output_count: 5,
+            payload_bytes: 16,
+            kind: OutputCommitKind::DisplayData,
+            segment_size: 2,
+        })
+        .await
+        .expect("measurement should run");
+
+        assert_eq!(metrics.iopub_messages_observed, 5);
+        assert_eq!(metrics.enqueued_outputs, 5);
+        assert_eq!(metrics.manifest_creations, 5);
+        assert_eq!(metrics.output_appends, 5);
+        assert_eq!(metrics.doc_append_calls, 3);
+        assert_eq!(metrics.committed_outputs, 5);
+        assert_eq!(metrics.segment_blobs, 3);
+        assert_eq!(metrics.durable_output_entries, 3);
+        assert!(metrics.segment_bytes > 0);
+        assert!(metrics.doc_save_bytes > 0);
+        assert!(metrics.sync_daemon_bytes > 0);
     }
 }

--- a/docs/architecture/output-commit-measurements.md
+++ b/docs/architecture/output-commit-measurements.md
@@ -1,55 +1,146 @@
-# Non-Stream Output Commit Measurements
+# Non-Stream Output Commit and Segment Measurements
 
-This measurement covers the remaining ordinary output path after the stream
-and `update_display_data` optimizations:
+This measurement covers ordinary output work after the stream,
+`update_display_data`, and ordered output-committer optimizations:
 
 - `display_data`
 - `execute_result`
 - `error`
 
-These outputs still run manifest creation and `RuntimeStateDoc.append_output`
-on the IOPub reader task. For `display_data` and `execute_result`, the
-measurement also includes the current blob-ref buffer preflight call with an
-empty buffer list. The measurement compares that current synchronous shape
-against an ordered-worker model where the IOPub-facing work is only an ordered
-enqueue and the same preflight, manifest, and doc writes happen later on a
-worker.
+The production path now keeps the IOPub reader hot by queueing these outputs
+and committing them in ordered batches. That fixes the reader-stall failure, but
+it does not change the storage contract: 1000 kernel outputs still become 1000
+RuntimeStateDoc output entries and one large Automerge sync frame.
+
+This benchmark now measures two separate costs:
+
+- **Hot-path work**: how much work runs before the IOPub reader can observe the
+  next kernel message.
+- **Document/sync amplification**: how many RuntimeStateDoc entries, saved-doc
+  bytes, and encoded Automerge sync bytes are produced for a burst.
 
 ## Running
 
 ```bash
 NTERACT_OUTPUT_COMMIT_COUNTS=10,100 \
 NTERACT_OUTPUT_COMMIT_PAYLOAD_BYTES=256 \
+NTERACT_OUTPUT_COMMIT_SEGMENT_SIZE=128 \
 cargo run -p runtimed --example output_commit_measure
 ```
 
 Each output line is JSON. The useful fields are:
 
-- `strategy`: `current` or `ordered_worker_model`
+- `strategy`: `current`, `ordered_worker_model`, or `blob_segment_model`
 - `kind`: `display_data`, `execute_result`, or `error`
 - `iopub_nanos`: time spent on the modeled IOPub reader path
 - `preflight_nanos`: time spent in display/execute blob-ref preflight
-- `worker_nanos`: time spent on worker-side manifest/doc writes
+- `worker_nanos`: time spent on worker-side manifest/doc/segment writes
 - `committed_outputs`: proof that both strategies commit the same number of outputs
+- `durable_output_entries`: number of RuntimeStateDoc output entries written
+- `doc_append_calls`: number of RuntimeStateDoc append calls
+- `doc_save_bytes`: saved Automerge document size after the burst
+- `sync_daemon_bytes`: encoded daemon-to-peer RuntimeStateDoc sync bytes after
+  the burst
+- `segment_blobs` / `segment_bytes`: segment blob count and total serialized
+  segment payload bytes, only for `blob_segment_model`
 
 Example shape:
 
 ```json
-{"strategy":"current","output_count":100,"payload_bytes":256,"kind":"display_data","iopub_nanos":405622706,"preflight_nanos":12624,"worker_nanos":0,"committed_outputs":100}
-{"strategy":"ordered_worker_model","output_count":100,"payload_bytes":256,"kind":"display_data","iopub_nanos":237084,"preflight_nanos":10378,"worker_nanos":394422709,"committed_outputs":100}
+{"strategy":"ordered_worker_model","output_count":1000,"payload_bytes":256,"kind":"display_data","durable_output_entries":1000,"doc_save_bytes":60705,"sync_daemon_bytes":434021,"committed_outputs":1000}
+{"strategy":"blob_segment_model","output_count":1000,"payload_bytes":256,"kind":"display_data","durable_output_entries":8,"segment_blobs":8,"segment_bytes":374200,"doc_save_bytes":2387,"sync_daemon_bytes":3452,"committed_outputs":1000}
 ```
 
-The local sample above shows the tradeoff: an ordered worker does not remove
-blob preflight, manifest, or Automerge write cost, but it moves that cost off
-the IOPub reader. This benchmark intentionally isolates ordinary non-stream
-output commits; stream-boundary flushes remain a separate ordering requirement.
-That is the optimization target for a follow-up implementation PR: keep
-`ExecutionDone` causally after durable output writes while preventing ordinary
-rich output bursts from delaying later IOPub status and control observations.
+The local sample above shows the next bottleneck. The ordered worker moves work
+off the IOPub reader and batches `append_outputs`, but the flat output model
+still produces the same Automerge sync payload as 1000 individual durable
+entries. A blob-backed segment changes the document shape: RuntimeStateDoc
+stores one ordered segment ref per chunk, while blob storage carries the ordered
+child manifests.
 
 The ordered-worker model uses an in-memory queue to isolate enqueue cost. A
 production queue must still be bounded or otherwise capacity-limited so sustained
 rich-output bursts do not trade IOPub latency for unbounded memory growth.
+
+## Local Sample
+
+Command:
+
+```bash
+NTERACT_OUTPUT_COMMIT_COUNTS=100,500,1000 \
+NTERACT_OUTPUT_COMMIT_PAYLOAD_BYTES=256 \
+NTERACT_OUTPUT_COMMIT_SEGMENT_SIZE=128 \
+cargo run -q -p runtimed --example output_commit_measure
+```
+
+Representative `display_data` results:
+
+| N | Strategy | Durable entries | Doc append calls | Saved doc bytes | Sync bytes | Segment bytes | Total time |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 100 | current | 100 | 100 | 6,784 | 43,448 | 0 | 454 ms |
+| 100 | ordered_worker_model | 100 | 1 | 6,800 | 43,448 | 0 | 169 ms |
+| 100 | blob_segment_model | 1 | 1 | 1,131 | 579 | 37,425 | 4.8 ms |
+| 500 | current | 500 | 500 | 30,626 | 217,021 | 0 | 10.7 s |
+| 500 | ordered_worker_model | 500 | 4 | 30,654 | 217,021 | 0 | 3.3 s |
+| 500 | blob_segment_model | 4 | 4 | 1,683 | 1,806 | 187,100 | 21 ms |
+| 1000 | current | 1000 | 1000 | 60,705 | 434,021 | 0 | 43.0 s |
+| 1000 | ordered_worker_model | 1000 | 8 | 60,705 | 434,021 | 0 | 12.8 s |
+| 1000 | blob_segment_model | 8 | 8 | 2,387 | 3,452 | 374,200 | 47 ms |
+
+For `execute_result` and `error`, the same shape holds. At N=1000,
+`execute_result` flat sync was 457,955 bytes versus 3,452 bytes for segments;
+`error` flat sync was 705,038 bytes versus 3,452 bytes for segments.
+
+Wall-clock numbers are local-machine benchmark artifacts. The more stable
+result is the amplification ratio: segment refs keep Automerge traffic nearly
+constant with segment count, while flat output entries scale with output count.
+
+## Blob-Backed Output Segment Model
+
+The measurement uses an internal prototype manifest:
+
+```json
+{
+  "output_type": "output_segment",
+  "output_id": "...",
+  "segment": {
+    "blob": "...",
+    "size": 374200,
+    "media_type": "application/vnd.nteract.output-segment+json",
+    "count": 128,
+    "first_output_id": "...",
+    "last_output_id": "..."
+  }
+}
+```
+
+The segment blob contains:
+
+```json
+{
+  "version": 1,
+  "outputs": [
+    { "output_type": "display_data", "output_id": "...", "data": { "...": { "inline": "..." } } }
+  ]
+}
+```
+
+This is deliberately not a kernel protocol change. The kernel still emits
+ordinary Jupyter messages, the daemon still creates normal child
+`OutputManifest`s, and the segment only changes the daemon-to-client storage
+projection. A production implementation should hide this behind RuntimeStateDoc
+projection/resolution so existing consumers can continue to ask for flat outputs
+when they need them.
+
+## Jupyter Rate Limits
+
+Jupyter Server also treats IOPub as a bounded resource. Its
+[`ZMQChannelsWebsocketConnection`](https://jupyter-server.readthedocs.io/en/stable/api/jupyter_server.services.kernels.connection.html#jupyter_server.services.kernels.connection.channels.ZMQChannelsWebsocketConnection)
+has `iopub_msg_rate_limit`, `iopub_data_rate_limit`, `rate_limit_window`, and a
+`limit_rate` switch for tuning IOPub throughput. That makes a bounded-output
+contract reasonable for nteract too: runtimes should not assume unlimited
+client-side output transport, and nteract should keep the kernel reader hot
+while moving bulk payloads out of the sync document.
 
 ## Production Queue
 


### PR DESCRIPTION
## Summary

- extend the output commit measurement harness with RuntimeStateDoc save/sync amplification metrics
- add a blob-backed `output_segment` prototype strategy that stores ordered child manifests in blob storage and writes segment refs into RuntimeStateDoc
- document local N=100/500/1000 results and the Jupyter Server IOPub rate-limit context

## Evidence

Local `display_data` N=1000 sample with 256-byte payloads and segment size 128:

- flat ordered worker: 1000 durable entries, 60,705 saved-doc bytes, 434,021 daemon sync bytes, ~12.8s total
- blob segment model: 8 durable entries, 2,387 saved-doc bytes, 3,452 daemon sync bytes, 374,200 segment blob bytes, ~47ms total

This PR is measurement/prototype only. It does not change production output transport or client projection.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p runtimed output_commit_measure --lib`
- `cargo check -p runtimed --example output_commit_measure`
- `NTERACT_OUTPUT_COMMIT_COUNTS=100,500,1000 NTERACT_OUTPUT_COMMIT_PAYLOAD_BYTES=256 NTERACT_OUTPUT_COMMIT_SEGMENT_SIZE=128 cargo run -q -p runtimed --example output_commit_measure`
