### PR TITLE
test(notebook-cloud): cover mixed output segmentation

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -30,7 +30,7 @@ test.describe("cloud renderer parity harness", () => {
 
     await expect(page.locator('[data-slot="read-only-notebook"]')).toHaveAttribute(
       "data-cell-count",
-      "8",
+      "9",
     );
     await expect(page.locator('[data-cell-id="code-streams"]')).toContainText(
       cloudOutputParityExpectedMarkers.stdout,
@@ -140,6 +140,42 @@ test.describe("cloud renderer parity harness", () => {
     await expect(
       page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
     ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
+  });
+
+  test("segments DOM output, interactive plugins, and Sift into separate lanes", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await openParityHarness(page);
+
+    const mixedCell = page.locator('[data-cell-id="mixed-interactive-sift-output"]');
+    await expect(mixedCell).toContainText(cloudOutputParityExpectedMarkers.mixedStream);
+    await expect(mixedCell.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
+      timeout: 60_000,
+    });
+    await expect(mixedCell.locator('[data-sift-output="true"]')).toHaveCount(1);
+    await expect(mixedCell.locator('[data-sift-output="true"] iframe')).toHaveCSS(
+      "pointer-events",
+      "none",
+    );
+
+    const frameHandles = await mixedCell
+      .locator('iframe[data-slot="isolated-frame"]')
+      .elementHandles();
+    const plotlyFrame = await frameHandles[0]?.contentFrame();
+    const siftFrame = await frameHandles[1]?.contentFrame();
+    if (!plotlyFrame || !siftFrame) {
+      throw new Error("mixed output segmentation frames did not attach");
+    }
+
+    await expect(plotlyFrame.locator('[data-slot="plotly-output"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(plotlyFrame.locator(".js-plotly-plot")).toBeVisible({ timeout: 60_000 });
+    await expect(siftFrame.locator("body")).toContainText(
+      cloudOutputParityExpectedMarkers.siftColumn,
+      { timeout: 90_000 },
+    );
   });
 
   test("chains wheel scroll from engaged Sift frames back to the notebook page", async ({

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -197,6 +197,67 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
       },
     ],
   },
+  {
+    id: "mixed-interactive-sift-output",
+    cell_type: "code",
+    source: [
+      "display(plotly_figure)",
+      "display(df)",
+      "# Plotly and Sift should not share one isolated frame.",
+    ].join("\n"),
+    execution_count: 8,
+    outputs: [
+      {
+        output_id: "mixed-output-stream",
+        output_type: "stream",
+        name: "stdout",
+        text: "Cloud mixed stream marker\n",
+      },
+      {
+        output_id: "mixed-output-plotly",
+        output_type: "display_data",
+        data: {
+          "application/vnd.plotly.v1+json": {
+            inline: JSON.stringify({
+              data: [
+                {
+                  x: [1, 2, 3, 4],
+                  y: [2, 1, 4, 3],
+                  type: "scatter",
+                  mode: "lines+markers",
+                  name: "Cloud Plotly segment",
+                  marker: { color: "#0f766e" },
+                },
+              ],
+              layout: {
+                title: "Cloud Plotly segment marker",
+                width: 520,
+                height: 300,
+                margin: { t: 48, r: 16, b: 40, l: 48 },
+              },
+              config: { staticPlot: true, displayModeBar: false },
+            }),
+          },
+          "text/plain": { inline: "Cloud Plotly fallback marker" },
+        },
+        metadata: {},
+      },
+      {
+        output_id: "mixed-output-sift",
+        output_type: "display_data",
+        data: {
+          "application/vnd.nteract.arrow-stream-manifest+json": {
+            inline: JSON.stringify({
+              chunks: [{ hash: ARROW_BLOB_HASH, size: 9352, row_count: 96 }],
+              complete: true,
+            }),
+          },
+          "text/plain": { inline: "Cloud mixed Sift Arrow marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
 ];
 
 export const cloudOutputParityExpectedMarkers = {
@@ -210,6 +271,7 @@ export const cloudOutputParityExpectedMarkers = {
   fallback: "Plain text fallback marker",
   siftStream: "Preparing Cloud Sift Arrow fixture",
   siftColumn: "score",
+  mixedStream: "Cloud mixed stream marker",
 } as const;
 
 export function cloudOutputParityBlobResolver(): BlobResolver {


### PR DESCRIPTION
## Summary

- adds a cloud render parity fixture that mixes DOM stream output, Plotly plugin output, and Sift Arrow output in one cell
- asserts the shared output segmentation keeps Plotly and Sift in separate output-document iframes while stream output stays in the notebook DOM
- keeps the existing Sift click-to-engage / scroll handoff checks intact

## Verification

- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
