### PR TITLE
[ipy-opt] Update output diff snapshots in place

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -3487,6 +3487,51 @@ pub fn diff_output_ids(
     )
 }
 
+/// Diff execution outputs by `output_id`, updating the caller-owned snapshot.
+///
+/// This is the hot-path variant used by WASM runtime-state sync. It still
+/// walks the current flat outputs, but it only clones manifests that are new
+/// or changed. Unchanged entries remain in `prev` in place, avoiding a full
+/// `output_id -> manifest` snapshot rebuild on every sync frame.
+pub fn diff_output_ids_in_place(
+    prev: &mut HashMap<String, serde_json::Value>,
+    current_executions: &HashMap<String, ExecutionState>,
+) -> OutputIdDiff {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut changed: Vec<(String, serde_json::Value)> = Vec::new();
+
+    for exec in current_executions.values() {
+        for output in &exec.outputs {
+            let Some(oid) = extract_output_id(output) else {
+                continue;
+            };
+            seen.insert(oid.clone());
+            let is_changed = match prev.get(&oid) {
+                None => true,
+                Some(prev_output) => prev_output != output,
+            };
+            if is_changed {
+                changed.push((oid.clone(), output.clone()));
+                prev.insert(oid, output.clone());
+            }
+        }
+    }
+
+    let mut removed: Vec<String> = Vec::new();
+    prev.retain(|oid, _| {
+        let keep = seen.contains(oid);
+        if !keep {
+            removed.push(oid.clone());
+        }
+        keep
+    });
+
+    OutputIdDiff {
+        changed,
+        removed_output_ids: removed,
+    }
+}
+
 /// Collect the ordered list of `output_id`s for a single execution.
 ///
 /// Returns the output_ids in order. Outputs without an `output_id` are skipped
@@ -4973,6 +5018,79 @@ mod tests {
         assert_eq!(extract_output_id(&with_id), Some("abc".to_string()));
         assert_eq!(extract_output_id(&empty), None);
         assert_eq!(extract_output_id(&missing), None);
+    }
+
+    #[test]
+    fn test_diff_output_ids_in_place_updates_only_changed_entries() {
+        let mut snapshot = HashMap::new();
+        let unchanged = test_stream("hash1");
+        let changed = test_stream("hash2-old");
+        let removed = test_stream("hash3");
+        snapshot.insert("stream-hash1".to_string(), unchanged.clone());
+        snapshot.insert("stream-hash2-old".to_string(), changed);
+        snapshot.insert("stream-hash3".to_string(), removed);
+
+        let mut changed_output = test_stream("hash2-old");
+        changed_output["text"]["blob"] = serde_json::Value::String("hash2-new".to_string());
+        changed_output["text"]["size"] = serde_json::Value::from(9);
+        let new_output = test_stream("hash4");
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                status: "running".to_string(),
+                execution_count: Some(1),
+                success: None,
+                outputs: vec![
+                    unchanged.clone(),
+                    changed_output.clone(),
+                    new_output.clone(),
+                ],
+                source: None,
+                seq: None,
+                submitted_by_actor_label: None,
+            },
+        );
+
+        let diff = diff_output_ids_in_place(&mut snapshot, &execs);
+
+        assert_eq!(
+            diff.changed,
+            vec![
+                ("stream-hash2-old".to_string(), changed_output.clone()),
+                ("stream-hash4".to_string(), new_output.clone()),
+            ]
+        );
+        assert_eq!(diff.removed_output_ids, vec!["stream-hash3"]);
+        assert_eq!(snapshot.get("stream-hash1"), Some(&unchanged));
+        assert_eq!(snapshot.get("stream-hash2-old"), Some(&changed_output));
+        assert_eq!(snapshot.get("stream-hash4"), Some(&new_output));
+        assert!(!snapshot.contains_key("stream-hash3"));
+    }
+
+    #[test]
+    fn test_diff_output_ids_wrapper_matches_in_place_diff() {
+        let prev = HashMap::from([("stream-hash1".to_string(), test_stream("hash1"))]);
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                status: "done".to_string(),
+                execution_count: Some(1),
+                success: Some(true),
+                outputs: vec![test_stream("hash1"), test_stream("hash2")],
+                source: None,
+                seq: None,
+                submitted_by_actor_label: None,
+            },
+        );
+
+        let (wrapper_diff, wrapper_snapshot) = diff_output_ids(&prev, &execs);
+        let mut in_place_snapshot = prev.clone();
+        let in_place_diff = diff_output_ids_in_place(&mut in_place_snapshot, &execs);
+
+        assert_eq!(wrapper_diff, in_place_diff);
+        assert_eq!(wrapper_snapshot, in_place_snapshot);
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use notebook_doc::{CellSnapshot, NotebookDoc};
 use notebook_wire::{frame_types, SessionControlMessage, SessionSyncStatusWire};
 use nteract_identity::{ActorLabel, Operator, Principal};
 use runtime_doc::{
-    diff_output_ids, output_ids_for_execution, ExecutionState, ExecutionViewChangeset,
+    diff_output_ids_in_place, output_ids_for_execution, ExecutionState, ExecutionViewChangeset,
     ExecutionViewProjector, RuntimeState, RuntimeStateDoc,
 };
 use serde::{Deserialize, Serialize};
@@ -2577,9 +2577,10 @@ impl NotebookHandle {
                 };
 
                 let output_changeset = if let Some(current_state) = state.as_ref() {
-                    let (id_diff, new_id_snapshot) =
-                        diff_output_ids(&self.prev_output_by_id, &current_state.executions);
-                    self.prev_output_by_id = new_id_snapshot;
+                    let id_diff = diff_output_ids_in_place(
+                        &mut self.prev_output_by_id,
+                        &current_state.executions,
+                    );
 
                     // Narrow each changed manifest inline so the frontend
                     // writes directly into the outputs store with no

--- a/crates/runtimed/examples/output_commit_measure.rs
+++ b/crates/runtimed/examples/output_commit_measure.rs
@@ -1,6 +1,7 @@
 use runtimed::output_commit_measure::{
     measure_current_output_commit_loop, measure_ordered_worker_output_commit_model,
-    measure_runtime_state_reader_paths, OutputCommitKind, OutputCommitMeasurementConfig,
+    measure_output_id_diff_paths, measure_runtime_state_reader_paths, OutputCommitKind,
+    OutputCommitMeasurementConfig,
 };
 
 #[tokio::main]
@@ -39,6 +40,10 @@ async fn main() -> anyhow::Result<()> {
 
             for reader in measure_runtime_state_reader_paths(config).await? {
                 println!("{}", serde_json::to_string(&reader)?);
+            }
+
+            for diff in measure_output_id_diff_paths(config).await? {
+                println!("{}", serde_json::to_string(&diff)?);
             }
         }
     }

--- a/crates/runtimed/src/output_commit_measure.rs
+++ b/crates/runtimed/src/output_commit_measure.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 use anyhow::{ensure, Context};
-use runtime_doc::RuntimeStateDoc;
+use runtime_doc::{diff_output_ids, diff_output_ids_in_place, RuntimeStateDoc};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -84,6 +84,18 @@ pub struct RuntimeStateReaderMeasurement {
     pub comms_seen: usize,
     pub queued_executions_seen: usize,
     pub reader_nanos: u128,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputIdDiffMeasurement {
+    pub strategy: &'static str,
+    pub output_count: usize,
+    pub payload_bytes: usize,
+    pub committed_outputs: usize,
+    pub changed_outputs: usize,
+    pub removed_outputs: usize,
+    pub snapshot_outputs: usize,
+    pub diff_nanos: u128,
 }
 
 impl OutputCommitMeasurement {
@@ -322,6 +334,91 @@ pub async fn measure_runtime_state_reader_paths(
     ])
 }
 
+pub async fn measure_output_id_diff_paths(
+    config: OutputCommitMeasurementConfig,
+) -> anyhow::Result<Vec<OutputIdDiffMeasurement>> {
+    let blob_root = output_commit_measure_blob_root();
+    tokio::fs::create_dir_all(&blob_root)
+        .await
+        .with_context(|| format!("create blob root {}", blob_root.display()))?;
+    let blob_store = BlobStore::new(blob_root.clone());
+    let redactor = OutputRedactor::disabled();
+    let mut doc = RuntimeStateDoc::new();
+    doc.create_execution_with_source(EXECUTION_ID, "pass", 0)?;
+    doc.set_execution_running(EXECUTION_ID)?;
+
+    for index in 0..config.output_count {
+        let output = measured_output(config.kind, index, config.payload_bytes);
+        let manifest = output_store::create_manifest_with_redactor(
+            &output,
+            &blob_store,
+            DEFAULT_INLINE_THRESHOLD,
+            &redactor,
+        )
+        .await
+        .context("create output manifest")?;
+        doc.append_output(EXECUTION_ID, &manifest.to_json())?;
+    }
+
+    let previous_state = doc.read_state();
+    let (_, previous_snapshot) = diff_output_ids(&Default::default(), &previous_state.executions);
+
+    let output = measured_output(config.kind, config.output_count, config.payload_bytes);
+    let manifest = output_store::create_manifest_with_redactor(
+        &output,
+        &blob_store,
+        DEFAULT_INLINE_THRESHOLD,
+        &redactor,
+    )
+    .await
+    .context("create output manifest")?;
+    doc.append_output(EXECUTION_ID, &manifest.to_json())?;
+    let current_state = doc.read_state();
+
+    let rebuild_started = Instant::now();
+    let (rebuild_diff, rebuild_snapshot) =
+        diff_output_ids(&previous_snapshot, &current_state.executions);
+    let rebuild_nanos = rebuild_started.elapsed().as_nanos();
+
+    let mut in_place_snapshot = previous_snapshot.clone();
+    let in_place_started = Instant::now();
+    let in_place_diff = diff_output_ids_in_place(&mut in_place_snapshot, &current_state.executions);
+    let in_place_nanos = in_place_started.elapsed().as_nanos();
+
+    ensure!(
+        rebuild_diff == in_place_diff,
+        "output-id diff paths produced different diffs"
+    );
+    ensure!(
+        rebuild_snapshot == in_place_snapshot,
+        "output-id diff paths produced different snapshots"
+    );
+
+    let _ = tokio::fs::remove_dir_all(&blob_root).await;
+    Ok(vec![
+        OutputIdDiffMeasurement {
+            strategy: "rebuild_output_id_snapshot",
+            output_count: config.output_count,
+            payload_bytes: config.payload_bytes,
+            committed_outputs: config.output_count + 1,
+            changed_outputs: rebuild_diff.changed.len(),
+            removed_outputs: rebuild_diff.removed_output_ids.len(),
+            snapshot_outputs: rebuild_snapshot.len(),
+            diff_nanos: rebuild_nanos,
+        },
+        OutputIdDiffMeasurement {
+            strategy: "in_place_output_id_snapshot",
+            output_count: config.output_count,
+            payload_bytes: config.payload_bytes,
+            committed_outputs: config.output_count + 1,
+            changed_outputs: in_place_diff.changed.len(),
+            removed_outputs: in_place_diff.removed_output_ids.len(),
+            snapshot_outputs: in_place_snapshot.len(),
+            diff_nanos: in_place_nanos,
+        },
+    ])
+}
+
 fn output_commit_measure_blob_root() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("runtimed-output-commit-measure-{}", Uuid::new_v4()))
 }
@@ -431,6 +528,27 @@ mod tests {
             assert_eq!(metric.committed_outputs, 4);
             assert_eq!(metric.comms_seen, 1);
             assert_eq!(metric.queued_executions_seen, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn output_id_diff_measure_compares_equivalent_paths() {
+        let metrics = measure_output_id_diff_paths(OutputCommitMeasurementConfig {
+            output_count: 4,
+            payload_bytes: 16,
+            kind: OutputCommitKind::DisplayData,
+        })
+        .await
+        .expect("measurement should run");
+
+        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics[0].strategy, "rebuild_output_id_snapshot");
+        assert_eq!(metrics[1].strategy, "in_place_output_id_snapshot");
+        for metric in metrics {
+            assert_eq!(metric.committed_outputs, 5);
+            assert_eq!(metric.changed_outputs, 1);
+            assert_eq!(metric.removed_outputs, 0);
+            assert_eq!(metric.snapshot_outputs, 5);
         }
     }
 }

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -52,7 +52,10 @@ known repeated work:
 5. Remove the dormant frontend optimistic `update_display_data` overlay instead
    of indexing it. RuntimeStateDoc changesets already carry display updates to
    the output store, so the best optimization is not maintaining unused work.
-6. Frontend output materialization cleanup so runtime outputs flow through the
+6. In-place WASM output-id diff snapshots so runtime sync compares the flat
+   output set without cloning every unchanged manifest into a fresh snapshot on
+   each frame.
+7. Frontend output materialization cleanup so runtime outputs flow through the
    output store rather than repeated whole-output JSON cache keys.
 
 Each item is independently mergeable and should include a small benchmark or


### PR DESCRIPTION
## Summary

- Add an in-place `output_id -> manifest` diff helper that preserves the existing flat output shape while avoiding full snapshot rebuilds on every WASM runtime-state sync frame.
- Switch `NotebookHandle` runtime-state sync to update its previous output snapshot in place.
- Extend the output commit measurement harness with equivalent rebuild-vs-in-place output-id diff timings.

## Compatibility

This keeps the existing client-facing `output_changeset` contract intact. Existing consumers still receive flat output ids, changed manifests, and removed output ids; no `output_segment` shape is exposed.

## Local verification

- `cargo test -p runtime-doc diff_output_ids -- --nocapture`
- `cargo test -p runtimed output_commit_measure -- --nocapture`
- `cargo test -p runtimed-wasm --lib --no-default-features`
- `cargo xtask wasm`
- `deno test --allow-read --allow-run --allow-env --no-check crates/runtimed-wasm/tests/`
- `cargo xtask lint --fix`
- `git diff --check`

## Measurement notes

Display-data output-id diff rows from the measurement harness:

- N=100: rebuild 472250 ns, in-place 233708 ns
- N=500: rebuild 2530166 ns, in-place 1137834 ns
- N=1000: rebuild 4421291 ns, in-place 2203375 ns

The first Deno snapshot run failed because the local fixture `.bin` files were Git LFS pointer text. After `git lfs pull --include='packages/runtimed/tests/fixtures/**'`, the same snapshot tests and full WASM Deno suite passed.
