### PR TITLE
fix(notebook-cloud): align hosted viewer theming

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -49,3 +49,13 @@ test("cloud report-mode rendering leaves output iframes unfocused for page scrol
     "cloud report rendering should not focus output iframes; focused iframes trap page scroll",
   );
 });
+
+test("cloud viewer exposes the shared theme toggle and cloud theme hook", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /import \{ ThemeToggle \} from "@\/components\/ui\/theme-toggle";/);
+  assert.match(sourceText, /useCloudTheme/);
+  assert.match(sourceText, /<ThemeToggle/);
+  assert.match(sourceText, /className="cloud-theme-toggle"/);
+});

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLOUD_THEME_STORAGE_KEY,
+  isCloudThemeMode,
+  resolveCloudThemeMode,
+  storedCloudThemeMode,
+} from "../viewer/theme.ts";
+
+describe("cloud viewer theme state", () => {
+  it("accepts the shared light/dark/system theme modes", () => {
+    assert.equal(isCloudThemeMode("light"), true);
+    assert.equal(isCloudThemeMode("dark"), true);
+    assert.equal(isCloudThemeMode("system"), true);
+    assert.equal(isCloudThemeMode("cream"), false);
+    assert.equal(isCloudThemeMode(null), false);
+  });
+
+  it("resolves system theme from the caller-provided media state", () => {
+    assert.equal(resolveCloudThemeMode("light", true), "light");
+    assert.equal(resolveCloudThemeMode("dark", false), "dark");
+    assert.equal(resolveCloudThemeMode("system", true), "dark");
+    assert.equal(resolveCloudThemeMode("system", false), "light");
+  });
+
+  it("reads a valid stored cloud theme and falls back to system for invalid values", () => {
+    const validStorage = {
+      getItem: (key: string) => (key === CLOUD_THEME_STORAGE_KEY ? "dark" : null),
+    };
+    const invalidStorage = {
+      getItem: (key: string) => (key === CLOUD_THEME_STORAGE_KEY ? "sepia" : null),
+    };
+
+    assert.equal(storedCloudThemeMode(validStorage), "dark");
+    assert.equal(storedCloudThemeMode(invalidStorage), "system");
+    assert.equal(storedCloudThemeMode(undefined), "system");
+  });
+});

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -87,6 +87,21 @@ body {
   pointer-events: auto;
 }
 
+.cloud-theme-toggle {
+  height: 2rem;
+  border-color: color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--background) 90%, transparent);
+  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.cloud-theme-toggle button {
+  width: 1.625rem;
+  height: 1.5rem;
+  border-radius: 999px;
+}
+
 .cloud-auth-menu {
   position: relative;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/cell/ReadOnlyNotebook";
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
@@ -44,7 +45,7 @@ import {
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
-import { installDocumentThemeSync } from "./theme";
+import { installDocumentThemeSync, useCloudTheme } from "./theme";
 import "./index.css";
 
 interface CloudViewerConfig {
@@ -162,6 +163,7 @@ function App() {
 
 function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   const { config, blobResolver, outputHostContext } = runtime;
+  const { theme, setTheme } = useCloudTheme();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: "Loading notebook snapshot...",
@@ -487,6 +489,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
 
         <div className="cloud-toolbar-actions">
+          <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
+
           <CloudAuthControls
             authState={authState}
             connectionActorLabel={connectionActorLabel}

--- a/apps/notebook-cloud/viewer/theme.ts
+++ b/apps/notebook-cloud/viewer/theme.ts
@@ -1,15 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ThemeMode } from "@/hooks/useTheme";
+
+export const CLOUD_THEME_STORAGE_KEY = "nteract:notebook-cloud:theme";
+
+type ThemeStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function isCloudThemeMode(value: string | null | undefined): value is ThemeMode {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+export function storedCloudThemeMode(storage: Pick<Storage, "getItem"> | undefined): ThemeMode {
+  if (!storage) return "system";
+  try {
+    const stored = storage.getItem(CLOUD_THEME_STORAGE_KEY);
+    if (isCloudThemeMode(stored)) return stored;
+  } catch {
+    // localStorage can be unavailable in private or locked-down contexts.
+  }
+  return "system";
+}
+
+export function resolveCloudThemeMode(
+  theme: ThemeMode,
+  systemPrefersDark = systemPrefersDarkMode(),
+): "light" | "dark" {
+  if (theme === "system") {
+    return systemPrefersDark ? "dark" : "light";
+  }
+  return theme;
+}
+
+export function applyCloudTheme(theme: ThemeMode): "light" | "dark" {
+  const resolved = resolveCloudThemeMode(theme);
+  if (typeof document === "undefined") return resolved;
+
+  const html = document.documentElement;
+  html.classList.toggle("dark", resolved === "dark");
+  html.classList.toggle("light", resolved === "light");
+  html.dataset.theme = resolved;
+  html.style.colorScheme = resolved;
+  return resolved;
+}
+
+export function setStoredCloudThemeMode(theme: ThemeMode, storage: ThemeStorage | undefined): void {
+  if (!storage) return;
+  try {
+    storage.setItem(CLOUD_THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore localStorage failures; the in-memory React state still applies.
+  }
+}
+
 export function installDocumentThemeSync(): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const apply = () => {
-    const isDark = mediaQuery.matches;
-    document.documentElement.classList.toggle("dark", isDark);
-    document.documentElement.classList.toggle("light", !isDark);
-    document.documentElement.dataset.theme = isDark ? "dark" : "light";
-    document.documentElement.style.colorScheme = isDark ? "dark" : "light";
-  };
+  applyCloudTheme(storedCloudThemeMode(window.localStorage));
+}
 
-  apply();
-  mediaQuery.addEventListener("change", apply);
+export function useCloudTheme() {
+  const [theme, setThemeState] = useState<ThemeMode>(() =>
+    typeof window === "undefined" ? "system" : storedCloudThemeMode(window.localStorage),
+  );
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() =>
+    resolveCloudThemeMode(theme),
+  );
+
+  const setTheme = useCallback((nextTheme: ThemeMode) => {
+    setThemeState(nextTheme);
+    setStoredCloudThemeMode(
+      nextTheme,
+      typeof window === "undefined" ? undefined : window.localStorage,
+    );
+  }, []);
+
+  useEffect(() => {
+    setResolvedTheme(applyCloudTheme(theme));
+    if (theme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const onSystemThemeChange = () => setResolvedTheme(applyCloudTheme("system"));
+    mediaQuery.addEventListener("change", onSystemThemeChange);
+    return () => mediaQuery.removeEventListener("change", onSystemThemeChange);
+  }, [theme]);
+
+  return { theme, setTheme, resolvedTheme };
+}
+
+function systemPrefersDarkMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }

--- a/src/components/isolated/__tests__/frame-config.test.ts
+++ b/src/components/isolated/__tests__/frame-config.test.ts
@@ -37,6 +37,28 @@ describe("isolated frame config", () => {
     });
   });
 
+  it("can seed hosted output documents with the initial theme without changing srcdoc hosts", () => {
+    expect(
+      createIsolatedFrameDocument({
+        outputDocumentUrl: "https://outputs.example/frame/?v=1#shell",
+        themeSeed: { theme: "dark", colorTheme: "cream" },
+      }),
+    ).toEqual({
+      kind: "src",
+      url: "https://outputs.example/frame/?v=1&nteract_theme=dark&nteract_color_theme=cream#shell",
+    });
+
+    expect(
+      createIsolatedFrameDocument({
+        isTauriRuntime: false,
+        themeSeed: { theme: "light", colorTheme: "cream" },
+      }),
+    ).toEqual({
+      kind: "srcdoc",
+      html: FRAME_HTML,
+    });
+  });
+
   it("detects Tauri globals without requiring a real browser window", () => {
     expect(isTauriFrameRuntime(undefined)).toBe(false);
     expect(isTauriFrameRuntime({ __TAURI__: {} })).toBe(true);

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -75,10 +75,12 @@ describe("generateFrameHtml", () => {
   });
 
   it("keeps the iframe bootstrap script parseable", () => {
-    const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+    const scripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
 
-    expect(script).toBeDefined();
-    expect(() => new Function(script ?? "")).not.toThrow();
+    expect(scripts.length).toBeGreaterThanOrEqual(1);
+    for (const script of scripts) {
+      expect(() => new Function(script)).not.toThrow();
+    }
   });
 
   it("renders text/plain without the obsolete ANSI fallback", () => {
@@ -88,12 +90,21 @@ describe("generateFrameHtml", () => {
   });
 
   describe("neutral defaults", () => {
-    it("bakes neutral dark defaults before theme sync arrives", () => {
+    it("seeds the frame theme before first paint", () => {
+      expect(source).toContain("new URLSearchParams(window.location.search)");
+      expect(source).toContain("params.get('nteract_theme')");
+      expect(source).toContain("matchMedia('(prefers-color-scheme: dark)')");
+      expect(source.indexOf("<script>")).toBeLessThan(source.indexOf("<style>"));
+    });
+
+    it("bakes neutral light defaults plus dark overrides before theme sync arrives", () => {
       expect(html).toContain("--bg-primary: transparent");
+      expect(html).toContain("--bg-secondary: #f5f5f5");
+      expect(html).toContain("--text-primary: #1a1a1a");
+      expect(html).toContain("--text-secondary: #666666");
+      expect(html).toContain("--border-color: #e0e0e0");
+      expect(html).toContain('[data-theme="dark"]');
       expect(html).toContain("--bg-secondary: #1a1a1a");
-      expect(html).toContain("--text-primary: #e0e0e0");
-      expect(html).toContain("--text-secondary: #a0a0a0");
-      expect(html).toContain("--border-color: #333333");
     });
 
     it("ships document typography for markdown and html outputs", () => {

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -134,6 +134,36 @@ describe("IsolatedFrame theme updates", () => {
     });
   });
 
+  it("seeds hosted output-document URLs with the mount-time theme without reloading on theme changes", async () => {
+    const { container, rerender } = render(
+      <IsolatedFrame
+        darkMode={false}
+        colorTheme="cream"
+        outputDocumentUrl="https://outputs.example/frame/"
+      />,
+    );
+
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    await waitFor(() => {
+      expect(iframe.src).toBe(
+        "https://outputs.example/frame/?nteract_theme=light&nteract_color_theme=cream",
+      );
+    });
+
+    rerender(
+      <IsolatedFrame
+        darkMode={true}
+        colorTheme="cream"
+        outputDocumentUrl="https://outputs.example/frame/"
+      />,
+    );
+
+    expect(iframe.src).toBe(
+      "https://outputs.example/frame/?nteract_theme=light&nteract_color_theme=cream",
+    );
+  });
+
   it("merges imperative host-context updates into MCP Apps-compatible notifications", async () => {
     const frameRef = { current: null as IsolatedFrameHandle | null };
     const { container } = render(

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -27,6 +27,11 @@ export const ISOLATED_FRAME_ALLOW_ATTR = "fullscreen *";
 
 export type IsolatedFrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
 
+export interface IsolatedFrameThemeSeed {
+  theme?: "light" | "dark" | null;
+  colorTheme?: string | null;
+}
+
 export interface TauriFrameGlobal {
   __TAURI__?: unknown;
   __TAURI_INTERNALS__?: unknown;
@@ -45,14 +50,43 @@ export function isTauriFrameRuntime(
 export function createIsolatedFrameDocument(options?: {
   isTauriRuntime?: boolean;
   outputDocumentUrl?: string | null;
+  themeSeed?: IsolatedFrameThemeSeed;
 }): IsolatedFrameDocument {
   const outputDocumentUrl = options?.outputDocumentUrl?.trim();
   if (outputDocumentUrl) {
-    return { kind: "src", url: outputDocumentUrl };
+    return { kind: "src", url: withIsolatedFrameThemeSeed(outputDocumentUrl, options?.themeSeed) };
   }
 
   if (options?.isTauriRuntime ?? isTauriFrameRuntime()) {
     return { kind: "src", url: NTERACT_FRAME_URL };
   }
   return { kind: "srcdoc", html: FRAME_HTML };
+}
+
+function withIsolatedFrameThemeSeed(
+  outputDocumentUrl: string,
+  themeSeed: IsolatedFrameThemeSeed | undefined,
+): string {
+  if (!themeSeed?.theme && !themeSeed?.colorTheme) {
+    return outputDocumentUrl;
+  }
+
+  try {
+    const isAbsoluteOrProtocolRelative =
+      /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(outputDocumentUrl) || outputDocumentUrl.startsWith("//");
+    const parsed = new URL(outputDocumentUrl, "https://nteract.invalid");
+    if (themeSeed.theme === "light" || themeSeed.theme === "dark") {
+      parsed.searchParams.set("nteract_theme", themeSeed.theme);
+    }
+    if (themeSeed.colorTheme && themeSeed.colorTheme !== "classic") {
+      parsed.searchParams.set("nteract_color_theme", themeSeed.colorTheme);
+    }
+
+    if (isAbsoluteOrProtocolRelative) {
+      return parsed.href;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return outputDocumentUrl;
+  }
 }

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="background: transparent; color-scheme: dark">
+<html style="background: transparent; color-scheme: light dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,13 +7,35 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https: http://127.0.0.1:*; style-src 'unsafe-inline' https: http://127.0.0.1:*; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *; worker-src 'self' blob:; frame-src 'none'; child-src 'none';"
     />
+    <script>
+      (function () {
+        try {
+          var params = new URLSearchParams(window.location.search);
+          var theme = params.get("nteract_theme");
+          var colorTheme = params.get("nteract_color_theme");
+          var isDark =
+            theme === "dark" ||
+            (theme !== "light" &&
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          var rootEl = document.documentElement;
+          rootEl.classList.add(isDark ? "dark" : "light");
+          rootEl.classList.remove(isDark ? "light" : "dark");
+          rootEl.setAttribute("data-theme", isDark ? "dark" : "light");
+          rootEl.style.colorScheme = isDark ? "dark" : "light";
+          if (colorTheme && colorTheme !== "classic") {
+            rootEl.setAttribute("data-color-theme", colorTheme);
+          }
+        } catch (_) {}
+      })();
+    </script>
     <style>
       :root {
         --bg-primary: transparent;
-        --bg-secondary: #1a1a1a;
-        --text-primary: #e0e0e0;
-        --text-secondary: #a0a0a0;
-        --border-color: #333333;
+        --bg-secondary: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666666;
+        --border-color: #e0e0e0;
         --accent-color: #3b82f6;
         --error-color: #ef4444;
         --success-color: #22c55e;
@@ -31,6 +53,15 @@
           system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         --output-mono-font: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
         --output-document-font: var(--output-ui-font);
+      }
+
+      .dark,
+      [data-theme="dark"] {
+        --bg-secondary: #1a1a1a;
+        --text-primary: #e0e0e0;
+        --text-secondary: #a0a0a0;
+        --border-color: #333333;
+        --accent-color: #60a5fa;
       }
 
       [data-color-theme="cream"] {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -324,6 +324,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const runtimeRef = useRef<IsolatedFrameRuntime | null>(null);
     const initialContentRef = useRef(initialContent);
+    const initialThemeSeedRef = useRef({
+      theme: darkMode ? ("dark" as const) : ("light" as const),
+      colorTheme: colorTheme ?? null,
+    });
     const applyMeasuredHeightRef = useRef<(contentHeight: number) => void>(() => {});
     const [frameDocument, setFrameDocument] = useState<IsolatedFrameDocument | null>(null);
     // Track iframe ready (bootstrap HTML loaded)
@@ -483,7 +487,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     // non-React adapters, and tests on the same source/sandbox contract.
     useEffect(() => {
       setFrameDocument(
-        createIsolatedFrameDocument({ outputDocumentUrl: resolvedOutputDocumentUrl }),
+        createIsolatedFrameDocument({
+          outputDocumentUrl: resolvedOutputDocumentUrl,
+          themeSeed: initialThemeSeedRef.current,
+        }),
       );
     }, [resolvedOutputDocumentUrl]);
 

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -109,6 +109,10 @@ export function createNteractOutputEmbed(
   const iframe = document.createElement("iframe");
   const documentSource = createIsolatedFrameDocument({
     outputDocumentUrl: options.outputDocumentUrl ?? options.hostContext?.nteract?.outputDocumentUrl,
+    themeSeed: {
+      theme: options.hostContext?.theme ?? null,
+      colorTheme: options.hostContext?.nteract?.colorTheme ?? null,
+    },
   });
   const injectedPlugins = new Set<string>();
   let disposed = false;


### PR DESCRIPTION
## Summary

- add a persisted light/dark/system theme controller for the hosted notebook-cloud viewer
- expose the shared `ThemeToggle` in the hosted cloud toolbar
- seed hosted output-document iframe URLs with the first render theme so markdown/code frames do not flash dark before the viewer applies light theme
- keep later iframe theme updates on the existing host-context message path instead of reloading output iframes

## Cloud lane / shared contract

This is intentionally cloud-facing: the product behavior is in `apps/notebook-cloud/viewer/*`, while the shared `src/components/isolated/*` changes only add the hosted output-document theme seed used by cloud and non-React embeds. MCP Apps CSS/resources work stays out of this PR.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-theme.test.ts test/viewer-render-props.test.ts test/html.test.ts`
- `pnpm test:run src/components/isolated/__tests__/frame-config.test.ts src/components/isolated/__tests__/frame-html.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/output-embed.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- deployed:
  - `nteract-notebook-cloud-outputs` version `d0bb9df6-2d61-448b-b5ef-ad32189e0e0b`
  - `nteract-notebook-cloud-assets` version `9fc6015d-d8a3-4b5b-908c-2c26ac43584d`
  - `nteract-notebook-cloud` version `9af7ba72-6bf8-4e9a-b798-b43fd153416d`
- hosted smoke against `https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-demo`
- Playwright deployed check: stored light theme seeds output-origin iframe URLs with `nteract_theme=light`; toggling dark updates the shell and output-origin frames through host-context messaging
