### PR TITLE
fix(runtimed): preserve launch-time queued executions

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -252,8 +252,9 @@ export function typedFrameFromRoomHostOutbound(frame: RoomHostOutboundFrame): Ui
 }
 
 function allowsHostedRuntimeStateWrite(identity: AuthenticatedConnection): boolean {
-  // Hosted editors are markdown-only until RuntimeStateDoc path validation lands.
-  return identity.scope === "owner" || identity.scope === "runtime_peer";
+  // Hosted editors/owners are markdown-only: executable RuntimeStateDoc
+  // mutations come from explicit runtime peers, not the editing channel.
+  return identity.scope === "runtime_peer";
 }
 
 function normalizeResult(value: unknown): RoomHostFrameResult {

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -475,6 +475,36 @@ describe("RoomMaterializer", () => {
       /cannot write RuntimeStateDoc changes/,
     );
   });
+
+  it("rejects owner-scoped RuntimeStateDoc execution changes", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=alice&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const runtimePeerConnection = { id: "peer-runtime-owner-principal", identity: runtimeIdentity };
+    const runtimePeer = new RuntimeStatePeerHandle(runtimeIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, runtimePeerConnection, runtimePeer);
+    runtimePeer.create_execution_with_source("exec-owner-forged", "print('owner')", 0);
+    const runtimeMessage = runtimePeer.flush_runtime_state_sync();
+    assert.ok(runtimeMessage);
+
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner"),
+    );
+    const ownerPeerConnection = { id: "peer-owner", identity: ownerIdentity };
+
+    await assert.rejects(
+      () =>
+        materializer.receiveFrame(ownerPeerConnection, {
+          type: FrameType.RUNTIME_STATE_SYNC,
+          payload: runtimeMessage,
+        }),
+      /cannot write RuntimeStateDoc changes/,
+    );
+  });
 });
 
 function syncHostWithClient(

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -39,7 +39,19 @@ enum RuntimeExecutionSavePhase {
 #[derive(Debug, Clone, PartialEq)]
 struct RuntimeStatePolicySnapshot {
     state: RuntimeState,
-    display_index: Option<Vec<(String, Vec<(String, String)>)>>,
+    display_index: Option<Vec<DisplayIndexPolicySnapshot>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DisplayIndexPolicySnapshot {
+    display_id: String,
+    entries: Vec<DisplayIndexEntryPolicySnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DisplayIndexEntryPolicySnapshot {
+    key: String,
+    value: String,
 }
 
 pub(super) fn runtime_file_save_fingerprint(
@@ -209,7 +221,7 @@ fn runtime_state_policy_snapshot(
 
 fn display_index_policy_snapshot(
     doc: &automerge::AutoCommit,
-) -> Option<Vec<(String, Vec<(String, String)>)>> {
+) -> Option<Vec<DisplayIndexPolicySnapshot>> {
     let Some((Value::Object(ObjType::Map), display_index_obj)) =
         doc.get(&ROOT, "display_index").ok().flatten()
     else {
@@ -232,26 +244,32 @@ fn display_index_policy_snapshot(
                         .flatten()
                         .map(|(value, _)| value.to_string())
                         .unwrap_or_else(|| "<missing>".to_string());
-                    entries.push((entry_key, value_repr));
+                    entries.push(DisplayIndexEntryPolicySnapshot {
+                        key: entry_key,
+                        value: value_repr,
+                    });
                 }
             }
             Some((value, _)) => {
-                entries.push((
-                    "<invalid-display-index-node>".to_string(),
-                    value.to_string(),
-                ));
+                entries.push(DisplayIndexEntryPolicySnapshot {
+                    key: "<invalid-display-index-node>".to_string(),
+                    value: value.to_string(),
+                });
             }
             None => {
-                entries.push((
-                    "<missing-display-index-node>".to_string(),
-                    "<missing>".to_string(),
-                ));
+                entries.push(DisplayIndexEntryPolicySnapshot {
+                    key: "<missing-display-index-node>".to_string(),
+                    value: "<missing>".to_string(),
+                });
             }
         }
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
-        display_index.push((display_id, entries));
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        display_index.push(DisplayIndexPolicySnapshot {
+            display_id,
+            entries,
+        });
     }
-    display_index.sort_by(|a, b| a.0.cmp(&b.0));
+    display_index.sort_by(|a, b| a.display_id.cmp(&b.display_id));
     Some(display_index)
 }
 

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -1,11 +1,13 @@
 use std::collections::HashMap;
 
-use automerge::sync;
+use automerge::{sync, ObjType, ReadDoc, Value, ROOT};
+use nteract_identity::ConnectionScope;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
 use notebook_doc::diff::extract_change_actors;
 use notebook_protocol::connection::NotebookFrameType;
+use runtime_doc::{CommDocEntry, RuntimeState, RuntimeStateError};
 
 use super::peer_writer::PeerWriter;
 use super::{NotebookRoom, RoomConnectionIdentity};
@@ -32,6 +34,12 @@ enum RuntimeExecutionSavePhase {
     TerminalEmpty,
     HasOutputs,
     Other,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct RuntimeStatePolicySnapshot {
+    state: RuntimeState,
+    display_index: Option<Vec<(String, Vec<(String, String)>)>>,
 }
 
 pub(super) fn runtime_file_save_fingerprint(
@@ -83,6 +91,7 @@ pub(super) async fn handle_runtime_state_frame(
             // v1: clone-preview validator. Replace with sync_message_new_changes
             // once nteract/automerge ships Patch 1.
             let heads_before = state_doc.get_heads();
+            let state_before = runtime_state_policy_snapshot(state_doc);
             let mut preview = runtime_doc::RuntimeStateDoc::from_doc(state_doc.doc().clone());
             let mut preview_peer_state = state_peer_state.clone();
             match preview.receive_sync_message_with_changes_recovering(
@@ -97,6 +106,12 @@ pub(super) async fn handle_runtime_state_frame(
                         .map_err(|error| {
                             runtime_doc::RuntimeStateError::UnauthorizedActor(error.to_string())
                         })?;
+                    let state_after = runtime_state_policy_snapshot(&preview);
+                    validate_runtime_state_sync_scope(
+                        &state_before,
+                        &state_after,
+                        connection_identity.scope(),
+                    )?;
                 }
                 Ok(false) => {}
                 Err(e) => {
@@ -183,6 +198,193 @@ fn send_runtime_state_sync_update(
     Ok(())
 }
 
+fn runtime_state_policy_snapshot(
+    state_doc: &runtime_doc::RuntimeStateDoc,
+) -> RuntimeStatePolicySnapshot {
+    RuntimeStatePolicySnapshot {
+        state: state_doc.read_state(),
+        display_index: display_index_policy_snapshot(state_doc.doc()),
+    }
+}
+
+fn display_index_policy_snapshot(
+    doc: &automerge::AutoCommit,
+) -> Option<Vec<(String, Vec<(String, String)>)>> {
+    let Some((Value::Object(ObjType::Map), display_index_obj)) =
+        doc.get(&ROOT, "display_index").ok().flatten()
+    else {
+        return None;
+    };
+
+    let mut display_index = Vec::new();
+    for display_id in doc.keys(&display_index_obj) {
+        let mut entries = Vec::new();
+        match doc
+            .get(&display_index_obj, display_id.as_str())
+            .ok()
+            .flatten()
+        {
+            Some((Value::Object(ObjType::Map), entries_obj)) => {
+                for entry_key in doc.keys(&entries_obj) {
+                    let value_repr = doc
+                        .get(&entries_obj, entry_key.as_str())
+                        .ok()
+                        .flatten()
+                        .map(|(value, _)| value.to_string())
+                        .unwrap_or_else(|| "<missing>".to_string());
+                    entries.push((entry_key, value_repr));
+                }
+            }
+            Some((value, _)) => {
+                entries.push((
+                    "<invalid-display-index-node>".to_string(),
+                    value.to_string(),
+                ));
+            }
+            None => {
+                entries.push((
+                    "<missing-display-index-node>".to_string(),
+                    "<missing>".to_string(),
+                ));
+            }
+        }
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        display_index.push((display_id, entries));
+    }
+    display_index.sort_by(|a, b| a.0.cmp(&b.0));
+    Some(display_index)
+}
+
+fn validate_runtime_state_sync_scope(
+    before: &RuntimeStatePolicySnapshot,
+    after: &RuntimeStatePolicySnapshot,
+    scope: ConnectionScope,
+) -> Result<(), RuntimeStateError> {
+    match scope {
+        ConnectionScope::RuntimePeer => Ok(()),
+        ConnectionScope::Editor | ConnectionScope::Owner => {
+            validate_comm_state_only_runtime_delta(before, after, scope)
+        }
+        ConnectionScope::Viewer => {
+            if before == after {
+                Ok(())
+            } else {
+                Err(runtime_state_policy_error(
+                    scope,
+                    "runtime state",
+                    "viewer connections are read-only",
+                ))
+            }
+        }
+    }
+}
+
+fn validate_comm_state_only_runtime_delta(
+    before: &RuntimeStatePolicySnapshot,
+    after: &RuntimeStatePolicySnapshot,
+    scope: ConnectionScope,
+) -> Result<(), RuntimeStateError> {
+    if before.state.kernel != after.state.kernel {
+        return Err(runtime_state_policy_error(scope, "kernel", "daemon-owned"));
+    }
+    if before.state.executions != after.state.executions {
+        return Err(runtime_state_policy_error(
+            scope,
+            "executions",
+            "execution intent must go through ExecuteCell or RunAllCells",
+        ));
+    }
+    if before.state.queue != after.state.queue {
+        return Err(runtime_state_policy_error(scope, "queue", "daemon-owned"));
+    }
+    if before.state.env != after.state.env {
+        return Err(runtime_state_policy_error(scope, "env", "daemon-owned"));
+    }
+    if before.state.trust != after.state.trust {
+        return Err(runtime_state_policy_error(scope, "trust", "daemon-owned"));
+    }
+    if before.state.last_saved != after.state.last_saved {
+        return Err(runtime_state_policy_error(
+            scope,
+            "last_saved",
+            "daemon-owned",
+        ));
+    }
+    if before.state.path != after.state.path {
+        return Err(runtime_state_policy_error(scope, "path", "daemon-owned"));
+    }
+    if before.state.project_context != after.state.project_context {
+        return Err(runtime_state_policy_error(
+            scope,
+            "project_context",
+            "daemon-owned",
+        ));
+    }
+    if before.display_index != after.display_index {
+        return Err(runtime_state_policy_error(
+            scope,
+            "display_index",
+            "output routing is daemon-owned",
+        ));
+    }
+
+    if before.state.comms.len() != after.state.comms.len() {
+        return Err(runtime_state_policy_error(
+            scope,
+            "comms",
+            "only existing comm state properties are writable",
+        ));
+    }
+
+    for (comm_id, before_comm) in &before.state.comms {
+        let Some(after_comm) = after.state.comms.get(comm_id) else {
+            return Err(runtime_state_policy_error(
+                scope,
+                "comms",
+                "comm entries cannot be removed by editor sync",
+            ));
+        };
+        validate_comm_metadata_unchanged(scope, comm_id, before_comm, after_comm)?;
+    }
+
+    Ok(())
+}
+
+fn validate_comm_metadata_unchanged(
+    scope: ConnectionScope,
+    comm_id: &str,
+    before: &CommDocEntry,
+    after: &CommDocEntry,
+) -> Result<(), RuntimeStateError> {
+    let metadata_unchanged = before.target_name == after.target_name
+        && before.model_module == after.model_module
+        && before.model_name == after.model_name
+        && before.outputs == after.outputs
+        && before.seq == after.seq
+        && before.capture_msg_id == after.capture_msg_id;
+
+    if metadata_unchanged {
+        Ok(())
+    } else {
+        Err(runtime_state_policy_error(
+            scope,
+            "comms",
+            &format!("comm metadata is daemon/runtime-owned for {comm_id}"),
+        ))
+    }
+}
+
+fn runtime_state_policy_error(
+    scope: ConnectionScope,
+    field: &str,
+    reason: &str,
+) -> RuntimeStateError {
+    RuntimeStateError::UnauthorizedActor(format!(
+        "scope {} cannot write RuntimeStateDoc {field}: {reason}",
+        scope.as_str()
+    ))
+}
+
 fn generate_runtime_state_sync_message(
     state_doc: &mut runtime_doc::RuntimeStateDoc,
     state_peer_state: &mut sync::State,
@@ -260,4 +462,107 @@ pub(crate) fn notebook_execution_context_id(
     notebook_path
         .map(str::to_string)
         .unwrap_or_else(|| room.id.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nteract_identity::ConnectionScope;
+    use runtime_doc::RuntimeStateDoc;
+    use serde_json::json;
+
+    #[test]
+    fn editor_runtime_state_policy_rejects_execution_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .create_execution_with_source("exec-forged", "print('oops')", 0)
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err = validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Editor)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("executions"),
+            "error should identify execution writes: {err}"
+        );
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_allows_existing_comm_state_update() {
+        let mut before_doc = RuntimeStateDoc::new();
+        before_doc
+            .put_comm(
+                "comm-1",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &json!({ "value": 1, "label": "before" }),
+                0,
+            )
+            .unwrap();
+        let before = runtime_state_policy_snapshot(&before_doc);
+
+        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
+        after_doc
+            .set_comm_state_property("comm-1", "value", &json!(2))
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap();
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_rejects_comm_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .put_comm(
+                "comm-forged",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &json!({ "value": 1 }),
+                0,
+            )
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err =
+            validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap_err();
+
+        assert!(
+            err.to_string().contains("comms"),
+            "error should identify comm topology writes: {err}"
+        );
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_rejects_display_index_changes() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc.add_display_index_entry("display-1", "exec-1", "out-1");
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err =
+            validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap_err();
+
+        assert!(
+            err.to_string().contains("display_index"),
+            "error should identify display index writes: {err}"
+        );
+    }
+
+    #[test]
+    fn runtime_peer_policy_allows_execution_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .create_execution_with_source("exec-runtime", "print('runtime')", 0)
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        validate_runtime_state_sync_scope(&before, &after, ConnectionScope::RuntimePeer).unwrap();
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -347,6 +347,20 @@ fn validate_comm_state_only_runtime_delta(
         validate_comm_metadata_unchanged(scope, comm_id, before_comm, after_comm)?;
     }
 
+    let mut expected_state = before.state.clone();
+    for (comm_id, after_comm) in &after.state.comms {
+        if let Some(expected_comm) = expected_state.comms.get_mut(comm_id) {
+            expected_comm.state = after_comm.state.clone();
+        }
+    }
+    if expected_state != after.state {
+        return Err(runtime_state_policy_error(
+            scope,
+            "runtime state",
+            "only comm state property mutations are allowed",
+        ));
+    }
+
     Ok(())
 }
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -39,7 +39,7 @@ use notebook_protocol::connection::{
     PackageManager,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
-use runtime_doc::{CommDocEntry, RuntimeLifecycle, RuntimeStateDoc};
+use runtime_doc::{CommDocEntry, ExecutionState, RuntimeLifecycle, RuntimeStateDoc};
 use runtime_doc::{KernelActivity, RuntimeStateHandle};
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{debug, error, info, warn};
@@ -456,34 +456,13 @@ pub async fn run_runtime_agent(
                                                 }
                                             }
 
-                                            // Check for new queued executions
-                                            for (eid, exec) in queued {
-                                                if seen_execution_ids.insert(eid.clone()) {
-                                                    if let Some(ref source) = exec.source {
-                                                        if let Some(ref mut k) = kernel {
-                                                            match kernel_state.queue_cell(
-                                                                eid.clone(),
-                                                                exec.cell_id.clone(),
-                                                                source.clone(),
-                                                                k,
-                                                            ).await {
-                                                                Ok(_) => {
-                                                                    info!(
-                                                                        "[runtime-agent] Queued execution {}",
-                                                                        eid
-                                                                    );
-                                                                }
-                                                                Err(e) => {
-                                                                    warn!(
-                                                                        "[runtime-agent] Failed to queue execution {}: {}",
-                                                                        eid, e
-                                                                    );
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
+                                            queue_synced_executions(
+                                                queued,
+                                                &mut seen_execution_ids,
+                                                &mut kernel_state,
+                                                kernel.as_mut(),
+                                            )
+                                            .await;
                                         }
                                         Ok(None) => {}
                                         Err(e) => {
@@ -789,6 +768,48 @@ async fn reconnect_with_backoff(
     Err(last_err.unwrap_or_else(|| anyhow::anyhow!("reconnect gave up with no last error")))
 }
 
+async fn queue_synced_executions<K: KernelConnection>(
+    queued: Vec<(String, ExecutionState)>,
+    seen_execution_ids: &mut HashSet<String>,
+    kernel_state: &mut KernelState,
+    kernel: Option<&mut K>,
+) -> usize {
+    let Some(kernel) = kernel else {
+        return 0;
+    };
+
+    let mut queued_count = 0;
+    for (eid, exec) in queued {
+        if seen_execution_ids.contains(&eid) {
+            continue;
+        }
+
+        let Some(source) = exec.source else {
+            debug!(
+                "[runtime-agent] Deferred queued execution {} without source",
+                eid
+            );
+            continue;
+        };
+
+        match kernel_state
+            .queue_cell(eid.clone(), exec.cell_id.clone(), source, &mut *kernel)
+            .await
+        {
+            Ok(_) => {
+                seen_execution_ids.insert(eid.clone());
+                queued_count += 1;
+                info!("[runtime-agent] Queued execution {}", eid);
+            }
+            Err(e) => {
+                warn!("[runtime-agent] Failed to queue execution {}: {}", eid, e);
+            }
+        }
+    }
+
+    queued_count
+}
+
 /// Handle a `RuntimeAgentRequest` and return a `RuntimeAgentResponse`.
 ///
 /// Also returns optional command receivers when a kernel is launched/restarted
@@ -868,6 +889,12 @@ async fn handle_runtime_agent_request(
                         launch_env_source,
                         launch_started.elapsed().as_millis()
                     );
+                    let queued = ctx
+                        .state
+                        .read(|sd| sd.get_queued_executions())
+                        .unwrap_or_default();
+                    queue_synced_executions(queued, seen_execution_ids, state, kernel.as_mut())
+                        .await;
                     (
                         RuntimeAgentResponse::KernelLaunched {
                             env_source: notebook_protocol::connection::EnvSource::parse(&es),
@@ -1809,6 +1836,50 @@ mod tests {
         };
         let state = KernelState::new(handle.clone());
         (ctx, state, handle)
+    }
+
+    #[tokio::test]
+    async fn queued_execution_seen_before_kernel_launch_is_not_dropped() {
+        let (_ctx, mut state, handle) = test_fixtures();
+        let mut seen_execution_ids = HashSet::new();
+
+        handle
+            .with_doc(|sd| sd.create_execution_with_source("e-prelaunch", "print('ready')", 0))
+            .unwrap();
+
+        let queued = handle.read(|sd| sd.get_queued_executions()).unwrap();
+        let queued_count = queue_synced_executions(
+            queued,
+            &mut seen_execution_ids,
+            &mut state,
+            None::<&mut MockKernel>,
+        )
+        .await;
+
+        assert_eq!(queued_count, 0);
+        assert!(seen_execution_ids.is_empty());
+        let pending = handle
+            .read(|sd| sd.get_execution("e-prelaunch").unwrap())
+            .unwrap();
+        assert_eq!(pending.status, "queued");
+
+        state.set_idle();
+        let mut mock = MockKernel;
+        let queued = handle.read(|sd| sd.get_queued_executions()).unwrap();
+        let queued_count =
+            queue_synced_executions(queued, &mut seen_execution_ids, &mut state, Some(&mut mock))
+                .await;
+
+        assert_eq!(queued_count, 1);
+        assert!(seen_execution_ids.contains("e-prelaunch"));
+        assert_eq!(
+            state.executing_cell().map(String::as_str),
+            Some("e-prelaunch")
+        );
+        let running = handle
+            .read(|sd| sd.get_execution("e-prelaunch").unwrap())
+            .unwrap();
+        assert_eq!(running.status, "running");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix a runtime-agent race where a CRDT-visible queued execution could be marked as seen before a kernel connection existed.
- Re-scan queued RuntimeStateDoc executions immediately after LaunchKernel succeeds so work queued during environment prep is handed to KernelState without waiting for another sync frame.
- Harden RuntimeStateDoc sync writes so owner/editor-scoped peers cannot forge executions, queue state, display routing, environment/trust/kernel state, or comm topology through raw RuntimeStateSync.
- Keep local widget support by allowing owner/editor peers to update existing comm state properties only; hosted cloud RuntimeStateSync is now runtime-peer-only until hosted widget/comms write semantics are explicit.
- Add regression coverage for launch-time queued execution delivery, local RuntimeStateDoc write policy, and hosted owner-scoped execution forgery.

## Why

The failing `runtimed-py Integration Tests` job accepted ExecuteCell during auto-launch, but the daemon logs never showed `[kernel-state] Queuing execution` or a Jupyter `execute_request`. That means the health check was waiting on a terminal execution state for work that had been published to RuntimeStateDoc but never delivered to the kernel.

The coordinator intentionally writes queued executions early so all peers can see queueing while the environment/kernel are still preparing. The runtime agent should only suppress an execution after it actually queues it into KernelState.

The same causal boundary matters for security: execution intent should enter through the gated `ExecuteCell` / `RunAllCells` request path, not through direct writes to the writable RuntimeStateDoc channel used for widget comm state.

## Verification

- `cargo test -p runtimed queued_execution_seen_before_kernel_launch_is_not_dropped -- --nocapture`
- `cargo test -p runtimed notebook_sync_server::peer_runtime_sync::tests:: -- --nocapture`
- `cargo test -p runtimed runtime_agent::tests:: -- --nocapture`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts`
- `cargo xtask lint --fix`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/Users/kyle/.codex/worktrees/cb82/nteract/target/debug/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_PYTEST_WORKERS=1 uv run pytest tests/test_daemon_integration.py::TestBasicConnectivity::test_session_connect -q -s`
