### PR TITLE
perf(frontend): reduce streaming table rerenders

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -29,8 +29,8 @@ import { logger } from "../lib/logger";
 import { getNotebookCellsSnapshot, useCell, useMaterializeVersion } from "../lib/notebook-cells";
 import {
   getCellOutputsSnapshot,
+  subscribeOutputsVersion,
   useOutputStructureVersion,
-  useOutputsVersion,
 } from "../lib/notebook-outputs";
 import type { CodeCell as CodeCellType, NotebookCell } from "../types";
 import { CellSkeleton } from "./CellSkeleton";
@@ -371,6 +371,7 @@ function NotebookViewContent({
   const presence = usePresenceContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const tailPinnedRef = useRef(false);
+  const tailScrollFrameRef = useRef<number | null>(null);
 
   // Read transient UI state from the store instead of props
   const focusedCellId = useFocusedCellId();
@@ -469,7 +470,6 @@ function NotebookViewContent({
   // output membership changes. Stream text/display payload updates keep the
   // same membership and should not rescan all hidden groups.
   const outputStructureVersion = useOutputStructureVersion();
-  const outputsVersion = useOutputsVersion();
 
   // Drag-and-drop state
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -627,19 +627,39 @@ function NotebookViewContent({
     return () => container.removeEventListener("scroll", handleScroll);
   }, []);
 
+  const scheduleTailScrollIfPinned = useCallback(() => {
+    if (!tailPinnedRef.current) return;
+    const container = containerRef.current;
+    if (!container || tailScrollFrameRef.current !== null) return;
+
+    tailScrollFrameRef.current = window.requestAnimationFrame(() => {
+      tailScrollFrameRef.current = null;
+      if (!tailPinnedRef.current) return;
+      const currentContainer = containerRef.current;
+      if (!currentContainer) return;
+      currentContainer.scrollTop = currentContainer.scrollHeight;
+    });
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (tailScrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(tailScrollFrameRef.current);
+        tailScrollFrameRef.current = null;
+      }
+    };
+  }, []);
+
   // If outputs or trailing cells arrive while the user is already at the
   // notebook tail, keep the tail anchored so last-cell outputs do not grow
   // below the viewport and vanish. Scrolling up opts out via tailPinnedRef.
   useEffect(() => {
-    if (!tailPinnedRef.current) return;
-    const container = containerRef.current;
-    if (!container) return;
+    return subscribeOutputsVersion(scheduleTailScrollIfPinned);
+  }, [scheduleTailScrollIfPinned]);
 
-    const frame = window.requestAnimationFrame(() => {
-      container.scrollTop = container.scrollHeight;
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [outputsVersion, cellIds.length]);
+  useEffect(() => {
+    scheduleTailScrollIfPinned();
+  }, [cellIds.length, scheduleTailScrollIfPinned]);
 
   // Scroll the current search match cell into view
   useEffect(() => {

--- a/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
@@ -1,3 +1,4 @@
+import { renderHook, act } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import type { NotebookCell } from "../../types";
 import {
@@ -7,6 +8,7 @@ import {
   resetNotebookCells,
   updateCellById,
   updateNotebookCells,
+  useMaterializeVersion,
 } from "../notebook-cells";
 
 const codeCell = (id: string, source = ""): NotebookCell => ({
@@ -169,6 +171,61 @@ describe("subscriber notifications", () => {
     expect(ref1).toHaveLength(1);
     expect(ref2).toHaveLength(2);
     expect(ref3).toHaveLength(3);
+  });
+});
+
+describe("materialization version", () => {
+  it("does not bump for output-only replacements", () => {
+    const firstOutput = {
+      output_type: "stream" as const,
+      name: "stdout" as const,
+      text: "first",
+    };
+    const secondOutput = {
+      output_type: "stream" as const,
+      name: "stdout" as const,
+      text: "second",
+    };
+    const cell = {
+      ...codeCell("a", "print('hello')"),
+      execution_count: 1,
+      outputs: [firstOutput],
+    };
+    replaceNotebookCells([cell]);
+    const firstCellRef = getCellById("a");
+
+    const renderCount = { current: 0 };
+    const { result } = renderHook(() => {
+      renderCount.current += 1;
+      return useMaterializeVersion();
+    });
+    const initialVersion = result.current;
+
+    act(() => {
+      replaceNotebookCells([{ ...cell, outputs: [secondOutput] }]);
+    });
+
+    expect(getCellById("a")).not.toBe(firstCellRef);
+    expect(result.current).toBe(initialVersion);
+    expect(renderCount.current).toBe(1);
+  });
+
+  it("bumps when cell chrome changes", () => {
+    replaceNotebookCells([codeCell("a", "old")]);
+
+    const renderCount = { current: 0 };
+    const { result } = renderHook(() => {
+      renderCount.current += 1;
+      return useMaterializeVersion();
+    });
+    const initialVersion = result.current;
+
+    act(() => {
+      replaceNotebookCells([codeCell("a", "new")]);
+    });
+
+    expect(result.current).toBe(initialVersion + 1);
+    expect(renderCount.current).toBe(2);
   });
 });
 

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -27,9 +27,10 @@ const _idsSubscribers = new Set<() => void>();
 // Per-cell subscribers (keyed by cell ID)
 const _cellSubscribers = new Map<string, Set<() => void>>();
 
-// Materialization version — bumps on replaceNotebookCells and
-// updateNotebookCells (full-array ops), but NOT on updateCellById.
-// Used by components that derive cross-cell state (e.g., hiddenGroups).
+// Materialization version — bumps when full-array ops change the ordered
+// cell list or cell chrome (source / metadata / type / execution count),
+// but not when they only refresh legacy `cell.outputs`. Used by components
+// that derive cross-cell state (e.g., hiddenGroups).
 let _materializeVersion = 0;
 const _materializeSubscribers = new Set<() => void>();
 
@@ -196,6 +197,28 @@ function cellsEqual(a: NotebookCell, b: NotebookCell): boolean {
   return true;
 }
 
+function cellChromeEqual(a: NotebookCell, b: NotebookCell): boolean {
+  if (a === b) return true;
+  if (a.cell_type !== b.cell_type) return false;
+  if (a.source !== b.source) return false;
+  if (JSON.stringify(a.metadata) !== JSON.stringify(b.metadata)) return false;
+
+  if (a.cell_type === "code") {
+    const bc = b as typeof a;
+    return a.execution_count === bc.execution_count;
+  }
+
+  if (a.cell_type === "markdown") {
+    const bm = b as typeof a;
+    return shallowRecordEqual(
+      a.resolvedAssets as Record<string, unknown> | undefined,
+      bm.resolvedAssets as Record<string, unknown> | undefined,
+    );
+  }
+
+  return true;
+}
+
 // ── Write operations ────────────────────────────────────────────────────
 
 /**
@@ -233,9 +256,13 @@ export function replaceNotebookCells(cells: NotebookCell[]): void {
   const newMap = new Map<string, NotebookCell>();
   const changedIds: string[] = [];
   let anySourceChanged = false;
+  let materializedChromeChanged = idsChanged;
 
   for (const cell of cells) {
     const prev = _cellMap.get(cell.id);
+    if (!prev || !cellChromeEqual(prev, cell)) {
+      materializedChromeChanged = true;
+    }
     if (prev && cellsEqual(prev, cell)) {
       // Structurally identical — preserve old reference, skip notification
       newMap.set(cell.id, prev);
@@ -268,7 +295,9 @@ export function replaceNotebookCells(cells: NotebookCell[]): void {
     emitIdsChange();
   }
 
-  emitMaterializeChange();
+  if (materializedChromeChanged) {
+    emitMaterializeChange();
+  }
 
   if (anySourceChanged) {
     emitSourceChange();
@@ -305,13 +334,21 @@ export function updateNotebookCells(
     newIds.some((id, i) => id !== _cellIds[i]);
 
   _cellMap = new Map(newCells.map((c) => [c.id, c]));
+  const materializedChromeChanged =
+    idsChanged ||
+    newCells.some((cell, i) => {
+      const prev = prevCells[i];
+      return !prev || !cellChromeEqual(prev, cell);
+    });
 
   if (idsChanged) {
     _cellIds = newIds;
     emitIdsChange();
   }
 
-  emitMaterializeChange();
+  if (materializedChromeChanged) {
+    emitMaterializeChange();
+  }
   emitSourceChange();
 
   // Notify per-cell subscribers for cells that actually changed

--- a/apps/notebook/src/lib/notebook-outputs.ts
+++ b/apps/notebook/src/lib/notebook-outputs.ts
@@ -249,7 +249,7 @@ export function useOutputStructureVersion(): number {
   );
 }
 
-function subscribeOutputsVersion(cb: () => void): () => void {
+export function subscribeOutputsVersion(cb: () => void): () => void {
   _outputsVersionSubscribers.add(cb);
   return () => {
     _outputsVersionSubscribers.delete(cb);

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f93d5e07539f52e32848c555489e1da09de4fdaa36e422b42ff3b6ec6a8bd76
-size 1601293
+oid sha256:a78a0727fe6643f3ca47e72216fdc29f3143fe62f4ae82da2193f9151c249243
+size 1601509

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -669,6 +669,69 @@ describe("createTable", () => {
       const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
       expect(stats?.dataset.value).toContain("60");
     });
+
+    it("preserves visible image-cell <img> elements when appended rows do not change them", async () => {
+      engine.destroy();
+      container.innerHTML = "";
+
+      const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const columns: Column[] = [
+        {
+          key: "id",
+          label: "ID",
+          width: 80,
+          sortable: true,
+          numeric: true,
+          columnType: "numeric",
+        },
+        {
+          key: "image",
+          label: "Image",
+          width: 140,
+          sortable: false,
+          numeric: false,
+          columnType: "image",
+        },
+      ];
+      const imageRows: unknown[][] = [
+        [1, [pngBytes]],
+        [2, [pngBytes]],
+      ];
+      const imageData: TableData = {
+        columns,
+        rowCount: imageRows.length,
+        getCell: (r, c) => String(imageRows[r][c] ?? ""),
+        getCellRaw: (r, c) => imageRows[r][c],
+        columnSummaries: columns.map(() => null),
+      };
+
+      engine = createTable(container, imageData);
+      const viewport = container.querySelector<HTMLElement>(".sift-viewport")!;
+      Object.defineProperty(viewport, "clientHeight", { value: 800, configurable: true });
+      viewport.dispatchEvent(new Event("scroll"));
+      await vi.advanceTimersByTimeAsync(20);
+
+      const beforeImg = container.querySelector<HTMLImageElement>(
+        '[aria-rowindex="2"] .sift-cell-image-thumb',
+      );
+      expect(beforeImg).not.toBeNull();
+      const beforeBlobUrl = beforeImg!.dataset.siftBlobUrl;
+      expect(beforeBlobUrl).toBeDefined();
+
+      imageRows.push([3, [pngBytes]]);
+      imageData.rowCount = imageRows.length;
+      engine.onBatchAppended();
+      await vi.advanceTimersByTimeAsync(20);
+
+      const afterImg = container.querySelector<HTMLImageElement>(
+        '[aria-rowindex="2"] .sift-cell-image-thumb',
+      );
+      expect(afterImg).toBe(beforeImg);
+      expect(afterImg!.dataset.siftBlobUrl).toBe(beforeBlobUrl);
+
+      const stats = container.querySelector(".sift-stat-rows") as HTMLElement;
+      expect(stats?.dataset.value).toContain("3");
+    });
   });
 
   describe("edge cases", () => {

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1362,9 +1362,16 @@ export function createTable(
     el: HTMLDivElement;
     cells: HTMLDivElement[];
     assignedRow: number;
+    assignedDataRow: number;
   };
 
   const pool: PooledRow[] = [];
+
+  function releasePooledRow(pr: PooledRow) {
+    pr.assignedRow = -1;
+    pr.assignedDataRow = -1;
+    pr.el.style.display = "none";
+  }
 
   function getPooledRow(): PooledRow {
     for (const pr of pool) {
@@ -1388,7 +1395,7 @@ export function createTable(
       el.appendChild(cells[c]);
     }
     rowPool.appendChild(el);
-    const pr: PooledRow = { el, cells, assignedRow: -1 };
+    const pr: PooledRow = { el, cells, assignedRow: -1, assignedDataRow: -1 };
     pool.push(pr);
     return pr;
   }
@@ -1633,8 +1640,14 @@ export function createTable(
 
     for (const pr of pool) {
       if (pr.assignedRow !== -1 && (pr.assignedRow < first || pr.assignedRow > last)) {
-        pr.el.style.display = "none";
-        pr.assignedRow = -1;
+        releasePooledRow(pr);
+      }
+    }
+
+    for (const pr of pool) {
+      if (pr.assignedRow === -1) continue;
+      if (viewIndices[pr.assignedRow] !== pr.assignedDataRow) {
+        releasePooledRow(pr);
       }
     }
 
@@ -1662,7 +1675,7 @@ export function createTable(
       const dataRow = viewIndices[r];
       let existing = false;
       for (const pr of pool) {
-        if (pr.assignedRow === r) {
+        if (pr.assignedRow === r && pr.assignedDataRow === dataRow) {
           existing = true;
           break;
         }
@@ -1671,6 +1684,7 @@ export function createTable(
 
       const pr = getPooledRow();
       pr.assignedRow = r;
+      pr.assignedDataRow = dataRow;
       pr.el.style.display = "";
       pr.el.style.transform = `translateY(${rowPositions[r] - virtualOffset}px)`;
       pr.el.style.height = rowHeights[r] + "px";
@@ -2003,8 +2017,7 @@ export function createTable(
     // Reset vertical scroll but preserve horizontal position
     viewport.scrollTop = 0;
     for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
+      releasePooledRow(pr);
     }
     scheduleRender();
     notifyChange();
@@ -2063,11 +2076,6 @@ export function createTable(
     }
 
     heightsDirty = true;
-    // Force visible rows to refresh
-    for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
-    }
     lastVisFirst = -1;
     lastVisLast = -1;
     scheduleRender();
@@ -2157,8 +2165,7 @@ export function createTable(
 
   function hidePooledRows() {
     for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
+      releasePooledRow(pr);
     }
   }
 
@@ -2554,8 +2561,7 @@ export function createTable(
     }
     viewport.scrollTop = 0;
     for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
+      releasePooledRow(pr);
     }
     lastVisFirst = -1;
     lastVisLast = -1;
@@ -2594,8 +2600,7 @@ export function createTable(
     applyFilterAndSort();
     viewport.scrollTop = 0;
     for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
+      releasePooledRow(pr);
     }
     scheduleRender();
   }
@@ -2637,8 +2642,7 @@ export function createTable(
         applyFilterAndSort();
         viewport.scrollTop = 0;
         for (const pr of pool) {
-          pr.assignedRow = -1;
-          pr.el.style.display = "none";
+          releasePooledRow(pr);
         }
         scheduleRender();
         notifyChange();
@@ -2690,8 +2694,7 @@ export function createTable(
           renderAllSummaries();
           heightsDirty = true;
           for (const pr of pool) {
-            pr.assignedRow = -1;
-            pr.el.style.display = "none";
+            releasePooledRow(pr);
           }
           scheduleRender();
         }
@@ -2724,8 +2727,7 @@ export function createTable(
           renderAllSummaries();
           heightsDirty = true;
           for (const pr of pool) {
-            pr.assignedRow = -1;
-            pr.el.style.display = "none";
+            releasePooledRow(pr);
           }
           scheduleRender();
         }
@@ -2781,8 +2783,7 @@ export function createTable(
     // Force re-render to update positions
     heightsDirty = true;
     for (const pr of pool) {
-      pr.assignedRow = -1;
-      pr.el.style.display = "none";
+      releasePooledRow(pr);
     }
     scheduleRender();
   }


### PR DESCRIPTION
## Summary

- keep Sift pooled rows attached to their data row so appended batches do not recreate visible image cells
- avoid notebook-wide React commits for output-version tail pinning by subscribing imperatively
- stop output-only full cell materializations from invalidating `useMaterializeVersion`
- update the isolated renderer CSS bundle pointer from the local dev build

## Verification

- `pnpm --dir packages/sift exec vp test run src/table.test.ts`
- `pnpm exec vp test run apps/notebook/src/lib/__tests__/notebook-cells.test.ts apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx apps/notebook/src/lib/__tests__/notebook-outputs.test.ts`
- `cargo xtask lint --fix`
