### PR TITLE
ci: configure Pullfrog Bedrock model

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -29,3 +29,6 @@ jobs:
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
+        env:
+          AWS_REGION: us-east-1
+          BEDROCK_MODEL_ID: us.anthropic.claude-opus-4-6-v1


### PR DESCRIPTION
## Summary

- Configure Pullfrog's Bedrock workflow env with `AWS_REGION=us-east-1`
- Set `BEDROCK_MODEL_ID` to Claude Opus 4.6 via the US Bedrock inference profile
- Leave `AWS_BEARER_TOKEN_BEDROCK` out of the workflow so it remains managed by Pullfrog BYOK secrets

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/pullfrog.yml`
- `git diff --check`
- `cargo xtask lint --fix`
