### PR TITLE
feat(figma): add sift slides table plugin

### DIFF
--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -120,6 +120,23 @@ describe("SiftTable", () => {
     expect(labels[2].textContent).toBe("Score");
   });
 
+  it("surfaces the mounted engine and visible data rows", async () => {
+    const rows = [
+      [1, "Alice", 95],
+      [2, "Bob", 87],
+      [3, "Carol", 92],
+    ];
+    const data = makeTableData(rows);
+    const onReady = vi.fn();
+
+    render(<SiftTable data={data} onReady={onReady} />);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const [engine, readyData] = onReady.mock.calls[0];
+    expect(readyData).toBe(data);
+    expect(engine.getVisibleDataRows(2)).toEqual([0]);
+  });
+
   it("shows row count in stats bar", async () => {
     const rows = Array.from({ length: 25 }, (_, i) => [i, `Person ${i}`, i * 10]);
     const data = makeTableData(rows);
@@ -178,6 +195,7 @@ describe("SiftTable", () => {
 
     expect(container.querySelector(".sift-viewport")).toBe(viewport);
     expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalled();
     expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ totalCount: 2 });
   });
 

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -67,6 +67,8 @@ export type SiftTableProps = {
   columnOverrides?: Record<string, Partial<Column>>;
   /** Called whenever sort or filter state changes from UI interaction. */
   onChange?: (state: TableEngineState) => void;
+  /** Called when a mounted engine is ready or receives replacement data. */
+  onReady?: (engine: TableEngine, tableData: TableData) => void;
   /** Optional control rendered in Sift's footer before built-in buttons. */
   footerControl?: ReactNode;
   /** CSS class name for the container div. */
@@ -273,6 +275,7 @@ export function SiftTable({
   typeOverrides,
   columnOverrides,
   onChange,
+  onReady,
   footerControl,
   className,
   style,
@@ -289,9 +292,15 @@ export function SiftTable({
   // Stable callback ref to avoid re-mounting engine when onChange identity changes
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
 
   const stableOnChange = useCallback((state: TableEngineState) => {
     onChangeRef.current?.(state);
+  }, []);
+
+  const notifyReady = useCallback((engine: TableEngine, tableData: TableData) => {
+    onReadyRef.current?.(engine, tableData);
   }, []);
 
   const getFooterControlElement = useCallback(() => {
@@ -345,6 +354,7 @@ export function SiftTable({
 
     if (engineRef.current) {
       engineRef.current.replaceData(dataSource);
+      notifyReady(engineRef.current, dataSource);
       setStatus("ready");
       return;
     }
@@ -356,8 +366,9 @@ export function SiftTable({
       onChange: stableOnChange,
       footerControl: getFooterControlElement(),
     });
+    notifyReady(engineRef.current, dataSource);
     setStatus("ready");
-  }, [dataSource, stableOnChange, getFooterControlElement, getEngineElement]);
+  }, [dataSource, stableOnChange, notifyReady, getFooterControlElement, getEngineElement]);
 
   // Load Arrow stream manifest chunks through the appendable WASM store.
   useEffect(() => {
@@ -370,6 +381,7 @@ export function SiftTable({
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
         engineRef.current.replaceData(tableData);
+        notifyReady(engineRef.current, tableData);
         disposePendingStore = null;
         return;
       }
@@ -379,6 +391,7 @@ export function SiftTable({
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
       });
+      notifyReady(engineRef.current, tableData);
       disposePendingStore = null;
     }
 
@@ -466,7 +479,14 @@ export function SiftTable({
       disposePendingStore?.();
       disposePendingStore = null;
     };
-  }, [manifestKey, columnOverrides, stableOnChange, getFooterControlElement, getEngineElement]);
+  }, [
+    manifestKey,
+    columnOverrides,
+    stableOnChange,
+    notifyReady,
+    getFooterControlElement,
+    getEngineElement,
+  ]);
 
   // Load from URL when `url` prop is provided.
   // Detects format via Content-Type header + magic byte fallback:
@@ -482,6 +502,7 @@ export function SiftTable({
     function mountEngine(tableData: TableData) {
       if (engineRef.current) {
         engineRef.current.replaceData(tableData);
+        notifyReady(engineRef.current, tableData);
         disposePendingStore = null;
         return;
       }
@@ -491,6 +512,7 @@ export function SiftTable({
         onChange: stableOnChange,
         footerControl: getFooterControlElement(),
       });
+      notifyReady(engineRef.current, tableData);
       disposePendingStore = null;
     }
 
@@ -635,6 +657,7 @@ export function SiftTable({
     typeOverrides,
     columnOverrides,
     stableOnChange,
+    notifyReady,
     getFooterControlElement,
     getEngineElement,
   ]);

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -148,6 +148,8 @@ export type TableEngine = {
   getFilters(): { column: string; filter: ColumnFilter }[];
   /** Get the full explorer state (sort + filters + counts) in a serializable format. */
   getState(): TableEngineState;
+  /** Data-row indices currently visible in the viewport, in the active filtered/sorted order. */
+  getVisibleDataRows(limit?: number): number[];
   /**
    * Currently focused (expanded) data row, or `null` when every row uses the
    * collapsed text-line cap. Tracked by data row, so focus survives sort
@@ -2619,6 +2621,22 @@ export function createTable(
     };
   }
 
+  function getVisibleDataRows(limit = 100): number[] {
+    if (filteredCount === 0 || limit <= 0) return [];
+    if (heightsDirty) recomputeAllHeights();
+
+    const headerH = headerEl.offsetHeight;
+    const virtualTop = viewport.scrollTop + virtualOffset;
+    const virtualBottom = virtualTop + Math.max(0, viewport.clientHeight - headerH);
+    const start = Math.min(filteredCount - 1, rowAtOffset(virtualTop));
+    const end = Math.min(filteredCount, rowAtOffset(virtualBottom) + 1, start + limit);
+    const rows: number[] = [];
+    for (let i = start; i < end; i++) {
+      rows.push(viewIndices[i]);
+    }
+    return rows;
+  }
+
   function notifyChange() {
     options?.onChange?.(getState());
   }
@@ -2837,6 +2855,7 @@ export function createTable(
     setSort: setSortByName,
     getFilters,
     getState,
+    getVisibleDataRows,
     getFocusedDataRow: () => focusedDataRow,
     setFocusedDataRow,
   };

--- a/plugins/figma-sift-slides/README.md
+++ b/plugins/figma-sift-slides/README.md
@@ -1,0 +1,14 @@
+# Sift Tables for Figma Slides
+
+Local Figma Slides plugin for scanning Sift datasets in a plugin panel and inserting the visible table window into a slide.
+
+This plugin runs the real `@nteract/sift` table in the plugin UI. Arrow IPC and Parquet sources go through the existing Sift WASM path. The Figma canvas output is intentionally a Figma-native table snapshot made from rectangles and text, because Figma's public Plugin API cannot create live `EMBED` interactive slide elements.
+
+## Build
+
+```sh
+pnpm --filter @nteract/figma-sift-slides build
+```
+
+Load `plugins/figma-sift-slides/manifest.json` as a development plugin in the Figma desktop app.
+

--- a/plugins/figma-sift-slides/README.md
+++ b/plugins/figma-sift-slides/README.md
@@ -7,8 +7,8 @@ This plugin runs the real `@nteract/sift` table in the plugin UI. Arrow IPC and 
 ## Build
 
 ```sh
+cargo xtask wasm sift
 pnpm --filter @nteract/figma-sift-slides build
 ```
 
 Load `plugins/figma-sift-slides/manifest.json` as a development plugin in the Figma desktop app.
-

--- a/plugins/figma-sift-slides/manifest.json
+++ b/plugins/figma-sift-slides/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Sift Tables for Slides",
+  "id": "sift-tables-for-slides-dev",
+  "api": "1.0.0",
+  "editorType": ["slides"],
+  "main": "dist/code.js",
+  "ui": "dist/ui.html",
+  "documentAccess": "dynamic-page",
+  "networkAccess": {
+    "allowedDomains": ["https://*", "http://localhost:*", "http://127.0.0.1:*"]
+  },
+  "relaunchButtons": [
+    {
+      "command": "open",
+      "name": "Open in Sift"
+    }
+  ]
+}

--- a/plugins/figma-sift-slides/package.json
+++ b/plugins/figma-sift-slides/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@nteract/figma-sift-slides",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build:main": "esbuild src/main/code.ts --bundle --outfile=dist/code.js --target=es2020 --format=iife",
+    "build:ui": "vp build && node scripts/inline-ui.mjs",
+    "build": "pnpm run clean && pnpm run build:main && pnpm run build:ui",
+    "check": "tsc -p tsconfig.ui.json --noEmit && tsc -p tsconfig.main.json --noEmit"
+  },
+  "dependencies": {
+    "@nteract/sift": "workspace:*",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.127.0",
+    "@types/node": "^20.10.0",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@tailwindcss/vite": "^4.2.2",
+    "@vitejs/plugin-react": "^6.0.1",
+    "esbuild": "^0.28.0",
+    "typescript": "~5.8.3",
+    "vite": "catalog:",
+    "vite-plus": "catalog:"
+  }
+}

--- a/plugins/figma-sift-slides/scripts/inline-ui.mjs
+++ b/plugins/figma-sift-slides/scripts/inline-ui.mjs
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(here, "..");
+const buildDir = resolve(pluginRoot, "dist/ui-build");
+const htmlPath = resolve(buildDir, "index.html");
+const outputPath = resolve(pluginRoot, "dist/ui.html");
+
+let html = readFileSync(htmlPath, "utf8");
+
+html = html.replace(
+  /<script type="module" crossorigin src="\.\/([^"]+)"><\/script>/g,
+  (_match, src) => {
+    const script = readFileSync(resolve(buildDir, src), "utf8");
+    return `<script type="module">\n${script}\n</script>`;
+  },
+);
+
+html = html.replace(/<link rel="stylesheet" crossorigin href="\.\/([^"]+)">/g, (_match, href) => {
+  const css = readFileSync(resolve(buildDir, href), "utf8");
+  return `<style>\n${css}\n</style>`;
+});
+
+writeFileSync(outputPath, html);
+
+if (existsSync(buildDir)) {
+  rmSync(buildDir, { recursive: true, force: true });
+}

--- a/plugins/figma-sift-slides/src/main/code.ts
+++ b/plugins/figma-sift-slides/src/main/code.ts
@@ -1,0 +1,291 @@
+/// <reference types="@figma/plugin-typings" />
+
+import type {
+  InsertTablePayload,
+  PluginToUiMessage,
+  SiftSourceMetadata,
+  UiToPluginMessage,
+} from "../shared";
+
+declare const __html__: string;
+
+const PLUGIN_DATA_SOURCE_KEY = "sift-table-source";
+const REGULAR_FONT: FontName = { family: "Inter", style: "Regular" };
+const MEDIUM_FONT: FontName = { family: "Inter", style: "Medium" };
+const SEMIBOLD_FONT: FontName = { family: "Inter", style: "Semi Bold" };
+
+const colors = {
+  bg: { r: 0.988, g: 0.992, b: 0.996 },
+  panel: { r: 1, g: 1, b: 1 },
+  rule: { r: 0.85, g: 0.87, b: 0.9 },
+  header: { r: 0.94, g: 0.96, b: 0.98 },
+  text: { r: 0.08, g: 0.09, b: 0.11 },
+  muted: { r: 0.36, g: 0.4, b: 0.46 },
+  accent: { r: 0.07, g: 0.35, b: 0.78 },
+};
+
+type StoredSiftSource = {
+  title: string;
+  source: SiftSourceMetadata;
+  totalRows: number;
+  filteredRows: number;
+  stateLabel: string;
+};
+
+figma.showUI(__html__, {
+  width: 980,
+  height: 760,
+  title: "Sift Tables",
+  themeColors: true,
+});
+
+hydrateSelectedSource();
+
+figma.ui.onmessage = async (message: UiToPluginMessage) => {
+  if (message.type === "notify") {
+    figma.notify(message.message);
+    return;
+  }
+
+  if (message.type !== "insert-table") return;
+
+  try {
+    const node = await insertTable(message.payload);
+    figma.currentPage.selection = [node];
+    figma.viewport.scrollAndZoomIntoView([node]);
+    postToUi({
+      type: "insert-result",
+      ok: true,
+      message: `Inserted ${message.payload.rows.length} rows into the focused slide.`,
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    figma.notify(errorMessage, { error: true });
+    postToUi({ type: "insert-result", ok: false, message: errorMessage });
+  }
+};
+
+function postToUi(message: PluginToUiMessage) {
+  figma.ui.postMessage(message);
+}
+
+function hydrateSelectedSource() {
+  for (const node of figma.currentPage.selection) {
+    const value = node.getPluginData(PLUGIN_DATA_SOURCE_KEY);
+    if (!value) continue;
+    try {
+      const payload = JSON.parse(value) as StoredSiftSource;
+      if (payload.source) {
+        postToUi({ type: "hydrate-source", source: payload.source });
+      }
+      return;
+    } catch {
+      return;
+    }
+  }
+}
+
+async function insertTable(payload: InsertTablePayload): Promise<FrameNode> {
+  if (payload.columns.length === 0) {
+    throw new Error("No columns available to insert.");
+  }
+  if (payload.rows.length === 0) {
+    throw new Error("No visible rows available to insert.");
+  }
+
+  await Promise.all([
+    figma.loadFontAsync(REGULAR_FONT),
+    figma.loadFontAsync(MEDIUM_FONT),
+    figma.loadFontAsync(SEMIBOLD_FONT),
+  ]);
+
+  const slide = findTargetSlide();
+  if (!slide) {
+    throw new Error("Open a Figma Slides deck and focus a slide before inserting a Sift table.");
+  }
+
+  const maxColumns = Math.min(payload.columns.length, 10);
+  const columns = payload.columns.slice(0, maxColumns);
+  const rows = payload.rows.map((row) => row.slice(0, maxColumns));
+  const columnWidth = Math.max(112, Math.min(220, Math.floor(1280 / maxColumns)));
+  const tableWidth = columnWidth * maxColumns;
+  const rowHeight = 38;
+  const headerHeight = 42;
+  const chromeHeight = 118;
+  const footerHeight = 36;
+  const width = tableWidth + 56;
+  const height = Math.min(
+    900,
+    chromeHeight + headerHeight + rows.length * rowHeight + footerHeight,
+  );
+
+  const frame = figma.createFrame();
+  frame.name = payload.title || "Sift table";
+  frame.resize(width, height);
+  frame.x = 160;
+  frame.y = 120;
+  frame.fills = [{ type: "SOLID", color: colors.panel }];
+  frame.strokes = [{ type: "SOLID", color: colors.rule }];
+  frame.strokeWeight = 1;
+  frame.cornerRadius = 14;
+  frame.clipsContent = true;
+  frame.setPluginData(PLUGIN_DATA_SOURCE_KEY, JSON.stringify(sourceMetadataFor(payload)));
+  frame.setRelaunchData({ open: "Open in Sift" });
+
+  slide.appendChild(frame);
+
+  const title = createText(payload.title || "Sift table", 24, SEMIBOLD_FONT, colors.text);
+  title.x = 28;
+  title.y = 24;
+  title.resize(width - 56, 30);
+  frame.appendChild(title);
+
+  const meta = createText(formatMeta(payload), 13, REGULAR_FONT, colors.muted);
+  meta.x = 28;
+  meta.y = 58;
+  meta.resize(width - 56, 22);
+  frame.appendChild(meta);
+
+  const tableX = 28;
+  const tableY = 94;
+  appendRowBackground(frame, tableX, tableY, tableWidth, headerHeight, colors.header);
+
+  for (let c = 0; c < columns.length; c++) {
+    appendVerticalRule(frame, tableX + c * columnWidth, tableY, height - tableY - footerHeight);
+    const label = createText(trimCell(columns[c], 26), 12, SEMIBOLD_FONT, colors.text);
+    label.x = tableX + c * columnWidth + 12;
+    label.y = tableY + 13;
+    label.resize(columnWidth - 20, 18);
+    frame.appendChild(label);
+  }
+  appendVerticalRule(frame, tableX + tableWidth, tableY, height - tableY - footerHeight);
+  appendHorizontalRule(frame, tableX, tableY + headerHeight, tableWidth);
+
+  rows.forEach((row, r) => {
+    const y = tableY + headerHeight + r * rowHeight;
+    appendRowBackground(
+      frame,
+      tableX,
+      y,
+      tableWidth,
+      rowHeight,
+      r % 2 === 0 ? colors.panel : colors.bg,
+    );
+    for (let c = 0; c < columns.length; c++) {
+      const cell = createText(trimCell(row[c] ?? "", 34), 11, REGULAR_FONT, colors.text);
+      cell.x = tableX + c * columnWidth + 12;
+      cell.y = y + 11;
+      cell.resize(columnWidth - 20, 18);
+      frame.appendChild(cell);
+    }
+    appendHorizontalRule(frame, tableX, y + rowHeight, tableWidth);
+  });
+
+  const footer = createText(
+    `${payload.visibleRows.toLocaleString()} visible rows inserted from ${payload.source.label}`,
+    12,
+    REGULAR_FONT,
+    colors.muted,
+  );
+  footer.x = 28;
+  footer.y = height - 28;
+  footer.resize(width - 56, 18);
+  frame.appendChild(footer);
+
+  return frame;
+}
+
+function findTargetSlide(): SlideNode | null {
+  const currentPage = figma.currentPage as PageNode & { focusedSlide?: SlideNode | null };
+  if (currentPage.focusedSlide?.type === "SLIDE") return currentPage.focusedSlide;
+
+  for (const node of figma.currentPage.selection) {
+    const slide = findAncestorSlide(node);
+    if (slide) return slide;
+  }
+
+  for (const row of figma.getCanvasGrid()) {
+    const slide = row.find((node): node is SlideNode => node.type === "SLIDE");
+    if (slide) return slide;
+  }
+  return null;
+}
+
+function findAncestorSlide(node: BaseNode): SlideNode | null {
+  let current: BaseNode | null = node;
+  while (current) {
+    if (current.type === "SLIDE") return current as SlideNode;
+    current = current.parent;
+  }
+  return null;
+}
+
+function appendRowBackground(
+  parent: FrameNode,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: RGB,
+) {
+  const rect = figma.createRectangle();
+  rect.name = "row background";
+  rect.x = x;
+  rect.y = y;
+  rect.resize(width, height);
+  rect.fills = [{ type: "SOLID", color }];
+  parent.appendChild(rect);
+}
+
+function appendHorizontalRule(parent: FrameNode, x: number, y: number, width: number) {
+  const rule = figma.createRectangle();
+  rule.name = "row rule";
+  rule.x = x;
+  rule.y = y;
+  rule.resize(width, 1);
+  rule.fills = [{ type: "SOLID", color: colors.rule }];
+  parent.appendChild(rule);
+}
+
+function appendVerticalRule(parent: FrameNode, x: number, y: number, height: number) {
+  const rule = figma.createRectangle();
+  rule.name = "column rule";
+  rule.x = x;
+  rule.y = y;
+  rule.resize(1, height);
+  rule.fills = [{ type: "SOLID", color: colors.rule }];
+  parent.appendChild(rule);
+}
+
+function createText(text: string, fontSize: number, fontName: FontName, color: RGB): TextNode {
+  const node = figma.createText();
+  node.fontName = fontName;
+  node.fontSize = fontSize;
+  node.characters = text;
+  node.fills = [{ type: "SOLID", color }];
+  return node;
+}
+
+function trimCell(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+function formatMeta(payload: InsertTablePayload): string {
+  const filtered =
+    payload.filteredRows === payload.totalRows
+      ? `${payload.totalRows.toLocaleString()} rows`
+      : `${payload.filteredRows.toLocaleString()} of ${payload.totalRows.toLocaleString()} rows`;
+  return `${filtered} - ${payload.stateLabel}`;
+}
+
+function sourceMetadataFor(payload: InsertTablePayload): StoredSiftSource {
+  return {
+    title: payload.title,
+    source: payload.source,
+    totalRows: payload.totalRows,
+    filteredRows: payload.filteredRows,
+    stateLabel: payload.stateLabel,
+  };
+}

--- a/plugins/figma-sift-slides/src/shared.ts
+++ b/plugins/figma-sift-slides/src/shared.ts
@@ -1,0 +1,37 @@
+export type SiftSourceMetadata = {
+  kind: "url" | "file";
+  label: string;
+  url?: string;
+};
+
+export type InsertTablePayload = {
+  title: string;
+  source: SiftSourceMetadata;
+  columns: string[];
+  rows: string[][];
+  totalRows: number;
+  filteredRows: number;
+  visibleRows: number;
+  stateLabel: string;
+};
+
+export type UiToPluginMessage =
+  | {
+      type: "insert-table";
+      payload: InsertTablePayload;
+    }
+  | {
+      type: "notify";
+      message: string;
+    };
+
+export type PluginToUiMessage =
+  | {
+      type: "insert-result";
+      ok: boolean;
+      message: string;
+    }
+  | {
+      type: "hydrate-source";
+      source: SiftSourceMetadata;
+    };

--- a/plugins/figma-sift-slides/src/ui/index.html
+++ b/plugins/figma-sift-slides/src/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sift Tables</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/plugins/figma-sift-slides/src/ui/main.tsx
+++ b/plugins/figma-sift-slides/src/ui/main.tsx
@@ -1,0 +1,464 @@
+import { SiftTable, type TableData, type TableEngine, type TableEngineState } from "@nteract/sift";
+import "@nteract/sift/style.css";
+import { createRoot } from "react-dom/client";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ensureModule, getModuleSync, loadIpc } from "../../../../packages/sift/src/predicate";
+import { createWasmTableData } from "../../../../packages/sift/src/wasm-table-data";
+import type {
+  InsertTablePayload,
+  PluginToUiMessage,
+  SiftSourceMetadata,
+  UiToPluginMessage,
+} from "../shared";
+import "./style.css";
+
+const DEMO_URL = "https://huggingface.co/datasets/spotify/resolve/main/data.parquet";
+const MAX_INSERT_ROWS = 40;
+const MAX_INSERT_COLUMNS = 10;
+
+type LoadedTable = {
+  data: TableData;
+  source: SiftSourceMetadata;
+};
+
+type LoadStatus =
+  | { kind: "idle"; message: string }
+  | { kind: "loading"; message: string }
+  | { kind: "ready"; message: string }
+  | { kind: "error"; message: string };
+
+function App() {
+  const [url, setUrl] = useState(DEMO_URL);
+  const [loaded, setLoaded] = useState<LoadedTable | null>(null);
+  const [engine, setEngine] = useState<TableEngine | null>(null);
+  const [engineState, setEngineState] = useState<TableEngineState | null>(null);
+  const [status, setStatus] = useState<LoadStatus>({
+    kind: "idle",
+    message: "Load Arrow IPC or Parquet to scan it with Sift.",
+  });
+  const [insertRows, setInsertRows] = useState(18);
+  const [insertColumns, setInsertColumns] = useState(8);
+  const loadedRef = useRef<LoadedTable | null>(null);
+  const engineRef = useRef<TableEngine | null>(null);
+
+  loadedRef.current = loaded;
+  engineRef.current = engine;
+
+  useEffect(() => {
+    window.onmessage = (event: MessageEvent<{ pluginMessage?: PluginToUiMessage }>) => {
+      const message = event.data.pluginMessage;
+      if (!message) return;
+      if (message.type === "insert-result") {
+        setStatus({
+          kind: message.ok ? "ready" : "error",
+          message: message.message,
+        });
+      } else if (message.type === "hydrate-source" && message.source.kind === "url") {
+        setUrl(message.source.url ?? message.source.label);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      loadedRef.current?.data.dispose?.();
+    };
+  }, []);
+
+  const loadUrl = useCallback(
+    async (nextUrl = url) => {
+      const trimmed = nextUrl.trim();
+      if (!trimmed) return;
+      setStatus({ kind: "loading", message: "Loading dataset through Sift WASM..." });
+      try {
+        const table = await loadTableFromUrl(trimmed);
+        loadedRef.current?.data.dispose?.();
+        setLoaded({
+          data: table,
+          source: { kind: "url", url: trimmed, label: labelFromUrl(trimmed) },
+        });
+        setEngine(null);
+        setEngineState(null);
+        setStatus({ kind: "ready", message: "Dataset loaded. Scroll and filter in Sift." });
+      } catch (error) {
+        setStatus({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    [url],
+  );
+
+  const loadFile = useCallback(async (file: File) => {
+    setStatus({ kind: "loading", message: `Loading ${file.name}...` });
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const table =
+        file.name.endsWith(".csv") || file.name.endsWith(".tsv") || file.name.endsWith(".json")
+          ? tableDataFromText(new TextDecoder().decode(bytes), file.name)
+          : await loadTableFromBytes(bytes, file.name);
+      loadedRef.current?.data.dispose?.();
+      setLoaded({ data: table, source: { kind: "file", label: file.name } });
+      setEngine(null);
+      setEngineState(null);
+      setStatus({ kind: "ready", message: "File loaded. Scroll and filter in Sift." });
+    } catch (error) {
+      setStatus({
+        kind: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, []);
+
+  const onReady = useCallback((readyEngine: TableEngine, tableData: TableData) => {
+    setEngine(readyEngine);
+    setEngineState(readyEngine.getState());
+    tableData.prefetchViewport?.(readyEngine.getVisibleDataRows(MAX_INSERT_ROWS));
+  }, []);
+
+  const visiblePreview = useMemo(() => {
+    if (!loaded || !engine) return null;
+    return collectVisibleRows(loaded.data, engine, insertRows, insertColumns);
+  }, [loaded, engine, insertRows, insertColumns, engineState]);
+
+  const insertVisibleRows = useCallback(() => {
+    const currentLoaded = loadedRef.current;
+    const currentEngine = engineRef.current;
+    if (!currentLoaded || !currentEngine) {
+      setStatus({ kind: "error", message: "Load a table before inserting." });
+      return;
+    }
+    const snapshot = collectVisibleRows(
+      currentLoaded.data,
+      currentEngine,
+      insertRows,
+      insertColumns,
+    );
+    if (snapshot.rows.length === 0) {
+      setStatus({ kind: "error", message: "No visible Sift rows to insert." });
+      return;
+    }
+    const state = currentEngine.getState();
+    const payload: InsertTablePayload = {
+      title: currentLoaded.source.label,
+      source: currentLoaded.source,
+      columns: snapshot.columns,
+      rows: snapshot.rows,
+      totalRows: state.totalCount,
+      filteredRows: state.filteredCount,
+      visibleRows: snapshot.rows.length,
+      stateLabel: formatStateLabel(state),
+    };
+    postToPlugin({ type: "insert-table", payload });
+    setStatus({ kind: "loading", message: "Inserting visible rows into the focused slide..." });
+  }, [insertColumns, insertRows]);
+
+  return (
+    <main className="plugin-shell">
+      <section className="control-bar">
+        <div className="source-controls">
+          <label className="field">
+            <span>Arrow or Parquet URL</span>
+            <input
+              value={url}
+              onChange={(event) => setUrl(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void loadUrl();
+              }}
+            />
+          </label>
+          <div className="button-row">
+            <button onClick={() => void loadUrl()}>Load URL</button>
+            <button
+              onClick={() => {
+                setUrl(DEMO_URL);
+                void loadUrl(DEMO_URL);
+              }}
+            >
+              Load demo
+            </button>
+            <label className="file-button">
+              Load file
+              <input
+                type="file"
+                accept=".arrow,.arrows,.ipc,.parquet,.csv,.tsv,.json"
+                onChange={(event) => {
+                  const file = event.currentTarget.files?.[0];
+                  if (file) void loadFile(file);
+                  event.currentTarget.value = "";
+                }}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="insert-controls">
+          <label className="number-field">
+            <span>Rows</span>
+            <input
+              type="number"
+              min={1}
+              max={MAX_INSERT_ROWS}
+              value={insertRows}
+              onChange={(event) => setInsertRows(clampNumber(event.currentTarget.value, 1, 40))}
+            />
+          </label>
+          <label className="number-field">
+            <span>Columns</span>
+            <input
+              type="number"
+              min={1}
+              max={MAX_INSERT_COLUMNS}
+              value={insertColumns}
+              onChange={(event) => setInsertColumns(clampNumber(event.currentTarget.value, 1, 10))}
+            />
+          </label>
+          <button className="primary" disabled={!visiblePreview} onClick={insertVisibleRows}>
+            Insert visible rows
+          </button>
+        </div>
+      </section>
+
+      <section className={`status-line ${status.kind}`}>{status.message}</section>
+
+      <section className="table-stage">
+        {loaded ? (
+          <SiftTable
+            data={loaded.data}
+            onReady={onReady}
+            onChange={(state) => setEngineState(state)}
+          />
+        ) : (
+          <div className="empty-state">
+            <strong>Sift runs here.</strong>
+            <span>Load a dataset to scan, filter, and then insert the current viewport.</span>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+async function loadTableFromUrl(url: string): Promise<TableData> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return loadTableFromBytes(bytes, url);
+}
+
+async function loadTableFromBytes(bytes: Uint8Array, label: string): Promise<TableData> {
+  await ensureModule();
+  const mod = getModuleSync();
+  const handle = isLikelyParquet(bytes, label) ? mod.load_parquet(bytes) : await loadIpc(bytes);
+  const { tableData, columns, prefetchViewport } = createWasmTableData(handle);
+  tableData.prefetchViewport = prefetchViewport;
+  tableData.recomputeSummaries = () => updateWasmSummaries(tableData);
+  updateWasmSummaries(tableData);
+
+  function updateWasmSummaries(data: TableData) {
+    const rowCount = mod.num_rows(handle);
+    data.rowCount = rowCount;
+    data.columnSummaries = columns.map((column, columnIndex) => {
+      switch (column.columnType) {
+        case "categorical": {
+          const counts = mod.store_value_counts(handle, columnIndex) as {
+            label: string;
+            count: number;
+          }[];
+          const pctOf = (count: number) =>
+            rowCount > 0 ? Math.round((count / rowCount) * 1000) / 10 : 0;
+          const allCategories = counts.map(({ label: category, count }) => ({
+            label: category,
+            count,
+            pct: pctOf(count),
+          }));
+          return {
+            kind: "categorical" as const,
+            uniqueCount: allCategories.length,
+            topCategories: allCategories.slice(0, 3),
+            othersCount: counts.slice(3).reduce((sum, entry) => sum + entry.count, 0),
+            othersPct: pctOf(counts.slice(3).reduce((sum, entry) => sum + entry.count, 0)),
+            allCategories,
+            medianTextLength: medianLength(allCategories.map((entry) => entry.label)),
+          };
+        }
+        case "boolean": {
+          const [trueCount, falseCount, nullCount] = mod.store_bool_counts(handle, columnIndex);
+          return { kind: "boolean" as const, trueCount, falseCount, nullCount, total: rowCount };
+        }
+        case "timestamp": {
+          const bins = mod.store_temporal_histogram(handle, columnIndex);
+          if (bins.length === 0) return null;
+          return {
+            kind: "timestamp" as const,
+            min: bins[0].x0,
+            max: bins[bins.length - 1].x1,
+            bins,
+            timezone: column.timezone,
+          };
+        }
+        case "numeric": {
+          const bins = mod.store_histogram(handle, columnIndex, 25);
+          if (bins.length === 0) return null;
+          return {
+            kind: "numeric" as const,
+            min: bins[0].x0,
+            max: bins[bins.length - 1].x1,
+            bins,
+          };
+        }
+        case "image":
+          return null;
+      }
+    });
+  }
+
+  return tableData;
+}
+
+function tableDataFromText(text: string, fileName: string): TableData {
+  const rows = fileName.endsWith(".json") ? rowsFromJson(text) : rowsFromDelimited(text, fileName);
+  if (rows.length === 0) throw new Error("No rows found in the file.");
+  const headers = rows[0].map((header, index) => header || `Column ${index + 1}`);
+  const body = rows.slice(1);
+  const columns = headers.map((header, index) => {
+    const values = body.map((row) => row[index]);
+    const numeric = values.every((value) => value === "" || Number.isFinite(Number(value)));
+    return {
+      key: header,
+      label: header,
+      width: Math.max(110, Math.min(240, header.length * 10 + 42)),
+      sortable: true,
+      numeric,
+      columnType: numeric ? ("numeric" as const) : ("categorical" as const),
+    };
+  });
+  return {
+    columns,
+    rowCount: body.length,
+    getCell(row, col) {
+      return body[row]?.[col] ?? "";
+    },
+    getCellRaw(row, col) {
+      const value = body[row]?.[col] ?? "";
+      return columns[col].numeric && value !== "" ? Number(value) : value;
+    },
+    columnSummaries: columns.map(() => null),
+  };
+}
+
+function collectVisibleRows(
+  tableData: TableData,
+  engine: TableEngine,
+  maxRows: number,
+  maxColumns: number,
+): { columns: string[]; rows: string[][] } {
+  const columns = tableData.columns.slice(0, maxColumns);
+  const visibleRows = engine.getVisibleDataRows(maxRows);
+  tableData.prefetchViewport?.(visibleRows);
+  return {
+    columns: columns.map((column) => column.label || column.key),
+    rows: visibleRows.map((dataRow) =>
+      columns.map((_column, columnIndex) => tableData.getCell(dataRow, columnIndex)),
+    ),
+  };
+}
+
+function isLikelyParquet(bytes: Uint8Array, label: string): boolean {
+  return (
+    label.endsWith(".parquet") ||
+    (bytes.length >= 4 &&
+      bytes[0] === 0x50 &&
+      bytes[1] === 0x41 &&
+      bytes[2] === 0x52 &&
+      bytes[3] === 0x31)
+  );
+}
+
+function rowsFromDelimited(text: string, fileName: string): string[][] {
+  const delimiter = fileName.endsWith(".tsv") ? "\t" : ",";
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => splitDelimitedLine(line, delimiter));
+}
+
+function splitDelimitedLine(line: string, delimiter: string): string[] {
+  const cells: string[] = [];
+  let cell = "";
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char === '"' && line[i + 1] === '"') {
+      cell += '"';
+      i++;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (char === delimiter && !quoted) {
+      cells.push(cell);
+      cell = "";
+    } else {
+      cell += char;
+    }
+  }
+  cells.push(cell);
+  return cells.map((value) => value.trim());
+}
+
+function rowsFromJson(text: string): string[][] {
+  const parsed = JSON.parse(text) as unknown;
+  if (!Array.isArray(parsed)) throw new Error("JSON import expects an array of objects.");
+  const objects = parsed.filter(
+    (entry): entry is Record<string, unknown> =>
+      entry !== null && typeof entry === "object" && !Array.isArray(entry),
+  );
+  const headers = Array.from(new Set(objects.flatMap((entry) => Object.keys(entry))));
+  return [
+    headers,
+    ...objects.map((entry) => headers.map((header) => stringifyCell(entry[header]))),
+  ];
+}
+
+function stringifyCell(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function formatStateLabel(state: TableEngineState): string {
+  const parts: string[] = [];
+  if (state.sort) parts.push(`sorted by ${state.sort.column} ${state.sort.direction}`);
+  if (state.filters.length > 0) parts.push(`${state.filters.length} filter(s)`);
+  return parts.length === 0 ? "unfiltered viewport" : parts.join(", ");
+}
+
+function labelFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    return decodeURIComponent(parts.length > 0 ? parts[parts.length - 1] : parsed.host);
+  } catch {
+    return url;
+  }
+}
+
+function medianLength(values: string[]): number {
+  if (values.length === 0) return 0;
+  const lengths = values.map((value) => value.length).sort((a, b) => a - b);
+  return lengths[Math.floor(lengths.length / 2)];
+}
+
+function clampNumber(value: string, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(parsed)));
+}
+
+function postToPlugin(message: UiToPluginMessage) {
+  parent.postMessage({ pluginMessage: message }, "*");
+}
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/plugins/figma-sift-slides/src/ui/style.css
+++ b/plugins/figma-sift-slides/src/ui/style.css
@@ -1,0 +1,174 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color: var(--figma-color-text, #111827);
+  background: var(--figma-color-bg, #ffffff);
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button,
+.file-button {
+  align-items: center;
+  background: var(--figma-color-bg-secondary, #f3f4f6);
+  border: 1px solid var(--figma-color-border, #d1d5db);
+  border-radius: 6px;
+  color: var(--figma-color-text, #111827);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  height: 32px;
+  justify-content: center;
+  padding: 0 10px;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.primary {
+  background: var(--figma-color-bg-brand, #0d63ce);
+  border-color: var(--figma-color-bg-brand, #0d63ce);
+  color: var(--figma-color-text-onbrand, #ffffff);
+}
+
+.plugin-shell {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  height: 100vh;
+  min-height: 0;
+}
+
+.control-bar {
+  align-items: end;
+  border-bottom: 1px solid var(--figma-color-border, #e5e7eb);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: 1fr auto;
+  padding: 12px;
+}
+
+.source-controls,
+.insert-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.source-controls {
+  align-items: end;
+  min-width: 0;
+}
+
+.insert-controls {
+  align-items: end;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.field,
+.number-field {
+  display: grid;
+  gap: 5px;
+}
+
+.field {
+  flex: 1;
+  min-width: 220px;
+}
+
+.field span,
+.number-field span {
+  color: var(--figma-color-text-secondary, #6b7280);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.field input,
+.number-field input {
+  border: 1px solid var(--figma-color-border, #d1d5db);
+  border-radius: 6px;
+  color: var(--figma-color-text, #111827);
+  height: 32px;
+  min-width: 0;
+  padding: 0 9px;
+}
+
+.number-field input {
+  width: 66px;
+}
+
+.file-button {
+  position: relative;
+}
+
+.file-button input {
+  inset: 0;
+  opacity: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.status-line {
+  border-bottom: 1px solid var(--figma-color-border, #e5e7eb);
+  color: var(--figma-color-text-secondary, #6b7280);
+  font-size: 12px;
+  min-height: 33px;
+  padding: 9px 12px;
+}
+
+.status-line.error {
+  color: var(--figma-color-text-danger, #b42318);
+}
+
+.status-line.ready {
+  color: var(--figma-color-text-success, #027a48);
+}
+
+.table-stage {
+  min-height: 0;
+  padding: 12px;
+}
+
+.table-stage > div {
+  height: 100%;
+}
+
+.empty-state {
+  align-items: center;
+  border: 1px dashed var(--figma-color-border, #d1d5db);
+  border-radius: 8px;
+  color: var(--figma-color-text-secondary, #6b7280);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  justify-content: center;
+}
+
+.empty-state strong {
+  color: var(--figma-color-text, #111827);
+}

--- a/plugins/figma-sift-slides/tsconfig.json
+++ b/plugins/figma-sift-slides/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/plugins/figma-sift-slides/tsconfig.main.json
+++ b/plugins/figma-sift-slides/tsconfig.main.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020"],
+    "types": ["@figma/plugin-typings"]
+  },
+  "include": ["src/shared.ts", "src/main"]
+}

--- a/plugins/figma-sift-slides/tsconfig.ui.json
+++ b/plugins/figma-sift-slides/tsconfig.ui.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "sift-wasm/*": ["../../crates/sift-wasm/pkg/*"]
+    }
+  },
+  "include": ["src/shared.ts", "src/ui"]
+}

--- a/plugins/figma-sift-slides/vite.config.ts
+++ b/plugins/figma-sift-slides/vite.config.ts
@@ -1,0 +1,29 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+import { defineConfig } from "vite-plus";
+
+const root = resolve(__dirname, "src/ui");
+const wasmPkg = resolve(__dirname, "../../crates/sift-wasm/pkg");
+
+export default defineConfig({
+  root,
+  base: "./",
+  plugins: [tailwindcss(), react()],
+  resolve: {
+    alias: {
+      "sift-wasm": wasmPkg,
+    },
+  },
+  build: {
+    assetsInlineLimit: 10_000_000,
+    chunkSizeWarningLimit: 10_000,
+    emptyOutDir: false,
+    outDir: resolve(__dirname, "dist/ui-build"),
+    rolldownOptions: {
+      output: {
+        codeSplitting: false,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,7 +213,7 @@ importers:
         version: 2.1.0(@auth/core@0.37.4)(@preact/signals-core@1.14.1)(@types/debug@4.1.12)(@types/node@20.19.37)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.32.0)(preact@10.24.3)(rxjs@7.8.2)(tsx@4.21.0)(typescript@5.8.3)(use-sync-external-store@1.6.0(react@19.1.0))(yaml@2.8.3)
       '@tailwindcss/vite':
         specifier: ^4.1.8
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -234,7 +234,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@wdio/cli':
         specifier: ^8.40.0
         version: 8.46.0
@@ -270,13 +270,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       webdriverio:
         specifier: ^8.40.0
         version: 8.46.0
@@ -301,7 +301,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.14
@@ -313,10 +313,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
 
   apps/notebook:
     dependencies:
@@ -449,7 +449,7 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.1.8
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.1.6
         version: 19.2.14
@@ -461,7 +461,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       portless:
         specifier: ^0.13.0
         version: 0.13.0
@@ -476,10 +476,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -507,7 +507,7 @@ importers:
         version: link:../../packages/runtimed-node
       '@tailwindcss/vite':
         specifier: ^4.1.8
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.37
@@ -519,7 +519,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
       tailwindcss:
         specifier: ^4.1.8
         version: 4.2.2
@@ -534,10 +534,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
 
   apps/renderer-test:
     dependencies:
@@ -553,7 +553,7 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.14
@@ -562,16 +562,16 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
 
   packages/notebook-host:
     dependencies:
@@ -673,7 +673,7 @@ importers:
         version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -703,13 +703,56 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+
+  plugins/figma-sift-slides:
+    dependencies:
+      '@nteract/sift':
+        specifier: workspace:*
+        version: link:../../packages/sift
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@figma/plugin-typings':
+        specifier: ^1.127.0
+        version: 1.127.0
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.37
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: 'catalog:'
+        version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
 
   plugins/nteract/pi:
     dependencies:
@@ -1391,6 +1434,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.0':
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
     engines: {node: '>=18'}
@@ -1399,6 +1448,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1415,6 +1470,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.0':
     resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
     engines: {node: '>=18'}
@@ -1423,6 +1484,12 @@ packages:
 
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1439,6 +1506,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.0':
     resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
     engines: {node: '>=18'}
@@ -1447,6 +1520,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1463,6 +1542,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.0':
     resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
     engines: {node: '>=18'}
@@ -1471,6 +1556,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -1487,6 +1578,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.0':
     resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
     engines: {node: '>=18'}
@@ -1495,6 +1592,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -1511,6 +1614,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.0':
     resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
     engines: {node: '>=18'}
@@ -1519,6 +1628,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -1535,6 +1650,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.0':
     resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
     engines: {node: '>=18'}
@@ -1543,6 +1664,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1559,6 +1686,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.0':
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
     engines: {node: '>=18'}
@@ -1567,6 +1700,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1583,6 +1722,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.0':
     resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
     engines: {node: '>=18'}
@@ -1591,6 +1736,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1607,6 +1758,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.0':
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
@@ -1615,6 +1772,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1631,6 +1794,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.0':
     resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
     engines: {node: '>=18'}
@@ -1639,6 +1808,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -1655,6 +1830,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.0':
     resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
     engines: {node: '>=18'}
@@ -1663,6 +1844,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1679,6 +1866,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.0':
     resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
     engines: {node: '>=18'}
@@ -1691,6 +1884,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1699,6 +1898,9 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@figma/plugin-typings@1.127.0':
+    resolution: {integrity: sha512-Y8fjfUCdWN6bUTs1wsd9GFZ3zF4USDVNmmxfUo/4Ia7NmFemSK2nBxOu7BKcusEHCERwiO7N8iOqw5jwvbL80g==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -6573,6 +6775,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -11103,10 +11310,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.0':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.0':
@@ -11115,10 +11328,16 @@ snapshots:
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.0':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.0':
@@ -11127,10 +11346,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.0':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.0':
@@ -11139,10 +11364,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.0':
@@ -11151,10 +11382,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.0':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.0':
@@ -11163,10 +11400,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.0':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.0':
@@ -11175,10 +11418,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.0':
@@ -11187,10 +11436,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.0':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.0':
@@ -11199,10 +11454,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.0':
@@ -11211,10 +11472,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.0':
@@ -11223,10 +11490,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.0':
@@ -11235,10 +11508,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.0':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.0':
@@ -11247,13 +11526,21 @@ snapshots:
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
   '@exodus/bytes@1.15.0': {}
+
+  '@figma/plugin-typings@1.127.0': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -14454,26 +14741,26 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
 
-  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
 
-  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
+  '@tailwindcss/vite@4.2.2(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
 
   '@tanstack/react-virtual@3.13.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -14844,20 +15131,20 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
 
-  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
 
-  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14911,7 +15198,7 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@oxc-project/runtime': 0.123.0
       '@oxc-project/types': 0.123.0
@@ -14919,13 +15206,14 @@ snapshots:
       postcss: 8.5.9
     optionalDependencies:
       '@types/node': 20.19.37
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
       typescript: 5.8.3
       yaml: 2.8.3
 
-  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@oxc-project/runtime': 0.123.0
       '@oxc-project/types': 0.123.0
@@ -14933,13 +15221,14 @@ snapshots:
       postcss: 8.5.9
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
       typescript: 5.8.3
       yaml: 2.8.3
 
-  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@oxc-project/runtime': 0.123.0
       '@oxc-project/types': 0.123.0
@@ -14947,6 +15236,7 @@ snapshots:
       postcss: 8.5.9
     optionalDependencies:
       '@types/node': 24.12.2
+      esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
@@ -14971,11 +15261,11 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.16':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -14985,7 +15275,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -15012,11 +15302,11 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -15026,7 +15316,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -15053,11 +15343,11 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -15067,7 +15357,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -15094,11 +15384,11 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       obug: 2.1.1
       pixelmatch: 7.1.0
@@ -15108,7 +15398,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       ws: 8.20.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -16438,6 +16728,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -20245,11 +20564,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.123.0
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@26.1.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -20290,11 +20609,11 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.123.0
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@20.19.37)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -20335,11 +20654,11 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.123.0
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -20380,11 +20699,11 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.123.0
-      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -20427,7 +20746,7 @@ snapshots:
 
   vite@7.3.2(@types/node@20.19.37)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
-      esbuild: 0.27.0
+      esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
   - packages/*
+  - plugins/figma-sift-slides
   - packages/runtimed-node/npm/*
   - plugins/nteract/*
 


### PR DESCRIPTION
## Summary

- add a local Figma Slides plugin package for scanning real Sift datasets in the plugin UI
- load Arrow IPC and Parquet through the existing Sift WASM path, plus small CSV/TSV/JSON helpers for local testing
- insert the currently visible Sift viewport into the focused slide as Figma-native rectangles/text
- expose Sift engine readiness and visible data-row indices through the React/table APIs

## Notes

Figma's public Plugin API can read and move `INTERACTIVE_SLIDE_ELEMENT` embed nodes, but cannot create live `EMBED` interactive slide elements or modify their backing data. This PR keeps the live scanning experience in the plugin UI and writes a native snapshot into the slide deck.

The built `plugins/figma-sift-slides/dist/` files are generated locally and ignored by the repo. Run `cargo xtask wasm sift`, then `pnpm --filter @nteract/figma-sift-slides build`, then load `plugins/figma-sift-slides/manifest.json` in Figma Desktop as a development plugin.

## Verification

- `cargo xtask wasm sift`
- `pnpm --filter @nteract/figma-sift-slides check`
- `pnpm --filter @nteract/figma-sift-slides build`
- `pnpm --filter @nteract/sift test -- src/react.test.tsx`
- `cargo xtask lint --fix`
