### PR TITLE
[ipy-opt] Avoid full state reads in agent sync

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -1349,50 +1349,11 @@ impl RuntimeStateDoc {
 
         let status = self.read_str(&entry, "status");
 
-        let execution_count = self
-            .doc
-            .get(&entry, "execution_count")
-            .ok()
-            .flatten()
-            .and_then(|(value, _)| match value {
-                Value::Scalar(s) => match s.as_ref() {
-                    ScalarValue::Int(n) => Some(*n),
-                    ScalarValue::Uint(n) => Some(*n as i64),
-                    _ => None,
-                },
-                _ => None,
-            });
-
-        let success = self
-            .doc
-            .get(&entry, "success")
-            .ok()
-            .flatten()
-            .and_then(|(value, _)| match value {
-                Value::Scalar(s) => match s.as_ref() {
-                    ScalarValue::Boolean(b) => Some(*b),
-                    _ => None,
-                },
-                _ => None,
-            });
-
+        let execution_count = self.read_execution_count(&entry);
+        let success = self.read_execution_success(&entry);
         let outputs = self.get_outputs(execution_id);
-
         let source = self.read_opt_str(&entry, "source");
-
-        let seq = self
-            .doc
-            .get(&entry, "seq")
-            .ok()
-            .flatten()
-            .and_then(|(value, _)| match value {
-                Value::Scalar(s) => match s.as_ref() {
-                    ScalarValue::Uint(n) => Some(*n),
-                    ScalarValue::Int(n) => Some(*n as u64),
-                    _ => None,
-                },
-                _ => None,
-            });
+        let seq = self.read_execution_seq(&entry);
 
         let submitted_by_actor_label = self.read_opt_str(&entry, "submitted_by_actor_label");
 
@@ -1407,17 +1368,83 @@ impl RuntimeStateDoc {
         })
     }
 
+    fn read_execution_count(&self, entry: &ObjId) -> Option<i64> {
+        self.doc
+            .get(entry, "execution_count")
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                Value::Scalar(s) => match s.as_ref() {
+                    ScalarValue::Int(n) => Some(*n),
+                    ScalarValue::Uint(n) => Some(*n as i64),
+                    _ => None,
+                },
+                _ => None,
+            })
+    }
+
+    fn read_execution_success(&self, entry: &ObjId) -> Option<bool> {
+        self.doc
+            .get(entry, "success")
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                Value::Scalar(s) => match s.as_ref() {
+                    ScalarValue::Boolean(b) => Some(*b),
+                    _ => None,
+                },
+                _ => None,
+            })
+    }
+
+    fn read_execution_seq(&self, entry: &ObjId) -> Option<u64> {
+        self.doc
+            .get(entry, "seq")
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                Value::Scalar(s) => match s.as_ref() {
+                    ScalarValue::Uint(n) => Some(*n),
+                    ScalarValue::Int(n) => Some(*n as u64),
+                    _ => None,
+                },
+                _ => None,
+            })
+    }
+
     /// Get execution entries with `status == "queued"`, sorted by `seq`.
     ///
     /// Used by the runtime agent to discover new work via CRDT sync. Returns
     /// `(execution_id, ExecutionState)` pairs in execution order.
     pub fn get_queued_executions(&self) -> Vec<(String, ExecutionState)> {
-        let state = self.read_state();
-        let mut queued: Vec<(String, ExecutionState)> = state
-            .executions
-            .into_iter()
-            .filter(|(_, exec)| exec.status == "queued")
-            .collect();
+        let Some(executions) = self.get_map("executions") else {
+            return Vec::new();
+        };
+
+        let mut queued = Vec::new();
+        for execution_id in self.doc.keys(&executions) {
+            let Some((_, entry)) = self.doc.get(&executions, &execution_id).ok().flatten() else {
+                continue;
+            };
+            let status = self.read_str(&entry, "status");
+            if status != "queued" {
+                continue;
+            }
+
+            queued.push((
+                execution_id,
+                ExecutionState {
+                    status,
+                    execution_count: self.read_execution_count(&entry),
+                    success: self.read_execution_success(&entry),
+                    outputs: Vec::new(),
+                    source: self.read_opt_str(&entry, "source"),
+                    seq: self.read_execution_seq(&entry),
+                    submitted_by_actor_label: self.read_opt_str(&entry, "submitted_by_actor_label"),
+                },
+            ));
+        }
+
         queued.sort_by_key(|(_, exec)| exec.seq.unwrap_or(u64::MAX));
         queued
     }
@@ -2572,6 +2599,25 @@ impl RuntimeStateDoc {
         })
     }
 
+    /// Read all comm entries without projecting the full RuntimeState.
+    ///
+    /// Runtime-agent sync handling diffs comm state on every state-frame
+    /// receive. Keeping that path narrow avoids materializing execution
+    /// outputs when only widget comm metadata is needed.
+    pub fn get_comms(&self) -> HashMap<String, CommDocEntry> {
+        let Some(comms_obj) = self.get_map("comms") else {
+            return HashMap::new();
+        };
+
+        let mut comms = HashMap::new();
+        for key in self.doc.keys(&comms_obj) {
+            if let Some(entry) = self.get_comm(&key) {
+                comms.insert(key, entry);
+            }
+        }
+        comms
+    }
+
     /// Append an output manifest to a comm's outputs list (OutputModel widgets).
     ///
     /// Returns `false` if the comm doesn't exist.
@@ -2758,19 +2804,7 @@ impl RuntimeStateDoc {
             })
             .unwrap_or_default();
 
-        // Read comms map
-        let comms = self
-            .get_map("comms")
-            .map(|comms_obj| {
-                let mut map = HashMap::new();
-                for key in self.doc.keys(&comms_obj) {
-                    if let Some(entry) = self.get_comm(&key) {
-                        map.insert(key, entry);
-                    }
-                }
-                map
-            })
-            .unwrap_or_default();
+        let comms = self.get_comms();
 
         RuntimeState {
             kernel: kernel_state,
@@ -4109,6 +4143,27 @@ mod tests {
     }
 
     #[test]
+    fn get_queued_executions_projects_only_queue_metadata() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution_with_source("done-exec", "display('done')", 1)
+            .unwrap();
+        doc.set_execution_running("done-exec").unwrap();
+        doc.append_output("done-exec", &test_display("hash-done"))
+            .unwrap();
+        doc.set_execution_done("done-exec", true).unwrap();
+        doc.create_execution_with_source("queued-exec", "display('queued')", 2)
+            .unwrap();
+
+        let queued = doc.get_queued_executions();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].0, "queued-exec");
+        assert_eq!(queued[0].1.status, "queued");
+        assert_eq!(queued[0].1.source.as_deref(), Some("display('queued')"));
+        assert_eq!(queued[0].1.seq, Some(2));
+        assert!(queued[0].1.outputs.is_empty());
+    }
+
+    #[test]
     fn read_state_projects_queued_executions_before_kernel_queue_catches_up() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution_with_source("exec-2", "y = 2", 2)
@@ -5256,6 +5311,29 @@ mod tests {
         assert_eq!(state.comms.len(), 2);
         assert_eq!(state.comms["comm-1"].model_name, "Slider");
         assert_eq!(state.comms["comm-2"].model_name, "Button");
+    }
+
+    #[test]
+    fn test_get_comms_matches_read_state_projection() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution_with_source("exec-1", "display('x')", 0)
+            .unwrap();
+        doc.set_execution_running("exec-1").unwrap();
+        doc.append_output("exec-1", &test_display("hash-output"))
+            .unwrap();
+        doc.put_comm(
+            "comm-1",
+            "jupyter.widget",
+            "mod",
+            "Slider",
+            &serde_json::json!({"v": 1}),
+            0,
+        )
+        .unwrap();
+
+        let comms = doc.get_comms();
+        let state = doc.read_state();
+        assert_eq!(comms, state.comms);
     }
 
     #[test]

--- a/crates/runtimed/examples/output_commit_measure.rs
+++ b/crates/runtimed/examples/output_commit_measure.rs
@@ -1,6 +1,6 @@
 use runtimed::output_commit_measure::{
     measure_current_output_commit_loop, measure_ordered_worker_output_commit_model,
-    OutputCommitKind, OutputCommitMeasurementConfig,
+    measure_runtime_state_reader_paths, OutputCommitKind, OutputCommitMeasurementConfig,
 };
 
 #[tokio::main]
@@ -36,6 +36,10 @@ async fn main() -> anyhow::Result<()> {
 
             let worker = measure_ordered_worker_output_commit_model(config).await?;
             println!("{}", serde_json::to_string(&worker)?);
+
+            for reader in measure_runtime_state_reader_paths(config).await? {
+                println!("{}", serde_json::to_string(&reader)?);
+            }
         }
     }
 

--- a/crates/runtimed/src/output_commit_measure.rs
+++ b/crates/runtimed/src/output_commit_measure.rs
@@ -75,6 +75,17 @@ pub struct OutputCommitMeasurement {
     pub total_nanos: u128,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeStateReaderMeasurement {
+    pub strategy: &'static str,
+    pub output_count: usize,
+    pub payload_bytes: usize,
+    pub committed_outputs: usize,
+    pub comms_seen: usize,
+    pub queued_executions_seen: usize,
+    pub reader_nanos: u128,
+}
+
 impl OutputCommitMeasurement {
     fn new(strategy: &'static str, config: OutputCommitMeasurementConfig) -> Self {
         Self {
@@ -224,6 +235,93 @@ pub async fn measure_ordered_worker_output_commit_model(
     Ok(metrics)
 }
 
+pub async fn measure_runtime_state_reader_paths(
+    config: OutputCommitMeasurementConfig,
+) -> anyhow::Result<Vec<RuntimeStateReaderMeasurement>> {
+    let blob_root = output_commit_measure_blob_root();
+    tokio::fs::create_dir_all(&blob_root)
+        .await
+        .with_context(|| format!("create blob root {}", blob_root.display()))?;
+    let blob_store = BlobStore::new(blob_root.clone());
+    let redactor = OutputRedactor::disabled();
+    let mut doc = RuntimeStateDoc::new();
+    doc.create_execution_with_source(EXECUTION_ID, "pass", 0)?;
+    doc.set_execution_running(EXECUTION_ID)?;
+    doc.put_comm(
+        "comm-output-measure",
+        "jupyter.widget",
+        "@jupyter-widgets/output",
+        "OutputModel",
+        &serde_json::json!({"value": "ready"}),
+        0,
+    )?;
+
+    for index in 0..config.output_count {
+        let output = measured_output(config.kind, index, config.payload_bytes);
+        let manifest = output_store::create_manifest_with_redactor(
+            &output,
+            &blob_store,
+            DEFAULT_INLINE_THRESHOLD,
+            &redactor,
+        )
+        .await
+        .context("create output manifest")?;
+        doc.append_output(EXECUTION_ID, &manifest.to_json())?;
+    }
+    doc.set_execution_done(EXECUTION_ID, true)?;
+    doc.create_execution_with_source("exec-output-commit-queued", "pass", 1)?;
+
+    let full_started = Instant::now();
+    let state = doc.read_state();
+    let full_comms_seen = state.comms.len();
+    let full_queued_seen = state
+        .executions
+        .values()
+        .filter(|execution| execution.status == "queued")
+        .count();
+    let full_nanos = full_started.elapsed().as_nanos();
+
+    let targeted_started = Instant::now();
+    let targeted_comms_seen = doc.get_comms().len();
+    let targeted_queued_seen = doc.get_queued_executions().len();
+    let targeted_nanos = targeted_started.elapsed().as_nanos();
+
+    ensure!(
+        full_comms_seen == targeted_comms_seen,
+        "comm reader mismatch"
+    );
+    ensure!(
+        full_queued_seen == targeted_queued_seen,
+        "queued execution reader mismatch"
+    );
+    ensure!(
+        doc.get_outputs(EXECUTION_ID).len() == config.output_count,
+        "reader measurement committed an unexpected number of outputs"
+    );
+
+    let _ = tokio::fs::remove_dir_all(&blob_root).await;
+    Ok(vec![
+        RuntimeStateReaderMeasurement {
+            strategy: "full_read_state_projection",
+            output_count: config.output_count,
+            payload_bytes: config.payload_bytes,
+            committed_outputs: config.output_count,
+            comms_seen: full_comms_seen,
+            queued_executions_seen: full_queued_seen,
+            reader_nanos: full_nanos,
+        },
+        RuntimeStateReaderMeasurement {
+            strategy: "targeted_comm_queue_readers",
+            output_count: config.output_count,
+            payload_bytes: config.payload_bytes,
+            committed_outputs: config.output_count,
+            comms_seen: targeted_comms_seen,
+            queued_executions_seen: targeted_queued_seen,
+            reader_nanos: targeted_nanos,
+        },
+    ])
+}
+
 fn output_commit_measure_blob_root() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("runtimed-output-commit-measure-{}", Uuid::new_v4()))
 }
@@ -314,5 +412,25 @@ mod tests {
         assert_eq!(metrics.manifest_creations, 4);
         assert_eq!(metrics.output_appends, 4);
         assert_eq!(metrics.committed_outputs, 4);
+    }
+
+    #[tokio::test]
+    async fn runtime_state_reader_measure_compares_equivalent_paths() {
+        let metrics = measure_runtime_state_reader_paths(OutputCommitMeasurementConfig {
+            output_count: 4,
+            payload_bytes: 16,
+            kind: OutputCommitKind::DisplayData,
+        })
+        .await
+        .expect("measurement should run");
+
+        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics[0].strategy, "full_read_state_projection");
+        assert_eq!(metrics[1].strategy, "targeted_comm_queue_readers");
+        for metric in metrics {
+            assert_eq!(metric.committed_outputs, 4);
+            assert_eq!(metric.comms_seen, 1);
+            assert_eq!(metric.queued_executions_seen, 1);
+        }
     }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -341,7 +341,7 @@ pub async fn run_runtime_agent(
                                     let sync_result = ctx.state.with_doc(|sd| {
                                         // Snapshot comm state before applying sync so we can
                                         // detect frontend-originated widget state changes.
-                                        let comms_before = sd.read_state().comms;
+                                        let comms_before = sd.get_comms();
 
                                         // Per-change actor filter: diff comm state against a
                                         // foreign-only view of the post-sync doc.
@@ -365,7 +365,7 @@ pub async fn run_runtime_agent(
                                                         Vec::new()
                                                     }
                                                 };
-                                                let comms_after = sd.read_state().comms;
+                                                let comms_after = sd.get_comms();
                                                 let superseded_hashes =
                                                     superseded_content_ref_hashes_by_comm(
                                                         &comms_before,

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -44,9 +44,12 @@ known repeated work:
    `display_index` without sorting and scanning every output in the execution.
 2. Cached or indexed output ordering metadata so append/upsert paths do not
    recompute order by decoding all manifests.
-3. WASM-side output-id indexing so runtime sync handling does not repeatedly
+3. Targeted RuntimeStateDoc readers for runtime-agent queue and comm handling
+   so state-sync bookkeeping does not materialize every flat output when it
+   only needs queued execution metadata or widget comm state.
+4. WASM-side output-id indexing so runtime sync handling does not repeatedly
    read the full runtime state just to derive output deltas.
-4. Frontend output materialization cleanup so runtime outputs flow through the
+5. Frontend output materialization cleanup so runtime outputs flow through the
    output store rather than repeated whole-output JSON cache keys.
 
 Each item is independently mergeable and should include a small benchmark or


### PR DESCRIPTION
## Summary

- avoid full `RuntimeStateDoc::read_state()` projection in the runtime-agent state-sync hot path when only comm state and queued execution metadata are needed
- add `RuntimeStateDoc::get_comms()` and make `get_queued_executions()` read execution metadata directly instead of materializing every output
- extend `output_commit_measure` with JSON measurements for full state projection versus targeted comm/queue readers
- update the runtime output optimization decision doc with this flat-path collapse

## Compatibility

- public output APIs remain flat: `get_outputs()`, `read_state()`, WASM/frontend/Python/MCP-visible output shapes are unchanged
- no segment manifests are introduced
- `.ipynb` save/load behavior is unchanged
- queued execution discovery still returns source, seq, execution status, and submitter metadata; queued executions do not carry materialized outputs

## Measurement

Command:

```bash
NTERACT_OUTPUT_COMMIT_COUNTS=100,500,1000 cargo run -p runtimed --example output_commit_measure --quiet
```

Representative `display_data` reader rows:

```json
{"strategy":"full_read_state_projection","output_count":100,"reader_nanos":6333584}
{"strategy":"targeted_comm_queue_readers","output_count":100,"reader_nanos":106792}
{"strategy":"full_read_state_projection","output_count":500,"reader_nanos":30435750}
{"strategy":"targeted_comm_queue_readers","output_count":500,"reader_nanos":113583}
{"strategy":"full_read_state_projection","output_count":1000,"reader_nanos":63747500}
{"strategy":"targeted_comm_queue_readers","output_count":1000,"reader_nanos":123625}
```

## Verification

- `cargo test -p runtime-doc`
- `cargo test -p runtimed runtime_agent -- --nocapture`
- `cargo test -p runtimed output_commit_measure -- --nocapture`
- `NTERACT_OUTPUT_COMMIT_COUNTS=100,500,1000 cargo run -p runtimed --example output_commit_measure --quiet`
- `cargo xtask lint --fix`
- `git diff --check`
