### PR TITLE
test(notebook-cloud): add renderer parity harness

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test, type Page } from "@playwright/test";
+import { cloudOutputParityExpectedMarkers } from "../../test/fixtures/cloud-output-parity";
+
+const ALLOWED_CONSOLE_MESSAGES = new Set([
+  "Allow attribute will take precedence over 'allowfullscreen'.",
+  "using deprecated parameters for the initialization function; pass a single object instead",
+]);
+
+test.describe("cloud renderer parity harness", () => {
+  let consoleProblems: string[];
+
+  test.beforeEach(async ({ page }) => {
+    consoleProblems = [];
+    page.on("console", (message) => {
+      const type = message.type();
+      if (type !== "error" && type !== "warning") return;
+      const text = message.text();
+      if (ALLOWED_CONSOLE_MESSAGES.has(text)) return;
+      consoleProblems.push(`[${type}] ${text}`);
+    });
+  });
+
+  test.afterEach(() => {
+    expect(consoleProblems).toEqual([]);
+  });
+
+  test("renders the canonical cloud output fixture through shared notebook components", async ({
+    page,
+  }) => {
+    await openParityHarness(page);
+
+    await expect(page.locator('[data-slot="read-only-notebook"]')).toHaveAttribute(
+      "data-cell-count",
+      "8",
+    );
+    await expect(page.locator('[data-cell-id="code-streams"]')).toContainText(
+      cloudOutputParityExpectedMarkers.stdout,
+    );
+    await expect(page.locator('[data-cell-id="code-streams"]')).toContainText(
+      cloudOutputParityExpectedMarkers.stderr,
+    );
+    await expect(page.locator('[data-cell-id="traceback-cell"]')).toContainText(
+      cloudOutputParityExpectedMarkers.traceback,
+    );
+    await expect(page.locator('[data-cell-id="image-json-output"]')).toContainText(
+      cloudOutputParityExpectedMarkers.json,
+    );
+    await expect(page.locator('[data-cell-id="rich-mime-fallback"]')).toContainText(
+      cloudOutputParityExpectedMarkers.fallback,
+    );
+
+    await expect(
+      page.frameLocator('[data-cell-id="markdown-intro"] iframe').locator("body"),
+    ).toContainText(cloudOutputParityExpectedMarkers.markdown, { timeout: 30_000 });
+    await expect(
+      page.frameLocator('[data-cell-id="html-output"] iframe').locator("body"),
+    ).toContainText(cloudOutputParityExpectedMarkers.html, { timeout: 30_000 });
+    await expect(
+      page.frameLocator('[data-cell-id="svg-output"] iframe').locator("body"),
+    ).toContainText(cloudOutputParityExpectedMarkers.svg, { timeout: 30_000 });
+  });
+
+  test("uses output document URLs for isolated frames without weakening the sandbox", async ({
+    page,
+  }) => {
+    await openParityHarness(page);
+
+    const iframes = page.locator('iframe[data-slot="isolated-frame"]');
+    await expect(iframes.first()).toBeAttached({ timeout: 30_000 });
+    const count = await iframes.count();
+    expect(count).toBeGreaterThanOrEqual(4);
+
+    for (let index = 0; index < count; index++) {
+      const iframe = iframes.nth(index);
+      await expect(iframe).toHaveAttribute("src", /\/output-document\/frame\.html$/);
+      await expect(iframe).not.toHaveAttribute("srcdoc", /./);
+      const sandbox = await iframe.getAttribute("sandbox");
+      expect(sandbox?.split(/\s+/)).toContain("allow-scripts");
+      expect(sandbox?.split(/\s+/)).not.toContain("allow-same-origin");
+    }
+  });
+
+  test("propagates theme changes into cloud output document iframes", async ({ page }) => {
+    await openParityHarness(page);
+
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(
+      page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),
+    ).toHaveAttribute("data-theme", "light", { timeout: 30_000 });
+
+    await page.getByTestId("theme-dark").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(
+      page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),
+    ).toHaveAttribute("data-theme", "dark", { timeout: 30_000 });
+  });
+
+  test("renders the Sift Arrow fixture through cloud-hosted renderer assets", async ({ page }) => {
+    test.setTimeout(120_000);
+    await openParityHarness(page);
+
+    const siftCell = page.locator('[data-cell-id="sift-arrow-output"]');
+    await expect(siftCell.locator('[data-sift-output="true"]')).toBeVisible({ timeout: 60_000 });
+    await expect(siftCell.locator("iframe")).toHaveAttribute(
+      "src",
+      /\/output-document\/frame\.html$/,
+    );
+    await expect(
+      page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
+    ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
+  });
+});
+
+async function openParityHarness(page: Page) {
+  await page.goto("/");
+  await expect(page.getByTestId("cloud-render-parity")).toHaveAttribute("data-ready", "true", {
+    timeout: 60_000,
+  });
+}

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -9,6 +9,8 @@
     "build": "pnpm run wasm && pnpm run renderer-plugins && pnpm run build:viewer",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",
+    "test:renderer-parity": "playwright test -c playwright.render-parity.config.ts",
+    "test:renderer-parity:update": "playwright test -c playwright.render-parity.config.ts --update-snapshots",
     "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",

--- a/apps/notebook-cloud/playwright.render-parity.config.ts
+++ b/apps/notebook-cloud/playwright.render-parity.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/render-parity",
+  timeout: 90_000,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:5182",
+    browserName: "chromium",
+    deviceScaleFactor: 1,
+    headless: true,
+    viewport: { width: 1280, height: 900 },
+  },
+  webServer: {
+    command: "pnpm exec vp dev -c test/render-parity/vite.config.ts",
+    port: 5182,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+  projects: [{ name: "chromium" }],
+});

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -1,0 +1,264 @@
+import type { BlobResolver } from "runtimed";
+import type { ReadOnlyNotebookCellData } from "../../../../src/components/cell/ReadOnlyNotebook";
+import type { SupportedLanguage } from "../../../../src/components/editor/languages";
+import type { NteractEmbedHostContextPatch } from "../../../../src/components/isolated/host-context";
+import { resolveCell, type RenderCell, type ResolvedCell } from "../../viewer/render-resolution.ts";
+
+const ARROW_BLOB_HASH = "sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f";
+
+const ONE_BY_ONE_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+export const cloudOutputParityRenderCells: readonly RenderCell[] = [
+  {
+    id: "markdown-intro",
+    cell_type: "markdown",
+    source: [
+      "# Cloud renderer parity",
+      "",
+      "Markdown **source** should flow through the shared read-only notebook renderer.",
+    ].join("\n"),
+  },
+  {
+    id: "code-streams",
+    cell_type: "code",
+    source: "print('stdout marker')\nprint('stderr marker')",
+    execution_count: 1,
+    metadata: { language: "python" },
+    outputs: [
+      {
+        output_id: "stream-stdout",
+        output_type: "stream",
+        name: "stdout",
+        text: "stdout marker\n",
+      },
+      {
+        output_id: "stream-stderr",
+        output_type: "stream",
+        name: "stderr",
+        text: "stderr marker\n",
+      },
+    ],
+  },
+  {
+    id: "traceback-cell",
+    cell_type: "code",
+    source: "def summarize_value(df):\n    return df['wrong_column']\n\nsummarize_value(df)",
+    execution_count: 2,
+    metadata: { language: "python" },
+    outputs: [
+      {
+        output_id: "traceback-output",
+        output_type: "error",
+        ename: "ColumnNotFoundError",
+        evalue: "wrong_column",
+        traceback: [
+          "Traceback (most recent call last):",
+          '  File "<cell>", line 4, in <module>',
+          '  File "<cell>", line 2, in summarize_value',
+          "ColumnNotFoundError: wrong_column",
+        ],
+      },
+    ],
+  },
+  {
+    id: "html-output",
+    cell_type: "code",
+    source: "display(HTML('<strong>Cloud HTML marker</strong>'))",
+    execution_count: 3,
+    outputs: [
+      {
+        output_id: "html-output-display",
+        output_type: "display_data",
+        data: {
+          "text/html": {
+            inline:
+              '<section id="cloud-html-marker"><strong>Cloud HTML output marker</strong></section>',
+          },
+          "text/plain": { inline: "Cloud HTML output marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
+    id: "svg-output",
+    cell_type: "code",
+    source: "display(SVG(...))",
+    execution_count: 4,
+    outputs: [
+      {
+        output_id: "svg-output-display",
+        output_type: "display_data",
+        data: {
+          "image/svg+xml": {
+            inline: [
+              '<svg role="img" aria-label="Cloud SVG marker" viewBox="0 0 220 80" xmlns="http://www.w3.org/2000/svg">',
+              '<rect width="220" height="80" rx="8" fill="#f8fafc" stroke="#0f766e" />',
+              '<text x="16" y="46" fill="#0f766e" font-size="20">Cloud SVG marker</text>',
+              "</svg>",
+            ].join(""),
+          },
+          "text/plain": { inline: "Cloud SVG marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
+    id: "image-json-output",
+    cell_type: "code",
+    source: "display(image); display(config)",
+    execution_count: 5,
+    outputs: [
+      {
+        output_id: "image-output-display",
+        output_type: "display_data",
+        data: {
+          "image/png": { inline: ONE_BY_ONE_PNG },
+        },
+        metadata: {
+          "image/png": { width: 18, height: 18 },
+        },
+      },
+      {
+        output_id: "json-output-display",
+        output_type: "display_data",
+        data: {
+          "application/json": {
+            inline: JSON.stringify({
+              renderer: "cloud",
+              marker: "Cloud JSON marker",
+              nested: { stable: true },
+            }),
+          },
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
+    id: "rich-mime-fallback",
+    cell_type: "code",
+    source: "display(custom_json)",
+    execution_count: 6,
+    outputs: [
+      {
+        output_id: "rich-mime-fallback-display",
+        output_type: "display_data",
+        data: {
+          "application/vnd.nteract.unknown+json": {
+            inline: JSON.stringify({ marker: "Unknown JSON MIME marker" }),
+          },
+          "text/plain": { inline: "Plain text fallback marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
+    id: "sift-arrow-output",
+    cell_type: "code",
+    source: [
+      "import polars as pl",
+      "# df contains utf8-view columns and is published as Arrow IPC",
+      "df",
+    ].join("\n"),
+    execution_count: 7,
+    outputs: [
+      {
+        output_id: "sift-arrow-display",
+        output_type: "display_data",
+        data: {
+          "application/vnd.nteract.arrow-stream-manifest+json": {
+            inline: JSON.stringify({
+              chunks: [{ hash: ARROW_BLOB_HASH, size: 9352, row_count: 96 }],
+              complete: true,
+            }),
+          },
+          "text/plain": { inline: "Cloud Sift Arrow marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
+];
+
+export const cloudOutputParityExpectedMarkers = {
+  markdown: "Cloud renderer parity",
+  stdout: "stdout marker",
+  stderr: "stderr marker",
+  traceback: "ColumnNotFoundError",
+  html: "Cloud HTML output marker",
+  svg: "Cloud SVG marker",
+  json: "Cloud JSON marker",
+  fallback: "Plain text fallback marker",
+  siftColumn: "score",
+} as const;
+
+export function cloudOutputParityBlobResolver(): BlobResolver {
+  return {
+    url(ref) {
+      if (ref.blob === ARROW_BLOB_HASH) return absoluteFixtureUrl("/fixture-blobs/sift.arrow");
+      return absoluteFixtureUrl(`/fixture-blobs/${encodeURIComponent(ref.blob)}`);
+    },
+    async fetch(ref) {
+      if (ref.blob === ARROW_BLOB_HASH) {
+        return fetch("/fixture-blobs/sift.arrow");
+      }
+      return new Response("missing cloud output parity fixture blob", { status: 404 });
+    },
+  };
+}
+
+export function cloudOutputParityHostContext(): NteractEmbedHostContextPatch {
+  return {
+    nteract: {
+      rendererAssetsBaseUrl: "/renderer-assets/",
+      outputDocumentUrl: "/output-document/frame.html",
+    },
+    platform: "web",
+  };
+}
+
+function absoluteFixtureUrl(path: string): string {
+  return new URL(path, globalThis.location?.href ?? "http://127.0.0.1:5182/").href;
+}
+
+export async function resolveCloudOutputParityCells(): Promise<ReadOnlyNotebookCellData[]> {
+  const blobResolver = cloudOutputParityBlobResolver();
+  const cells = await Promise.all(
+    cloudOutputParityRenderCells.map((cell, index) =>
+      resolveCell(cell, blobResolver, index, "python"),
+    ),
+  );
+  return cells.map(toReadOnlyNotebookCell);
+}
+
+function toReadOnlyNotebookCell(cell: ResolvedCell): ReadOnlyNotebookCellData {
+  return {
+    ...cell,
+    language: supportedLanguage(cell.language),
+  };
+}
+
+function supportedLanguage(language: string | null): SupportedLanguage | null {
+  switch (language) {
+    case "python":
+    case "ipython":
+    case "markdown":
+    case "sql":
+    case "html":
+    case "javascript":
+    case "typescript":
+    case "json":
+    case "yaml":
+    case "toml":
+    case "plain":
+      return language;
+    case null:
+      return null;
+    default:
+      return "plain";
+  }
+}

--- a/apps/notebook-cloud/test/render-parity/index.html
+++ b/apps/notebook-cloud/test/render-parity/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" class="light" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>notebook-cloud renderer parity</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -1,0 +1,116 @@
+import { StrictMode, useEffect, useMemo, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { ReadOnlyNotebook } from "../../../../../src/components/cell/ReadOnlyNotebook";
+import { IsolatedRendererProvider } from "../../../../../src/components/isolated/isolated-renderer-context";
+import { MediaProvider } from "../../../../../src/components/outputs/media-provider";
+import { CLOUD_VIEWER_PRIORITY } from "../../../viewer/mime-policy";
+import {
+  cloudOutputParityExpectedMarkers,
+  cloudOutputParityHostContext,
+  resolveCloudOutputParityCells,
+} from "../../fixtures/cloud-output-parity";
+import "../../../viewer/index.css";
+import "./style.css";
+
+const rendererBundle = () => import("virtual:isolated-renderer");
+
+type ThemeMode = "light" | "dark";
+
+function applyTheme(theme: ThemeMode): void {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+  document.documentElement.classList.toggle("light", theme === "light");
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+function CloudRendererParityHarness() {
+  const [theme, setTheme] = useState<ThemeMode>("light");
+  const [cells, setCells] = useState<Awaited<ReturnType<typeof resolveCloudOutputParityCells>>>([]);
+  const [error, setError] = useState<string | null>(null);
+  const hostContext = useMemo(() => cloudOutputParityHostContext(), []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveCloudOutputParityCells()
+      .then((resolvedCells) => {
+        if (!cancelled) setCells(resolvedCells);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <main className="cloud-render-parity-page">
+        <div data-testid="parity-error">{error}</div>
+      </main>
+    );
+  }
+
+  return (
+    <main
+      className="cloud-render-parity-page"
+      data-testid="cloud-render-parity"
+      data-ready={cells.length > 0 ? "true" : "false"}
+      data-theme={theme}
+    >
+      <header className="cloud-render-parity-header">
+        <div>
+          <p>notebook-cloud</p>
+          <h1>Renderer parity fixture</h1>
+        </div>
+        <div className="cloud-render-parity-actions" aria-label="Theme controls">
+          <button
+            type="button"
+            data-testid="theme-light"
+            data-active={theme === "light" ? "true" : "false"}
+            onClick={() => setTheme("light")}
+          >
+            Light
+          </button>
+          <button
+            type="button"
+            data-testid="theme-dark"
+            data-active={theme === "dark" ? "true" : "false"}
+            onClick={() => setTheme("dark")}
+          >
+            Dark
+          </button>
+        </div>
+      </header>
+      <div data-testid="fixture-markers" hidden>
+        {Object.values(cloudOutputParityExpectedMarkers).join("\n")}
+      </div>
+      <IsolatedRendererProvider loader={rendererBundle}>
+        <MediaProvider priority={CLOUD_VIEWER_PRIORITY}>
+          <ReadOnlyNotebook
+            cells={cells}
+            priority={CLOUD_VIEWER_PRIORITY}
+            hostContext={hostContext}
+            className="cloud-render-parity-notebook"
+            label="Cloud renderer parity notebook"
+          />
+        </MediaProvider>
+      </IsolatedRendererProvider>
+    </main>
+  );
+}
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Missing root element");
+}
+
+createRoot(root).render(
+  <StrictMode>
+    <CloudRendererParityHarness />
+  </StrictMode>,
+);

--- a/apps/notebook-cloud/test/render-parity/src/style.css
+++ b/apps/notebook-cloud/test/render-parity/src/style.css
@@ -1,0 +1,62 @@
+.cloud-render-parity-page {
+  min-height: 100vh;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.cloud-render-parity-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  background: color-mix(in srgb, var(--background) 92%, transparent);
+  padding: 1rem 1.5rem;
+  backdrop-filter: blur(12px);
+}
+
+.cloud-render-parity-header p {
+  margin: 0;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.cloud-render-parity-header h1 {
+  margin: 0.125rem 0 0;
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.cloud-render-parity-actions {
+  display: inline-flex;
+  gap: 0.375rem;
+}
+
+.cloud-render-parity-actions button {
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
+  font: inherit;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.cloud-render-parity-actions button[data-active="true"] {
+  color: var(--background);
+  background: var(--foreground);
+}
+
+.cloud-render-parity-notebook {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 4rem;
+}

--- a/apps/notebook-cloud/test/render-parity/vite.config.ts
+++ b/apps/notebook-cloud/test/render-parity/vite.config.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig, type Plugin } from "vite-plus";
+import { siftWasmCacheKey } from "../../../../src/build/renderer-plugin-builder";
+import { isolatedRendererPlugin } from "../../../notebook/vite-plugin-isolated-renderer";
+
+const appDir = path.resolve(__dirname, "../..");
+const repoRoot = path.resolve(appDir, "../..");
+const harnessRoot = path.join(appDir, "test/render-parity");
+const frameHtmlPath = path.join(repoRoot, "src/components/isolated/frame.html");
+const siftWasmPath = path.join(repoRoot, "crates/sift-wasm/pkg/sift_wasm_bg.wasm");
+const siftArrowPath = path.join(
+  repoRoot,
+  "packages/runtimed/tests/fixtures/sift_arrow_output/blobs/sha256-10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f.arrow",
+);
+
+function cloudRendererParityFixtureServer(): Plugin {
+  return {
+    name: "notebook-cloud-renderer-parity-fixtures",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const parsed = new URL(req.url ?? "/", "http://127.0.0.1");
+        if (parsed.pathname === "/output-document/frame.html") {
+          res.setHeader("content-type", "text/html; charset=utf-8");
+          res.setHeader("cache-control", "no-store");
+          res.end(fs.readFileSync(frameHtmlPath, "utf8"));
+          return;
+        }
+
+        if (parsed.pathname === "/renderer-assets/sift_wasm.wasm") {
+          res.setHeader("access-control-allow-origin", "*");
+          res.setHeader("content-type", "application/wasm");
+          res.setHeader("cache-control", "no-store");
+          fs.createReadStream(siftWasmPath).pipe(res);
+          return;
+        }
+
+        if (parsed.pathname === "/fixture-blobs/sift.arrow") {
+          res.setHeader("access-control-allow-origin", "*");
+          res.setHeader("content-type", "application/vnd.apache.arrow.stream");
+          res.setHeader("cache-control", "no-store");
+          fs.createReadStream(siftArrowPath).pipe(res);
+          return;
+        }
+
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig({
+  root: harnessRoot,
+  plugins: [react(), tailwindcss(), isolatedRendererPlugin(), cloudRendererParityFixtureServer()],
+  resolve: {
+    alias: {
+      "@/": path.join(repoRoot, "src") + "/",
+      "~/": path.join(repoRoot, "apps/notebook/src") + "/",
+    },
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 5182,
+    strictPort: true,
+    fs: {
+      allow: [repoRoot],
+    },
+  },
+  define: {
+    __SIFT_WASM_CACHE_KEY__: JSON.stringify(siftWasmCacheKey()),
+    "process.env.NODE_ENV": JSON.stringify("development"),
+  },
+});

--- a/apps/notebook-cloud/test/renderer-contract.test.ts
+++ b/apps/notebook-cloud/test/renderer-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(appDir, "../..");
+
+describe("cloud renderer host contract", () => {
+  it("keeps cloud API route knowledge out of shared renderer code", () => {
+    const checkedFiles = [
+      ...sourceFiles(path.join(appDir, "viewer")),
+      ...sourceFiles(path.join(repoRoot, "src/components/isolated")),
+      ...sourceFiles(path.join(repoRoot, "src/isolated-renderer")),
+    ].filter((file) => !file.includes(`${path.sep}__tests__${path.sep}`));
+
+    const offenders = checkedFiles.filter((file) =>
+      fs.readFileSync(file, "utf8").includes("/api/n"),
+    );
+
+    assert.deepEqual(
+      offenders.map((file) => path.relative(repoRoot, file)),
+      [],
+      "renderer paths must receive host URLs through BlobResolver/host context instead of reconstructing cloud API routes",
+    );
+  });
+});
+
+function sourceFiles(root: string): string[] {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) return sourceFiles(fullPath);
+    if (!/\.(ts|tsx|js|jsx)$/.test(entry.name)) return [];
+    return [fullPath];
+  });
+}

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -258,12 +258,14 @@ describe("RoomHostHandle", () => {
       success: boolean;
       execution_count: number;
       output_ids: string[];
+      submitted_by_actor_label: string | null;
     };
     assert.deepEqual(execution, {
       status: "done",
       success: true,
       execution_count: 1,
       output_ids: ["out-stdout-1"],
+      submitted_by_actor_label: null,
     });
     assert.deepEqual(viewer.get_output_by_id("out-stdout-1"), {
       output_type: "stream",
@@ -461,6 +463,7 @@ describe("RoomMaterializer", () => {
       success: null,
       execution_count: null,
       output_ids: [],
+      submitted_by_actor_label: null,
     });
 
     await assert.rejects(

--- a/apps/notebook-cloud/viewer/sift-preload.ts
+++ b/apps/notebook-cloud/viewer/sift-preload.ts
@@ -1,14 +1,9 @@
 import type { JupyterOutput } from "../../../src/components/cell/jupyter-output";
+import { rendererPluginNameForMime } from "../../../src/components/isolated/renderer-plugin-info";
 import { selectMimeType } from "../../../src/components/outputs/mime-priority";
 import { resolveSiftWasmUrl } from "../../../src/isolated-renderer/sift-assets";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import type { ResolvedCell } from "./render-resolution";
-
-const SIFT_MIME_TYPES = new Set([
-  "application/vnd.apache.parquet",
-  "application/vnd.apache.arrow.stream",
-  "application/vnd.nteract.arrow-stream-manifest+json",
-]);
 
 interface SiftWasmPreloadOptions {
   blobBasePath: string;
@@ -62,5 +57,5 @@ function outputUsesSift(output: JupyterOutput): boolean {
   }
 
   const mimeType = selectMimeType(output.data, CLOUD_VIEWER_PRIORITY);
-  return mimeType != null && SIFT_MIME_TYPES.has(mimeType);
+  return mimeType != null && rendererPluginNameForMime(mimeType) === "sift";
 }

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -80,10 +80,12 @@ runtime document code rather than duplicating projection in a Worker-local JSON
 format.
 
 In the current prototype the Worker materializes a JSON render response on
-request. The browser viewer consumes that response with the framework-agnostic
-`createNteractOutputEmbed()` surface, so markdown cells, rich display data,
-stdout/stderr, Plotly/Vega/Leaflet, and Sift-style table outputs go through the
-same isolated renderer path as desktop instead of a Worker-local DOM renderer.
+request. The browser viewer normalizes that host response into shared
+`ReadOnlyNotebookCellData`, then renders through the same React notebook output
+stack as desktop: `ReadOnlyNotebook` → `ReadOnlyNotebookCell` → `OutputArea` →
+`MediaRouter` / isolated iframe. The framework-agnostic
+`createNteractOutputEmbed()` surface remains the non-React embedding contract,
+but the cloud notebook viewer itself should not fork a separate DOM renderer.
 
 ## Decision 4: Blob refs stay host-neutral
 
@@ -152,7 +154,41 @@ deployments, with Worker-owned `/renderer-assets/*`, `/plugins/*`, and
 dedicated renderer asset Worker binds only `dist/plugins`; it is not a notebook
 API or blob origin.
 
-## Decision 6: Presence stays typed-frame v4 CBOR
+## Decision 6: Cloud owns adaptation, shared components own rendering
+
+The cloud renderer boundary is intentionally narrow:
+
+- Worker: authenticate reads, load snapshot pairs, materialize render-cache JSON,
+  and map content-addressed blobs to host URLs.
+- Cloud viewer: own the browser shell, live-room bridge, theme selection,
+  presence chrome, and normalization from render JSON to shared cell/output
+  props.
+- Shared renderer components: own MIME priority, output manifest resolution,
+  plugin installation, iframe sandboxing, scroll handoff, and output DOM.
+
+Cloud code may adapt host-specific inputs into the shared renderer contract, but
+it must not teach renderer plugins or shared isolated-frame code about
+`/api/n/:id`, Worker catalog routes, ACLs, or Cloudflare-specific auth. Blob
+URLs, renderer asset URLs, and output document URLs are host configuration
+passed through `BlobResolver` and host context.
+
+The notebook-cloud app carries a cloud-owned renderer parity fixture and
+Playwright harness. That harness mounts semantic cloud render cells through the
+same `ReadOnlyNotebook` path as the deployed viewer, serves output documents and
+fixture blobs from local Vite middleware, and checks:
+
+- markdown, code source, streams, errors, HTML, SVG, image, JSON, MIME fallback,
+  and Arrow/Sift outputs;
+- isolated iframe sandbox attributes and hosted output-document URL mode;
+- light/dark theme propagation from cloud shell into output frames;
+- no renderer/plugin dependency on hard-coded cloud API paths.
+
+`apps/renderer-test` remains the lower-level isolated-renderer harness for raw
+iframe payloads. MCP Apps should align to the same host-context contract, but
+cloud renderer parity work should stay in `apps/notebook-cloud` unless a shared
+renderer API needs a small, documented extension.
+
+## Decision 7: Presence stays typed-frame v4 CBOR
 
 Cloud rooms relay frame type `0x04` as canonical nteract presence CBOR. The
 Worker decodes and rewrites ingress presence with shared `runtimed-wasm`


### PR DESCRIPTION
## Summary

- add a Vite + Playwright renderer parity harness for notebook-cloud that renders semantic cloud fixture cells through the shared `ReadOnlyNotebook` / `OutputArea` stack
- cover markdown, streams, errors, HTML, SVG, image/JSON fallback, unknown JSON fallback, theme propagation, iframe sandboxing, and Sift Arrow rendering through hosted renderer assets
- document the cloud/shared rendering boundary in the hosted artifacts ADR and keep cloud API route knowledge out of shared renderer code
- align stale notebook-cloud runtime materializer expectations with the current `submitted_by_actor_label` execution field

## Verification

- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `cargo xtask lint --fix`
