### PR TITLE
fix(renderer): keep LLM previews out of MIME selection

### DIFF
--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -206,6 +206,27 @@ describe("MCP App structured content adapter", () => {
     expect(payload.data).not.toBe("assistant summary");
   });
 
+  it("keeps LLM previews out of MCP App render payloads", async () => {
+    const cell = cellWithOutputs([
+      {
+        output_id: "preview-only-output",
+        output_type: "display_data",
+        data: {
+          "text/llm+plain": "assistant summary\nsecond line",
+        },
+      },
+    ]);
+
+    const outputs = mcpAppCellsToSharedOutputs([cell], undefined);
+    const payloads = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830"),
+    });
+
+    expect(mcpAppCellPreviewText(cell)).toBe("assistant summary");
+    expect(mcpAppCellHasRichOutput(cell)).toBe(false);
+    expect(payloads).toEqual([]);
+  });
+
   it("keeps plain and JSON-only MCP App cells collapsed by default", () => {
     expect(
       mcpAppCellHasRichOutput(

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -76,6 +76,27 @@ describe("getSelectedMimeType", () => {
       expect(getSelectedMimeType(data)).toBe("custom/mime-type");
     });
 
+    it("skips LLM previews when falling back to unknown renderable MIME types", () => {
+      const data = {
+        "text/llm+plain": "assistant summary",
+        "application/x-custom-rich+json": { value: 42 },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/x-custom-rich+json");
+    });
+
+    it("never selects LLM preview MIME as a render target", () => {
+      expect(getSelectedMimeType({ "text/llm+plain": "assistant summary" })).toBeNull();
+      expect(
+        getSelectedMimeType(
+          {
+            "text/llm+plain": "assistant summary",
+            "text/plain": "plain fallback",
+          },
+          ["text/llm+plain", "text/plain"],
+        ),
+      ).toBe("text/plain");
+    });
+
     it("uses DEFAULT_PRIORITY when no custom priority provided", () => {
       const data = {
         "text/plain": "plain",

--- a/src/components/outputs/mime-priority.ts
+++ b/src/components/outputs/mime-priority.ts
@@ -57,7 +57,13 @@ export const DEFAULT_PRIORITY = [
   "text/plain",
 ] as const;
 
+const PREVIEW_ONLY_MIME_TYPES = new Set(["text/llm+plain"]);
+
 export type MimeType = (typeof DEFAULT_PRIORITY)[number] | string;
+
+export function isPreviewOnlyMimeType(mimeType: string): boolean {
+  return PREVIEW_ONLY_MIME_TYPES.has(mimeType);
+}
 
 /**
  * Select the best MIME type from available data based on priority.
@@ -68,10 +74,16 @@ export function selectMimeType(
 ): MimeType | null {
   const availableTypes = Object.keys(data);
   for (const mimeType of priority) {
-    if (availableTypes.includes(mimeType) && data[mimeType] != null) {
+    if (
+      availableTypes.includes(mimeType) &&
+      !isPreviewOnlyMimeType(mimeType) &&
+      data[mimeType] != null
+    ) {
       return mimeType;
     }
   }
-  const firstAvailable = availableTypes.find((type) => data[type] != null);
+  const firstAvailable = availableTypes.find(
+    (type) => !isPreviewOnlyMimeType(type) && data[type] != null,
+  );
   return firstAvailable || null;
 }


### PR DESCRIPTION
## Summary

- Treat `text/llm+plain` as a preview-only MIME type in shared MIME selection.
- Keep richer known and unknown renderable MIME types selected ahead of LLM previews.
- Preserve MCP App collapsed preview behavior while preventing preview text from becoming a render payload.

## Context

PR #2998 made daemon-provided LLM previews useful for collapsed MCP App cell headers. This keeps that behavior, but makes the renderer boundary explicit: `text/llm+plain` can summarize an output, but it is not a user-facing output format.

That protects Sift, blob-backed tables, and other rich outputs from being displaced by model-facing preview text, including the fallback path for custom MIME types not listed in `DEFAULT_PRIORITY`.

## Tests

- `pnpm exec vp test run src/components/outputs/__tests__/media-router.test.tsx src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm exec vp test run src/components/outputs/__tests__ src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm --dir apps/mcp-app exec vp test run src`
- `cargo xtask lint --fix`
