### PR TITLE
fix(notebook-cloud): seed viewer theme before first paint

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -51,7 +51,10 @@ import {
   type PendingNotebookInviteRow,
 } from "./sharing-storage.ts";
 import { normalizeInviteEmail, normalizeProviderHint } from "./sharing.ts";
-import { viewerThemeBootstrapScript } from "./viewer-theme-bootstrap.ts";
+import {
+  viewerThemeBootstrapScript,
+  viewerThemeFirstPaintStyle,
+} from "./viewer-theme-bootstrap.ts";
 
 export { NotebookRoom };
 
@@ -1775,6 +1778,7 @@ function viewer(notebookId: string, env: Env, headsHash?: string): Response {
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>nteract cloud notebook ${title}</title>
+  <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
   <link rel="stylesheet" href="/assets/notebook-cloud-viewer.css" />
 </head>

--- a/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
+++ b/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
@@ -1,5 +1,28 @@
 export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
 
+export function viewerThemeFirstPaintStyle(): string {
+  return `html {
+  background: oklch(1 0 0);
+  color-scheme: light;
+}
+
+html.dark {
+  background: oklch(0.145 0 0);
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  background: oklch(1 0 0);
+  color: oklch(0.145 0 0);
+}
+
+html.dark body {
+  background: oklch(0.145 0 0);
+  color: oklch(0.985 0 0);
+}`;
+}
+
 export function viewerThemeBootstrapScript(): string {
   return `(() => {
   let stored;

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -2,7 +2,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import worker, { escapeHtml, scriptJsonForHtml } from "../src/index.ts";
 import type { DurableObjectNamespace, Env, ExecutionContext } from "../src/cloudflare-types.ts";
-import { viewerThemeBootstrapScript } from "../src/viewer-theme-bootstrap.ts";
+import {
+  viewerThemeBootstrapScript,
+  viewerThemeFirstPaintStyle,
+} from "../src/viewer-theme-bootstrap.ts";
 
 describe("HTML script serialization", () => {
   it("escapes text and attribute metacharacters", () => {
@@ -53,6 +56,10 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.ok(
+      html.indexOf(viewerThemeFirstPaintStyle()) < html.indexOf(viewerThemeBootstrapScript()),
+      "theme first-paint style must apply before the bootstrap script resolves the final theme",
+    );
     assert.ok(
       html.indexOf(viewerThemeBootstrapScript()) <
         html.indexOf("/assets/notebook-cloud-viewer.css"),

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -6,11 +6,22 @@ import {
   resolveCloudViewerTheme,
   storedCloudViewerTheme,
 } from "../viewer/theme.ts";
-import { viewerThemeBootstrapScript } from "../src/viewer-theme-bootstrap.ts";
+import {
+  viewerThemeBootstrapScript,
+  viewerThemeFirstPaintStyle,
+} from "../src/viewer-theme-bootstrap.ts";
 
 describe("cloud viewer theme helpers", () => {
   it("uses the cloud-specific storage key", () => {
     assert.equal(CLOUD_VIEWER_THEME_STORAGE_KEY, "nteract.cloud.viewer.theme");
+  });
+
+  it("ships a light default surface that class changes can flip before the bundle CSS loads", () => {
+    const css = viewerThemeFirstPaintStyle();
+
+    assert.match(css, /html \{\s+background: oklch\(1 0 0\);\s+color-scheme: light;/);
+    assert.match(css, /html\.dark \{\s+background: oklch\(0\.145 0 0\);\s+color-scheme: dark;/);
+    assert.match(css, /html\.dark body \{/);
   });
 
   it("resolves explicit and system themes", () => {

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -90,6 +90,11 @@ describe("generateFrameHtml", () => {
   });
 
   describe("neutral defaults", () => {
+    it("starts from an explicit light color scheme until the theme hint script resolves", () => {
+      expect(html).toContain('<html style="background: transparent; color-scheme: light">');
+      expect(html).not.toContain("color-scheme: light dark");
+    });
+
     it("seeds the frame theme before first paint", () => {
       expect(source).toContain("new URLSearchParams(window.location.search)");
       expect(source).toContain("params.get('nteract_theme')");

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html style="background: transparent; color-scheme: light dark">
+<html style="background: transparent; color-scheme: light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary

- add a tiny inline first-paint surface style to the cloud viewer shell before the external viewer CSS loads
- keep the shared isolated output document on an explicit light color scheme until its theme hint bootstrap resolves the final theme
- cover the ordering and frame default with cloud and isolated-frame tests

## Verification

- `pnpm --dir apps/notebook-cloud test -- viewer-theme html`
- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

PR #3018 still appears open on GitHub, so this branch avoids the Sift scroll-handoff code path and stays limited to theme first-paint behavior.
