### PR TITLE
feat(sift): add image viewer navigation

### DIFF
--- a/packages/sift/e2e/image-viewer.spec.ts
+++ b/packages/sift/e2e/image-viewer.spec.ts
@@ -37,10 +37,40 @@ test.describe("Image Viewer", () => {
     const viewerImg = viewer.locator(".sift-image-viewer-img");
     await expect(viewerImg).toBeVisible();
 
+    const naturalSize = await viewerImg.evaluate(
+      (img) =>
+        new Promise<{ width: number; height: number }>((resolve) => {
+          const finish = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+          if (img.complete && img.naturalWidth > 0) {
+            finish();
+          } else {
+            img.addEventListener("load", finish, { once: true });
+          }
+        }),
+    );
+
     const viewerBox = await viewerImg.boundingBox();
     expect(viewerBox).not.toBeNull();
     expect(viewerBox!.width).toBeGreaterThan(thumbBox!.width);
     expect(viewerBox!.height).toBeGreaterThan(thumbBox!.height);
+    expect(viewerBox!.width).toBeLessThanOrEqual(naturalSize.width + 1);
+    expect(viewerBox!.height).toBeLessThanOrEqual(naturalSize.height + 1);
+
+    const meta = viewer.locator(".sift-image-viewer-meta");
+    await expect(meta).toContainText(/^Image 1 of \d+/);
+    const initialMeta = (await meta.textContent()) ?? "";
+    const imageTotal = Number(initialMeta.match(/Image 1 of (\d+)/)?.[1] ?? 0);
+    expect(imageTotal).toBeGreaterThan(1);
+
+    const nextButton = viewer.locator(".sift-image-viewer-next");
+    await expect(nextButton).toBeVisible();
+    await nextButton.click();
+    await expect(viewerImg).toHaveAttribute("data-sift-image-viewer-index", "1");
+    await expect(meta).toContainText(`Image 2 of ${imageTotal}`);
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(viewerImg).toHaveAttribute("data-sift-image-viewer-index", "0");
+    await expect(meta).toContainText(`Image 1 of ${imageTotal}`);
 
     await page.keyboard.press("Escape");
     await expect(viewer).toHaveCount(0);

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -75,8 +75,10 @@
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "lucide-react": "^0.513.0",
     "rxjs": "^7.8.2",
     "tailwind-merge": "^3.5.0",
     "tslib": "^2.8.1"

--- a/packages/sift/src/components/image-viewer.tsx
+++ b/packages/sift/src/components/image-viewer.tsx
@@ -1,0 +1,179 @@
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { createElement, useEffect, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Button } from "./ui/button";
+
+export type ImageViewerItem = {
+  bytes: Uint8Array;
+  mime: string;
+  sourceIndex: number;
+};
+
+export type ImageViewerHandle = {
+  unmount(): void;
+};
+
+type ImageViewerProps = {
+  items: ImageViewerItem[];
+  initialIndex: number;
+  columnLabel: string;
+  onClose: () => void;
+};
+
+function createImageObjectUrl(bytes: Uint8Array, mime: string): string {
+  return URL.createObjectURL(new Blob([bytes.slice() as Uint8Array<ArrayBuffer>], { type: mime }));
+}
+
+function formatMeta(columnLabel: string, index: number, total: number, dimensions: string | null) {
+  const position = `Image ${index + 1} of ${total}`;
+  const parts = /^images?$/i.test(columnLabel) ? [position] : [columnLabel, position];
+  if (dimensions) parts.push(dimensions);
+  return parts.join(" - ");
+}
+
+function ImageViewer({ items, initialIndex, columnLabel, onClose }: ImageViewerProps) {
+  const [currentIndex, setCurrentIndex] = useState(initialIndex);
+  const [dimensions, setDimensions] = useState<string | null>(null);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const item = items[currentIndex];
+  const hasMultiple = items.length > 1;
+  const meta = formatMeta(columnLabel, currentIndex, items.length, dimensions);
+
+  useEffect(() => {
+    const url = createImageObjectUrl(item.bytes, item.mime);
+    setObjectUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [item]);
+
+  useEffect(() => {
+    dialogRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  function navigate(delta: number) {
+    setDimensions(null);
+    setObjectUrl(null);
+    setCurrentIndex((index) => (index + delta + items.length) % items.length);
+  }
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        case "ArrowLeft":
+          if (hasMultiple) {
+            e.preventDefault();
+            navigate(-1);
+          }
+          break;
+        case "ArrowRight":
+          if (hasMultiple) {
+            e.preventDefault();
+            navigate(1);
+          }
+          break;
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [hasMultiple, items.length, onClose]);
+
+  return (
+    <>
+      <div className="sift-image-viewer-backdrop" onClick={onClose} />
+      <div
+        ref={dialogRef}
+        className="sift-image-viewer"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${columnLabel} viewer, ${meta}`}
+        tabIndex={-1}
+      >
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="sift-image-viewer-close"
+          aria-label="Close image viewer"
+          onClick={onClose}
+        >
+          <X />
+          <span className="sr-only">Close image viewer</span>
+        </Button>
+        {hasMultiple && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="sift-image-viewer-nav sift-image-viewer-prev"
+            aria-label="Previous image"
+            onClick={() => navigate(-1)}
+          >
+            <ChevronLeft />
+            <span className="sr-only">Previous image</span>
+          </Button>
+        )}
+        <figure className="sift-image-viewer-frame">
+          {objectUrl && (
+            <img
+              className="sift-image-viewer-img"
+              alt={`${columnLabel} image ${currentIndex + 1} of ${items.length}`}
+              decoding="async"
+              src={objectUrl}
+              data-sift-image-viewer-index={item.sourceIndex}
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                setDimensions(
+                  img.naturalWidth > 0 && img.naturalHeight > 0
+                    ? `${img.naturalWidth} x ${img.naturalHeight}`
+                    : null,
+                );
+              }}
+            />
+          )}
+          <figcaption className="sift-image-viewer-meta">{meta}</figcaption>
+        </figure>
+        {hasMultiple && (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="sift-image-viewer-nav sift-image-viewer-next"
+            aria-label="Next image"
+            onClick={() => navigate(1)}
+          >
+            <ChevronRight />
+            <span className="sr-only">Next image</span>
+          </Button>
+        )}
+      </div>
+    </>
+  );
+}
+
+export function mountImageViewer(props: Omit<ImageViewerProps, "onClose">): ImageViewerHandle {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  let closed = false;
+  let handle: ImageViewerHandle;
+
+  function close() {
+    handle.unmount();
+  }
+
+  handle = {
+    unmount() {
+      if (closed) return;
+      closed = true;
+      root.unmount();
+      container.remove();
+    },
+  };
+
+  root.render(createElement(ImageViewer, { ...props, onClose: close }));
+  return handle;
+}

--- a/packages/sift/src/components/ui/button.tsx
+++ b/packages/sift/src/components/ui/button.tsx
@@ -1,0 +1,51 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  [
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium",
+    "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--sift-accent)]",
+    "disabled:pointer-events-none disabled:opacity-50",
+    "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  ].join(" "),
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-[var(--sift-accent)] text-white shadow hover:bg-[color-mix(in_srgb,var(--sift-accent)_86%,black)]",
+        outline:
+          "border border-[var(--sift-rule)] bg-[var(--sift-panel)] text-[var(--sift-ink)] shadow-sm hover:bg-[color-mix(in_srgb,var(--sift-accent)_8%,var(--sift-panel))]",
+        ghost:
+          "text-[var(--sift-ink)] hover:bg-[color-mix(in_srgb,var(--sift-accent)_8%,transparent)]",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -826,16 +826,29 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 32px;
+  padding: 32px 64px 48px;
   outline: none;
   pointer-events: none;
 }
 
+.sift-image-viewer-frame {
+  display: flex;
+  max-width: calc(100vw - 128px);
+  max-height: calc(100vh - 104px);
+  margin: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  pointer-events: auto;
+}
+
 .sift-image-viewer-img {
-  width: min(88vw, 1120px);
-  height: min(82vh, 760px);
-  max-width: 100%;
-  max-height: calc(100vh - 112px);
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: min(88vw, 1120px);
+  max-height: min(78vh, 720px);
   object-fit: contain;
   border-radius: 6px;
   background:
@@ -851,30 +864,43 @@ h1 {
     -8px 0;
   background-size: 16px 16px;
   box-shadow: 0 18px 48px var(--sift-detail-shadow);
-  pointer-events: auto;
+}
+
+.sift-image-viewer-meta {
+  max-width: min(88vw, 1120px);
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, white 26%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--sift-panel) 92%, transparent);
+  color: var(--sift-ink);
+  font: 600 12px/1.2 var(--sift-font);
+  box-shadow: 0 8px 24px var(--sift-detail-shadow);
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sift-image-viewer-close {
   position: absolute;
   top: 16px;
   right: 16px;
-  width: 32px;
-  height: 32px;
-  border: 1px solid color-mix(in srgb, white 70%, transparent);
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--sift-panel) 92%, transparent);
-  color: var(--sift-ink);
-  font: 22px/1 var(--sift-font);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 8px 24px var(--sift-detail-shadow);
   pointer-events: auto;
 }
 
-.sift-image-viewer-close:hover {
-  background: var(--sift-panel);
+.sift-image-viewer-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: auto;
+}
+
+.sift-image-viewer-prev {
+  left: 16px;
+}
+
+.sift-image-viewer-next {
+  right: 16px;
 }
 
 /* --- Boolean summary in header --- */

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -1,4 +1,5 @@
 import { layout, prepare } from "@chenglou/pretext";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { type Column, createTable, type TableData, type TableEngine } from "./table";
 
@@ -362,11 +363,12 @@ describe("createTable", () => {
       expect(focusedRow).not.toBeNull();
     });
 
-    it("opens a larger image viewer when a thumbnail is clicked", async () => {
+    it("opens a larger image viewer with metadata and image-list navigation", async () => {
       engine.destroy();
       container.innerHTML = "";
 
       const pngBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const gifBytes = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
       const columns: Column[] = [
         {
           key: "id",
@@ -385,7 +387,7 @@ describe("createTable", () => {
           columnType: "image",
         },
       ];
-      const imageRows: unknown[][] = [[1, [pngBytes]]];
+      const imageRows: unknown[][] = [[1, [pngBytes, gifBytes]]];
       const imageData: TableData = {
         columns,
         rowCount: imageRows.length,
@@ -407,21 +409,50 @@ describe("createTable", () => {
       expect(thumbButton).not.toBeNull();
       expect(thumbImg?.dataset.siftBlobUrl).toBeDefined();
 
-      thumbButton!.click();
+      await act(async () => {
+        thumbButton!.click();
+      });
+      await flushRAF();
 
       const viewer = document.body.querySelector<HTMLElement>(".sift-image-viewer");
       const viewerImg = viewer?.querySelector<HTMLImageElement>(".sift-image-viewer-img");
+      const viewerMeta = viewer?.querySelector<HTMLElement>(".sift-image-viewer-meta");
       expect(viewer).not.toBeNull();
       expect(viewerImg?.src).toMatch(/^blob:/);
       expect(viewerImg?.src).not.toBe(thumbImg!.dataset.siftBlobUrl);
+      expect(viewerImg?.dataset.siftImageViewerIndex).toBe("0");
+      expect(viewerMeta?.textContent).toBe("Image 1 of 2");
       expect(engine.getFocusedDataRow()).toBeNull();
 
-      const viewerUrl = viewerImg!.src;
       const revokeSpy = vi.spyOn(URL, "revokeObjectURL");
-      document.body.querySelector<HTMLButtonElement>(".sift-image-viewer-close")!.click();
+      const firstViewerUrl = viewerImg!.src;
+      await act(async () => {
+        document.body.querySelector<HTMLButtonElement>(".sift-image-viewer-next")!.click();
+      });
+      await flushRAF();
+      const secondViewerImg = viewer?.querySelector<HTMLImageElement>(".sift-image-viewer-img");
+      expect(secondViewerImg?.dataset.siftImageViewerIndex).toBe("1");
+      expect(viewerMeta?.textContent).toBe("Image 2 of 2");
+      expect(revokeSpy).toHaveBeenCalledWith(firstViewerUrl);
+
+      const secondViewerUrl = secondViewerImg!.src;
+      await act(async () => {
+        window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+      });
+      await flushRAF();
+      const finalViewerImg = viewer?.querySelector<HTMLImageElement>(".sift-image-viewer-img");
+      expect(finalViewerImg?.dataset.siftImageViewerIndex).toBe("0");
+      expect(viewerMeta?.textContent).toBe("Image 1 of 2");
+      expect(revokeSpy).toHaveBeenCalledWith(secondViewerUrl);
+
+      const finalViewerUrl = finalViewerImg!.src;
+      await act(async () => {
+        document.body.querySelector<HTMLButtonElement>(".sift-image-viewer-close")!.click();
+      });
+      await flushRAF();
 
       expect(document.body.querySelector(".sift-image-viewer")).toBeNull();
-      expect(revokeSpy).toHaveBeenCalledWith(viewerUrl);
+      expect(revokeSpy).toHaveBeenCalledWith(finalViewerUrl);
       revokeSpy.mockRestore();
     });
   });

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -9,6 +9,11 @@ import {
 } from "rxjs";
 import { fitColumnWidths } from "./auto-width";
 import { type ColumnAction, mountColumnMenu, unmountColumnMenu } from "./column-menu";
+import {
+  type ImageViewerHandle,
+  type ImageViewerItem,
+  mountImageViewer,
+} from "./components/image-viewer";
 import { renderColumnSummary, unmountColumnSummary } from "./sparkline";
 // --- Types ---
 
@@ -1580,70 +1585,34 @@ export function createTable(
     }
   }
 
-  type ActiveImageViewer = {
-    backdrop: HTMLDivElement;
-    dialog: HTMLDivElement;
-    objectUrl: string;
-  };
-
-  let activeImageViewer: ActiveImageViewer | null = null;
+  let activeImageViewer: ImageViewerHandle | null = null;
 
   function dismissImageViewer() {
     if (!activeImageViewer) return;
-    URL.revokeObjectURL(activeImageViewer.objectUrl);
-    activeImageViewer.backdrop.remove();
-    activeImageViewer.dialog.remove();
+    activeImageViewer.unmount();
     activeImageViewer = null;
-    window.removeEventListener("keydown", onImageViewerKeyDown);
   }
 
-  function onImageViewerKeyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      dismissImageViewer();
-    }
+  function getImageViewerItems(chunks: Uint8Array[]): ImageViewerItem[] {
+    return chunks.flatMap((bytes, sourceIndex) => {
+      const mime = sniffImageMime(bytes);
+      return mime ? [{ bytes, mime, sourceIndex }] : [];
+    });
   }
 
   function showImageViewer(dataRow: number, colIndex: number, imageIndex: number) {
     const chunks = getImageChunks(data.getCellRaw(dataRow, colIndex));
-    const bytes = chunks[imageIndex];
-    if (!bytes) return;
-    const mime = sniffImageMime(bytes);
-    if (!mime) return;
+    const items = getImageViewerItems(chunks);
+    if (items.length === 0) return;
+    const initialIndex = items.findIndex((item) => item.sourceIndex === imageIndex);
+    if (initialIndex < 0) return;
 
     dismissImageViewer();
-
-    const objectUrl = createImageObjectUrl(bytes, mime);
-    const backdrop = document.createElement("div");
-    backdrop.className = "sift-image-viewer-backdrop";
-    backdrop.addEventListener("click", dismissImageViewer);
-
-    const dialog = document.createElement("div");
-    dialog.className = "sift-image-viewer";
-    dialog.setAttribute("role", "dialog");
-    dialog.setAttribute("aria-modal", "true");
-    dialog.setAttribute("aria-label", `${columns[colIndex]?.label ?? "Image"} viewer`);
-    dialog.tabIndex = -1;
-
-    const closeBtn = document.createElement("button");
-    closeBtn.type = "button";
-    closeBtn.className = "sift-image-viewer-close";
-    closeBtn.setAttribute("aria-label", "Close image viewer");
-    closeBtn.textContent = "×";
-    closeBtn.addEventListener("click", dismissImageViewer);
-
-    const img = document.createElement("img");
-    img.className = "sift-image-viewer-img";
-    img.alt = "";
-    img.decoding = "async";
-    img.src = objectUrl;
-
-    dialog.appendChild(closeBtn);
-    dialog.appendChild(img);
-    document.body.appendChild(backdrop);
-    document.body.appendChild(dialog);
-    activeImageViewer = { backdrop, dialog, objectUrl };
-    window.addEventListener("keydown", onImageViewerKeyDown);
-    dialog.focus({ preventScroll: true });
+    activeImageViewer = mountImageViewer({
+      items,
+      initialIndex,
+      columnLabel: columns[colIndex]?.label ?? "Image",
+    });
   }
 
   // --- Render loop ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,12 +646,18 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      lucide-react:
+        specifier: ^0.513.0
+        version: 0.513.0(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0


### PR DESCRIPTION
## Summary
- move the Sift image viewer into a React-mounted component using a local registry-style Button primitive and lucide icons
- keep viewer images at natural size unless constrained by the lightbox area
- add image count/dimensions plus click and keyboard navigation for multi-image cells

## Verification
- pnpm --dir packages/sift test -- table.test.ts
- pnpm --dir packages/sift build
- pnpm --dir packages/sift test:e2e -- e2e/image-viewer.spec.ts
- cargo xtask lint --fix
- manual Playwright inspection of the MathNet image sample viewer
