### PR TITLE
refactor(renderer): share output frame sizing policy

### DIFF
--- a/src/components/isolated/__tests__/output-frame-sizing.test.ts
+++ b/src/components/isolated/__tests__/output-frame-sizing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  outputFrameContainerDimensions,
+  outputFrameDisplayHeight,
+  sameOutputFrameContainerDimensions,
+  undefinedIfEmptyContainerDimensions,
+} from "../output-frame-sizing";
+
+describe("output frame sizing policy", () => {
+  it("grows to measured content when auto height is enabled", () => {
+    expect(outputFrameDisplayHeight(2600.2, { autoHeight: true, maxHeight: 400 })).toBe(2601);
+  });
+
+  it("caps measured content when auto height is disabled", () => {
+    expect(outputFrameDisplayHeight(900, { autoHeight: false, maxHeight: 400 })).toBe(400);
+  });
+
+  it("honors a minimum height for React-managed frames", () => {
+    expect(outputFrameDisplayHeight(4, { autoHeight: false, maxHeight: 400, minHeight: 24 })).toBe(
+      24,
+    );
+  });
+
+  it("advertises width and capped-height policy as host context dimensions", () => {
+    const iframe = document.createElement("iframe");
+    vi.spyOn(iframe, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 321.4,
+      bottom: 0,
+      left: 0,
+      width: 321.4,
+      height: 120,
+      toJSON: () => ({}),
+    });
+
+    expect(
+      outputFrameContainerDimensions(iframe, {
+        autoHeight: false,
+        maxHeight: 640,
+      }),
+    ).toEqual({ width: 321, maxHeight: 640 });
+  });
+
+  it("can preserve IsolatedFrame's undefined empty-dimensions state", () => {
+    expect(undefinedIfEmptyContainerDimensions({})).toBeUndefined();
+    expect(sameOutputFrameContainerDimensions(undefined, {})).toBe(true);
+    expect(sameOutputFrameContainerDimensions({ width: 320 }, { width: 321 })).toBe(false);
+  });
+});

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -87,6 +87,15 @@ export type {
   NteractOutputRendererPlugin,
   NteractOutputRendererPluginLoader,
 } from "./output-embed";
+export {
+  DEFAULT_OUTPUT_FRAME_MAX_HEIGHT,
+  DEFAULT_OUTPUT_FRAME_MIN_HEIGHT,
+  outputFrameContainerDimensions,
+  outputFrameDisplayHeight,
+  sameOutputFrameContainerDimensions,
+  undefinedIfEmptyContainerDimensions,
+} from "./output-frame-sizing";
+export type { OutputFrameSizingPolicy } from "./output-frame-sizing";
 export { McpAppOutputFrame } from "./mcp-app-output-frame";
 export type { McpAppOutputFrameProps } from "./mcp-app-output-frame";
 export {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -19,6 +19,14 @@ import type { NteractEmbedContainerDimensions, NteractEmbedHostContextPatch } fr
 import { createNteractEmbedHostContext, mergeNteractEmbedHostContext } from "./host-context";
 import { IsolatedFrameRuntime } from "./isolated-frame-runtime";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
+import {
+  DEFAULT_OUTPUT_FRAME_MAX_HEIGHT,
+  DEFAULT_OUTPUT_FRAME_MIN_HEIGHT,
+  outputFrameContainerDimensions,
+  outputFrameDisplayHeight,
+  sameOutputFrameContainerDimensions,
+  undefinedIfEmptyContainerDimensions,
+} from "./output-frame-sizing";
 import { scrollFrameWheelBoundary } from "./scroll-boundary";
 
 export interface IsolatedFrameProps {
@@ -231,34 +239,6 @@ export interface IsolatedFrameHandle {
   isIframeReady: boolean;
 }
 
-function iframeContainerDimensions(
-  iframe: HTMLIFrameElement | null,
-  autoHeight: boolean,
-  maxHeight: number,
-): NteractEmbedContainerDimensions | undefined {
-  const dimensions: NteractEmbedContainerDimensions = {};
-  const width = iframe ? Math.round(iframe.getBoundingClientRect().width) : 0;
-  if (width > 0) {
-    dimensions.width = width;
-  }
-  if (!autoHeight && Number.isFinite(maxHeight)) {
-    dimensions.maxHeight = maxHeight;
-  }
-  return Object.keys(dimensions).length > 0 ? dimensions : undefined;
-}
-
-function sameContainerDimensions(
-  a: NteractEmbedContainerDimensions | undefined,
-  b: NteractEmbedContainerDimensions | undefined,
-): boolean {
-  return (
-    (a?.width ?? null) === (b?.width ?? null) &&
-    (a?.maxWidth ?? null) === (b?.maxWidth ?? null) &&
-    (a?.height ?? null) === (b?.height ?? null) &&
-    (a?.maxHeight ?? null) === (b?.maxHeight ?? null)
-  );
-}
-
 /**
  * IsolatedFrame component - Renders untrusted content in a secure iframe.
  *
@@ -302,8 +282,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       colorTheme,
       hostContext,
       outputDocumentUrl,
-      minHeight = 24,
-      maxHeight = 2000,
+      minHeight = DEFAULT_OUTPUT_FRAME_MIN_HEIGHT,
+      maxHeight = DEFAULT_OUTPUT_FRAME_MAX_HEIGHT,
       autoHeight = false,
       className = "",
       allowWheelBoundaryScroll = true,
@@ -416,9 +396,11 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const applyMeasuredHeight = useCallback(
       (contentHeight: number) => {
         measuredHeightRef.current = contentHeight;
-        const newHeight = autoHeight
-          ? Math.max(minHeight, contentHeight)
-          : Math.max(minHeight, Math.min(maxHeight, contentHeight));
+        const newHeight = outputFrameDisplayHeight(contentHeight, {
+          autoHeight,
+          maxHeight,
+          minHeight,
+        });
         if (displayHeightRef.current === newHeight) {
           return;
         }
@@ -525,8 +507,12 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       if (!iframe) return;
 
       const updateContainerDimensions = () => {
-        const next = iframeContainerDimensions(iframe, autoHeight, maxHeight);
-        setContainerDimensions((prev) => (sameContainerDimensions(prev, next) ? prev : next));
+        const next = undefinedIfEmptyContainerDimensions(
+          outputFrameContainerDimensions(iframe, { autoHeight, maxHeight, minHeight }),
+        );
+        setContainerDimensions((prev) =>
+          sameOutputFrameContainerDimensions(prev, next) ? prev : next,
+        );
       };
 
       updateContainerDimensions();
@@ -540,7 +526,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         observer?.disconnect();
         window.removeEventListener("resize", updateContainerDimensions);
       };
-    }, [autoHeight, frameDocument, maxHeight]);
+    }, [autoHeight, frameDocument, maxHeight, minHeight]);
 
     const resolvedHostContext = useMemo(
       () =>

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -17,6 +17,11 @@ import {
   type IsolatedFrameRuntimeDiagnosticLevel,
 } from "./isolated-frame-runtime";
 import {
+  DEFAULT_OUTPUT_FRAME_MAX_HEIGHT,
+  outputFrameContainerDimensions,
+  outputFrameDisplayHeight,
+} from "./output-frame-sizing";
+import {
   resolveEmbeddableOutputs,
   type NteractEmbeddableOutput,
   type ResolveEmbeddableOutputsOptions,
@@ -75,25 +80,7 @@ export interface NteractOutputEmbedHandle {
   dispose(): void;
 }
 
-const DEFAULT_MAX_HEIGHT = 2000;
 let frameCounter = 0;
-
-function clampHeight(height: number, autoHeight: boolean, maxHeight: number): number {
-  const rounded = Math.max(1, Math.ceil(height));
-  return autoHeight ? rounded : Math.min(maxHeight, rounded);
-}
-
-function containerDimensions(
-  iframe: HTMLIFrameElement,
-  autoHeight: boolean,
-  maxHeight: number,
-): NteractEmbedContainerDimensions {
-  const rect = iframe.getBoundingClientRect();
-  const dimensions: NteractEmbedContainerDimensions = {};
-  if (rect.width > 0) dimensions.width = Math.round(rect.width);
-  if (!autoHeight && Number.isFinite(maxHeight)) dimensions.maxHeight = maxHeight;
-  return dimensions;
-}
 
 function isBundleProvider(
   provider: NteractOutputRendererBundleProvider,
@@ -105,7 +92,7 @@ export function createNteractOutputEmbed(
   options: NteractOutputEmbedOptions,
 ): NteractOutputEmbedHandle {
   const autoHeight = options.autoHeight ?? true;
-  const maxHeight = options.maxHeight ?? DEFAULT_MAX_HEIGHT;
+  const maxHeight = options.maxHeight ?? DEFAULT_OUTPUT_FRAME_MAX_HEIGHT;
   const iframe = document.createElement("iframe");
   const documentSource = createIsolatedFrameDocument({
     outputDocumentUrl: options.outputDocumentUrl ?? options.hostContext?.nteract?.outputDocumentUrl,
@@ -178,7 +165,7 @@ export function createNteractOutputEmbed(
   runtime.activate();
 
   function applyHeight(height: number) {
-    const nextHeight = clampHeight(height, autoHeight, maxHeight);
+    const nextHeight = outputFrameDisplayHeight(height, { autoHeight, maxHeight });
     if (nextHeight === lastHeight) return;
     lastHeight = nextHeight;
     iframe.style.height = `${nextHeight}px`;
@@ -188,7 +175,7 @@ export function createNteractOutputEmbed(
   function applySizeChanged(size: NteractEmbedContainerDimensions) {
     const nextSize: NteractEmbedContainerDimensions = { ...size };
     if (size.height != null) {
-      const nextHeight = clampHeight(size.height, autoHeight, maxHeight);
+      const nextHeight = outputFrameDisplayHeight(size.height, { autoHeight, maxHeight });
       nextSize.height = nextHeight;
       if (nextHeight !== lastHeight) {
         lastHeight = nextHeight;
@@ -204,7 +191,7 @@ export function createNteractOutputEmbed(
       createNteractEmbedHostContext({
         isDark,
         colorTheme: hostContextPatch.nteract?.colorTheme,
-        containerDimensions: containerDimensions(iframe, autoHeight, maxHeight),
+        containerDimensions: outputFrameContainerDimensions(iframe, { autoHeight, maxHeight }),
       }),
       hostContextPatch,
     );

--- a/src/components/isolated/output-frame-sizing.ts
+++ b/src/components/isolated/output-frame-sizing.ts
@@ -1,0 +1,51 @@
+import type { NteractEmbedContainerDimensions } from "./host-context";
+
+export const DEFAULT_OUTPUT_FRAME_MAX_HEIGHT = 2000;
+export const DEFAULT_OUTPUT_FRAME_MIN_HEIGHT = 24;
+
+export interface OutputFrameSizingPolicy {
+  autoHeight: boolean;
+  maxHeight: number;
+  minHeight?: number;
+}
+
+export function outputFrameDisplayHeight(
+  contentHeight: number,
+  { autoHeight, maxHeight, minHeight = 1 }: OutputFrameSizingPolicy,
+): number {
+  const measuredHeight = Math.max(minHeight, Math.ceil(contentHeight));
+  return autoHeight ? measuredHeight : Math.min(maxHeight, measuredHeight);
+}
+
+export function outputFrameContainerDimensions(
+  iframe: HTMLIFrameElement | null,
+  { autoHeight, maxHeight }: OutputFrameSizingPolicy,
+): NteractEmbedContainerDimensions {
+  const dimensions: NteractEmbedContainerDimensions = {};
+  const width = iframe ? Math.round(iframe.getBoundingClientRect().width) : 0;
+  if (width > 0) {
+    dimensions.width = width;
+  }
+  if (!autoHeight && Number.isFinite(maxHeight)) {
+    dimensions.maxHeight = maxHeight;
+  }
+  return dimensions;
+}
+
+export function undefinedIfEmptyContainerDimensions(
+  dimensions: NteractEmbedContainerDimensions,
+): NteractEmbedContainerDimensions | undefined {
+  return Object.keys(dimensions).length > 0 ? dimensions : undefined;
+}
+
+export function sameOutputFrameContainerDimensions(
+  a: NteractEmbedContainerDimensions | undefined,
+  b: NteractEmbedContainerDimensions | undefined,
+): boolean {
+  return (
+    (a?.width ?? null) === (b?.width ?? null) &&
+    (a?.maxWidth ?? null) === (b?.maxWidth ?? null) &&
+    (a?.height ?? null) === (b?.height ?? null) &&
+    (a?.maxHeight ?? null) === (b?.maxHeight ?? null)
+  );
+}


### PR DESCRIPTION
## Summary

- add a shared output-frame sizing policy for isolated renderer iframes
- switch both the React `IsolatedFrame` path and the MCP Apps `createNteractOutputEmbed` path to use the shared height/container-dimensions helpers
- cover the shared policy with focused tests for auto-height, max-height, min-height, and host-context dimensions

## Spec / design note

The MCP Apps spec treats `HostContext.containerDimensions` and `ui/notifications/size-changed` as the contract between a host iframe and the view. nteract has two host-side iframe adapters today: the main in-app `IsolatedFrame` and the MCP Apps embed adapter. This slice keeps their public behavior the same while moving the duplicated height cap and container-dimension policy into one shared module, making `apps/mcp-app` one step closer to a thin transport/host adapter over the shared isolated renderer.

Sandboxing is unchanged. Both paths still use the shared isolated-frame sandbox configuration, which intentionally excludes `allow-same-origin`.

## Verification

- `pnpm exec vp test run src/components/isolated/__tests__/output-frame-sizing.test.ts src/components/isolated/__tests__/output-embed.test.ts src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
- `pnpm exec vp test run src/components/isolated/__tests__`
- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo xtask lint --fix`
