### PR TITLE
fix(mcp-app): respect host frame CSP

### DIFF
--- a/apps/mcp-app/src/components/cell.tsx
+++ b/apps/mcp-app/src/components/cell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import type { McpUiHostCapabilities, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import type { CellData } from "../types";
 import { getPreviewText } from "../lib/rich-output";
 import { CodeBlock } from "./code-block";
@@ -9,6 +9,7 @@ interface CellProps {
   cell: CellData;
   blobBaseUrl?: string;
   hostContext?: McpUiHostContext | null;
+  hostCapabilities?: McpUiHostCapabilities | null;
   defaultExpanded: boolean;
   forceExpanded?: boolean | null;
   /** Hide the source toggle (single-cell responses don't need it). */
@@ -27,6 +28,7 @@ export function Cell({
   cell,
   blobBaseUrl,
   hostContext,
+  hostCapabilities,
   defaultExpanded,
   forceExpanded,
   hideSource,
@@ -82,7 +84,12 @@ export function Cell({
           )}
           {cell.outputs?.length > 0 && (
             <div className="outputs">
-              <SharedCellOutputs cell={cell} blobBaseUrl={blobBaseUrl} hostContext={hostContext} />
+              <SharedCellOutputs
+                cell={cell}
+                blobBaseUrl={blobBaseUrl}
+                hostContext={hostContext}
+                hostCapabilities={hostCapabilities}
+              />
             </div>
           )}
         </div>

--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import type { McpUiHostCapabilities, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { rendererCode, rendererCss } from "virtual:isolated-renderer";
 import {
   createDaemonRendererPluginLoader,
@@ -20,9 +20,15 @@ interface SharedCellOutputsProps {
   cell: CellData;
   blobBaseUrl?: string;
   hostContext?: McpUiHostContext | null;
+  hostCapabilities?: McpUiHostCapabilities | null;
 }
 
-export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCellOutputsProps) {
+export function SharedCellOutputs({
+  cell,
+  blobBaseUrl,
+  hostContext,
+  hostCapabilities,
+}: SharedCellOutputsProps) {
   const rendererPluginLoader = useMemo(
     () => createDaemonRendererPluginLoader(blobBaseUrl),
     [blobBaseUrl],
@@ -31,7 +37,11 @@ export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCell
     () => daemonRendererAssetsBaseUrl(blobBaseUrl),
     [blobBaseUrl],
   );
-  const outputDocumentUrl = useMemo(() => daemonOutputFrameUrl(blobBaseUrl), [blobBaseUrl]);
+  const hostFrameCsp = hostCapabilities?.sandbox?.csp;
+  const outputDocumentUrl = useMemo(
+    () => daemonOutputFrameUrl(blobBaseUrl, hostFrameCsp ?? { frameDomains: [] }),
+    [blobBaseUrl, hostFrameCsp],
+  );
   const handleDiagnostic = useCallback(
     (
       phase: string,

--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -1,7 +1,11 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, useState } from "react";
 import "./style.css";
-import { App, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  type McpUiHostCapabilities,
+  type McpUiHostContext,
+} from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { NteractContent } from "./types";
 import { Cell } from "./components/cell";
@@ -64,6 +68,7 @@ function McpApp() {
   const [content, setContent] = useState<NteractContent | null>(null);
   const [allExpanded, setAllExpanded] = useState<boolean | null>(null);
   const [hostContext, setHostContext] = useState<McpUiHostContext | null>(null);
+  const [hostCapabilities, setHostCapabilities] = useState<McpUiHostCapabilities | null>(null);
 
   useEffect(() => {
     const app = new App(NTERACT_MCP_APP_INFO, NTERACT_MCP_APP_CAPABILITIES);
@@ -104,6 +109,7 @@ function McpApp() {
         });
         const ctx = app.getHostContext();
         const capabilities = app.getHostCapabilities();
+        setHostCapabilities(capabilities ?? null);
         hostLog("info", "app-connected", {
           host: app.getHostVersion(),
           loggingAdvertised: capabilities?.logging !== undefined,
@@ -123,6 +129,7 @@ function McpApp() {
     return () => {
       hostLog("debug", "app-dispose");
       setHostLogSink(null);
+      setHostCapabilities(null);
       setContent(null);
     };
   }, []);
@@ -161,6 +168,7 @@ function McpApp() {
           cell={cell}
           blobBaseUrl={blobBaseUrl}
           hostContext={hostContext}
+          hostCapabilities={hostCapabilities}
           defaultExpanded={!isMultiCell || hasRichOutput(cell)}
           forceExpanded={isMultiCell ? allExpanded : null}
           hideSource={!isMultiCell}

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a4bc9a938f77200b621a846d0464cc3699e1f0ca3cb8baf59e6313d7faf0e2cc
-size 1486991
+oid sha256:2e46f0919b5bb28b07a4b55662c8d7201f41aeb3b4304c87b5547cb746a75bca
+size 1487204

--- a/apps/notebook/src/renderer-plugins/markdown.js
+++ b/apps/notebook/src/renderer-plugins/markdown.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:019edce25592fa50f4f3ef66791587a69a2deb6e3ce0063a6f11ccda00253fe0
-size 1118104
+oid sha256:9a605b4e4d50d49ae2639630ad9dc7470c9a008542db6cd45a41ca6141c83458
+size 1118148

--- a/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
+++ b/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
@@ -21,6 +21,40 @@ describe("daemon renderer assets", () => {
     expect(daemonRendererAssetsBaseUrl(undefined)).toBeUndefined();
   });
 
+  it("uses the daemon output frame only when the host frame CSP allows it", () => {
+    expect(
+      daemonOutputFrameUrl("http://localhost:47830/", {
+        frameDomains: ["http://localhost:47830"],
+      }),
+    ).toBe("http://localhost:47830/output-frame");
+    expect(
+      daemonOutputFrameUrl("http://localhost:47830/", {
+        frameDomains: ["http://localhost:*"],
+      }),
+    ).toBe("http://localhost:47830/output-frame");
+    expect(
+      daemonOutputFrameUrl("https://renderer.example.test/", {
+        frameDomains: ["https://*.example.test"],
+      }),
+    ).toBe("https://renderer.example.test/output-frame");
+    expect(
+      daemonOutputFrameUrl("https://renderer.example.test/", {
+        frameDomains: ["https://renderer.example.test:443"],
+      }),
+    ).toBe("https://renderer.example.test/output-frame");
+    expect(
+      daemonOutputFrameUrl("http://localhost/", {
+        frameDomains: ["http://localhost:80"],
+      }),
+    ).toBe("http://localhost/output-frame");
+    expect(
+      daemonOutputFrameUrl("http://localhost:47830/", {
+        frameDomains: ["https://outputs.example.test"],
+      }),
+    ).toBeNull();
+    expect(daemonOutputFrameUrl("http://localhost:47830/", { frameDomains: [] })).toBeNull();
+  });
+
   it("fetches raw renderer plugin assets from the daemon renderer-plugin route", async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       const pathname = new URL(url).pathname;

--- a/src/components/isolated/daemon-renderer-assets.ts
+++ b/src/components/isolated/daemon-renderer-assets.ts
@@ -3,6 +3,10 @@ import { rendererPluginInfoForMime } from "./renderer-plugin-info";
 
 declare const __DAEMON_PLUGIN_ASSET_HASHES__: Record<string, string> | undefined;
 
+export interface DaemonRendererAssetCsp {
+  frameDomains?: readonly string[];
+}
+
 const PLUGIN_ASSET_HASHES =
   typeof __DAEMON_PLUGIN_ASSET_HASHES__ === "object" ? __DAEMON_PLUGIN_ASSET_HASHES__ : {};
 
@@ -54,9 +58,77 @@ export function createDaemonRendererPluginLoader(
   };
 }
 
-export function daemonOutputFrameUrl(blobBaseUrl: string | undefined): string | null {
+interface ParsedCspSource {
+  protocol: string;
+  hostname: string;
+  port: string;
+}
+
+const CSP_SOURCE_RE =
+  /^([a-zA-Z][a-zA-Z\d+.-]*:)\/\/(\[[^\]]+\]|\*\.[^/:?#]+|[^/:?#]+)(?::(\*|\d+))?(?:[/?#]|$)/;
+
+function parseCspSource(source: string): ParsedCspSource | null {
+  const match = CSP_SOURCE_RE.exec(source.trim());
+  if (!match) return null;
+  const protocol = match[1].toLowerCase();
+  return {
+    protocol,
+    hostname: match[2].toLowerCase(),
+    port: normalizeCspSourcePort(protocol, match[3] ?? ""),
+  };
+}
+
+function normalizeCspSourcePort(protocol: string, port: string): string {
+  if ((protocol === "https:" && port === "443") || (protocol === "http:" && port === "80")) {
+    return "";
+  }
+  return port;
+}
+
+function sourceHostMatches(sourceHost: string, targetHost: string): boolean {
+  if (sourceHost.startsWith("*.")) {
+    const suffix = sourceHost.slice(2);
+    return targetHost.endsWith(`.${suffix}`) && targetHost !== suffix;
+  }
+  return sourceHost === targetHost;
+}
+
+function sourcePortMatches(sourcePort: string, targetPort: string): boolean {
+  return sourcePort === "*" || sourcePort === targetPort;
+}
+
+function frameDomainsAllowUrl(domains: readonly string[] | undefined, url: string): boolean {
+  if (!domains || domains.length === 0) return false;
+
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const targetHost = target.hostname.toLowerCase();
+  const targetPort = target.port;
+  return domains.some((domain) => {
+    if (domain === "*") return true;
+    const source = parseCspSource(domain);
+    if (!source) return false;
+    return (
+      source.protocol === target.protocol.toLowerCase() &&
+      sourceHostMatches(source.hostname, targetHost) &&
+      sourcePortMatches(source.port, targetPort)
+    );
+  });
+}
+
+export function daemonOutputFrameUrl(
+  blobBaseUrl: string | undefined,
+  hostCsp?: DaemonRendererAssetCsp | null,
+): string | null {
   if (!blobBaseUrl) return null;
-  return `${trimTrailingSlash(blobBaseUrl)}/output-frame`;
+  const url = `${trimTrailingSlash(blobBaseUrl)}/output-frame`;
+  if (!hostCsp) return url;
+  return frameDomainsAllowUrl(hostCsp.frameDomains, url) ? url : null;
 }
 
 export function daemonRendererAssetsBaseUrl(blobBaseUrl: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary

- avoids loading the daemon `/output-frame` iframe when the MCP host sandbox CSP does not allow that frame URL
- falls back to the existing inline/srcdoc isolated output shell for hosts like Claude that expose `frame-src 'self' blob: data:`
- keeps the daemon frame path available for hosts that explicitly advertise a compatible `frameDomains` entry
- updates the generated renderer bundles for the shared isolated renderer

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/isolated/__tests__/daemon-renderer-assets.test.ts src/components/isolated/__tests__/mcp-app-output-frame.test.tsx apps/mcp-app/src`
- `pnpm exec vp build && node build-html.js` from `apps/mcp-app`
