### PR TITLE
fix(mcp-app): declare display capabilities

### DIFF
--- a/apps/mcp-app/src/__tests__/app-config.test.ts
+++ b/apps/mcp-app/src/__tests__/app-config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { McpUiAppCapabilitiesSchema } from "@modelcontextprotocol/ext-apps";
+import { NTERACT_MCP_APP_CAPABILITIES, NTERACT_MCP_APP_INFO } from "../app-config";
+
+describe("MCP app configuration", () => {
+  it("declares inline display support during ui/initialize", () => {
+    expect(NTERACT_MCP_APP_INFO).toEqual({
+      name: "nteract",
+      version: "0.1.0",
+    });
+    expect(NTERACT_MCP_APP_CAPABILITIES).toEqual({
+      availableDisplayModes: ["inline"],
+    });
+    expect(McpUiAppCapabilitiesSchema.parse(NTERACT_MCP_APP_CAPABILITIES)).toEqual(
+      NTERACT_MCP_APP_CAPABILITIES,
+    );
+  });
+});

--- a/apps/mcp-app/src/app-config.ts
+++ b/apps/mcp-app/src/app-config.ts
@@ -1,0 +1,11 @@
+import type { McpUiAppCapabilities } from "@modelcontextprotocol/ext-apps";
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+
+export const NTERACT_MCP_APP_INFO = {
+  name: "nteract",
+  version: "0.1.0",
+} satisfies Implementation;
+
+export const NTERACT_MCP_APP_CAPABILITIES = {
+  availableDisplayModes: ["inline"],
+} satisfies McpUiAppCapabilities;

--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -14,6 +14,7 @@ import { Cell } from "./components/cell";
 import { SummaryHeader } from "./components/summary-header";
 import { hasRichOutput } from "./lib/rich-output";
 import { errorDetails, hostLog, setHostLogSink } from "./lib/host-log";
+import { NTERACT_MCP_APP_CAPABILITIES, NTERACT_MCP_APP_INFO } from "./app-config";
 
 /**
  * Collapse the widget to 0px when there's nothing to render.
@@ -70,7 +71,7 @@ function McpApp() {
   const [hostContext, setHostContext] = useState<McpUiHostContext | null>(null);
 
   useEffect(() => {
-    const app = new App({ name: "nteract", version: "0.1.0" });
+    const app = new App(NTERACT_MCP_APP_INFO, NTERACT_MCP_APP_CAPABILITIES);
 
     app.ontoolresult = (result: CallToolResult) => {
       const structured = result.structuredContent as NteractContent | undefined;


### PR DESCRIPTION
## Summary

- move the MCP app implementation info and capabilities into a small config module
- pass `availableDisplayModes: ["inline"]` to the MCP Apps `App` constructor so `ui/initialize` advertises the app's display contract
- cover the config with a schema-backed test against `McpUiAppCapabilitiesSchema`

## Design note

The MCP Apps spec requires the View to include `appCapabilities` in `ui/initialize`, and display modes are part of that contract. nteract's MCP app is currently an inline output renderer around the shared isolated renderer, so this keeps `apps/mcp-app` as a thin protocol adapter while making its negotiated capabilities explicit.

## Verification

- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo xtask lint --fix`
