### PR TITLE
fix(outputs): lock engaged Sift scroll boundaries

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -175,9 +175,7 @@ test.describe("cloud renderer parity harness", () => {
     );
   });
 
-  test("chains wheel scroll from engaged Sift frames back to the notebook page", async ({
-    page,
-  }) => {
+  test("locks wheel scroll inside engaged Sift frames at table boundaries", async ({ page }) => {
     test.setTimeout(120_000);
     await openParityHarness(page);
 
@@ -213,9 +211,8 @@ test.describe("cloud renderer parity harness", () => {
 
     const before = await page.evaluate(() => window.scrollY);
     await viewport.dispatchEvent("wheel", { deltaY: 500, bubbles: true, cancelable: true });
-    await expect
-      .poll(() => page.evaluate(() => window.scrollY), { timeout: 5_000 })
-      .toBeGreaterThan(before);
+    await page.waitForTimeout(250);
+    await expect(page.evaluate(() => window.scrollY)).resolves.toBe(before);
   });
 });
 

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -563,7 +563,9 @@ function OutputAreaSingle({
     outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
   const shouldScrollPassthroughFrame =
     shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
-  const allowWheelBoundaryScroll = !focused && !shouldScrollPassthroughFrame;
+  const shouldLockSiftWheelBoundary = hasSiftOutputs && staticFrameInteractionActive;
+  const allowWheelBoundaryScroll =
+    !focused && !shouldScrollPassthroughFrame && !shouldLockSiftWheelBoundary;
   const showSiftInteractionCue =
     hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
   const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -403,7 +403,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByText("Click inside the table to scroll")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
@@ -424,7 +424,7 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
   });
 
@@ -442,6 +442,7 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByText("Table focused")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Click inside the table to scroll" }),

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -856,8 +856,8 @@
 
         // Honor the inner scroller's `overscroll-behavior-y`. Renderers that
         // set `none` or `contain` are explicitly asking not to chain vertical
-        // scroll to the host. Sift leaves vertical chaining enabled so the
-        // notebook can keep scrolling when the table reaches a boundary.
+        // scroll to the host. The host can also decline wheel-boundary
+        // forwarding for engaged frames that should lock scroll in place.
         function scrollerOptsOutOfChaining(scroller) {
           if (!scroller) return false;
           var behavior = window.getComputedStyle(scroller).overscrollBehaviorY;


### PR DESCRIPTION
## Summary

- Keep inactive Sift outputs on the existing click-to-engage scroll passthrough path.
- Lock engaged Sift frames at their scroll boundaries instead of forwarding wheel deltas to the notebook page.
- Update shared OutputArea unit coverage and cloud render-parity E2E coverage for the new behavior.

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/frame-html.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
