### PR TITLE
fix(renderer): suppress KaTeX newline warnings

### DIFF
--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -1,12 +1,14 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
 import { StaticCodeBlock } from "@/components/editor/static-highlight";
+import type { Options as RehypeKatexOptions } from "rehype-katex";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
+import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
@@ -25,6 +27,15 @@ interface MarkdownOutputProps {
    */
   enableCopyCode?: boolean;
 }
+
+const remarkPlugins: NonNullable<ReactMarkdownOptions["remarkPlugins"]> = [remarkGfm, remarkMath];
+const rehypeKatexOptions = {
+  strict: katexStrict,
+} satisfies RehypeKatexOptions;
+const rehypePlugins: NonNullable<ReactMarkdownOptions["rehypePlugins"]> = [
+  [rehypeKatex, rehypeKatexOptions],
+  rehypeRaw,
+];
 
 /**
  * Check if the current window is inside an iframe
@@ -112,9 +123,6 @@ export function MarkdownOutput({
         "Use OutputArea or IsolatedFrame for markdown content.",
     );
   }
-
-  const remarkPlugins = [remarkGfm, remarkMath];
-  const rehypePlugins = [rehypeKatex, rehypeRaw];
 
   return (
     <div data-slot="markdown-output" className={cn("not-prose py-2", className)}>

--- a/src/components/outputs/math-output.tsx
+++ b/src/components/outputs/math-output.tsx
@@ -1,5 +1,6 @@
 import katex from "katex";
 import { useEffect, useRef } from "react";
+import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
@@ -40,6 +41,7 @@ export function MathOutput({ content, className }: MathOutputProps) {
     const { latex, displayMode } = parseLatex(content);
     katex.render(latex, ref.current, {
       displayMode,
+      strict: katexStrict,
       throwOnError: false,
       trust: true,
     });

--- a/src/components/widgets/controls/html-math-widget.tsx
+++ b/src/components/widgets/controls/html-math-widget.tsx
@@ -9,6 +9,7 @@ import "katex/dist/katex.min.css";
 
 import katex from "katex";
 import { Label } from "@/components/ui/label";
+import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import { useWidgetModelValue } from "../widget-store-context";
@@ -20,6 +21,7 @@ function processMath(content: string): string {
     try {
       return katex.renderToString(math.trim(), {
         displayMode: true,
+        strict: katexStrict,
         throwOnError: false,
       });
     } catch {
@@ -32,6 +34,7 @@ function processMath(content: string): string {
     try {
       return katex.renderToString(math.trim(), {
         displayMode: false,
+        strict: katexStrict,
         throwOnError: false,
       });
     } catch {

--- a/src/lib/__tests__/katex-options.test.ts
+++ b/src/lib/__tests__/katex-options.test.ts
@@ -7,9 +7,8 @@ describe("katexStrict", () => {
     vi.restoreAllMocks();
   });
 
-  it("suppresses only display newline strict warnings", () => {
-    expect(katexStrict("newLineInDisplayMode", "", {} as never)).toBe("ignore");
-    expect(katexStrict("htmlExtension", "", {} as never)).toBe("warn");
+  it("uses permissive KaTeX compatibility mode", () => {
+    expect(katexStrict).toBe("ignore");
   });
 
   it("prevents KaTeX from logging display newline warnings", () => {

--- a/src/lib/__tests__/katex-options.test.ts
+++ b/src/lib/__tests__/katex-options.test.ts
@@ -1,0 +1,36 @@
+import katex from "katex";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { katexStrict } from "../katex-options";
+
+describe("katexStrict", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("suppresses only display newline strict warnings", () => {
+    expect(katexStrict("newLineInDisplayMode", "", {} as never)).toBe("ignore");
+    expect(katexStrict("htmlExtension", "", {} as never)).toBe("warn");
+  });
+
+  it("prevents KaTeX from logging display newline warnings", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const element = document.createElement("div");
+
+    katex.render(String.raw`a \\ b`, element, {
+      displayMode: true,
+      throwOnError: false,
+    });
+    expect(
+      warn.mock.calls.some(([message]) => String(message).includes("newLineInDisplayMode")),
+    ).toBe(true);
+
+    warn.mockClear();
+    katex.render(String.raw`a \\ b`, element, {
+      displayMode: true,
+      strict: katexStrict,
+      throwOnError: false,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/katex-options.ts
+++ b/src/lib/katex-options.ts
@@ -1,6 +1,4 @@
-import type { StrictFunction } from "katex";
+import type { KatexOptions } from "katex";
 
-const SUPPRESSED_KATEX_STRICT_CODES = new Set(["newLineInDisplayMode"]);
-
-export const katexStrict: StrictFunction = (errorCode) =>
-  SUPPRESSED_KATEX_STRICT_CODES.has(errorCode) ? "ignore" : "warn";
+// Prefer Jupyter/MathJax-style permissive rendering for user-authored math.
+export const katexStrict = "ignore" satisfies NonNullable<KatexOptions["strict"]>;

--- a/src/lib/katex-options.ts
+++ b/src/lib/katex-options.ts
@@ -1,0 +1,6 @@
+import type { StrictFunction } from "katex";
+
+const SUPPRESSED_KATEX_STRICT_CODES = new Set(["newLineInDisplayMode"]);
+
+export const katexStrict: StrictFunction = (errorCode) =>
+  SUPPRESSED_KATEX_STRICT_CODES.has(errorCode) ? "ignore" : "warn";


### PR DESCRIPTION
## Summary

- add a shared KaTeX option that uses permissive `strict: "ignore"` rendering
- apply it to markdown math, direct `text/latex` outputs, and HTMLMath widgets
- add a regression test proving KaTeX warns by default and stays quiet with the shared option

## Verification

- `pnpm test:run src/lib/__tests__/katex-options.test.ts`
- `pnpm test:run src/components/outputs/__tests__ src/components/widgets/__tests__ src/lib/__tests__/katex-options.test.ts`
- `cargo xtask lint --fix`
- `pnpm test:run`
