### PR TITLE
refactor(mcp-app): share preview text policy

### DIFF
--- a/apps/mcp-app/src/lib/rich-output.ts
+++ b/apps/mcp-app/src/lib/rich-output.ts
@@ -1,5 +1,8 @@
 import type { CellData } from "../types";
-import { mcpAppCellHasRichOutput } from "@/components/isolated/mcp-app-structured-content";
+import {
+	mcpAppCellHasRichOutput,
+	mcpAppCellPreviewText,
+} from "@/components/isolated/mcp-app-structured-content";
 
 /** Whether a cell has any output that should be visually expanded. */
 export function hasRichOutput(cell: CellData): boolean {
@@ -8,43 +11,5 @@ export function hasRichOutput(cell: CellData): boolean {
 
 /** Extract a one-line preview string for a collapsed cell. */
 export function getPreviewText(cell: CellData): string {
-	for (const output of cell.outputs ?? []) {
-		// Prefer text/llm+plain (AI-synthesized summary)
-		if (output.data?.["text/llm+plain"]) {
-			return firstLine(String(output.data["text/llm+plain"]));
-		}
-	}
-
-	for (const output of cell.outputs ?? []) {
-		// text/plain from display_data or execute_result
-		if (
-			(output.output_type === "display_data" || output.output_type === "execute_result") &&
-			output.data?.["text/plain"]
-		) {
-			return firstLine(String(output.data["text/plain"]));
-		}
-	}
-
-	for (const output of cell.outputs ?? []) {
-		// Stream stdout
-		if (output.output_type === "stream" && output.text) {
-			return firstLine(String(output.text));
-		}
-	}
-
-	for (const output of cell.outputs ?? []) {
-		// Error
-		if (output.output_type === "error") {
-			const name = output.ename || "Error";
-			const value = output.evalue || "";
-			return value ? `${name}: ${value}` : name;
-		}
-	}
-
-	return cell.status || "";
-}
-
-function firstLine(text: string): string {
-	const line = text.split("\n")[0]?.trim() ?? "";
-	return line;
+	return mcpAppCellPreviewText(cell);
 }

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -3,6 +3,7 @@ import { resolveEmbeddableOutputs } from "../embeddable-output";
 import {
   createMcpAppBlobResolver,
   mcpAppCellHasRichOutput,
+  mcpAppCellPreviewText,
   mcpAppCellsToSharedOutputs,
   mcpAppStructuredContentToSharedOutputInputs,
   type McpAppCellData,
@@ -189,5 +190,40 @@ describe("MCP App structured content adapter", () => {
         ]),
       ),
     ).toBe(false);
+  });
+
+  it("selects collapsed MCP App previews from shared structured content policy", () => {
+    expect(
+      mcpAppCellPreviewText(
+        cellWithOutputs([
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "raw stream\nsecond line",
+          },
+          {
+            output_type: "display_data",
+            data: {
+              "text/plain": "plain display\nsecond line",
+              "text/llm+plain": "assistant summary\nsecond line",
+            },
+          },
+        ]),
+      ),
+    ).toBe("assistant summary");
+
+    expect(
+      mcpAppCellPreviewText(
+        cellWithOutputs([
+          {
+            output_type: "error",
+            ename: "ValueError",
+            evalue: "bad value",
+          },
+        ]),
+      ),
+    ).toBe("ValueError: bad value");
+
+    expect(mcpAppCellPreviewText({ ...cellWithOutputs([]), status: "queued" })).toBe("queued");
   });
 });

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -96,6 +96,7 @@ export type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from ".
 export {
   createInlineOnlyBlobResolver,
   createMcpAppBlobResolver,
+  mcpAppCellPreviewText,
   mcpAppCellsToSharedOutputs,
   mcpAppStructuredContentToSharedOutputInputs,
 } from "./mcp-app-structured-content";

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -144,6 +144,43 @@ export function mcpAppCellHasRichOutput(cell: McpAppCellData): boolean {
   });
 }
 
+function firstPreviewLine(text: string): string {
+  return text.split("\n")[0]?.trim() ?? "";
+}
+
+export function mcpAppCellPreviewText(cell: McpAppCellData): string {
+  for (const output of cell.outputs ?? []) {
+    if (output.data?.["text/llm+plain"]) {
+      return firstPreviewLine(String(output.data["text/llm+plain"]));
+    }
+  }
+
+  for (const output of cell.outputs ?? []) {
+    if (
+      (output.output_type === "display_data" || output.output_type === "execute_result") &&
+      output.data?.["text/plain"]
+    ) {
+      return firstPreviewLine(String(output.data["text/plain"]));
+    }
+  }
+
+  for (const output of cell.outputs ?? []) {
+    if (output.output_type === "stream" && output.text) {
+      return firstPreviewLine(String(output.text));
+    }
+  }
+
+  for (const output of cell.outputs ?? []) {
+    if (output.output_type === "error") {
+      const name = output.ename || "Error";
+      const value = output.evalue || "";
+      return value ? `${name}: ${value}` : name;
+    }
+  }
+
+  return cell.status || "";
+}
+
 export function createMcpAppBlobResolver(blobBaseUrl: string): OutputBlobResolver {
   const base = trimTrailingSlash(blobBaseUrl);
   const url = (ref: { blob: string }) => `${base}/blob/${encodeURIComponent(ref.blob)}`;


### PR DESCRIPTION
## Summary

- move MCP App collapsed preview text selection into the shared structured-content adapter
- keep `apps/mcp-app` as a thin compatibility wrapper over shared output policy
- cover preview precedence for `text/llm+plain`, errors, and empty/status-only cells

## Verification

- `pnpm test:run src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm test:run apps/mcp-app/src`
- `cargo xtask lint --fix`
- `vp run nteract-mcp-app#build`
