### PR TITLE
fix(wasm): use object init for bindgen modules

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -3,7 +3,6 @@ import { cloudOutputParityExpectedMarkers } from "../../test/fixtures/cloud-outp
 
 const ALLOWED_CONSOLE_MESSAGES = new Set([
   "Allow attribute will take precedence over 'allowfullscreen'.",
-  "using deprecated parameters for the initialization function; pass a single object instead",
 ]);
 
 test.describe("cloud renderer parity harness", () => {

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -1,5 +1,7 @@
 declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
-  export default function init(moduleOrPath?: unknown): Promise<unknown>;
+  export default function init(moduleOrPath?: {
+    module_or_path: unknown | Promise<unknown>;
+  }): Promise<unknown>;
   export function decode_presence_frame(payload: Uint8Array): unknown;
   export function encode_cursor_presence(
     peerId: string,

--- a/crates/runtimed-wasm/tests/cross_impl_test.ts
+++ b/crates/runtimed-wasm/tests/cross_impl_test.ts
@@ -45,7 +45,7 @@ init = mod.default;
 NotebookHandle = mod.NotebookHandle;
 
 const wasmBytes = await Deno.readFile(wasmBinPath);
-await init(wasmBytes);
+await init({ module_or_path: wasmBytes });
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -40,7 +40,7 @@ init = mod.default;
 NotebookHandle = mod.NotebookHandle;
 
 const wasmBytes = await Deno.readFile(wasmBinPath);
-await init(wasmBytes);
+await init({ module_or_path: wasmBytes });
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -23,7 +23,7 @@ const wasmBinPath = new URL(
 
 const mod = await import(wasmJsPath.href);
 const wasmBytes = await Deno.readFile(wasmBinPath);
-await mod.default(wasmBytes);
+await mod.default({ module_or_path: wasmBytes });
 
 Deno.test("Presence: standalone decoder reads real cursor CBOR", () => {
   const payload = mod.encode_cursor_presence(

--- a/crates/runtimed-wasm/tests/snapshot_test.ts
+++ b/crates/runtimed-wasm/tests/snapshot_test.ts
@@ -29,7 +29,7 @@ init = mod.default;
 NotebookHandle = mod.NotebookHandle;
 
 const wasmBytes = await Deno.readFile(wasmBinPath);
-await init(wasmBytes);
+await init({ module_or_path: wasmBytes });
 
 async function readFixtureBytes(scenario: string, name: string): Promise<Uint8Array> {
   return await Deno.readFile(new URL(`${scenario}/${name}`, fixturesDir));

--- a/crates/runtimed-wasm/tests/splice_source_test.ts
+++ b/crates/runtimed-wasm/tests/splice_source_test.ts
@@ -50,7 +50,7 @@ init = mod.default;
 NotebookHandle = mod.NotebookHandle;
 
 const wasmBytes = await Deno.readFile(wasmBinPath);
-await init(wasmBytes);
+await init({ module_or_path: wasmBytes });
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -119,7 +119,7 @@ export function setWasmUrl(url: string): void {
 export async function ensureModule(): Promise<PredicateModule> {
   if (mod) return mod;
   const wasm = await import("sift-wasm/sift_wasm.js");
-  await wasm.default(configuredWasmUrl);
+  await wasm.default({ module_or_path: configuredWasmUrl });
   mod = wasm as unknown as PredicateModule;
   return mod;
 }


### PR DESCRIPTION
## Summary

- update Sift's wasm loader to use wasm-bindgen's object-form initialization
- update runtimed-wasm Deno tests to initialize with `{ module_or_path }`
- tighten notebook-cloud wasm typings and remove the now-unwanted console warning allowlist
- rebuild renderer plugin assets and verify the generated Sift bundle uses object-form init

## Verification

- `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/deno_smoke_test.ts crates/runtimed-wasm/tests/cross_impl_test.ts crates/runtimed-wasm/tests/splice_source_test.ts crates/runtimed-wasm/tests/presence_test.ts crates/runtimed-wasm/tests/snapshot_test.ts`
- `pnpm --filter @nteract/sift test`
- `pnpm --filter notebook-cloud typecheck`
- `cargo xtask renderer-plugins`
- `pnpm test:run`
- `cargo xtask lint --fix`
- `git diff --check`
