### PR TITLE
fix(renderer): segment mixed output frames

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -102,8 +102,15 @@ test.describe("cloud renderer parity harness", () => {
     await openParityHarness(page);
 
     const siftCell = page.locator('[data-cell-id="sift-arrow-output"]');
+    await expect(siftCell).toContainText(cloudOutputParityExpectedMarkers.siftStream);
+    await expect(siftCell).toContainText("Cloud Sift widget progress marker");
     await expect(siftCell.locator('[data-sift-output="true"]')).toBeVisible({ timeout: 60_000 });
-    await expect(siftCell.locator("iframe")).toHaveAttribute(
+    await expect(siftCell.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(1);
+    await expect(siftCell.locator('[data-sift-output="true"] iframe')).toHaveCSS(
+      "pointer-events",
+      "none",
+    );
+    await expect(siftCell.locator('[data-sift-output="true"] iframe')).toHaveAttribute(
       "src",
       /\/output-document\/frame\.html\?nteract_theme=light$/,
     );

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -167,6 +167,21 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
     execution_count: 7,
     outputs: [
       {
+        output_id: "sift-arrow-stdout",
+        output_type: "stream",
+        name: "stdout",
+        text: "Preparing Cloud Sift Arrow fixture\n",
+      },
+      {
+        output_id: "sift-arrow-widget-progress",
+        output_type: "display_data",
+        data: {
+          "application/vnd.jupyter.widget-view+json": { model_id: "cloud-sift-progress" },
+          "text/plain": "Cloud Sift widget progress marker",
+        },
+        metadata: {},
+      },
+      {
         output_id: "sift-arrow-display",
         output_type: "display_data",
         data: {
@@ -193,6 +208,7 @@ export const cloudOutputParityExpectedMarkers = {
   svg: "Cloud SVG marker",
   json: "Cloud JSON marker",
   fallback: "Plain text fallback marker",
+  siftStream: "Preparing Cloud Sift Arrow fixture",
   siftColumn: "score",
 } as const;
 

--- a/apps/notebook/e2e/isolated-rich-output.spec.ts
+++ b/apps/notebook/e2e/isolated-rich-output.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "./helpers";
 
 test.describe("isolated rich output rendering", () => {
-  test("keeps stream text visible when a pandas dataframe renders in the iframe", async ({
+  test("keeps stream text in DOM when a pandas dataframe renders in the iframe", async ({
     page,
   }) => {
     test.setTimeout(180_000);
@@ -43,9 +43,12 @@ test.describe("isolated rich output rendering", () => {
     await executeCell(cell);
     await waitForKernelStatus(page, "idle", 120_000);
 
-    const frame = cell.frameLocator('[data-slot="isolated-frame"]');
+    const outputAreas = cell.locator('[data-slot="output-area"]');
+    await expect(outputAreas).toHaveCount(2, { timeout: 60_000 });
+    await expect(outputAreas.first()).toContainText("stream before", { timeout: 60_000 });
+
+    const frame = outputAreas.nth(1).frameLocator('[data-slot="isolated-frame"]');
     const frameBody = frame.locator("body");
-    await expect(frameBody).toContainText("stream before", { timeout: 60_000 });
     await expect
       .poll(async () => normalizeOutputText(await frameBody.innerText()), { timeout: 60_000 })
       .toMatch(/a\s*#\s*1|b\s*#\s*3|a b 0 1 3 1 2 4/i);

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -25,6 +25,8 @@ The shared runtime work now gives us a cleaner path:
   helpers instead of local protocol copies.
 - Hosted output documents, renderer sidecars, and private blob reads have
   separate origin boundaries; see `hosted-output-origin-isolation.md`.
+- Mixed output lists are segmented by the shared output renderer, not by the
+  cloud viewer; see `output-rendering-segmentation.md`.
 
 ## Decision 1: Durable publish artifacts are snapshot pairs
 

--- a/docs/architecture/output-rendering-segmentation.md
+++ b/docs/architecture/output-rendering-segmentation.md
@@ -1,0 +1,115 @@
+# Output Rendering Segmentation
+
+**Status:** Draft, 2026-05-26.
+
+## Context
+
+Notebook cells can emit a heterogeneous ordered output stream. A realistic cell
+can produce stdout, progress widgets, an output widget, HTML, and a DataFrame
+that renders through Sift. Historically `OutputArea` made an all-or-nothing
+choice: if any output needed iframe isolation, the whole output list rendered
+inside one isolated frame.
+
+That single-frame path preserved order, but it also mixed outputs with different
+interaction contracts:
+
+- stdout/stderr and structured safe outputs do not need an iframe;
+- widget and chart outputs need an iframe that can own pointer and wheel events;
+- document-like HTML/markdown/SVG outputs want page scrolling by default;
+- Sift tables need a click-to-engage frame so the notebook page can scroll
+  through large tables until the user deliberately interacts with the table.
+
+The problem is visible in hosted notebook-cloud and desktop. A Sift DataFrame
+that shares a frame with widget/progress outputs inherits the widget frame's
+focus and wheel behavior, so the table can trap page scroll. Solving this in
+cloud alone would fork renderer behavior and contradict the hosted artifacts ADR:
+cloud should use the shared `ReadOnlyNotebook` / `OutputArea` / isolated-frame
+stack.
+
+Related docs:
+
+- `src/components/isolated/AGENTS.md`
+- `docs/architecture/frontend-sync-bridge.md`
+- `docs/architecture/hosted-notebook-artifacts.md`
+- `docs/architecture/hosted-output-origin-isolation.md`
+
+## Decision: Segment outputs by rendering lane
+
+`OutputArea` owns output segmentation for both desktop and hosted cloud. It
+preserves the original output order, but it may render consecutive outputs in
+separate lane segments when their interaction contracts differ.
+
+The lanes are:
+
+1. **Main DOM lane.** Outputs that are safe for the parent DOM: streams, classic
+   errors/rich tracebacks, plain text, raster images, JSON, audio, and video.
+   These render without an iframe.
+2. **Static isolated lane.** Document-like output that needs sandbox isolation
+   but should not capture page scroll by default, such as markdown, HTML, and
+   SVG. These frames use the existing scroll-passthrough / click-to-engage
+   behavior.
+3. **Interactive isolated lane.** Widgets, output widgets, charts, maps,
+   JavaScript, and unknown rich MIME outputs. These may need iframe-local
+   pointer and wheel handling, and consecutive interactive outputs can share a
+   frame.
+4. **Sift isolated lane.** Each Sift-capable DataFrame output gets its own
+   isolated frame. Sift remains click-to-engage so large tables do not trap
+   notebook page scrolling until the user deliberately focuses the table.
+
+For example, a cell that emits:
+
+```text
+stdout
+stdout
+widget progress
+widget progress update
+output widget
+Sift DataFrame
+```
+
+renders as:
+
+```text
+DOM segment:
+  stdout
+  stdout
+
+Interactive iframe segment:
+  widget progress
+  widget progress update
+  output widget
+
+Sift iframe segment:
+  Sift DataFrame
+```
+
+The segmentation boundary is a rendering concern only. It does not change
+output IDs, output ordering, durable output manifests, renderer plugin
+registration, or notebook sync semantics.
+
+## Invariants
+
+- Shared `OutputArea` owns this behavior; cloud viewer code must not fork a
+  parallel renderer to get different segmentation.
+- Iframe sandbox flags stay unchanged and must continue to omit
+  `allow-same-origin`.
+- Renderer plugins do not learn cloud routes such as `/api/n/:id`; host context
+  and blob resolvers continue to provide URLs.
+- Sift standalone framing must work in both desktop and notebook-cloud.
+- Segmenting must preserve visual order and stable output IDs so renderer
+  updates still target the same logical output.
+
+## Non-Goals
+
+- This ADR does not change the kernel output protocol or RuntimeStateDoc shape.
+- This ADR does not define widget replay or output widget semantics.
+- This ADR does not require every rich output to be isolated separately; only
+  lane changes and Sift outputs force a frame boundary.
+
+## Open Questions
+
+1. Whether static isolated outputs should always be one output per frame or
+   whether consecutive static outputs should continue to share one frame.
+2. Whether Sift should eventually expose a parent-controlled wheel handoff API
+   that lets it share an iframe with other outputs without losing page-scroll
+   ergonomics.

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -296,28 +296,29 @@ function splitOutputSegments(
   return segments;
 }
 
-function shouldSegmentOutputLanes(
+function segmentedOutputLanes(
   outputs: readonly JupyterOutput[],
   isolated: OutputAreaProps["isolated"],
   onToggleCollapse: OutputAreaProps["onToggleCollapse"],
   priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  if (isolated !== "auto") return false;
+): OutputSegment[] {
+  if (isolated !== "auto") return [];
   // The legacy collapse control is output-area scoped. Keep it as a single
   // control until segmentation owns one shared wrapper instead of several
   // sibling OutputAreaSingle wrappers.
-  if (onToggleCollapse) return false;
-  if (outputs.length <= 1) return false;
+  if (onToggleCollapse) return [];
+  if (outputs.length <= 1) return [];
 
-  return splitOutputSegments(outputs, priority).length > 1;
+  const segments = splitOutputSegments(outputs, priority);
+  return segments.length > 1 ? segments : [];
 }
 
 function outputSegmentKey(segment: OutputSegment, index: number): string {
-  return [
-    segment.lane,
-    index,
-    ...segment.outputs.map((output) => output.output_id ?? output.output_type),
-  ].join("\0");
+  const firstOutput = segment.outputs[0];
+  if (firstOutput?.output_id) {
+    return [segment.lane, firstOutput.output_id].join("\0");
+  }
+  return [segment.lane, index, firstOutput?.output_type ?? "empty"].join("\0");
 }
 
 function scrollElementIntoComfortableView(element: HTMLElement | null): boolean {
@@ -559,10 +560,12 @@ export function OutputArea({
   priority = DEFAULT_PRIORITY,
   ...props
 }: OutputAreaProps) {
-  if (shouldSegmentOutputLanes(outputs, isolated, onToggleCollapse, priority)) {
+  const outputSegments = segmentedOutputLanes(outputs, isolated, onToggleCollapse, priority);
+
+  if (outputSegments.length > 0) {
     return (
       <>
-        {splitOutputSegments(outputs, priority).map((segment, index) => (
+        {outputSegments.map((segment, index) => (
           <OutputAreaSingle
             key={outputSegmentKey(segment, index)}
             {...props}

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -261,6 +261,65 @@ function outputUsesSift(
   return false;
 }
 
+interface OutputSegment {
+  lane: "dom" | "static-frame" | "interactive-frame" | "sift-frame";
+  outputs: JupyterOutput[];
+}
+
+function outputSegmentLane(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): OutputSegment["lane"] {
+  if (!outputNeedsIsolation(output, priority)) return "dom";
+  if (outputUsesSift(output, priority)) return "sift-frame";
+  if (outputAllowsScrollPassthrough(output, priority)) return "static-frame";
+  return "interactive-frame";
+}
+
+function splitOutputSegments(
+  outputs: readonly JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): OutputSegment[] {
+  const segments: OutputSegment[] = [];
+
+  for (const output of outputs) {
+    const lane = outputSegmentLane(output, priority);
+    const previous = segments.at(-1);
+
+    if (lane !== "sift-frame" && previous && previous.lane === lane) {
+      previous.outputs.push(output);
+    } else {
+      segments.push({ lane, outputs: [output] });
+    }
+  }
+
+  return segments;
+}
+
+function shouldSegmentOutputLanes(
+  outputs: readonly JupyterOutput[],
+  isolated: OutputAreaProps["isolated"],
+  onToggleCollapse: OutputAreaProps["onToggleCollapse"],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  if (isolated !== "auto") return false;
+  // The legacy collapse control is output-area scoped. Keep it as a single
+  // control until segmentation owns one shared wrapper instead of several
+  // sibling OutputAreaSingle wrappers.
+  if (onToggleCollapse) return false;
+  if (outputs.length <= 1) return false;
+
+  return splitOutputSegments(outputs, priority).length > 1;
+}
+
+function outputSegmentKey(segment: OutputSegment, index: number): string {
+  return [
+    segment.lane,
+    index,
+    ...segment.outputs.map((output) => output.output_id ?? output.output_type),
+  ].join("\0");
+}
+
 function scrollElementIntoComfortableView(element: HTMLElement | null): boolean {
   if (!element || typeof window === "undefined") return false;
 
@@ -303,7 +362,9 @@ function outputNeedsIsolation(
 
 /**
  * Check if any outputs in the array need iframe isolation.
- * If any output needs isolation, ALL outputs should go to the iframe.
+ * For a single render segment, any isolated output makes that segment render
+ * in the iframe. `OutputArea` splits mixed output lists into lane segments
+ * before this check so DOM-safe streams do not have to share widget/Sift frames.
  *
  * Not exported: keeping every `.tsx` export limited to components and
  * hooks lets React Fast Refresh hot-patch this module instead of bailing
@@ -492,6 +553,41 @@ function withTracebackExecutionTargets(
  * ```
  */
 export function OutputArea({
+  outputs,
+  isolated = "auto",
+  onToggleCollapse,
+  priority = DEFAULT_PRIORITY,
+  ...props
+}: OutputAreaProps) {
+  if (shouldSegmentOutputLanes(outputs, isolated, onToggleCollapse, priority)) {
+    return (
+      <>
+        {splitOutputSegments(outputs, priority).map((segment, index) => (
+          <OutputAreaSingle
+            key={outputSegmentKey(segment, index)}
+            {...props}
+            outputs={segment.outputs}
+            isolated="auto"
+            onToggleCollapse={onToggleCollapse}
+            priority={priority}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <OutputAreaSingle
+      {...props}
+      outputs={outputs}
+      isolated={isolated}
+      onToggleCollapse={onToggleCollapse}
+      priority={priority}
+    />
+  );
+}
+
+function OutputAreaSingle({
   outputs,
   cellId,
   executionCount,

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -560,31 +560,57 @@ export function OutputArea({
   priority = DEFAULT_PRIORITY,
   ...props
 }: OutputAreaProps) {
+  const { onSearchMatchCount, preloadIframe = false, ...passthroughProps } = props;
+  const segmentedSearchMatchCountsRef = useRef(new Map<string, number>());
   const outputSegments = segmentedOutputLanes(outputs, isolated, onToggleCollapse, priority);
+  const outputSegmentKeys = outputSegments.map(outputSegmentKey);
 
   if (outputSegments.length > 0) {
     return (
       <>
-        {outputSegments.map((segment, index) => (
-          <OutputAreaSingle
-            key={outputSegmentKey(segment, index)}
-            {...props}
-            outputs={segment.outputs}
-            isolated="auto"
-            onToggleCollapse={onToggleCollapse}
-            priority={priority}
-          />
-        ))}
+        {outputSegments.map((segment, index) => {
+          const segmentKey = outputSegmentKeys[index] ?? outputSegmentKey(segment, index);
+          return (
+            <OutputAreaSingle
+              key={segmentKey}
+              {...passthroughProps}
+              outputs={segment.outputs}
+              isolated="auto"
+              onSearchMatchCount={
+                onSearchMatchCount
+                  ? (count) => {
+                      const counts = segmentedSearchMatchCountsRef.current;
+                      const activeKeys = new Set(outputSegmentKeys);
+                      for (const key of counts.keys()) {
+                        if (!activeKeys.has(key)) counts.delete(key);
+                      }
+                      counts.set(segmentKey, count);
+                      const total = outputSegmentKeys.reduce(
+                        (sum, key) => sum + (counts.get(key) ?? 0),
+                        0,
+                      );
+                      onSearchMatchCount(total);
+                    }
+                  : undefined
+              }
+              onToggleCollapse={onToggleCollapse}
+              preloadIframe={segment.lane === "dom" ? false : preloadIframe}
+              priority={priority}
+            />
+          );
+        })}
       </>
     );
   }
 
   return (
     <OutputAreaSingle
-      {...props}
+      {...passthroughProps}
       outputs={outputs}
       isolated={isolated}
+      onSearchMatchCount={onSearchMatchCount}
       onToggleCollapse={onToggleCollapse}
+      preloadIframe={preloadIframe}
       priority={priority}
     />
   );

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -553,6 +553,40 @@ describe("OutputArea iframe theme sync", () => {
     expect(isolatedFrameMountCount).toBe(1);
   });
 
+  it("aggregates search match counts across segmented output lanes", async () => {
+    const onSearchMatchCount = vi.fn();
+
+    render(
+      <OutputArea
+        outputs={[...makeStreamOutput("foo foo\n"), makeWidgetOutput()]}
+        searchQuery="foo"
+        onSearchMatchCount={onSearchMatchCount}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onSearchMatchCount).toHaveBeenCalledWith(2);
+    });
+
+    lastFrameMessageHandler?.({
+      type: "search_results",
+      payload: { count: 1 },
+    });
+
+    expect(onSearchMatchCount).toHaveBeenLastCalledWith(3);
+  });
+
+  it("does not preload hidden iframes for DOM-only segments", () => {
+    render(
+      <OutputArea
+        outputs={[...makeStreamOutput("stdout one\n"), makeWidgetOutput()]}
+        preloadIframe
+      />,
+    );
+
+    expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
+  });
+
   it("keeps the legacy collapse control scoped to one mixed output area", () => {
     const outputs: JupyterOutput[] = [
       ...makeStreamOutput("stdout one\n"),

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -6,6 +6,7 @@ import { OutputArea, type JupyterOutput } from "../OutputArea";
 let mockDarkMode = false;
 let mockColorTheme: string | undefined;
 let lastFrameMessageHandler: ((message: unknown) => void) | undefined;
+let isolatedFrameMountCount = 0;
 
 const mockFrameHandle = {
   send: vi.fn(),
@@ -50,6 +51,10 @@ vi.mock("@/components/isolated", async () => {
     ref,
   ) {
     React.useImperativeHandle(ref, () => mockFrameHandle);
+
+    React.useEffect(() => {
+      isolatedFrameMountCount += 1;
+    }, []);
 
     React.useEffect(() => {
       onReady?.();
@@ -201,6 +206,7 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.search.mockClear();
     mockFrameHandle.searchNavigate.mockClear();
     lastFrameMessageHandler = undefined;
+    isolatedFrameMountCount = 0;
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
     vi.mocked(needsPlugin).mockReturnValue(false);
   });
@@ -511,6 +517,42 @@ describe("OutputArea iframe theme sync", () => {
     });
   });
 
+  it("keeps an existing segmented iframe mounted when outputs append to its lane", async () => {
+    const stream = makeStreamOutput("stdout one\n");
+    const firstWidget = makeWidgetOutput("widget-progress-1", "model-progress-1");
+    const secondWidget = makeWidgetOutput("widget-progress-2", "model-progress-2");
+    const { rerender } = render(<OutputArea outputs={[...stream, firstWidget]} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "application/vnd.jupyter.widget-view+json",
+          outputId: "widget-progress-1",
+        }),
+      ]);
+    });
+
+    expect(isolatedFrameMountCount).toBe(1);
+
+    rerender(<OutputArea outputs={[...stream, firstWidget, secondWidget]} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "application/vnd.jupyter.widget-view+json",
+          outputId: "widget-progress-1",
+        }),
+        expect.objectContaining({
+          mimeType: "application/vnd.jupyter.widget-view+json",
+          outputId: "widget-progress-2",
+        }),
+      ]);
+    });
+    expect(isolatedFrameMountCount).toBe(1);
+  });
+
   it("keeps the legacy collapse control scoped to one mixed output area", () => {
     const outputs: JupyterOutput[] = [
       ...makeStreamOutput("stdout one\n"),
@@ -546,6 +588,30 @@ describe("OutputArea iframe theme sync", () => {
         }),
       ]);
     });
+  });
+
+  it("forwards traceback navigation messages from isolated outputs", async () => {
+    const onNavigateToTracebackCell = vi.fn();
+    const target = { cellId: "cell-from-traceback", label: "Cell [3]" };
+
+    render(
+      <OutputArea
+        outputs={makeMarkdownOutput()}
+        isolated
+        onNavigateToTracebackCell={onNavigateToTracebackCell}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastFrameMessageHandler).toBeDefined();
+    });
+
+    lastFrameMessageHandler?.({
+      type: "traceback_navigate",
+      payload: { target },
+    });
+
+    expect(onNavigateToTracebackCell).toHaveBeenCalledWith(target);
   });
 
   it("constrains isolated iframe outputs when maxHeight is explicit", () => {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -103,7 +103,19 @@ function makeStreamOutput(text = "hey\n"): JupyterOutput[] {
   ];
 }
 
-function makeMixedIsolatedOutputs(): JupyterOutput[] {
+function makeWidgetOutput(outputId = "widget-output", modelId = "widget-model"): JupyterOutput {
+  return {
+    output_id: outputId,
+    output_type: "display_data",
+    data: {
+      "application/vnd.jupyter.widget-view+json": { model_id: modelId },
+      "text/plain": "Widget fallback",
+    },
+    metadata: {},
+  };
+}
+
+function makeMixedDocumentOutputs(): JupyterOutput[] {
   return [
     {
       output_id: "mixed-stream-output",
@@ -458,20 +470,62 @@ describe("OutputArea iframe theme sync", () => {
     expect(outputContent.style.maxHeight).toBe("");
   });
 
-  it("keeps mixed auto-isolated outputs together in one iframe render batch", async () => {
-    const onNavigateToTracebackCell = vi.fn();
+  it("segments mixed auto outputs into DOM, interactive iframe, and standalone sift iframe lanes", async () => {
+    const outputs: JupyterOutput[] = [
+      ...makeStreamOutput("stdout one\n"),
+      ...makeStreamOutput("stdout two\n"),
+      makeWidgetOutput("widget-progress-1", "model-progress-1"),
+      makeWidgetOutput("widget-progress-2", "model-progress-2"),
+      ...makeParquetOutput(),
+    ];
 
-    render(
-      <OutputArea
-        outputs={makeMixedIsolatedOutputs()}
-        resolveTracebackExecutionTarget={(executionId, sourceHash) =>
-          executionId === "exec-run" && sourceHash === "source-hash-run"
-            ? { cellId: "cell-run", label: "Run Cell" }
-            : null
-        }
-        onNavigateToTracebackCell={onNavigateToTracebackCell}
-      />,
-    );
+    render(<OutputArea outputs={outputs} />);
+
+    expect(screen.getByText(/stdout one/)).toBeInTheDocument();
+    expect(screen.getByText(/stdout two/)).toBeInTheDocument();
+
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(2);
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frames[0].getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
+    expect(frames[1].getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frames[1].getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "application/vnd.jupyter.widget-view+json",
+          outputId: "widget-progress-1",
+        }),
+        expect.objectContaining({
+          mimeType: "application/vnd.jupyter.widget-view+json",
+          outputId: "widget-progress-2",
+        }),
+      ]);
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "application/vnd.apache.parquet",
+          outputId: "parquet-output",
+        }),
+      ]);
+    });
+  });
+
+  it("keeps the legacy collapse control scoped to one mixed output area", () => {
+    const outputs: JupyterOutput[] = [
+      ...makeStreamOutput("stdout one\n"),
+      makeWidgetOutput("widget-progress-1", "model-progress-1"),
+      ...makeParquetOutput(),
+    ];
+
+    render(<OutputArea outputs={outputs} onToggleCollapse={vi.fn()} />);
+
+    expect(screen.getAllByRole("button", { name: "Hide outputs" })).toHaveLength(1);
+    expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
+  });
+
+  it("keeps forced-isolated mixed outputs together when a caller opts out of lane segmentation", async () => {
+    render(<OutputArea outputs={makeMixedDocumentOutputs()} isolated />);
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
@@ -488,31 +542,9 @@ describe("OutputArea iframe theme sync", () => {
         expect.objectContaining({
           mimeType: "application/vnd.nteract.traceback+json",
           data: expect.objectContaining({ ename: "RecursionError" }),
-          metadata: expect.objectContaining({
-            tracebackExecutionTargets: [
-              {
-                execution_id: "exec-run",
-                source_hash: "source-hash-run",
-                target: { cellId: "cell-run", label: "Run Cell" },
-              },
-            ],
-          }),
           outputIndex: 2,
         }),
       ]);
-    });
-
-    expect(screen.queryByText("stream before")).toBeNull();
-    expect(screen.queryByText("RecursionError")).toBeNull();
-
-    lastFrameMessageHandler?.({
-      type: "traceback_navigate",
-      payload: { target: { cellId: "cell-run", label: "Run Cell" } },
-    });
-
-    expect(onNavigateToTracebackCell).toHaveBeenCalledWith({
-      cellId: "cell-run",
-      label: "Run Cell",
     });
   });
 


### PR DESCRIPTION
## Summary

- document the shared output rendering segmentation model for DOM, static isolated, interactive isolated, and Sift lanes
- split `OutputArea` auto-rendered mixed output lists so DOM-safe output stays in-page, widget/chart output remains grouped in an interactive iframe, and each Sift output gets its own click-to-engage frame
- extend notebook-cloud renderer parity coverage with a mixed stream/widget-fallback/Sift fixture so hosted Sift stays standalone without cloud-local renderer forks

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-theme.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook test:e2e:browser -- e2e/isolated-rich-output.spec.ts --project=chromium`
- `cargo xtask lint --fix`
