### PR TITLE
[ipy-opt] Split structural output store updates

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -27,7 +27,11 @@ import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorReg
 import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
 import { logger } from "../lib/logger";
 import { getNotebookCellsSnapshot, useCell, useMaterializeVersion } from "../lib/notebook-cells";
-import { getCellOutputsSnapshot, useOutputsVersion } from "../lib/notebook-outputs";
+import {
+  getCellOutputsSnapshot,
+  useOutputStructureVersion,
+  useOutputsVersion,
+} from "../lib/notebook-outputs";
 import type { CodeCell as CodeCellType, NotebookCell } from "../types";
 import { CellSkeleton } from "./CellSkeleton";
 import { CodeCell } from "./CodeCell";
@@ -459,10 +463,12 @@ function NotebookViewContent({
 
   // Track full materializations for cross-cell derived state
   const materializeVersion = useMaterializeVersion();
-  // Recompute hidden-group membership when any output changes. Phase
-  // C-lite stopped updating `cell.outputs` on output-only frames, so
-  // without this subscription a source-hidden cell receiving its first
-  // output would stay collapsed until a structural change fired.
+  // Recompute hidden-group membership when outputs are added, removed, or
+  // change kind. Phase C-lite stopped updating `cell.outputs` on output-only
+  // frames, so source-hidden cells still need a store signal when their
+  // output membership changes. Stream text/display payload updates keep the
+  // same membership and should not rescan all hidden groups.
+  const outputStructureVersion = useOutputStructureVersion();
   const outputsVersion = useOutputsVersion();
 
   // Drag-and-drop state
@@ -532,11 +538,11 @@ function NotebookViewContent({
   // Recomputes on structural changes and full materializations (metadata changes)
   const hiddenGroups = useMemo(() => {
     // Depend on cellIds (structural changes), materializeVersion (metadata
-    // changes like source_hidden), and outputsVersion (output appends that
-    // expand a source-hidden cell out of its collapsed group).
+    // changes like source_hidden), and outputStructureVersion (output adds,
+    // removals, or type changes that affect hidden grouping / error counts).
     void cellIds;
     void materializeVersion;
-    void outputsVersion;
+    void outputStructureVersion;
     const cells = getNotebookCellsSnapshot();
     const groups = new Map<
       string,
@@ -577,7 +583,7 @@ function NotebookViewContent({
       }
     }
     return groups;
-  }, [cellIds, materializeVersion, outputsVersion]);
+  }, [cellIds, materializeVersion, outputStructureVersion]);
   const hiddenGroupsRef = useRef(hiddenGroups);
   hiddenGroupsRef.current = hiddenGroups;
 

--- a/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
+++ b/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
@@ -18,6 +18,9 @@ import {
   useCell,
 } from "../notebook-cells";
 import {
+  deleteOutput,
+  useOutputStructureVersion,
+  useOutputsVersion,
   resetNotebookOutputs,
   setOutput,
   useCellOutputs,
@@ -42,6 +45,15 @@ function streamOutput(text: string): JupyterOutput {
   return { output_type: "stream", name: "stdout", text };
 }
 
+function errorOutput(ename: string): JupyterOutput {
+  return {
+    output_type: "error",
+    ename,
+    evalue: "boom",
+    traceback: [],
+  };
+}
+
 function codeCell(id: string): NotebookCell {
   return {
     id,
@@ -54,6 +66,60 @@ function codeCell(id: string): NotebookCell {
 }
 
 describe("Phase C-lite: cell subscription / outputs decoupling", () => {
+  it("keeps structural output version stable for a stream append burst", () => {
+    const structureRenderCount = { current: 0 };
+    const structureOnly = renderHook(() => {
+      structureRenderCount.current += 1;
+      return useOutputStructureVersion();
+    });
+    const { result } = renderHook(() => ({
+      anyOutputVersion: useOutputsVersion(),
+      structureVersion: useOutputStructureVersion(),
+    }));
+
+    const initialAny = result.current.anyOutputVersion;
+    const initialStructure = result.current.structureVersion;
+
+    act(() => {
+      setOutput("o1", streamOutput("a"));
+    });
+
+    expect(result.current.anyOutputVersion).toBe(initialAny + 1);
+    expect(result.current.structureVersion).toBe(initialStructure + 1);
+    expect(structureOnly.result.current).toBe(initialStructure + 1);
+    expect(structureRenderCount.current).toBe(2);
+
+    const burstSize = 1000;
+    act(() => {
+      for (let i = 0; i < burstSize; i++) {
+        setOutput("o1", streamOutput(`a-appended-${i}`));
+      }
+    });
+
+    expect(result.current.anyOutputVersion).toBe(initialAny + 1 + burstSize);
+    expect(result.current.structureVersion).toBe(initialStructure + 1);
+    expect(structureOnly.result.current).toBe(initialStructure + 1);
+    expect(structureRenderCount.current).toBe(2);
+
+    act(() => {
+      setOutput("o1", errorOutput("RuntimeError"));
+    });
+
+    expect(result.current.anyOutputVersion).toBe(initialAny + 2 + burstSize);
+    expect(result.current.structureVersion).toBe(initialStructure + 2);
+    expect(structureOnly.result.current).toBe(initialStructure + 2);
+    expect(structureRenderCount.current).toBe(3);
+
+    act(() => {
+      deleteOutput("o1");
+    });
+
+    expect(result.current.anyOutputVersion).toBe(initialAny + 3 + burstSize);
+    expect(result.current.structureVersion).toBe(initialStructure + 3);
+    expect(structureOnly.result.current).toBe(initialStructure + 3);
+    expect(structureRenderCount.current).toBe(4);
+  });
+
   it("output mutations don't change the cell snapshot reference", () => {
     replaceNotebookCells([codeCell("c1")]);
     // Sanity: the cell landed in the store

--- a/apps/notebook/src/lib/notebook-outputs.ts
+++ b/apps/notebook/src/lib/notebook-outputs.ts
@@ -36,11 +36,17 @@ const _subscribers = new Map<string, Set<() => void>>();
 // is intentionally NOT used by `useCellOutputs` (per-cell hooks subscribe
 // only to their own output_ids so a noisy cell can't fan re-renders to
 // every other cell — see P1 review note). It exists for a narrow set of
-// cross-cell derived consumers (NotebookView's hidden-group membership
-// and error-count totals) that need to recompute whenever any output in
-// the notebook changes.
+// cross-cell derived consumers such as tail pinning that need to observe
+// every output payload change in the notebook.
 let _outputsVersion = 0;
 const _outputsVersionSubscribers = new Set<() => void>();
+
+// Narrower version for derived views that only care whether output
+// membership or output kinds changed. Stream appends and display payload
+// updates still notify the exact output subscriber and `_outputsVersion`,
+// but they do not need to recompute hidden-cell grouping / error counts.
+let _outputStructureVersion = 0;
+const _outputStructureVersionSubscribers = new Set<() => void>();
 
 function emitOutputChange(output_id: string): void {
   const subs = _subscribers.get(output_id);
@@ -55,6 +61,17 @@ function emitOutputChange(output_id: string): void {
   }
   _outputsVersion = (_outputsVersion + 1) | 0;
   for (const cb of _outputsVersionSubscribers) {
+    try {
+      cb();
+    } catch {
+      // subscriber errors must not break the dispatch loop
+    }
+  }
+}
+
+function emitOutputStructureChange(): void {
+  _outputStructureVersion = (_outputStructureVersion + 1) | 0;
+  for (const cb of _outputStructureVersionSubscribers) {
     try {
       cb();
     } catch {
@@ -166,8 +183,10 @@ function getOutputSnapshot(output_id: string): () => JupyterOutput | undefined {
 export function setOutput(output_id: string, output: JupyterOutput): void {
   const prev = _outputMap.get(output_id);
   if (prev === output) return;
+  const structureChanged = prev === undefined || prev.output_type !== output.output_type;
   _outputMap.set(output_id, output);
   emitOutputChange(output_id);
+  if (structureChanged) emitOutputStructureChange();
 }
 
 /** Remove a single output. Notifies its subscribers with `undefined`. */
@@ -175,6 +194,7 @@ export function deleteOutput(output_id: string): void {
   if (!_outputMap.has(output_id)) return;
   _outputMap.delete(output_id);
   emitOutputChange(output_id);
+  emitOutputStructureChange();
 }
 
 /** Bulk drop outputs. Useful on clear_outputs / execution restart. */
@@ -192,6 +212,7 @@ export function resetNotebookOutputs(): void {
   const ids = [..._outputMap.keys()];
   _outputMap.clear();
   for (const id of ids) emitOutputChange(id);
+  if (ids.length > 0) emitOutputStructureChange();
 }
 
 // ── Cross-cell derived state ──────────────────────────────────────────
@@ -213,6 +234,21 @@ export function useOutputsVersion(): number {
   );
 }
 
+/**
+ * Subscribe to output membership / kind changes only.
+ *
+ * A stream append or `update_display_data` payload replacement keeps the
+ * same output_id and output_type, so cross-cell structural views should not
+ * recompute. New outputs, removals, and output_type transitions do advance
+ * this counter.
+ */
+export function useOutputStructureVersion(): number {
+  return useSyncExternalStore(
+    subscribeOutputStructureVersion,
+    getOutputStructureVersionSnapshot,
+  );
+}
+
 function subscribeOutputsVersion(cb: () => void): () => void {
   _outputsVersionSubscribers.add(cb);
   return () => {
@@ -222,6 +258,17 @@ function subscribeOutputsVersion(cb: () => void): () => void {
 
 function getOutputsVersionSnapshot(): number {
   return _outputsVersion;
+}
+
+function subscribeOutputStructureVersion(cb: () => void): () => void {
+  _outputStructureVersionSubscribers.add(cb);
+  return () => {
+    _outputStructureVersionSubscribers.delete(cb);
+  };
+}
+
+function getOutputStructureVersionSnapshot(): number {
+  return _outputStructureVersion;
 }
 
 // ── Sync helpers for cross-cell derived state ─────────────────────────

--- a/docs/architecture/runtime-output-optimization.md
+++ b/docs/architecture/runtime-output-optimization.md
@@ -56,7 +56,10 @@ known repeated work:
    output set without cloning every unchanged manifest into a fresh snapshot on
    each frame.
 7. Frontend output materialization cleanup so runtime outputs flow through the
-   output store rather than repeated whole-output JSON cache keys.
+   output store rather than repeated whole-output JSON cache keys. Notebook-wide
+   derived views should subscribe to the narrowest output signal they need:
+   tail pinning still observes every output payload change, while hidden-group
+   membership and error counts observe only output adds/removals/type changes.
 
 Each item is independently mergeable and should include a small benchmark or
 stress case that proves the eliminated work.


### PR DESCRIPTION
## Summary

- Split the notebook output store into a payload-level version and a structural version.
- Move `NotebookView` hidden-output grouping and error-count recomputation onto the structural signal.
- Keep tail pinning subscribed to every output payload update so streaming behavior remains unchanged.

## Compatibility

This does not change the durable output model, protocol surface, persisted data, or flat client output shape. It only narrows one frontend subscription path so display payload updates and stream append bursts do not force hidden-group scans when output membership and output types are unchanged.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-outputs.test.ts apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx apps/notebook/src/lib/__tests__/frame-pipeline.test.ts`
- `cargo xtask lint --fix`
- `git diff --check origin/main`
