### PR TITLE
feat(mcp): canonicalize client display names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,6 +4393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mcp-client-branding"
+version = "0.1.0"
+
+[[package]]
 name = "mcp-supervisor"
 version = "0.4.1"
 dependencies = [
@@ -7312,6 +7316,7 @@ dependencies = [
  "chrono",
  "dirs",
  "fancy-regex 0.14.0",
+ "mcp-client-branding",
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/runtimed-node",
     "crates/runtimed-py",
     "crates/runtimed-wasm",
+    "crates/mcp-client-branding",
     "crates/mcp-supervisor",
     "crates/runt-mcp",
     "crates/runt-mcp-proxy",

--- a/crates/mcp-client-branding/Cargo.toml
+++ b/crates/mcp-client-branding/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mcp-client-branding"
+version = "0.1.0"
+edition.workspace = true
+description = "Canonical display names for known MCP clients"
+repository.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mcp-client-branding/src/lib.rs
+++ b/crates/mcp-client-branding/src/lib.rs
@@ -1,0 +1,175 @@
+//! Canonical display names for known MCP clients.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+use std::borrow::Cow;
+
+/// Canonical display names for known MCP client implementation names.
+///
+/// MCP clients often send a machine-oriented `Implementation.name` without a
+/// human-readable `Implementation.title`. Keep this table as the single
+/// fallback source for turning those raw names into user-facing labels.
+pub const CLIENT_DISPLAY_NAME_MAPPINGS: &[(&str, &str)] = &[
+    ("@librechat/api-client", "LibreChat"),
+    ("@n8n/n8n-nodes-langchain.mcpClientTool", "N8N MCP Client"),
+    ("Alpic", "Alpic"),
+    ("amp-mcp-client", "AmpCode"),
+    ("Anthropic/API", "Anthropic API"),
+    ("Anthropic/ClaudeAI", "Claude.ai"),
+    ("antigravity-client", "Google Antigravity"),
+    ("apify-mcp-client", "Apify MCP Client"),
+    ("arcade", "Arcade"),
+    ("ChatGPT", "ChatGPT"),
+    ("Cherry Studio", "Cherry Studio"),
+    ("claude-ai", "Claude Desktop"),
+    ("claude-desktop", "Claude Desktop"),
+    ("claude-code", "Claude Code"),
+    ("Cline", "Cline"),
+    ("CodeRabbit", "CodeRabbit"),
+    ("codex-mcp-client", "OpenAI Codex"),
+    ("codex-cli", "OpenAI Codex"),
+    ("com.raycast.macos", "Raycast"),
+    ("continue-cli-client", "Continue CLI Client"),
+    ("continue-client", "Continue"),
+    ("crush", "Crush"),
+    ("cursor-vscode", "Cursor"),
+    ("Cursor", "Cursor"),
+    ("cursor", "Cursor"),
+    ("docker-mcp-gateway", "Docker MCP Gateway"),
+    ("dust-mcp-client", "Dust"),
+    ("emacs", "Emacs"),
+    ("Eglot", "Emacs"),
+    ("etherassist-mcp-client", "EtherAssist"),
+    ("example-client", "Example Client"),
+    ("factory-cli", "Factory CLI"),
+    ("gemini-cli", "Gemini CLI"),
+    ("gemini-cli-mcp-client", "Gemini CLI"),
+    ("gitguardian", "GitGuardian"),
+    ("github-copilot-developer", "GitHub Copilot CLI"),
+    ("goose", "Goose"),
+    ("helix", "Helix"),
+    ("Jan-Streamable-Client", "Jan AI"),
+    ("jetbrains-ai-assistant-client", "JetBrains AI Assistant"),
+    ("JetBrains-IU-copilot-intellij", "JetBrains AI Assistant"),
+    (
+        "JetBrains-IU/copilot-intellij",
+        "GitHub Copilot for IntelliJ",
+    ),
+    (
+        "JetBrains-JBC-copilot-intellij",
+        "JetBrains AI Assistant with GitHub Copilot",
+    ),
+    ("Kilo-Code", "Kilo Code"),
+    ("lobehub-mcp-client", "LobeHub"),
+    ("make-app-mcp-client", "Make MCP Client"),
+    ("mcp", "Python SDK default"),
+    ("mcp-python-client", "Python SDK default"),
+    ("mcp-cli", "MCP CLI"),
+    ("mcp-cli-client", "MCP CLI"),
+    ("mcs", "Copilot Studio"),
+    ("mise", "Mise"),
+    ("Mistral", "Mistral AI: Le Chat"),
+    ("my-awesome-client", "Go SDK example"),
+    ("openai-mcp", "OpenAI/ChatGPT MCP connector"),
+    ("opencode", "Opencode"),
+    ("Postman-Client", "Postman"),
+    ("q-cli", "Amazon Q CLI"),
+    ("Q-DEV-CLI", "Amazon Q CLI"),
+    ("replit-workspace", "Replit"),
+    ("Roo Code", "Roo Code"),
+    ("Roo-Code", "Roo Code"),
+    ("spring-ai-mcp-client", "Spring AI MCP Client"),
+    ("test-client", "Smithery test & playground"),
+    ("Trae", "Trae"),
+    ("Visual Studio Code", "Visual Studio Code"),
+    ("Visual Studio Code - Insiders", "Visual Studio Code"),
+    ("warp", "Warp"),
+    ("Windsurf", "Windsurf"),
+    ("windsurf-client", "Windsurf Editor"),
+    ("Xcode-copilot-xcode", "GitHub Copilot for Xcode"),
+    ("Zed", "Zed"),
+    ("zed", "Zed"),
+];
+
+/// Return the canonical display name for a known raw MCP client name or alias.
+pub fn canonical_display_name(client_name: &str) -> Option<&'static str> {
+    let client_name = client_name.trim();
+    if client_name.is_empty() {
+        return None;
+    }
+
+    CLIENT_DISPLAY_NAME_MAPPINGS
+        .iter()
+        .find_map(|(raw_name, display_name)| (*raw_name == client_name).then_some(*display_name))
+}
+
+/// Resolve a user-facing MCP client display name.
+///
+/// Client-provided titles are already the display-name path, so they win. When
+/// a title is missing, known raw implementation names and aliases map to their
+/// official names before falling back to the trimmed raw name.
+pub fn display_name<'a>(
+    client_name: &'a str,
+    client_title: Option<&'a str>,
+) -> Option<Cow<'a, str>> {
+    if let Some(title) = client_title
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+    {
+        return Some(Cow::Borrowed(title));
+    }
+
+    if let Some(display_name) = canonical_display_name(client_name) {
+        return Some(Cow::Borrowed(display_name));
+    }
+
+    let client_name = client_name.trim();
+    if client_name.is_empty() {
+        None
+    } else {
+        Some(Cow::Borrowed(client_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_display_name_maps_known_clients_and_aliases() {
+        assert_eq!(canonical_display_name("claude-ai"), Some("Claude Desktop"));
+        assert_eq!(
+            canonical_display_name("claude-desktop"),
+            Some("Claude Desktop")
+        );
+        assert_eq!(canonical_display_name("cursor-vscode"), Some("Cursor"));
+        assert_eq!(canonical_display_name("cursor"), Some("Cursor"));
+        assert_eq!(
+            canonical_display_name("Visual Studio Code - Insiders"),
+            Some("Visual Studio Code")
+        );
+        assert_eq!(canonical_display_name("zed"), Some("Zed"));
+        assert_eq!(canonical_display_name("unknown-client"), None);
+    }
+
+    #[test]
+    fn display_name_prefers_title_then_mapping_then_raw_name() {
+        assert_eq!(
+            display_name("claude-ai", Some("Claude Custom")).as_deref(),
+            Some("Claude Custom")
+        );
+        assert_eq!(
+            display_name("claude-ai", None).as_deref(),
+            Some("Claude Desktop")
+        );
+        assert_eq!(
+            display_name("  unknown-client  ", None).as_deref(),
+            Some("unknown-client")
+        );
+        assert_eq!(display_name("  ", None).as_deref(), None);
+        assert_eq!(
+            display_name("claude-ai", Some("  ")).as_deref(),
+            Some("Claude Desktop")
+        );
+    }
+}

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -19,6 +19,7 @@ notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
+mcp-client-branding = { path = "../mcp-client-branding" }
 runt-workspace = { path = "../runt-workspace" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -240,19 +240,18 @@ impl ServerHandler for NteractMcp {
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         // Sniff client name on first call for use as the notebook peer label.
-        // The title (e.g., "Claude Desktop") is preferred over the name ("claude-desktop").
+        // The title (e.g., "Claude Desktop") is preferred over the raw
+        // implementation name ("claude-ai"), then known names are canonicalized.
         {
             let current = self.peer_label.read().await;
             if *current == "Inkwell" {
                 drop(current);
                 if let Some(info) = context.peer.peer_info() {
-                    let label = info
-                        .client_info
-                        .title
-                        .as_deref()
-                        .unwrap_or(&info.client_info.name);
-                    if !label.is_empty() {
-                        *self.peer_label.write().await = label.to_string();
+                    if let Some(label) = mcp_client_branding::display_name(
+                        &info.client_info.name,
+                        info.client_info.title.as_deref(),
+                    ) {
+                        *self.peer_label.write().await = label.into_owned();
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Add `mcp-client-branding`, a tiny Rust crate that owns canonical MCP client display-name mappings.
- Map raw MCP client implementation names and aliases like `claude-ai`, `claude-desktop`, `cursor`, and `zed` to user-facing labels.
- Use the resolver in `runt-mcp` peer-label detection while preserving title-first behavior when clients provide `Implementation.title`.

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
- `cargo test -p mcp-client-branding -p runt-workspace`
- `cargo test -p runt-mcp`
- `git diff --check origin/main...HEAD`
