### PR TITLE
fix(notebook-cloud): seed viewer theme before stylesheet

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -51,6 +51,7 @@ import {
   type PendingNotebookInviteRow,
 } from "./sharing-storage.ts";
 import { normalizeInviteEmail, normalizeProviderHint } from "./sharing.ts";
+import { viewerThemeBootstrapScript } from "./viewer-theme-bootstrap.ts";
 
 export { NotebookRoom };
 
@@ -1774,6 +1775,7 @@ function viewer(notebookId: string, env: Env, headsHash?: string): Response {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>nteract cloud notebook ${title}</title>
+  <script>${viewerThemeBootstrapScript()}</script>
   <link rel="stylesheet" href="/assets/notebook-cloud-viewer.css" />
 </head>
 <body>

--- a/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
+++ b/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
@@ -1,0 +1,18 @@
+export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
+
+export function viewerThemeBootstrapScript(): string {
+  return `(() => {
+  let stored;
+  try {
+    stored = window.localStorage?.getItem(${JSON.stringify(CLOUD_VIEWER_THEME_STORAGE_KEY)});
+  } catch {}
+  const theme = stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+  const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  const resolved = theme === "system" ? (prefersDark ? "dark" : "light") : theme;
+  const root = document.documentElement;
+  root.classList.toggle("dark", resolved === "dark");
+  root.classList.toggle("light", resolved === "light");
+  root.dataset.theme = resolved;
+  root.style.colorScheme = resolved;
+})();`;
+}

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import worker, { escapeHtml, scriptJsonForHtml } from "../src/index.ts";
 import type { DurableObjectNamespace, Env, ExecutionContext } from "../src/cloudflare-types.ts";
+import { viewerThemeBootstrapScript } from "../src/viewer-theme-bootstrap.ts";
 
 describe("HTML script serialization", () => {
   it("escapes text and attribute metacharacters", () => {
@@ -52,6 +53,11 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.ok(
+      html.indexOf(viewerThemeBootstrapScript()) <
+        html.indexOf("/assets/notebook-cloud-viewer.css"),
+      "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
+    );
     assert.match(html, /"renderEndpoint":"\/api\/n\/demo\/renders\/heads-123"/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -1,10 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import vm from "node:vm";
 import {
   CLOUD_VIEWER_THEME_STORAGE_KEY,
   resolveCloudViewerTheme,
   storedCloudViewerTheme,
 } from "../viewer/theme.ts";
+import { viewerThemeBootstrapScript } from "../src/viewer-theme-bootstrap.ts";
 
 describe("cloud viewer theme helpers", () => {
   it("uses the cloud-specific storage key", () => {
@@ -28,6 +30,22 @@ describe("cloud viewer theme helpers", () => {
     assert.equal(storedCloudViewerTheme(storageLike(storage)), "system");
     assert.equal(storedCloudViewerTheme(undefined), "system");
   });
+
+  it("seeds the saved light theme before CSS can apply system dark fallback", () => {
+    const result = runBootstrapTheme({ storedTheme: "light", systemPrefersDark: true });
+
+    assert.equal(result.datasetTheme, "light");
+    assert.equal(result.colorScheme, "light");
+    assert.deepEqual(result.classes, ["light"]);
+  });
+
+  it("falls back to system theme when no explicit stored theme is available", () => {
+    const result = runBootstrapTheme({ storedTheme: "invalid", systemPrefersDark: true });
+
+    assert.equal(result.datasetTheme, "dark");
+    assert.equal(result.colorScheme, "dark");
+    assert.deepEqual(result.classes, ["dark"]);
+  });
 });
 
 function storageLike(values: Map<string, string>): Pick<Storage, "getItem"> {
@@ -35,5 +53,50 @@ function storageLike(values: Map<string, string>): Pick<Storage, "getItem"> {
     getItem(key: string): string | null {
       return values.get(key) ?? null;
     },
+  };
+}
+
+function runBootstrapTheme({
+  storedTheme,
+  systemPrefersDark,
+}: {
+  storedTheme: string | null;
+  systemPrefersDark: boolean;
+}): { classes: string[]; datasetTheme: string | undefined; colorScheme: string | undefined } {
+  const classes = new Set<string>();
+  const root = {
+    classList: {
+      toggle(name: string, enabled: boolean): void {
+        if (enabled) {
+          classes.add(name);
+        } else {
+          classes.delete(name);
+        }
+      },
+    },
+    dataset: {} as { theme?: string },
+    style: {} as { colorScheme?: string },
+  };
+
+  vm.runInNewContext(viewerThemeBootstrapScript(), {
+    document: { documentElement: root },
+    window: {
+      localStorage: {
+        getItem(key: string): string | null {
+          assert.equal(key, CLOUD_VIEWER_THEME_STORAGE_KEY);
+          return storedTheme;
+        },
+      },
+      matchMedia(query: string): { matches: boolean } {
+        assert.equal(query, "(prefers-color-scheme: dark)");
+        return { matches: systemPrefersDark };
+      },
+    },
+  });
+
+  return {
+    classes: Array.from(classes).sort(),
+    datasetTheme: root.dataset.theme,
+    colorScheme: root.style.colorScheme,
   };
 }

--- a/apps/notebook-cloud/viewer/theme.ts
+++ b/apps/notebook-cloud/viewer/theme.ts
@@ -1,7 +1,8 @@
+import { CLOUD_VIEWER_THEME_STORAGE_KEY } from "../src/viewer-theme-bootstrap.ts";
+export { CLOUD_VIEWER_THEME_STORAGE_KEY } from "../src/viewer-theme-bootstrap.ts";
+
 export type CloudViewerThemeMode = "light" | "dark" | "system";
 export type ResolvedCloudViewerTheme = "light" | "dark";
-
-export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
 
 export function storedCloudViewerTheme(
   storage: Pick<Storage, "getItem"> | undefined = browserLocalStorage(),


### PR DESCRIPTION
## Summary

- seed the hosted cloud viewer theme in the Worker HTML shell before the stylesheet loads
- share the cloud viewer theme storage key between the Worker bootstrap and the React viewer helper
- cover the saved-light-on-dark-system first-paint case and assert the bootstrap script precedes the CSS link

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/viewer-theme.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`

## Notes

- This does not loosen iframe sandboxing or CSP. The viewer page already omits `script-src` because the sandboxed renderer bootstrap still inherits parent CSP.
- The change is intentionally cloud shell only; shared renderer behavior is unchanged.
