### PR TITLE
fix(notebook-cloud): sync viewer output themes

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -72,7 +72,10 @@ test.describe("cloud renderer parity harness", () => {
 
     for (let index = 0; index < count; index++) {
       const iframe = iframes.nth(index);
-      await expect(iframe).toHaveAttribute("src", /\/output-document\/frame\.html$/);
+      await expect(iframe).toHaveAttribute(
+        "src",
+        /\/output-document\/frame\.html\?nteract_theme=light$/,
+      );
       await expect(iframe).not.toHaveAttribute("srcdoc", /./);
       const sandbox = await iframe.getAttribute("sandbox");
       expect(sandbox?.split(/\s+/)).toContain("allow-scripts");
@@ -103,7 +106,7 @@ test.describe("cloud renderer parity harness", () => {
     await expect(siftCell.locator('[data-sift-output="true"]')).toBeVisible({ timeout: 60_000 });
     await expect(siftCell.locator("iframe")).toHaveAttribute(
       "src",
-      /\/output-document\/frame\.html$/,
+      /\/output-document\/frame\.html\?nteract_theme=light$/,
     );
     await expect(
       page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  CLOUD_VIEWER_THEME_STORAGE_KEY,
+  outputDocumentUrlForTheme,
+  resolveCloudViewerTheme,
+  storedCloudViewerTheme,
+} from "../viewer/theme.ts";
+
+describe("cloud viewer theme helpers", () => {
+  it("uses the cloud-specific storage key", () => {
+    assert.equal(CLOUD_VIEWER_THEME_STORAGE_KEY, "nteract.cloud.viewer.theme");
+  });
+
+  it("resolves explicit and system themes", () => {
+    assert.equal(resolveCloudViewerTheme("light", true), "light");
+    assert.equal(resolveCloudViewerTheme("dark", false), "dark");
+    assert.equal(resolveCloudViewerTheme("system", true), "dark");
+    assert.equal(resolveCloudViewerTheme("system", false), "light");
+  });
+
+  it("ignores invalid stored theme values", () => {
+    const storage = new Map<string, string>();
+    storage.set(CLOUD_VIEWER_THEME_STORAGE_KEY, "sepia");
+
+    assert.equal(storedCloudViewerTheme(storageLike(storage)), "system");
+  });
+
+  it("adds the resolved theme to hosted output document URLs", () => {
+    assert.equal(
+      outputDocumentUrlForTheme(
+        "https://outputs.example/frame/",
+        "light",
+        "https://cloud.test/n/demo",
+      ),
+      "https://outputs.example/frame/?nteract_theme=light",
+    );
+    assert.equal(
+      outputDocumentUrlForTheme("/frame/?existing=1", "dark", "https://cloud.test/n/demo"),
+      "https://cloud.test/frame/?existing=1&nteract_theme=dark",
+    );
+    assert.equal(outputDocumentUrlForTheme(null, "light", "https://cloud.test/n/demo"), undefined);
+  });
+});
+
+function storageLike(values: Map<string, string>): Pick<Storage, "getItem"> {
+  return {
+    getItem(key: string): string | null {
+      return values.get(key) ?? null;
+    },
+  };
+}

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   CLOUD_VIEWER_THEME_STORAGE_KEY,
-  outputDocumentUrlForTheme,
   resolveCloudViewerTheme,
   storedCloudViewerTheme,
 } from "../viewer/theme.ts";
@@ -24,22 +23,6 @@ describe("cloud viewer theme helpers", () => {
     storage.set(CLOUD_VIEWER_THEME_STORAGE_KEY, "sepia");
 
     assert.equal(storedCloudViewerTheme(storageLike(storage)), "system");
-  });
-
-  it("adds the resolved theme to hosted output document URLs", () => {
-    assert.equal(
-      outputDocumentUrlForTheme(
-        "https://outputs.example/frame/",
-        "light",
-        "https://cloud.test/n/demo",
-      ),
-      "https://outputs.example/frame/?nteract_theme=light",
-    );
-    assert.equal(
-      outputDocumentUrlForTheme("/frame/?existing=1", "dark", "https://cloud.test/n/demo"),
-      "https://cloud.test/frame/?existing=1&nteract_theme=dark",
-    );
-    assert.equal(outputDocumentUrlForTheme(null, "light", "https://cloud.test/n/demo"), undefined);
   });
 });
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -87,6 +87,21 @@ body {
   pointer-events: auto;
 }
 
+.cloud-theme-toggle {
+  height: 2rem;
+  border-color: color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--background) 90%, transparent);
+  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.cloud-theme-toggle button {
+  width: 1.625rem;
+  height: 1.625rem;
+  border-radius: 999px;
+}
+
 .cloud-auth-menu {
   position: relative;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -9,7 +9,9 @@ import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
+import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { isTextAttributionEvent } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
@@ -44,7 +46,12 @@ import {
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
-import { installDocumentThemeSync } from "./theme";
+import {
+  applyDocumentTheme,
+  CLOUD_VIEWER_THEME_STORAGE_KEY,
+  installDocumentThemeSync,
+  outputDocumentUrlForTheme,
+} from "./theme";
 import "./index.css";
 
 interface CloudViewerConfig {
@@ -75,7 +82,6 @@ type ViewerStatus =
 interface ViewerRuntime {
   config: CloudViewerConfig;
   blobResolver: ReturnType<typeof createNotebookCloudBlobResolver>;
-  outputHostContext: NteractEmbedHostContextPatch;
 }
 
 type ViewerRuntimeState =
@@ -132,14 +138,6 @@ function loadViewerRuntime(): ViewerRuntimeState {
           baseUrl: location.href,
           blobBasePath: config.blobBasePath,
         }),
-        outputHostContext: {
-          nteract: {
-            rendererAssetsBaseUrl: new URL(config.rendererAssetsBasePath, location.href).href,
-            outputDocumentUrl: config.outputDocumentBaseUrl
-              ? new URL(config.outputDocumentBaseUrl, location.href).href
-              : undefined,
-          },
-        },
       },
     };
   } catch (error) {
@@ -161,7 +159,8 @@ function App() {
 }
 
 function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
-  const { config, blobResolver, outputHostContext } = runtime;
+  const { config, blobResolver } = runtime;
+  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: "Loading notebook snapshot...",
@@ -186,6 +185,23 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     cloudPrototypeAuthFromWindow(),
   );
   const textAttributionSequenceRef = useRef(0);
+  const outputHostContext = useMemo<NteractEmbedHostContextPatch>(
+    () => ({
+      nteract: {
+        rendererAssetsBaseUrl: new URL(config.rendererAssetsBasePath, location.href).href,
+        outputDocumentUrl: outputDocumentUrlForTheme(
+          config.outputDocumentBaseUrl,
+          resolvedTheme,
+          location.href,
+        ),
+      },
+    }),
+    [config.outputDocumentBaseUrl, config.rendererAssetsBasePath, resolvedTheme],
+  );
+
+  useEffect(() => {
+    applyDocumentTheme(resolvedTheme);
+  }, [resolvedTheme]);
 
   useEffect(() => {
     cellsRef.current = cells;
@@ -487,6 +503,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
 
         <div className="cloud-toolbar-actions">
+          <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
+
           <CloudAuthControls
             authState={authState}
             connectionActorLabel={connectionActorLabel}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -50,7 +50,6 @@ import {
   applyDocumentTheme,
   CLOUD_VIEWER_THEME_STORAGE_KEY,
   installDocumentThemeSync,
-  outputDocumentUrlForTheme,
 } from "./theme";
 import "./index.css";
 
@@ -189,14 +188,12 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     () => ({
       nteract: {
         rendererAssetsBaseUrl: new URL(config.rendererAssetsBasePath, location.href).href,
-        outputDocumentUrl: outputDocumentUrlForTheme(
-          config.outputDocumentBaseUrl,
-          resolvedTheme,
-          location.href,
-        ),
+        outputDocumentUrl: config.outputDocumentBaseUrl
+          ? new URL(config.outputDocumentBaseUrl, location.href).href
+          : undefined,
       },
     }),
-    [config.outputDocumentBaseUrl, config.rendererAssetsBasePath, resolvedTheme],
+    [config.outputDocumentBaseUrl, config.rendererAssetsBasePath],
   );
 
   useEffect(() => {

--- a/apps/notebook-cloud/viewer/theme.ts
+++ b/apps/notebook-cloud/viewer/theme.ts
@@ -1,15 +1,62 @@
+export type CloudViewerThemeMode = "light" | "dark" | "system";
+export type ResolvedCloudViewerTheme = "light" | "dark";
+
+export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
+
+export function storedCloudViewerTheme(
+  storage: Pick<Storage, "getItem"> | undefined = browserLocalStorage(),
+): CloudViewerThemeMode {
+  try {
+    const stored = storage?.getItem(CLOUD_VIEWER_THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+  } catch {
+    // localStorage may be unavailable in private or embedded contexts.
+  }
+  return "system";
+}
+
+export function resolveCloudViewerTheme(
+  theme: CloudViewerThemeMode,
+  systemPrefersDark = prefersDarkTheme(),
+): ResolvedCloudViewerTheme {
+  if (theme === "system") return systemPrefersDark ? "dark" : "light";
+  return theme;
+}
+
+export function applyDocumentTheme(theme: ResolvedCloudViewerTheme): void {
+  if (typeof document === "undefined") return;
+
+  const isDark = theme === "dark";
+  document.documentElement.classList.toggle("dark", isDark);
+  document.documentElement.classList.toggle("light", !isDark);
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function outputDocumentUrlForTheme(
+  outputDocumentBaseUrl: string | null | undefined,
+  theme: ResolvedCloudViewerTheme,
+  pageUrl = typeof location === "undefined" ? "http://localhost/" : location.href,
+): string | undefined {
+  if (!outputDocumentBaseUrl) return undefined;
+
+  const url = new URL(outputDocumentBaseUrl, pageUrl);
+  url.searchParams.set("nteract_theme", theme);
+  return url.href;
+}
+
 export function installDocumentThemeSync(): void {
-  if (typeof window === "undefined" || typeof document === "undefined") return;
+  applyDocumentTheme(resolveCloudViewerTheme(storedCloudViewerTheme()));
+}
 
-  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-  const apply = () => {
-    const isDark = mediaQuery.matches;
-    document.documentElement.classList.toggle("dark", isDark);
-    document.documentElement.classList.toggle("light", !isDark);
-    document.documentElement.dataset.theme = isDark ? "dark" : "light";
-    document.documentElement.style.colorScheme = isDark ? "dark" : "light";
-  };
+function prefersDarkTheme(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
 
-  apply();
-  mediaQuery.addEventListener("change", apply);
+function browserLocalStorage(): Pick<Storage, "getItem"> | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.localStorage;
 }

--- a/apps/notebook-cloud/viewer/theme.ts
+++ b/apps/notebook-cloud/viewer/theme.ts
@@ -35,18 +35,6 @@ export function applyDocumentTheme(theme: ResolvedCloudViewerTheme): void {
   document.documentElement.style.colorScheme = theme;
 }
 
-export function outputDocumentUrlForTheme(
-  outputDocumentBaseUrl: string | null | undefined,
-  theme: ResolvedCloudViewerTheme,
-  pageUrl = typeof location === "undefined" ? "http://localhost/" : location.href,
-): string | undefined {
-  if (!outputDocumentBaseUrl) return undefined;
-
-  const url = new URL(outputDocumentBaseUrl, pageUrl);
-  url.searchParams.set("nteract_theme", theme);
-  return url.href;
-}
-
 export function installDocumentThemeSync(): void {
   applyDocumentTheme(resolveCloudViewerTheme(storedCloudViewerTheme()));
 }

--- a/src/components/isolated/__tests__/frame-config.test.ts
+++ b/src/components/isolated/__tests__/frame-config.test.ts
@@ -37,6 +37,28 @@ describe("isolated frame config", () => {
     });
   });
 
+  it("can add an initial theme hint to output document URLs", () => {
+    expect(
+      createIsolatedFrameDocument({
+        outputDocumentUrl: "https://outputs.example/frame/?existing=1",
+        initialTheme: "dark",
+      }),
+    ).toEqual({
+      kind: "src",
+      url: "https://outputs.example/frame/?existing=1&nteract_theme=dark",
+    });
+
+    expect(
+      createIsolatedFrameDocument({
+        outputDocumentUrl: "/output-document/frame.html?existing=1#anchor",
+        initialTheme: "light",
+      }),
+    ).toEqual({
+      kind: "src",
+      url: "/output-document/frame.html?existing=1&nteract_theme=light#anchor",
+    });
+  });
+
   it("detects Tauri globals without requiring a real browser window", () => {
     expect(isTauriFrameRuntime(undefined)).toBe(false);
     expect(isTauriFrameRuntime({ __TAURI__: {} })).toBe(true);

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -96,6 +96,12 @@ describe("generateFrameHtml", () => {
       expect(html).toContain("--border-color: #333333");
     });
 
+    it("can apply a hosted output theme hint before parent sync arrives", () => {
+      expect(html).toContain("nteract_theme");
+      expect(html).toContain("applyInitialThemeHint");
+      expect(html).toContain("setFrameTheme");
+    });
+
     it("ships document typography for markdown and html outputs", () => {
       expect(source).toContain(
         "--output-document-font: KaTeX_Main, Georgia, 'Times New Roman', serif",

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -332,4 +332,17 @@ describe("IsolatedFrame theme updates", () => {
     expect(iframe.getAttribute("src")).toBe("nteract-frame://localhost/");
     expect(iframe.getAttribute("srcdoc")).toBeNull();
   });
+
+  it("adds the initial hosted theme hint without reloading on theme changes", () => {
+    const { container, rerender } = render(
+      <IsolatedFrame darkMode={false} outputDocumentUrl="https://outputs.example/frame/" />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    expect(iframe.getAttribute("src")).toBe("https://outputs.example/frame/?nteract_theme=light");
+
+    rerender(<IsolatedFrame darkMode outputDocumentUrl="https://outputs.example/frame/" />);
+
+    expect(iframe.getAttribute("src")).toBe("https://outputs.example/frame/?nteract_theme=light");
+  });
 });

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -44,15 +44,32 @@ export function isTauriFrameRuntime(
 
 export function createIsolatedFrameDocument(options?: {
   isTauriRuntime?: boolean;
+  initialTheme?: "light" | "dark";
   outputDocumentUrl?: string | null;
 }): IsolatedFrameDocument {
   const outputDocumentUrl = options?.outputDocumentUrl?.trim();
   if (outputDocumentUrl) {
-    return { kind: "src", url: outputDocumentUrl };
+    return { kind: "src", url: withThemeHint(outputDocumentUrl, options?.initialTheme) };
   }
 
   if (options?.isTauriRuntime ?? isTauriFrameRuntime()) {
     return { kind: "src", url: NTERACT_FRAME_URL };
   }
   return { kind: "srcdoc", html: FRAME_HTML };
+}
+
+function withThemeHint(outputDocumentUrl: string, theme: "light" | "dark" | undefined): string {
+  if (!theme) return outputDocumentUrl;
+
+  try {
+    const url = new URL(outputDocumentUrl);
+    url.searchParams.set("nteract_theme", theme);
+    return url.href;
+  } catch {
+    const hashIndex = outputDocumentUrl.indexOf("#");
+    const beforeHash = hashIndex === -1 ? outputDocumentUrl : outputDocumentUrl.slice(0, hashIndex);
+    const hash = hashIndex === -1 ? "" : outputDocumentUrl.slice(hashIndex);
+    const separator = beforeHash.includes("?") ? "&" : "?";
+    return `${beforeHash}${separator}nteract_theme=${theme}${hash}`;
+  }
 }

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -236,6 +236,71 @@
         let hostFontStyle = null;
         const IFRAME_HEIGHT_FUDGE_PX = 2;
 
+        function setFrameTheme(isDark, colorTheme, cssVariables) {
+          const rootEl = document.documentElement;
+
+          // Apply color theme attribute first so CSS var computation can read it
+          if (colorTheme) {
+            rootEl.setAttribute("data-color-theme", colorTheme);
+          } else if (colorTheme === null || colorTheme === "") {
+            rootEl.removeAttribute("data-color-theme");
+          }
+
+          if (isDark !== undefined) {
+            // Set class for Tailwind dark: variant and CSS selectors
+            if (isDark) {
+              rootEl.classList.add("dark");
+              rootEl.classList.remove("light");
+            } else {
+              rootEl.classList.add("light");
+              rootEl.classList.remove("dark");
+            }
+            // Set data-theme for components that check this attribute
+            rootEl.setAttribute("data-theme", isDark ? "dark" : "light");
+            // Set color-scheme for prefers-color-scheme media queries
+            rootEl.style.colorScheme = isDark ? "dark" : "light";
+            // Set CSS variables — cream uses warm tones matching Sift's palette
+            var ct = rootEl.getAttribute("data-color-theme");
+            var isCream = ct === "cream";
+            rootEl.style.setProperty("--bg-primary", "transparent");
+            rootEl.style.setProperty(
+              "--bg-secondary",
+              isCream ? (isDark ? "#242120" : "#f0ede7") : isDark ? "#1a1a1a" : "#f5f5f5",
+            );
+            rootEl.style.setProperty(
+              "--text-primary",
+              isCream ? (isDark ? "#e8e2dc" : "#1e1a18") : isDark ? "#e0e0e0" : "#1a1a1a",
+            );
+            rootEl.style.setProperty(
+              "--text-secondary",
+              isCream ? (isDark ? "#9a918a" : "#6e655f") : isDark ? "#a0a0a0" : "#666666",
+            );
+            rootEl.style.setProperty(
+              "--border-color",
+              isCream ? (isDark ? "#3a3533" : "#d8cec3") : isDark ? "#333333" : "#e0e0e0",
+            );
+          }
+
+          if (cssVariables) {
+            Object.entries(cssVariables).forEach(function ([key, value]) {
+              rootEl.style.setProperty(key, value);
+            });
+          }
+        }
+
+        function applyInitialThemeHint() {
+          try {
+            var themeHint = new URL(window.location.href).searchParams.get("nteract_theme");
+            if (themeHint === "light" || themeHint === "dark") {
+              setFrameTheme(themeHint === "dark");
+            }
+          } catch (_error) {
+            // srcDoc and custom-scheme frames may not have a parseable URL.
+          }
+        }
+
+        applyInitialThemeHint();
+
         function measureDocumentHeight() {
           var doc = document.documentElement;
           var body = document.body;
@@ -478,55 +543,7 @@
 
         function handleTheme(payload) {
           const { isDark, colorTheme, cssVariables } = payload || {};
-          const rootEl = document.documentElement;
-
-          // Apply color theme attribute first so CSS var computation can read it
-          if (colorTheme) {
-            rootEl.setAttribute("data-color-theme", colorTheme);
-          } else if (colorTheme === null || colorTheme === "") {
-            rootEl.removeAttribute("data-color-theme");
-          }
-
-          if (isDark !== undefined) {
-            // Set class for Tailwind dark: variant and CSS selectors
-            if (isDark) {
-              rootEl.classList.add("dark");
-              rootEl.classList.remove("light");
-            } else {
-              rootEl.classList.add("light");
-              rootEl.classList.remove("dark");
-            }
-            // Set data-theme for components that check this attribute
-            rootEl.setAttribute("data-theme", isDark ? "dark" : "light");
-            // Set color-scheme for prefers-color-scheme media queries
-            rootEl.style.colorScheme = isDark ? "dark" : "light";
-            // Set CSS variables — cream uses warm tones matching Sift's palette
-            var ct = rootEl.getAttribute("data-color-theme");
-            var isCream = ct === "cream";
-            rootEl.style.setProperty("--bg-primary", "transparent");
-            rootEl.style.setProperty(
-              "--bg-secondary",
-              isCream ? (isDark ? "#242120" : "#f0ede7") : isDark ? "#1a1a1a" : "#f5f5f5",
-            );
-            rootEl.style.setProperty(
-              "--text-primary",
-              isCream ? (isDark ? "#e8e2dc" : "#1e1a18") : isDark ? "#e0e0e0" : "#1a1a1a",
-            );
-            rootEl.style.setProperty(
-              "--text-secondary",
-              isCream ? (isDark ? "#9a918a" : "#6e655f") : isDark ? "#a0a0a0" : "#666666",
-            );
-            rootEl.style.setProperty(
-              "--border-color",
-              isCream ? (isDark ? "#3a3533" : "#d8cec3") : isDark ? "#333333" : "#e0e0e0",
-            );
-          }
-
-          if (cssVariables) {
-            Object.entries(cssVariables).forEach(function ([key, value]) {
-              rootEl.style.setProperty(key, value);
-            });
-          }
+          setFrameTheme(isDark, colorTheme, cssVariables);
         }
 
         function handleHostContext(payload) {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -478,12 +478,17 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     }, [applyMeasuredHeight]);
 
     const resolvedOutputDocumentUrl = outputDocumentUrl ?? hostContext?.nteract?.outputDocumentUrl;
+    const frameDocumentThemeRef = useRef<"light" | "dark">(darkMode ? "dark" : "light");
+    frameDocumentThemeRef.current = darkMode ? "dark" : "light";
 
     // Create frame document on mount. The shared config keeps React, future
     // non-React adapters, and tests on the same source/sandbox contract.
     useEffect(() => {
       setFrameDocument(
-        createIsolatedFrameDocument({ outputDocumentUrl: resolvedOutputDocumentUrl }),
+        createIsolatedFrameDocument({
+          outputDocumentUrl: resolvedOutputDocumentUrl,
+          initialTheme: frameDocumentThemeRef.current,
+        }),
       );
     }, [resolvedOutputDocumentUrl]);
 


### PR DESCRIPTION
## Summary

- add cloud viewer light/dark/system theme controls using the shared theme toggle
- pass the resolved cloud viewer theme into hosted output-document iframe URLs
- let the shared isolated frame bootstrap apply that hosted theme hint before parent sync arrives

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- PR stays draft pending Bedrock/opencode review and GitHub CI.
