### PR TITLE
fix(mcp-app): preview blob output summaries

### DIFF
--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -176,6 +176,36 @@ describe("MCP App structured content adapter", () => {
     ).toBe(true);
   });
 
+  it("keeps richer blob-backed renders selected when an LLM preview is present", async () => {
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "sift-output",
+            output_type: "display_data",
+            data: {
+              "text/llm+plain": "assistant summary",
+              "application/vnd.apache.parquet": "http://localhost:47830/blob/table-hash",
+              "text/plain": "table fallback",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830"),
+    });
+
+    expect(payload).toMatchObject({
+      mimeType: "application/vnd.apache.parquet",
+      data: "http://localhost:47830/blob/table-hash",
+      outputId: "sift-output",
+    });
+    expect(payload.data).not.toBe("assistant summary");
+  });
+
   it("keeps plain and JSON-only MCP App cells collapsed by default", () => {
     expect(
       mcpAppCellHasRichOutput(

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -226,4 +226,42 @@ describe("MCP App structured content adapter", () => {
 
     expect(mcpAppCellPreviewText({ ...cellWithOutputs([]), status: "queued" })).toBe("queued");
   });
+
+  it("uses daemon-provided LLM previews for blob-backed streams and tracebacks", () => {
+    expect(
+      mcpAppCellPreviewText(
+        cellWithOutputs([
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "http://localhost:47830/blob/stream-hash",
+            llm_preview: {
+              head: "line 0\nline 1\n",
+              tail: "line 99\n",
+              total_lines: 100,
+              total_bytes: 50_000,
+            },
+          },
+        ]),
+      ),
+    ).toBe("line 0");
+
+    expect(
+      mcpAppCellPreviewText(
+        cellWithOutputs([
+          {
+            output_type: "error",
+            ename: "RecursionError",
+            evalue: "too deep",
+            traceback: "http://localhost:47830/blob/traceback-hash",
+            llm_preview: {
+              last_frame: "RecursionError: too deep",
+              frames: 200,
+              total_bytes: 8_000,
+            },
+          },
+        ]),
+      ),
+    ).toBe("RecursionError: too deep");
+  });
 });

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -6,12 +6,13 @@ export interface McpAppCellOutput {
   output_type: "stream" | "error" | "display_data" | "execute_result";
   output_id?: string;
   name?: string;
-  text?: string;
+  text?: unknown;
   ename?: string;
   evalue?: string;
   traceback?: string[] | string;
-  data?: Record<string, string>;
+  data?: Record<string, unknown>;
   execution_count?: number | null;
+  llm_preview?: unknown;
 }
 
 export interface McpAppCellData {
@@ -148,11 +149,34 @@ function firstPreviewLine(text: string): string {
   return text.split("\n")[0]?.trim() ?? "";
 }
 
+function stringFromRecord(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function previewFromLlmPreview(preview: unknown): string {
+  if (typeof preview === "string") return firstPreviewLine(preview);
+  if (typeof preview !== "object" || preview === null) return "";
+
+  const record = preview as Record<string, unknown>;
+  return firstPreviewLine(
+    stringFromRecord(record, "last_frame") ??
+      stringFromRecord(record, "head") ??
+      stringFromRecord(record, "tail") ??
+      "",
+  );
+}
+
 export function mcpAppCellPreviewText(cell: McpAppCellData): string {
   for (const output of cell.outputs ?? []) {
     if (output.data?.["text/llm+plain"]) {
       return firstPreviewLine(String(output.data["text/llm+plain"]));
     }
+  }
+
+  for (const output of cell.outputs ?? []) {
+    const preview = previewFromLlmPreview(output.llm_preview);
+    if (preview) return preview;
   }
 
   for (const output of cell.outputs ?? []) {


### PR DESCRIPTION
## Summary

- Teach the shared MCP App structured-content adapter to consume daemon-provided `llm_preview` payloads for collapsed cell previews.
- Prevent blob-backed stream and traceback outputs from collapsing to blob URLs or weaker fallback text when the server already sent a safe summary.
- Keep `text/llm+plain` as the highest-priority preview signal, then use `llm_preview`, then preserve the existing text/plain, stream, error, and status fallbacks.

## Design Notes

This keeps `apps/mcp-app` moving toward a thin MCP Apps host/transport wrapper over the shared isolated renderer. The preview policy now follows structuredContent emitted by `runt-mcp` instead of adding app-local blob fetch or preview parsing logic.

This also lines up with MCP Apps spec direction: the app consumes structured tool results and stays agnostic to transport details beyond resolving shared output manifests.

## Tests

- `pnpm test:run src/components/isolated/__tests__/mcp-app-structured-content.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo test -p runt-mcp structured_`
- `cargo xtask lint --fix`
