### PR TITLE
fix(renderer): preserve MCP size dimensions

### DIFF
--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   MCP_NOTIFICATIONS_MESSAGE,
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
+  MCP_UI_SIZE_CHANGED,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
   NTERACT_THEME,
@@ -58,6 +59,7 @@ function createRuntime(
     onBootstrapReady: vi.fn(),
     onRendererReady: vi.fn(),
     onResize: vi.fn(),
+    onSizeChanged: vi.fn(),
     onRenderComplete: vi.fn(),
     onLinkClick: vi.fn(),
     onMouseDown: vi.fn(),
@@ -132,6 +134,19 @@ describe("IsolatedFrameRuntime", () => {
       "warn",
       "isolated-renderer",
     );
+  });
+
+  it("forwards MCP Apps size-changed dimensions alongside legacy height resize", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime();
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    transport.notificationHandlers.get(MCP_UI_SIZE_CHANGED)?.({ height: 240, width: 640 });
+
+    expect(callbacks.onSizeChanged).toHaveBeenCalledWith({ height: 240, width: 640 });
+    expect(callbacks.onResize).toHaveBeenCalledWith(240);
   });
 
   it("sends host context once per channel for equivalent content", () => {

--- a/src/components/isolated/__tests__/output-embed.test.ts
+++ b/src/components/isolated/__tests__/output-embed.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { createNteractOutputEmbed } from "../output-embed";
 import { ISOLATED_FRAME_SANDBOX_ATTRS } from "../frame-config";
 import {
+  MCP_UI_SIZE_CHANGED,
   NTERACT_INSTALL_RENDERER,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
@@ -142,6 +143,31 @@ describe("createNteractOutputEmbed", () => {
 
     expect(handle.iframe.style.height).toBe("400px");
     expect(onSizeChanged).toHaveBeenCalledWith({ height: 400 });
+
+    handle.dispose();
+  });
+
+  it("preserves MCP Apps size-changed width while applying height policy", () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    const onSizeChanged = vi.fn();
+
+    const handle = createNteractOutputEmbed({
+      target,
+      rendererBundle: { rendererCode: "", rendererCss: "" },
+      autoHeight: false,
+      maxHeight: 400,
+      onSizeChanged,
+    });
+    const frameWindow = handle.iframe.contentWindow!;
+    bootstrapFrame(frameWindow);
+    const transport = MockJsonRpcTransport.instances[0];
+
+    onSizeChanged.mockClear();
+    transport.notificationHandlers.get(MCP_UI_SIZE_CHANGED)?.({ height: 900, width: 614 });
+
+    expect(handle.iframe.style.height).toBe("400px");
+    expect(onSizeChanged).toHaveBeenCalledWith({ height: 400, width: 614 });
 
     handle.dispose();
   });

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -1,7 +1,7 @@
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
 import { isIframeMessage } from "./frame-bridge";
 import { rendererBundleDetails } from "./diagnostics";
-import type { NteractEmbedHostContext } from "./host-context";
+import type { NteractEmbedContainerDimensions, NteractEmbedHostContext } from "./host-context";
 import { JsonRpcTransport } from "./jsonrpc-transport";
 import {
   MCP_NOTIFICATIONS_MESSAGE,
@@ -64,6 +64,7 @@ export interface IsolatedFrameRuntimeCallbacks {
   onBootstrapReady: (event: { isReload: boolean; generation: number }) => void;
   onRendererReady: () => void;
   onResize: (height: number) => void;
+  onSizeChanged?: (size: NteractEmbedContainerDimensions) => void;
   onRenderComplete: (height: number) => void;
   onLinkClick: (url: string, newTab: boolean) => void;
   onMouseDown: () => void;
@@ -118,6 +119,10 @@ function objectRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function optionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function stableHostContextKey(value: unknown): string {
@@ -550,14 +555,22 @@ export class IsolatedFrameRuntime {
       }
     });
     transport.onNotification(MCP_UI_SIZE_CHANGED, (params) => {
-      const p = params as { height?: number; width?: number };
+      const p = params as { height?: unknown; width?: unknown };
+      const height = optionalFiniteNumber(p.height);
+      const width = optionalFiniteNumber(p.width);
+      const size: NteractEmbedContainerDimensions = {};
+      if (height != null) size.height = height;
+      if (width != null) size.width = width;
       this.callbacks.onDiagnostic("size-changed", {
-        height: p.height ?? null,
-        width: p.width ?? null,
+        height: height ?? null,
+        width: width ?? null,
         protocol: "mcp-ui",
       });
-      if (p.height != null) {
-        this.callbacks.onResize(p.height);
+      if (Object.keys(size).length > 0) {
+        this.callbacks.onSizeChanged?.(size);
+      }
+      if (height != null) {
+        this.callbacks.onResize(height);
       }
     });
     transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -152,6 +152,7 @@ export function createNteractOutputEmbed(
       notifyHostContext();
     },
     onResize: (height: number) => applyHeight(height),
+    onSizeChanged: (size: NteractEmbedContainerDimensions) => applySizeChanged(size),
     onRenderComplete: (height: number) => applyHeight(height),
     onLinkClick: (url: string, newTab: boolean) =>
       options.onMessage?.({ type: "link_click", payload: { url, newTab } }),
@@ -182,6 +183,19 @@ export function createNteractOutputEmbed(
     lastHeight = nextHeight;
     iframe.style.height = `${nextHeight}px`;
     options.onSizeChanged?.({ height: nextHeight });
+  }
+
+  function applySizeChanged(size: NteractEmbedContainerDimensions) {
+    const nextSize: NteractEmbedContainerDimensions = { ...size };
+    if (size.height != null) {
+      const nextHeight = clampHeight(size.height, autoHeight, maxHeight);
+      nextSize.height = nextHeight;
+      if (nextHeight !== lastHeight) {
+        lastHeight = nextHeight;
+        iframe.style.height = `${nextHeight}px`;
+      }
+    }
+    options.onSizeChanged?.(nextSize);
   }
 
   function currentHostContext(): NteractEmbedHostContext {


### PR DESCRIPTION
## Summary

- forward MCP Apps `ui/notifications/size-changed` width and height through the shared isolated frame runtime
- keep the existing legacy height resize callback so main-app renderer behavior stays compatible
- have `createNteractOutputEmbed` apply its own height policy while preserving any reported width in `onSizeChanged`

## Design note

This keeps MCP Apps behavior in the shared isolated renderer instead of adding another sizing rule in `apps/mcp-app`. The MCP Apps message carries a dimensions object, but the runtime previously reduced it to `height`; this PR makes the shared embed API reflect the MCP shape while retaining the existing height-only resize path for current callers.

## Verification

- `pnpm test:run src/components/isolated/__tests__/output-embed.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
- `cargo xtask lint --fix`
