### PR TITLE
fix(widgets): show stale widget snapshots

### DIFF
--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -4,6 +4,58 @@ import type { BlobResolver } from "runtimed";
 import { resolveCell, resolveOutputs } from "../viewer/render-resolution.ts";
 
 describe("cloud viewer render resolution", () => {
+  it("turns static widget views into text fallbacks", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_id: "widget-output",
+          output_type: "display_data",
+          data: {
+            "application/vnd.jupyter.widget-view+json": {
+              model_id: "slider-1",
+            },
+            "text/llm+plain": "IntSlider slider: 7 (0-10)",
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_type, "display_data");
+    if (outputs[0].output_type === "display_data") {
+      assert.equal(outputs[0].data["application/vnd.jupyter.widget-view+json"], undefined);
+      assert.equal(outputs[0].data["text/plain"], "IntSlider slider: 7 (0-10)");
+      assert.equal(outputs[0].data["text/llm+plain"], "IntSlider slider: 7 (0-10)");
+    }
+  });
+
+  it("does not leave widget-only outputs on a loading state", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_id: "widget-output",
+          output_type: "display_data",
+          data: {
+            "application/vnd.jupyter.widget-view+json": {
+              model_id: "slider-1",
+            },
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_type, "display_data");
+    if (outputs[0].output_type === "display_data") {
+      assert.equal(outputs[0].data["application/vnd.jupyter.widget-view+json"], undefined);
+      assert.equal(outputs[0].data["text/plain"], "Widget state unavailable");
+    }
+  });
+
   it("keeps healthy outputs when one manifest fails to resolve", async () => {
     const outputs = await resolveOutputs(
       [

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -4,6 +4,7 @@ import {
   resolveManifest,
   type OutputManifest,
 } from "@/components/isolated/output-manifest";
+import { WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import type { BlobResolver } from "runtimed";
 
 export interface RenderCell {
@@ -85,7 +86,11 @@ async function resolveOutput(
   }
 
   if (isOutputManifest(output)) {
-    return resolveManifest(output as OutputManifest, blobResolver) as Promise<JupyterOutput>;
+    const resolved = (await resolveManifest(
+      output as OutputManifest,
+      blobResolver,
+    )) as JupyterOutput;
+    return normalizeStaticWidgetOutput(resolved);
   }
 
   if (isManifestWithMissingOutputId(output)) {
@@ -93,10 +98,25 @@ async function resolveOutput(
   }
 
   if (isJupyterOutput(output)) {
-    return identifyJupyterOutput(output, syntheticOutputId);
+    return normalizeStaticWidgetOutput(identifyJupyterOutput(output, syntheticOutputId));
   }
 
   return null;
+}
+
+function normalizeStaticWidgetOutput(output: JupyterOutput): JupyterOutput {
+  if (output.output_type !== "display_data" && output.output_type !== "execute_result") {
+    return output;
+  }
+  if (!(WIDGET_VIEW_MIME in output.data)) return output;
+
+  const fallback = output.data["text/plain"] ?? output.data["text/llm+plain"];
+
+  const data = { ...output.data };
+  delete data[WIDGET_VIEW_MIME];
+  if (!("text/plain" in data)) data["text/plain"] = String(fallback ?? "Widget state unavailable");
+
+  return { ...output, data };
 }
 
 function identifyJupyterOutput(output: JupyterOutput, outputId: string): JupyterOutput {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   deriveEnvManager,
   deriveRuntimeKind,
@@ -11,10 +19,12 @@ import {
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
+import { SavedWidgetStateProvider } from "@/components/widgets/saved-widget-state-context";
 import {
   useWidgetStoreRequired,
   WidgetStoreProvider,
 } from "@/components/widgets/widget-store-context";
+import { parseSavedWidgetModels, parseWidgetViewModelId } from "@/components/widgets/widget-state";
 import { type BlobUploader, WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { useSyncedTheme } from "@/hooks/useSyncedSettings";
@@ -69,7 +79,7 @@ import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { getNotebookCellsSnapshot } from "./lib/notebook-cells";
 import { useNotebookQueueProjection } from "./lib/notebook-executions";
-import { useDetectRuntime } from "./lib/notebook-metadata";
+import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
 import { startWindowFocusHandler } from "./lib/window-focus";
 import type { JupyterOutput } from "./types";
@@ -1871,21 +1881,30 @@ const updateManager = new WidgetUpdateManager({
 });
 
 function WidgetViewRenderer({ data }: { data: unknown }) {
-  const { model_id } = data as { model_id: string };
-  return <WidgetView modelId={model_id} />;
+  const modelId = parseWidgetViewModelId(data);
+  return modelId ? <WidgetView modelId={modelId} /> : null;
 }
 
 const MEDIA_RENDERERS = {
   "application/vnd.jupyter.widget-view+json": WidgetViewRenderer,
 };
 
+function NotebookSavedWidgetStateProvider({ children }: { children: ReactNode }) {
+  const metadata = useNotebookMetadata();
+  const savedWidgetModels = useMemo(() => parseSavedWidgetModels(metadata), [metadata]);
+
+  return <SavedWidgetStateProvider models={savedWidgetModels}>{children}</SavedWidgetStateProvider>;
+}
+
 export default function App() {
   return (
     <ErrorBoundary fallback={AppErrorFallback}>
       <WidgetStoreProvider sendMessage={sendMessage} updateManager={updateManager}>
-        <MediaProvider renderers={MEDIA_RENDERERS}>
-          <AppContent />
-        </MediaProvider>
+        <NotebookSavedWidgetStateProvider>
+          <MediaProvider renderers={MEDIA_RENDERERS}>
+            <AppContent />
+          </MediaProvider>
+        </NotebookSavedWidgetStateProvider>
       </WidgetStoreProvider>
     </ErrorBoundary>
   );

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -27,33 +27,38 @@ fn is_viz_mime(mime: &str) -> bool {
             && (mime.ends_with("+json") || mime.ends_with(".json")))
 }
 
+/// Inputs for [`cell_structured_content_from_manifests`].
+pub struct CellStructuredContentManifestInput<'a> {
+    pub cell_id: &'a str,
+    pub cell_type: &'a str,
+    pub source: &'a str,
+    pub output_manifests: &'a [serde_json::Value],
+    pub execution_count: Option<i64>,
+    pub status: &'a str,
+    pub blob_base_url: &'a Option<String>,
+    pub comms: Option<&'a HashMap<String, CommDocEntry>>,
+}
+
 /// Build structuredContent JSON directly from manifest Values and blob URLs.
 ///
 /// Unlike [`cell_structured_content`] which requires fully-resolved outputs,
 /// this function reads inline content directly from ContentRef entries and
 /// emits blob URLs for anything stored in the blob store. Zero blob fetches.
 pub fn cell_structured_content_from_manifests(
-    cell_id: &str,
-    cell_type: &str,
-    source: &str,
-    output_manifests: &[serde_json::Value],
-    execution_count: Option<i64>,
-    status: &str,
-    blob_base_url: &Option<String>,
-    comms: Option<&HashMap<String, CommDocEntry>>,
+    input: CellStructuredContentManifestInput<'_>,
 ) -> Value {
     let mut content = json!({
         "cell": {
-            "cell_id": cell_id,
-            "source": source,
-            "cell_type": cell_type,
-            "outputs": output_manifests.iter().map(|m| manifest_output_to_structured(m, blob_base_url, comms)).collect::<Vec<_>>(),
-            "execution_count": execution_count,
-            "status": status,
+            "cell_id": input.cell_id,
+            "source": input.source,
+            "cell_type": input.cell_type,
+            "outputs": input.output_manifests.iter().map(|m| manifest_output_to_structured(m, input.blob_base_url, input.comms)).collect::<Vec<_>>(),
+            "execution_count": input.execution_count,
+            "status": input.status,
         }
     });
 
-    if let Some(base) = blob_base_url {
+    if let Some(base) = input.blob_base_url {
         content["blob_base_url"] = Value::String(base.clone());
     }
 
@@ -825,16 +830,16 @@ mod tests {
             "text": inline_ref("output"),
         })];
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = cell_structured_content_from_manifests(
-            "cell-123",
-            "code",
-            "print('hello')",
-            &manifests,
-            Some(3),
-            "done",
-            &blob_base,
-            None,
-        );
+        let result = cell_structured_content_from_manifests(CellStructuredContentManifestInput {
+            cell_id: "cell-123",
+            cell_type: "code",
+            source: "print('hello')",
+            output_manifests: &manifests,
+            execution_count: Some(3),
+            status: "done",
+            blob_base_url: &blob_base,
+            comms: None,
+        });
         assert_eq!(result["cell"]["cell_id"], "cell-123");
         assert_eq!(result["cell"]["cell_type"], "code");
         assert_eq!(result["cell"]["source"], "print('hello')");

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -10,8 +10,12 @@
 //! fetches — structured content is always compact.
 
 use notebook_doc::mime::MimeKind;
+use runtime_doc::CommDocEntry;
 use runtimed_outputs::output_resolver;
 use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
 
 /// Check if a MIME type is a visualization spec (Plotly, Vega-Lite, Vega).
 fn is_viz_mime(mime: &str) -> bool {
@@ -36,13 +40,14 @@ pub fn cell_structured_content_from_manifests(
     execution_count: Option<i64>,
     status: &str,
     blob_base_url: &Option<String>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
 ) -> Value {
     let mut content = json!({
         "cell": {
             "cell_id": cell_id,
             "source": source,
             "cell_type": cell_type,
-            "outputs": output_manifests.iter().map(|m| manifest_output_to_structured(m, blob_base_url)).collect::<Vec<_>>(),
+            "outputs": output_manifests.iter().map(|m| manifest_output_to_structured(m, blob_base_url, comms)).collect::<Vec<_>>(),
             "execution_count": execution_count,
             "status": status,
         }
@@ -59,7 +64,11 @@ pub fn cell_structured_content_from_manifests(
 ///
 /// Reads inline content directly from ContentRef entries and emits blob URLs
 /// for blob-stored content. No blob fetches are performed.
-fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String>) -> Value {
+fn manifest_output_to_structured(
+    manifest: &Value,
+    blob_base_url: &Option<String>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
+) -> Value {
     let output_type = manifest
         .get("output_type")
         .and_then(|v| v.as_str())
@@ -230,6 +239,19 @@ fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String
                 }
             }
 
+            // Synthesize a safe widget summary for MCP App/static clients that
+            // cannot attach to the live comm bridge. Do not include raw widget
+            // state here; Password widgets can store plaintext values.
+            if !data.contains_key("text/llm+plain") {
+                if let (Some(data_map), Some(comms)) =
+                    (manifest.get("data").and_then(|v| v.as_object()), comms)
+                {
+                    if let Some(summary) = widget_summary_from_data_map(data_map, comms) {
+                        data.insert("text/llm+plain".to_string(), Value::String(summary));
+                    }
+                }
+            }
+
             let mut result = json!({
                 "output_type": output_type,
                 "data": data,
@@ -243,6 +265,38 @@ fn manifest_output_to_structured(manifest: &Value, blob_base_url: &Option<String
         }
         _ => attach_id(json!({"output_type": output_type})),
     }
+}
+
+fn widget_model_id_from_content_ref(content_ref: &Value) -> Option<String> {
+    if let Some(inline) = content_ref.get("inline") {
+        if let Some(raw) = inline.as_str() {
+            return serde_json::from_str::<Value>(raw).ok().and_then(|v| {
+                v.get("model_id")
+                    .and_then(|id| id.as_str())
+                    .map(str::to_string)
+            });
+        }
+        return inline
+            .get("model_id")
+            .and_then(|id| id.as_str())
+            .map(str::to_string);
+    }
+
+    content_ref
+        .get("model_id")
+        .and_then(|id| id.as_str())
+        .map(str::to_string)
+}
+
+fn widget_summary_from_data_map(
+    data_map: &serde_json::Map<String, Value>,
+    comms: &HashMap<String, CommDocEntry>,
+) -> Option<String> {
+    let model_id = widget_model_id_from_content_ref(data_map.get(WIDGET_VIEW_MIME)?)?;
+    let entry = comms.get(&model_id)?;
+    Some(output_resolver::format_widget_summary(
+        &model_id, entry, comms,
+    ))
 }
 
 /// Resolve a text ContentRef to a JSON value (inline text or blob URL).
@@ -281,7 +335,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -297,7 +351,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -313,7 +367,7 @@ mod tests {
                 "text/plain": inline_ref("fallback"),
             },
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -337,7 +391,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -356,7 +410,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -377,7 +431,7 @@ mod tests {
             "text": inline_ref("hi"),
         });
         assert_eq!(
-            manifest_output_to_structured(&stream, &blob_base)["output_id"],
+            manifest_output_to_structured(&stream, &blob_base, None)["output_id"],
             "id-stream"
         );
 
@@ -389,7 +443,7 @@ mod tests {
             "traceback": inline_ref("[\"l1\"]"),
         });
         assert_eq!(
-            manifest_output_to_structured(&error, &blob_base)["output_id"],
+            manifest_output_to_structured(&error, &blob_base, None)["output_id"],
             "id-error"
         );
 
@@ -401,7 +455,7 @@ mod tests {
             },
         });
         assert_eq!(
-            manifest_output_to_structured(&display, &blob_base)["output_id"],
+            manifest_output_to_structured(&display, &blob_base, None)["output_id"],
             "id-display"
         );
     }
@@ -416,7 +470,7 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hi"),
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert!(result.get("output_id").is_none());
     }
 
@@ -428,7 +482,7 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hi"),
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert!(result.get("output_id").is_none());
     }
 
@@ -445,7 +499,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let data = result["data"]
             .as_object()
             .expect("data should be an object");
@@ -469,7 +523,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let data = result["data"]
             .as_object()
             .expect("data should be an object");
@@ -490,7 +544,7 @@ mod tests {
                 "text/plain": inline_ref("<Figure>"),
             },
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         let data = result["data"]
             .as_object()
             .expect("data should be an object");
@@ -511,7 +565,7 @@ mod tests {
                 "text/plain": inline_ref("<Audio>"),
             },
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         let data = result["data"]
             .as_object()
             .expect("data should be an object");
@@ -531,7 +585,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
@@ -549,11 +603,73 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         let Some(data) = result["data"].as_object() else {
             panic!("data should be an object");
         };
         assert_eq!(data["text/llm+plain"], "Summary of output");
+    }
+
+    #[test]
+    fn structured_widget_view_gets_safe_summary_from_comms() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.jupyter.widget-view+json": inline_ref(r#"{"model_id":"slider-1"}"#),
+            },
+        });
+        let mut comms = HashMap::new();
+        comms.insert(
+            "slider-1".to_string(),
+            CommDocEntry {
+                target_name: "jupyter.widget".to_string(),
+                model_module: "@jupyter-widgets/controls".to_string(),
+                model_name: "IntSliderModel".to_string(),
+                state: json!({"value": 7, "min": 0, "max": 10}),
+                outputs: Vec::new(),
+                seq: 0,
+                capture_msg_id: String::new(),
+            },
+        );
+
+        let result = manifest_output_to_structured(&manifest, &None, Some(&comms));
+        let summary = result["data"]["text/llm+plain"]
+            .as_str()
+            .expect("widget summary should be present");
+
+        assert!(summary.contains("IntSlider"));
+        assert!(summary.contains("7"));
+    }
+
+    #[test]
+    fn structured_widget_summary_masks_password_values() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.jupyter.widget-view+json": inline_ref(r#"{"model_id":"password-1"}"#),
+            },
+        });
+        let mut comms = HashMap::new();
+        comms.insert(
+            "password-1".to_string(),
+            CommDocEntry {
+                target_name: "jupyter.widget".to_string(),
+                model_module: "@jupyter-widgets/controls".to_string(),
+                model_name: "PasswordModel".to_string(),
+                state: json!({"value": "hunter2"}),
+                outputs: Vec::new(),
+                seq: 0,
+                capture_msg_id: String::new(),
+            },
+        );
+
+        let result = manifest_output_to_structured(&manifest, &None, Some(&comms));
+        let summary = result["data"]["text/llm+plain"]
+            .as_str()
+            .expect("widget summary should be present");
+
+        assert!(summary.contains("****"));
+        assert!(!summary.contains("hunter2"));
     }
 
     #[test]
@@ -563,7 +679,7 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hello"),
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert_eq!(result["output_type"], "stream");
         assert_eq!(result["name"], "stdout");
         assert_eq!(result["text"], "hello");
@@ -577,7 +693,7 @@ mod tests {
             "text": blob_ref("stream_hash", 5_000),
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         assert_eq!(result["text"], "http://localhost:9999/blob/stream_hash");
     }
 
@@ -590,7 +706,7 @@ mod tests {
             "evalue": "bad",
             "traceback": inline_ref(r#"["line 1", "line 2"]"#),
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert_eq!(result["output_type"], "error");
         assert_eq!(result["ename"], "ValueError");
         // Traceback should be a parsed JSON array, not the raw ContentRef
@@ -611,7 +727,7 @@ mod tests {
             "traceback": blob_ref("tb_hash_123", 8_000),
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         assert_eq!(
             result["traceback"],
             "http://localhost:9999/blob/tb_hash_123"
@@ -627,7 +743,7 @@ mod tests {
             "evalue": "oops",
             "traceback": ["line 1", "line 2"],
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         let Some(tb) = result["traceback"].as_array() else {
             panic!("legacy array should pass through");
         };
@@ -643,7 +759,7 @@ mod tests {
             },
             "execution_count": 7,
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert_eq!(result["execution_count"], 7);
     }
 
@@ -661,7 +777,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         assert_eq!(result["text"], "http://localhost:9999/blob/stream_hash");
         assert_eq!(result["llm_preview"]["total_lines"], 100);
         assert_eq!(result["llm_preview"]["head"], "line 0\n");
@@ -681,7 +797,7 @@ mod tests {
             },
         });
         let blob_base = Some("http://localhost:9999".to_string());
-        let result = manifest_output_to_structured(&manifest, &blob_base);
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
         assert_eq!(result["traceback"], "http://localhost:9999/blob/tb_hash");
         assert_eq!(result["llm_preview"]["frames"], 200);
         assert_eq!(
@@ -697,7 +813,7 @@ mod tests {
             "name": "stdout",
             "text": inline_ref("hello"),
         });
-        let result = manifest_output_to_structured(&manifest, &None);
+        let result = manifest_output_to_structured(&manifest, &None, None);
         assert!(result.get("llm_preview").is_none());
     }
 
@@ -717,6 +833,7 @@ mod tests {
             Some(3),
             "done",
             &blob_base,
+            None,
         );
         assert_eq!(result["cell"]["cell_id"], "cell-123");
         assert_eq!(result["cell"]["cell_type"], "code");

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -282,6 +282,7 @@ pub async fn run_all_cells(
                     exec.execution_count,
                     display_status,
                     &server.blob_base_url,
+                    comms,
                 );
                 if let Some(mut cell_data) = wrapped.get("cell").cloned() {
                     if let Some(eid) = eid {
@@ -502,6 +503,7 @@ async fn render_execution_result(
             exec.execution_count,
             display_status,
             &server.blob_base_url,
+            comms,
         );
         wrapped.get("cell").cloned().map(|mut cell_data| {
             if let Some(obj) = cell_data.as_object_mut() {

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -275,14 +275,16 @@ pub async fn run_all_cells(
             let snap_outputs = handle.get_cell_outputs(&cell.id).unwrap_or_default();
             if !snap_outputs.is_empty() {
                 let wrapped = crate::structured::cell_structured_content_from_manifests(
-                    &snap.id,
-                    &snap.cell_type,
-                    &snap.source,
-                    &snap_outputs,
-                    exec.execution_count,
-                    display_status,
-                    &server.blob_base_url,
-                    comms,
+                    crate::structured::CellStructuredContentManifestInput {
+                        cell_id: &snap.id,
+                        cell_type: &snap.cell_type,
+                        source: &snap.source,
+                        output_manifests: &snap_outputs,
+                        execution_count: exec.execution_count,
+                        status: display_status,
+                        blob_base_url: &server.blob_base_url,
+                        comms,
+                    },
                 );
                 if let Some(mut cell_data) = wrapped.get("cell").cloned() {
                     if let Some(eid) = eid {
@@ -496,14 +498,16 @@ async fn render_execution_result(
         None
     } else {
         let wrapped = crate::structured::cell_structured_content_from_manifests(
-            &snap.id,
-            &snap.cell_type,
-            &snap.source,
-            &exec.outputs,
-            exec.execution_count,
-            display_status,
-            &server.blob_base_url,
-            comms,
+            crate::structured::CellStructuredContentManifestInput {
+                cell_id: &snap.id,
+                cell_type: &snap.cell_type,
+                source: &snap.source,
+                output_manifests: &exec.outputs,
+                execution_count: exec.execution_count,
+                status: display_status,
+                blob_base_url: &server.blob_base_url,
+                comms,
+            },
         );
         wrapped.get("cell").cloned().map(|mut cell_data| {
             if let Some(obj) = cell_data.as_object_mut() {

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -556,14 +556,16 @@ pub async fn build_execution_result(
             ec_str.parse().ok()
         };
         Some(crate::structured::cell_structured_content_from_manifests(
-            &snap.id,
-            &snap.cell_type,
-            &snap.source,
-            &outputs,
-            ec,
-            &result.status,
-            &server.blob_base_url,
-            runtime_comms.as_ref(),
+            crate::structured::CellStructuredContentManifestInput {
+                cell_id: &snap.id,
+                cell_type: &snap.cell_type,
+                source: &snap.source,
+                output_manifests: &outputs,
+                execution_count: ec,
+                status: &result.status,
+                blob_base_url: &server.blob_base_url,
+                comms: runtime_comms.as_ref(),
+            },
         ))
     } else {
         None

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -546,6 +546,7 @@ pub async fn build_execution_result(
     // Outputs live in RuntimeStateDoc, keyed by execution_id, so we fetch
     // them separately from the cell snapshot.
     let cell_snapshot = handle.get_cell(&result.cell_id);
+    let runtime_comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let mut structured_content = if let Some(snap) = cell_snapshot {
         let outputs = handle.get_cell_outputs(&result.cell_id).unwrap_or_default();
         let ec_str = cell_read::get_cell_execution_count_from_runtime(handle, &snap.id);
@@ -562,6 +563,7 @@ pub async fn build_execution_result(
             ec,
             &result.status,
             &server.blob_base_url,
+            runtime_comms.as_ref(),
         ))
     } else {
         None

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -40,6 +40,13 @@ import {
   type TracebackExecutionResolver,
 } from "@/components/outputs/traceback-output";
 import { useWidgetStore } from "@/components/widgets/widget-store-context";
+import { useSavedWidgetModels } from "@/components/widgets/saved-widget-state-context";
+import {
+  parseWidgetViewModelId,
+  WIDGET_VIEW_MIME,
+  type SavedWidgetModels,
+} from "@/components/widgets/widget-state";
+import type { WidgetStore } from "@/components/widgets/widget-store";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { highlightTextInDom } from "@/lib/highlight-text";
@@ -51,6 +58,28 @@ const handleIframeError = (err: { message: string; stack?: string }) =>
 
 function formatPluginLoadError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function withSavedWidgetStateHint(
+  payload: RenderPayload,
+  store: WidgetStore | undefined,
+  savedWidgetModels: SavedWidgetModels,
+): RenderPayload {
+  if (payload.mimeType !== WIDGET_VIEW_MIME) return payload;
+
+  const modelId = parseWidgetViewModelId(payload.data);
+  if (!modelId || store?.getModel(modelId)) return payload;
+
+  const savedModel = savedWidgetModels.get(modelId);
+  if (!savedModel) return payload;
+
+  return {
+    ...payload,
+    widgetStateHint: {
+      ...payload.widgetStateHint,
+      savedModel,
+    },
+  };
 }
 
 const FOCUSED_OUTPUT_WELL_VIEWPORT_RATIO = 0.8;
@@ -539,6 +568,7 @@ function OutputAreaSingle({
 
   // Get widget store context (may be null if not in provider)
   const widgetContext = useWidgetStore();
+  const savedWidgetModels = useSavedWidgetModels();
 
   // Determine if we should use isolation (when we have outputs)
   const shouldIsolate =
@@ -776,7 +806,11 @@ function OutputAreaSingle({
           cellId,
           priority,
         }).map((payload) =>
-          withTracebackExecutionTargets(payload, resolveTracebackExecutionTarget),
+          withSavedWidgetStateHint(
+            withTracebackExecutionTargets(payload, resolveTracebackExecutionTarget),
+            widgetContext?.store,
+            savedWidgetModels,
+          ),
         );
       } catch (error) {
         if (gen !== renderGenRef.current) return;
@@ -801,7 +835,15 @@ function OutputAreaSingle({
         frameRef.current?.search(searchQueryRef.current);
       }
     },
-    [cellId, outputs, priority, resolveTracebackExecutionTarget, shouldUseBridge, widgetContext],
+    [
+      cellId,
+      outputs,
+      priority,
+      resolveTracebackExecutionTarget,
+      savedWidgetModels,
+      shouldUseBridge,
+      widgetContext,
+    ],
   );
 
   const handleIsolatedFrameReady = useCallback(() => {

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -176,6 +176,36 @@ describe("MCP App structured content adapter", () => {
     ).toBe(true);
   });
 
+  it("marks widget-view outputs as static when only MCP structured content is available", async () => {
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "widget-output",
+            output_type: "display_data",
+            data: {
+              "application/vnd.jupyter.widget-view+json": JSON.stringify({ model_id: "abc" }),
+              "text/llm+plain": "IntSlider abc: 7 (0-10)",
+            },
+          },
+        ]),
+      ],
+      undefined,
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830"),
+    });
+
+    expect(payload).toMatchObject({
+      mimeType: "application/vnd.jupyter.widget-view+json",
+      metadata: {
+        nteractWidgetMissingState: "stale",
+        nteractWidgetSummary: "IntSlider abc: 7 (0-10)",
+      },
+    });
+  });
+
   it("keeps richer blob-backed renders selected when an LLM preview is present", async () => {
     const outputs = mcpAppCellsToSharedOutputs(
       [

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -1,4 +1,5 @@
 import type { NteractEmbedHostContextPatch } from "./host-context";
+import type { WidgetViewStateHint } from "@/components/widgets/widget-state";
 
 export interface EvalMessage {
   type: "eval";
@@ -37,6 +38,8 @@ export interface RenderPayload {
   append?: boolean;
   /** If true, replace all existing outputs with this single output */
   replace?: boolean;
+  /** Static widget-view state/summary for render surfaces without a live comm bridge. */
+  widgetStateHint?: WidgetViewStateHint;
 }
 
 /**

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -1,6 +1,7 @@
 import type { NteractEmbeddableOutput, ResolveEmbeddableOutputsOptions } from "./embeddable-output";
 import type { ContentRef, OutputBlobResolver, OutputManifest } from "./output-manifest";
 import { selectMimeType } from "@/components/outputs/mime-priority";
+import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 
 export interface McpAppCellOutput {
   output_type: "stream" | "error" | "display_data" | "execute_result";
@@ -65,6 +66,19 @@ function fallbackOutputId(cell: McpAppCellData, outputIndex: number): string {
   return `${cell.cell_id}:output:${outputIndex}`;
 }
 
+function widgetViewMetadata(data: Record<string, unknown>): Record<string, unknown> {
+  if (selectMimeType(data) !== WIDGET_VIEW_MIME) return {};
+  if (!parseWidgetViewModelId(data[WIDGET_VIEW_MIME])) return {};
+
+  const summary = typeof data["text/llm+plain"] === "string" ? data["text/llm+plain"] : undefined;
+  return {
+    [WIDGET_VIEW_MIME]: {
+      nteractWidgetMissingState: "stale",
+      ...(summary ? { nteractWidgetSummary: summary } : {}),
+    },
+  };
+}
+
 function cellOutputToManifest(
   cell: McpAppCellData,
   output: McpAppCellOutput,
@@ -88,7 +102,7 @@ function cellOutputToManifest(
           output_id,
           output_type: "execute_result",
           data,
-          metadata: {},
+          metadata: widgetViewMetadata(output.data),
           execution_count: output.execution_count ?? null,
         };
       }
@@ -96,7 +110,7 @@ function cellOutputToManifest(
         output_id,
         output_type: "display_data",
         data,
-        metadata: {},
+        metadata: widgetViewMetadata(output.data),
       };
     }
     case "stream":

--- a/src/components/widgets/__tests__/widget-state.test.ts
+++ b/src/components/widgets/__tests__/widget-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseSavedWidgetModels, parseWidgetViewModelId, WIDGET_STATE_MIME } from "../widget-state";
+
+describe("widget state parsing", () => {
+  it("extracts the model id from object or string widget-view payloads", () => {
+    expect(parseWidgetViewModelId({ model_id: "abc" })).toBe("abc");
+    expect(parseWidgetViewModelId('{"model_id":"def"}')).toBe("def");
+    expect(parseWidgetViewModelId('{"not_model_id":"def"}')).toBeNull();
+  });
+
+  it("parses saved models from Jupyter widget-state metadata", () => {
+    const models = parseSavedWidgetModels({
+      widgets: {
+        [WIDGET_STATE_MIME]: {
+          version_major: 2,
+          version_minor: 0,
+          state: {
+            "slider-1": {
+              model_name: "IntSliderModel",
+              model_module: "@jupyter-widgets/controls",
+              model_module_version: "2.0.0",
+              state: {
+                value: 5,
+                min: 0,
+                max: 10,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(models.get("slider-1")).toMatchObject({
+      id: "slider-1",
+      modelName: "IntSliderModel",
+      modelModule: "@jupyter-widgets/controls",
+      modelModuleVersion: "2.0.0",
+      state: {
+        value: 5,
+        min: 0,
+        max: 10,
+      },
+    });
+  });
+});

--- a/src/components/widgets/__tests__/widget-view.test.tsx
+++ b/src/components/widgets/__tests__/widget-view.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vite-plus/test";
+import { SavedWidgetStateProvider } from "../saved-widget-state-context";
+import { createWidgetStore } from "../widget-store";
+import { WidgetStoreContext } from "../widget-store-context";
+import { WidgetView } from "../widget-view";
+
+function renderWithWidgetStore(children: ReactNode) {
+  const store = createWidgetStore();
+  return render(
+    <WidgetStoreContext.Provider
+      value={{
+        store,
+        sendUpdate: async () => {},
+        sendCustom: () => {},
+        closeComm: () => {},
+      }}
+    >
+      {children}
+    </WidgetStoreContext.Provider>,
+  );
+}
+
+describe("WidgetView stale/static states", () => {
+  it("renders a saved widget snapshot instead of loading when metadata has the model", () => {
+    renderWithWidgetStore(
+      <SavedWidgetStateProvider
+        models={
+          new Map([
+            [
+              "slider-1",
+              {
+                id: "slider-1",
+                modelName: "IntSliderModel",
+                modelModule: "@jupyter-widgets/controls",
+                state: { value: 7, min: 0, max: 10 },
+              },
+            ],
+          ])
+        }
+      >
+        <WidgetView modelId="slider-1" />
+      </SavedWidgetStateProvider>,
+    );
+
+    expect(screen.getByText("Widget snapshot")).toBeInTheDocument();
+    expect(screen.getByText("IntSlider: 7 (0-10)")).toBeInTheDocument();
+    expect(screen.queryByText("Loading widget...")).not.toBeInTheDocument();
+  });
+
+  it("renders an unavailable state for static surfaces without model state", () => {
+    renderWithWidgetStore(
+      <WidgetView modelId="missing-1" widgetStateHint={{ missingState: "stale" }} />,
+    );
+
+    expect(screen.getByText("Widget state unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Loading widget...")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/widgets/saved-widget-state-context.tsx
+++ b/src/components/widgets/saved-widget-state-context.tsx
@@ -1,0 +1,27 @@
+import { createContext, type ReactNode, useContext } from "react";
+import type { SavedWidgetModel, SavedWidgetModels } from "./widget-state";
+
+const EMPTY_SAVED_WIDGET_MODELS: SavedWidgetModels = new Map();
+
+const SavedWidgetStateContext = createContext<SavedWidgetModels>(EMPTY_SAVED_WIDGET_MODELS);
+
+export interface SavedWidgetStateProviderProps {
+  children: ReactNode;
+  models?: SavedWidgetModels | null;
+}
+
+export function SavedWidgetStateProvider({ children, models }: SavedWidgetStateProviderProps) {
+  return (
+    <SavedWidgetStateContext.Provider value={models ?? EMPTY_SAVED_WIDGET_MODELS}>
+      {children}
+    </SavedWidgetStateContext.Provider>
+  );
+}
+
+export function useSavedWidgetModels(): SavedWidgetModels {
+  return useContext(SavedWidgetStateContext);
+}
+
+export function useSavedWidgetModel(modelId: string): SavedWidgetModel | undefined {
+  return useSavedWidgetModels().get(modelId);
+}

--- a/src/components/widgets/widget-state.ts
+++ b/src/components/widgets/widget-state.ts
@@ -1,0 +1,134 @@
+import type { WidgetModel } from "./widget-store";
+
+export const WIDGET_VIEW_MIME = "application/vnd.jupyter.widget-view+json";
+export const WIDGET_STATE_MIME = "application/vnd.jupyter.widget-state+json";
+
+export interface SavedWidgetModel {
+  id: string;
+  modelName: string;
+  modelModule: string;
+  modelModuleVersion?: string;
+  state: Record<string, unknown>;
+}
+
+export type SavedWidgetModels = Map<string, SavedWidgetModel>;
+
+export interface WidgetViewStateHint {
+  savedModel?: SavedWidgetModel;
+  summary?: string;
+  missingState?: "stale";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return null;
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseWidgetViewModelId(value: unknown): string | null {
+  const record = parseJsonObject(value);
+  return stringValue(record?.model_id) ?? null;
+}
+
+function extractWidgetStateBlock(value: unknown): Record<string, unknown> | null {
+  const record = parseJsonObject(value);
+  if (!record) return null;
+
+  const direct = parseJsonObject(record[WIDGET_STATE_MIME]);
+  if (direct) return direct;
+
+  const widgets = parseJsonObject(record.widgets);
+  if (widgets) {
+    const fromWidgets = parseJsonObject(widgets[WIDGET_STATE_MIME]);
+    if (fromWidgets) return fromWidgets;
+  }
+
+  if (isRecord(record.state)) return record;
+  return null;
+}
+
+export function parseSavedWidgetModels(value: unknown): SavedWidgetModels {
+  const block = extractWidgetStateBlock(value);
+  const state = parseJsonObject(block?.state);
+  if (!state) return new Map();
+
+  const models: SavedWidgetModels = new Map();
+  for (const [id, rawModel] of Object.entries(state)) {
+    const model = parseJsonObject(rawModel);
+    const modelState = parseJsonObject(model?.state);
+    if (!model || !modelState) continue;
+
+    const modelName =
+      stringValue(model.model_name) ?? stringValue(modelState._model_name) ?? "UnknownModel";
+    const modelModule =
+      stringValue(model.model_module) ?? stringValue(modelState._model_module) ?? "";
+    const modelModuleVersion =
+      stringValue(model.model_module_version) ?? stringValue(modelState._model_module_version);
+
+    models.set(id, {
+      id,
+      modelName,
+      modelModule,
+      modelModuleVersion,
+      state: modelState,
+    });
+  }
+
+  return models;
+}
+
+function widgetDisplayName(modelName: string): string {
+  return modelName.endsWith("Model") ? modelName.slice(0, -"Model".length) : modelName;
+}
+
+function compactValue(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return String(value);
+  }
+  try {
+    const json = JSON.stringify(value);
+    return json.length > 80 ? `${json.slice(0, 77)}...` : json;
+  } catch {
+    return String(value);
+  }
+}
+
+export function isSecretWidget(modelName: string): boolean {
+  return modelName === "PasswordModel";
+}
+
+export function formatSavedWidgetSummary(model: SavedWidgetModel | WidgetModel): string {
+  const name = widgetDisplayName(model.modelName);
+  if (isSecretWidget(model.modelName)) return `${name}: value hidden`;
+
+  const description =
+    typeof model.state.description === "string" && model.state.description.length > 0
+      ? `${model.state.description}: `
+      : "";
+
+  if ("value" in model.state) {
+    const value = compactValue(model.state.value);
+    if ("min" in model.state && "max" in model.state) {
+      return `${description}${name}: ${value} (${compactValue(model.state.min)}-${compactValue(
+        model.state.max,
+      )})`;
+    }
+    return `${description}${name}: ${value}`;
+  }
+
+  return `${description}${name}`;
+}

--- a/src/components/widgets/widget-view.tsx
+++ b/src/components/widgets/widget-view.tsx
@@ -7,14 +7,21 @@
  * - Unknown widgets → UnsupportedWidget fallback
  */
 
+import type { ReactNode } from "react";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import { WidgetErrorFallback } from "@/lib/widget-error-fallback";
 import { AnyWidgetView, isAnyWidget } from "./anywidget-view";
+import { useSavedWidgetModel } from "./saved-widget-state-context";
 import { useLayoutStyles } from "./use-layout-styles";
 import { getWidgetComponent } from "./widget-registry";
 import type { WidgetModel } from "./widget-store";
 import { useWasWidgetClosed, useWidgetModel } from "./widget-store-context";
+import {
+  formatSavedWidgetSummary,
+  type SavedWidgetModel,
+  type WidgetViewStateHint,
+} from "./widget-state";
 
 // === Props ===
 
@@ -23,6 +30,8 @@ export interface WidgetViewProps {
   modelId: string;
   /** Optional className for the container */
   className?: string;
+  /** Optional non-live state for disconnected/static render surfaces. */
+  widgetStateHint?: WidgetViewStateHint;
 }
 
 // === Fallback Components ===
@@ -35,6 +44,31 @@ function LoadingWidget({ modelId, className }: WidgetViewProps) {
       data-widget-loading="true"
     >
       Loading widget...
+    </div>
+  );
+}
+
+interface StaticWidgetProps extends WidgetViewProps {
+  savedModel?: SavedWidgetModel;
+  summary?: string;
+}
+
+function StaticWidget({ modelId, className, savedModel, summary }: StaticWidgetProps) {
+  const text = summary ?? (savedModel ? formatSavedWidgetSummary(savedModel) : null);
+
+  return (
+    <div
+      className={cn(
+        "rounded border border-dashed border-muted-foreground/40 bg-muted/30 p-3 text-sm",
+        className,
+      )}
+      data-widget-id={modelId}
+      data-widget-static="true"
+    >
+      <div className="font-medium text-muted-foreground">
+        {savedModel ? "Widget snapshot" : "Widget state unavailable"}
+      </div>
+      {text && <div className="text-xs text-muted-foreground/80 mt-1">{text}</div>}
     </div>
   );
 }
@@ -73,9 +107,11 @@ function UnsupportedWidget({ model, className }: UnsupportedWidgetProps) {
  * </WidgetStoreProvider>
  * ```
  */
-export function WidgetView({ modelId, className }: WidgetViewProps) {
+export function WidgetView({ modelId, className, widgetStateHint }: WidgetViewProps) {
   const model = useWidgetModel(modelId);
   const wasClosed = useWasWidgetClosed(modelId);
+  const savedModelFromContext = useSavedWidgetModel(modelId);
+  const savedModel = widgetStateHint?.savedModel ?? savedModelFromContext;
   // Get child layout styles (grid_area for positioning within grid containers)
   const { childStyle } = useLayoutStyles(modelId);
 
@@ -84,13 +120,27 @@ export function WidgetView({ modelId, className }: WidgetViewProps) {
     return null;
   }
 
-  // Model not loaded yet - show loading state
+  // Model not loaded yet. Prefer an explicit static/saved snapshot when
+  // available; otherwise keep the true loading state for live widget bridges.
   if (!model) {
+    if (savedModel || widgetStateHint?.summary) {
+      return (
+        <StaticWidget
+          modelId={modelId}
+          className={className}
+          savedModel={savedModel}
+          summary={widgetStateHint?.summary}
+        />
+      );
+    }
+    if (widgetStateHint?.missingState === "stale") {
+      return <StaticWidget modelId={modelId} className={className} />;
+    }
     return <LoadingWidget modelId={modelId} className={className} />;
   }
 
   // Determine the rendered widget content
-  let renderedWidget: React.ReactNode;
+  let renderedWidget: ReactNode;
 
   // anywidgets have _esm field - render with ESM loader
   if (isAnyWidget(model)) {

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -58,6 +58,7 @@ import {
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
+import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { measureDocumentHeight } from "./layout-measure";
 import { outputEntryIdForPayload } from "./output-identity";
 // Import widget support
@@ -749,9 +750,24 @@ function OutputRenderer({
   }
 
   // Widget view - render interactive Jupyter widget
-  if (mimeType === "application/vnd.jupyter.widget-view+json") {
-    const widgetData = data as { model_id: string };
-    return <WidgetView modelId={widgetData.model_id} />;
+  if (mimeType === WIDGET_VIEW_MIME) {
+    const modelId = parseWidgetViewModelId(data);
+    if (!modelId) return null;
+    const metadataHint =
+      metadata?.nteractWidgetMissingState === "stale" ||
+      typeof metadata?.nteractWidgetSummary === "string"
+        ? {
+            missingState:
+              metadata?.nteractWidgetMissingState === "stale" ? ("stale" as const) : undefined,
+            summary:
+              typeof metadata?.nteractWidgetSummary === "string"
+                ? metadata.nteractWidgetSummary
+                : undefined,
+          }
+        : undefined;
+    return (
+      <WidgetView modelId={modelId} widgetStateHint={payload.widgetStateHint ?? metadataHint} />
+    );
   }
 
   // HTML


### PR DESCRIPTION
## Summary

- Parse saved Jupyter widget-state metadata and pass saved widget snapshots into isolated widget views when no live comm model is available.
- Add stale/static widget rendering for MCP Apps and cloud-hosted output paths so widget views do not sit on "Loading widget..." forever.
- Synthesize safe MCP widget summaries from live comm state without sending raw widget state through structured content; password values remain masked.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/widgets/__tests__/widget-state.test.ts src/components/widgets/__tests__/widget-view.test.tsx src/components/isolated/__tests__/mcp-app-structured-content.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/render-resolution.test.ts test/mime-policy.test.ts`
- `cargo test -p runt-mcp structured::tests::`
