### PR TITLE
fix(renderer): let engaged Sift frames chain page scroll

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -118,6 +118,49 @@ test.describe("cloud renderer parity harness", () => {
       page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
     ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
   });
+
+  test("chains wheel scroll from engaged Sift frames back to the notebook page", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await openParityHarness(page);
+
+    const siftCell = page.locator('[data-cell-id="sift-arrow-output"]');
+    await expect(
+      page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
+    ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
+
+    await page.evaluate(() => {
+      const spacer = document.createElement("div");
+      spacer.dataset.testid = "scroll-boundary-spacer";
+      spacer.style.height = "2400px";
+      document.body.appendChild(spacer);
+    });
+    await siftCell.scrollIntoViewIfNeeded();
+
+    await siftCell.getByRole("button", { name: "Click inside the table to scroll" }).click({
+      force: true,
+    });
+    await expect(siftCell.locator('[data-sift-output="true"] iframe')).toHaveCSS(
+      "pointer-events",
+      "auto",
+    );
+
+    const viewport = page
+      .frameLocator('[data-cell-id="sift-arrow-output"] iframe')
+      .locator(".sift-viewport");
+    await viewport.waitFor({ timeout: 30_000 });
+    await expect(viewport).toHaveCSS("overscroll-behavior-y", "auto");
+    await viewport.evaluate((element) => {
+      element.scrollTop = element.scrollHeight - element.clientHeight;
+    });
+
+    const before = await page.evaluate(() => window.scrollY);
+    await viewport.dispatchEvent("wheel", { deltaY: 500, bubbles: true, cancelable: true });
+    await expect
+      .poll(() => page.evaluate(() => window.scrollY), { timeout: 5_000 })
+      .toBeGreaterThan(before);
+  });
 });
 
 async function openParityHarness(page: Page) {

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -632,7 +632,8 @@ h1 {
   min-height: 0; /* allow flex shrinking */
   overflow-y: auto;
   overflow-x: auto;
-  overscroll-behavior: none; /* kill elastic bounce entirely — no rubberbanding on iOS */
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
   overflow-anchor: none;
   position: relative;
 }

--- a/packages/sift/src/style.test.ts
+++ b/packages/sift/src/style.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, it } from "vite-plus/test";
 const styleCss = readFileSync("src/style.css", "utf8");
 
 describe("Sift stylesheet", () => {
+  it("lets vertical wheel gestures chain at table boundaries", () => {
+    expect(styleCss).toMatch(/overscroll-behavior-x:\s*contain;/);
+    expect(styleCss).toMatch(/overscroll-behavior-y:\s*auto;/);
+  });
+
   it("themes the WebKit scrollbar corner with the table surface", () => {
     expect(styleCss).toMatch(
       /\.sift-viewport::-webkit-scrollbar-corner\s*\{\s*background:\s*var\(--sift-bg\);\s*\}/,

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -563,8 +563,7 @@ function OutputAreaSingle({
     outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
   const shouldScrollPassthroughFrame =
     shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const allowWheelBoundaryScroll =
-    !focused && !shouldScrollPassthroughFrame && !(hasSiftOutputs && staticFrameInteractionActive);
+  const allowWheelBoundaryScroll = !focused && !shouldScrollPassthroughFrame;
   const showSiftInteractionCue =
     hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
   const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -403,7 +403,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
     expect(screen.queryByText("Click inside the table to scroll")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
@@ -424,7 +424,7 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
     expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
   });
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -854,12 +854,10 @@
           return false;
         }
 
-        // Honor the inner scroller's `overscroll-behavior-y`. Sift sets
-        // `overscroll-behavior: none` on `.sift-viewport` to opt out of
-        // scroll-chaining; without this check we'd forward the wheel to
-        // the parent at the table's top/bottom anyway, scrolling the
-        // notebook out from under the user mid-interaction. `contain`
-        // also opts out — same behavior as `none` for chaining purposes.
+        // Honor the inner scroller's `overscroll-behavior-y`. Renderers that
+        // set `none` or `contain` are explicitly asking not to chain vertical
+        // scroll to the host. Sift leaves vertical chaining enabled so the
+        // notebook can keep scrolling when the table reaches a boundary.
         function scrollerOptsOutOfChaining(scroller) {
           if (!scroller) return false;
           var behavior = window.getComputedStyle(scroller).overscrollBehaviorY;


### PR DESCRIPTION
## Summary

- let engaged Sift output iframes keep using the parent wheel-boundary bridge
- change Sift viewport CSS so horizontal overscroll stays contained while vertical scroll can chain at table boundaries
- add cloud renderer-parity coverage that engages the real Sift iframe and asserts wheel scrolling continues the notebook page

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir packages/sift test -- src/style.test.ts`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
