### PR TITLE
fix(runtimed): queue cells while kernel launch resolves

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1845,6 +1845,105 @@ async fn test_apply_ipynb_changes_updates_execution_count() {
 }
 
 #[tokio::test]
+async fn execute_cell_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+    let room = Arc::new(room);
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "print('queued while resolving')")
+            .unwrap();
+    }
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        .unwrap();
+
+    let response = crate::requests::execute_cell::handle(&room, "cell-1".to_string(), None).await;
+
+    let execution_id = match response {
+        crate::protocol::NotebookResponse::CellQueued { execution_id, .. } => execution_id,
+        other => panic!("expected CellQueued, got {other:?}"),
+    };
+    assert_eq!(
+        room.doc.read().await.get_execution_id("cell-1").as_deref(),
+        Some(execution_id.as_str())
+    );
+
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
+    let execution = state
+        .executions
+        .get(&execution_id)
+        .expect("queued execution should exist");
+    assert_eq!(execution.status, "queued");
+    assert_eq!(
+        execution.source.as_deref(),
+        Some("print('queued while resolving')")
+    );
+    assert_eq!(state.queue.executing, None);
+    assert_eq!(
+        state
+            .queue
+            .queued
+            .iter()
+            .map(|entry| entry.execution_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![execution_id.as_str()]
+    );
+}
+
+#[tokio::test]
+async fn run_all_cells_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "print('first')").unwrap();
+        doc.add_cell(1, "cell-2", "code").unwrap();
+        doc.update_source("cell-2", "print('second')").unwrap();
+    }
+    room.state
+        .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
+        .unwrap();
+
+    let response = crate::requests::run_all_cells::handle(&room, None).await;
+
+    let queued = match response {
+        crate::protocol::NotebookResponse::AllCellsQueued { queued } => queued,
+        other => panic!("expected AllCellsQueued, got {other:?}"),
+    };
+    assert_eq!(queued.len(), 2);
+
+    let first_execution_id = queued[0].execution_id.as_str();
+    let second_execution_id = queued[1].execution_id.as_str();
+    let doc = room.doc.read().await;
+    assert_eq!(
+        doc.get_execution_id("cell-1").as_deref(),
+        Some(first_execution_id)
+    );
+    assert_eq!(
+        doc.get_execution_id("cell-2").as_deref(),
+        Some(second_execution_id)
+    );
+    drop(doc);
+
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
+    assert_eq!(state.queue.executing, None);
+    assert_eq!(
+        state
+            .queue
+            .queued
+            .iter()
+            .map(|entry| entry.execution_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![first_execution_id, second_execution_id]
+    );
+}
+
+#[tokio::test]
 async fn test_apply_ipynb_changes_updates_existing_cell_attachments() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, _) = test_room_with_path(&tmp, "test.ipynb");

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -11,6 +11,8 @@ use crate::notebook_sync_server::{
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
+use crate::requests::publish_startup_queue_from_queued_executions;
+use crate::requests::runtime_launch_in_progress;
 use crate::requests::trim_runtime_executions_for_doc;
 use crate::task_supervisor::spawn_best_effort;
 use notebook_protocol::protocol::ExecutionIdRejectionReason;
@@ -66,29 +68,25 @@ async fn handle_inner(
     requested_execution_id: Option<String>,
     observed_heads: Option<Vec<String>>,
 ) -> NotebookResponse {
-    // Agent-backed kernel: write execution to RuntimeStateDoc queue.
-    // The runtime agent discovers it via CRDT sync and executes.
-    // Check runtime_agent_request_tx (not runtime_agent_handle) to ensure the runtime agent's
-    // sync connection is still live — a stale handle with no connection
-    // would leave queued executions orphaned.
+    // Agent-backed kernel: write execution to RuntimeStateDoc queue. During
+    // launch, queue in the doc before the agent connects so all clients observe
+    // the same pending work. Once running, require a live sync connection.
     {
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
-        if has_runtime_agent {
-            // Check if kernel is shut down — return NoKernel instead
-            // of silently queuing into a dead kernel.
-            {
-                let lifecycle = room
-                    .state
-                    .read(|sd| sd.read_state().kernel.lifecycle)
-                    .unwrap_or(RuntimeLifecycle::NotStarted);
-                if matches!(
-                    lifecycle,
-                    RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
-                ) {
-                    return NotebookResponse::NoKernel {};
-                }
-            }
+        let lifecycle = room
+            .state
+            .read(|sd| sd.read_state().kernel.lifecycle)
+            .unwrap_or(RuntimeLifecycle::NotStarted);
+        if matches!(
+            lifecycle,
+            RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
+        ) {
+            return NotebookResponse::NoKernel {};
+        }
+        let queue_for_starting_kernel =
+            !has_runtime_agent && runtime_launch_in_progress(&lifecycle);
 
+        if has_runtime_agent || queue_for_starting_kernel {
             let (source, execution_id, format_heads) = match queue_cell_if_current(
                 room,
                 &cell_id,
@@ -101,8 +99,16 @@ async fn handle_inner(
                     source,
                     execution_id,
                     format_heads,
-                } => (source, execution_id, format_heads),
+                } => {
+                    if queue_for_starting_kernel {
+                        publish_startup_queue_from_queued_executions(room);
+                    }
+                    (source, execution_id, format_heads)
+                }
                 QueueCellResult::AlreadyActive { execution_id } => {
+                    if queue_for_starting_kernel {
+                        publish_startup_queue_from_queued_executions(room);
+                    }
                     return NotebookResponse::CellQueued {
                         cell_id,
                         execution_id,

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use notebook_protocol::protocol::BlobUploadErrorKind;
+use runtime_doc::{QueueEntry, RuntimeLifecycle};
 use tracing::{debug, warn};
 
 use crate::daemon::Daemon;
@@ -29,6 +30,33 @@ use crate::protocol::{NotebookRequest, NotebookResponse};
 /// trimming cannot know which terminal executions are still referenced by
 /// document models.
 pub(crate) const MAX_EXECUTION_ENTRIES: usize = 64;
+
+pub(crate) fn runtime_launch_in_progress(lifecycle: &RuntimeLifecycle) -> bool {
+    matches!(
+        lifecycle,
+        RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::PreparingEnv
+            | RuntimeLifecycle::Launching
+            | RuntimeLifecycle::Connecting
+    )
+}
+
+pub(crate) fn publish_startup_queue_from_queued_executions(room: &NotebookRoom) {
+    if let Err(e) = room.state.with_doc(|state_doc| {
+        let queued: Vec<QueueEntry> = state_doc
+            .get_queued_executions()
+            .into_iter()
+            .map(|(execution_id, _)| QueueEntry { execution_id })
+            .collect();
+        state_doc.set_queue(None, &queued)?;
+        Ok(())
+    }) {
+        warn!(
+            "[notebook-sync] Failed to publish startup queue projection: {}",
+            e
+        );
+    }
+}
 
 pub(crate) mod approve_project_environment;
 pub(crate) mod approve_trust;

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -8,6 +8,8 @@ use tracing::warn;
 use crate::notebook_sync_server::NotebookRoom;
 use crate::protocol::{NotebookResponse, QueueEntry};
 use crate::requests::guarded;
+use crate::requests::publish_startup_queue_from_queued_executions;
+use crate::requests::runtime_launch_in_progress;
 use crate::requests::trim_runtime_executions_for_doc;
 use notebook_protocol::protocol::ExecutionIdRejectionReason;
 
@@ -87,24 +89,25 @@ async fn handle_inner(
     requested_execution_ids: Option<HashMap<String, String>>,
     observed_heads: Option<Vec<String>>,
 ) -> NotebookResponse {
-    // Agent path — write all cells to RuntimeStateDoc queue
+    // RuntimeStateDoc is the source of truth for visible queued work. During
+    // kernel launch we can queue before the agent connects; once running, a
+    // live agent sync connection is required.
     {
         let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
-        if has_runtime_agent {
-            // Check if kernel is shut down.
-            {
-                let lifecycle = room
-                    .state
-                    .read(|sd| sd.read_state().kernel.lifecycle)
-                    .unwrap_or(RuntimeLifecycle::NotStarted);
-                if matches!(
-                    lifecycle,
-                    RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
-                ) {
-                    return NotebookResponse::NoKernel {};
-                }
-            }
+        let lifecycle = room
+            .state
+            .read(|sd| sd.read_state().kernel.lifecycle)
+            .unwrap_or(RuntimeLifecycle::NotStarted);
+        if matches!(
+            lifecycle,
+            RuntimeLifecycle::Shutdown | RuntimeLifecycle::Error
+        ) {
+            return NotebookResponse::NoKernel {};
+        }
+        let queue_for_starting_kernel =
+            !has_runtime_agent && runtime_launch_in_progress(&lifecycle);
 
+        if has_runtime_agent || queue_for_starting_kernel {
             let queued = {
                 let mut doc = room.doc.write().await;
                 if let Some(observed_heads) = observed_heads.as_deref() {
@@ -249,6 +252,9 @@ async fn handle_inner(
                 queued
             };
 
+            if queue_for_starting_kernel {
+                publish_startup_queue_from_queued_executions(room);
+            }
             return NotebookResponse::AllCellsQueued { queued };
         }
     }


### PR DESCRIPTION
## Summary

- queue ExecuteCell and RunAllCells requests in RuntimeStateDoc while kernel launch is still resolving/preparing/launching/connecting
- publish a startup queue projection from daemon-authored queued executions so every connected client sees the same queued state
- add regressions for ExecuteCell and RunAllCells during the Resolving lifecycle

## Verification

- `cargo test -p runtimed queues_in_runtime_doc_while_kernel_launch_is_resolving -- --nocapture`
- `cargo xtask lint --fix`
