### PR TITLE
fix(outputs): keep Sift in standalone boundaries

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -25,7 +25,7 @@ test.describe("cloud renderer parity harness", () => {
 
     await expect(page.locator('[data-slot="read-only-notebook"]')).toHaveAttribute(
       "data-cell-count",
-      "9",
+      "10",
     );
     await expect(page.locator('[data-cell-id="code-streams"]')).toContainText(
       cloudOutputParityExpectedMarkers.stdout,
@@ -173,6 +173,45 @@ test.describe("cloud renderer parity harness", () => {
       cloudOutputParityExpectedMarkers.siftColumn,
       { timeout: 90_000 },
     );
+  });
+
+  test("keeps Sift in a standalone iframe for forced and collapsible boundaries", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    await openParityHarness(page);
+
+    const forced = page.getByTestId("forced-sift-boundary");
+    await expect(forced).toContainText(cloudOutputParityExpectedMarkers.boundaryStream);
+    await expect(forced.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
+      timeout: 60_000,
+    });
+    await expect(forced.locator('[data-sift-output="true"]')).toHaveCount(1);
+
+    const forcedFrameHandles = await forced
+      .locator('iframe[data-slot="isolated-frame"]')
+      .elementHandles();
+    const forcedHtmlFrame = await forcedFrameHandles[0]?.contentFrame();
+    const forcedSiftFrame = await forcedFrameHandles[1]?.contentFrame();
+    if (!forcedHtmlFrame || !forcedSiftFrame) {
+      throw new Error("forced Sift boundary frames did not attach");
+    }
+    await expect(forcedHtmlFrame.locator("body")).toContainText(
+      cloudOutputParityExpectedMarkers.boundaryHtml,
+      { timeout: 30_000 },
+    );
+    await expect(forcedSiftFrame.locator("body")).toContainText(
+      cloudOutputParityExpectedMarkers.siftColumn,
+      { timeout: 90_000 },
+    );
+
+    const collapsible = page.getByTestId("collapsible-sift-boundary");
+    await expect(collapsible.getByRole("button", { name: "Hide outputs" })).toHaveCount(1);
+    await expect(collapsible).toContainText(cloudOutputParityExpectedMarkers.boundaryStream);
+    await expect(collapsible.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
+      timeout: 60_000,
+    });
+    await expect(collapsible.locator('[data-sift-output="true"]')).toHaveCount(1);
   });
 
   test("locks wheel scroll inside engaged Sift frames at table boundaries", async ({ page }) => {

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -258,6 +258,50 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
       },
     ],
   },
+  {
+    id: "sift-html-boundary-output",
+    cell_type: "code",
+    source: [
+      "print('Cloud boundary stream marker')",
+      "display(HTML('<strong>Cloud boundary HTML marker</strong>'))",
+      "display(df)",
+    ].join("\n"),
+    execution_count: 9,
+    outputs: [
+      {
+        output_id: "boundary-output-stream",
+        output_type: "stream",
+        name: "stdout",
+        text: "Cloud boundary stream marker\n",
+      },
+      {
+        output_id: "boundary-output-html",
+        output_type: "display_data",
+        data: {
+          "text/html": {
+            inline:
+              '<section id="cloud-boundary-html-marker"><strong>Cloud boundary HTML marker</strong></section>',
+          },
+          "text/plain": { inline: "Cloud boundary HTML marker" },
+        },
+        metadata: {},
+      },
+      {
+        output_id: "boundary-output-sift",
+        output_type: "display_data",
+        data: {
+          "application/vnd.nteract.arrow-stream-manifest+json": {
+            inline: JSON.stringify({
+              chunks: [{ hash: ARROW_BLOB_HASH, size: 9352, row_count: 96 }],
+              complete: true,
+            }),
+          },
+          "text/plain": { inline: "Cloud boundary Sift Arrow marker" },
+        },
+        metadata: {},
+      },
+    ],
+  },
 ];
 
 export const cloudOutputParityExpectedMarkers = {
@@ -272,6 +316,8 @@ export const cloudOutputParityExpectedMarkers = {
   siftStream: "Preparing Cloud Sift Arrow fixture",
   siftColumn: "score",
   mixedStream: "Cloud mixed stream marker",
+  boundaryStream: "Cloud boundary stream marker",
+  boundaryHtml: "Cloud boundary HTML marker",
 } as const;
 
 export function cloudOutputParityBlobResolver(): BlobResolver {

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode, useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+import { OutputArea } from "../../../../../src/components/cell/OutputArea";
 import { ReadOnlyNotebook } from "../../../../../src/components/cell/ReadOnlyNotebook";
 import { IsolatedRendererProvider } from "../../../../../src/components/isolated/isolated-renderer-context";
 import { MediaProvider } from "../../../../../src/components/outputs/media-provider";
@@ -20,8 +21,13 @@ const rendererBundle = () => import("virtual:isolated-renderer");
 function CloudRendererParityHarness() {
   const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const [cells, setCells] = useState<Awaited<ReturnType<typeof resolveCloudOutputParityCells>>>([]);
+  const [boundaryCollapsed, setBoundaryCollapsed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hostContext = useMemo(() => cloudOutputParityHostContext(), []);
+  const boundaryOutputs = useMemo(
+    () => [...(cells.find((cell) => cell.id === "sift-html-boundary-output")?.outputs ?? [])],
+    [cells],
+  );
 
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
@@ -78,6 +84,31 @@ function CloudRendererParityHarness() {
             className="cloud-render-parity-notebook"
             label="Cloud renderer parity notebook"
           />
+          {boundaryOutputs.length > 0 ? (
+            <section aria-label="Sift boundary controls" className="cloud-render-parity-boundaries">
+              <div data-testid="forced-sift-boundary">
+                <h2>Forced isolated Sift boundary</h2>
+                <OutputArea
+                  cellId="forced-sift-boundary"
+                  outputs={boundaryOutputs}
+                  isolated
+                  priority={CLOUD_VIEWER_PRIORITY}
+                  hostContext={hostContext}
+                />
+              </div>
+              <div data-testid="collapsible-sift-boundary">
+                <h2>Collapsible Sift boundary</h2>
+                <OutputArea
+                  cellId="collapsible-sift-boundary"
+                  outputs={boundaryOutputs}
+                  collapsed={boundaryCollapsed}
+                  onToggleCollapse={() => setBoundaryCollapsed((value) => !value)}
+                  priority={CLOUD_VIEWER_PRIORITY}
+                  hostContext={hostContext}
+                />
+              </div>
+            </section>
+          ) : null}
         </MediaProvider>
       </IsolatedRendererProvider>
     </main>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -116,6 +116,11 @@ interface OutputAreaProps {
    */
   onToggleCollapse?: () => void;
   /**
+   * Total output count to report when a segmented output area shares one
+   * collapse control across multiple rendered lanes.
+   */
+  collapseOutputCount?: number;
+  /**
    * Maximum height before scrolling. Set to enable scroll behavior.
    */
   maxHeight?: number;
@@ -413,7 +418,12 @@ export function OutputArea({
   priority = DEFAULT_PRIORITY,
   ...props
 }: OutputAreaProps) {
-  const { onSearchMatchCount, preloadIframe = false, ...passthroughProps } = props;
+  const {
+    onSearchMatchCount,
+    preloadIframe = false,
+    collapsed = false,
+    ...passthroughProps
+  } = props;
   const segmentedSearchMatchCountsRef = useRef(new Map<string, number>());
   const outputSegments = segmentedOutputLanes(outputs, {
     isolated,
@@ -426,11 +436,14 @@ export function OutputArea({
     return (
       <>
         {outputSegments.map((segment, index) => {
+          if (collapsed && index > 0) return null;
           const segmentKey = outputSegmentKeys[index] ?? outputSegmentKey(segment, index);
           return (
             <OutputAreaSingle
               key={segmentKey}
               {...passthroughProps}
+              collapsed={collapsed}
+              collapseOutputCount={outputs.length}
               outputs={segment.outputs}
               isolated="auto"
               onSearchMatchCount={
@@ -450,7 +463,7 @@ export function OutputArea({
                     }
                   : undefined
               }
-              onToggleCollapse={onToggleCollapse}
+              onToggleCollapse={index === 0 ? onToggleCollapse : undefined}
               preloadIframe={segment.lane === "dom" ? false : preloadIframe}
               priority={priority}
             />
@@ -463,6 +476,7 @@ export function OutputArea({
   return (
     <OutputAreaSingle
       {...passthroughProps}
+      collapsed={collapsed}
       outputs={outputs}
       isolated={isolated}
       onSearchMatchCount={onSearchMatchCount}
@@ -478,6 +492,7 @@ function OutputAreaSingle({
   cellId,
   executionCount,
   collapsed = false,
+  collapseOutputCount = outputs.length,
   onToggleCollapse,
   maxHeight,
   focused = false,
@@ -861,7 +876,7 @@ function OutputAreaSingle({
           {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
           <span>
             {collapsed
-              ? `Show ${outputs.length} output${outputs.length > 1 ? "s" : ""}`
+              ? `Show ${collapseOutputCount} output${collapseOutputCount > 1 ? "s" : ""}`
               : "Hide outputs"}
           </span>
         </button>

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -590,7 +590,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
   });
 
-  it("keeps the legacy collapse control scoped to one mixed output area", () => {
+  it("keeps one collapse control while splitting Sift into its own boundary", () => {
     const outputs: JupyterOutput[] = [
       ...makeStreamOutput("stdout one\n"),
       makeWidgetOutput("widget-progress-1", "model-progress-1"),
@@ -600,10 +600,36 @@ describe("OutputArea iframe theme sync", () => {
     render(<OutputArea outputs={outputs} onToggleCollapse={vi.fn()} />);
 
     expect(screen.getAllByRole("button", { name: "Hide outputs" })).toHaveLength(1);
-    expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(2);
+    expect(frames[0].parentElement?.getAttribute("data-sift-output")).toBeNull();
+    expect(frames[1].parentElement?.getAttribute("data-sift-output")).toBe("true");
   });
 
-  it("keeps forced-isolated mixed outputs together when a caller opts out of lane segmentation", async () => {
+  it("reports the full collapsed output count for segmented Sift boundaries", () => {
+    const outputs: JupyterOutput[] = [
+      ...makeStreamOutput("stdout one\n"),
+      makeWidgetOutput("widget-progress-1", "model-progress-1"),
+      ...makeParquetOutput(),
+    ];
+
+    render(<OutputArea outputs={outputs} collapsed onToggleCollapse={vi.fn()} />);
+
+    expect(screen.getAllByRole("button", { name: "Show 3 outputs" })).toHaveLength(1);
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+  });
+
+  it("preserves collapsed state for non-segmented mixed outputs", () => {
+    render(
+      <OutputArea outputs={makeMixedDocumentOutputs()} collapsed onToggleCollapse={vi.fn()} />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Show 3 outputs" })).toHaveLength(1);
+    expect(screen.queryByText("stream before")).toBeNull();
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+  });
+
+  it("keeps forced-isolated non-Sift mixed outputs together", async () => {
     render(<OutputArea outputs={makeMixedDocumentOutputs()} isolated />);
 
     await waitFor(() => {
@@ -624,6 +650,46 @@ describe("OutputArea iframe theme sync", () => {
           outputIndex: 2,
         }),
       ]);
+    });
+  });
+
+  it("splits forced-isolated Sift outputs away from stream and HTML siblings", async () => {
+    const outputs: JupyterOutput[] = [
+      ...makeStreamOutput("stream before\n"),
+      {
+        output_id: "forced-html-output",
+        output_type: "display_data",
+        data: { "text/html": "<b>unsafe html</b>" },
+        metadata: {},
+      },
+      ...makeParquetOutput(),
+    ];
+
+    render(<OutputArea outputs={outputs} isolated />);
+
+    expect(screen.getByText(/stream before/)).toBeInTheDocument();
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(2);
+    expect(frames[0].parentElement?.getAttribute("data-sift-output")).toBeNull();
+    expect(frames[1].parentElement?.getAttribute("data-sift-output")).toBe("true");
+
+    await waitFor(() => {
+      const batches = mockFrameHandle.renderBatch.mock.calls.map(([batch]) => batch);
+      expect(
+        batches.some((batch) => batch.some((payload) => payload.mimeType === "text/html")),
+      ).toBe(true);
+      expect(
+        batches.some((batch) =>
+          batch.some((payload) => payload.mimeType === "application/vnd.apache.parquet"),
+        ),
+      ).toBe(true);
+      expect(
+        batches.some(
+          (batch) =>
+            batch.some((payload) => payload.mimeType === "text/html") &&
+            batch.some((payload) => payload.mimeType === "application/vnd.apache.parquet"),
+        ),
+      ).toBe(false);
     });
   });
 

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -111,7 +111,7 @@ describe("output lane policy", () => {
     expect(hasWidgetOutputs(segments[1].outputs)).toBe(true);
   });
 
-  it("only enables segmentation for mixed auto-isolated output groups without collapse controls", () => {
+  it("keeps ordinary mixed output groups together when forced or collapsible", () => {
     const outputs = [
       streamOutput(),
       displayOutput("widget", {
@@ -126,5 +126,22 @@ describe("output lane policy", () => {
     expect(segmentedOutputLanes(outputs, { isolated: true })).toEqual([]);
     expect(segmentedOutputLanes(outputs, { hasCollapseControl: true })).toEqual([]);
     expect(segmentedOutputLanes([outputs[1]])).toEqual([]);
+  });
+
+  it("still splits Sift into standalone boundaries when forced or collapsible", () => {
+    const outputs = [
+      streamOutput(),
+      displayOutput("html", { "text/html": "<b>html</b>" }),
+      displayOutput("table", {
+        "application/vnd.apache.parquet": "http://localhost/blob/table",
+      }),
+    ];
+
+    expect(
+      segmentedOutputLanes(outputs, { isolated: true }).map((segment) => segment.lane),
+    ).toEqual(["dom", "static-frame", "sift-frame"]);
+    expect(
+      segmentedOutputLanes(outputs, { hasCollapseControl: true }).map((segment) => segment.lane),
+    ).toEqual(["dom", "static-frame", "sift-frame"]);
   });
 });

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -140,10 +140,13 @@ export function segmentedOutputLanes(
     priority = DEFAULT_PRIORITY,
   }: OutputSegmentationOptions = {},
 ): OutputSegment[] {
-  if (isolated !== "auto") return [];
-  if (hasCollapseControl) return [];
   if (outputs.length <= 1) return [];
 
   const segments = splitOutputSegments(outputs, priority);
+  const hasSiftBoundary = segments.some((segment) => segment.lane === "sift-frame");
+  if (isolated !== "auto" || hasCollapseControl) {
+    return hasSiftBoundary && segments.length > 1 ? segments : [];
+  }
+
   return segments.length > 1 ? segments : [];
 }


### PR DESCRIPTION
## Summary

- keep Sift outputs in their own isolated iframe boundary even when an output group is forced isolated or has a collapse control
- preserve the old single-frame behavior for non-Sift forced/collapsible mixed output groups
- add Vite/Playwright renderer parity coverage for forced and collapsible Sift boundaries

## Verification

- `pnpm test:run src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
