### PR TITLE
fix(notebook-cloud): seed viewer theme surface

### DIFF
--- a/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
+++ b/apps/notebook-cloud/src/viewer-theme-bootstrap.ts
@@ -2,24 +2,34 @@ export const CLOUD_VIEWER_THEME_STORAGE_KEY = "nteract.cloud.viewer.theme";
 
 export function viewerThemeFirstPaintStyle(): string {
   return `html {
-  background: oklch(1 0 0);
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  background: var(--background);
   color-scheme: light;
 }
 
-html.dark {
-  background: oklch(0.145 0 0);
+html.light,
+html[data-theme="light"] {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  background: var(--background);
+  color-scheme: light;
+}
+
+html.dark,
+html[data-theme="dark"] {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  background: var(--background);
   color-scheme: dark;
 }
 
-body {
+body,
+#root {
+  min-height: 100%;
   margin: 0;
-  background: oklch(1 0 0);
-  color: oklch(0.145 0 0);
-}
-
-html.dark body {
-  background: oklch(0.145 0 0);
-  color: oklch(0.985 0 0);
+  background: var(--background);
+  color: var(--foreground);
 }`;
 }
 

--- a/apps/notebook-cloud/test/viewer-theme.test.ts
+++ b/apps/notebook-cloud/test/viewer-theme.test.ts
@@ -19,9 +19,14 @@ describe("cloud viewer theme helpers", () => {
   it("ships a light default surface that class changes can flip before the bundle CSS loads", () => {
     const css = viewerThemeFirstPaintStyle();
 
-    assert.match(css, /html \{\s+background: oklch\(1 0 0\);\s+color-scheme: light;/);
-    assert.match(css, /html\.dark \{\s+background: oklch\(0\.145 0 0\);\s+color-scheme: dark;/);
-    assert.match(css, /html\.dark body \{/);
+    assert.match(css, /html \{\s+--background: oklch\(1 0 0\);/);
+    assert.match(css, /--foreground: oklch\(0\.145 0 0\);/);
+    assert.match(css, /html\.light,\s+html\[data-theme="light"\] \{/);
+    assert.match(css, /html\.dark,\s+html\[data-theme="dark"\] \{/);
+    assert.match(css, /--background: oklch\(0\.145 0 0\);/);
+    assert.match(css, /body,\s+#root \{\s+min-height: 100%;/);
+    assert.match(css, /background: var\(--background\);/);
+    assert.match(css, /color: var\(--foreground\);/);
   });
 
   it("resolves explicit and system themes", () => {


### PR DESCRIPTION
## Summary
- seed the hosted viewer first-paint CSS with shared `--background` / `--foreground` variables
- cover `html.light`, `html.dark`, `data-theme`, `body`, and `#root` before the viewer bundle CSS loads
- update theme helper coverage so the loading surface stays aligned with the cloud theme bootstrap

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-theme.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
