### PR TITLE
fix(mcp-app): avoid framed output shell

### DIFF
--- a/apps/mcp-app/src/components/cell.tsx
+++ b/apps/mcp-app/src/components/cell.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import type { McpUiHostCapabilities, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import type { CellData } from "../types";
 import { getPreviewText } from "../lib/rich-output";
 import { CodeBlock } from "./code-block";
@@ -9,7 +9,6 @@ interface CellProps {
   cell: CellData;
   blobBaseUrl?: string;
   hostContext?: McpUiHostContext | null;
-  hostCapabilities?: McpUiHostCapabilities | null;
   defaultExpanded: boolean;
   forceExpanded?: boolean | null;
   /** Hide the source toggle (single-cell responses don't need it). */
@@ -28,7 +27,6 @@ export function Cell({
   cell,
   blobBaseUrl,
   hostContext,
-  hostCapabilities,
   defaultExpanded,
   forceExpanded,
   hideSource,
@@ -84,12 +82,7 @@ export function Cell({
           )}
           {cell.outputs?.length > 0 && (
             <div className="outputs">
-              <SharedCellOutputs
-                cell={cell}
-                blobBaseUrl={blobBaseUrl}
-                hostContext={hostContext}
-                hostCapabilities={hostCapabilities}
-              />
+              <SharedCellOutputs cell={cell} blobBaseUrl={blobBaseUrl} hostContext={hostContext} />
             </div>
           )}
         </div>

--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useMemo } from "react";
-import type { McpUiHostCapabilities, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
+import type { McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { rendererCode, rendererCss } from "virtual:isolated-renderer";
 import {
   createDaemonRendererPluginLoader,
-  daemonOutputFrameUrl,
   daemonRendererAssetsBaseUrl,
 } from "@/components/isolated/daemon-renderer-assets";
 import { McpAppOutputFrame } from "@/components/isolated/mcp-app-output-frame";
@@ -20,15 +19,9 @@ interface SharedCellOutputsProps {
   cell: CellData;
   blobBaseUrl?: string;
   hostContext?: McpUiHostContext | null;
-  hostCapabilities?: McpUiHostCapabilities | null;
 }
 
-export function SharedCellOutputs({
-  cell,
-  blobBaseUrl,
-  hostContext,
-  hostCapabilities,
-}: SharedCellOutputsProps) {
+export function SharedCellOutputs({ cell, blobBaseUrl, hostContext }: SharedCellOutputsProps) {
   const rendererPluginLoader = useMemo(
     () => createDaemonRendererPluginLoader(blobBaseUrl),
     [blobBaseUrl],
@@ -36,11 +29,6 @@ export function SharedCellOutputs({
   const rendererAssetsBaseUrl = useMemo(
     () => daemonRendererAssetsBaseUrl(blobBaseUrl),
     [blobBaseUrl],
-  );
-  const hostFrameCsp = hostCapabilities?.sandbox?.csp;
-  const outputDocumentUrl = useMemo(
-    () => daemonOutputFrameUrl(blobBaseUrl, hostFrameCsp ?? { frameDomains: [] }),
-    [blobBaseUrl, hostFrameCsp],
   );
   const handleDiagnostic = useCallback(
     (
@@ -72,7 +60,6 @@ export function SharedCellOutputs({
       rendererBundle={SHARED_RENDERER_BUNDLE}
       rendererPluginLoader={rendererPluginLoader}
       rendererAssetsBaseUrl={rendererAssetsBaseUrl}
-      outputDocumentUrl={outputDocumentUrl}
       className="shared-output-frame"
       onDiagnostic={handleDiagnostic}
       onError={handleError}

--- a/apps/mcp-app/src/mcp-app.tsx
+++ b/apps/mcp-app/src/mcp-app.tsx
@@ -1,11 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { useEffect, useState } from "react";
 import "./style.css";
-import {
-  App,
-  type McpUiHostCapabilities,
-  type McpUiHostContext,
-} from "@modelcontextprotocol/ext-apps";
+import { App, type McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { NteractContent } from "./types";
 import { Cell } from "./components/cell";
@@ -68,7 +64,6 @@ function McpApp() {
   const [content, setContent] = useState<NteractContent | null>(null);
   const [allExpanded, setAllExpanded] = useState<boolean | null>(null);
   const [hostContext, setHostContext] = useState<McpUiHostContext | null>(null);
-  const [hostCapabilities, setHostCapabilities] = useState<McpUiHostCapabilities | null>(null);
 
   useEffect(() => {
     const app = new App(NTERACT_MCP_APP_INFO, NTERACT_MCP_APP_CAPABILITIES);
@@ -109,7 +104,6 @@ function McpApp() {
         });
         const ctx = app.getHostContext();
         const capabilities = app.getHostCapabilities();
-        setHostCapabilities(capabilities ?? null);
         hostLog("info", "app-connected", {
           host: app.getHostVersion(),
           loggingAdvertised: capabilities?.logging !== undefined,
@@ -129,7 +123,6 @@ function McpApp() {
     return () => {
       hostLog("debug", "app-dispose");
       setHostLogSink(null);
-      setHostCapabilities(null);
       setContent(null);
     };
   }, []);
@@ -168,7 +161,6 @@ function McpApp() {
           cell={cell}
           blobBaseUrl={blobBaseUrl}
           hostContext={hostContext}
-          hostCapabilities={hostCapabilities}
           defaultExpanded={!isMultiCell || hasRichOutput(cell)}
           forceExpanded={isMultiCell ? allExpanded : null}
           hideSource={!isMultiCell}

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -27,7 +27,6 @@ const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
 /// MCP Apps spec CSP fields (from ext-apps specification):
 /// - `resourceDomains` → `img-src`, `script-src`, `style-src`, `font-src`, `media-src`
 /// - `connectDomains`  → `connect-src` (fetch/XHR/WebSocket)
-/// - `frameDomains`    → `frame-src` (nested output iframe shell)
 ///
 /// `prefersBorder: false` asks hosts to avoid adding an extra host-provided
 /// border/background around the renderer. The output surface already owns its
@@ -35,11 +34,9 @@ const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
 ///
 /// The daemon's blob HTTP server URL is needed in `connectDomains` for
 /// `fetch()` calls to resolve blob-stored output data and raw renderer plugin
-/// assets. It is also needed in `frameDomains` so the MCP App can host shared
-/// isolated output iframes from `{blob_base_url}/output-frame` instead of
-/// depending on host-specific `srcdoc` CSP behavior. `resourceDomains` keeps
-/// the daemon origin available for static sidecars and host implementations
-/// that treat iframe resource loads conservatively.
+/// assets. `resourceDomains` keeps the daemon origin available for static
+/// sidecars and host implementations that treat iframe resource loads
+/// conservatively.
 ///
 /// Claude Desktop requires `localhost` (not `127.0.0.1`) for domain allowlists.
 fn resource_ui_meta(blob_base_url: &Option<String>) -> Meta {
@@ -51,8 +48,7 @@ fn resource_ui_meta(blob_base_url: &Option<String>) -> Meta {
             "csp".to_string(),
             serde_json::json!({
                 "resourceDomains": [url],
-                "connectDomains": [url],
-                "frameDomains": [url]
+                "connectDomains": [url]
             }),
         );
     }
@@ -524,12 +520,7 @@ mod tests {
                 .expect("connect domains")[0],
             "https://outputs.example.test"
         );
-        assert_eq!(
-            csp.get("frameDomains")
-                .and_then(|value| value.as_array())
-                .expect("frame domains")[0],
-            "https://outputs.example.test"
-        );
+        assert!(csp.get("frameDomains").is_none());
     }
 
     #[test]

--- a/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
+++ b/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
@@ -54,7 +54,6 @@ describe("McpAppOutputFrame", () => {
         rendererBundle={rendererBundle}
         rendererPluginLoader={rendererPluginLoader}
         rendererAssetsBaseUrl="http://localhost:47830/plugins/"
-        outputDocumentUrl="http://localhost:47830/output-frame"
       />,
     );
 
@@ -64,13 +63,11 @@ describe("McpAppOutputFrame", () => {
       expect.objectContaining({
         rendererBundle,
         rendererPluginLoader,
-        outputDocumentUrl: "http://localhost:47830/output-frame",
         hostContext: expect.objectContaining({
           theme: "dark",
           containerDimensions: undefined,
           nteract: {
             rendererAssetsBaseUrl: "http://localhost:47830/plugins/",
-            outputDocumentUrl: "http://localhost:47830/output-frame",
           },
         }),
       }),
@@ -79,6 +76,10 @@ describe("McpAppOutputFrame", () => {
       string,
       unknown
     >;
+    expect(options).not.toHaveProperty("outputDocumentUrl");
+    expect((options.hostContext as Record<string, unknown>)?.nteract).not.toHaveProperty(
+      "outputDocumentUrl",
+    );
     expect(options).not.toHaveProperty("autoHeight");
     expect(options).not.toHaveProperty("maxHeight");
     expect(mockHandle.renderBatch).toHaveBeenCalledWith([

--- a/src/components/isolated/mcp-app-output-frame.tsx
+++ b/src/components/isolated/mcp-app-output-frame.tsx
@@ -24,7 +24,6 @@ export interface McpAppOutputFrameProps {
   rendererBundle: NteractOutputRendererBundleProvider;
   rendererPluginLoader?: NteractOutputRendererPluginLoader;
   rendererAssetsBaseUrl?: string;
-  outputDocumentUrl?: string | null;
   autoHeight?: boolean;
   maxHeight?: number;
   className?: string;
@@ -46,7 +45,6 @@ export function McpAppOutputFrame({
   rendererBundle,
   rendererPluginLoader,
   rendererAssetsBaseUrl,
-  outputDocumentUrl,
   autoHeight,
   maxHeight,
   className,
@@ -69,9 +67,8 @@ export function McpAppOutputFrame({
     () =>
       mcpAppHostContextToNteractEmbedPatch(hostContext, {
         rendererAssetsBaseUrl,
-        outputDocumentUrl: outputDocumentUrl ?? undefined,
       }),
-    [hostContext, rendererAssetsBaseUrl, outputDocumentUrl],
+    [hostContext, rendererAssetsBaseUrl],
   );
   const hostContextPatchRef = useRef(hostContextPatch);
   const onDiagnosticRef = useRef(onDiagnostic);
@@ -84,7 +81,7 @@ export function McpAppOutputFrame({
 
   useEffect(() => {
     setFailed(false);
-  }, [outputCells, blobBaseUrl, rendererBundle, rendererPluginLoader, outputDocumentUrl]);
+  }, [outputCells, blobBaseUrl, rendererBundle, rendererPluginLoader]);
 
   useEffect(() => {
     if (failed || !targetRef.current || outputs.length === 0) return;
@@ -95,7 +92,6 @@ export function McpAppOutputFrame({
       rendererPluginLoader,
       blobResolver,
       hostContext: hostContextPatchRef.current,
-      outputDocumentUrl,
       ...(autoHeight === undefined ? {} : { autoHeight }),
       ...(maxHeight === undefined ? {} : { maxHeight }),
       onDiagnostic(...args) {
@@ -119,7 +115,6 @@ export function McpAppOutputFrame({
     blobResolver,
     failed,
     maxHeight,
-    outputDocumentUrl,
     outputs.length,
     rendererBundle,
     rendererPluginLoader,


### PR DESCRIPTION
## Summary

- Force MCP app output rendering to use the inline isolated shell instead of daemon `/output-frame` URLs.
- Remove `frameDomains` from the MCP UI resource CSP metadata because the app no longer needs to frame the daemon origin.
- Keep daemon renderer plugin/blob fetch support through `resourceDomains` and `connectDomains`.

## Why

Claude Desktop is still enforcing `frame-src 'self' blob: data:` even when host capabilities appear to include the requested daemon frame domain. Continuing to pass `http://localhost:<port>/output-frame` leaves the app blank behind CSP errors. This fails closed to the srcdoc/blob shell path for MCP apps.

## Verification

- `pnpm test:run apps/mcp-app/src src/components/isolated/__tests__/mcp-app-output-frame.test.tsx src/components/isolated/__tests__/daemon-renderer-assets.test.ts`
- `cargo test -p runt-mcp resources::tests::output_resource_meta_includes_blob_domains_for_mcp_ui_csp`
- `cd apps/mcp-app && pnpm exec vp build && node build-html.js`
- `cargo xtask lint --fix`
- `git diff --check`
