### PR TITLE
fix(renderer): route isolated diagnostics through host logging

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -31,6 +31,7 @@ import {
   useCellExecutionId,
   useExecution,
 } from "../lib/notebook-executions";
+import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
 import { useCellOutputs } from "../lib/notebook-outputs";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
@@ -484,6 +485,7 @@ export const CodeCell = memo(function CodeCell({
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}
               onIframeMouseDown={handleOutputMouseDown}
+              onDiagnostic={logNotebookIsolatedDiagnostic}
               resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
               onNavigateToTracebackCell={handleTracebackCellNavigate}
               focused={outputFocused}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -31,6 +31,7 @@ import {
 } from "../lib/cell-ui-state";
 import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
+import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
 import { logger } from "../lib/logger";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
@@ -568,6 +569,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                 onMouseDown={activatePreviewFrameInteraction}
                 onDoubleClick={handleDoubleClick}
                 onError={handleIframeError}
+                onDiagnostic={logNotebookIsolatedDiagnostic}
                 className="w-full"
               />
             </div>

--- a/apps/notebook/src/lib/__tests__/isolated-diagnostics.test.ts
+++ b/apps/notebook/src/lib/__tests__/isolated-diagnostics.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { ISOLATED_DIAGNOSTICS_STORAGE_KEY } from "@/components/isolated";
+import { logNotebookIsolatedDiagnostic } from "../isolated-diagnostics";
+import { logger } from "../logger";
+
+vi.mock("../logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe("logNotebookIsolatedDiagnostic", () => {
+  afterEach(() => {
+    window.localStorage.removeItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY);
+    vi.clearAllMocks();
+  });
+
+  it("suppresses debug diagnostics unless explicitly enabled", () => {
+    logNotebookIsolatedDiagnostic("renderer-ready", { generation: 1 });
+
+    expect(logger.debug).not.toHaveBeenCalled();
+
+    window.localStorage.setItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY, "debug");
+    logNotebookIsolatedDiagnostic("renderer-ready", { generation: 1 });
+
+    expect(logger.debug).toHaveBeenCalledWith("[isolated-frame] renderer-ready", {
+      generation: 1,
+    });
+  });
+
+  it("routes warnings and errors through the notebook host logger", () => {
+    logNotebookIsolatedDiagnostic(
+      "rendered-empty-after-paint",
+      { expectedOutputCount: 1 },
+      "warn",
+      "isolated-renderer",
+    );
+    logNotebookIsolatedDiagnostic(
+      "renderer-plugin-install-failed",
+      { message: "failed" },
+      "error",
+      "isolated-renderer",
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith("[isolated-renderer] rendered-empty-after-paint", {
+      expectedOutputCount: 1,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      "[isolated-renderer] renderer-plugin-install-failed",
+      { message: "failed" },
+    );
+  });
+});

--- a/apps/notebook/src/lib/isolated-diagnostics.ts
+++ b/apps/notebook/src/lib/isolated-diagnostics.ts
@@ -1,0 +1,18 @@
+import {
+  shouldLogIsolatedDiagnostic,
+  type IsolatedDiagnosticHandler,
+} from "@/components/isolated/diagnostics";
+import { logger } from "./logger";
+
+export const logNotebookIsolatedDiagnostic: IsolatedDiagnosticHandler = (
+  phase,
+  details = {},
+  level = "debug",
+  source = "isolated-frame",
+) => {
+  if (!shouldLogIsolatedDiagnostic(level)) {
+    return;
+  }
+
+  logger[level](`[${source}] ${phase}`, details);
+};

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:984b2c323e90ffc5e7afeb83fa5eac2eaff00d910d120cbb4e7c530d1b3b5d23
-size 1486528
+oid sha256:a4bc9a938f77200b621a846d0464cc3699e1f0ca3cb8baf59e6313d7faf0e2cc
+size 1486991

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -15,6 +15,7 @@ import {
   CommBridgeManager,
   type IframeToParentMessage,
   IsolatedFrame,
+  type IsolatedDiagnosticHandler,
   type IsolatedFrameHandle,
   type RenderPayload,
 } from "@/components/isolated";
@@ -183,6 +184,10 @@ interface OutputAreaProps {
    * Use to update cell focus when the click is captured by the iframe.
    */
   onIframeMouseDown?: () => void;
+  /**
+   * Callback for structured isolated renderer diagnostics.
+   */
+  onDiagnostic?: IsolatedDiagnosticHandler;
   /**
    * Host-specific context passed through to isolated output iframes. Cloud
    * viewers use this for renderer sidecar asset bases; desktop callers can
@@ -505,6 +510,7 @@ export function OutputArea({
   searchQuery,
   onSearchMatchCount,
   onIframeMouseDown,
+  onDiagnostic,
   hostContext,
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
@@ -927,6 +933,7 @@ export function OutputArea({
                 onWidgetUpdate={onWidgetUpdate}
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}
+                onDiagnostic={onDiagnostic}
                 hostContext={hostContext}
                 outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
               />

--- a/src/components/isolated/__tests__/diagnostics.test.ts
+++ b/src/components/isolated/__tests__/diagnostics.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { ISOLATED_DIAGNOSTICS_STORAGE_KEY, logIsolatedDiagnostic } from "../diagnostics";
+
+describe("isolated diagnostics", () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY);
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY);
+    vi.restoreAllMocks();
+  });
+
+  it("suppresses debug diagnostics by default", () => {
+    logIsolatedDiagnostic({
+      source: "isolated-frame",
+      phase: "renderer-ready",
+      details: { generation: 1 },
+    });
+
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it("allows debug diagnostics when explicitly opted in", () => {
+    window.localStorage.setItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY, "debug");
+
+    logIsolatedDiagnostic({
+      source: "isolated-frame",
+      phase: "renderer-ready",
+      details: { generation: 1 },
+    });
+
+    expect(console.debug).toHaveBeenCalledWith("[isolated-frame] renderer-ready", {
+      generation: 1,
+    });
+  });
+
+  it("keeps warning diagnostics visible", () => {
+    logIsolatedDiagnostic({
+      source: "isolated-renderer",
+      phase: "rendered-empty-after-paint",
+      level: "warn",
+      details: { expectedOutputCount: 1 },
+    });
+
+    expect(console.warn).toHaveBeenCalledWith("[isolated-renderer] rendered-empty-after-paint", {
+      expectedOutputCount: 1,
+    });
+  });
+});

--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { IsolatedFrameRuntime } from "../isolated-frame-runtime";
 import type { IsolatedFrameRendererBundle } from "../isolated-frame-runtime";
 import {
+  MCP_NOTIFICATIONS_MESSAGE,
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
   NTERACT_RENDER_OUTPUT,
@@ -102,6 +103,35 @@ describe("IsolatedFrameRuntime", () => {
     transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
 
     expect(transport.notify).toHaveBeenCalledWith(NTERACT_RENDER_OUTPUT, payload);
+  });
+
+  it("preserves structured MCP log notifications as isolated diagnostics", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime();
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    transport.notificationHandlers.get(MCP_NOTIFICATIONS_MESSAGE)?.({
+      level: "warning",
+      logger: "nteract.isolated-renderer",
+      data: {
+        source: "isolated-renderer",
+        phase: "renderer-plugin-install-failed",
+        details: { message: "failed" },
+      },
+    });
+
+    expect(callbacks.onDiagnostic).toHaveBeenCalledWith(
+      "renderer-plugin-install-failed",
+      {
+        logger: "nteract.isolated-renderer",
+        protocol: "mcp-ui",
+        message: "failed",
+      },
+      "warn",
+      "isolated-renderer",
+    );
   });
 
   it("sends host context once per channel for equivalent content", () => {

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
+  MCP_UI_SIZE_CHANGED,
   NTERACT_RENDERER_READY,
   NTERACT_RESIZE,
   NTERACT_THEME,
@@ -254,13 +255,21 @@ describe("IsolatedFrame theme updates", () => {
   });
 
   it("keeps the JSON-RPC transport alive when frame diagnostics props change", () => {
+    const onDiagnosticA = vi.fn();
+    const onDiagnosticB = vi.fn();
     const { container, rerender, unmount } = render(
-      <IsolatedFrame darkMode={false} name="code-Out[*]" />,
+      <IsolatedFrame darkMode={false} name="code-Out[*]" onDiagnostic={onDiagnosticA} />,
     );
     const iframe = container.querySelector("iframe") as HTMLIFrameElement;
     const iframeWindow = iframe.contentWindow as Window;
 
     dispatchIframeReady(iframeWindow);
+    expect(onDiagnosticA).toHaveBeenCalledWith(
+      "bootstrap-ready",
+      expect.objectContaining({ frameName: "code-Out[*]" }),
+      "debug",
+      "isolated-frame",
+    );
 
     const transport = MockJsonRpcTransport.instances[0];
     expect(transport).toBeDefined();
@@ -269,12 +278,23 @@ describe("IsolatedFrame theme updates", () => {
       transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
     });
 
-    rerender(<IsolatedFrame darkMode={false} name="code-Out[1]" />);
+    rerender(<IsolatedFrame darkMode={false} name="code-Out[1]" onDiagnostic={onDiagnosticB} />);
 
     expect(transport.stop).not.toHaveBeenCalled();
     expect(transport.request).not.toHaveBeenCalledWith(MCP_UI_RESOURCE_TEARDOWN, {
       reason: "unmount",
     });
+
+    act(() => {
+      transport.notificationHandlers.get(MCP_UI_SIZE_CHANGED)?.({ height: 42, width: 320 });
+    });
+
+    expect(onDiagnosticB).toHaveBeenCalledWith(
+      "size-changed",
+      expect.objectContaining({ frameName: "code-Out[1]", height: 42, width: 320 }),
+      "debug",
+      "isolated-frame",
+    );
 
     unmount();
 

--- a/src/components/isolated/diagnostics.ts
+++ b/src/components/isolated/diagnostics.ts
@@ -9,8 +9,38 @@ export interface IsolatedDiagnosticEvent {
   details?: Record<string, unknown>;
 }
 
+export type IsolatedDiagnosticHandler = (
+  phase: string,
+  details?: Record<string, unknown>,
+  level?: IsolatedDiagnosticLevel,
+  source?: IsolatedDiagnosticSource,
+) => void;
+
+export const ISOLATED_DIAGNOSTICS_STORAGE_KEY = "notebook-isolated-diagnostics";
+
+export function isolatedDebugDiagnosticsEnabled(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const value = window.localStorage?.getItem(ISOLATED_DIAGNOSTICS_STORAGE_KEY)?.toLowerCase();
+    return value === "1" || value === "true" || value === "debug" || value === "verbose";
+  } catch {
+    return false;
+  }
+}
+
+export function shouldLogIsolatedDiagnostic(level: IsolatedDiagnosticLevel = "debug"): boolean {
+  return level !== "debug" || isolatedDebugDiagnosticsEnabled();
+}
+
 export function logIsolatedDiagnostic(event: IsolatedDiagnosticEvent): void {
   const { source, phase, level = "debug", details = {} } = event;
+  if (!shouldLogIsolatedDiagnostic(level)) {
+    return;
+  }
+
   const logger = console[level] ?? console.debug;
   logger(`[${source}] ${phase}`, details);
 }

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -59,6 +59,18 @@ export type {
 export { IsolationTest } from "./IsolationTest";
 export type { IsolatedFrameHandle, IsolatedFrameProps } from "./isolated-frame";
 export { IsolatedFrame } from "./isolated-frame";
+export {
+  ISOLATED_DIAGNOSTICS_STORAGE_KEY,
+  isolatedDebugDiagnosticsEnabled,
+  logIsolatedDiagnostic,
+  shouldLogIsolatedDiagnostic,
+} from "./diagnostics";
+export type {
+  IsolatedDiagnosticEvent,
+  IsolatedDiagnosticHandler,
+  IsolatedDiagnosticLevel,
+  IsolatedDiagnosticSource,
+} from "./diagnostics";
 export { IsolatedFrameRuntime, TYPE_TO_METHOD } from "./isolated-frame-runtime";
 export type {
   IsolatedFrameRendererBundle,

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -105,6 +105,21 @@ function diagnosticLevelFromMcpLog(level: string | undefined): IsolatedFrameRunt
   return "debug";
 }
 
+function isDiagnosticSource(
+  value: unknown,
+): value is "isolated-frame" | "isolated-renderer" | "iframe-libraries" {
+  return (
+    value === "isolated-frame" || value === "isolated-renderer" || value === "iframe-libraries"
+  );
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 function stableHostContextKey(value: unknown): string {
   // Host-context patches can arrive with equivalent object content but different
   // key insertion order. Use a stable key for delivery deduping instead of
@@ -624,15 +639,15 @@ export class IsolatedFrameRuntime {
         logger?: string;
         data?: unknown;
       };
-      this.callbacks.onDiagnostic(
-        "iframe-log-message",
-        {
-          logger: p.logger ?? null,
-          data: p.data ?? null,
-          protocol: "mcp-ui",
-        },
-        diagnosticLevelFromMcpLog(p.level),
-      );
+      const data = objectRecord(p.data);
+      const phase = typeof data?.phase === "string" ? data.phase : "iframe-log-message";
+      const source = isDiagnosticSource(data?.source) ? data.source : "isolated-frame";
+      const structuredDetails = objectRecord(data?.details);
+      const details =
+        structuredDetails && phase !== "iframe-log-message"
+          ? { logger: p.logger ?? null, protocol: "mcp-ui", ...structuredDetails }
+          : { logger: p.logger ?? null, data: p.data ?? null, protocol: "mcp-ui" };
+      this.callbacks.onDiagnostic(phase, details, diagnosticLevelFromMcpLog(p.level), source);
     });
   }
 

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
-import { logIsolatedDiagnostic } from "./diagnostics";
+import { logIsolatedDiagnostic, type IsolatedDiagnosticHandler } from "./diagnostics";
 import {
   createIsolatedFrameDocument,
   ISOLATED_FRAME_ALLOW_ATTR,
@@ -146,6 +146,12 @@ export interface IsolatedFrameProps {
    * Callback for all messages from the iframe (for debugging or custom handling).
    */
   onMessage?: (message: IframeToParentMessage) => void;
+
+  /**
+   * Callback for structured renderer diagnostics. Hosts can route this to their
+   * own logging transport; when omitted, diagnostics use the console fallback.
+   */
+  onDiagnostic?: IsolatedDiagnosticHandler;
 
   /**
    * When true, iframe starts hidden (0 height, 0 opacity) and reveals
@@ -310,6 +316,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       onWidgetUpdate,
       onError,
       onMessage,
+      onDiagnostic,
       revealOnRender = false,
     },
     ref,
@@ -354,7 +361,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onWidgetUpdateRef = useRef(onWidgetUpdate);
     const onErrorRef = useRef(onError);
     const onMessageRef = useRef(onMessage);
+    const onDiagnosticRef = useRef(onDiagnostic);
     const allowWheelBoundaryScrollRef = useRef(allowWheelBoundaryScroll);
+    const frameDiagnosticContextRef = useRef({
+      frameId: id ?? null,
+      frameName: name ?? null,
+    });
 
     const logFrameDiagnostic = useCallback(
       (
@@ -388,8 +400,13 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onWidgetUpdateRef.current = onWidgetUpdate;
     onErrorRef.current = onError;
     onMessageRef.current = onMessage;
+    onDiagnosticRef.current = onDiagnostic;
     allowWheelBoundaryScrollRef.current = allowWheelBoundaryScroll;
     initialContentRef.current = initialContent;
+    frameDiagnosticContextRef.current = {
+      frameId: id ?? null,
+      frameName: name ?? null,
+    };
     logFrameDiagnosticRef.current = logFrameDiagnostic;
 
     const applyMeasuredHeight = useCallback(
@@ -467,7 +484,16 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             onMessageRef.current?.(message);
           },
           onDiagnostic: (phase, details = {}, level = "debug", source = "isolated-frame") => {
-            logFrameDiagnosticRef.current(phase, details, level, source);
+            const enrichedDetails = {
+              ...frameDiagnosticContextRef.current,
+              generation: runtimeRef.current?.generation ?? 0,
+              ...details,
+            };
+            if (onDiagnosticRef.current) {
+              onDiagnosticRef.current(phase, enrichedDetails, level, source);
+            } else {
+              logFrameDiagnosticRef.current(phase, details, level, source);
+            }
           },
         },
       });

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -29,6 +29,7 @@ import type {
 import { mergeNteractEmbedHostContext } from "@/components/isolated/host-context";
 import { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
 import {
+  MCP_NOTIFICATIONS_MESSAGE,
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
   MCP_UI_SIZE_CHANGED,
@@ -275,6 +276,19 @@ function emitRendererDiagnostic(
   level: IsolatedDiagnosticLevel = "debug",
 ) {
   if (rpcTransport) {
+    if (level === "warn" || level === "error") {
+      rpcTransport.notify(MCP_NOTIFICATIONS_MESSAGE, {
+        level: level === "warn" ? "warning" : "error",
+        logger: "nteract.isolated-renderer",
+        data: {
+          source: "isolated-renderer",
+          phase,
+          details,
+        },
+      });
+      return;
+    }
+
     rpcTransport.notify(NTERACT_DIAGNOSTIC, {
       source: "isolated-renderer",
       phase,

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -273,7 +273,6 @@ function SiftRenderer({ data, mimeType, interactionActive = false }: RendererPro
     console.warn("[sift-renderer] missing table URL", { mimeType, data });
     return <pre style={{ whiteSpace: "pre-wrap" }}>Unable to load Arrow stream manifest</pre>;
   }
-  console.debug("[sift-renderer] render", { mimeType, url: url.slice(0, 120) });
   configureWasm(url);
 
   return (


### PR DESCRIPTION
## Summary

- suppress routine isolated renderer debug diagnostics unless `notebook-isolated-diagnostics` is enabled
- route notebook isolated frame diagnostics through the host logger and MCP Apps-style warning/error `notifications/message` events
- remove direct Sift renderer debug logging and add regression coverage

## Verification

- `pnpm test:run src/components/isolated/__tests__ src/isolated-renderer/__tests__ apps/notebook/src/lib/__tests__/isolated-diagnostics.test.ts src/components/cell/__tests__/OutputArea.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm test:run`
- `cargo xtask lint --fix`
- `git diff --check`
