### PR TITLE
fix(notebook-cloud): align hosted viewer theming

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -49,3 +49,13 @@ test("cloud report-mode rendering leaves output iframes unfocused for page scrol
     "cloud report rendering should not focus output iframes; focused iframes trap page scroll",
   );
 });
+
+test("cloud viewer exposes the shared theme toggle and shared theme hook", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /import \{ ThemeToggle \} from "@\/components\/ui\/theme-toggle";/);
+  assert.match(sourceText, /useTheme\(CLOUD_VIEWER_THEME_STORAGE_KEY\)/);
+  assert.match(sourceText, /<ThemeToggle/);
+  assert.match(sourceText, /className="cloud-theme-toggle"/);
+});

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -18,11 +18,15 @@ describe("cloud viewer theme helpers", () => {
     assert.equal(resolveCloudViewerTheme("system", false), "light");
   });
 
-  it("ignores invalid stored theme values", () => {
+  it("reads valid stored themes and ignores invalid stored values", () => {
     const storage = new Map<string, string>();
-    storage.set(CLOUD_VIEWER_THEME_STORAGE_KEY, "sepia");
+    storage.set(CLOUD_VIEWER_THEME_STORAGE_KEY, "dark");
 
+    assert.equal(storedCloudViewerTheme(storageLike(storage)), "dark");
+
+    storage.set(CLOUD_VIEWER_THEME_STORAGE_KEY, "sepia");
     assert.equal(storedCloudViewerTheme(storageLike(storage)), "system");
+    assert.equal(storedCloudViewerTheme(undefined), "system");
   });
 });
 

--- a/src/components/isolated/__tests__/frame-config.test.ts
+++ b/src/components/isolated/__tests__/frame-config.test.ts
@@ -37,25 +37,35 @@ describe("isolated frame config", () => {
     });
   });
 
-  it("can add an initial theme hint to output document URLs", () => {
+  it("can seed hosted output documents with the initial theme without changing srcdoc hosts", () => {
     expect(
       createIsolatedFrameDocument({
-        outputDocumentUrl: "https://outputs.example/frame/?existing=1",
-        initialTheme: "dark",
+        outputDocumentUrl: "https://outputs.example/frame/?v=1#shell",
+        themeSeed: { theme: "dark", colorTheme: "cream" },
       }),
     ).toEqual({
       kind: "src",
-      url: "https://outputs.example/frame/?existing=1&nteract_theme=dark",
+      url: "https://outputs.example/frame/?v=1&nteract_theme=dark&nteract_color_theme=cream#shell",
     });
 
     expect(
       createIsolatedFrameDocument({
         outputDocumentUrl: "/output-document/frame.html?existing=1#anchor",
-        initialTheme: "light",
+        themeSeed: { theme: "light", colorTheme: null },
       }),
     ).toEqual({
       kind: "src",
       url: "/output-document/frame.html?existing=1&nteract_theme=light#anchor",
+    });
+
+    expect(
+      createIsolatedFrameDocument({
+        isTauriRuntime: false,
+        themeSeed: { theme: "light", colorTheme: "cream" },
+      }),
+    ).toEqual({
+      kind: "srcdoc",
+      html: FRAME_HTML,
     });
   });
 

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -75,10 +75,12 @@ describe("generateFrameHtml", () => {
   });
 
   it("keeps the iframe bootstrap script parseable", () => {
-    const script = html.match(/<script>([\s\S]*)<\/script>/)?.[1];
+    const scripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
 
-    expect(script).toBeDefined();
-    expect(() => new Function(script ?? "")).not.toThrow();
+    expect(scripts.length).toBeGreaterThanOrEqual(1);
+    for (const script of scripts) {
+      expect(() => new Function(script)).not.toThrow();
+    }
   });
 
   it("renders text/plain without the obsolete ANSI fallback", () => {
@@ -88,12 +90,21 @@ describe("generateFrameHtml", () => {
   });
 
   describe("neutral defaults", () => {
-    it("bakes neutral dark defaults before theme sync arrives", () => {
+    it("seeds the frame theme before first paint", () => {
+      expect(source).toContain("new URLSearchParams(window.location.search)");
+      expect(source).toContain("params.get('nteract_theme')");
+      expect(source).toContain("matchMedia('(prefers-color-scheme: dark)')");
+      expect(source.indexOf("<script>")).toBeLessThan(source.indexOf("<style>"));
+    });
+
+    it("bakes neutral light defaults plus dark overrides before theme sync arrives", () => {
       expect(html).toContain("--bg-primary: transparent");
+      expect(html).toContain("--bg-secondary: #f5f5f5");
+      expect(html).toContain("--text-primary: #1a1a1a");
+      expect(html).toContain("--text-secondary: #666666");
+      expect(html).toContain("--border-color: #e0e0e0");
+      expect(html).toContain('[data-theme="dark"]');
       expect(html).toContain("--bg-secondary: #1a1a1a");
-      expect(html).toContain("--text-primary: #e0e0e0");
-      expect(html).toContain("--text-secondary: #a0a0a0");
-      expect(html).toContain("--border-color: #333333");
     });
 
     it("can apply a hosted output theme hint before parent sync arrives", () => {

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -135,6 +135,36 @@ describe("IsolatedFrame theme updates", () => {
     });
   });
 
+  it("seeds hosted output-document URLs with the mount-time theme without reloading on theme changes", async () => {
+    const { container, rerender } = render(
+      <IsolatedFrame
+        darkMode={false}
+        colorTheme="cream"
+        outputDocumentUrl="https://outputs.example/frame/"
+      />,
+    );
+
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    await waitFor(() => {
+      expect(iframe.src).toBe(
+        "https://outputs.example/frame/?nteract_theme=light&nteract_color_theme=cream",
+      );
+    });
+
+    rerender(
+      <IsolatedFrame
+        darkMode={true}
+        colorTheme="cream"
+        outputDocumentUrl="https://outputs.example/frame/"
+      />,
+    );
+
+    expect(iframe.src).toBe(
+      "https://outputs.example/frame/?nteract_theme=light&nteract_color_theme=cream",
+    );
+  });
+
   it("merges imperative host-context updates into MCP Apps-compatible notifications", async () => {
     const frameRef = { current: null as IsolatedFrameHandle | null };
     const { container } = render(

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -27,6 +27,11 @@ export const ISOLATED_FRAME_ALLOW_ATTR = "fullscreen *";
 
 export type IsolatedFrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
 
+export interface IsolatedFrameThemeSeed {
+  theme?: "light" | "dark" | null;
+  colorTheme?: string | null;
+}
+
 export interface TauriFrameGlobal {
   __TAURI__?: unknown;
   __TAURI_INTERNALS__?: unknown;
@@ -44,12 +49,12 @@ export function isTauriFrameRuntime(
 
 export function createIsolatedFrameDocument(options?: {
   isTauriRuntime?: boolean;
-  initialTheme?: "light" | "dark";
   outputDocumentUrl?: string | null;
+  themeSeed?: IsolatedFrameThemeSeed;
 }): IsolatedFrameDocument {
   const outputDocumentUrl = options?.outputDocumentUrl?.trim();
   if (outputDocumentUrl) {
-    return { kind: "src", url: withThemeHint(outputDocumentUrl, options?.initialTheme) };
+    return { kind: "src", url: withIsolatedFrameThemeSeed(outputDocumentUrl, options?.themeSeed) };
   }
 
   if (options?.isTauriRuntime ?? isTauriFrameRuntime()) {
@@ -58,18 +63,30 @@ export function createIsolatedFrameDocument(options?: {
   return { kind: "srcdoc", html: FRAME_HTML };
 }
 
-function withThemeHint(outputDocumentUrl: string, theme: "light" | "dark" | undefined): string {
-  if (!theme) return outputDocumentUrl;
+function withIsolatedFrameThemeSeed(
+  outputDocumentUrl: string,
+  themeSeed: IsolatedFrameThemeSeed | undefined,
+): string {
+  if (!themeSeed?.theme && !themeSeed?.colorTheme) {
+    return outputDocumentUrl;
+  }
 
   try {
-    const url = new URL(outputDocumentUrl);
-    url.searchParams.set("nteract_theme", theme);
-    return url.href;
+    const isAbsoluteOrProtocolRelative =
+      /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(outputDocumentUrl) || outputDocumentUrl.startsWith("//");
+    const parsed = new URL(outputDocumentUrl, "https://nteract.invalid");
+    if (themeSeed.theme === "light" || themeSeed.theme === "dark") {
+      parsed.searchParams.set("nteract_theme", themeSeed.theme);
+    }
+    if (themeSeed.colorTheme && themeSeed.colorTheme !== "classic") {
+      parsed.searchParams.set("nteract_color_theme", themeSeed.colorTheme);
+    }
+
+    if (isAbsoluteOrProtocolRelative) {
+      return parsed.href;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
   } catch {
-    const hashIndex = outputDocumentUrl.indexOf("#");
-    const beforeHash = hashIndex === -1 ? outputDocumentUrl : outputDocumentUrl.slice(0, hashIndex);
-    const hash = hashIndex === -1 ? "" : outputDocumentUrl.slice(hashIndex);
-    const separator = beforeHash.includes("?") ? "&" : "?";
-    return `${beforeHash}${separator}nteract_theme=${theme}${hash}`;
+    return outputDocumentUrl;
   }
 }

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="background: transparent; color-scheme: dark">
+<html style="background: transparent; color-scheme: light dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,13 +7,35 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https: http://127.0.0.1:*; style-src 'unsafe-inline' https: http://127.0.0.1:*; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *; worker-src 'self' blob:; frame-src 'none'; child-src 'none';"
     />
+    <script>
+      (function () {
+        try {
+          var params = new URLSearchParams(window.location.search);
+          var theme = params.get("nteract_theme");
+          var colorTheme = params.get("nteract_color_theme");
+          var isDark =
+            theme === "dark" ||
+            (theme !== "light" &&
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          var rootEl = document.documentElement;
+          rootEl.classList.add(isDark ? "dark" : "light");
+          rootEl.classList.remove(isDark ? "light" : "dark");
+          rootEl.setAttribute("data-theme", isDark ? "dark" : "light");
+          rootEl.style.colorScheme = isDark ? "dark" : "light";
+          if (colorTheme && colorTheme !== "classic") {
+            rootEl.setAttribute("data-color-theme", colorTheme);
+          }
+        } catch (_) {}
+      })();
+    </script>
     <style>
       :root {
         --bg-primary: transparent;
-        --bg-secondary: #1a1a1a;
-        --text-primary: #e0e0e0;
-        --text-secondary: #a0a0a0;
-        --border-color: #333333;
+        --bg-secondary: #f5f5f5;
+        --text-primary: #1a1a1a;
+        --text-secondary: #666666;
+        --border-color: #e0e0e0;
         --accent-color: #3b82f6;
         --error-color: #ef4444;
         --success-color: #22c55e;
@@ -31,6 +53,15 @@
           system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         --output-mono-font: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
         --output-document-font: var(--output-ui-font);
+      }
+
+      .dark,
+      [data-theme="dark"] {
+        --bg-secondary: #1a1a1a;
+        --text-primary: #e0e0e0;
+        --text-secondary: #a0a0a0;
+        --border-color: #333333;
+        --accent-color: #60a5fa;
       }
 
       [data-color-theme="cream"] {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -331,6 +331,10 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const runtimeRef = useRef<IsolatedFrameRuntime | null>(null);
     const initialContentRef = useRef(initialContent);
+    const initialThemeSeedRef = useRef({
+      theme: darkMode ? ("dark" as const) : ("light" as const),
+      colorTheme: colorTheme ?? null,
+    });
     const applyMeasuredHeightRef = useRef<(contentHeight: number) => void>(() => {});
     const [frameDocument, setFrameDocument] = useState<IsolatedFrameDocument | null>(null);
     // Track iframe ready (bootstrap HTML loaded)
@@ -504,8 +508,6 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     }, [applyMeasuredHeight]);
 
     const resolvedOutputDocumentUrl = outputDocumentUrl ?? hostContext?.nteract?.outputDocumentUrl;
-    const frameDocumentThemeRef = useRef<"light" | "dark">(darkMode ? "dark" : "light");
-    frameDocumentThemeRef.current = darkMode ? "dark" : "light";
 
     // Create frame document on mount. The shared config keeps React, future
     // non-React adapters, and tests on the same source/sandbox contract.
@@ -513,7 +515,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       setFrameDocument(
         createIsolatedFrameDocument({
           outputDocumentUrl: resolvedOutputDocumentUrl,
-          initialTheme: frameDocumentThemeRef.current,
+          themeSeed: initialThemeSeedRef.current,
         }),
       );
     }, [resolvedOutputDocumentUrl]);

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -109,6 +109,10 @@ export function createNteractOutputEmbed(
   const iframe = document.createElement("iframe");
   const documentSource = createIsolatedFrameDocument({
     outputDocumentUrl: options.outputDocumentUrl ?? options.hostContext?.nteract?.outputDocumentUrl,
+    themeSeed: {
+      theme: options.hostContext?.theme ?? null,
+      colorTheme: options.hostContext?.nteract?.colorTheme ?? null,
+    },
   });
   const injectedPlugins = new Set<string>();
   let disposed = false;


### PR DESCRIPTION
## Summary

Finishes and supersedes #2975 on top of current `origin/main`.

- keeps the hosted cloud viewer on the shared `useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY)` path that landed after #2975
- seeds hosted output-document iframes with `nteract_theme` and `nteract_color_theme` URL hints before first paint
- preserves the no-reload iframe theme sync path after bootstrap
- updates focused cloud/isolated-frame tests for the current generated frame HTML output

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-config.test.ts src/components/isolated/__tests__/frame-html.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/output-embed.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-theme.test.ts test/viewer-render-props.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
