### PR TITLE
fix(runtimed): attribute queued executions to submitter

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -185,6 +185,7 @@ export const CodeCell = memo(function CodeCell({
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
+  const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
   const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
 
   // Check cell metadata for visibility (JupyterLab convention)
@@ -369,6 +370,7 @@ export const CodeCell = memo(function CodeCell({
       count={executionCount}
       isExecuting={isExecuting}
       isQueued={isQueued}
+      submittedByActorLabel={submittedByActorLabel}
       onExecute={onExecute}
       onInterrupt={onInterrupt}
     />

--- a/apps/notebook/src/lib/notebook-executions.ts
+++ b/apps/notebook/src/lib/notebook-executions.ts
@@ -21,6 +21,8 @@ export interface ExecutionSnapshot {
   success: boolean | null;
   /** Output IDs in emission order. Resolve via `useOutput(output_id)`. */
   output_ids: string[];
+  /** Authenticated actor label for the client that submitted this execution. */
+  submitted_by_actor_label?: string | null;
 }
 
 export interface NotebookQueueProjectionSnapshot {
@@ -77,7 +79,8 @@ function snapshotsEqual(a: ExecutionSnapshot, b: ExecutionSnapshot): boolean {
   if (
     a.execution_count !== b.execution_count ||
     a.status !== b.status ||
-    a.success !== b.success
+    a.success !== b.success ||
+    (a.submitted_by_actor_label ?? null) !== (b.submitted_by_actor_label ?? null)
   ) {
     return false;
   }

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -288,6 +288,7 @@ mod tests {
                 outputs,
                 source: Some("print('hi')".to_string()),
                 seq: Some(1),
+                submitted_by_actor_label: None,
             },
         );
         tx.send(runtime).expect("send runtime");

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -370,6 +370,7 @@ pub async fn get_results(
             outputs: record.outputs,
             source: record.source,
             seq: record.seq,
+            submitted_by_actor_label: record.submitted_by_actor_label,
         };
         let execution_cell_map = record
             .cell_id
@@ -553,6 +554,7 @@ mod tests {
                 execution_count: Some(3),
                 source: Some("print('hi')".to_string()),
                 seq: Some(0),
+                submitted_by_actor_label: None,
                 outputs: vec![serde_json::json!({
                     "output_type": "stream",
                     "name": "stdout",

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -199,6 +199,12 @@ pub struct ExecutionState {
     /// queued entries by this to determine execution order.
     #[serde(default)]
     pub seq: Option<u64>,
+    /// Authenticated actor label for the client that submitted this execution.
+    ///
+    /// Set by the daemon coordinator when it accepts an execute/run-all request.
+    /// Older RuntimeStateDocs omit it.
+    #[serde(default)]
+    pub submitted_by_actor_label: Option<String>,
 }
 
 /// Environment sync state snapshot.
@@ -1175,6 +1181,18 @@ impl RuntimeStateDoc {
         source: &str,
         seq: u64,
     ) -> Result<bool, RuntimeStateError> {
+        self.create_execution_with_source_and_submitter(execution_id, source, seq, None)
+    }
+
+    /// Create a new execution entry with source code, queue sequence number,
+    /// and the authenticated actor that submitted it.
+    pub fn create_execution_with_source_and_submitter(
+        &mut self,
+        execution_id: &str,
+        source: &str,
+        seq: u64,
+        submitted_by_actor_label: Option<&str>,
+    ) -> Result<bool, RuntimeStateError> {
         let executions = self.scaffold_map("executions")?;
 
         // Don't overwrite if it already exists (idempotent)
@@ -1197,6 +1215,10 @@ impl RuntimeStateDoc {
         self.doc.put_object(&entry, "outputs", ObjType::Map)?;
         self.doc.put(&entry, "source", source)?;
         self.doc.put(&entry, "seq", ScalarValue::Uint(seq))?;
+        if let Some(actor_label) = submitted_by_actor_label {
+            self.doc
+                .put(&entry, "submitted_by_actor_label", actor_label)?;
+        }
         Ok(true)
     }
 
@@ -1346,6 +1368,8 @@ impl RuntimeStateDoc {
                 _ => None,
             });
 
+        let submitted_by_actor_label = self.read_opt_str(&entry, "submitted_by_actor_label");
+
         Some(ExecutionState {
             status,
             execution_count,
@@ -1353,6 +1377,7 @@ impl RuntimeStateDoc {
             outputs,
             source,
             seq,
+            submitted_by_actor_label,
         })
     }
 
@@ -3955,6 +3980,29 @@ mod tests {
         assert_eq!(es.status, "queued");
         assert_eq!(es.source, Some("x = 42".to_string()));
         assert_eq!(es.seq, Some(0));
+        assert_eq!(es.submitted_by_actor_label, None);
+    }
+
+    #[test]
+    fn test_create_execution_with_source_and_submitter() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(doc
+            .create_execution_with_source_and_submitter(
+                "exec-1",
+                "x = 42",
+                0,
+                Some("local:kyle/agent:codex:s1"),
+            )
+            .unwrap());
+
+        let es = doc.get_execution("exec-1").unwrap();
+        assert_eq!(es.status, "queued");
+        assert_eq!(es.source, Some("x = 42".to_string()));
+        assert_eq!(es.seq, Some(0));
+        assert_eq!(
+            es.submitted_by_actor_label.as_deref(),
+            Some("local:kyle/agent:codex:s1")
+        );
     }
 
     #[test]
@@ -5205,6 +5253,7 @@ mod tests {
                 outputs: vec![test_stream("hash1")],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -5224,6 +5273,7 @@ mod tests {
                 outputs: vec![],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -5244,6 +5294,7 @@ mod tests {
                 outputs: vec![],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -5267,6 +5318,7 @@ mod tests {
                 outputs: vec![test_stream("hash1")],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
         let (changed, snapshot) = diff_execution_outputs(&prev, &execs);
@@ -5287,6 +5339,7 @@ mod tests {
                 outputs: vec![],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
         let (changed, snapshot) = diff_execution_outputs(&snapshot, &execs);
@@ -5319,6 +5372,7 @@ mod tests {
                 outputs: vec![],
                 source: None,
                 seq: None,
+                submitted_by_actor_label: None,
             },
         );
 

--- a/crates/runtime-doc/src/projection.rs
+++ b/crates/runtime-doc/src/projection.rs
@@ -91,6 +91,8 @@ pub struct ExecutionViewSnapshot {
     pub status: String,
     pub success: Option<bool>,
     pub output_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub submitted_by_actor_label: Option<String>,
 }
 
 /// Queue state projected in execution-id terms.
@@ -305,13 +307,14 @@ fn execution_snapshot(exec: &ExecutionState) -> ExecutionViewSnapshot {
         status: exec.status.clone(),
         success: exec.success,
         output_ids: output_ids_for_execution(exec),
+        submitted_by_actor_label: exec.submitted_by_actor_label.clone(),
     }
 }
 
 fn execution_fingerprint(exec: &ExecutionState) -> String {
     let output_ids = output_ids_for_execution(exec);
     format!(
-        "{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}",
         exec.execution_count
             .map(|count| count.to_string())
             .unwrap_or_default(),
@@ -319,7 +322,8 @@ fn execution_fingerprint(exec: &ExecutionState) -> String {
         exec.success
             .map(|success| success.to_string())
             .unwrap_or_default(),
-        output_ids.join(",")
+        output_ids.join(","),
+        exec.submitted_by_actor_label.as_deref().unwrap_or_default()
     )
 }
 
@@ -337,6 +341,7 @@ mod tests {
             outputs: vec![],
             source: None,
             seq: None,
+            submitted_by_actor_label: None,
         }
     }
 
@@ -356,6 +361,7 @@ mod tests {
                 .collect(),
             source: None,
             seq: None,
+            submitted_by_actor_label: None,
         }
     }
 
@@ -492,6 +498,27 @@ mod tests {
         assert_eq!(changeset.execution_upserts.len(), 1);
         assert_eq!(changeset.execution_upserts[0].0, "exec-1");
         assert_eq!(changeset.execution_upserts[0].1.output_ids, vec!["new"]);
+    }
+
+    #[test]
+    fn execution_view_projects_submitter_actor_label() {
+        let cell_pointers = pointers(&[("cell-1", Some("exec-1"))]);
+        let mut state = RuntimeState::default();
+        let mut exec = exec("queued", None);
+        exec.submitted_by_actor_label = Some("local:kyle/agent:codex:s1".to_string());
+        state.executions.insert("exec-1".to_string(), exec);
+
+        let mut projector = ExecutionViewProjector::default();
+        let changeset = projector.project_all(cell_pointers, &state);
+
+        assert_eq!(changeset.execution_upserts.len(), 1);
+        assert_eq!(
+            changeset.execution_upserts[0]
+                .1
+                .submitted_by_actor_label
+                .as_deref(),
+            Some("local:kyle/agent:codex:s1")
+        );
     }
 
     #[test]

--- a/crates/runtimed-client/src/execution_store.rs
+++ b/crates/runtimed-client/src/execution_store.rs
@@ -31,6 +31,8 @@ pub struct ExecutionRecord {
     pub source: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub submitted_by_actor_label: Option<String>,
     #[serde(default)]
     pub outputs: Vec<serde_json::Value>,
     pub created_at: DateTime<Utc>,
@@ -58,6 +60,7 @@ impl ExecutionRecord {
             execution_count: exec.execution_count,
             source: exec.source.clone(),
             seq: exec.seq,
+            submitted_by_actor_label: exec.submitted_by_actor_label.clone(),
             outputs: exec.outputs.clone(),
             created_at: now,
             updated_at: now,
@@ -84,6 +87,7 @@ impl ExecutionRecord {
             && self.execution_count == other.execution_count
             && self.source == other.source
             && self.seq == other.seq
+            && self.submitted_by_actor_label == other.submitted_by_actor_label
             && self.outputs == other.outputs
     }
 
@@ -400,6 +404,7 @@ mod tests {
             execution_count: Some(1),
             source: Some("1 + 1".to_string()),
             seq: Some(0),
+            submitted_by_actor_label: None,
             outputs: vec![serde_json::json!({
                 "output_type": "stream",
                 "output_id": "old",

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -2069,6 +2069,7 @@ async fn cell_result_from_record(
         outputs: record.outputs,
         source: record.source,
         seq: record.seq,
+        submitted_by_actor_label: record.submitted_by_actor_label,
     };
     cell_result_from_execution_state(
         &execution_id,
@@ -2386,6 +2387,7 @@ mod tests {
             outputs: vec![],
             source: Some("1 + 1".to_string()),
             seq: Some(9),
+            submitted_by_actor_label: None,
         };
 
         let result =
@@ -2422,6 +2424,7 @@ mod tests {
             outputs: vec![],
             source: Some("print('ok')".to_string()),
             seq: Some(11),
+            submitted_by_actor_label: None,
         };
         let record = runtimed_client::execution_store::ExecutionRecord::from_execution_state(
             "exec-from-store",

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1052,6 +1052,8 @@ pub struct PyExecutionState {
     pub execution_count: Option<i64>,
     /// Whether the execution succeeded (set on completion).
     pub success: Option<bool>,
+    /// Authenticated actor label for the client that submitted this execution.
+    pub submitted_by_actor_label: Option<String>,
 }
 
 #[pymethods]
@@ -1078,6 +1080,7 @@ pub struct PyExecutionViewSnapshot {
     pub status: String,
     pub success: Option<bool>,
     pub output_ids: Vec<String>,
+    pub submitted_by_actor_label: Option<String>,
 }
 
 #[pymethods]
@@ -1153,6 +1156,7 @@ impl From<runtime_doc::ExecutionViewSnapshot> for PyExecutionViewSnapshot {
             status: snapshot.status,
             success: snapshot.success,
             output_ids: snapshot.output_ids,
+            submitted_by_actor_label: snapshot.submitted_by_actor_label,
         }
     }
 }
@@ -1353,6 +1357,7 @@ impl From<runtime_doc::RuntimeState> for PyRuntimeState {
                             status: es.status,
                             execution_count: es.execution_count,
                             success: es.success,
+                            submitted_by_actor_label: es.submitted_by_actor_label,
                         },
                     )
                 })
@@ -1472,6 +1477,7 @@ mod tests {
                 outputs: vec![json!({"output_type": "stream", "name": "stdout"})],
                 source: Some("print('ok')".to_string()),
                 seq: Some(7),
+                submitted_by_actor_label: Some("local:kyle/agent:codex:s1".to_string()),
             },
         );
 
@@ -1551,6 +1557,12 @@ mod tests {
         assert_eq!(
             py_state.executions["exec-1"].__repr__(),
             "ExecutionState(status=done, success=Some(true))"
+        );
+        assert_eq!(
+            py_state.executions["exec-1"]
+                .submitted_by_actor_label
+                .as_deref(),
+            Some("local:kyle/agent:codex:s1")
         );
         assert_eq!(py_state.comms["comm-1"].model_name, "IntSliderModel");
         assert_eq!(

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1362,6 +1362,7 @@ impl NotebookHandle {
             status,
             execution_count,
             success,
+            submitted_by_actor_label,
             ..
         } = exec;
         let summary = serde_json::json!({
@@ -1369,6 +1370,7 @@ impl NotebookHandle {
             "status": status,
             "success": success,
             "output_ids": output_ids,
+            "submitted_by_actor_label": submitted_by_actor_label,
         });
         serialize_to_js(&summary).unwrap_or(JsValue::UNDEFINED)
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -7761,6 +7761,7 @@ mod tests {
                 execution_count: Some(1),
                 source: Some("display('live')".to_string()),
                 seq: Some(0),
+                submitted_by_actor_label: None,
                 outputs: vec![serde_json::json!({
                     "output_type": "display_data",
                     "data": {"image/png": {"blob": "live-blob", "size": 4}}
@@ -7783,6 +7784,7 @@ mod tests {
             execution_count: Some(1),
             source: Some("display('expired')".to_string()),
             seq: Some(0),
+            submitted_by_actor_label: None,
             outputs: vec![serde_json::json!({
                 "output_type": "display_data",
                 "data": {"image/png": {"blob": "expired-blob", "size": 4}}

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -149,6 +149,7 @@ where
         multipart_uploads.clone(),
         notebook_id.clone(),
         peer_id.to_string(),
+        connection_identity.actor_label().as_str().to_string(),
     );
     let mut put_blob_worker = spawn_put_blob_worker(
         room.blob_store.clone(),

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -149,6 +149,7 @@ pub(super) fn spawn_peer_request_worker(
     multipart_uploads: MultipartUploadState,
     notebook_id: String,
     peer_id: String,
+    submitter_actor_label: String,
 ) -> PeerRequestWorker {
     let (tx, mut rx) = mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(
         PEER_REQUEST_QUEUE_CAPACITY,
@@ -175,7 +176,13 @@ pub(super) fn spawn_peer_request_worker(
                     {
                         response
                     } else {
-                        handle_notebook_request(&room, envelope.request, daemon.clone()).await
+                        handle_notebook_request(
+                            &room,
+                            envelope.request,
+                            daemon.clone(),
+                            Some(submitter_actor_label.as_str()),
+                        )
+                        .await
                     }
                 }
                 Err(error) => notebook_protocol::protocol::NotebookResponse::Error { error },

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -2585,6 +2585,7 @@ async fn test_load_notebook_reuses_matching_durable_execution_id() {
             execution_count: Some(7),
             source: Some("print('hi')".to_string()),
             seq: Some(0),
+            submitted_by_actor_label: None,
             outputs,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -2663,6 +2664,7 @@ async fn test_load_notebook_mints_execution_id_when_durable_record_no_longer_mat
             execution_count: Some(7),
             source: Some("print('hi')".to_string()),
             seq: Some(0),
+            submitted_by_actor_label: None,
             outputs: vec![serde_json::json!({
                 "output_type": "stream",
                 "name": "stdout",

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1860,7 +1860,13 @@ async fn execute_cell_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
         .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
         .unwrap();
 
-    let response = crate::requests::execute_cell::handle(&room, "cell-1".to_string(), None).await;
+    let response = crate::requests::execute_cell::handle_with_submitter(
+        &room,
+        "cell-1".to_string(),
+        None,
+        Some("local:kyle/agent:codex:s1"),
+    )
+    .await;
 
     let execution_id = match response {
         crate::protocol::NotebookResponse::CellQueued { execution_id, .. } => execution_id,
@@ -1880,6 +1886,10 @@ async fn execute_cell_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
     assert_eq!(
         execution.source.as_deref(),
         Some("print('queued while resolving')")
+    );
+    assert_eq!(
+        execution.submitted_by_actor_label.as_deref(),
+        Some("local:kyle/agent:codex:s1")
     );
     assert_eq!(state.queue.executing, None);
     assert_eq!(
@@ -1909,7 +1919,12 @@ async fn run_all_cells_queues_in_runtime_doc_while_kernel_launch_is_resolving() 
         .with_doc(|sd| sd.set_lifecycle(&RuntimeLifecycle::Resolving))
         .unwrap();
 
-    let response = crate::requests::run_all_cells::handle(&room, None).await;
+    let response = crate::requests::run_all_cells::handle_with_submitter(
+        &room,
+        None,
+        Some("local:kyle/desktop:window-1"),
+    )
+    .await;
 
     let queued = match response {
         crate::protocol::NotebookResponse::AllCellsQueued { queued } => queued,
@@ -1931,6 +1946,20 @@ async fn run_all_cells_queues_in_runtime_doc_while_kernel_launch_is_resolving() 
     drop(doc);
 
     let state = room.state.read(|sd| sd.read_state()).unwrap();
+    assert_eq!(
+        state
+            .executions
+            .get(first_execution_id)
+            .and_then(|execution| execution.submitted_by_actor_label.as_deref()),
+        Some("local:kyle/desktop:window-1")
+    );
+    assert_eq!(
+        state
+            .executions
+            .get(second_execution_id)
+            .and_then(|execution| execution.submitted_by_actor_label.as_deref()),
+        Some("local:kyle/desktop:window-1")
+    );
     assert_eq!(state.queue.executing, None);
     assert_eq!(
         state

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -42,24 +42,33 @@ fn validate_requested_execution_id(
     Ok(())
 }
 
-pub(crate) async fn handle(
+pub(crate) async fn handle_with_submitter(
     room: &Arc<NotebookRoom>,
     cell_id: String,
     execution_id: Option<String>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
-    handle_inner(room, cell_id, execution_id, None).await
+    handle_inner(room, cell_id, execution_id, None, submitter_actor_label).await
 }
 
-pub(crate) async fn handle_guarded(
+pub(crate) async fn handle_guarded_with_submitter(
     room: &Arc<NotebookRoom>,
     cell_id: String,
     execution_id: Option<String>,
     observed_heads: Vec<String>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     if let Err(rejection) = guarded::ensure_trusted(room).await {
         return rejection.into_response();
     }
-    handle_inner(room, cell_id, execution_id, Some(observed_heads)).await
+    handle_inner(
+        room,
+        cell_id,
+        execution_id,
+        Some(observed_heads),
+        submitter_actor_label,
+    )
+    .await
 }
 
 async fn handle_inner(
@@ -67,6 +76,7 @@ async fn handle_inner(
     cell_id: String,
     requested_execution_id: Option<String>,
     observed_heads: Option<Vec<String>>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     // Agent-backed kernel: write execution to RuntimeStateDoc queue. During
     // launch, queue in the doc before the agent connects so all clients observe
@@ -92,6 +102,7 @@ async fn handle_inner(
                 &cell_id,
                 requested_execution_id.as_deref(),
                 observed_heads.as_deref(),
+                submitter_actor_label,
             )
             .await
             {
@@ -173,6 +184,7 @@ async fn queue_cell_if_current(
     cell_id: &str,
     requested_execution_id: Option<&str>,
     observed_heads: Option<&[String]>,
+    submitter_actor_label: Option<&str>,
 ) -> QueueCellResult {
     if let Some(execution_id) = requested_execution_id {
         if let Err(reason) = validate_requested_execution_id(execution_id, false) {
@@ -251,7 +263,12 @@ async fn queue_cell_if_current(
             if sd.get_execution(&execution_id).is_some() {
                 return Ok(false);
             }
-            sd.create_execution_with_source(&execution_id, &cell.source, seq)
+            sd.create_execution_with_source_and_submitter(
+                &execution_id,
+                &cell.source,
+                seq,
+                submitter_actor_label,
+            )
         }) {
             Ok(true) => break,
             Ok(false) if requested_execution_id.is_none() => {

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -157,6 +157,7 @@ pub(crate) async fn handle_notebook_request(
     room: &Arc<NotebookRoom>,
     request: NotebookRequest,
     daemon: Arc<Daemon>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     debug!(
         "[notebook-sync] Handling request: {}",
@@ -173,26 +174,47 @@ pub(crate) async fn handle_notebook_request(
         NotebookRequest::ExecuteCell {
             cell_id,
             execution_id,
-        } => execute_cell::handle(room, cell_id, execution_id).await,
+        } => {
+            execute_cell::handle_with_submitter(room, cell_id, execution_id, submitter_actor_label)
+                .await
+        }
 
         NotebookRequest::ExecuteCellGuarded {
             cell_id,
             execution_id,
             observed_heads,
-        } => execute_cell::handle_guarded(room, cell_id, execution_id, observed_heads).await,
+        } => {
+            execute_cell::handle_guarded_with_submitter(
+                room,
+                cell_id,
+                execution_id,
+                observed_heads,
+                submitter_actor_label,
+            )
+            .await
+        }
 
         NotebookRequest::InterruptExecution {} => interrupt_execution::handle(room).await,
 
         NotebookRequest::ShutdownKernel {} => shutdown_kernel::handle(room).await,
 
         NotebookRequest::RunAllCells { cell_execution_ids } => {
-            run_all_cells::handle(room, cell_execution_ids).await
+            run_all_cells::handle_with_submitter(room, cell_execution_ids, submitter_actor_label)
+                .await
         }
 
         NotebookRequest::RunAllCellsGuarded {
             cell_execution_ids,
             observed_heads,
-        } => run_all_cells::handle_guarded(room, cell_execution_ids, observed_heads).await,
+        } => {
+            run_all_cells::handle_guarded_with_submitter(
+                room,
+                cell_execution_ids,
+                observed_heads,
+                submitter_actor_label,
+            )
+            .await
+        }
 
         NotebookRequest::SendComm { message } => send_comm::handle(room, message).await,
 

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -66,28 +66,37 @@ fn allocate_daemon_execution_id(allocated_execution_ids: &mut HashSet<String>) -
     None
 }
 
-pub(crate) async fn handle(
+pub(crate) async fn handle_with_submitter(
     room: &NotebookRoom,
     cell_execution_ids: Option<HashMap<String, String>>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
-    handle_inner(room, cell_execution_ids, None).await
+    handle_inner(room, cell_execution_ids, None, submitter_actor_label).await
 }
 
-pub(crate) async fn handle_guarded(
+pub(crate) async fn handle_guarded_with_submitter(
     room: &NotebookRoom,
     cell_execution_ids: Option<HashMap<String, String>>,
     observed_heads: Vec<String>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     if let Err(rejection) = guarded::ensure_trusted(room).await {
         return rejection.into_response();
     }
-    handle_inner(room, cell_execution_ids, Some(observed_heads)).await
+    handle_inner(
+        room,
+        cell_execution_ids,
+        Some(observed_heads),
+        submitter_actor_label,
+    )
+    .await
 }
 
 async fn handle_inner(
     room: &NotebookRoom,
     requested_execution_ids: Option<HashMap<String, String>>,
     observed_heads: Option<Vec<String>>,
+    submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     // RuntimeStateDoc is the source of truth for visible queued work. During
     // kernel launch we can queue before the agent connects; once running, a
@@ -186,7 +195,12 @@ async fn handle_inner(
                 let mut created_execution_ids = Vec::new();
                 match room.state.with_doc(|sd| {
                     for (execution_id, _, source, seq) in &entries {
-                        if sd.create_execution_with_source(execution_id, source, *seq)? {
+                        if sd.create_execution_with_source_and_submitter(
+                            execution_id,
+                            source,
+                            *seq,
+                            submitter_actor_label,
+                        )? {
                             created_execution_ids.push(execution_id.clone());
                         } else {
                             return Ok(Some(execution_id.clone()));

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -26,6 +26,7 @@ export interface ExecutionViewSnapshot {
   status: "queued" | "running" | "done" | "error" | (string & {});
   success: boolean | null;
   output_ids: string[];
+  submitted_by_actor_label?: string | null;
 }
 
 export interface ExecutionQueueProjection {

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -46,6 +46,7 @@ export interface ExecutionViewSnapshot {
   status: "queued" | "running" | "done" | "error" | (string & {});
   success: boolean | null;
   output_ids: string[];
+  submitted_by_actor_label?: string | null;
 }
 
 export interface ExecutionQueueProjection {

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -7,6 +7,8 @@ interface CompactExecutionButtonProps {
   isExecuting?: boolean;
   /** Whether the cell is queued for execution */
   isQueued?: boolean;
+  /** Authenticated actor label for the client that submitted the active execution */
+  submittedByActorLabel?: string | null;
   /** Called when user clicks to execute */
   onExecute?: () => void;
   /** Called when user clicks to interrupt */
@@ -27,6 +29,7 @@ export function CompactExecutionButton({
   count,
   isExecuting = false,
   isQueued = false,
+  submittedByActorLabel = null,
   onExecute,
   onInterrupt,
   className,
@@ -40,6 +43,16 @@ export function CompactExecutionButton({
     }
   };
 
+  const title = isExecuting
+    ? submittedByActorLabel
+      ? `Stop execution submitted by ${submittedByActorLabel}`
+      : "Stop execution"
+    : isQueued
+      ? submittedByActorLabel
+        ? `Queued for execution by ${submittedByActorLabel}`
+        : "Queued for execution"
+      : "Run cell";
+
   return (
     <button
       type="button"
@@ -51,7 +64,7 @@ export function CompactExecutionButton({
         isQueued ? "cursor-default" : "cursor-pointer",
         className,
       )}
-      title={isExecuting ? "Stop execution" : isQueued ? "Queued for execution" : "Run cell"}
+      title={title}
       aria-disabled={isQueued || undefined}
       data-testid="execute-button"
     >


### PR DESCRIPTION
## Summary

- record the authenticated submitter actor label on daemon-created RuntimeStateDoc execution entries
- pass the peer connection identity through execute/run-all request handling
- expose the submitter actor in execution projections, Python/Node/TS bindings, and the cell execution button tooltip

## Verification

- `cargo test -p runtime-doc submitter -- --nocapture`
- `cargo test -p runtimed queues_in_runtime_doc_while_kernel_launch_is_resolving -- --nocapture`
- `cargo check -p runtimed-py --lib`
- `cargo check --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets`
- `cargo xtask wasm`
- `pnpm test:run apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts apps/notebook/src/lib/__tests__/notebook-executions.test.ts packages/runtimed-node/tests/session.test.ts`
- `cargo xtask lint --fix`

## Notes

- `cargo test -p runtimed-py runtime_state_conversion_preserves_queue_executions_and_widget_state -- --nocapture` still fails to link on this machine because the local PyO3 test binary cannot resolve `_Py*` symbols; `cargo check -p runtimed-py --lib` passes.
