### PR TITLE
[ipy-opt] Index frontend display updates

### DIFF
--- a/apps/notebook/src/lib/__tests__/notebook-outputs.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-outputs.test.ts
@@ -6,13 +6,9 @@ import {
   getOutputById,
   resetNotebookOutputs,
   setOutput,
+  updateOutputsByDisplayId,
   useOutput,
 } from "../notebook-outputs";
-
-// The useOutput hook is shaped like React's useSyncExternalStore; here we
-// reach into the subscribe/get pair via the exported module-level helpers
-// plus a manual subscribe on the store. Tests exercise the invariants at
-// the store layer only -- no React rendering.
 
 afterEach(() => {
   resetNotebookOutputs();
@@ -23,6 +19,20 @@ const streamOutput = (text: string): JupyterOutput => ({
   name: "stdout",
   text,
 });
+
+function displayOutput(
+  output_id: string,
+  display_id: string,
+  text: string,
+): JupyterOutput {
+  return {
+    output_id,
+    output_type: "display_data",
+    display_id,
+    data: { "text/plain": text },
+    metadata: {},
+  };
+}
 
 describe("notebook-outputs store", () => {
   it("returns undefined for unknown output_ids", () => {
@@ -97,5 +107,98 @@ describe("notebook-outputs store", () => {
     // outside a React test environment here, so the assertion is simply
     // that the export exists and is a function.
     expect(typeof useOutput).toBe("function");
+  });
+});
+
+describe("notebook output store display_id updates", () => {
+  it("updates every display-capable output with the matching display_id", () => {
+    setOutput("out-1", displayOutput("out-1", "plot", "before"));
+    setOutput("out-2", {
+      output_id: "out-2",
+      output_type: "execute_result",
+      display_id: "plot",
+      execution_count: 1,
+      data: { "text/plain": "old result" },
+      metadata: {},
+    });
+    setOutput("stream-1", {
+      output_id: "stream-1",
+      output_type: "stream",
+      name: "stdout",
+      text: "plot",
+    });
+
+    updateOutputsByDisplayId(
+      "plot",
+      { "text/plain": "after" },
+      { updated: true },
+    );
+
+    expect(getOutputById("out-1")).toMatchObject({
+      data: { "text/plain": "after" },
+      metadata: { updated: true },
+    });
+    expect(getOutputById("out-2")).toMatchObject({
+      data: { "text/plain": "after" },
+      metadata: { updated: true },
+    });
+    expect(getOutputById("stream-1")).toMatchObject({ text: "plot" });
+  });
+
+  it("moves an output between display_id buckets on replacement", () => {
+    setOutput("out-1", displayOutput("out-1", "old-display", "before"));
+    setOutput("out-1", displayOutput("out-1", "new-display", "before"));
+
+    updateOutputsByDisplayId("old-display", { "text/plain": "wrong" });
+    expect(getOutputById("out-1")).toMatchObject({
+      data: { "text/plain": "before" },
+    });
+
+    updateOutputsByDisplayId("new-display", { "text/plain": "right" });
+    expect(getOutputById("out-1")).toMatchObject({
+      data: { "text/plain": "right" },
+    });
+  });
+
+  it("removes deleted and reset outputs from display_id lookup", () => {
+    setOutput("deleted", displayOutput("deleted", "plot", "before"));
+    deleteOutput("deleted");
+    updateOutputsByDisplayId("plot", { "text/plain": "after" });
+    expect(getOutputById("deleted")).toBeUndefined();
+
+    setOutput("reset", displayOutput("reset", "plot", "before"));
+    resetNotebookOutputs();
+    updateOutputsByDisplayId("plot", { "text/plain": "after" });
+    expect(getOutputById("reset")).toBeUndefined();
+  });
+
+  it("does not scan unrelated outputs for every display update", () => {
+    let throwOnDisplayIdRead = false;
+    const unrelated = {
+      output_id: "unrelated",
+      output_type: "display_data",
+      data: { "text/plain": "unrelated" },
+      metadata: {},
+    } as JupyterOutput;
+    Object.defineProperty(unrelated, "display_id", {
+      enumerable: true,
+      get() {
+        if (throwOnDisplayIdRead) {
+          throw new Error("display_id scan reached unrelated output");
+        }
+        return "other-display";
+      },
+    });
+
+    setOutput("target", displayOutput("target", "target-display", "before"));
+    setOutput("unrelated", unrelated);
+    throwOnDisplayIdRead = true;
+
+    expect(() =>
+      updateOutputsByDisplayId("target-display", { "text/plain": "after" }),
+    ).not.toThrow();
+    expect(getOutputById("target")).toMatchObject({
+      data: { "text/plain": "after" },
+    });
   });
 });

--- a/apps/notebook/src/lib/notebook-outputs.ts
+++ b/apps/notebook/src/lib/notebook-outputs.ts
@@ -22,6 +22,7 @@ import {
 //
 // Responsibilities:
 //   _outputMap    — output manifest by output_id
+//   _displayIndex — display_id -> output_ids for optimistic display updates
 //   subscribers   — per-output set of callbacks
 //
 // Writers: the frame pipeline, fed by `RuntimeStateSyncApplied.output_changeset`
@@ -29,8 +30,14 @@ import {
 // ---------------------------------------------------------------------------
 
 const _outputMap: Map<string, JupyterOutput> = new Map();
+const _displayIndex: Map<string, Set<string>> = new Map();
 
 const _subscribers = new Map<string, Set<() => void>>();
+
+type DisplayCapableOutput = Extract<
+  JupyterOutput,
+  { output_type: "display_data" | "execute_result" }
+>;
 
 // Coarse version counter bumped on every setOutput / deleteOutput. This
 // is intentionally NOT used by `useCellOutputs` (per-cell hooks subscribe
@@ -155,6 +162,44 @@ function getOutputSnapshot(output_id: string): () => JupyterOutput | undefined {
   return () => _outputMap.get(output_id);
 }
 
+function isDisplayCapableOutput(
+  output: JupyterOutput,
+): output is DisplayCapableOutput {
+  return (
+    output.output_type === "display_data" ||
+    output.output_type === "execute_result"
+  );
+}
+
+function getDisplayId(output: JupyterOutput): string | undefined {
+  if (isDisplayCapableOutput(output)) {
+    return output.display_id;
+  }
+  return undefined;
+}
+
+function addDisplayIndexEntry(output_id: string, output: JupyterOutput): void {
+  const display_id = getDisplayId(output);
+  if (display_id === undefined) return;
+  let outputIds = _displayIndex.get(display_id);
+  if (!outputIds) {
+    outputIds = new Set();
+    _displayIndex.set(display_id, outputIds);
+  }
+  outputIds.add(output_id);
+}
+
+function removeDisplayIndexEntry(output_id: string, output: JupyterOutput): void {
+  const display_id = getDisplayId(output);
+  if (display_id === undefined) return;
+  const outputIds = _displayIndex.get(display_id);
+  if (!outputIds) return;
+  outputIds.delete(output_id);
+  if (outputIds.size === 0) {
+    _displayIndex.delete(display_id);
+  }
+}
+
 // ── Write operations ────────────────────────────────────────────────────
 
 /**
@@ -166,13 +211,17 @@ function getOutputSnapshot(output_id: string): () => JupyterOutput | undefined {
 export function setOutput(output_id: string, output: JupyterOutput): void {
   const prev = _outputMap.get(output_id);
   if (prev === output) return;
+  if (prev) removeDisplayIndexEntry(output_id, prev);
   _outputMap.set(output_id, output);
+  addDisplayIndexEntry(output_id, output);
   emitOutputChange(output_id);
 }
 
 /** Remove a single output. Notifies its subscribers with `undefined`. */
 export function deleteOutput(output_id: string): void {
-  if (!_outputMap.has(output_id)) return;
+  const prev = _outputMap.get(output_id);
+  if (!prev) return;
+  removeDisplayIndexEntry(output_id, prev);
   _outputMap.delete(output_id);
   emitOutputChange(output_id);
 }
@@ -200,14 +249,18 @@ export function updateOutputsByDisplayId(
   data: Record<string, unknown>,
   metadata?: Record<string, unknown>,
 ): void {
-  for (const [output_id, output] of _outputMap) {
+  const outputIds = _displayIndex.get(display_id);
+  if (!outputIds) return;
+  for (const output_id of [...outputIds]) {
+    const output = _outputMap.get(output_id);
     if (
-      (output.output_type === "display_data" ||
-        output.output_type === "execute_result") &&
-      output.display_id === display_id
+      !output ||
+      !isDisplayCapableOutput(output) ||
+      output.display_id !== display_id
     ) {
-      setOutput(output_id, { ...output, data, metadata });
+      continue;
     }
+    setOutput(output_id, { ...output, data, metadata });
   }
 }
 
@@ -215,6 +268,7 @@ export function updateOutputsByDisplayId(
 export function resetNotebookOutputs(): void {
   const ids = [..._outputMap.keys()];
   _outputMap.clear();
+  _displayIndex.clear();
   for (const id of ids) emitOutputChange(id);
 }
 

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -49,7 +49,10 @@ known repeated work:
    only needs queued execution metadata or widget comm state.
 4. WASM-side output-id indexing so runtime sync handling does not repeatedly
    read the full runtime state just to derive output deltas.
-5. Frontend output materialization cleanup so runtime outputs flow through the
+5. Frontend display-id indexing so optimistic `update_display_data` repainting
+   touches only matching output ids instead of scanning the whole output store
+   for every display update.
+6. Frontend output materialization cleanup so runtime outputs flow through the
    output store rather than repeated whole-output JSON cache keys.
 
 Each item is independently mergeable and should include a small benchmark or


### PR DESCRIPTION
## Summary

- add a private `display_id -> output_id` index to the notebook output store
- keep the index synchronized on output set, delete, batch delete, and reset
- document the frontend display-update index as the next safe flat-path optimization

## Compatibility

This keeps the existing flat `JupyterOutput` store contract. It does not add segment manifests, change output object shape, or change `.ipynb` persistence/export behavior.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-outputs.test.ts`
- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-outputs.test.ts apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts apps/notebook/src/lib/__tests__/frame-pipeline.test.ts`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

This follows merged #2973. It should stay draft until adversarial review, Pullfrog review, GitHub CI, and any targeted display-update stress check are complete.
