### PR TITLE
refactor(renderer): share output lane policy

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -12,12 +12,18 @@ import {
   useState,
 } from "react";
 import {
+  anyOutputNeedsIsolation,
   CommBridgeManager,
+  hasWidgetOutputs,
   type IframeToParentMessage,
   IsolatedFrame,
   type IsolatedDiagnosticHandler,
   type IsolatedFrameHandle,
+  outputAllowsScrollPassthrough,
+  type OutputSegment,
+  outputUsesSift,
   type RenderPayload,
+  segmentedOutputLanes,
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
@@ -26,9 +32,7 @@ import {
   type IdentifiedJupyterOutput,
 } from "@/components/isolated/output-payloads";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
-import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
-import { selectMimeType } from "@/components/outputs/mime-priority";
 import {
   TracebackOutput,
   type TracebackCellTarget,
@@ -211,108 +215,6 @@ function normalizeText(text: string | string[]): string {
   return Array.isArray(text) ? text.join("") : text;
 }
 
-function isScrollPassthroughMimeType(mimeType: string): boolean {
-  // Static document-like outputs (markdown / HTML / SVG) and sift's
-  // interactive tables (parquet / arrow stream) all behave better as
-  // click-to-engage: the page wheels through them by default;
-  // pointer-down on the wrapper hands events back to the iframe so
-  // sift's column drag, sort, and internal scroll work; pointer-out
-  // releases. Without sift on this list the iframe traps every wheel
-  // gesture that crosses its 600px box.
-  return (
-    mimeType === "text/markdown" ||
-    mimeType === "text/html" ||
-    mimeType === "image/svg+xml" ||
-    mimeType === "application/vnd.apache.parquet" ||
-    mimeType === "application/vnd.apache.arrow.stream" ||
-    mimeType === "application/vnd.nteract.arrow-stream-manifest+json"
-  );
-}
-
-function isSiftMimeType(mimeType: string): boolean {
-  return (
-    mimeType === "application/vnd.apache.parquet" ||
-    mimeType === "application/vnd.apache.arrow.stream" ||
-    mimeType === "application/vnd.nteract.arrow-stream-manifest+json"
-  );
-}
-
-function outputAllowsScrollPassthrough(
-  output: JupyterOutput,
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  if (output.output_type === "execute_result" || output.output_type === "display_data") {
-    const mimeType = selectMimeType(output.data, priority);
-    return mimeType != null && isScrollPassthroughMimeType(mimeType);
-  }
-
-  return true;
-}
-
-function outputUsesSift(
-  output: JupyterOutput,
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  if (output.output_type === "execute_result" || output.output_type === "display_data") {
-    const mimeType = selectMimeType(output.data, priority);
-    return mimeType != null && isSiftMimeType(mimeType);
-  }
-
-  return false;
-}
-
-interface OutputSegment {
-  lane: "dom" | "static-frame" | "interactive-frame" | "sift-frame";
-  outputs: JupyterOutput[];
-}
-
-function outputSegmentLane(
-  output: JupyterOutput,
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): OutputSegment["lane"] {
-  if (!outputNeedsIsolation(output, priority)) return "dom";
-  if (outputUsesSift(output, priority)) return "sift-frame";
-  if (outputAllowsScrollPassthrough(output, priority)) return "static-frame";
-  return "interactive-frame";
-}
-
-function splitOutputSegments(
-  outputs: readonly JupyterOutput[],
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): OutputSegment[] {
-  const segments: OutputSegment[] = [];
-
-  for (const output of outputs) {
-    const lane = outputSegmentLane(output, priority);
-    const previous = segments.at(-1);
-
-    if (lane !== "sift-frame" && previous && previous.lane === lane) {
-      previous.outputs.push(output);
-    } else {
-      segments.push({ lane, outputs: [output] });
-    }
-  }
-
-  return segments;
-}
-
-function segmentedOutputLanes(
-  outputs: readonly JupyterOutput[],
-  isolated: OutputAreaProps["isolated"],
-  onToggleCollapse: OutputAreaProps["onToggleCollapse"],
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): OutputSegment[] {
-  if (isolated !== "auto") return [];
-  // The legacy collapse control is output-area scoped. Keep it as a single
-  // control until segmentation owns one shared wrapper instead of several
-  // sibling OutputAreaSingle wrappers.
-  if (onToggleCollapse) return [];
-  if (outputs.length <= 1) return [];
-
-  const segments = splitOutputSegments(outputs, priority);
-  return segments.length > 1 ? segments : [];
-}
-
 function outputSegmentKey(segment: OutputSegment, index: number): string {
   const firstOutput = segment.outputs[0];
   if (firstOutput?.output_id) {
@@ -343,55 +245,6 @@ function scrollElementIntoComfortableView(element: HTMLElement | null): boolean 
 
   window.scrollBy({ top, behavior: "auto" });
   return true;
-}
-
-/**
- * Check if a single output needs iframe isolation.
- * Uses the safe-list: anything not explicitly safe defaults to isolation.
- */
-function outputNeedsIsolation(
-  output: JupyterOutput,
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  if (output.output_type === "execute_result" || output.output_type === "display_data") {
-    const mimeType = selectMimeType(output.data, priority);
-    return mimeType ? !isSafeForMainDom(mimeType) : false;
-  }
-  // stream and error outputs don't need isolation
-  return false;
-}
-
-/**
- * Check if any outputs in the array need iframe isolation.
- * For a single render segment, any isolated output makes that segment render
- * in the iframe. `OutputArea` splits mixed output lists into lane segments
- * before this check so DOM-safe streams do not have to share widget/Sift frames.
- *
- * Not exported: keeping every `.tsx` export limited to components and
- * hooks lets React Fast Refresh hot-patch this module instead of bailing
- * to a full reload on every edit.
- */
-function anyOutputNeedsIsolation(
-  outputs: JupyterOutput[],
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  return outputs.some((output) => outputNeedsIsolation(output, priority));
-}
-
-/**
- * Check if outputs contain any widget MIME types.
- */
-function hasWidgetOutputs(
-  outputs: JupyterOutput[],
-  priority: readonly string[] = DEFAULT_PRIORITY,
-): boolean {
-  return outputs.some((output) => {
-    if (output.output_type === "execute_result" || output.output_type === "display_data") {
-      const mimeType = selectMimeType(output.data, priority);
-      return mimeType === "application/vnd.jupyter.widget-view+json";
-    }
-    return false;
-  });
 }
 
 function requireIdentifiedOutputs(outputs: JupyterOutput[]): IdentifiedJupyterOutput[] {
@@ -562,7 +415,11 @@ export function OutputArea({
 }: OutputAreaProps) {
   const { onSearchMatchCount, preloadIframe = false, ...passthroughProps } = props;
   const segmentedSearchMatchCountsRef = useRef(new Map<string, number>());
-  const outputSegments = segmentedOutputLanes(outputs, isolated, onToggleCollapse, priority);
+  const outputSegments = segmentedOutputLanes(outputs, {
+    isolated,
+    hasCollapseControl: onToggleCollapse !== undefined,
+    priority,
+  });
   const outputSegmentKeys = outputSegments.map(outputSegmentKey);
 
   if (outputSegments.length > 0) {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -33,7 +33,8 @@ vi.mock("@/components/isolated/iframe-libraries", () => ({
   needsPlugin: vi.fn(() => false),
 }));
 
-vi.mock("@/components/isolated", async () => {
+vi.mock("@/components/isolated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/isolated")>();
   const React = await import("react");
 
   const MockIsolatedFrame = React.forwardRef<
@@ -81,6 +82,7 @@ vi.mock("@/components/isolated", async () => {
   });
 
   return {
+    ...actual,
     CommBridgeManager: class CommBridgeManager {},
     IsolatedFrame: MockIsolatedFrame,
   };

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import {
+  anyOutputNeedsIsolation,
+  hasWidgetOutputs,
+  outputAllowsScrollPassthrough,
+  outputSegmentLane,
+  outputUsesSift,
+  segmentedOutputLanes,
+  selectedOutputMimeType,
+  splitOutputSegments,
+} from "../output-lane-policy";
+
+function streamOutput(text = "hello\n"): JupyterOutput {
+  return {
+    output_id: "stream-output",
+    output_type: "stream",
+    name: "stdout",
+    text,
+  };
+}
+
+function displayOutput(output_id: string, data: Record<string, unknown>): JupyterOutput {
+  return {
+    output_id,
+    output_type: "display_data",
+    data,
+    metadata: {},
+  };
+}
+
+describe("output lane policy", () => {
+  it("selects richer Sift bytes before text fallbacks", () => {
+    const output = displayOutput("table-output", {
+      "text/html": "<table></table>",
+      "application/vnd.apache.parquet": "http://localhost:47830/blob/table",
+      "text/plain": "table fallback",
+    });
+
+    expect(selectedOutputMimeType(output)).toBe("application/vnd.apache.parquet");
+    expect(outputUsesSift(output)).toBe(true);
+    expect(outputAllowsScrollPassthrough(output)).toBe(true);
+    expect(outputSegmentLane(output)).toBe("sift-frame");
+  });
+
+  it("classifies static and interactive iframe outputs separately", () => {
+    expect(outputSegmentLane(displayOutput("markdown-output", { "text/markdown": "# hi" }))).toBe(
+      "static-frame",
+    );
+    expect(
+      outputSegmentLane(displayOutput("plotly-output", { "application/vnd.plotly.v1+json": {} })),
+    ).toBe("interactive-frame");
+  });
+
+  it("keeps DOM-safe outputs out of isolated lanes", () => {
+    const outputs = [
+      streamOutput(),
+      displayOutput("plain-output", { "text/plain": "plain text" }),
+      displayOutput("json-output", { "application/json": JSON.stringify({ ok: true }) }),
+    ];
+
+    expect(outputs.map((output) => outputSegmentLane(output))).toEqual(["dom", "dom", "dom"]);
+    expect(anyOutputNeedsIsolation(outputs)).toBe(false);
+  });
+
+  it("does not mark display outputs without a selected MIME as scroll passthrough", () => {
+    const output = displayOutput("empty-display", {
+      "text/plain": null,
+    });
+
+    expect(selectedOutputMimeType(output)).toBeNull();
+    expect(outputAllowsScrollPassthrough(output)).toBe(false);
+    expect(outputSegmentLane(output)).toBe("dom");
+  });
+
+  it("segments adjacent compatible lanes while keeping Sift outputs standalone", () => {
+    const widgetOne = displayOutput("widget-1", {
+      "application/vnd.jupyter.widget-view+json": { model_id: "one" },
+    });
+    const widgetTwo = displayOutput("widget-2", {
+      "application/vnd.jupyter.widget-view+json": { model_id: "two" },
+    });
+    const tableOne = displayOutput("table-1", {
+      "application/vnd.apache.parquet": "http://localhost/blob/table-1",
+    });
+    const tableTwo = displayOutput("table-2", {
+      "application/vnd.apache.parquet": "http://localhost/blob/table-2",
+    });
+
+    const segments = splitOutputSegments([
+      streamOutput("one\n"),
+      streamOutput("two\n"),
+      widgetOne,
+      widgetTwo,
+      tableOne,
+      tableTwo,
+    ]);
+
+    expect(segments.map((segment) => segment.lane)).toEqual([
+      "dom",
+      "interactive-frame",
+      "sift-frame",
+      "sift-frame",
+    ]);
+    expect(segments.map((segment) => segment.outputs.map((output) => output.output_id))).toEqual([
+      ["stream-output", "stream-output"],
+      ["widget-1", "widget-2"],
+      ["table-1"],
+      ["table-2"],
+    ]);
+    expect(hasWidgetOutputs(segments[1].outputs)).toBe(true);
+  });
+
+  it("only enables segmentation for mixed auto-isolated output groups without collapse controls", () => {
+    const outputs = [
+      streamOutput(),
+      displayOutput("widget", {
+        "application/vnd.jupyter.widget-view+json": { model_id: "widget" },
+      }),
+    ];
+
+    expect(segmentedOutputLanes(outputs).map((segment) => segment.lane)).toEqual([
+      "dom",
+      "interactive-frame",
+    ]);
+    expect(segmentedOutputLanes(outputs, { isolated: true })).toEqual([]);
+    expect(segmentedOutputLanes(outputs, { hasCollapseControl: true })).toEqual([]);
+    expect(segmentedOutputLanes([outputs[1]])).toEqual([]);
+  });
+});

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -101,6 +101,21 @@ export {
   undefinedIfEmptyContainerDimensions,
 } from "./output-frame-sizing";
 export type { OutputFrameSizingPolicy } from "./output-frame-sizing";
+export {
+  anyOutputNeedsIsolation,
+  hasWidgetOutputs,
+  isScrollPassthroughMimeType,
+  isSiftMimeType,
+  outputAllowsScrollPassthrough,
+  outputNeedsIsolation,
+  outputSegmentLane,
+  outputUsesSift,
+  outputUsesWidget,
+  segmentedOutputLanes,
+  selectedOutputMimeType,
+  splitOutputSegments,
+} from "./output-lane-policy";
+export type { OutputLane, OutputSegment, OutputSegmentationOptions } from "./output-lane-policy";
 export { McpAppOutputFrame } from "./mcp-app-output-frame";
 export type { McpAppOutputFrameProps } from "./mcp-app-output-frame";
 export {

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -1,0 +1,149 @@
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
+import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
+
+export type OutputLane = "dom" | "static-frame" | "interactive-frame" | "sift-frame";
+
+export interface OutputSegment {
+  lane: OutputLane;
+  outputs: JupyterOutput[];
+}
+
+export interface OutputSegmentationOptions {
+  isolated?: boolean | "auto";
+  hasCollapseControl?: boolean;
+  priority?: readonly string[];
+}
+
+const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
+  // Static document-like outputs (markdown / HTML / SVG) and sift's
+  // interactive tables all behave better as click-to-engage: the page wheels
+  // through them by default, while pointer-down hands events back to the iframe.
+  "text/markdown",
+  "text/html",
+  "image/svg+xml",
+  "application/vnd.apache.parquet",
+  "application/vnd.apache.arrow.stream",
+  "application/vnd.nteract.arrow-stream-manifest+json",
+]);
+
+const SIFT_MIME_TYPES = new Set([
+  "application/vnd.apache.parquet",
+  "application/vnd.apache.arrow.stream",
+  "application/vnd.nteract.arrow-stream-manifest+json",
+]);
+
+export function selectedOutputMimeType(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): string | null {
+  if (output.output_type === "execute_result" || output.output_type === "display_data") {
+    return selectMimeType(output.data, priority);
+  }
+
+  return null;
+}
+
+export function isScrollPassthroughMimeType(mimeType: string): boolean {
+  return SCROLL_PASSTHROUGH_MIME_TYPES.has(mimeType);
+}
+
+export function isSiftMimeType(mimeType: string): boolean {
+  return SIFT_MIME_TYPES.has(mimeType);
+}
+
+export function outputAllowsScrollPassthrough(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  if (output.output_type !== "execute_result" && output.output_type !== "display_data") {
+    return true;
+  }
+
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType !== null && isScrollPassthroughMimeType(mimeType);
+}
+
+export function outputUsesSift(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType !== null && isSiftMimeType(mimeType);
+}
+
+export function outputUsesWidget(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType === "application/vnd.jupyter.widget-view+json";
+}
+
+export function outputNeedsIsolation(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType !== null && !isSafeForMainDom(mimeType);
+}
+
+export function anyOutputNeedsIsolation(
+  outputs: readonly JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputs.some((output) => outputNeedsIsolation(output, priority));
+}
+
+export function hasWidgetOutputs(
+  outputs: readonly JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputs.some((output) => outputUsesWidget(output, priority));
+}
+
+export function outputSegmentLane(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): OutputLane {
+  if (!outputNeedsIsolation(output, priority)) return "dom";
+  if (outputUsesSift(output, priority)) return "sift-frame";
+  if (outputAllowsScrollPassthrough(output, priority)) return "static-frame";
+  return "interactive-frame";
+}
+
+export function splitOutputSegments(
+  outputs: readonly JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): OutputSegment[] {
+  const segments: OutputSegment[] = [];
+
+  for (const output of outputs) {
+    const lane = outputSegmentLane(output, priority);
+    const previous = segments.at(-1);
+
+    if (lane !== "sift-frame" && previous && previous.lane === lane) {
+      previous.outputs.push(output);
+    } else {
+      segments.push({ lane, outputs: [output] });
+    }
+  }
+
+  return segments;
+}
+
+export function segmentedOutputLanes(
+  outputs: readonly JupyterOutput[],
+  {
+    isolated = "auto",
+    hasCollapseControl = false,
+    priority = DEFAULT_PRIORITY,
+  }: OutputSegmentationOptions = {},
+): OutputSegment[] {
+  if (isolated !== "auto") return [];
+  if (hasCollapseControl) return [];
+  if (outputs.length <= 1) return [];
+
+  const segments = splitOutputSegments(outputs, priority);
+  return segments.length > 1 ? segments : [];
+}


### PR DESCRIPTION
## Summary

- move output MIME/lane classification out of `OutputArea.tsx` into shared isolated-renderer policy
- keep the existing DOM/static-frame/interactive-frame/Sift segmentation behavior unchanged
- add direct policy tests for Sift priority, scroll passthrough, widget detection, and segmentation guardrails

## Context

The MCP Apps renderer work is converging on `apps/mcp-app` as a transport/host adapter over the shared isolated renderer. This slice pulls the main app's lane policy into `src/components/isolated`, where MCP app adapters and other embed paths can reuse it instead of rediscovering MIME-specific behavior in React component internals.

This is a mechanical extraction only: iframe sandboxing is unchanged, including the no-`allow-same-origin` invariant.

## Tests

- `pnpm exec vp test run src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm exec vp test run src/components/isolated/__tests__`
- `cargo xtask lint --fix`
