### PR TITLE
fix(release): version Codex plugin marketplace entries

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,6 +6,7 @@
   "plugins": [
     {
       "name": "nteract",
+      "version": "0.3.1",
       "source": {
         "source": "local",
         "path": "./plugins/nteract"
@@ -18,6 +19,7 @@
     },
     {
       "name": "nightly",
+      "version": "0.3.1",
       "source": {
         "source": "local",
         "path": "./plugins/nightly"

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -35,8 +35,8 @@ enum Format {
 struct Target {
     path: &'static str,
     format: Format,
-    /// How many version occurrences to bump in the file. `.claude-plugin/marketplace.json`
-    /// has two plugin entries; everything else has one top-level version.
+    /// How many version occurrences to bump in the file. Marketplace files
+    /// have two plugin entries; everything else has one top-level version.
     matches: usize,
 }
 
@@ -294,6 +294,11 @@ const TARGETS: &[Target] = &[
     },
     Target {
         path: ".claude-plugin/marketplace.json",
+        format: Format::Json,
+        matches: 2,
+    },
+    Target {
+        path: ".agents/plugins/marketplace.json",
         format: Format::Json,
         matches: 2,
     },

--- a/scripts/assemble-plugin-dist.sh
+++ b/scripts/assemble-plugin-dist.sh
@@ -191,12 +191,12 @@ PY
 codex_marketplace_json="$out_dir/.agents/plugins/marketplace.json"
 mkdir -p "$out_dir/.agents/plugins"
 
-python3 - "$codex_marketplace_json" "$plugin_name" "./plugins/$plugin_name" <<'PY'
+python3 - "$codex_marketplace_json" "$plugin_name" "./plugins/$plugin_name" "$plugin_version" <<'PY'
 import json
 import os
 import sys
 
-path, plugin_name, source_path = sys.argv[1:4]
+path, plugin_name, source_path, plugin_version = sys.argv[1:5]
 
 try:
     with open(path) as f:
@@ -211,6 +211,7 @@ plugins = data.setdefault("plugins", [])
 
 entry = {
     "name": plugin_name,
+    "version": plugin_version,
     "source": {
         "source": "local",
         "path": source_path,


### PR DESCRIPTION
## Summary

- add `version` fields to the Codex plugin marketplace entries
- make the release distribution assembler write those versions from the source plugin manifest
- include `.agents/plugins/marketplace.json` in `cargo xtask bump` so release bumps keep Codex marketplace metadata current

## Verification

- `cargo xtask lint --fix`
- release assembly dry run for stable and nightly into a temporary distribution checkout
- `bash -n scripts/assemble-plugin-dist.sh`
- `jq` checks for versioned Codex marketplace entries

## Related follow-up already applied

- hotfixed `nteract/agent-plugins` `main` at `ea950b9` so current marketplace metadata advertises `0.3.1`
