### PR TITLE
fix(traceback): include cell ids in notebook frames

### DIFF
--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -287,6 +287,7 @@ mod tests {
                     .or((status == "error").then_some(false)),
                 outputs,
                 source: Some("print('hi')".to_string()),
+                cell_id: None,
                 seq: Some(1),
                 submitted_by_actor_label: None,
             },

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -369,6 +369,7 @@ pub async fn get_results(
             success: record.success,
             outputs: record.outputs,
             source: record.source,
+            cell_id: record.cell_id.clone(),
             seq: record.seq,
             submitted_by_actor_label: record.submitted_by_actor_label,
         };

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -194,6 +194,10 @@ pub struct ExecutionState {
     /// Set by the coordinator when creating the execution entry.
     #[serde(default)]
     pub source: Option<String>,
+    /// Notebook cell that submitted this execution, when the execution came
+    /// from a notebook cell.
+    #[serde(default)]
+    pub cell_id: Option<String>,
     /// Queue sequence number for ordering.
     /// Monotonic counter owned by the coordinator; the runtime agent sorts
     /// queued entries by this to determine execution order.
@@ -1219,6 +1223,25 @@ impl RuntimeStateDoc {
         seq: u64,
         submitted_by_actor_label: Option<&str>,
     ) -> Result<bool, RuntimeStateError> {
+        self.create_execution_with_source_provenance(
+            execution_id,
+            source,
+            seq,
+            submitted_by_actor_label,
+            None,
+        )
+    }
+
+    /// Create a new execution entry with source code, queue sequence number,
+    /// authenticated submitter, and optional notebook cell provenance.
+    pub fn create_execution_with_source_provenance(
+        &mut self,
+        execution_id: &str,
+        source: &str,
+        seq: u64,
+        submitted_by_actor_label: Option<&str>,
+        cell_id: Option<&str>,
+    ) -> Result<bool, RuntimeStateError> {
         let executions = self.scaffold_map("executions")?;
 
         // Don't overwrite if it already exists (idempotent)
@@ -1240,6 +1263,9 @@ impl RuntimeStateDoc {
         self.doc.put(&entry, "success", ScalarValue::Null)?;
         self.doc.put_object(&entry, "outputs", ObjType::Map)?;
         self.doc.put(&entry, "source", source)?;
+        if let Some(cell_id) = cell_id {
+            self.doc.put(&entry, "cell_id", cell_id)?;
+        }
         self.doc.put(&entry, "seq", ScalarValue::Uint(seq))?;
         if let Some(actor_label) = submitted_by_actor_label {
             self.doc
@@ -1353,6 +1379,7 @@ impl RuntimeStateDoc {
         let success = self.read_execution_success(&entry);
         let outputs = self.get_outputs(execution_id);
         let source = self.read_opt_str(&entry, "source");
+        let cell_id = self.read_opt_str(&entry, "cell_id");
         let seq = self.read_execution_seq(&entry);
 
         let submitted_by_actor_label = self.read_opt_str(&entry, "submitted_by_actor_label");
@@ -1363,6 +1390,7 @@ impl RuntimeStateDoc {
             success,
             outputs,
             source,
+            cell_id,
             seq,
             submitted_by_actor_label,
         })
@@ -1439,6 +1467,7 @@ impl RuntimeStateDoc {
                     success: self.read_execution_success(&entry),
                     outputs: Vec::new(),
                     source: self.read_opt_str(&entry, "source"),
+                    cell_id: self.read_opt_str(&entry, "cell_id"),
                     seq: self.read_execution_seq(&entry),
                     submitted_by_actor_label: self.read_opt_str(&entry, "submitted_by_actor_label"),
                 },
@@ -4165,6 +4194,34 @@ mod tests {
     }
 
     #[test]
+    fn test_create_execution_with_source_provenance() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(doc
+            .create_execution_with_source_provenance(
+                "exec-1",
+                "x = 42",
+                0,
+                Some("local:kyle/agent:codex:s1"),
+                Some("cell-1"),
+            )
+            .unwrap());
+
+        let es = doc.get_execution("exec-1").unwrap();
+        assert_eq!(es.status, "queued");
+        assert_eq!(es.source.as_deref(), Some("x = 42"));
+        assert_eq!(es.cell_id.as_deref(), Some("cell-1"));
+        assert_eq!(es.seq, Some(0));
+        assert_eq!(
+            es.submitted_by_actor_label.as_deref(),
+            Some("local:kyle/agent:codex:s1")
+        );
+
+        let queued = doc.get_queued_executions();
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].1.cell_id.as_deref(), Some("cell-1"));
+    }
+
+    #[test]
     fn test_get_queued_executions_sorted_by_seq() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution_with_source("exec-3", "z = 3", 2)
@@ -5047,6 +5104,7 @@ mod tests {
                     new_output.clone(),
                 ],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5080,6 +5138,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![test_stream("hash1"), test_stream("hash2")],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5567,6 +5626,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![test_stream("hash1")],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5587,6 +5647,7 @@ mod tests {
                 success: None,
                 outputs: vec![],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5608,6 +5669,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5632,6 +5694,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![test_stream("hash1")],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5653,6 +5716,7 @@ mod tests {
                 success: None,
                 outputs: vec![],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },
@@ -5686,6 +5750,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![],
                 source: None,
+                cell_id: None,
                 seq: None,
                 submitted_by_actor_label: None,
             },

--- a/crates/runtime-doc/src/projection.rs
+++ b/crates/runtime-doc/src/projection.rs
@@ -340,6 +340,7 @@ mod tests {
             success: None,
             outputs: vec![],
             source: None,
+            cell_id: None,
             seq: None,
             submitted_by_actor_label: None,
         }
@@ -360,6 +361,7 @@ mod tests {
                 .map(|output_id| json!({ "output_id": output_id }))
                 .collect(),
             source: None,
+            cell_id: None,
             seq: None,
             submitted_by_actor_label: None,
         }

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -2068,6 +2068,7 @@ async fn cell_result_from_record(
         success: record.success,
         outputs: record.outputs,
         source: record.source,
+        cell_id: record.cell_id,
         seq: record.seq,
         submitted_by_actor_label: record.submitted_by_actor_label,
     };
@@ -2386,6 +2387,7 @@ mod tests {
             success: Some(true),
             outputs: vec![],
             source: Some("1 + 1".to_string()),
+            cell_id: None,
             seq: Some(9),
             submitted_by_actor_label: None,
         };
@@ -2423,6 +2425,7 @@ mod tests {
             success: Some(true),
             outputs: vec![],
             source: Some("print('ok')".to_string()),
+            cell_id: None,
             seq: Some(11),
             submitted_by_actor_label: None,
         };

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -651,18 +651,18 @@ pub async fn resolve_output_for_llm(
             if ctx.length == OutputLength::Preview {
                 if let Some(blob_hash) = traceback_val.get("blob").and_then(|v| v.as_str()) {
                     if let Some(preview) = manifest.get("llm_preview") {
-                        if let Some(cell_map) = ctx.execution_cell_map {
-                            if let Some(tb) = rich_traceback_lines_for_llm(
-                                manifest,
-                                cell_map,
-                                &blob_base_url,
-                                &blob_store_path,
-                                ctx.length,
-                            )
-                            .await
-                            {
-                                return Some(Output::error(&ename, &evalue, tb));
-                            }
+                        // Prefer structured rich traceback content even for preview output so
+                        // notebook frames can use stable cell IDs. If the blob is unavailable
+                        // or malformed, fall back to the precomputed lightweight preview below.
+                        if let Some(tb) = rich_traceback_lines_for_llm(
+                            manifest,
+                            ctx.execution_cell_map,
+                            &blob_base_url,
+                            &blob_store_path,
+                        )
+                        .await
+                        {
+                            return Some(Output::error(&ename, &evalue, tb));
                         }
                         let tb = render_error_preview(preview, blob_hash, &blob_base_url);
                         return Some(Output::error(&ename, &evalue, tb));
@@ -678,19 +678,14 @@ pub async fn resolve_output_for_llm(
                     resolve_text_ref(traceback_val, &blob_base_url, &blob_store_path).await?;
                 serde_json::from_str::<Vec<String>>(&tb_str).ok()?
             };
-            let traceback = if let Some(cell_map) = ctx.execution_cell_map {
-                rich_traceback_lines_for_llm(
-                    manifest,
-                    cell_map,
-                    &blob_base_url,
-                    &blob_store_path,
-                    ctx.length,
-                )
-                .await
-                .unwrap_or(traceback)
-            } else {
-                traceback
-            };
+            let traceback = rich_traceback_lines_for_llm(
+                manifest,
+                ctx.execution_cell_map,
+                &blob_base_url,
+                &blob_store_path,
+            )
+            .await
+            .unwrap_or(traceback);
             Some(Output::error(&ename, &evalue, traceback))
         }
         "display_data" | "execute_result" => {
@@ -709,15 +704,11 @@ pub async fn resolve_output_for_llm(
 
 async fn rich_traceback_lines_for_llm(
     manifest: &serde_json::Value,
-    execution_cell_map: &HashMap<String, String>,
+    execution_cell_map: Option<&HashMap<String, String>>,
     blob_base_url: &Option<String>,
     blob_store_path: &Option<PathBuf>,
-    length: OutputLength,
 ) -> Option<Vec<String>> {
     let rich_ref = manifest.get("rich")?;
-    if length == OutputLength::Preview && rich_ref.get("blob").is_some() {
-        return None;
-    }
     let rich_json = resolve_text_ref(rich_ref, blob_base_url, blob_store_path).await?;
     let payload: Value = serde_json::from_str(&rich_json).ok()?;
     synthesize_rich_traceback_lines(&payload, execution_cell_map)
@@ -725,7 +716,7 @@ async fn rich_traceback_lines_for_llm(
 
 fn synthesize_rich_traceback_lines(
     payload: &Value,
-    execution_cell_map: &HashMap<String, String>,
+    execution_cell_map: Option<&HashMap<String, String>>,
 ) -> Option<Vec<String>> {
     let ename = payload.get("ename")?.as_str()?;
     let evalue = payload.get("evalue").and_then(Value::as_str).unwrap_or("");
@@ -767,7 +758,7 @@ fn synthesize_rich_traceback_lines(
 
 fn rich_location_line(
     source: &Value,
-    execution_cell_map: &HashMap<String, String>,
+    execution_cell_map: Option<&HashMap<String, String>>,
     name: Option<&str>,
 ) -> Option<String> {
     let filename = source.get("filename").and_then(Value::as_str).unwrap_or("");
@@ -790,11 +781,21 @@ fn rich_location_line(
         .and_then(|r| r.get("execution_id"))
         .or_else(|| source.get("execution_id"))
         .and_then(Value::as_str);
+    let explicit_cell_id = source_ref
+        .and_then(|r| r.get("cell_id"))
+        .or_else(|| source.get("cell_id"))
+        .and_then(Value::as_str);
     let source_hash = source_ref
         .and_then(|r| r.get("source_hash"))
         .or_else(|| source.get("source_hash"))
         .and_then(Value::as_str);
-    let cell_id = execution_id.and_then(|eid| execution_cell_map.get(eid));
+    let execution_count = source_ref
+        .and_then(|r| r.get("execution_count"))
+        .or_else(|| source.get("execution_count"))
+        .and_then(Value::as_i64);
+    let mapped_cell_id =
+        execution_id.and_then(|eid| execution_cell_map.and_then(|map| map.get(eid)));
+    let cell_id = explicit_cell_id.or(mapped_cell_id.map(String::as_str));
 
     let label = cell_id
         .map(|cid| format!("Cell {cid}"))
@@ -805,6 +806,11 @@ fn rich_location_line(
     }
     if let Some(eid) = execution_id {
         details.push(format!("execution_id={eid}"));
+    }
+    if cell_id.is_none() {
+        if let Some(count) = execution_count {
+            details.push(format!("execution_count={count}"));
+        }
     }
     if let Some(hash) = source_hash {
         details.push(format!("source_hash={hash}"));
@@ -2679,6 +2685,172 @@ mod tests {
         assert!(!traceback.contains("In["));
         assert!(traceback.contains("pd.not_real()"));
         assert!(!traceback.contains("/var/folders/x/T/ipykernel_39879"));
+    }
+
+    #[tokio::test]
+    async fn llm_error_prefers_blobbed_rich_traceback_over_legacy_preview() {
+        let Ok(dir) = tempfile::tempdir() else {
+            panic!("tempdir should succeed");
+        };
+        let store_path = dir.path().to_path_buf();
+        let rich_hash = "abcdef1234567890";
+        let rich_dir = store_path.join(&rich_hash[..2]);
+        std::fs::create_dir_all(&rich_dir).expect("create rich blob dir");
+
+        let rich = json!({
+            "ename": "IndexError",
+            "evalue": "list index out of range",
+            "execution": {"execution_id": "exec-run", "cell_id": "cell-run"},
+            "frames": [
+                {
+                    "filename": "/tmp/ipykernel_1/run.py",
+                    "lineno": 6,
+                    "name": "<module>",
+                    "source_ref": {
+                        "kind": "notebook_execution",
+                        "execution_id": "exec-run",
+                        "cell_id": "cell-run",
+                        "compiled_filename": "/tmp/ipykernel_1/run.py"
+                    },
+                    "lines": [{"lineno": 6, "source": "records = image_scatter_records(ds_slice)", "highlight": true}]
+                },
+                {
+                    "filename": "/tmp/ipykernel_1/helper.py",
+                    "lineno": 12,
+                    "name": "image_scatter_records",
+                    "source_ref": {
+                        "kind": "notebook_execution",
+                        "execution_id": "exec-helper",
+                        "cell_id": "cell-helper",
+                        "compiled_filename": "/tmp/ipykernel_1/helper.py"
+                    },
+                    "lines": [{"lineno": 12, "source": "\"image\": row[\"images\"][0],", "highlight": true}]
+                }
+            ],
+            "text": "Traceback fallback still says Current Cell (In[21])"
+        });
+        std::fs::write(
+            rich_dir.join(&rich_hash[2..]),
+            serde_json::to_string(&rich).unwrap(),
+        )
+        .expect("write rich blob");
+
+        let fallback_traceback = serde_json::to_string(&json!(["legacy traceback"])).unwrap();
+        let manifest = serde_json::json!({
+            "output_type": "error",
+            "ename": "IndexError",
+            "evalue": "list index out of range",
+            "traceback": inline_ref(&fallback_traceback),
+            "rich": {"blob": rich_hash, "size": 4096},
+            "llm_preview": {
+                "last_frame": "Line 12 in Earlier Cell (In[20]), in image_scatter_records",
+                "total_bytes": 4096u64,
+                "frames": 2u32,
+            },
+        });
+
+        let Some(out) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                blob_store_path: Some(&store_path),
+                ..Default::default()
+            },
+        )
+        .await
+        else {
+            panic!("resolve should succeed");
+        };
+        let traceback = out.traceback.unwrap_or_default().join("\n");
+
+        assert!(
+            traceback.contains("Line 6 in Cell cell-run (cell_id=cell-run, execution_id=exec-run)")
+        );
+        assert!(traceback.contains(
+            "Line 12 in Cell cell-helper (cell_id=cell-helper, execution_id=exec-helper), in image_scatter_records"
+        ));
+        assert!(traceback.contains("\"image\": row[\"images\"][0],"));
+        assert!(!traceback.contains("In["));
+        assert!(!traceback.contains("full traceback at"));
+    }
+
+    #[tokio::test]
+    async fn llm_error_preview_falls_back_when_rich_blob_is_unavailable() {
+        let Ok(dir) = tempfile::tempdir() else {
+            panic!("tempdir should succeed");
+        };
+        let missing_rich_hash = "missing1234567890";
+        let traceback_hash = "traceback1234567";
+        let manifest = serde_json::json!({
+            "output_type": "error",
+            "ename": "IndexError",
+            "evalue": "list index out of range",
+            "traceback": {"blob": traceback_hash, "size": 4096},
+            "rich": {"blob": missing_rich_hash, "size": 4096},
+            "llm_preview": {
+                "last_frame": "Line 12 in Earlier Cell (In[20]), in image_scatter_records",
+                "total_bytes": 4096u64,
+                "frames": 2u32,
+            },
+        });
+
+        let Some(out) = resolve_output_for_llm(
+            &manifest,
+            ResolveCtx {
+                blob_store_path: Some(dir.path()),
+                ..Default::default()
+            },
+        )
+        .await
+        else {
+            panic!("resolve should succeed");
+        };
+        let traceback = out.traceback.unwrap_or_default().join("\n");
+
+        assert!(traceback.contains("Line 12 in Earlier Cell (In[20]), in image_scatter_records"));
+        assert!(traceback.contains("2 traceback frames, 4096 bytes total"));
+    }
+
+    #[tokio::test]
+    async fn llm_error_rich_traceback_without_cell_ids_keeps_execution_count() {
+        let rich = json!({
+            "ename": "RuntimeError",
+            "evalue": "boom",
+            "frames": [
+                {
+                    "filename": "/tmp/ipykernel_1/helper.py",
+                    "lineno": 12,
+                    "name": "image_scatter_records",
+                    "source_ref": {
+                        "kind": "notebook_execution",
+                        "execution_id": "exec-helper",
+                        "execution_count": 20,
+                        "compiled_filename": "/tmp/ipykernel_1/helper.py"
+                    },
+                    "lines": [{"lineno": 12, "source": "\"image\": row[\"images\"][0],", "highlight": true}]
+                }
+            ],
+            "text": "fallback text"
+        });
+        let fallback_traceback = serde_json::to_string(&json!(["fallback traceback"])).unwrap();
+        let rich_json = serde_json::to_string(&rich).unwrap();
+        let manifest = serde_json::json!({
+            "output_type": "error",
+            "ename": "RuntimeError",
+            "evalue": "boom",
+            "traceback": inline_ref(&fallback_traceback),
+            "rich": inline_ref(&rich_json),
+        });
+
+        let Some(out) = resolve_output_for_llm(&manifest, ResolveCtx::default()).await else {
+            panic!("resolve should succeed");
+        };
+        let traceback = out.traceback.unwrap_or_default().join("\n");
+
+        assert!(traceback.contains(
+            "Line 12 in Notebook Execution (execution_id=exec-helper, execution_count=20), in image_scatter_records"
+        ));
+        assert!(traceback.contains("\"image\": row[\"images\"][0],"));
+        assert!(!traceback.contains("In["));
     }
 
     #[tokio::test]

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1476,6 +1476,7 @@ mod tests {
                 success: Some(true),
                 outputs: vec![json!({"output_type": "stream", "name": "stdout"})],
                 source: Some("print('ok')".to_string()),
+                cell_id: None,
                 seq: Some(7),
                 submitted_by_actor_label: Some("local:kyle/agent:codex:s1".to_string()),
             },

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -2783,7 +2783,12 @@ impl KernelConnection for JupyterKernel {
 
     // ── Execute ──────────────────────────────────────────────────────────
 
-    async fn execute(&mut self, execution_id: &str, source: &str) -> Result<()> {
+    async fn execute(
+        &mut self,
+        execution_id: &str,
+        cell_id: Option<&str>,
+        source: &str,
+    ) -> Result<()> {
         let shell = self
             .shell_writer
             .as_mut()
@@ -2795,10 +2800,14 @@ impl KernelConnection for JupyterKernel {
         let request = ExecuteRequest::new(source.to_string());
         let mut message: JupyterMessage = request.into();
         message.header.msg_id = execution_id.to_string();
+        let mut nteract_metadata = serde_json::json!({
+            "execution_id": execution_id,
+        });
+        if let Some(cell_id) = cell_id {
+            nteract_metadata["cell_id"] = serde_json::Value::String(cell_id.to_string());
+        }
         message.metadata = serde_json::json!({
-            "nteract": {
-                "execution_id": execution_id,
-            },
+            "nteract": nteract_metadata,
         });
 
         // Register execution_id BEFORE sending so IOPub can identify replies

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -94,6 +94,7 @@ pub trait KernelConnection: Send {
     fn execute(
         &mut self,
         execution_id: &str,
+        cell_id: Option<&str>,
         source: &str,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
 

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -99,6 +99,7 @@ impl KernelState {
     pub async fn queue_cell(
         &mut self,
         execution_id: String,
+        cell_id: Option<String>,
         source: String,
         conn: &mut impl KernelConnection,
     ) -> Result<String> {
@@ -123,6 +124,7 @@ impl KernelState {
         // Add to queue.
         self.queue.push_back(QueuedCell {
             execution_id: execution_id.clone(),
+            cell_id,
             code: source,
         });
 
@@ -336,7 +338,8 @@ impl KernelState {
         }
 
         // Send execute request via the connection
-        conn.execute(&cell.execution_id, &cell.code).await?;
+        conn.execute(&cell.execution_id, cell.cell_id.as_deref(), &cell.code)
+            .await?;
 
         info!(
             "[kernel-state] Sent execute_request: execution_id={}",
@@ -429,7 +432,12 @@ mod tests {
             unimplemented!("tests create MockKernel directly")
         }
 
-        async fn execute(&mut self, execution_id: &str, _source: &str) -> Result<()> {
+        async fn execute(
+            &mut self,
+            execution_id: &str,
+            _cell_id: Option<&str>,
+            _source: &str,
+        ) -> Result<()> {
             self.executes.push(execution_id.to_string());
             Ok(())
         }
@@ -507,11 +515,11 @@ mod tests {
 
         // Queue two cells — first starts executing, second stays queued
         state
-            .queue_cell("e1".into(), "x=1".into(), &mut mock)
+            .queue_cell("e1".into(), None, "x=1".into(), &mut mock)
             .await
             .unwrap();
         state
-            .queue_cell("e2".into(), "x=2".into(), &mut mock)
+            .queue_cell("e2".into(), None, "x=2".into(), &mut mock)
             .await
             .unwrap();
 
@@ -539,7 +547,7 @@ mod tests {
         state.set_idle();
 
         state
-            .queue_cell("e1".into(), "x=1".into(), &mut mock)
+            .queue_cell("e1".into(), None, "x=1".into(), &mut mock)
             .await
             .unwrap();
 
@@ -572,11 +580,11 @@ mod tests {
         state.set_idle();
 
         state
-            .queue_cell("e1".into(), "x=1".into(), &mut mock)
+            .queue_cell("e1".into(), None, "x=1".into(), &mut mock)
             .await
             .unwrap();
         state
-            .queue_cell("e2".into(), "x=2".into(), &mut mock)
+            .queue_cell("e2".into(), None, "x=2".into(), &mut mock)
             .await
             .unwrap();
 

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -408,6 +408,7 @@ pub(crate) fn apply_display_manifest_updates(
 #[derive(Debug, Clone)]
 pub struct QueuedCell {
     pub execution_id: String,
+    pub cell_id: Option<String>,
     pub code: String,
 }
 

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -263,11 +263,12 @@ async fn queue_cell_if_current(
             if sd.get_execution(&execution_id).is_some() {
                 return Ok(false);
             }
-            sd.create_execution_with_source_and_submitter(
+            sd.create_execution_with_source_provenance(
                 &execution_id,
                 &cell.source,
                 seq,
                 submitter_actor_label,
+                Some(cell_id),
             )
         }) {
             Ok(true) => break,

--- a/crates/runtimed/src/requests/run_all_cells.rs
+++ b/crates/runtimed/src/requests/run_all_cells.rs
@@ -194,12 +194,13 @@ async fn handle_inner(
                 // cannot dangle. Any single failure aborts the whole batch.
                 let mut created_execution_ids = Vec::new();
                 match room.state.with_doc(|sd| {
-                    for (execution_id, _, source, seq) in &entries {
-                        if sd.create_execution_with_source_and_submitter(
+                    for (execution_id, cell_id, source, seq) in &entries {
+                        if sd.create_execution_with_source_provenance(
                             execution_id,
                             source,
                             *seq,
                             submitter_actor_label,
+                            Some(cell_id),
                         )? {
                             created_execution_ids.push(execution_id.clone());
                         } else {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -463,6 +463,7 @@ pub async fn run_runtime_agent(
                                                         if let Some(ref mut k) = kernel {
                                                             match kernel_state.queue_cell(
                                                                 eid.clone(),
+                                                                exec.cell_id.clone(),
                                                                 source.clone(),
                                                                 k,
                                                             ).await {
@@ -1721,7 +1722,7 @@ mod tests {
         ) -> Result<(Self, QueueCommandReceivers)> {
             unimplemented!()
         }
-        async fn execute(&mut self, _: &str, _: &str) -> Result<()> {
+        async fn execute(&mut self, _: &str, _: Option<&str>, _: &str) -> Result<()> {
             Ok(())
         }
         async fn interrupt(&mut self) -> Result<()> {
@@ -1818,11 +1819,11 @@ mod tests {
 
         // Queue two cells: c1 starts executing, c2 stays queued
         state
-            .queue_cell("e1".into(), "x=1".into(), &mut mock)
+            .queue_cell("e1".into(), None, "x=1".into(), &mut mock)
             .await
             .unwrap();
         state
-            .queue_cell("e2".into(), "x=2".into(), &mut mock)
+            .queue_cell("e2".into(), None, "x=2".into(), &mut mock)
             .await
             .unwrap();
 
@@ -1928,7 +1929,7 @@ mod tests {
 
         // Cell A is executing via the normal queue path
         state
-            .queue_cell("eA".into(), "while True: pass".into(), &mut mock)
+            .queue_cell("eA".into(), None, "while True: pass".into(), &mut mock)
             .await
             .unwrap();
         assert!(state.executing_cell().is_some());
@@ -1984,11 +1985,11 @@ mod tests {
 
         // Queue cell A (executing) and cell B (queued)
         state
-            .queue_cell("eA".into(), "while True: pass".into(), &mut mock)
+            .queue_cell("eA".into(), None, "while True: pass".into(), &mut mock)
             .await
             .unwrap();
         state
-            .queue_cell("eB".into(), "1 + 1".into(), &mut mock)
+            .queue_cell("eB".into(), None, "1 + 1".into(), &mut mock)
             .await
             .unwrap();
 
@@ -2023,7 +2024,7 @@ mod tests {
         // A stale CellError from eA must not poison the next execution.
         let mut mock = MockKernel;
         state
-            .queue_cell("eC".into(), "1 + 1".into(), &mut mock)
+            .queue_cell("eC".into(), None, "1 + 1".into(), &mut mock)
             .await
             .unwrap();
         assert!(state.executing_cell().is_none());

--- a/crates/runtimed/src/user_error.rs
+++ b/crates/runtimed/src/user_error.rs
@@ -46,6 +46,8 @@ pub struct RichSourceRef {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hash: Option<String>,
@@ -62,6 +64,8 @@ pub struct RichFrame {
     /// Execution provenance for frames compiled from notebook source.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -89,6 +93,8 @@ pub struct RichSyntax {
     pub offset: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_count: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -131,6 +137,8 @@ pub struct RichTraceback {
 pub struct RichExecutionContext {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_count: Option<u32>,
 }
@@ -396,6 +404,7 @@ impl PendingFrame {
             lineno: self.lineno,
             name: self.name,
             execution_id: None,
+            cell_id: None,
             execution_count: None,
             source_hash: None,
             source_ref: None,
@@ -822,6 +831,7 @@ mod tests {
                     "evalue": "bad",
                     "execution": {
                         "execution_id": "exec-run",
+                        "cell_id": "cell-run",
                         "execution_count": 3
                     },
                     "frames": [{
@@ -829,11 +839,13 @@ mod tests {
                         "lineno": 2,
                         "name": "boom",
                         "execution_id": "exec-def",
+                        "cell_id": "cell-def",
                         "execution_count": 2,
                         "source_hash": "sha256:abc",
                         "source_ref": {
                             "kind": "notebook_execution",
                             "execution_id": "exec-def",
+                            "cell_id": "cell-def",
                             "execution_count": 2,
                             "source_hash": "sha256:abc",
                             "compiled_filename": "/tmp/ipykernel_1/123.py"
@@ -856,10 +868,17 @@ mod tests {
         assert_eq!(
             rt.execution
                 .as_ref()
+                .and_then(|execution| execution.cell_id.as_deref()),
+            Some("cell-run")
+        );
+        assert_eq!(
+            rt.execution
+                .as_ref()
                 .and_then(|execution| execution.execution_count),
             Some(3)
         );
         assert_eq!(rt.frames[0].execution_id.as_deref(), Some("exec-def"));
+        assert_eq!(rt.frames[0].cell_id.as_deref(), Some("cell-def"));
         assert_eq!(rt.frames[0].execution_count, Some(2));
         assert_eq!(rt.frames[0].source_hash.as_deref(), Some("sha256:abc"));
         assert_eq!(
@@ -868,6 +887,13 @@ mod tests {
                 .as_ref()
                 .map(|source_ref| source_ref.kind.as_str()),
             Some("notebook_execution")
+        );
+        assert_eq!(
+            rt.frames[0]
+                .source_ref
+                .as_ref()
+                .and_then(|source_ref| source_ref.cell_id.as_deref()),
+            Some("cell-def")
         );
         assert_eq!(
             rt.frames[0]

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -180,6 +180,8 @@ export interface ExecutionState {
   status: "queued" | "running" | "done" | "error";
   execution_count: number | null;
   success: boolean | null;
+  /** Notebook cell that submitted this execution, when available. */
+  cell_id?: string | null;
   /** Queue sequence number from RuntimeStateDoc; used as execution recency. */
   seq?: number | null;
   /**

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_traceback.py
@@ -129,6 +129,12 @@ def _metadata_execution_id(metadata: dict[str, Any]) -> str | None:
     return _coerce_metadata_str(nteract_execution_id)
 
 
+def _metadata_cell_id(metadata: dict[str, Any]) -> str | None:
+    nteract = metadata.get("nteract")
+    nteract_cell_id = nteract.get("cell_id") if isinstance(nteract, dict) else None
+    return _coerce_metadata_str(nteract_cell_id)
+
+
 def _current_parent(ip: Any | None) -> dict[str, Any]:
     if ip is None:
         return {}
@@ -153,6 +159,7 @@ def _current_execution_context(ip: Any | None) -> dict[str, Any]:
     context: dict[str, Any] = {
         "execution_id": _metadata_execution_id(metadata)
         or _coerce_metadata_str(header.get("msg_id")),
+        "cell_id": _metadata_cell_id(metadata),
         "execution_count": _current_input_count(ip),
     }
     return {key: value for key, value in context.items() if value}
@@ -181,6 +188,7 @@ def _register_cell_source(
     raw_cell: Any,
     *,
     execution_id: str | None,
+    cell_id: str | None,
     execution_count: int | None,
 ) -> None:
     if not isinstance(raw_cell, str):
@@ -193,6 +201,7 @@ def _register_cell_source(
     source_ref = {
         "kind": _NOTEBOOK_EXECUTION_SOURCE_KIND,
         "execution_id": execution_id,
+        "cell_id": cell_id,
         "execution_count": execution_count,
         "source_hash": source_hash,
         "compiled_filename": filename,
@@ -200,6 +209,7 @@ def _register_cell_source(
     source_ref = {key: value for key, value in source_ref.items() if value}
     provenance = {
         "execution_id": execution_id,
+        "cell_id": cell_id,
         "execution_count": execution_count,
         "source_hash": source_hash,
         "source_ref": source_ref,
@@ -249,11 +259,13 @@ def _install_cell_registry_hook(ip: Any) -> None:
             execution_id = _metadata_execution_id(metadata) or _coerce_metadata_str(
                 header.get("msg_id")
             )
+            cell_id = _metadata_cell_id(metadata)
             execution_count = _execution_count_for_info(ip, info)
             _register_cell_source(
                 ip,
                 getattr(info, "raw_cell", None),
                 execution_id=execution_id,
+                cell_id=cell_id,
                 execution_count=execution_count,
             )
         except BaseException as err:  # noqa: BLE001
@@ -342,25 +354,34 @@ def _is_notebook_source(item: dict[str, Any]) -> bool:
     )
 
 
-def _execution_count_label(item: dict[str, Any]) -> str | None:
+def _source_ref(item: dict[str, Any]) -> dict[str, Any] | None:
     source_ref = item.get("source_ref")
-    count = None
     if isinstance(source_ref, dict):
-        count = _coerce_execution_count(source_ref.get("execution_count"))
-    if count is None:
-        count = _coerce_execution_count(item.get("execution_count"))
-    return f"In[{count}]" if count is not None else None
+        return source_ref
+    return None
+
+
+def _source_ref_str(item: dict[str, Any], key: str) -> str | None:
+    source_ref = _source_ref(item)
+    value = source_ref.get(key) if source_ref is not None else None
+    return _coerce_metadata_str(value) or _coerce_metadata_str(item.get(key))
+
+
+def _source_ref_execution_count(item: dict[str, Any]) -> int | None:
+    source_ref = _source_ref(item)
+    value = source_ref.get("execution_count") if source_ref is not None else None
+    return _coerce_execution_count(value) or _coerce_execution_count(item.get("execution_count"))
 
 
 def _notebook_source_label(item: dict[str, Any], current_execution_id: str | None) -> str:
-    source_ref = item.get("source_ref")
-    execution_id = item.get("execution_id")
-    if isinstance(source_ref, dict):
-        execution_id = source_ref.get("execution_id") or execution_id
+    cell_id = _source_ref_str(item, "cell_id")
+    if cell_id:
+        return f"Cell {cell_id}"
+    execution_id = _source_ref_str(item, "execution_id")
     if execution_id and execution_id == current_execution_id:
         return "Current Cell"
     if execution_id:
-        return "Earlier Cell"
+        return "Notebook Execution"
     return "Notebook Cell"
 
 
@@ -373,10 +394,22 @@ def _format_traceback_location(
     lineno = item.get("lineno") or 0
     if _is_notebook_source(item):
         label = _notebook_source_label(item, current_execution_id)
-        count_label = _execution_count_label(item)
         location = f"Line {lineno} in {label}"
-        if count_label:
-            location += f" ({count_label})"
+        details = []
+        cell_id = _source_ref_str(item, "cell_id")
+        execution_id = _source_ref_str(item, "execution_id")
+        execution_count = _source_ref_execution_count(item)
+        source_hash = _source_ref_str(item, "source_hash")
+        if cell_id:
+            details.append(f"cell_id={cell_id}")
+        if execution_id:
+            details.append(f"execution_id={execution_id}")
+        if not cell_id and execution_count is not None:
+            details.append(f"execution_count={execution_count}")
+        if source_hash:
+            details.append(f"source_hash={source_hash}")
+        if details:
+            location += f" ({', '.join(details)})"
         if function_name and function_name != "<module>":
             location += f", in {function_name}"
         return location

--- a/python/nteract-kernel-launcher/tests/test_traceback.py
+++ b/python/nteract-kernel-launcher/tests/test_traceback.py
@@ -338,7 +338,7 @@ def test_install_registers_pre_run_cell_provenance_hook(monkeypatch):
     )
     ip = _FakeKernelShell(
         {
-            "metadata": {"nteract": {"execution_id": "exec-1"}},
+            "metadata": {"nteract": {"execution_id": "exec-1", "cell_id": "cell-1"}},
             "header": {"msg_id": "exec-1"},
         }
     )
@@ -351,11 +351,13 @@ def test_install_registers_pre_run_cell_provenance_hook(monkeypatch):
 
     registry = getattr(ip, _traceback._CELL_REGISTRY_ATTR)
     assert registry["/tmp/ipykernel_1/abc.py"]["execution_id"] == "exec-1"
+    assert registry["/tmp/ipykernel_1/abc.py"]["cell_id"] == "cell-1"
     assert registry["/tmp/ipykernel_1/abc.py"]["execution_count"] == 1
     assert registry["/tmp/ipykernel_1/abc.py"]["source_hash"].startswith("sha256:")
     assert registry["/tmp/ipykernel_1/abc.py"]["source_ref"] == {
         "kind": "notebook_execution",
         "execution_id": "exec-1",
+        "cell_id": "cell-1",
         "execution_count": 1,
         "source_hash": registry["/tmp/ipykernel_1/abc.py"]["source_hash"],
         "compiled_filename": "/tmp/ipykernel_1/abc.py",
@@ -363,6 +365,64 @@ def test_install_registers_pre_run_cell_provenance_hook(monkeypatch):
 
 
 def test_build_payload_attaches_execution_provenance_to_prior_function_frame():
+    filename = "/tmp/ipykernel_1/defined_elsewhere.py"
+    source = "def defined_elsewhere():\n    raise RuntimeError('from definition')\n"
+    linecache.cache[filename] = (len(source), None, source.splitlines(True), filename)
+    ip = SimpleNamespace(
+        execution_count=4,
+        parent_header={
+            "metadata": {},
+            "header": {"msg_id": "exec-run"},
+        },
+    )
+    setattr(
+        ip,
+        _traceback._CELL_REGISTRY_ATTR,
+        {
+            filename: {
+                "execution_id": "exec-def",
+                "cell_id": "cell-def",
+                "execution_count": 2,
+                "source_hash": "sha256:def",
+                "source_ref": {
+                    "kind": "notebook_execution",
+                    "execution_id": "exec-def",
+                    "cell_id": "cell-def",
+                    "execution_count": 2,
+                    "source_hash": "sha256:def",
+                    "compiled_filename": filename,
+                },
+            }
+        },
+    )
+    namespace = {}
+    try:
+        exec(compile(source, filename, "exec"), namespace)
+        namespace["defined_elsewhere"]()
+    except RuntimeError as exc:
+        payload = build_rich_payload(type(exc), exc, exc.__traceback__, ip)
+    finally:
+        linecache.cache.pop(filename, None)
+
+    frame = next(frame for frame in payload["frames"] if frame["filename"] == filename)
+    assert frame["execution_id"] == "exec-def"
+    assert frame["cell_id"] == "cell-def"
+    assert frame["execution_count"] == 2
+    assert frame["source_hash"] == "sha256:def"
+    assert frame["source_ref"]["kind"] == "notebook_execution"
+    assert frame["source_ref"]["compiled_filename"] == filename
+    assert (
+        "Line 2 in Cell cell-def "
+        "(cell_id=cell-def, execution_id=exec-def, source_hash=sha256:def), "
+        "in defined_elsewhere"
+    ) in payload["text"]
+    assert "In[" not in payload["text"]
+    assert filename not in payload["text"]
+    assert filename in payload["raw_text"]
+    assert payload["execution"] == {"execution_id": "exec-run", "execution_count": 3}
+
+
+def test_build_payload_preserves_execution_count_when_cell_id_unavailable():
     filename = "/tmp/ipykernel_1/defined_elsewhere.py"
     source = "def defined_elsewhere():\n    raise RuntimeError('from definition')\n"
     linecache.cache[filename] = (len(source), None, source.splitlines(True), filename)
@@ -400,16 +460,12 @@ def test_build_payload_attaches_execution_provenance_to_prior_function_frame():
     finally:
         linecache.cache.pop(filename, None)
 
-    frame = next(frame for frame in payload["frames"] if frame["filename"] == filename)
-    assert frame["execution_id"] == "exec-def"
-    assert frame["execution_count"] == 2
-    assert frame["source_hash"] == "sha256:def"
-    assert frame["source_ref"]["kind"] == "notebook_execution"
-    assert frame["source_ref"]["compiled_filename"] == filename
-    assert "Line 2 in Earlier Cell (In[2]), in defined_elsewhere" in payload["text"]
-    assert filename not in payload["text"]
-    assert filename in payload["raw_text"]
-    assert payload["execution"] == {"execution_id": "exec-run", "execution_count": 3}
+    assert (
+        "Line 2 in Notebook Execution "
+        "(execution_id=exec-def, execution_count=2, source_hash=sha256:def), "
+        "in defined_elsewhere"
+    ) in payload["text"]
+    assert "In[" not in payload["text"]
 
 
 def test_syntax_error_payload_attaches_execution_provenance():
@@ -417,7 +473,7 @@ def test_syntax_error_payload_attaches_execution_provenance():
     ip = SimpleNamespace(
         execution_count=6,
         parent_header={
-            "metadata": {"nteract": {"execution_id": "exec-syntax"}},
+            "metadata": {"nteract": {"execution_id": "exec-syntax", "cell_id": "cell-syntax"}},
             "header": {"msg_id": "exec-syntax"},
         },
     )
@@ -427,11 +483,13 @@ def test_syntax_error_payload_attaches_execution_provenance():
         {
             filename: {
                 "execution_id": "exec-syntax",
+                "cell_id": "cell-syntax",
                 "execution_count": 5,
                 "source_hash": "sha256:syntax",
                 "source_ref": {
                     "kind": "notebook_execution",
                     "execution_id": "exec-syntax",
+                    "cell_id": "cell-syntax",
                     "execution_count": 5,
                     "source_hash": "sha256:syntax",
                     "compiled_filename": filename,
@@ -446,10 +504,15 @@ def test_syntax_error_payload_attaches_execution_provenance():
         payload = build_rich_payload(type(exc), exc, exc.__traceback__, ip)
 
     assert payload["syntax"]["execution_id"] == "exec-syntax"
+    assert payload["syntax"]["cell_id"] == "cell-syntax"
     assert payload["syntax"]["execution_count"] == 5
     assert payload["syntax"]["source_hash"] == "sha256:syntax"
     assert payload["syntax"]["source_ref"]["kind"] == "notebook_execution"
-    assert "Line 1 in Current Cell (In[5])" in payload["text"]
+    assert (
+        "Line 1 in Cell cell-syntax "
+        "(cell_id=cell-syntax, execution_id=exec-syntax, source_hash=sha256:syntax)"
+    ) in payload["text"]
+    assert "In[" not in payload["text"]
     assert filename not in payload["text"]
     assert filename in payload["raw_text"]
 

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -163,6 +163,39 @@ describe("TracebackOutput", () => {
     expect(onNavigateToCell).toHaveBeenCalledWith({ cellId: "cell-def" });
   });
 
+  it("uses structured cell ids when execution lookup is unavailable", () => {
+    const onNavigateToCell = vi.fn();
+
+    render(
+      <TracebackOutput
+        data={{
+          ename: "IndexError",
+          evalue: "list index out of range",
+          frames: [
+            {
+              filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
+              lineno: 12,
+              name: "image_scatter_records",
+              cell_id: "cell-helper",
+              source_ref: {
+                kind: "notebook_execution",
+                cell_id: "cell-helper",
+                execution_id: "exec-helper",
+                compiled_filename: "/var/folders/x/T/ipykernel_39879/3398808089.py",
+              },
+              lines: [{ lineno: 12, source: 'row["images"][0]', highlight: true }],
+            },
+          ],
+        }}
+        onNavigateToCell={onNavigateToCell}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-helper" }));
+
+    expect(onNavigateToCell).toHaveBeenCalledWith({ cellId: "cell-helper" });
+  });
+
   it("copies the sanitized traceback text", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -39,6 +39,7 @@ interface Frame {
   name: string;
   /** Execution provenance for clients that want to jump to source. */
   execution_id?: string;
+  cell_id?: string;
   execution_count?: number;
   source_hash?: string;
   source_ref?: SourceRef;
@@ -60,6 +61,7 @@ interface SyntaxInfo {
   lineno: number;
   offset: number;
   execution_id?: string;
+  cell_id?: string;
   execution_count?: number;
   source_hash?: string;
   source_ref?: SourceRef;
@@ -109,12 +111,14 @@ interface TracebackPayload {
 
 interface ExecutionInfo {
   execution_id?: string;
+  cell_id?: string;
   execution_count?: number;
 }
 
 interface SourceRef {
   kind?: string;
   execution_id?: string;
+  cell_id?: string;
   execution_count?: number;
   source_hash?: string;
   compiled_filename?: string;
@@ -561,7 +565,7 @@ function LocationLabel({
 function sourceLocation(
   source: Pick<
     Frame | SyntaxInfo,
-    "filename" | "execution_id" | "execution_count" | "source_hash" | "source_ref"
+    "filename" | "execution_id" | "cell_id" | "execution_count" | "source_hash" | "source_ref"
   >,
   currentExecutionId: string | undefined,
   resolveExecutionTarget?: TracebackExecutionResolver,
@@ -570,6 +574,7 @@ function sourceLocation(
   const filename = asOptionalString(source.filename) ?? "Unknown source";
   const executionId =
     asOptionalString(sourceRef?.execution_id) ?? asOptionalString(source.execution_id);
+  const cellId = asOptionalString(sourceRef?.cell_id) ?? asOptionalString(source.cell_id);
   const sourceHash =
     asOptionalString(sourceRef?.source_hash) ?? asOptionalString(source.source_hash);
   const compiledFilename = asOptionalString(sourceRef?.compiled_filename) ?? filename;
@@ -580,7 +585,9 @@ function sourceLocation(
 
   const isNotebookSource =
     sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(filename);
-  const target = executionId ? (resolveExecutionTarget?.(executionId, sourceHash) ?? null) : null;
+  const target =
+    (executionId ? (resolveExecutionTarget?.(executionId, sourceHash) ?? null) : null) ??
+    (cellId ? { cellId } : null);
   if (target) titleParts.unshift(`Cell: ${target.cellId}`);
   const title = titleParts.join("\n") || filename;
 
@@ -707,7 +714,13 @@ function synthesizeTracebackText(
 function copyLocationLine(
   source: Pick<
     Frame | SyntaxInfo,
-    "filename" | "lineno" | "execution_id" | "execution_count" | "source_hash" | "source_ref"
+    | "filename"
+    | "lineno"
+    | "execution_id"
+    | "cell_id"
+    | "execution_count"
+    | "source_hash"
+    | "source_ref"
   >,
   currentExecutionId: string | undefined,
   resolveExecutionTarget?: TracebackExecutionResolver,


### PR DESCRIPTION
## Summary

- carry notebook `cell_id` provenance from RuntimeStateDoc execution entries through Jupyter execute request metadata
- include `cell_id` in Python rich traceback payloads and Rust rich traceback structs
- make MCP/LLM error rendering prefer structured rich traceback blobs so notebook frames render as stable `Cell <id>` locations instead of `In[n]`
- let the frontend traceback renderer navigate directly from structured `cell_id` when execution-id lookup is unavailable

## Verification

- `cargo xtask lint --fix`
- `cargo check -p runtime-doc -p runtimed -p runt-mcp -p runtimed-node -p runtimed-wasm -p notebook-sync -p runtimed-py`
- `cargo test -p runtime-doc test_create_execution_with_source_provenance -- --nocapture`
- `cargo test -p runtimed-outputs llm_error_ -- --nocapture`
- `uv run --package nteract-kernel-launcher pytest python/nteract-kernel-launcher/tests/test_traceback.py`
- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx`

## Note

The broad `cargo test -p runtime-doc -p runtimed-outputs -p runtimed -p runt-mcp -p notebook-sync` run hit one transient `kernel_ports::tests::successful_reservation_releases_on_drop` failure with `Address already in use`; rerunning that exact test passed.
