### PR TITLE
fix(renderer): avoid duplicate iframe fullscreen policy

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -1,10 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import { cloudOutputParityExpectedMarkers } from "../../test/fixtures/cloud-output-parity";
 
-const ALLOWED_CONSOLE_MESSAGES = new Set([
-  "Allow attribute will take precedence over 'allowfullscreen'.",
-]);
-
 test.describe("cloud renderer parity harness", () => {
   let consoleProblems: string[];
 
@@ -14,7 +10,6 @@ test.describe("cloud renderer parity harness", () => {
       const type = message.type();
       if (type !== "error" && type !== "warning") return;
       const text = message.text();
-      if (ALLOWED_CONSOLE_MESSAGES.has(text)) return;
       consoleProblems.push(`[${type}] ${text}`);
     });
   });
@@ -79,6 +74,8 @@ test.describe("cloud renderer parity harness", () => {
       const sandbox = await iframe.getAttribute("sandbox");
       expect(sandbox?.split(/\s+/)).toContain("allow-scripts");
       expect(sandbox?.split(/\s+/)).not.toContain("allow-same-origin");
+      await expect(iframe).toHaveAttribute("allow", "fullscreen *");
+      await expect(iframe).not.toHaveAttribute("allowfullscreen", /./);
     }
   });
 

--- a/apps/renderer-test/e2e/render.spec.ts
+++ b/apps/renderer-test/e2e/render.spec.ts
@@ -12,7 +12,6 @@ test.describe("Renderer plugin fixtures", () => {
       const type = message.type();
       if (type !== "error" && type !== "warning") return;
       const text = message.text();
-      if (text === "Allow attribute will take precedence over 'allowfullscreen'.") return;
       consoleProblems.push(`[${type}] ${text}`);
     });
   });

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -14,7 +14,7 @@ Keep the sandbox to exactly these flags:
 allow-scripts allow-downloads allow-forms allow-pointer-lock
 ```
 
-Fullscreen (sift maximize, maps, 3D) comes from the separate `allowFullScreen` iframe attribute, not a sandbox token. `allow-same-origin` stays off — adding it would give cell output access to `window.__TAURI__`, all Tauri APIs, parent DOM, localStorage, and cookies. A CI test in `src/components/isolated/__tests__/isolated-frame.test.ts` asserts the list stays clean; it's the single most important security invariant in this tree. `allow-popups` and `allow-modals` were removed to shrink the phishing surface — leave them out.
+Fullscreen (sift maximize, maps, 3D) comes from the iframe `allow="fullscreen *"` Permissions Policy attribute, not a sandbox token. `allow-same-origin` stays off — adding it would give cell output access to `window.__TAURI__`, all Tauri APIs, parent DOM, localStorage, and cookies. A CI test in `src/components/isolated/__tests__/isolated-frame.test.ts` asserts the list stays clean; it's the single most important security invariant in this tree. `allow-popups` and `allow-modals` were removed to shrink the phishing surface — leave them out.
 
 ### Custom URI scheme + sandbox-induced opaque origin
 

--- a/src/components/isolated/__tests__/output-embed.test.ts
+++ b/src/components/isolated/__tests__/output-embed.test.ts
@@ -70,6 +70,7 @@ describe("createNteractOutputEmbed", () => {
     expect(handle.iframe.getAttribute("sandbox")).toBe(ISOLATED_FRAME_SANDBOX_ATTRS);
     expect(handle.iframe.getAttribute("sandbox")).not.toContain("allow-same-origin");
     expect(handle.iframe.getAttribute("allow")).toBe("fullscreen *");
+    expect(handle.iframe.hasAttribute("allowfullscreen")).toBe(false);
 
     handle.dispose();
 

--- a/src/components/isolated/frame-config.ts
+++ b/src/components/isolated/frame-config.ts
@@ -19,8 +19,8 @@ export const ISOLATED_FRAME_SANDBOX_ATTRS = [
   "allow-downloads", // Allow file downloads (e.g., from widgets)
   "allow-forms", // Allow form submissions
   "allow-pointer-lock", // For interactive visualizations
-  // Fullscreen for sift maximize, maps, 3D, etc. is enabled via the
-  // separate `allowFullScreen` iframe attribute (not a sandbox flag).
+  // Fullscreen for sift maximize, maps, 3D, etc. is enabled via the iframe
+  // `allow` policy below, not as a sandbox flag.
 ].join(" ");
 
 export const ISOLATED_FRAME_ALLOW_ATTR = "fullscreen *";

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -656,7 +656,6 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         src={frameDocument.kind === "src" ? frameDocument.url : undefined}
         srcDoc={frameDocument.kind === "srcdoc" ? frameDocument.html : undefined}
         sandbox={ISOLATED_FRAME_SANDBOX_ATTRS}
-        allowFullScreen
         allow={ISOLATED_FRAME_ALLOW_ATTR}
         className={className}
         data-slot="isolated-frame"

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -113,7 +113,6 @@ export function createNteractOutputEmbed(
   iframe.title = "";
   iframe.setAttribute("sandbox", ISOLATED_FRAME_SANDBOX_ATTRS);
   iframe.setAttribute("allow", ISOLATED_FRAME_ALLOW_ATTR);
-  iframe.setAttribute("allowfullscreen", "");
   iframe.setAttribute("data-slot", "isolated-frame");
   iframe.style.width = "100%";
   iframe.style.height = "1px";


### PR DESCRIPTION
## Summary

- Removes the duplicate legacy `allowfullscreen` attribute from shared isolated output iframes.
- Keeps fullscreen capability on the existing `allow="fullscreen *"` policy.
- Tightens notebook-cloud renderer parity coverage so Chrome console warnings from output iframes fail the test again.

## Verification

- `pnpm test:run src/components/isolated/__tests__/output-embed.test.ts`
- `pnpm test:run src/components/isolated/__tests__/isolated-frame-theme.test.tsx src/components/isolated/__tests__/output-embed.test.ts`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/renderer-test test:e2e`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
