### PR TITLE
[ipy-opt] Remove dormant display update overlay

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -21,14 +21,12 @@ import {
   replaceNotebookCells,
   resetNotebookCells,
   updateCellById,
-  updateNotebookCells,
   useCellIds,
 } from "../lib/notebook-cells";
 import {
   applyExecutionViewChangeset,
   resetRuntimeStoresProjection,
 } from "../lib/project-runtime-stores";
-import { updateOutputsByDisplayId } from "../lib/notebook-outputs";
 import { cloneNotebookFile, openNotebookFile, saveNotebook } from "../lib/notebook-file-ops";
 import { setNotebookHandle } from "../lib/notebook-metadata";
 import { resetPoolState } from "../lib/pool-state";
@@ -518,38 +516,6 @@ export function useAutomergeNotebook() {
 
   const cloneNotebook = useCallback(() => cloneNotebookFile(host), [host]);
 
-  // ── Output overlays (optimistic, pre-sync) ─────────────────────────
-
-  const updateOutputByDisplayId = useCallback(
-    (
-      displayId: string,
-      newData: Record<string, unknown>,
-      newMetadata?: Record<string, unknown>,
-    ) => {
-      // Keep the cell snapshot in sync for cross-cell readers that still
-      // inspect `cell.outputs` directly.
-      updateNotebookCells((prev) =>
-        prev.map((c) => {
-          if (c.cell_type !== "code") return c;
-          let changed = false;
-          const updatedOutputs = c.outputs.map((output) => {
-            if (isDisplayCapableJupyterOutput(output) && output.display_id === displayId) {
-              changed = true;
-              return { ...output, data: newData, metadata: newMetadata };
-            }
-            return output;
-          });
-          return changed ? { ...c, outputs: updatedOutputs } : c;
-        }),
-      );
-      // Per-output store projection. Patches every matching output so
-      // <OutputArea> repaints instantly without waiting for the next
-      // runtime_state sync to flow through the projection.
-      updateOutputsByDisplayId(displayId, newData, newMetadata);
-    },
-    [],
-  );
-
   const applyExecutionCountFromDaemon = useCallback((cellId: string, count: number) => {
     updateCellById(cellId, (c) => (c.cell_type === "code" ? { ...c, execution_count: count } : c));
   }, []);
@@ -603,7 +569,6 @@ export function useAutomergeNotebook() {
     openNotebook,
     cloneNotebook,
     loadError,
-    updateOutputByDisplayId,
     applyExecutionCountFromDaemon,
     setCellSourceHidden,
     setCellOutputsHidden,

--- a/apps/notebook/src/lib/notebook-outputs.ts
+++ b/apps/notebook/src/lib/notebook-outputs.ts
@@ -187,30 +187,6 @@ export function getOutputById(output_id: string): JupyterOutput | undefined {
   return _outputMap.get(output_id);
 }
 
-/**
- * Apply a display_update to every output in the store with the matching
- * `display_id`. The daemon also writes the update into RuntimeStateDoc,
- * but that sync may lag the broadcast; patching the store directly gives
- * the UI instant feedback. Only touches outputs that carry a `data`
- * payload (display_data / execute_result) - stream / error outputs have
- * no display_id.
- */
-export function updateOutputsByDisplayId(
-  display_id: string,
-  data: Record<string, unknown>,
-  metadata?: Record<string, unknown>,
-): void {
-  for (const [output_id, output] of _outputMap) {
-    if (
-      (output.output_type === "display_data" ||
-        output.output_type === "execute_result") &&
-      output.display_id === display_id
-    ) {
-      setOutput(output_id, { ...output, data, metadata });
-    }
-  }
-}
-
 /** Reset the entire store. Called on notebook switch or full reset. */
 export function resetNotebookOutputs(): void {
   const ids = [..._outputMap.keys()];

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -49,7 +49,10 @@ known repeated work:
    only needs queued execution metadata or widget comm state.
 4. WASM-side output-id indexing so runtime sync handling does not repeatedly
    read the full runtime state just to derive output deltas.
-5. Frontend output materialization cleanup so runtime outputs flow through the
+5. Remove the dormant frontend optimistic `update_display_data` overlay instead
+   of indexing it. RuntimeStateDoc changesets already carry display updates to
+   the output store, so the best optimization is not maintaining unused work.
+6. Frontend output materialization cleanup so runtime outputs flow through the
    output store rather than repeated whole-output JSON cache keys.
 
 Each item is independently mergeable and should include a small benchmark or


### PR DESCRIPTION
## Summary

- Remove the unused optimistic `update_display_data` overlay returned from `useAutomergeNotebook`.
- Remove the matching unused `updateOutputsByDisplayId` output-store helper.
- Update the runtime-output optimization note: this path should be deleted, not indexed, because RuntimeStateDoc changesets already carry display updates to the output store.

## Why

Pullfrog's follow-up review on #2977 found the display-id index optimized a dormant path. The callback was returned from the hook, but no component or integration consumed it. The active display update path is the RuntimeStateDoc changeset projection into the output store.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-outputs.test.ts`
- `cargo xtask lint --fix`
- `git diff --check`
