### PR TITLE
fix(mcp-app): align rich output expansion with renderer

### DIFF
--- a/apps/mcp-app/src/lib/rich-output.ts
+++ b/apps/mcp-app/src/lib/rich-output.ts
@@ -1,40 +1,9 @@
 import type { CellData } from "../types";
-
-/** MIME types that represent rich visual content the human needs to see. */
-const RICH_MIME_TYPES = new Set([
-	"image/png",
-	"image/jpeg",
-	"image/gif",
-	"image/webp",
-	"image/svg+xml",
-	"text/html",
-	"text/markdown",
-	"text/latex",
-	"application/vnd.plotly.v1+json",
-	"application/geo+json",
-]);
-
-/** Prefix patterns for vega/vegalite (versioned MIME types). */
-const RICH_MIME_PREFIXES = [
-	"application/vnd.vegalite.v",
-	"application/vnd.vega.v",
-];
-
-function isRichMime(mime: string): boolean {
-	if (RICH_MIME_TYPES.has(mime)) return true;
-	return RICH_MIME_PREFIXES.some((p) => mime.startsWith(p));
-}
+import { mcpAppCellHasRichOutput } from "@/components/isolated/mcp-app-structured-content";
 
 /** Whether a cell has any output that should be visually expanded. */
 export function hasRichOutput(cell: CellData): boolean {
-	if (!cell.outputs?.length) return false;
-	return cell.outputs.some((output) => {
-		if (output.output_type === "display_data" || output.output_type === "execute_result") {
-			if (!output.data) return false;
-			return Object.keys(output.data).some(isRichMime);
-		}
-		return false;
-	});
+	return mcpAppCellHasRichOutput(cell);
 }
 
 /** Extract a one-line preview string for a collapsed cell. */

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { resolveEmbeddableOutputs } from "../embeddable-output";
 import {
   createMcpAppBlobResolver,
+  mcpAppCellHasRichOutput,
   mcpAppCellsToSharedOutputs,
   mcpAppStructuredContentToSharedOutputInputs,
   type McpAppCellData,
@@ -141,5 +142,52 @@ describe("MCP App structured content adapter", () => {
       },
       outputId: "error-output",
     });
+  });
+
+  it("uses shared MIME priority when deciding whether MCP App cells should expand", () => {
+    expect(
+      mcpAppCellHasRichOutput(
+        cellWithOutputs([
+          {
+            output_type: "display_data",
+            data: {
+              "text/plain": "Widget view",
+              "application/vnd.jupyter.widget-view+json": JSON.stringify({ model_id: "abc" }),
+            },
+          },
+        ]),
+      ),
+    ).toBe(true);
+
+    expect(
+      mcpAppCellHasRichOutput(
+        cellWithOutputs([
+          {
+            output_type: "display_data",
+            data: {
+              "text/html": "<table></table>",
+              "application/vnd.apache.parquet": "http://localhost:47830/blob/table",
+              "text/plain": "table fallback",
+            },
+          },
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps plain and JSON-only MCP App cells collapsed by default", () => {
+    expect(
+      mcpAppCellHasRichOutput(
+        cellWithOutputs([
+          {
+            output_type: "execute_result",
+            data: {
+              "text/plain": "42",
+              "application/json": JSON.stringify({ value: 42 }),
+            },
+          },
+        ]),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -1,5 +1,6 @@
 import type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from "./embeddable-output";
 import type { ContentRef, OutputBlobResolver, OutputManifest } from "./output-manifest";
+import { selectMimeType } from "@/components/outputs/mime-priority";
 
 export interface McpAppCellOutput {
   output_type: "stream" | "error" | "display_data" | "execute_result";
@@ -32,6 +33,8 @@ export interface McpSharedOutputInputs {
   outputs: NteractEmbeddableOutput[];
   resolveOptions: ResolveEmbeddableOutputsOptions;
 }
+
+const COLLAPSED_PREVIEW_MIME_TYPES = new Set(["text/plain", "text/llm+plain", "application/json"]);
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -127,6 +130,18 @@ export function mcpAppCellsToSharedOutputs(
       return manifest ? [manifest] : [];
     }),
   );
+}
+
+export function mcpAppCellHasRichOutput(cell: McpAppCellData): boolean {
+  return (cell.outputs ?? []).some((output) => {
+    if (output.output_type !== "display_data" && output.output_type !== "execute_result") {
+      return false;
+    }
+    if (!output.data) return false;
+
+    const selectedMime = selectMimeType(output.data);
+    return selectedMime != null && !COLLAPSED_PREVIEW_MIME_TYPES.has(selectedMime);
+  });
 }
 
 export function createMcpAppBlobResolver(blobBaseUrl: string): OutputBlobResolver {


### PR DESCRIPTION
## Summary

- move MCP App rich-output expansion decisions onto the shared isolated renderer MIME priority
- keep plain, `text/llm+plain`, and JSON-only outputs collapsed by default
- cover widget and Arrow/parquet-style outputs so supported rich renderer formats expand in multi-cell app results

## Verification

- `pnpm test:run src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm test:run apps/mcp-app/src`
- `cargo xtask lint --fix`
