### PR TITLE
refactor(renderer): share daemon asset adapter

### DIFF
--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -1,15 +1,15 @@
 import { useCallback, useMemo } from "react";
 import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { rendererCode, rendererCss } from "virtual:isolated-renderer";
-import { McpAppOutputFrame } from "@/components/isolated/mcp-app-output-frame";
-import type { NteractOutputRendererBundleProvider } from "@/components/isolated/output-embed";
-import type { CellData } from "../types";
-import { errorDetails, hostLog } from "../lib/host-log";
 import {
   createDaemonRendererPluginLoader,
   daemonOutputFrameUrl,
   daemonRendererAssetsBaseUrl,
-} from "../lib/shared-renderer-plugin-loader";
+} from "@/components/isolated/daemon-renderer-assets";
+import { McpAppOutputFrame } from "@/components/isolated/mcp-app-output-frame";
+import type { NteractOutputRendererBundleProvider } from "@/components/isolated/output-embed";
+import type { CellData } from "../types";
+import { errorDetails, hostLog } from "../lib/host-log";
 
 const SHARED_RENDERER_BUNDLE: NteractOutputRendererBundleProvider = {
   rendererCode,

--- a/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
+++ b/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
@@ -1,9 +1,24 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { createDaemonRendererPluginLoader } from "../shared-renderer-plugin-loader";
+import {
+  createDaemonRendererPluginLoader,
+  daemonOutputFrameUrl,
+  daemonRendererAssetsBaseUrl,
+} from "../daemon-renderer-assets";
 
-describe("createDaemonRendererPluginLoader", () => {
+describe("daemon renderer assets", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+  });
+
+  it("builds daemon output frame and plugin asset base URLs from the blob base URL", () => {
+    expect(daemonOutputFrameUrl("http://localhost:47830/")).toBe(
+      "http://localhost:47830/output-frame",
+    );
+    expect(daemonRendererAssetsBaseUrl("http://localhost:47830/")).toBe(
+      "http://localhost:47830/plugins/",
+    );
+    expect(daemonOutputFrameUrl(undefined)).toBeNull();
+    expect(daemonRendererAssetsBaseUrl(undefined)).toBeUndefined();
   });
 
   it("fetches raw renderer plugin assets from the daemon renderer-plugin route", async () => {

--- a/src/components/isolated/daemon-renderer-assets.ts
+++ b/src/components/isolated/daemon-renderer-assets.ts
@@ -1,5 +1,5 @@
-import type { NteractOutputRendererPluginLoader } from "@/components/isolated/output-embed";
-import { rendererPluginInfoForMime } from "@/components/isolated/renderer-plugin-info";
+import type { NteractOutputRendererPluginLoader } from "./output-embed";
+import { rendererPluginInfoForMime } from "./renderer-plugin-info";
 
 declare const __DAEMON_PLUGIN_ASSET_HASHES__: Record<string, string> | undefined;
 
@@ -29,7 +29,7 @@ export function createDaemonRendererPluginLoader(
 ): NteractOutputRendererPluginLoader | undefined {
   if (!blobBaseUrl) return undefined;
 
-  const cache = new Map<string, Promise<{ code: string; css?: string } | undefined>>();
+  const cache = new Map<string, Promise<{ id: string; code: string; css?: string } | undefined>>();
 
   return (mime) => {
     const info = rendererPluginInfoForMime(mime);

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -60,6 +60,11 @@ export { IsolationTest } from "./IsolationTest";
 export type { IsolatedFrameHandle, IsolatedFrameProps } from "./isolated-frame";
 export { IsolatedFrame } from "./isolated-frame";
 export {
+  createDaemonRendererPluginLoader,
+  daemonOutputFrameUrl,
+  daemonRendererAssetsBaseUrl,
+} from "./daemon-renderer-assets";
+export {
   ISOLATED_DIAGNOSTICS_STORAGE_KEY,
   isolatedDebugDiagnosticsEnabled,
   logIsolatedDiagnostic,


### PR DESCRIPTION
## Summary

- move the daemon renderer plugin/output-frame asset adapter into the shared isolated renderer package
- switch the MCP app output bridge to use that shared adapter instead of app-local glue
- move the adapter tests beside the shared renderer code and cover output-frame/base URL handling

## Notes

This does not change MIME selection or blob resolution. Blob-backed rich renderers still flow through `McpAppOutputFrame` and the normal shared renderer plugin path; this only centralizes the daemon asset URL policy used by MCP Apps.

## Tests

- `pnpm exec vp test run src/components/isolated/__tests__/daemon-renderer-assets.test.ts`
- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo xtask lint --fix`
