### PR TITLE
fix(runtime-doc): gate hosted runtime state writes

### DIFF
--- a/apps/notebook-cloud/src/authorization.ts
+++ b/apps/notebook-cloud/src/authorization.ts
@@ -69,6 +69,9 @@ export function aclRowsCoverScope(
   rows: NotebookAclRow[],
   requestedScope: ConnectionScope,
 ): boolean {
+  if (requestedScope === "runtime_peer") {
+    return rows.some((row) => row.scope === "runtime_peer");
+  }
   const granted = rows.reduce((mask, row) => mask | capabilityMask(row.scope), 0);
   const requested = capabilityMask(requestedScope);
   return (granted & requested) === requested;

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -2,7 +2,7 @@ import type { DurableObjectState, Env } from "./cloudflare-types.ts";
 import { FrameType, encodeTypedFrame, type FrameTypeValue, type TypedFrame } from "./protocol.ts";
 import { createEmptyRoomHost, loadRoomHostSnapshot, type RoomHostHandle } from "./runtimed-wasm.ts";
 import { getNotebookCatalog } from "./storage.ts";
-import { allowsNotebookWrite, type AuthenticatedConnection } from "./identity.ts";
+import type { AuthenticatedConnection } from "./identity.ts";
 import { cloudLog, durationMs, errorMessage } from "./observability.ts";
 
 const ROOM_HOST_ACTOR_LABEL = "system/schema:notebook-cloud-room";
@@ -47,15 +47,7 @@ export class RoomMaterializer {
   ) {}
 
   async syncPeer(peer: RoomPeer): Promise<RoomHostFrameResult> {
-    return this.withHost((host) =>
-      normalizeResult(
-        host.sync_peer(
-          peer.id,
-          allowsNotebookWrite(peer.identity.scope),
-          allowsHostedRuntimeStateWrite(peer.identity),
-        ),
-      ),
-    );
+    return this.withHost((host) => normalizeResult(host.sync_peer(peer.id, peer.identity.scope)));
   }
 
   async removePeer(peerId: string): Promise<void> {
@@ -65,10 +57,6 @@ export class RoomMaterializer {
   }
 
   async receiveFrame(peer: RoomPeer, frame: TypedFrame): Promise<RoomHostFrameResult> {
-    const canWrite =
-      frame.type === FrameType.AUTOMERGE_SYNC
-        ? allowsNotebookWrite(peer.identity.scope)
-        : allowsHostedRuntimeStateWrite(peer.identity);
     const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);
     return this.withHost((host) =>
@@ -76,7 +64,7 @@ export class RoomMaterializer {
         host.receive_peer_frame(
           peer.id,
           peer.identity.principal,
-          canWrite,
+          peer.identity.scope,
           canWriteAllNotebookChanges,
           encoded,
         ),
@@ -249,12 +237,6 @@ export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {
 
 export function typedFrameFromRoomHostOutbound(frame: RoomHostOutboundFrame): Uint8Array {
   return encodeTypedFrame(frame.frame_type, toUint8Array(frame.payload));
-}
-
-function allowsHostedRuntimeStateWrite(identity: AuthenticatedConnection): boolean {
-  // Hosted editors/owners are markdown-only: executable RuntimeStateDoc
-  // mutations come from explicit runtime peers, not the editing channel.
-  return identity.scope === "runtime_peer";
 }
 
 function normalizeResult(value: unknown): RoomHostFrameResult {

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -47,9 +47,12 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_dependency_fingerprint(): string | undefined;
     get_heads_hex(): string[];
     get_metadata_snapshot_json(): string | undefined;
+    get_runtime_state(): unknown;
     get_runtime_state_heads_hex(): string[];
     receive_frame(frameBytes: Uint8Array): unknown;
     reset_sync_state(): void;
+    set_comm_state_batch(commId: string, patchJson: string): boolean;
+    set_comm_state_property(commId: string, key: string, valueJson: string): boolean;
     update_source(cellId: string, source: string): boolean;
     free(): void;
   }
@@ -62,14 +65,17 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     receive_peer_frame(
       peerId: string,
       principal: string,
-      canWrite: boolean,
+      connectionScope: "viewer" | "editor" | "runtime_peer" | "owner",
       canWriteAllNotebookChanges: boolean,
       frameBytes: Uint8Array,
     ): unknown;
     remove_peer(peerId: string): void;
     save_notebook(): Uint8Array;
     save_runtime_state_doc(): Uint8Array;
-    sync_peer(peerId: string, canWriteNotebook: boolean, canWriteRuntimeState: boolean): unknown;
+    sync_peer(
+      peerId: string,
+      connectionScope: "viewer" | "editor" | "runtime_peer" | "owner",
+    ): unknown;
     free(): void;
   }
 
@@ -81,6 +87,14 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     create_execution_with_source(executionId: string, source: string, seq: number): boolean;
     flush_runtime_state_sync(): Uint8Array | undefined;
     generate_runtime_state_sync_reply(): Uint8Array | undefined;
+    put_comm_json(
+      commId: string,
+      targetName: string,
+      modelModule: string,
+      modelName: string,
+      stateJson: string,
+      seq: number,
+    ): void;
     receive_frame(frameBytes: Uint8Array): unknown;
     save(): Uint8Array;
     set_actor(actorLabel: string): void;

--- a/apps/notebook-cloud/test/authorization.test.ts
+++ b/apps/notebook-cloud/test/authorization.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { aclRowsCoverScope } from "../src/authorization.ts";
+import type { NotebookAclRow } from "../src/storage.ts";
+
+describe("notebook cloud authorization", () => {
+  it("does not derive runtime_peer authority from human write roles", () => {
+    assert.equal(aclRowsCoverScope([aclRow("editor")], "runtime_peer"), false);
+    assert.equal(aclRowsCoverScope([aclRow("owner")], "runtime_peer"), false);
+    assert.equal(aclRowsCoverScope([aclRow("runtime_peer")], "editor"), false);
+    assert.equal(aclRowsCoverScope([aclRow("runtime_peer")], "owner"), false);
+    assert.equal(aclRowsCoverScope([aclRow("runtime_peer")], "runtime_peer"), true);
+  });
+});
+
+function aclRow(scope: NotebookAclRow["scope"]): NotebookAclRow {
+  return {
+    notebook_id: "demo",
+    subject: "user:dev:alice",
+    scope,
+    created_at: "2026-05-27T00:00:00.000Z",
+  };
+}

--- a/apps/notebook-cloud/test/authorization.test.ts
+++ b/apps/notebook-cloud/test/authorization.test.ts
@@ -16,8 +16,11 @@ describe("notebook cloud authorization", () => {
 function aclRow(scope: NotebookAclRow["scope"]): NotebookAclRow {
   return {
     notebook_id: "demo",
+    subject_kind: "principal",
     subject: "user:dev:alice",
     scope,
     created_at: "2026-05-27T00:00:00.000Z",
+    updated_at: "2026-05-27T00:00:00.000Z",
+    created_by_actor_label: "system/test",
   };
 }

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -20,6 +20,8 @@ before(async () => {
   await initializeRuntimedWasm(wasmBytes);
 });
 
+type TestConnectionScope = "viewer" | "editor" | "runtime_peer" | "owner";
+
 describe("RoomHostHandle", () => {
   it("hosts NotebookDoc sync with per-peer state", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
@@ -35,7 +37,7 @@ describe("RoomHostHandle", () => {
     const ownerResult = host.receive_peer_frame(
       "peer-owner",
       "user:dev:alice",
-      true,
+      "owner",
       true,
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
     ) as {
@@ -92,7 +94,7 @@ describe("RoomHostHandle", () => {
     const result = host.receive_peer_frame(
       "peer-owner",
       "user:dev:alice",
-      true,
+      "owner",
       true,
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
     ) as {
@@ -136,7 +138,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-editor",
           "user:dev:bob",
-          true,
+          "editor",
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -158,7 +160,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-editor",
           "user:dev:bob",
-          true,
+          "editor",
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -179,7 +181,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-alice",
           "user:dev:alice",
-          true,
+          "owner",
           true,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -200,7 +202,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-viewer",
           "user:dev:alice",
-          false,
+          "viewer",
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -216,7 +218,7 @@ describe("RoomHostHandle", () => {
       host,
       "peer-runtime",
       "user:dev:runtime-service",
-      true,
+      "runtime_peer",
       false,
       runtime,
     );
@@ -240,7 +242,7 @@ describe("RoomHostHandle", () => {
     const result = host.receive_peer_frame(
       "peer-runtime",
       "user:dev:runtime-service",
-      true,
+      "runtime_peer",
       false,
       encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, message),
     ) as {
@@ -282,7 +284,7 @@ describe("RoomHostHandle", () => {
       host,
       "peer-runtime",
       "user:dev:runtime-service",
-      true,
+      "runtime_peer",
       false,
       forged,
     );
@@ -296,7 +298,36 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-runtime",
           "user:dev:runtime-service",
-          true,
+          "runtime_peer",
+          false,
+          encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, message),
+        ),
+      /not authorized/,
+    );
+  });
+
+  it("rejects peer RuntimeStateDoc changes authored as system actors", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const forged = new RuntimeStatePeerHandle("system/forged-runtime");
+    syncRuntimeHostWithRuntimePeer(
+      host,
+      "peer-runtime",
+      "user:dev:runtime-service",
+      "runtime_peer",
+      false,
+      forged,
+    );
+
+    forged.create_execution("exec-forged-system");
+    const message = forged.flush_runtime_state_sync();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-runtime",
+          "user:dev:runtime-service",
+          "runtime_peer",
           false,
           encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, message),
         ),
@@ -325,7 +356,7 @@ describe("RoomHostHandle", () => {
         host.receive_peer_frame(
           "peer-runtime",
           "user:dev:runtime-service",
-          false,
+          "runtime_peer",
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
@@ -466,14 +497,74 @@ describe("RoomMaterializer", () => {
       submitted_by_actor_label: null,
     });
 
+    const forgedEditorRuntime = new RuntimeStatePeerHandle(editorIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, editorPeerConnection, forgedEditorRuntime);
+    forgedEditorRuntime.create_execution_with_source("exec-editor-forged", "print('editor')", 0);
     await assert.rejects(
       () =>
-        materializer.receiveFrame(editorPeerConnection, {
-          type: FrameType.RUNTIME_STATE_SYNC,
-          payload: runtimeMessage,
-        }),
-      /cannot write RuntimeStateDoc changes/,
+        applyRuntimePeerChangesToMaterializer(
+          materializer,
+          editorPeerConnection,
+          forgedEditorRuntime,
+        ),
+      /executions/,
     );
+  });
+
+  it("allows owner-scoped RuntimeStateDoc changes to existing comm state", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const runtimePeerConnection = { id: "peer-runtime", identity: runtimeIdentity };
+    const runtimePeer = new RuntimeStatePeerHandle(runtimeIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, runtimePeerConnection, runtimePeer);
+    runtimePeer.put_comm_json(
+      "comm-widget",
+      "jupyter.widget",
+      "anywidget",
+      "AnyModel",
+      JSON.stringify({ value: 1, label: "before" }),
+      0,
+    );
+    const runtimeMessage = runtimePeer.flush_runtime_state_sync();
+    assert.ok(runtimeMessage);
+    await materializer.receiveFrame(runtimePeerConnection, {
+      type: FrameType.RUNTIME_STATE_SYNC,
+      payload: runtimeMessage,
+    });
+
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=owner"),
+    );
+    const ownerPeerConnection = { id: "peer-owner", identity: ownerIdentity };
+    const owner = NotebookHandle.create_bootstrap(ownerIdentity.actorLabel);
+    await syncMaterializerRuntimeStateWithClient(materializer, ownerPeerConnection, owner);
+    assert.equal(owner.set_comm_state_property("comm-widget", "value", JSON.stringify(2)), true);
+    const accepted = await applyRuntimeClientChangesToMaterializer(
+      materializer,
+      ownerPeerConnection,
+      owner,
+    );
+    assert.equal(accepted.changed, true);
+    assert.equal(accepted.runtime_state_changed, true);
+
+    const viewerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=carol&operator=desktop:c&scope=viewer"),
+    );
+    const viewer = NotebookHandle.create_bootstrap(viewerIdentity.actorLabel);
+    await syncMaterializerRuntimeStateWithClient(
+      materializer,
+      { id: "peer-viewer", identity: viewerIdentity },
+      viewer,
+    );
+    const runtimeState = viewer.get_runtime_state() as {
+      comms: Record<string, { state: Record<string, unknown> }>;
+    };
+    assert.equal(runtimeState.comms["comm-widget"].state.value, 2);
   });
 
   it("rejects owner-scoped RuntimeStateDoc execution changes", async () => {
@@ -502,7 +593,7 @@ describe("RoomMaterializer", () => {
           type: FrameType.RUNTIME_STATE_SYNC,
           payload: runtimeMessage,
         }),
-      /cannot write RuntimeStateDoc changes/,
+      /executions/,
     );
   });
 });
@@ -515,7 +606,8 @@ function syncHostWithClient(
   canWriteAllNotebookChanges: boolean,
   client: NotebookHandle,
 ): void {
-  let result = host.sync_peer(peerId, canWrite, canWrite) as {
+  const scope = notebookScopeFor(canWrite, canWriteAllNotebookChanges);
+  let result = host.sync_peer(peerId, scope) as {
     outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
   };
   for (let round = 0; round < 8; round += 1) {
@@ -528,7 +620,7 @@ function syncHostWithClient(
       const next = host.receive_peer_frame(
         peerId,
         principal,
-        canWrite,
+        scope,
         canWriteAllNotebookChanges,
         reply,
       ) as {
@@ -548,12 +640,13 @@ function applyClientChangesToHost(
   canWriteAllNotebookChanges: boolean,
   client: NotebookHandle,
 ): void {
+  const scope = notebookScopeFor(canWrite, canWriteAllNotebookChanges);
   const message = client.flush_local_changes();
   assert.ok(message);
   host.receive_peer_frame(
     peerId,
     principal,
-    canWrite,
+    scope,
     canWriteAllNotebookChanges,
     encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
   );
@@ -585,6 +678,88 @@ async function syncMaterializerWithClient(
       outbound,
     };
   }
+}
+
+async function applyRuntimeClientChangesToMaterializer(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  client: NotebookHandle,
+) {
+  const message = client.flush_runtime_state_sync();
+  assert.ok(message);
+  let result = await materializer.receiveFrame(peer, {
+    type: FrameType.RUNTIME_STATE_SYNC,
+    payload: message,
+  });
+
+  for (let round = 0; round < 8 && !result.changed; round += 1) {
+    const replies = applyRuntimeOutboundToClient(result.outbound, peer.id, client);
+    if (replies.length === 0) {
+      break;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.RUNTIME_STATE_SYNC,
+        payload: reply.slice(1),
+      });
+      if (next.changed) {
+        result = next;
+      }
+      outbound.push(...next.outbound);
+    }
+    if (!result.changed) {
+      result = {
+        changed: false,
+        notebook_changed: false,
+        runtime_state_changed: false,
+        outbound,
+      };
+    }
+  }
+
+  return result;
+}
+
+async function applyRuntimePeerChangesToMaterializer(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  runtime: RuntimeStatePeerHandle,
+) {
+  const message = runtime.flush_runtime_state_sync();
+  assert.ok(message);
+  let result = await materializer.receiveFrame(peer, {
+    type: FrameType.RUNTIME_STATE_SYNC,
+    payload: message,
+  });
+
+  for (let round = 0; round < 8 && !result.changed; round += 1) {
+    const replies = applyRuntimeOutboundToRuntimePeer(result.outbound, peer.id, runtime);
+    if (replies.length === 0) {
+      break;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.RUNTIME_STATE_SYNC,
+        payload: reply.slice(1),
+      });
+      if (next.changed) {
+        result = next;
+      }
+      outbound.push(...next.outbound);
+    }
+    if (!result.changed) {
+      result = {
+        changed: false,
+        notebook_changed: false,
+        runtime_state_changed: false,
+        outbound,
+      };
+    }
+  }
+
+  return result;
 }
 
 async function syncMaterializerWithRuntimePeer(
@@ -685,13 +860,14 @@ function syncRuntimeHostWithClient(
   canWriteAllNotebookChanges: boolean,
   client: NotebookHandle,
 ): void {
+  const scope = runtimeScopeFor(canWrite);
   const outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }> = [];
   const initial = client.flush_runtime_state_sync();
   if (initial) {
     const reply = host.receive_peer_frame(
       peerId,
       principal,
-      canWrite,
+      scope,
       canWriteAllNotebookChanges,
       encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, initial),
     ) as {
@@ -700,7 +876,7 @@ function syncRuntimeHostWithClient(
     outbound.push(...reply.outbound);
   }
 
-  const hostSync = host.sync_peer(peerId, false, canWrite) as {
+  const hostSync = host.sync_peer(peerId, scope) as {
     outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
   };
   outbound.push(...hostSync.outbound);
@@ -715,7 +891,7 @@ function syncRuntimeHostWithClient(
       const next = host.receive_peer_frame(
         peerId,
         principal,
-        canWrite,
+        scope,
         canWriteAllNotebookChanges,
         reply,
       ) as {
@@ -731,11 +907,11 @@ function syncRuntimeHostWithRuntimePeer(
   host: Awaited<ReturnType<typeof createEmptyRoomHost>>,
   peerId: string,
   principal: string,
-  canWrite: boolean,
+  scope: TestConnectionScope,
   canWriteAllNotebookChanges: boolean,
   runtime: RuntimeStatePeerHandle,
 ): void {
-  let result = host.sync_peer(peerId, false, canWrite) as {
+  let result = host.sync_peer(peerId, scope) as {
     outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
   };
   for (let round = 0; round < 8; round += 1) {
@@ -748,7 +924,7 @@ function syncRuntimeHostWithRuntimePeer(
       const next = host.receive_peer_frame(
         peerId,
         principal,
-        canWrite,
+        scope,
         canWriteAllNotebookChanges,
         reply,
       ) as {
@@ -758,6 +934,20 @@ function syncRuntimeHostWithRuntimePeer(
     }
     result = { outbound };
   }
+}
+
+function notebookScopeFor(
+  canWrite: boolean,
+  canWriteAllNotebookChanges: boolean,
+): TestConnectionScope {
+  if (!canWrite) {
+    return "viewer";
+  }
+  return canWriteAllNotebookChanges ? "owner" : "editor";
+}
+
+function runtimeScopeFor(canWrite: boolean): TestConnectionScope {
+  return canWrite ? "runtime_peer" : "viewer";
 }
 
 function applyRuntimeOutboundToClient(
@@ -773,9 +963,22 @@ function applyRuntimeOutboundToClient(
     const events = client.receive_frame(
       encodeTypedFrame(frame.frame_type, new Uint8Array(frame.payload)),
     ) as Array<{ type: string; reply?: number[] }>;
+    let sawRuntimeStateSync = false;
     for (const event of events ?? []) {
-      if (event.type === "runtime_state_sync_applied" && event.reply) {
+      if (
+        event.type === "runtime_state_sync_applied" ||
+        event.type === "runtime_state_sync_error"
+      ) {
+        sawRuntimeStateSync = true;
+      }
+      if (event.reply) {
         replies.push(encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array(event.reply)));
+      }
+    }
+    if (sawRuntimeStateSync) {
+      const reply = client.generate_runtime_state_sync_reply();
+      if (reply) {
+        replies.push(encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, reply));
       }
     }
   }

--- a/crates/runtime-doc/src/lib.rs
+++ b/crates/runtime-doc/src/lib.rs
@@ -1,12 +1,17 @@
 mod doc;
 pub mod error;
 mod handle;
+mod policy;
 mod projection;
 mod types;
 
 pub use doc::*;
 pub use error::RuntimeStateError;
 pub use handle::RuntimeStateHandle;
+pub use policy::{
+    runtime_state_policy_snapshot, validate_runtime_state_sync_scope, RuntimeStatePolicySnapshot,
+    RuntimeStateWriteScope,
+};
 pub use projection::{
     diff_executions, ExecutionTransition, ExecutionTransitionKind, ExecutionViewChangeset,
     ExecutionViewProjector, ExecutionViewSnapshot, NotebookQueueProjection, QueueProjection,

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -195,14 +195,6 @@ fn validate_comm_state_only_runtime_delta(
         ));
     }
 
-    if before.state.comms.len() != after.state.comms.len() {
-        return Err(runtime_state_policy_error(
-            scope,
-            "comms",
-            "only existing comm state properties are writable",
-        ));
-    }
-
     for (comm_id, before_comm) in &before.state.comms {
         let Some(after_comm) = after.state.comms.get(comm_id) else {
             return Err(runtime_state_policy_error(
@@ -212,6 +204,15 @@ fn validate_comm_state_only_runtime_delta(
             ));
         };
         validate_comm_metadata_unchanged(scope, comm_id, before_comm, after_comm)?;
+    }
+    for comm_id in after.state.comms.keys() {
+        if !before.state.comms.contains_key(comm_id) {
+            return Err(runtime_state_policy_error(
+                scope,
+                "comms",
+                "comm entries cannot be created by editor sync",
+            ));
+        }
     }
 
     let mut expected_state = before.state.clone();

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -1,0 +1,421 @@
+use automerge::{ObjType, ReadDoc, Value, ROOT};
+
+use crate::{CommDocEntry, RuntimeState, RuntimeStateDoc, RuntimeStateError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeStateWriteScope {
+    Viewer,
+    Editor,
+    RuntimePeer,
+    Owner,
+}
+
+impl RuntimeStateWriteScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Viewer => "viewer",
+            Self::Editor => "editor",
+            Self::RuntimePeer => "runtime_peer",
+            Self::Owner => "owner",
+        }
+    }
+
+    pub const fn allows_runtime_state_write(self) -> bool {
+        matches!(self, Self::Editor | Self::RuntimePeer | Self::Owner)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeStatePolicySnapshot {
+    state: RuntimeState,
+    root_keys: Vec<String>,
+    display_index: Option<Vec<DisplayIndexPolicySnapshot>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DisplayIndexPolicySnapshot {
+    display_id: String,
+    entries: Vec<DisplayIndexEntryPolicySnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DisplayIndexEntryPolicySnapshot {
+    key: String,
+    value: String,
+}
+
+pub fn runtime_state_policy_snapshot(state_doc: &RuntimeStateDoc) -> RuntimeStatePolicySnapshot {
+    RuntimeStatePolicySnapshot {
+        state: state_doc.read_state(),
+        root_keys: root_key_policy_snapshot(state_doc.doc()),
+        display_index: display_index_policy_snapshot(state_doc.doc()),
+    }
+}
+
+fn root_key_policy_snapshot(doc: &automerge::AutoCommit) -> Vec<String> {
+    let mut keys: Vec<String> = doc.keys(&ROOT).collect();
+    keys.sort();
+    keys
+}
+
+fn display_index_policy_snapshot(
+    doc: &automerge::AutoCommit,
+) -> Option<Vec<DisplayIndexPolicySnapshot>> {
+    let Some((Value::Object(ObjType::Map), display_index_obj)) =
+        doc.get(&ROOT, "display_index").ok().flatten()
+    else {
+        return None;
+    };
+
+    let mut display_index = Vec::new();
+    for display_id in doc.keys(&display_index_obj) {
+        let mut entries = Vec::new();
+        match doc
+            .get(&display_index_obj, display_id.as_str())
+            .ok()
+            .flatten()
+        {
+            Some((Value::Object(ObjType::Map), entries_obj)) => {
+                for entry_key in doc.keys(&entries_obj) {
+                    let value_repr = doc
+                        .get(&entries_obj, entry_key.as_str())
+                        .ok()
+                        .flatten()
+                        .map(|(value, _)| value.to_string())
+                        .unwrap_or_else(|| "<missing>".to_string());
+                    entries.push(DisplayIndexEntryPolicySnapshot {
+                        key: entry_key,
+                        value: value_repr,
+                    });
+                }
+            }
+            Some((value, _)) => {
+                entries.push(DisplayIndexEntryPolicySnapshot {
+                    key: "<invalid-display-index-node>".to_string(),
+                    value: value.to_string(),
+                });
+            }
+            None => {
+                entries.push(DisplayIndexEntryPolicySnapshot {
+                    key: "<missing-display-index-node>".to_string(),
+                    value: "<missing>".to_string(),
+                });
+            }
+        }
+        entries.sort_by(|a, b| a.key.cmp(&b.key));
+        display_index.push(DisplayIndexPolicySnapshot {
+            display_id,
+            entries,
+        });
+    }
+    display_index.sort_by(|a, b| a.display_id.cmp(&b.display_id));
+    Some(display_index)
+}
+
+pub fn validate_runtime_state_sync_scope(
+    before: &RuntimeStatePolicySnapshot,
+    after: &RuntimeStatePolicySnapshot,
+    scope: RuntimeStateWriteScope,
+) -> Result<(), RuntimeStateError> {
+    match scope {
+        // Runtime peers are daemon-equivalent writers for RuntimeStateDoc.
+        // Hosted/cloud auth must grant this scope explicitly; it must not be
+        // derived from human editor/owner roles.
+        RuntimeStateWriteScope::RuntimePeer => Ok(()),
+        RuntimeStateWriteScope::Editor | RuntimeStateWriteScope::Owner => {
+            validate_comm_state_only_runtime_delta(before, after, scope)
+        }
+        RuntimeStateWriteScope::Viewer => {
+            if before == after {
+                Ok(())
+            } else {
+                Err(runtime_state_policy_error(
+                    scope,
+                    "runtime state",
+                    "viewer connections are read-only",
+                ))
+            }
+        }
+    }
+}
+
+fn validate_comm_state_only_runtime_delta(
+    before: &RuntimeStatePolicySnapshot,
+    after: &RuntimeStatePolicySnapshot,
+    scope: RuntimeStateWriteScope,
+) -> Result<(), RuntimeStateError> {
+    if before.root_keys != after.root_keys {
+        return Err(runtime_state_policy_error(
+            scope,
+            "schema",
+            "raw RuntimeStateDoc root keys are daemon/runtime-owned",
+        ));
+    }
+    if before.state.kernel != after.state.kernel {
+        return Err(runtime_state_policy_error(scope, "kernel", "daemon-owned"));
+    }
+    if before.state.executions != after.state.executions {
+        return Err(runtime_state_policy_error(
+            scope,
+            "executions",
+            "execution intent must go through ExecuteCell or RunAllCells",
+        ));
+    }
+    if before.state.queue != after.state.queue {
+        return Err(runtime_state_policy_error(scope, "queue", "daemon-owned"));
+    }
+    if before.state.env != after.state.env {
+        return Err(runtime_state_policy_error(scope, "env", "daemon-owned"));
+    }
+    if before.state.trust != after.state.trust {
+        return Err(runtime_state_policy_error(scope, "trust", "daemon-owned"));
+    }
+    if before.state.last_saved != after.state.last_saved {
+        return Err(runtime_state_policy_error(
+            scope,
+            "last_saved",
+            "daemon-owned",
+        ));
+    }
+    if before.state.path != after.state.path {
+        return Err(runtime_state_policy_error(scope, "path", "daemon-owned"));
+    }
+    if before.state.project_context != after.state.project_context {
+        return Err(runtime_state_policy_error(
+            scope,
+            "project_context",
+            "daemon-owned",
+        ));
+    }
+    if before.display_index != after.display_index {
+        return Err(runtime_state_policy_error(
+            scope,
+            "display_index",
+            "output routing is daemon-owned",
+        ));
+    }
+
+    if before.state.comms.len() != after.state.comms.len() {
+        return Err(runtime_state_policy_error(
+            scope,
+            "comms",
+            "only existing comm state properties are writable",
+        ));
+    }
+
+    for (comm_id, before_comm) in &before.state.comms {
+        let Some(after_comm) = after.state.comms.get(comm_id) else {
+            return Err(runtime_state_policy_error(
+                scope,
+                "comms",
+                "comm entries cannot be removed by editor sync",
+            ));
+        };
+        validate_comm_metadata_unchanged(scope, comm_id, before_comm, after_comm)?;
+    }
+
+    let mut expected_state = before.state.clone();
+    for (comm_id, after_comm) in &after.state.comms {
+        if let Some(expected_comm) = expected_state.comms.get_mut(comm_id) {
+            expected_comm.state = after_comm.state.clone();
+        }
+    }
+    if expected_state != after.state {
+        return Err(runtime_state_policy_error(
+            scope,
+            "runtime state",
+            "only comm state property mutations are allowed",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_comm_metadata_unchanged(
+    scope: RuntimeStateWriteScope,
+    comm_id: &str,
+    before: &CommDocEntry,
+    after: &CommDocEntry,
+) -> Result<(), RuntimeStateError> {
+    let metadata_unchanged = before.target_name == after.target_name
+        && before.model_module == after.model_module
+        && before.model_name == after.model_name
+        && before.outputs == after.outputs
+        && before.seq == after.seq
+        && before.capture_msg_id == after.capture_msg_id;
+
+    if metadata_unchanged {
+        Ok(())
+    } else {
+        Err(runtime_state_policy_error(
+            scope,
+            "comms",
+            &format!("comm metadata is daemon/runtime-owned for {comm_id}"),
+        ))
+    }
+}
+
+fn runtime_state_policy_error(
+    scope: RuntimeStateWriteScope,
+    field: &str,
+    reason: &str,
+) -> RuntimeStateError {
+    RuntimeStateError::UnauthorizedActor(format!(
+        "scope {} cannot write RuntimeStateDoc {field}: {reason}",
+        scope.as_str()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use automerge::transaction::Transactable;
+    use serde_json::json;
+
+    #[test]
+    fn editor_runtime_state_policy_rejects_execution_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .create_execution_with_source("exec-forged", "print('oops')", 0)
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err =
+            validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Editor)
+                .unwrap_err();
+
+        assert!(
+            err.to_string().contains("executions"),
+            "error should identify execution writes: {err}"
+        );
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_allows_existing_comm_state_update() {
+        let mut before_doc = RuntimeStateDoc::new();
+        before_doc
+            .put_comm(
+                "comm-1",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &json!({ "value": 1, "label": "before" }),
+                0,
+            )
+            .unwrap();
+        let before = runtime_state_policy_snapshot(&before_doc);
+
+        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
+        after_doc
+            .set_comm_state_property("comm-1", "value", &json!(2))
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Owner).unwrap();
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_rejects_comm_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .put_comm(
+                "comm-forged",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &json!({ "value": 1 }),
+                0,
+            )
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err = validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Owner)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("comms"),
+            "error should identify comm topology writes: {err}"
+        );
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_rejects_display_index_changes() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc.add_display_index_entry("display-1", "exec-1", "out-1");
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err = validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Owner)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("display_index"),
+            "error should identify display index writes: {err}"
+        );
+    }
+
+    #[test]
+    fn owner_runtime_state_policy_rejects_hidden_root_keys() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .doc_mut()
+            .put(ROOT, "future_root_key", "hidden")
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err = validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Owner)
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("schema"),
+            "error should identify raw schema writes: {err}"
+        );
+    }
+
+    #[test]
+    fn viewer_runtime_state_policy_rejects_comm_state_update() {
+        let mut before_doc = RuntimeStateDoc::new();
+        before_doc
+            .put_comm(
+                "comm-1",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &json!({ "value": 1 }),
+                0,
+            )
+            .unwrap();
+        let before = runtime_state_policy_snapshot(&before_doc);
+
+        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
+        after_doc
+            .set_comm_state_property("comm-1", "value", &json!(2))
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        let err =
+            validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::Viewer)
+                .unwrap_err();
+
+        assert!(
+            err.to_string().contains("viewer connections are read-only"),
+            "error should identify viewer read-only policy: {err}"
+        );
+    }
+
+    #[test]
+    fn runtime_peer_policy_allows_execution_creation() {
+        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
+        let mut after_doc = RuntimeStateDoc::new();
+        after_doc
+            .create_execution_with_source("exec-runtime", "print('runtime')", 0)
+            .unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::RuntimePeer)
+            .unwrap();
+    }
+}

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -16,10 +16,11 @@ use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
 use notebook_doc::{CellSnapshot, NotebookDoc};
 use notebook_wire::{frame_types, SessionControlMessage, SessionSyncStatusWire};
-use nteract_identity::{ActorLabel, Operator, Principal};
+use nteract_identity::{ActorLabel, ConnectionScope, Operator, Principal};
 use runtime_doc::{
-    diff_output_ids_in_place, output_ids_for_execution, ExecutionState, ExecutionViewChangeset,
-    ExecutionViewProjector, RuntimeState, RuntimeStateDoc,
+    diff_output_ids_in_place, output_ids_for_execution, runtime_state_policy_snapshot,
+    validate_runtime_state_sync_scope, ExecutionState, ExecutionViewChangeset,
+    ExecutionViewProjector, RuntimeState, RuntimeStateDoc, RuntimeStateWriteScope,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -412,6 +413,29 @@ impl RuntimeStatePeerHandle {
             .append_output(execution_id, &manifest)
             .map_err(|e| JsError::new(&format!("append output failed: {e}")))
     }
+
+    pub fn put_comm_json(
+        &mut self,
+        comm_id: &str,
+        target_name: &str,
+        model_module: &str,
+        model_name: &str,
+        state_json: &str,
+        seq: u32,
+    ) -> Result<(), JsError> {
+        let state: serde_json::Value = serde_json::from_str(state_json)
+            .map_err(|e| JsError::new(&format!("decode comm state json: {e}")))?;
+        self.state_doc
+            .put_comm(
+                comm_id,
+                target_name,
+                model_module,
+                model_name,
+                &state,
+                seq.into(),
+            )
+            .map_err(|e| JsError::new(&format!("put comm failed: {e}")))
+    }
 }
 
 /// Durable-Object room host for NotebookDoc + RuntimeStateDoc sync.
@@ -473,17 +497,13 @@ impl RoomHostHandle {
     /// The Worker calls this immediately after accepting a socket and after the
     /// peer receives `cloud_room_ready`. It lets read-only viewers receive the
     /// current document without authoring any local Automerge changes.
-    pub fn sync_peer(
-        &mut self,
-        peer_id: &str,
-        can_write_notebook: bool,
-        can_write_runtime_state: bool,
-    ) -> Result<JsValue, JsError> {
+    pub fn sync_peer(&mut self, peer_id: &str, connection_scope: &str) -> Result<JsValue, JsError> {
+        let connection_scope = parse_connection_scope(connection_scope)?;
         let mut result = RoomHostFrameResult::empty();
         self.queue_current_sync_for_peer(
             peer_id,
-            can_write_notebook,
-            can_write_runtime_state,
+            connection_scope.allows_notebook_write(),
+            connection_scope.allows_runtime_state_write(),
             &mut result.outbound,
         )?;
         serialize_to_js(&result).map_err(|e| JsError::new(&format!("serialize room result: {e}")))
@@ -499,7 +519,7 @@ impl RoomHostHandle {
         &mut self,
         peer_id: &str,
         principal: &str,
-        can_write: bool,
+        connection_scope: &str,
         can_write_all_notebook_changes: bool,
         frame_bytes: &[u8],
     ) -> Result<JsValue, JsError> {
@@ -507,18 +527,21 @@ impl RoomHostHandle {
             return Err(JsError::new("typed frame cannot be empty"));
         }
 
+        let connection_scope = parse_connection_scope(connection_scope)?;
+        let runtime_scope = runtime_state_write_scope(connection_scope);
+        let can_write_notebook = connection_scope.allows_notebook_write();
         let frame_type = frame_bytes[0];
         let payload = &frame_bytes[1..];
         let result = match frame_type {
             frame_types::AUTOMERGE_SYNC => self.receive_notebook_sync(
                 peer_id,
                 principal,
-                can_write,
+                can_write_notebook,
                 can_write_all_notebook_changes,
                 payload,
             )?,
             frame_types::RUNTIME_STATE_SYNC => {
-                self.receive_runtime_state_sync(peer_id, principal, can_write, payload)?
+                self.receive_runtime_state_sync(peer_id, principal, runtime_scope, payload)?
             }
             _ => RoomHostFrameResult::empty(),
         };
@@ -620,12 +643,13 @@ impl RoomHostHandle {
         &mut self,
         peer_id: &str,
         principal: &str,
-        can_write: bool,
+        scope: RuntimeStateWriteScope,
         payload: &[u8],
     ) -> Result<RoomHostFrameResult, JsError> {
         let message = sync::Message::decode(payload)
             .map_err(|e| JsError::new(&format!("decode runtime state sync: {e}")))?;
         let has_changes = !message.changes.is_empty();
+        let can_write = scope.allows_runtime_state_write();
         if has_changes && !can_write {
             return Err(JsError::new(
                 "connection scope cannot write RuntimeStateDoc changes",
@@ -648,6 +672,10 @@ impl RoomHostHandle {
                 .map_err(|e| JsError::new(&format!("runtime state auth preview failed: {e}")))?;
             let actors = extract_change_actors(preview.doc_mut(), &heads_before);
             validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+            let state_before = runtime_state_policy_snapshot(&self.state_doc);
+            let state_after = runtime_state_policy_snapshot(&preview);
+            validate_runtime_state_sync_scope(&state_before, &state_after, scope)
+                .map_err(|e| JsError::new(&e.to_string()))?;
         }
 
         let heads_before = self.state_doc.get_heads();
@@ -783,6 +811,21 @@ fn room_peer_sync_state(can_write: bool) -> sync::State {
     }
 }
 
+fn parse_connection_scope(scope: &str) -> Result<ConnectionScope, JsError> {
+    scope
+        .parse()
+        .map_err(|e| JsError::new(&format!("unknown connection scope: {e}")))
+}
+
+fn runtime_state_write_scope(scope: ConnectionScope) -> RuntimeStateWriteScope {
+    match scope {
+        ConnectionScope::Viewer => RuntimeStateWriteScope::Viewer,
+        ConnectionScope::Editor => RuntimeStateWriteScope::Editor,
+        ConnectionScope::RuntimePeer => RuntimeStateWriteScope::RuntimePeer,
+        ConnectionScope::Owner => RuntimeStateWriteScope::Owner,
+    }
+}
+
 fn validate_room_actor_labels<'a>(
     principal: &str,
     labels: impl IntoIterator<Item = &'a str>,
@@ -791,7 +834,6 @@ fn validate_room_actor_labels<'a>(
         .map_err(|e| JsError::new(&format!("authenticated principal is invalid: {e}")))?;
     for label in labels {
         match ActorLabel::parse(label.to_string()) {
-            Ok(actor) if actor.principal() == Principal::SYSTEM => {}
             Ok(actor) if actor.principal() == expected.as_str() => {}
             Ok(actor) => {
                 return Err(JsError::new(&format!(
@@ -1129,11 +1171,13 @@ impl NotebookHandle {
     /// This is the preferred constructor for sync-only clients. The daemon
     /// populates the full document via Automerge sync.
     pub fn create_bootstrap(actor_label: &str) -> Result<NotebookHandle, JsError> {
+        let mut state_doc = RuntimeStateDoc::try_new_empty()
+            .map_err(|e| JsError::new(&format!("create runtime state doc failed: {}", e)))?;
+        state_doc.set_actor(actor_label);
         Ok(NotebookHandle {
             doc: NotebookDoc::bootstrap(notebook_doc::TextEncoding::Utf16CodeUnit, actor_label),
             sync_state: sync::State::new(),
-            state_doc: RuntimeStateDoc::try_new_empty()
-                .map_err(|e| JsError::new(&format!("create runtime state doc failed: {}", e)))?,
+            state_doc,
             state_sync_state: sync::State::new(),
             prev_output_by_id: HashMap::new(),
             execution_view_projector: ExecutionViewProjector::default(),
@@ -1220,6 +1264,7 @@ impl NotebookHandle {
     /// Tags all subsequent edits with this label for provenance tracking.
     pub fn set_actor(&mut self, actor_label: &str) {
         self.doc.set_actor(actor_label);
+        self.state_doc.set_actor(actor_label);
     }
 
     /// Return the deduplicated, sorted list of actor labels that have

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -672,10 +672,15 @@ impl RoomHostHandle {
                 .map_err(|e| JsError::new(&format!("runtime state auth preview failed: {e}")))?;
             let actors = extract_change_actors(preview.doc_mut(), &heads_before);
             validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
-            let state_before = runtime_state_policy_snapshot(&self.state_doc);
-            let state_after = runtime_state_policy_snapshot(&preview);
-            validate_runtime_state_sync_scope(&state_before, &state_after, scope)
-                .map_err(|e| JsError::new(&e.to_string()))?;
+            if scope != RuntimeStateWriteScope::RuntimePeer {
+                let state_before = runtime_state_policy_snapshot(&self.state_doc);
+                let state_after = runtime_state_policy_snapshot(&preview);
+                validate_runtime_state_sync_scope(&state_before, &state_after, scope)
+                    .map_err(|e| JsError::new(&e.to_string()))?;
+            }
+            // This is a synchronous WASM host path: no await or host callback
+            // can interleave another RuntimeStateDoc writer between the
+            // validated preview and the real apply below.
         }
 
         let heads_before = self.state_doc.get_heads();

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -62,8 +62,6 @@ impl RoomConnectionIdentity {
     ) -> anyhow::Result<()> {
         for label in labels {
             match ActorLabel::parse(label.to_string()) {
-                // Reserved for future system/schema:* seed and import writes.
-                Ok(actor) if actor.principal() == nteract_identity::Principal::SYSTEM => {}
                 Ok(actor) if actor.principal() == self.auth.principal().as_str() => {}
                 Ok(actor) => anyhow::bail!(
                     "actor principal {} is not authorized for authenticated principal {}",

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -87,7 +87,7 @@ pub(super) async fn handle_runtime_state_frame(
             // v1: clone-preview validator. Replace with sync_message_new_changes
             // once nteract/automerge ships Patch 1.
             let heads_before = state_doc.get_heads();
-            let state_before = runtime_state_policy_snapshot(state_doc);
+            let write_scope = runtime_state_write_scope(connection_identity.scope());
             let mut preview = runtime_doc::RuntimeStateDoc::from_doc(state_doc.doc().clone());
             let mut preview_peer_state = state_peer_state.clone();
             match preview.receive_sync_message_with_changes_recovering(
@@ -102,12 +102,18 @@ pub(super) async fn handle_runtime_state_frame(
                         .map_err(|error| {
                             runtime_doc::RuntimeStateError::UnauthorizedActor(error.to_string())
                         })?;
-                    let state_after = runtime_state_policy_snapshot(&preview);
-                    validate_runtime_state_sync_scope(
-                        &state_before,
-                        &state_after,
-                        runtime_state_write_scope(connection_identity.scope()),
-                    )?;
+                    if write_scope != RuntimeStateWriteScope::RuntimePeer {
+                        let state_before = runtime_state_policy_snapshot(state_doc);
+                        let state_after = runtime_state_policy_snapshot(&preview);
+                        validate_runtime_state_sync_scope(
+                            &state_before,
+                            &state_after,
+                            write_scope,
+                        )?;
+                    }
+                    // `with_doc` holds the RuntimeStateDoc lock for the whole
+                    // preview/apply sequence, so the validated message and peer
+                    // state cannot diverge through another writer before apply.
                 }
                 Ok(false) => {}
                 Err(e) => {

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use automerge::{sync, ObjType, ReadDoc, Value, ROOT};
+use automerge::sync;
 use nteract_identity::ConnectionScope;
 use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
 use notebook_doc::diff::extract_change_actors;
 use notebook_protocol::connection::NotebookFrameType;
-use runtime_doc::{CommDocEntry, RuntimeState, RuntimeStateError};
+use runtime_doc::{
+    runtime_state_policy_snapshot, validate_runtime_state_sync_scope, RuntimeStateWriteScope,
+};
 
 use super::peer_writer::PeerWriter;
 use super::{NotebookRoom, RoomConnectionIdentity};
@@ -34,24 +36,6 @@ enum RuntimeExecutionSavePhase {
     TerminalEmpty,
     HasOutputs,
     Other,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct RuntimeStatePolicySnapshot {
-    state: RuntimeState,
-    display_index: Option<Vec<DisplayIndexPolicySnapshot>>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct DisplayIndexPolicySnapshot {
-    display_id: String,
-    entries: Vec<DisplayIndexEntryPolicySnapshot>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct DisplayIndexEntryPolicySnapshot {
-    key: String,
-    value: String,
 }
 
 pub(super) fn runtime_file_save_fingerprint(
@@ -122,7 +106,7 @@ pub(super) async fn handle_runtime_state_frame(
                     validate_runtime_state_sync_scope(
                         &state_before,
                         &state_after,
-                        connection_identity.scope(),
+                        runtime_state_write_scope(connection_identity.scope()),
                     )?;
                 }
                 Ok(false) => {}
@@ -210,211 +194,13 @@ fn send_runtime_state_sync_update(
     Ok(())
 }
 
-fn runtime_state_policy_snapshot(
-    state_doc: &runtime_doc::RuntimeStateDoc,
-) -> RuntimeStatePolicySnapshot {
-    RuntimeStatePolicySnapshot {
-        state: state_doc.read_state(),
-        display_index: display_index_policy_snapshot(state_doc.doc()),
-    }
-}
-
-fn display_index_policy_snapshot(
-    doc: &automerge::AutoCommit,
-) -> Option<Vec<DisplayIndexPolicySnapshot>> {
-    let Some((Value::Object(ObjType::Map), display_index_obj)) =
-        doc.get(&ROOT, "display_index").ok().flatten()
-    else {
-        return None;
-    };
-
-    let mut display_index = Vec::new();
-    for display_id in doc.keys(&display_index_obj) {
-        let mut entries = Vec::new();
-        match doc
-            .get(&display_index_obj, display_id.as_str())
-            .ok()
-            .flatten()
-        {
-            Some((Value::Object(ObjType::Map), entries_obj)) => {
-                for entry_key in doc.keys(&entries_obj) {
-                    let value_repr = doc
-                        .get(&entries_obj, entry_key.as_str())
-                        .ok()
-                        .flatten()
-                        .map(|(value, _)| value.to_string())
-                        .unwrap_or_else(|| "<missing>".to_string());
-                    entries.push(DisplayIndexEntryPolicySnapshot {
-                        key: entry_key,
-                        value: value_repr,
-                    });
-                }
-            }
-            Some((value, _)) => {
-                entries.push(DisplayIndexEntryPolicySnapshot {
-                    key: "<invalid-display-index-node>".to_string(),
-                    value: value.to_string(),
-                });
-            }
-            None => {
-                entries.push(DisplayIndexEntryPolicySnapshot {
-                    key: "<missing-display-index-node>".to_string(),
-                    value: "<missing>".to_string(),
-                });
-            }
-        }
-        entries.sort_by(|a, b| a.key.cmp(&b.key));
-        display_index.push(DisplayIndexPolicySnapshot {
-            display_id,
-            entries,
-        });
-    }
-    display_index.sort_by(|a, b| a.display_id.cmp(&b.display_id));
-    Some(display_index)
-}
-
-fn validate_runtime_state_sync_scope(
-    before: &RuntimeStatePolicySnapshot,
-    after: &RuntimeStatePolicySnapshot,
-    scope: ConnectionScope,
-) -> Result<(), RuntimeStateError> {
+fn runtime_state_write_scope(scope: ConnectionScope) -> RuntimeStateWriteScope {
     match scope {
-        ConnectionScope::RuntimePeer => Ok(()),
-        ConnectionScope::Editor | ConnectionScope::Owner => {
-            validate_comm_state_only_runtime_delta(before, after, scope)
-        }
-        ConnectionScope::Viewer => {
-            if before == after {
-                Ok(())
-            } else {
-                Err(runtime_state_policy_error(
-                    scope,
-                    "runtime state",
-                    "viewer connections are read-only",
-                ))
-            }
-        }
+        ConnectionScope::Viewer => RuntimeStateWriteScope::Viewer,
+        ConnectionScope::Editor => RuntimeStateWriteScope::Editor,
+        ConnectionScope::RuntimePeer => RuntimeStateWriteScope::RuntimePeer,
+        ConnectionScope::Owner => RuntimeStateWriteScope::Owner,
     }
-}
-
-fn validate_comm_state_only_runtime_delta(
-    before: &RuntimeStatePolicySnapshot,
-    after: &RuntimeStatePolicySnapshot,
-    scope: ConnectionScope,
-) -> Result<(), RuntimeStateError> {
-    if before.state.kernel != after.state.kernel {
-        return Err(runtime_state_policy_error(scope, "kernel", "daemon-owned"));
-    }
-    if before.state.executions != after.state.executions {
-        return Err(runtime_state_policy_error(
-            scope,
-            "executions",
-            "execution intent must go through ExecuteCell or RunAllCells",
-        ));
-    }
-    if before.state.queue != after.state.queue {
-        return Err(runtime_state_policy_error(scope, "queue", "daemon-owned"));
-    }
-    if before.state.env != after.state.env {
-        return Err(runtime_state_policy_error(scope, "env", "daemon-owned"));
-    }
-    if before.state.trust != after.state.trust {
-        return Err(runtime_state_policy_error(scope, "trust", "daemon-owned"));
-    }
-    if before.state.last_saved != after.state.last_saved {
-        return Err(runtime_state_policy_error(
-            scope,
-            "last_saved",
-            "daemon-owned",
-        ));
-    }
-    if before.state.path != after.state.path {
-        return Err(runtime_state_policy_error(scope, "path", "daemon-owned"));
-    }
-    if before.state.project_context != after.state.project_context {
-        return Err(runtime_state_policy_error(
-            scope,
-            "project_context",
-            "daemon-owned",
-        ));
-    }
-    if before.display_index != after.display_index {
-        return Err(runtime_state_policy_error(
-            scope,
-            "display_index",
-            "output routing is daemon-owned",
-        ));
-    }
-
-    if before.state.comms.len() != after.state.comms.len() {
-        return Err(runtime_state_policy_error(
-            scope,
-            "comms",
-            "only existing comm state properties are writable",
-        ));
-    }
-
-    for (comm_id, before_comm) in &before.state.comms {
-        let Some(after_comm) = after.state.comms.get(comm_id) else {
-            return Err(runtime_state_policy_error(
-                scope,
-                "comms",
-                "comm entries cannot be removed by editor sync",
-            ));
-        };
-        validate_comm_metadata_unchanged(scope, comm_id, before_comm, after_comm)?;
-    }
-
-    let mut expected_state = before.state.clone();
-    for (comm_id, after_comm) in &after.state.comms {
-        if let Some(expected_comm) = expected_state.comms.get_mut(comm_id) {
-            expected_comm.state = after_comm.state.clone();
-        }
-    }
-    if expected_state != after.state {
-        return Err(runtime_state_policy_error(
-            scope,
-            "runtime state",
-            "only comm state property mutations are allowed",
-        ));
-    }
-
-    Ok(())
-}
-
-fn validate_comm_metadata_unchanged(
-    scope: ConnectionScope,
-    comm_id: &str,
-    before: &CommDocEntry,
-    after: &CommDocEntry,
-) -> Result<(), RuntimeStateError> {
-    let metadata_unchanged = before.target_name == after.target_name
-        && before.model_module == after.model_module
-        && before.model_name == after.model_name
-        && before.outputs == after.outputs
-        && before.seq == after.seq
-        && before.capture_msg_id == after.capture_msg_id;
-
-    if metadata_unchanged {
-        Ok(())
-    } else {
-        Err(runtime_state_policy_error(
-            scope,
-            "comms",
-            &format!("comm metadata is daemon/runtime-owned for {comm_id}"),
-        ))
-    }
-}
-
-fn runtime_state_policy_error(
-    scope: ConnectionScope,
-    field: &str,
-    reason: &str,
-) -> RuntimeStateError {
-    RuntimeStateError::UnauthorizedActor(format!(
-        "scope {} cannot write RuntimeStateDoc {field}: {reason}",
-        scope.as_str()
-    ))
 }
 
 fn generate_runtime_state_sync_message(
@@ -494,107 +280,4 @@ pub(crate) fn notebook_execution_context_id(
     notebook_path
         .map(str::to_string)
         .unwrap_or_else(|| room.id.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use nteract_identity::ConnectionScope;
-    use runtime_doc::RuntimeStateDoc;
-    use serde_json::json;
-
-    #[test]
-    fn editor_runtime_state_policy_rejects_execution_creation() {
-        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
-        let mut after_doc = RuntimeStateDoc::new();
-        after_doc
-            .create_execution_with_source("exec-forged", "print('oops')", 0)
-            .unwrap();
-        let after = runtime_state_policy_snapshot(&after_doc);
-
-        let err = validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Editor)
-            .unwrap_err();
-
-        assert!(
-            err.to_string().contains("executions"),
-            "error should identify execution writes: {err}"
-        );
-    }
-
-    #[test]
-    fn owner_runtime_state_policy_allows_existing_comm_state_update() {
-        let mut before_doc = RuntimeStateDoc::new();
-        before_doc
-            .put_comm(
-                "comm-1",
-                "jupyter.widget",
-                "anywidget",
-                "AnyModel",
-                &json!({ "value": 1, "label": "before" }),
-                0,
-            )
-            .unwrap();
-        let before = runtime_state_policy_snapshot(&before_doc);
-
-        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
-        after_doc
-            .set_comm_state_property("comm-1", "value", &json!(2))
-            .unwrap();
-        let after = runtime_state_policy_snapshot(&after_doc);
-
-        validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap();
-    }
-
-    #[test]
-    fn owner_runtime_state_policy_rejects_comm_creation() {
-        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
-        let mut after_doc = RuntimeStateDoc::new();
-        after_doc
-            .put_comm(
-                "comm-forged",
-                "jupyter.widget",
-                "anywidget",
-                "AnyModel",
-                &json!({ "value": 1 }),
-                0,
-            )
-            .unwrap();
-        let after = runtime_state_policy_snapshot(&after_doc);
-
-        let err =
-            validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap_err();
-
-        assert!(
-            err.to_string().contains("comms"),
-            "error should identify comm topology writes: {err}"
-        );
-    }
-
-    #[test]
-    fn owner_runtime_state_policy_rejects_display_index_changes() {
-        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
-        let mut after_doc = RuntimeStateDoc::new();
-        after_doc.add_display_index_entry("display-1", "exec-1", "out-1");
-        let after = runtime_state_policy_snapshot(&after_doc);
-
-        let err =
-            validate_runtime_state_sync_scope(&before, &after, ConnectionScope::Owner).unwrap_err();
-
-        assert!(
-            err.to_string().contains("display_index"),
-            "error should identify display index writes: {err}"
-        );
-    }
-
-    #[test]
-    fn runtime_peer_policy_allows_execution_creation() {
-        let before = runtime_state_policy_snapshot(&RuntimeStateDoc::new());
-        let mut after_doc = RuntimeStateDoc::new();
-        after_doc
-            .create_execution_with_source("exec-runtime", "print('runtime')", 0)
-            .unwrap();
-        let after = runtime_state_policy_snapshot(&after_doc);
-
-        validate_runtime_state_sync_scope(&before, &after, ConnectionScope::RuntimePeer).unwrap();
-    }
 }

--- a/python/pr-reviewer/pyproject.toml
+++ b/python/pr-reviewer/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.scripts]
+architecture-review = "pr_reviewer.architecture_cli:main"
 pr-review = "pr_reviewer.cli:main"
 
 [build-system]

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from pr_reviewer.config import ReviewerConfig
-from pr_reviewer.prompt import SYSTEM_PROMPT, build_review_prompt
+from pr_reviewer.prompt import SYSTEM_PROMPT, build_architecture_prompt, build_review_prompt
 from pr_reviewer.schema import ReviewReport, normalize_structured_output
 from pr_reviewer.workspace import ReviewWorkspace
 
@@ -225,6 +225,48 @@ async def run_review(
     extra_prompt: str | None = None,
 ) -> ReviewReport:
     prompt = f"{SYSTEM_PROMPT}\n\n{build_review_prompt(workspace, extra_prompt=extra_prompt)}"
+    try:
+        run = await run_opencode(prompt, cwd=workspace.path, config=config)
+        verdict, terminal_reason, summary, findings = normalize_structured_output(
+            parse_structured_review_json(run.text)
+        )
+    except RuntimeError as exc:
+        return build_infra_uncertain_report(
+            workspace=workspace,
+            config=config,
+            run=OpencodeRunResult(text="", session_id=None, cost_usd=None),
+            error=exc,
+        )
+    except (JSONDecodeError, ValueError) as exc:
+        return build_infra_uncertain_report(
+            workspace=workspace,
+            config=config,
+            run=run,
+            error=exc,
+        )
+    return ReviewReport(
+        verdict=verdict,
+        terminal_reason=terminal_reason,
+        summary=summary,
+        findings=findings,
+        reviewed_diff=workspace.reviewed_diff,
+        model=config.model,
+        session_id=run.session_id,
+        workspace=str(workspace.path),
+        cost_usd=run.cost_usd,
+        raw_result=run.text,
+    )
+
+
+async def run_architecture_review(
+    workspace: ReviewWorkspace,
+    *,
+    config: ReviewerConfig,
+    review_prompt: str,
+) -> ReviewReport:
+    prompt = (
+        f"{SYSTEM_PROMPT}\n\n{build_architecture_prompt(workspace, review_prompt=review_prompt)}"
+    )
     try:
         run = await run_opencode(prompt, cwd=workspace.path, config=config)
         verdict, terminal_reason, summary, findings = normalize_structured_output(

--- a/python/pr-reviewer/src/pr_reviewer/architecture_cli.py
+++ b/python/pr-reviewer/src/pr_reviewer/architecture_cli.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from pr_reviewer import git
+from pr_reviewer.agent import run_architecture_review, run_doctor
+from pr_reviewer.cli import CLEAR, FINDINGS, INFRA_ERROR, INFRA_UNCERTAIN, NEEDS_HUMAN
+from pr_reviewer.config import DEFAULT_DOCTOR_MAX_TURNS, ReviewerConfig, estimate_review_turns
+from pr_reviewer.report import write_report
+from pr_reviewer.workspace import prepare_architecture_workspace
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="architecture-review",
+        description="Run an opencode-backed architecture review over a local diff.",
+    )
+    add_common_args(parser, default_max_turns=None)
+    parser.add_argument("--base", default="origin/main", help="Base ref for the local diff.")
+    parser.add_argument("--head", default="HEAD", help="Committed head ref for the local diff.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root to review. Defaults to the current git checkout.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Review JSON output path. Defaults to .context/reviews/architecture-review.json.",
+    )
+    parser.add_argument(
+        "--committed-only",
+        action="store_true",
+        help="Exclude staged, unstaged, and untracked working-tree changes.",
+    )
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt", help="Architecture review prompt.")
+    prompt_group.add_argument(
+        "--prompt-file",
+        type=Path,
+        help="Path to a markdown/text file containing the architecture review prompt.",
+    )
+    return parser
+
+
+def build_doctor_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="architecture-review doctor",
+        description="Smoke-test opencode model access.",
+    )
+    add_common_args(parser, default_max_turns=DEFAULT_DOCTOR_MAX_TURNS)
+    return parser
+
+
+def add_common_args(parser: argparse.ArgumentParser, *, default_max_turns: int | None) -> None:
+    parser.add_argument("--model", default=None)
+    parser.add_argument("--aws-region", default=None)
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=default_max_turns,
+        help="Advisory review budget recorded in report metadata.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=None,
+        help="Hard wall-clock timeout for the opencode subprocess.",
+    )
+
+
+def config_from_args(args: argparse.Namespace, *, max_turns: int | None = None) -> ReviewerConfig:
+    return ReviewerConfig.from_env(
+        model=args.model,
+        aws_region=args.aws_region,
+        max_turns=max_turns if max_turns is not None else args.max_turns,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+def read_review_prompt(args: argparse.Namespace) -> str:
+    if args.prompt_file is not None:
+        return args.prompt_file.read_text().strip()
+    return str(args.prompt).strip()
+
+
+def run_architecture_command(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root or git.git_root(Path.cwd())
+    output_path = args.out or repo_root / ".context" / "reviews" / "architecture-review.json"
+    workspace = prepare_architecture_workspace(
+        repo_root,
+        base_ref=args.base,
+        head_ref=args.head,
+        include_uncommitted=not args.committed_only,
+    )
+    max_turns = (
+        args.max_turns
+        if args.max_turns is not None
+        else estimate_review_turns(
+            diff_patch=workspace.diff_patch,
+            changed_files=workspace.reviewed_diff.changed_files,
+        )
+    )
+    report = asyncio.run(
+        run_architecture_review(
+            workspace,
+            config=config_from_args(args, max_turns=max_turns),
+            review_prompt=read_review_prompt(args),
+        )
+    )
+    write_report(
+        output_path,
+        report,
+        metadata={
+            "mode": "architecture",
+            "workspace": str(workspace.path),
+            "base": args.base,
+            "head": args.head,
+            "include_uncommitted": not args.committed_only,
+            "max_turns": max_turns,
+        },
+    )
+    print(f"review written: {output_path}")
+    if report.verdict == "clear":
+        return CLEAR
+    if report.verdict == "findings":
+        return FINDINGS
+    if report.verdict == "needs_human":
+        return NEEDS_HUMAN
+    if report.verdict == "infra_uncertain":
+        return INFRA_UNCERTAIN
+    return INFRA_ERROR
+
+
+def run_doctor_command(args: argparse.Namespace) -> int:
+    config = config_from_args(args)
+    result = asyncio.run(run_doctor(config))
+    if result.strip().rstrip(".") != "OK":
+        print(f"doctor returned unexpected response: {result!r}", file=sys.stderr)
+        return INFRA_ERROR
+    print(f"opencode smoke test OK: model={config.model} region={config.aws_region}")
+    return CLEAR
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv and argv[0] == "doctor":
+        parser = build_doctor_parser()
+        args = parser.parse_args(argv[1:])
+        command = "doctor"
+    else:
+        parser = build_parser()
+        args = parser.parse_args(argv)
+        command = "review"
+
+    try:
+        code = run_doctor_command(args) if command == "doctor" else run_architecture_command(args)
+    except Exception as exc:
+        print(f"architecture-review failed: {exc}", file=sys.stderr)
+        raise SystemExit(INFRA_ERROR) from exc
+    raise SystemExit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pr-reviewer/src/pr_reviewer/prompt.py
+++ b/python/pr-reviewer/src/pr_reviewer/prompt.py
@@ -72,3 +72,47 @@ Full diff:
     if extra_prompt:
         prompt += f"\nAdditional review constraints:\n{extra_prompt}\n"
     return prompt
+
+
+def build_architecture_prompt(workspace: ReviewWorkspace, *, review_prompt: str) -> str:
+    files = "\n".join(f"- {name}" for name in workspace.reviewed_diff.changed_files)
+    return f"""\
+Review this local architecture diff.
+
+Review goal:
+{review_prompt}
+
+Base ref: {workspace.reviewed_diff.base_ref}
+Head ref: {workspace.reviewed_diff.head_ref}
+Merge base: {workspace.reviewed_diff.merge_base}
+
+Changed files:
+{files or "- (none)"}
+
+Diff stat:
+{workspace.reviewed_diff.diff_stat or "(empty)"}
+
+You are in the workspace being reviewed. Inspect files as needed and compare the
+current local changes against the full diff below. Return exactly one JSON
+object and no prose, markdown, or code fence. The JSON shape is:
+{{
+  "verdict": "clear" | "findings" | "needs_human" | "infra_uncertain",
+  "terminal_reason": "review_complete" | "actionable_findings" |
+    "needs_human" | "budget_exhausted" | "infra_uncertain",
+  "summary": "short architecture review summary",
+  "findings": [
+    {{
+      "severity": "blocker" | "high" | "medium" | "low",
+      "file": "path/to/file",
+      "line": 123,
+      "title": "short issue title",
+      "evidence": "why this is a real architecture, security, product, or maintenance risk",
+      "suggested_fix": "concrete fix, or null",
+      "confidence": "high" | "medium" | "low"
+    }}
+  ]
+}}
+
+Full diff:
+{workspace.diff_patch or "(empty)"}
+"""

--- a/python/pr-reviewer/src/pr_reviewer/workspace.py
+++ b/python/pr-reviewer/src/pr_reviewer/workspace.py
@@ -66,8 +66,154 @@ def prepare_review_workspace(
     )
 
 
+def prepare_architecture_workspace(
+    repo_root: Path,
+    *,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+    include_uncommitted: bool = True,
+    runner: git.CommandRunner = git.run,
+) -> ReviewWorkspace:
+    merge_base = git.merge_base(base_ref, head_ref, cwd=repo_root, runner=runner)
+    files = _unique_sorted(
+        git.changed_files(base_ref, head_ref, cwd=repo_root, runner=runner)
+        + (
+            _diff_name_only(
+                ["git", "diff", "--find-renames", "--name-only", "--cached", head_ref],
+                repo_root,
+                runner,
+            )
+            + _diff_name_only(
+                ["git", "diff", "--find-renames", "--name-only", head_ref], repo_root, runner
+            )
+            + _untracked_files(repo_root, runner)
+            if include_uncommitted
+            else []
+        )
+    )
+    committed_stat = git.diff_stat(base_ref, head_ref, cwd=repo_root, runner=runner)
+    committed_patch = git.diff_patch(base_ref, head_ref, cwd=repo_root, runner=runner)
+    stat_parts = [committed_stat]
+    patch_parts = [committed_patch]
+
+    if include_uncommitted:
+        stat_parts.extend(
+            [
+                _optional_git_stdout(
+                    ["git", "diff", "--find-renames", "--stat", "--cached", head_ref],
+                    repo_root,
+                    runner,
+                ),
+                _optional_git_stdout(
+                    ["git", "diff", "--find-renames", "--stat", head_ref],
+                    repo_root,
+                    runner,
+                ),
+                _untracked_stat(repo_root, runner),
+            ]
+        )
+        patch_parts.extend(
+            [
+                _optional_git_stdout(
+                    ["git", "diff", "--find-renames", "--cached", head_ref],
+                    repo_root,
+                    runner,
+                ),
+                _optional_git_stdout(
+                    ["git", "diff", "--find-renames", head_ref],
+                    repo_root,
+                    runner,
+                ),
+                _untracked_patch(repo_root, runner),
+            ]
+        )
+
+    title = f"Architecture review for {git.current_branch(repo_root, runner=runner) or head_ref}"
+    pr = git.PullRequestInfo(
+        number=0,
+        url=f"local-diff:{repo_root}",
+        title=title,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        head_sha=head_ref,
+        base_sha=None,
+    )
+    head_label = "working-tree" if include_uncommitted else head_ref
+    return ReviewWorkspace(
+        path=repo_root,
+        pr=pr,
+        base_ref=base_ref,
+        head_ref=head_label,
+        reviewed_diff=ReviewedDiff(
+            base_ref=base_ref,
+            head_ref=head_label,
+            merge_base=merge_base,
+            changed_files=files,
+            diff_stat=_join_nonempty(stat_parts),
+        ),
+        diff_patch=_join_nonempty(patch_parts),
+    )
+
+
 def remove_review_workspace(
     path: Path, *, repo_root: Path, runner: git.CommandRunner = git.run
 ) -> None:
     runner(["git", "worktree", "remove", "--force", str(path)], cwd=repo_root, check=False)
     shutil.rmtree(path, ignore_errors=True)
+
+
+def _unique_sorted(values: list[str]) -> list[str]:
+    return sorted({value for value in values if value})
+
+
+def _diff_name_only(
+    args: list[str],
+    cwd: Path,
+    runner: git.CommandRunner,
+) -> list[str]:
+    return [line for line in _optional_git_stdout(args, cwd, runner).splitlines() if line]
+
+
+def _optional_git_stdout(
+    args: list[str],
+    cwd: Path,
+    runner: git.CommandRunner,
+) -> str:
+    result = runner(args, cwd=cwd, check=False)
+    return result.stdout if result.returncode in {0, 1} else ""
+
+
+def _untracked_files(cwd: Path, runner: git.CommandRunner) -> list[str]:
+    result = runner(["git", "ls-files", "--others", "--exclude-standard"], cwd=cwd)
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _untracked_patch(cwd: Path, runner: git.CommandRunner) -> str:
+    patches: list[str] = []
+    for path in _untracked_files(cwd, runner):
+        full_path = cwd / path
+        if not full_path.is_file():
+            continue
+        result = runner(
+            ["git", "diff", "--no-index", "--", "/dev/null", path],
+            cwd=cwd,
+            check=False,
+        )
+        if result.stdout:
+            patches.append(result.stdout)
+    return _join_nonempty(patches)
+
+
+def _untracked_stat(cwd: Path, runner: git.CommandRunner) -> str:
+    entries: list[str] = []
+    for path in _untracked_files(cwd, runner):
+        full_path = cwd / path
+        if not full_path.is_file():
+            continue
+        line_count = len(full_path.read_text(errors="ignore").splitlines())
+        entries.append(f" {path} | {line_count} {'+' * min(line_count, 20)}")
+    return "\n".join(entries)
+
+
+def _join_nonempty(parts: list[str]) -> str:
+    return "\n".join(part.rstrip() for part in parts if part and part.strip())

--- a/python/pr-reviewer/tests/test_architecture.py
+++ b/python/pr-reviewer/tests/test_architecture.py
@@ -1,0 +1,77 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from pr_reviewer.architecture_cli import build_parser, read_review_prompt
+from pr_reviewer.prompt import build_architecture_prompt
+from pr_reviewer.workspace import prepare_architecture_workspace
+
+
+def run_git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, text=True, capture_output=True)
+
+
+def test_architecture_parser_requires_prompt() -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+    args = parser.parse_args(["--prompt", "Review the architecture boundary."])
+    assert args.prompt == "Review the architecture boundary."
+    assert args.base == "origin/main"
+
+
+def test_read_review_prompt_accepts_prompt_file(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("Review causal ownership.\n")
+    args = build_parser().parse_args(["--prompt-file", str(prompt_file)])
+
+    assert read_review_prompt(args) == "Review causal ownership."
+
+
+def test_prepare_architecture_workspace_includes_untracked_files(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init")
+    run_git(repo, "config", "user.email", "reviewer@example.com")
+    run_git(repo, "config", "user.name", "Reviewer")
+    (repo / "tracked.py").write_text("print('old')\n")
+    run_git(repo, "add", "tracked.py")
+    run_git(repo, "commit", "-m", "initial")
+
+    (repo / "tracked.py").write_text("print('new')\n")
+    (repo / "draft.py").write_text("print('draft')\n")
+
+    workspace = prepare_architecture_workspace(repo, base_ref="HEAD")
+
+    assert workspace.path == repo
+    assert workspace.pr.number == 0
+    assert workspace.reviewed_diff.head_ref == "working-tree"
+    assert workspace.reviewed_diff.changed_files == ["draft.py", "tracked.py"]
+    assert "diff --git a/tracked.py b/tracked.py" in workspace.diff_patch
+    assert "diff --git a/draft.py b/draft.py" in workspace.diff_patch
+
+
+def test_build_architecture_prompt_uses_review_goal(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init")
+    run_git(repo, "config", "user.email", "reviewer@example.com")
+    run_git(repo, "config", "user.name", "Reviewer")
+    (repo / "tracked.py").write_text("print('old')\n")
+    run_git(repo, "add", "tracked.py")
+    run_git(repo, "commit", "-m", "initial")
+    (repo / "tracked.py").write_text("print('new')\n")
+    workspace = prepare_architecture_workspace(repo, base_ref="HEAD")
+
+    prompt = build_architecture_prompt(
+        workspace,
+        review_prompt="Review the security and product architecture.",
+    )
+
+    assert "Review this local architecture diff." in prompt
+    assert "Review the security and product architecture." in prompt
+    assert "- tracked.py" in prompt
+    assert "diff --git a/tracked.py b/tracked.py" in prompt


### PR DESCRIPTION
## Summary

- adds `architecture-review`, a repo-local opencode wrapper for local branch/worktree architecture reviews with custom prompts
- moves RuntimeStateDoc write authorization into shared `runtime-doc` policy used by daemon and hosted WASM room hosts
- allows owner/editor scopes to sync existing widget comm state while rejecting execution, queue, kernel, output-routing, hidden-root, and comm-topology mutations
- makes `runtime_peer` authority explicit in hosted ACL checks so human owner/editor rows cannot self-select runtime service authority

## Review Notes

- Ran four read-only subagent lanes: product, security, protocol/causality, and maintenance.
- Ran `architecture-review` twice with a RuntimeStateDoc/security/product/protocol prompt.
- Disposition: all actionable wrapper findings fixed except the suggested raw-root WASM integration test. That remains covered in `runtime-doc` policy unit tests because adding a public raw-forge helper to the cloud WASM API would expand the surface just for a test.

## Verification

- `uv run pytest python/pr-reviewer/tests -q`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/authorization.test.ts test/room-materializer.test.ts`
- `cargo test -p runtime-doc policy`
- `cargo test -p runtimed-wasm --lib`
- `cargo test -p runtimed identity`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `cargo xtask wasm`
- `cargo xtask lint --fix`
