### PR TITLE
[ipy-opt] Optimize display update output projection

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -1882,6 +1882,12 @@ impl RuntimeStateDoc {
             .collect()
     }
 
+    /// Read one output manifest by execution id and output id.
+    pub fn get_output(&self, execution_id: &str, output_id: &str) -> Option<serde_json::Value> {
+        let output_entry = self.get_output_entry(execution_id, output_id)?;
+        self.read_output_manifest(&output_entry)
+    }
+
     /// Get all outputs across all executions.
     ///
     /// Returns `(execution_id, output_id, manifest)` triples.
@@ -5746,6 +5752,32 @@ mod tests {
         let outputs = sd.get_outputs("exec-1");
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["output_id"], "my-uuid-123");
+    }
+
+    #[test]
+    fn get_output_reads_exact_manifest_by_id() {
+        let mut sd = RuntimeStateDoc::new();
+        sd.create_execution("exec-1").unwrap();
+
+        let m1 = serde_json::json!({
+            "output_type": "stream",
+            "output_id": "stdout-1",
+            "name": "stdout",
+            "text": {"inline": "first\n"}
+        });
+        let m2 = serde_json::json!({
+            "output_type": "display_data",
+            "output_id": "display-1",
+            "data": {"text/plain": {"inline": "second"}},
+            "metadata": {},
+            "transient": {"display_id": "disp-1"}
+        });
+        sd.append_output("exec-1", &m1).unwrap();
+        sd.append_output("exec-1", &m2).unwrap();
+
+        assert_eq!(sd.get_output("exec-1", "display-1"), Some(m2));
+        assert!(sd.get_output("exec-1", "missing").is_none());
+        assert!(sd.get_output("missing-exec", "display-1").is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -325,20 +325,17 @@ pub(crate) fn collect_display_update_targets(
     if !index_entries.is_empty() {
         let mut targets = Vec::new();
         for (exec_id, target_output_id) in &index_entries {
-            let outputs = state_doc.get_outputs(exec_id);
-            for output_value in outputs {
-                let manifest: OutputManifest = match serde_json::from_value(output_value) {
-                    Ok(m) => m,
-                    Err(_) => continue,
-                };
-                if manifest.output_id() == target_output_id {
-                    targets.push(DisplayUpdateTarget {
-                        execution_id: exec_id.clone(),
-                        output_id: target_output_id.clone(),
-                        manifest,
-                    });
-                }
-            }
+            let Some(output_value) = state_doc.get_output(exec_id, target_output_id) else {
+                continue;
+            };
+            let Ok(manifest) = serde_json::from_value(output_value) else {
+                continue;
+            };
+            targets.push(DisplayUpdateTarget {
+                execution_id: exec_id.clone(),
+                output_id: target_output_id.clone(),
+                manifest,
+            });
         }
         targets
     } else {

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -1,0 +1,101 @@
+# Runtime Output Optimization Plan
+
+Runtime output performance has two different problems:
+
+- **Hot-path duplication**: repeated output scans, manifest decoding, sorting,
+  snapshot reads, and frontend store invalidation around the existing flat
+  output model.
+- **Document amplification**: ordinary bursts still become one RuntimeStateDoc
+  output entry per kernel output, so Automerge sync bytes scale with output
+  count even when the IOPub reader is no longer blocked.
+
+The first category is mergeable without changing protocol shape. The second
+category likely needs blob-backed output segments, but only after every public
+reader has a flat projection/resolution layer.
+
+## Decision 1: Public output APIs stay flat
+
+Existing clients must continue to observe normal output manifests through:
+
+- `RuntimeStateDoc::get_outputs`, `get_all_outputs`, `get_execution`, and
+  `read_state`
+- runtimed-wasm `outputIdChanges`
+- TypeScript output stores
+- MCP and Python execution results
+- `.ipynb` save/export
+- display-id update paths
+- widget OutputModel replay
+
+An `output_segment` record is an internal storage record, not a public output.
+Do not enable a production segment writer until unresolved segment records are
+hidden from all of those consumers.
+
+This rejects a visible "VStack" or manifest-batch protocol as the first
+production step. Batching can be the internal storage representation, but the
+client contract remains ordered flat outputs until we intentionally version a
+new consumer protocol.
+
+## Decision 2: Optimize duplicated flat-path work first
+
+The first safe stack should keep the manifest shape unchanged while removing
+known repeated work:
+
+1. Exact output lookup by `(execution_id, output_id)` so display updates can use
+   `display_index` without sorting and scanning every output in the execution.
+2. Cached or indexed output ordering metadata so append/upsert paths do not
+   recompute order by decoding all manifests.
+3. WASM-side output-id indexing so runtime sync handling does not repeatedly
+   read the full runtime state just to derive output deltas.
+4. Frontend output materialization cleanup so runtime outputs flow through the
+   output store rather than repeated whole-output JSON cache keys.
+
+Each item is independently mergeable and should include a small benchmark or
+stress case that proves the eliminated work.
+
+## Decision 3: Segment storage needs projection before writing
+
+The measured blob-backed segment model reduces Automerge traffic by storing
+ordered child manifests in blobs and putting one segment reference per chunk in
+RuntimeStateDoc. That model is promising, but production needs these layers
+first:
+
+1. A shared output segment schema and resolver.
+2. Resolver support in MCP/Python/save paths that expands segments to flat
+   child outputs.
+3. Frontend and WASM projection support so `outputIdChanges` carries child
+   output ids and manifests, not segment placeholders.
+4. Display update semantics for segmented outputs, or a writer rule that keeps
+   display-id-addressable outputs flat.
+5. Widget OutputModel semantics, or a writer rule that keeps widget-captured
+   outputs flat.
+
+The first production writer should be conservative: segment only append-only
+ordinary outputs with no `display_id` and no widget capture until replacement
+semantics are explicitly handled.
+
+## Decision 4: Kernel-side easing is semantic
+
+Producer-side optimization is useful, but it cannot be a blanket coalescer:
+
+- stdout/stderr buffering can be tuned because stream output is append-only
+  text.
+- `update_display_data` can be coalesced by `display_id` because the Jupyter
+  protocol describes it as replacing prior display state.
+- ordinary `display_data`, `execute_result`, `error`, and arbitrary comm events
+  are durable semantic events and must not be collapsed transparently.
+
+Any runtime-controlled kernel buffering should be explicit nteract API surface,
+with a final flush before terminal execution state.
+
+## Measurement Contract
+
+Benchmarks should cover N=100, 500, and 1000 for:
+
+- raw IOPub display bursts
+- current flat RuntimeStateDoc output commits
+- optimized flat-path commits
+- future segmented storage with flat projection
+
+Success means preserving ordinary display count and order, preserving final
+display-id state before execution completion, keeping interrupts responsive, and
+showing both local CPU/work reduction and RuntimeStateDoc sync-byte impact.


### PR DESCRIPTION
## Summary

- documents the runtime output optimization plan and compatibility boundary
- adds `RuntimeStateDoc::get_output(execution_id, output_id)` for exact manifest reads
- uses the display index to read display-update targets directly instead of sorting/scanning every output in the execution

## Compatibility

This keeps RuntimeStateDoc output storage and every public output shape flat. It does not enable the blob-backed `output_segment` writer from the measurement PR.

## Verification

- `cargo test -p runtime-doc get_output_reads_exact_manifest_by_id`
- `cargo test -p runtimed output_prep::tests::test_update_display_id_updates_all_matching_outputs`
- `cargo xtask lint --fix`
