### PR TITLE
fix(mcp): remove cell positions from summaries

### DIFF
--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -214,11 +214,20 @@ fn collapse_and_truncate(text: &str, preview_chars: usize) -> String {
     format!("{truncated}…[+{remaining} chars]")
 }
 
-/// Format a compact one-line cell summary (matches Python _format_cell_summary).
+/// Width of the visual divider in assistant-facing cell summaries.
+const CELL_SUMMARY_DIVIDER: &str =
+    "────────────────────────────────────────────────────────────────────";
+
+/// Upper bound for one rendered output body inside a cell summary.
 ///
-/// Example output:
-///   0 | markdown | id=cell-1be2a179 | # Crate Download Analysis
-///   1 | code | running | id=cell-e18fcc2a | exec=4 | exec_id=exec-7f3a2b | import requests…[+45 chars]
+/// Output resolvers already cap large payloads, but summaries often include
+/// many cells, so keep each output bounded independently.
+const MAX_CELL_SUMMARY_OUTPUT_CHARS: usize = 2_400;
+
+/// Format an assistant-friendly cell summary block.
+///
+/// The block intentionally avoids numeric cell positions. Agents should copy
+/// `cell_id` values and use `after_cell_id` for ordering mutations.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CellSummaryContext<'a> {
     pub execution_count: Option<&'a str>,
@@ -227,52 +236,130 @@ pub struct CellSummaryContext<'a> {
 }
 
 pub fn format_cell_summary(
-    index: usize,
     cell_id: &str,
     cell_type: &str,
     source: &str,
     context: CellSummaryContext<'_>,
     preview_chars: usize,
+    outputs: &[Output],
 ) -> String {
-    let mut parts = vec![index.to_string(), cell_type.to_string()];
-
-    // Status (running/queued) comes before id, like in Python
+    let mut header_parts = vec![format!("⏺ ━━━ cell {cell_id}"), format!("({cell_type})")];
     if let Some(st) = context.status {
         if !st.is_empty() {
-            parts.push(st.to_string());
+            header_parts.push(format!("{} {st}", status_icon(st)));
         }
     }
-
-    parts.push(format!("id={cell_id}"));
-
-    // execution_count as exec=N (only for code cells with a value)
     if let Some(ec) = context.execution_count {
         if !ec.is_empty() && cell_type == "code" {
-            parts.push(format!("exec={ec}"));
+            header_parts.push(format!("[{ec}]"));
         }
     }
-
     if let Some(eid) = context.execution_id {
         if !eid.is_empty() && cell_type == "code" {
-            parts.push(format!("exec_id={eid}"));
+            header_parts.push(format!("exec={eid}"));
         }
     }
+    header_parts.push("━━━".to_string());
 
-    // Source preview — collapse to single line, strip whitespace
-    if !source.is_empty() {
-        let source_line: String = source.split_whitespace().collect::<Vec<_>>().join(" ");
-        let char_count = source_line.chars().count();
-        let preview = if char_count > preview_chars {
-            let truncated: String = source_line.chars().take(preview_chars).collect();
-            let remaining = char_count - preview_chars;
-            format!("{truncated}…[+{remaining} chars]")
-        } else {
-            source_line
-        };
-        parts.push(preview);
+    let mut sections = vec![header_parts.join(" "), String::new(), "  In:".to_string()];
+    let source_preview = truncate_chars(source.trim_end(), preview_chars);
+    if source_preview.is_empty() {
+        sections.push("      (empty)".to_string());
+    } else {
+        sections.push(indent_block(&source_preview, "      "));
     }
 
-    parts.join(" | ")
+    for output in outputs {
+        let Some(output_section) = format_summary_output(output) else {
+            continue;
+        };
+        sections.push(String::new());
+        sections.push(format!("  {CELL_SUMMARY_DIVIDER}"));
+        sections.push(String::new());
+        sections.push(output_section);
+    }
+
+    sections.join("\n")
+}
+
+fn format_summary_output(output: &Output) -> Option<String> {
+    let label = output_summary_label(output);
+    let text = format_output_text(output).unwrap_or_else(|| non_text_output_summary(output));
+    let text = truncate_chars(text.trim_end(), MAX_CELL_SUMMARY_OUTPUT_CHARS);
+    if text.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "  Out [{label}]:\n{}",
+        indent_block(&text, "      ")
+    ))
+}
+
+fn output_summary_label(output: &Output) -> String {
+    match output.output_type.as_str() {
+        "stream" => output.name.as_deref().unwrap_or("stream").to_string(),
+        "error" => "error".to_string(),
+        "display_data" | "execute_result" => output
+            .data
+            .as_ref()
+            .and_then(best_output_mime)
+            .unwrap_or(output.output_type.as_str())
+            .to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn best_output_mime(data: &std::collections::HashMap<String, DataValue>) -> Option<&str> {
+    for mime in TEXT_MIME_PRIORITY {
+        if data.contains_key(*mime) {
+            return Some(*mime);
+        }
+    }
+    data.keys().map(String::as_str).min()
+}
+
+fn non_text_output_summary(output: &Output) -> String {
+    let Some(data) = &output.data else {
+        return String::new();
+    };
+    let mut mimes: Vec<&str> = data.keys().map(String::as_str).collect();
+    mimes.sort_unstable();
+    if mimes.is_empty() {
+        String::new()
+    } else {
+        format!("[non-text output: {}]", mimes.join(", "))
+    }
+}
+
+fn indent_block(text: &str, indent: &str) -> String {
+    text.lines()
+        .map(|line| format!("{indent}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    let max_chars = max_chars.max(1);
+    let char_count = text.chars().count();
+    if char_count <= max_chars {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_chars).collect();
+    let remaining = char_count - max_chars;
+    format!("{truncated}…[+{remaining} chars]")
+}
+
+fn status_icon(status: &str) -> &'static str {
+    match status {
+        "idle" | "done" => "✓",
+        "error" => "✗",
+        "running" => "◐",
+        "queued" => "⧗",
+        "cancelled" => "⊘",
+        "never_run" => "○",
+        _ => "?",
+    }
 }
 
 /// Format a cell header line (matches Python _format_header).
@@ -291,16 +378,7 @@ pub fn format_cell_header(
 
     if let Some(st) = status {
         if !st.is_empty() {
-            let icon = match st {
-                "idle" | "done" => "✓",
-                "error" => "✗",
-                "running" => "◐",
-                "queued" => "⧗",
-                "cancelled" => "⊘",
-                "never_run" => "○",
-                _ => "?",
-            };
-            parts.push(format!("{icon} {st}"));
+            parts.push(format!("{} {st}", status_icon(st)));
         }
     }
 
@@ -517,7 +595,6 @@ mod tests {
     #[test]
     fn format_cell_summary_truncates_long_source() {
         let summary = format_cell_summary(
-            3,
             "cell-abc",
             "code",
             "import numpy as np\nimport pandas as pd",
@@ -527,9 +604,10 @@ mod tests {
                 execution_id: Some("exec-123"),
             },
             15,
+            &[],
         );
-        assert!(summary.starts_with("3 | code | idle | id=cell-abc | exec=5 | "));
-        assert!(summary.contains("exec_id=exec-123"));
+        assert!(summary.starts_with("⏺ ━━━ cell cell-abc (code) ✓ idle [5] exec=exec-123"));
+        assert!(summary.contains("\n  In:\n"));
         assert!(summary.contains("…[+"));
         assert!(summary.contains(" chars]"));
     }
@@ -539,7 +617,6 @@ mod tests {
         // Markdown cells don't have execution counts; the exec= field
         // must not appear even if a value was threaded through.
         let summary = format_cell_summary(
-            0,
             "cell-md",
             "markdown",
             "# Hello",
@@ -549,25 +626,50 @@ mod tests {
                 execution_id: Some("exec-md"),
             },
             50,
+            &[],
         );
         assert!(!summary.contains("exec="));
-        assert!(!summary.contains("exec_id="));
         assert!(summary.contains("# Hello"));
     }
 
     #[test]
-    fn format_cell_summary_collapses_whitespace() {
-        // Multi-line or multi-space source must render on a single line.
+    fn format_cell_summary_preserves_multiline_source() {
         let summary = format_cell_summary(
-            0,
             "cell-x",
             "code",
             "x = 1\n\n\n  y   =    2",
             CellSummaryContext::default(),
             100,
+            &[],
         );
-        assert!(summary.contains("x = 1 y = 2"));
-        assert!(!summary.contains('\n'));
+        assert!(summary.contains("      x = 1"));
+        assert!(summary.contains("        y   =    2"));
+    }
+
+    #[test]
+    fn format_cell_summary_renders_text_output_blocks() {
+        let outputs = vec![Output::display_data(data(&[(
+            "text/llm+plain",
+            DataValue::Text("HuggingFace Dataset: 2,000 rows × 12 features".into()),
+        )]))];
+
+        let summary = format_cell_summary(
+            "73fe9d2b-b4ab-4d39-ba90-fec52a1c3360",
+            "code",
+            "ds_slice",
+            CellSummaryContext {
+                execution_count: None,
+                status: Some("done"),
+                execution_id: None,
+            },
+            120,
+            &outputs,
+        );
+
+        assert!(summary.contains("⏺ ━━━ cell 73fe9d2b-b4ab-4d39-ba90-fec52a1c3360 (code) ✓ done"));
+        assert!(summary.contains("  In:\n      ds_slice"));
+        assert!(summary.contains("  Out [text/llm+plain]:"));
+        assert!(summary.contains("      HuggingFace Dataset: 2,000 rows × 12 features"));
     }
 
     #[test]

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -281,10 +281,11 @@ fn cells_json(notebook_id: &str, handle: &notebook_sync::handle::DocHandle) -> S
     let status_by_cell = crate::tools::cell_read::build_cell_status_map(handle);
     let execution_count_by_cell = crate::tools::cell_read::build_cell_execution_count_map(handle);
     let outputs_by_cell = handle.get_all_outputs();
-    let cells: Vec<_> = handle
-        .get_cells()
-        .into_iter()
-        .map(|cell| {
+    let cells = handle.get_cells();
+    let cell_entries: Vec<_> = cells
+        .iter()
+        .enumerate()
+        .map(|(index, cell)| {
             let execution_id = handle.get_cell_execution_id(&cell.id);
             let status = status_by_cell.get(&cell.id).cloned().or_else(|| {
                 (cell.cell_type == "code" && execution_id.is_none()).then(|| "never_run".into())
@@ -293,7 +294,8 @@ fn cells_json(notebook_id: &str, handle: &notebook_sync::handle::DocHandle) -> S
                 "cell_id": cell.id,
                 "uri": notebook_cell_uri(notebook_id, &cell.id),
                 "cell_type": cell.cell_type,
-                "position": cell.position,
+                "previous_cell_id": previous_cell_id(&cells, index),
+                "next_cell_id": next_cell_id(&cells, index),
                 "source_preview": source_preview(&cell.source, 160),
                 "execution_id": execution_id,
                 "execution_count": execution_count_by_cell.get(&cell.id),
@@ -304,9 +306,20 @@ fn cells_json(notebook_id: &str, handle: &notebook_sync::handle::DocHandle) -> S
         .collect();
     serde_json::to_string_pretty(&serde_json::json!({
         "notebook_id": notebook_id,
-        "cells": cells,
+        "cells": cell_entries,
     }))
     .unwrap_or_else(|_| "{}".into())
+}
+
+fn previous_cell_id(cells: &[notebook_doc::CellSnapshot], index: usize) -> Option<&str> {
+    index
+        .checked_sub(1)
+        .and_then(|previous| cells.get(previous))
+        .map(|cell| cell.id.as_str())
+}
+
+fn next_cell_id(cells: &[notebook_doc::CellSnapshot], index: usize) -> Option<&str> {
+    cells.get(index + 1).map(|cell| cell.id.as_str())
 }
 
 fn cell_json(
@@ -326,6 +339,10 @@ fn cell_json(
     });
     let outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
     let execution_count = (!execution_count.is_empty()).then_some(execution_count);
+    let cells = handle.get_cells();
+    let cell_index = cells.iter().position(|candidate| candidate.id == cell_id);
+    let previous_cell_id = cell_index.and_then(|index| previous_cell_id(&cells, index));
+    let next_cell_id = cell_index.and_then(|index| next_cell_id(&cells, index));
 
     Ok(serde_json::to_string_pretty(&serde_json::json!({
         "notebook_id": notebook_id,
@@ -333,7 +350,8 @@ fn cell_json(
             "cell_id": cell.id,
             "uri": notebook_cell_uri(notebook_id, cell_id),
             "cell_type": cell.cell_type,
-            "position": cell.position,
+            "previous_cell_id": previous_cell_id,
+            "next_cell_id": next_cell_id,
             "source": cell.source,
             "metadata": cell.metadata,
             "tags": cell.tags(),

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -314,28 +314,16 @@ pub async fn get_all_cells(
         }
         _ => {
             // summary format
-            let mut lines = Vec::new();
-            for (i, cell) in slice.iter().enumerate() {
+            let mut blocks = Vec::new();
+            for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec = cell_ec_map.get(&cell.id).map(String::as_str);
                 let execution_id = handle.get_cell_execution_id(&cell.id);
                 let display_status =
                     display_status_for_cell(&cell.cell_type, status, execution_id.as_deref());
-                let line = formatting::format_cell_summary(
-                    start + i,
-                    &cell.id,
-                    &cell.cell_type,
-                    &cell.source,
-                    formatting::CellSummaryContext {
-                        execution_count: ec,
-                        status: display_status,
-                        execution_id: execution_id.as_deref(),
-                    },
-                    preview_chars,
-                );
                 let raw_outputs = outputs_by_cell.get(&cell.id).unwrap_or(&empty_outputs);
-                if include_outputs && !raw_outputs.is_empty() {
-                    let outputs = output_resolver::resolve_cell_outputs_for_llm(
+                let outputs = if include_outputs && !raw_outputs.is_empty() {
+                    output_resolver::resolve_cell_outputs_for_llm(
                         raw_outputs,
                         output_resolver::ResolveCtx {
                             blob_base_url: server.blob_base_url.as_deref(),
@@ -345,24 +333,24 @@ pub async fn get_all_cells(
                             ..Default::default()
                         },
                     )
-                    .await;
-                    let output_summaries =
-                        output_summary_lines(&outputs, raw_outputs, preview_chars);
-                    if !output_summaries.is_empty() {
-                        let summary = output_summaries
-                            .into_iter()
-                            .map(|line| format!("  └─ {line}"))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        lines.push(format!("{line}\n{summary}"));
-                    } else {
-                        lines.push(line);
-                    }
+                    .await
                 } else {
-                    lines.push(line);
-                }
+                    Vec::new()
+                };
+                blocks.push(formatting::format_cell_summary(
+                    &cell.id,
+                    &cell.cell_type,
+                    &cell.source,
+                    formatting::CellSummaryContext {
+                        execution_count: ec,
+                        status: display_status,
+                        execution_id: execution_id.as_deref(),
+                    },
+                    preview_chars,
+                    &outputs,
+                ));
             }
-            tool_success(&lines.join("\n"))
+            tool_success(&blocks.join("\n\n"))
         }
     }
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -386,8 +386,7 @@ fn format_cell_summaries(handle: &notebook_sync::handle::DocHandle) -> String {
     let cell_ec_map = crate::tools::cell_read::build_cell_execution_count_map(handle);
     cells
         .iter()
-        .enumerate()
-        .map(|(i, cell)| {
+        .map(|cell| {
             let status = cell_status_map.get(&cell.id).map(String::as_str);
             let ec = cell_ec_map.get(&cell.id).map(String::as_str);
             let execution_id = handle.get_cell_execution_id(&cell.id);
@@ -399,7 +398,6 @@ fn format_cell_summaries(handle: &notebook_sync::handle::DocHandle) -> String {
                 }
             });
             formatting::format_cell_summary(
-                i,
                 &cell.id,
                 &cell.cell_type,
                 &cell.source,
@@ -409,10 +407,11 @@ fn format_cell_summaries(handle: &notebook_sync::handle::DocHandle) -> String {
                     execution_id: execution_id.as_deref(),
                 },
                 60,
+                &[],
             )
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n\n")
 }
 
 #[allow(dead_code)] // Fields used by schemars for tool input schema generation


### PR DESCRIPTION
## Summary

- remove raw cell `position` from MCP notebook resources
- expose `previous_cell_id` / `next_cell_id` instead so agents have ID anchors
- replace one-line cell summaries with assistant-friendly blocks that show cell ID, type, status, input preview, and optional text output blocks

## Verification

- `cargo test -p runt-mcp`
- `cargo xtask lint --fix`
- `cargo xtask sync-tool-cache --check`
- `git diff --check`
