### PR TITLE
test(notebook-cloud): exercise shared system theme path

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -90,7 +90,30 @@ test.describe("cloud renderer parity harness", () => {
       page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),
     ).toHaveAttribute("data-theme", "light", { timeout: 30_000 });
 
-    await page.getByTestId("theme-dark").click();
+    await page.getByTitle("Dark theme").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(
+      page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),
+    ).toHaveAttribute("data-theme", "dark", { timeout: 30_000 });
+  });
+
+  test("resolves system theme through the shared cloud theme toggle", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await openParityHarness(page);
+
+    await expect(page.getByTestId("cloud-render-parity")).toHaveAttribute(
+      "data-theme-mode",
+      "system",
+    );
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(
+      page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),
+    ).toHaveAttribute("data-theme", "dark", { timeout: 30_000 });
+
+    await page.getByTitle("Light theme").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+
+    await page.getByTitle("System theme").click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
     await expect(
       page.frameLocator('[data-cell-id="html-output"] iframe').locator("html"),

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -3,7 +3,10 @@ import { createRoot } from "react-dom/client";
 import { ReadOnlyNotebook } from "../../../../../src/components/cell/ReadOnlyNotebook";
 import { IsolatedRendererProvider } from "../../../../../src/components/isolated/isolated-renderer-context";
 import { MediaProvider } from "../../../../../src/components/outputs/media-provider";
+import { ThemeToggle } from "../../../../../src/components/ui/theme-toggle";
+import { useTheme } from "../../../../../src/hooks/useTheme";
 import { CLOUD_VIEWER_PRIORITY } from "../../../viewer/mime-policy";
+import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "../../../viewer/theme";
 import {
   cloudOutputParityExpectedMarkers,
   cloudOutputParityHostContext,
@@ -14,24 +17,15 @@ import "./style.css";
 
 const rendererBundle = () => import("virtual:isolated-renderer");
 
-type ThemeMode = "light" | "dark";
-
-function applyTheme(theme: ThemeMode): void {
-  document.documentElement.classList.toggle("dark", theme === "dark");
-  document.documentElement.classList.toggle("light", theme === "light");
-  document.documentElement.dataset.theme = theme;
-  document.documentElement.style.colorScheme = theme;
-}
-
 function CloudRendererParityHarness() {
-  const [theme, setTheme] = useState<ThemeMode>("light");
+  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const [cells, setCells] = useState<Awaited<ReturnType<typeof resolveCloudOutputParityCells>>>([]);
   const [error, setError] = useState<string | null>(null);
   const hostContext = useMemo(() => cloudOutputParityHostContext(), []);
 
   useEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
+    applyDocumentTheme(resolvedTheme);
+  }, [resolvedTheme]);
 
   useEffect(() => {
     let cancelled = false;
@@ -60,7 +54,8 @@ function CloudRendererParityHarness() {
       className="cloud-render-parity-page"
       data-testid="cloud-render-parity"
       data-ready={cells.length > 0 ? "true" : "false"}
-      data-theme={theme}
+      data-theme={resolvedTheme}
+      data-theme-mode={theme}
     >
       <header className="cloud-render-parity-header">
         <div>
@@ -68,22 +63,7 @@ function CloudRendererParityHarness() {
           <h1>Renderer parity fixture</h1>
         </div>
         <div className="cloud-render-parity-actions" aria-label="Theme controls">
-          <button
-            type="button"
-            data-testid="theme-light"
-            data-active={theme === "light" ? "true" : "false"}
-            onClick={() => setTheme("light")}
-          >
-            Light
-          </button>
-          <button
-            type="button"
-            data-testid="theme-dark"
-            data-active={theme === "dark" ? "true" : "false"}
-            onClick={() => setTheme("dark")}
-          >
-            Dark
-          </button>
+          <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
         </div>
       </header>
       <div data-testid="fixture-markers" hidden>

--- a/apps/notebook-cloud/test/render-parity/src/style.css
+++ b/apps/notebook-cloud/test/render-parity/src/style.css
@@ -39,22 +39,6 @@
   gap: 0.375rem;
 }
 
-.cloud-render-parity-actions button {
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 999px;
-  padding: 0.35rem 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
-  font: inherit;
-  font-size: 0.8125rem;
-  cursor: pointer;
-}
-
-.cloud-render-parity-actions button[data-active="true"] {
-  color: var(--background);
-  background: var(--foreground);
-}
-
 .cloud-render-parity-notebook {
   max-width: 980px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary

- switches the notebook-cloud render-parity harness to the shared cloud theme hook and `ThemeToggle`
- keeps document theme application on the same cloud helper path as the deployed viewer
- adds Playwright coverage for `system` theme resolution propagating into hosted output-document iframes

## Verification

- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
