### PR TITLE
refactor(mcp-app): share output frame adapter

### DIFF
--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -1,17 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { rendererCode, rendererCss } from "virtual:isolated-renderer";
-import {
-  createInlineOnlyBlobResolver,
-  createMcpAppBlobResolver,
-  mcpAppCellsToSharedOutputs,
-} from "@/components/isolated/mcp-app-structured-content";
-import {
-  createNteractOutputEmbed,
-  type NteractOutputEmbedHandle,
-  type NteractOutputRendererBundleProvider,
-} from "@/components/isolated/output-embed";
-import { mcpAppHostContextToNteractEmbedPatch } from "@/components/isolated/host-context";
+import { McpAppOutputFrame } from "@/components/isolated/mcp-app-output-frame";
+import type { NteractOutputRendererBundleProvider } from "@/components/isolated/output-embed";
 import type { CellData } from "../types";
 import { errorDetails, hostLog } from "../lib/host-log";
 import {
@@ -34,91 +25,50 @@ interface SharedCellOutputsProps {
 }
 
 export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCellOutputsProps) {
-  const targetRef = useRef<HTMLDivElement | null>(null);
-  const handleRef = useRef<NteractOutputEmbedHandle | null>(null);
-  const [failed, setFailed] = useState(false);
-
-  const outputs = useMemo(
-    () => mcpAppCellsToSharedOutputs([cell], blobBaseUrl),
-    [cell, blobBaseUrl],
+  const rendererPluginLoader = useMemo(
+    () => createDaemonRendererPluginLoader(blobBaseUrl),
+    [blobBaseUrl],
   );
-  const pluginLoader = useMemo(() => createDaemonRendererPluginLoader(blobBaseUrl), [blobBaseUrl]);
-  const hostContextPatch = useMemo(
-    () =>
-      mcpAppHostContextToNteractEmbedPatch(hostContext, {
-        rendererAssetsBaseUrl: daemonRendererAssetsBaseUrl(blobBaseUrl),
-      }),
-    [hostContext, blobBaseUrl],
-  );
-  const hostContextPatchRef = useRef(hostContextPatch);
-  const blobResolver = useMemo(
-    () => (blobBaseUrl ? createMcpAppBlobResolver(blobBaseUrl) : createInlineOnlyBlobResolver()),
+  const rendererAssetsBaseUrl = useMemo(
+    () => daemonRendererAssetsBaseUrl(blobBaseUrl),
     [blobBaseUrl],
   );
   const outputDocumentUrl = useMemo(() => daemonOutputFrameUrl(blobBaseUrl), [blobBaseUrl]);
-
-  useEffect(() => {
-    setFailed(false);
-  }, [cell.cell_id, blobBaseUrl]);
-
-  useEffect(() => {
-    if (failed || !targetRef.current || outputs.length === 0) return;
-
-    // The embed lifetime is tied to the output container, not output identity.
-    // Content changes with the same output count are delivered by the render
-    // effect below so the iframe is not torn down between equivalent cells.
-    const handle = createNteractOutputEmbed({
-      target: targetRef.current,
-      rendererBundle: SHARED_RENDERER_BUNDLE,
-      rendererPluginLoader: pluginLoader,
-      blobResolver,
-      hostContext: hostContextPatchRef.current,
-      outputDocumentUrl,
-      autoHeight: false,
-      maxHeight: SHARED_OUTPUT_MAX_HEIGHT,
-      onDiagnostic(phase, details, level = "debug", source = "isolated-frame") {
-        if (level !== "error" && level !== "warn") return;
-        hostLog(level === "warn" ? "warning" : "error", "shared-output-renderer-diagnostic", {
-          phase,
-          source,
-          details,
-        });
-      },
-      onError(error) {
-        hostLog("error", "shared-output-renderer-failed", {
-          error: errorDetails(error),
-        });
-        handleRef.current?.dispose();
-        handleRef.current = null;
-        setFailed(true);
-      },
-    });
-
-    handleRef.current = handle;
-    return () => {
-      handle.dispose();
-      if (handleRef.current === handle) handleRef.current = null;
-    };
-  }, [blobBaseUrl, blobResolver, failed, outputDocumentUrl, outputs.length, pluginLoader]);
-
-  useEffect(() => {
-    if (failed || outputs.length === 0) return;
-    handleRef.current?.renderBatch(outputs).catch((error) => {
-      hostLog("error", "shared-output-render-failed", {
-        error: errorDetails(error),
+  const handleDiagnostic = useCallback(
+    (
+      phase: string,
+      details?: Record<string, unknown>,
+      level: "debug" | "info" | "warn" | "error" = "debug",
+      source: "isolated-frame" | "isolated-renderer" | "iframe-libraries" = "isolated-frame",
+    ) => {
+      if (level !== "error" && level !== "warn") return;
+      hostLog(level === "warn" ? "warning" : "error", "shared-output-renderer-diagnostic", {
+        phase,
+        source,
+        details,
       });
-      handleRef.current?.dispose();
-      handleRef.current = null;
-      setFailed(true);
+    },
+    [],
+  );
+  const handleError = useCallback((error: { message: string; stack?: string }) => {
+    hostLog("error", "shared-output-renderer-failed", {
+      error: errorDetails(error),
     });
-  }, [failed, outputs]);
+  }, []);
 
-  useEffect(() => {
-    hostContextPatchRef.current = hostContextPatch;
-    handleRef.current?.setHostContext(hostContextPatch);
-  }, [hostContextPatch]);
-
-  if (failed) return null;
-
-  return <div ref={targetRef} className="shared-output-frame" />;
+  return (
+    <McpAppOutputFrame
+      cell={cell}
+      blobBaseUrl={blobBaseUrl}
+      hostContext={hostContext}
+      rendererBundle={SHARED_RENDERER_BUNDLE}
+      rendererPluginLoader={rendererPluginLoader}
+      rendererAssetsBaseUrl={rendererAssetsBaseUrl}
+      outputDocumentUrl={outputDocumentUrl}
+      maxHeight={SHARED_OUTPUT_MAX_HEIGHT}
+      className="shared-output-frame"
+      onDiagnostic={handleDiagnostic}
+      onError={handleError}
+    />
+  );
 }

--- a/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
+++ b/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
@@ -1,0 +1,91 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createNteractOutputEmbed } from "../output-embed";
+import { McpAppOutputFrame, type McpAppCellData } from "../mcp-app-output-frame";
+
+const mockHandle = {
+  iframe: document.createElement("iframe"),
+  render: vi.fn(async () => {}),
+  renderBatch: vi.fn(async () => {}),
+  renderResolved: vi.fn(async () => {}),
+  setHostContext: vi.fn(),
+  setRendererBundle: vi.fn(),
+  dispose: vi.fn(),
+};
+
+vi.mock("../output-embed", () => ({
+  createNteractOutputEmbed: vi.fn(() => mockHandle),
+}));
+
+function cellWithHtmlOutput(): McpAppCellData {
+  return {
+    cell_id: "cell-1",
+    cell_type: "code",
+    source: "display(table)",
+    execution_count: 1,
+    status: "done",
+    outputs: [
+      {
+        output_id: "output-1",
+        output_type: "display_data",
+        data: {
+          "text/html": "<table></table>",
+          "text/plain": "fallback",
+        },
+      },
+    ],
+  };
+}
+
+describe("McpAppOutputFrame", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adapts MCP App cell outputs into the shared isolated output embed", async () => {
+    const rendererBundle = { rendererCode: "renderer", rendererCss: "css" };
+    const rendererPluginLoader = vi.fn(async () => undefined);
+
+    render(
+      <McpAppOutputFrame
+        cell={cellWithHtmlOutput()}
+        blobBaseUrl="http://localhost:47830"
+        hostContext={{ theme: "dark", containerDimensions: { width: 640 } }}
+        rendererBundle={rendererBundle}
+        rendererPluginLoader={rendererPluginLoader}
+        rendererAssetsBaseUrl="http://localhost:47830/plugins/"
+        outputDocumentUrl="http://localhost:47830/output-frame"
+      />,
+    );
+
+    await waitFor(() => expect(mockHandle.renderBatch).toHaveBeenCalled());
+
+    expect(createNteractOutputEmbed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rendererBundle,
+        rendererPluginLoader,
+        outputDocumentUrl: "http://localhost:47830/output-frame",
+        autoHeight: false,
+        maxHeight: 2000,
+        hostContext: expect.objectContaining({
+          theme: "dark",
+          containerDimensions: undefined,
+          nteract: {
+            rendererAssetsBaseUrl: "http://localhost:47830/plugins/",
+            outputDocumentUrl: "http://localhost:47830/output-frame",
+          },
+        }),
+      }),
+    );
+    expect(mockHandle.renderBatch).toHaveBeenCalledWith([
+      expect.objectContaining({
+        output_id: "output-1",
+        output_type: "display_data",
+        data: {
+          "text/html": { inline: "<table></table>" },
+          "text/plain": { inline: "fallback" },
+        },
+      }),
+    ]);
+  });
+});

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -75,6 +75,8 @@ export type {
   NteractOutputRendererPlugin,
   NteractOutputRendererPluginLoader,
 } from "./output-embed";
+export { McpAppOutputFrame } from "./mcp-app-output-frame";
+export type { McpAppOutputFrameProps } from "./mcp-app-output-frame";
 export {
   createBlobResolver,
   createHttpBlobResolver,

--- a/src/components/isolated/mcp-app-output-frame.tsx
+++ b/src/components/isolated/mcp-app-output-frame.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  createInlineOnlyBlobResolver,
+  createMcpAppBlobResolver,
+  mcpAppCellsToSharedOutputs,
+  type McpAppCellData,
+} from "./mcp-app-structured-content";
+import { mcpAppHostContextToNteractEmbedPatch, type McpAppHostContextLike } from "./host-context";
+import {
+  createNteractOutputEmbed,
+  type NteractOutputEmbedDiagnosticHandler,
+  type NteractOutputEmbedHandle,
+  type NteractOutputRendererBundleProvider,
+  type NteractOutputRendererPluginLoader,
+} from "./output-embed";
+
+export type { McpAppCellData } from "./mcp-app-structured-content";
+
+const DEFAULT_MCP_APP_OUTPUT_MAX_HEIGHT = 2000;
+
+export interface McpAppOutputFrameProps {
+  cell?: McpAppCellData;
+  cells?: readonly McpAppCellData[];
+  blobBaseUrl?: string;
+  hostContext?: McpAppHostContextLike | null;
+  rendererBundle: NteractOutputRendererBundleProvider;
+  rendererPluginLoader?: NteractOutputRendererPluginLoader;
+  rendererAssetsBaseUrl?: string;
+  outputDocumentUrl?: string | null;
+  autoHeight?: boolean;
+  maxHeight?: number;
+  className?: string;
+  onDiagnostic?: NteractOutputEmbedDiagnosticHandler;
+  onError?: (error: { message: string; stack?: string }) => void;
+}
+
+function cellsForProps(
+  props: Pick<McpAppOutputFrameProps, "cell" | "cells">,
+): readonly McpAppCellData[] {
+  return props.cells ?? (props.cell ? [props.cell] : []);
+}
+
+export function McpAppOutputFrame({
+  cell,
+  cells,
+  blobBaseUrl,
+  hostContext,
+  rendererBundle,
+  rendererPluginLoader,
+  rendererAssetsBaseUrl,
+  outputDocumentUrl,
+  autoHeight = false,
+  maxHeight = DEFAULT_MCP_APP_OUTPUT_MAX_HEIGHT,
+  className,
+  onDiagnostic,
+  onError,
+}: McpAppOutputFrameProps) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const handleRef = useRef<NteractOutputEmbedHandle | null>(null);
+  const [failed, setFailed] = useState(false);
+  const outputCells = useMemo(() => cellsForProps({ cell, cells }), [cell, cells]);
+  const outputs = useMemo(
+    () => mcpAppCellsToSharedOutputs(outputCells, blobBaseUrl),
+    [outputCells, blobBaseUrl],
+  );
+  const blobResolver = useMemo(
+    () => (blobBaseUrl ? createMcpAppBlobResolver(blobBaseUrl) : createInlineOnlyBlobResolver()),
+    [blobBaseUrl],
+  );
+  const hostContextPatch = useMemo(
+    () =>
+      mcpAppHostContextToNteractEmbedPatch(hostContext, {
+        rendererAssetsBaseUrl,
+        outputDocumentUrl: outputDocumentUrl ?? undefined,
+      }),
+    [hostContext, rendererAssetsBaseUrl, outputDocumentUrl],
+  );
+  const hostContextPatchRef = useRef(hostContextPatch);
+  const onDiagnosticRef = useRef(onDiagnostic);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    onDiagnosticRef.current = onDiagnostic;
+    onErrorRef.current = onError;
+  }, [onDiagnostic, onError]);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [outputCells, blobBaseUrl, rendererBundle, rendererPluginLoader, outputDocumentUrl]);
+
+  useEffect(() => {
+    if (failed || !targetRef.current || outputs.length === 0) return;
+
+    const handle = createNteractOutputEmbed({
+      target: targetRef.current,
+      rendererBundle,
+      rendererPluginLoader,
+      blobResolver,
+      hostContext: hostContextPatchRef.current,
+      outputDocumentUrl,
+      autoHeight,
+      maxHeight,
+      onDiagnostic(...args) {
+        onDiagnosticRef.current?.(...args);
+      },
+      onError(error) {
+        handleRef.current?.dispose();
+        handleRef.current = null;
+        setFailed(true);
+        onErrorRef.current?.(error);
+      },
+    });
+
+    handleRef.current = handle;
+    return () => {
+      handle.dispose();
+      if (handleRef.current === handle) handleRef.current = null;
+    };
+  }, [
+    autoHeight,
+    blobResolver,
+    failed,
+    maxHeight,
+    outputDocumentUrl,
+    outputs.length,
+    rendererBundle,
+    rendererPluginLoader,
+  ]);
+
+  useEffect(() => {
+    if (failed || outputs.length === 0) return;
+    handleRef.current?.renderBatch(outputs).catch((error) => {
+      const details =
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : { message: String(error) };
+      handleRef.current?.dispose();
+      handleRef.current = null;
+      setFailed(true);
+      onErrorRef.current?.(details);
+    });
+  }, [failed, outputs]);
+
+  useEffect(() => {
+    hostContextPatchRef.current = hostContextPatch;
+    handleRef.current?.setHostContext(hostContextPatch);
+  }, [hostContextPatch]);
+
+  if (failed) return null;
+
+  return <div ref={targetRef} className={className} />;
+}


### PR DESCRIPTION
## Summary

- add a shared `McpAppOutputFrame` adapter in `src/components/isolated` for MCP App cell outputs
- keep the MCP app wrapper responsible only for daemon URLs, renderer assets, and host logging
- cover the adapter contract with a focused component test

## Verification

- `pnpm test:run src/components/isolated/__tests__/mcp-app-output-frame.test.tsx src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm test:run apps/mcp-app/src`
- `cargo xtask lint --fix`
- `vp run nteract-mcp-app#build`
