### PR TITLE
fix(mcp-app): apply host container dimensions

### DIFF
--- a/apps/mcp-app/src/lib/__tests__/host-document-context.test.ts
+++ b/apps/mcp-app/src/lib/__tests__/host-document-context.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  applyMcpAppContainerDimensions,
+  applyMcpAppHostDocumentContext,
+} from "../host-document-context";
+
+function rootElement() {
+  return document.createElement("html");
+}
+
+describe("MCP app host document context", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.cssText = "";
+  });
+
+  it("maps fixed host container dimensions to viewport-filling root styles", () => {
+    const root = rootElement();
+
+    applyMcpAppContainerDimensions({ height: 320, width: 640 }, root);
+
+    expect(root.style.height).toBe("100vh");
+    expect(root.style.width).toBe("100vw");
+    expect(root.style.maxHeight).toBe("");
+    expect(root.style.maxWidth).toBe("");
+  });
+
+  it("maps flexible host container dimensions to root max constraints", () => {
+    const root = rootElement();
+
+    applyMcpAppContainerDimensions({ maxHeight: 480, maxWidth: 720 }, root);
+
+    expect(root.style.maxHeight).toBe("480px");
+    expect(root.style.maxWidth).toBe("720px");
+    expect(root.style.height).toBe("");
+    expect(root.style.width).toBe("");
+  });
+
+  it("clears stale dimension styles when host dimensions become unbounded", () => {
+    const root = rootElement();
+    root.style.height = "100vh";
+    root.style.maxHeight = "400px";
+    root.style.width = "100vw";
+    root.style.maxWidth = "600px";
+
+    applyMcpAppContainerDimensions(undefined, root);
+
+    expect(root.style.height).toBe("");
+    expect(root.style.maxHeight).toBe("");
+    expect(root.style.width).toBe("");
+    expect(root.style.maxWidth).toBe("");
+  });
+
+  it("applies host theme, style variables, and container dimensions together", () => {
+    const root = document.documentElement;
+
+    applyMcpAppHostDocumentContext(
+      {
+        theme: "dark",
+        styles: {
+          variables: {
+            "--color-text-primary": "rgb(1, 2, 3)",
+          },
+        },
+        containerDimensions: {
+          maxHeight: 512,
+          width: 900,
+        },
+      },
+      root,
+    );
+
+    expect(root.getAttribute("data-theme")).toBe("dark");
+    expect(root.style.colorScheme).toBe("dark");
+    expect(root.style.getPropertyValue("--color-text-primary")).toBe("rgb(1, 2, 3)");
+    expect(root.style.maxHeight).toBe("512px");
+    expect(root.style.width).toBe("100vw");
+  });
+});

--- a/apps/mcp-app/src/lib/host-document-context.ts
+++ b/apps/mcp-app/src/lib/host-document-context.ts
@@ -1,0 +1,64 @@
+import {
+  applyDocumentTheme,
+  applyHostFonts,
+  applyHostStyleVariables,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
+
+type ContainerDimensions = NonNullable<McpUiHostContext["containerDimensions"]>;
+
+function finiteDimension(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function dimensionValue(
+  dimensions: ContainerDimensions | undefined,
+  key: string,
+): number | undefined {
+  if (!dimensions || typeof dimensions !== "object") return undefined;
+  return finiteDimension((dimensions as Record<string, unknown>)[key]);
+}
+
+export function applyMcpAppContainerDimensions(
+  dimensions: ContainerDimensions | undefined,
+  root: HTMLElement = document.documentElement,
+) {
+  const height = dimensionValue(dimensions, "height");
+  const maxHeight = dimensionValue(dimensions, "maxHeight");
+  const width = dimensionValue(dimensions, "width");
+  const maxWidth = dimensionValue(dimensions, "maxWidth");
+
+  if (height !== undefined) {
+    root.style.height = "100vh";
+    root.style.removeProperty("max-height");
+  } else if (maxHeight !== undefined) {
+    root.style.maxHeight = `${maxHeight}px`;
+    root.style.removeProperty("height");
+  } else {
+    root.style.removeProperty("height");
+    root.style.removeProperty("max-height");
+  }
+
+  if (width !== undefined) {
+    root.style.width = "100vw";
+    root.style.removeProperty("max-width");
+  } else if (maxWidth !== undefined) {
+    root.style.maxWidth = `${maxWidth}px`;
+    root.style.removeProperty("width");
+  } else {
+    root.style.removeProperty("width");
+    root.style.removeProperty("max-width");
+  }
+}
+
+export function applyMcpAppHostDocumentContext(
+  hostContext: McpUiHostContext | null | undefined,
+  root: HTMLElement = document.documentElement,
+) {
+  if (!hostContext) return;
+
+  if (hostContext.theme) applyDocumentTheme(hostContext.theme);
+  if (hostContext.styles?.variables) applyHostStyleVariables(hostContext.styles.variables, root);
+  if (hostContext.styles?.css?.fonts) applyHostFonts(hostContext.styles.css.fonts);
+  applyMcpAppContainerDimensions(hostContext.containerDimensions, root);
+}

--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -1,13 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, useState } from "react";
 import "./style.css";
-import {
-  App,
-  applyDocumentTheme,
-  applyHostStyleVariables,
-  applyHostFonts,
-  type McpUiHostContext,
-} from "@modelcontextprotocol/ext-apps";
+import { App, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { NteractContent } from "./types";
 import { Cell } from "./components/cell";
@@ -15,6 +9,7 @@ import { SummaryHeader } from "./components/summary-header";
 import { hasRichOutput } from "./lib/rich-output";
 import { errorDetails, hostLog, setHostLogSink } from "./lib/host-log";
 import { NTERACT_MCP_APP_CAPABILITIES, NTERACT_MCP_APP_INFO } from "./app-config";
+import { applyMcpAppHostDocumentContext } from "./lib/host-document-context";
 
 /**
  * Collapse the widget to 0px when there's nothing to render.
@@ -89,10 +84,9 @@ function McpApp() {
     };
 
     app.onhostcontextchanged = (ctx: McpUiHostContext) => {
-      setHostContext(app.getHostContext() ?? ctx);
-      if (ctx.theme) applyDocumentTheme(ctx.theme);
-      if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
-      if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+      const nextContext = app.getHostContext() ?? ctx;
+      setHostContext(nextContext);
+      applyMcpAppHostDocumentContext(nextContext);
     };
 
     app.onerror = (error) => {
@@ -117,9 +111,7 @@ function McpApp() {
           displayMode: ctx?.displayMode,
           containerDimensions: ctx?.containerDimensions,
         });
-        if (ctx?.theme) applyDocumentTheme(ctx.theme);
-        if (ctx?.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
-        if (ctx?.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+        applyMcpAppHostDocumentContext(ctx);
         setHostContext(ctx ?? null);
       })
       .catch((error) => {


### PR DESCRIPTION
## Summary

- add an MCP app document-context adapter that applies host theme, styles, fonts, and container dimensions in one place
- map fixed `HostContext.containerDimensions` to viewport-filling root styles and flexible dimensions to root max constraints
- use the SDK-merged host context for host-context-change notifications so partial updates do not accidentally drop existing host fields

## Context

The MCP Apps spec says `HostContext.containerDimensions` describes the iframe/container holding the app: fixed dimensions should fill the available viewport, while max dimensions should constrain shrink-wrapped content. This PR applies that behavior to the outer nteract MCP app document. Nested shared output frames still compute their own dimensions and do not reuse the outer app container dimensions.

## Tests

- `pnpm --dir apps/mcp-app exec vp test run src/lib/__tests__/host-document-context.test.ts src/__tests__/app-config.test.ts src/lib/__tests__/host-log.test.ts`
- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo xtask lint --fix`
