### PR TITLE
fix(widgets): save live widget state metadata

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -510,8 +510,21 @@ async fn widget_state_metadata_from_comms(
             continue;
         };
 
-        let (resolved_state, buffers) =
-            resolve_widget_state_content_refs(entry.state.clone(), blob_store).await?;
+        let (resolved_state, buffers) = match resolve_widget_state_content_refs(
+            entry.state.clone(),
+            blob_store,
+        )
+        .await
+        {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                warn!(
+                        "[notebook-sync] Skipping widget comm {} while materializing widget state metadata: {err}",
+                        comm_id
+                    );
+                continue;
+            }
+        };
         let mut model = serde_json::Map::new();
         model.insert(
             "model_name".to_string(),

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -1,4 +1,10 @@
 use super::*;
+use base64::Engine as _;
+
+pub(crate) const JUPYTER_WIDGET_TARGET: &str = "jupyter.widget";
+pub(crate) const WIDGET_STATE_MIME: &str = "application/vnd.jupyter.widget-state+json";
+const WIDGET_STATE_VERSION_MAJOR: i64 = 2;
+const WIDGET_STATE_VERSION_MINOR: i64 = 0;
 
 #[derive(Debug)]
 pub(crate) enum SaveError {
@@ -194,10 +200,23 @@ pub(crate) async fn save_notebook_to_disk(
 
     // Metadata comes entirely from the doc. No disk rescue; the
     // snapshot carries unknown keys as extras.
-    let metadata = metadata_snapshot
+    let mut metadata = metadata_snapshot
         .as_ref()
         .map(|s| serde_json::to_value(s).unwrap_or_else(|_| serde_json::json!({})))
         .unwrap_or_else(|| serde_json::json!({}));
+    let comms = room.state.read(|sd| sd.get_comms()).unwrap_or_default();
+    match widget_state_metadata_from_comms(&comms, &room.blob_store).await {
+        Ok(Some(widget_state)) => {
+            insert_widget_state_metadata(&mut metadata, widget_state);
+        }
+        Ok(None) => {}
+        Err(err) => {
+            warn!(
+                "[notebook-sync] Failed to materialize widget state metadata; \
+                 preserving existing notebook metadata: {err}"
+            );
+        }
+    }
 
     // We always write cell IDs, so nbformat_minor is at least 5.
     let existing_minor = existing_raw
@@ -459,6 +478,310 @@ async fn resolve_cell_output(
         },
         Err(_) => output.clone(),
     }
+}
+
+async fn widget_state_metadata_from_comms(
+    comms: &HashMap<String, runtime_doc::CommDocEntry>,
+    blob_store: &BlobStore,
+) -> Result<Option<serde_json::Value>, String> {
+    let mut entries: Vec<_> = comms
+        .iter()
+        .filter(|(_, entry)| entry.target_name == JUPYTER_WIDGET_TARGET)
+        .collect();
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut state = serde_json::Map::new();
+    for (comm_id, entry) in entries {
+        let Some(model_name) = widget_model_field(&entry.model_name, &entry.state, "_model_name")
+        else {
+            warn!(
+                "[notebook-sync] Skipping widget comm {} with missing model_name",
+                comm_id
+            );
+            continue;
+        };
+        let Some(model_module) =
+            widget_model_field(&entry.model_module, &entry.state, "_model_module")
+        else {
+            warn!(
+                "[notebook-sync] Skipping widget comm {} with missing model_module",
+                comm_id
+            );
+            continue;
+        };
+
+        let (resolved_state, buffers) =
+            resolve_widget_state_content_refs(entry.state.clone(), blob_store).await?;
+        let mut model = serde_json::Map::new();
+        model.insert(
+            "model_name".to_string(),
+            serde_json::Value::String(model_name),
+        );
+        model.insert(
+            "model_module".to_string(),
+            serde_json::Value::String(model_module),
+        );
+        if let Some(model_module_version) =
+            widget_model_field("", &entry.state, "_model_module_version")
+        {
+            model.insert(
+                "model_module_version".to_string(),
+                serde_json::Value::String(model_module_version),
+            );
+        }
+        model.insert("state".to_string(), resolved_state);
+        if !buffers.is_empty() {
+            model.insert("buffers".to_string(), serde_json::Value::Array(buffers));
+        }
+        state.insert(comm_id.clone(), serde_json::Value::Object(model));
+    }
+
+    if state.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(serde_json::json!({
+        "version_major": WIDGET_STATE_VERSION_MAJOR,
+        "version_minor": WIDGET_STATE_VERSION_MINOR,
+        "state": state,
+    })))
+}
+
+fn widget_model_field(
+    entry_value: &str,
+    state: &serde_json::Value,
+    state_key: &str,
+) -> Option<String> {
+    if !entry_value.is_empty() {
+        return Some(entry_value.to_string());
+    }
+    state
+        .get(state_key)
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn insert_widget_state_metadata(metadata: &mut serde_json::Value, widget_state: serde_json::Value) {
+    if !metadata.is_object() {
+        *metadata = serde_json::json!({});
+    }
+    let Some(metadata_obj) = metadata.as_object_mut() else {
+        return;
+    };
+    let widgets = metadata_obj
+        .entry("widgets".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    if !widgets.is_object() {
+        *widgets = serde_json::json!({});
+    }
+    if let Some(widgets_obj) = widgets.as_object_mut() {
+        widgets_obj.insert(WIDGET_STATE_MIME.to_string(), widget_state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum WidgetStatePathSegment {
+    Key(String),
+    Index(usize),
+}
+
+impl WidgetStatePathSegment {
+    fn to_widget_path_value(&self) -> serde_json::Value {
+        match self {
+            Self::Key(key) => serde_json::Value::String(key.clone()),
+            Self::Index(index) => serde_json::json!(*index),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WidgetStateContentRef {
+    path: Vec<WidgetStatePathSegment>,
+    blob: String,
+    media_type: Option<String>,
+}
+
+async fn resolve_widget_state_content_refs(
+    mut state: serde_json::Value,
+    blob_store: &BlobStore,
+) -> Result<(serde_json::Value, Vec<serde_json::Value>), String> {
+    let mut refs = Vec::new();
+    collect_widget_state_content_refs(&state, &mut Vec::new(), &mut refs);
+
+    let mut buffers = Vec::new();
+    for content_ref in refs {
+        let bytes = blob_store
+            .get(&content_ref.blob)
+            .await
+            .map_err(|err| {
+                format!(
+                    "failed to read widget state blob {}: {err}",
+                    content_ref.blob
+                )
+            })?
+            .ok_or_else(|| format!("widget state blob {} not found", content_ref.blob))?;
+
+        if widget_state_ref_is_binary(content_ref.media_type.as_deref()) {
+            remove_widget_state_value_for_buffer(&mut state, &content_ref.path)?;
+            buffers.push(serde_json::json!({
+                "encoding": "base64",
+                "path": content_ref
+                    .path
+                    .iter()
+                    .map(WidgetStatePathSegment::to_widget_path_value)
+                    .collect::<Vec<_>>(),
+                "data": base64::engine::general_purpose::STANDARD.encode(bytes),
+            }));
+        } else {
+            let replacement =
+                widget_state_blob_to_json_value(&bytes, content_ref.media_type.as_deref())?;
+            set_widget_state_value_at_path(&mut state, &content_ref.path, replacement)?;
+        }
+    }
+
+    Ok((state, buffers))
+}
+
+fn collect_widget_state_content_refs(
+    value: &serde_json::Value,
+    path: &mut Vec<WidgetStatePathSegment>,
+    refs: &mut Vec<WidgetStateContentRef>,
+) {
+    if let Some((blob, media_type)) = widget_state_content_ref(value) {
+        refs.push(WidgetStateContentRef {
+            path: path.clone(),
+            blob,
+            media_type,
+        });
+        return;
+    }
+
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                path.push(WidgetStatePathSegment::Key(key.clone()));
+                collect_widget_state_content_refs(child, path, refs);
+                path.pop();
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                path.push(WidgetStatePathSegment::Index(index));
+                collect_widget_state_content_refs(child, path, refs);
+                path.pop();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn widget_state_content_ref(value: &serde_json::Value) -> Option<(String, Option<String>)> {
+    let object = value.as_object()?;
+    let blob = object.get("blob")?.as_str()?.to_string();
+    let has_size = object.get("size").is_some_and(serde_json::Value::is_number);
+    if !has_size {
+        return None;
+    }
+    let media_type = object
+        .get("media_type")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    Some((blob, media_type))
+}
+
+fn widget_state_ref_is_binary(media_type: Option<&str>) -> bool {
+    match media_type {
+        Some(media_type) => notebook_doc::mime::is_binary_mime(media_type),
+        None => true,
+    }
+}
+
+fn widget_state_blob_to_json_value(
+    bytes: &[u8],
+    media_type: Option<&str>,
+) -> Result<serde_json::Value, String> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|err| format!("widget state text blob is not valid UTF-8: {err}"))?;
+    if media_type.is_some_and(|mime| mime == "application/json" || mime.ends_with("+json")) {
+        serde_json::from_str(text)
+            .map_err(|err| format!("widget state JSON blob is invalid: {err}"))
+    } else {
+        Ok(serde_json::Value::String(text.to_string()))
+    }
+}
+
+fn set_widget_state_value_at_path(
+    state: &mut serde_json::Value,
+    path: &[WidgetStatePathSegment],
+    replacement: serde_json::Value,
+) -> Result<(), String> {
+    let Some((last, parent_path)) = path.split_last() else {
+        *state = replacement;
+        return Ok(());
+    };
+    let parent = widget_state_value_mut_at_path(state, parent_path)?;
+    match (parent, last) {
+        (serde_json::Value::Object(map), WidgetStatePathSegment::Key(key)) => {
+            map.insert(key.clone(), replacement);
+            Ok(())
+        }
+        (serde_json::Value::Array(items), WidgetStatePathSegment::Index(index)) => {
+            let Some(item) = items.get_mut(*index) else {
+                return Err(format!("widget state array index {index} out of bounds"));
+            };
+            *item = replacement;
+            Ok(())
+        }
+        _ => Err("widget state content ref path shape changed while resolving".to_string()),
+    }
+}
+
+fn remove_widget_state_value_for_buffer(
+    state: &mut serde_json::Value,
+    path: &[WidgetStatePathSegment],
+) -> Result<(), String> {
+    let Some((last, parent_path)) = path.split_last() else {
+        *state = serde_json::Value::Null;
+        return Ok(());
+    };
+    let parent = widget_state_value_mut_at_path(state, parent_path)?;
+    match (parent, last) {
+        (serde_json::Value::Object(map), WidgetStatePathSegment::Key(key)) => {
+            map.remove(key);
+            Ok(())
+        }
+        (serde_json::Value::Array(items), WidgetStatePathSegment::Index(index)) => {
+            let Some(item) = items.get_mut(*index) else {
+                return Err(format!("widget state array index {index} out of bounds"));
+            };
+            *item = serde_json::Value::Null;
+            Ok(())
+        }
+        _ => Err("widget state buffer path shape changed while resolving".to_string()),
+    }
+}
+
+fn widget_state_value_mut_at_path<'a>(
+    mut value: &'a mut serde_json::Value,
+    path: &[WidgetStatePathSegment],
+) -> Result<&'a mut serde_json::Value, String> {
+    for segment in path {
+        value = match (value, segment) {
+            (serde_json::Value::Object(map), WidgetStatePathSegment::Key(key)) => map
+                .get_mut(key)
+                .ok_or_else(|| format!("widget state object key {key:?} missing"))?,
+            (serde_json::Value::Array(items), WidgetStatePathSegment::Index(index)) => items
+                .get_mut(*index)
+                .ok_or_else(|| format!("widget state array index {index} out of bounds"))?,
+            _ => {
+                return Err(
+                    "widget state content ref path shape changed while resolving".to_string(),
+                )
+            }
+        };
+    }
+    Ok(value)
 }
 
 /// Configuration for the persist debouncer timing.

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1376,6 +1376,178 @@ async fn test_save_notebook_to_disk_with_outputs() {
 }
 
 #[tokio::test]
+async fn test_save_notebook_to_disk_writes_widget_state_metadata_from_runtime_comms() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "widget-state.ipynb");
+    let eid = "widget-exec-1";
+    let model_id = "slider-model";
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-widget", "code").unwrap();
+        doc.update_source("cell-widget", "slider").unwrap();
+        doc.set_execution_id("cell-widget", Some(eid)).unwrap();
+    }
+
+    room.state
+        .with_doc(|sd| {
+            sd.create_execution(eid)?;
+            sd.set_execution_count(eid, 1)?;
+            sd.set_outputs(
+                eid,
+                &[serde_json::json!({
+                    "output_type": "display_data",
+                    "output_id": "widget-output-runtime-only",
+                    "data": {
+                        "text/plain": "IntSlider(value=42)",
+                        "application/vnd.jupyter.widget-view+json": {
+                            "version_major": 2,
+                            "version_minor": 0,
+                            "model_id": model_id
+                        }
+                    },
+                    "metadata": {}
+                })],
+            )?;
+            sd.set_execution_done(eid, true)?;
+            sd.put_comm(
+                model_id,
+                "jupyter.widget",
+                "@jupyter-widgets/controls",
+                "IntSliderModel",
+                &serde_json::json!({
+                    "_model_module": "@jupyter-widgets/controls",
+                    "_model_module_version": "2.0.0",
+                    "_model_name": "IntSliderModel",
+                    "_view_module": "@jupyter-widgets/controls",
+                    "_view_module_version": "2.0.0",
+                    "_view_name": "IntSliderView",
+                    "description": "Answer",
+                    "value": 42
+                }),
+                0,
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let widget_state = &saved["metadata"]["widgets"][WIDGET_STATE_MIME];
+    assert_eq!(widget_state["version_major"], serde_json::json!(2));
+    assert_eq!(widget_state["version_minor"], serde_json::json!(0));
+    assert_eq!(
+        widget_state["state"][model_id]["model_name"],
+        serde_json::json!("IntSliderModel")
+    );
+    assert_eq!(
+        widget_state["state"][model_id]["model_module"],
+        serde_json::json!("@jupyter-widgets/controls")
+    );
+    assert_eq!(
+        widget_state["state"][model_id]["model_module_version"],
+        serde_json::json!("2.0.0")
+    );
+    assert_eq!(
+        widget_state["state"][model_id]["state"]["value"],
+        serde_json::json!(42)
+    );
+    assert_eq!(
+        saved["cells"][0]["outputs"][0]["data"]["application/vnd.jupyter.widget-view+json"]
+            ["model_id"],
+        serde_json::json!(model_id),
+        "the original widget view output should remain in the cell output"
+    );
+    assert!(
+        !content.contains("widget-output-runtime-only"),
+        "runtime-only output_id leaked to saved .ipynb:\n{content}"
+    );
+}
+
+#[tokio::test]
+async fn test_save_notebook_to_disk_resolves_widget_state_content_refs() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "widget-state-refs.ipynb");
+
+    let esm = "export default { render() {} }";
+    let esm_hash = room
+        .blob_store
+        .put(esm.as_bytes(), "text/javascript")
+        .await
+        .unwrap();
+    let options = serde_json::json!({"items": [1, 2, 3]});
+    let options_bytes = serde_json::to_vec(&options).unwrap();
+    let options_hash = room
+        .blob_store
+        .put(&options_bytes, "application/json")
+        .await
+        .unwrap();
+    let binary = b"abc123";
+    let binary_hash = room
+        .blob_store
+        .put(binary, "application/octet-stream")
+        .await
+        .unwrap();
+
+    room.state
+        .with_doc(|sd| {
+            sd.put_comm(
+                "binary-widget",
+                "jupyter.widget",
+                "anywidget",
+                "AnyModel",
+                &serde_json::json!({
+                    "_model_module": "anywidget",
+                    "_model_module_version": "0.9.18",
+                    "_model_name": "AnyModel",
+                    "_esm": {
+                        "blob": esm_hash,
+                        "size": esm.len(),
+                        "media_type": "text/javascript"
+                    },
+                    "options": {
+                        "blob": options_hash,
+                        "size": options_bytes.len(),
+                        "media_type": "application/json"
+                    },
+                    "value": {
+                        "blob": binary_hash,
+                        "size": binary.len(),
+                        "media_type": "application/octet-stream"
+                    }
+                }),
+                0,
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let model = &saved["metadata"]["widgets"][WIDGET_STATE_MIME]["state"]["binary-widget"];
+    let state = &model["state"];
+
+    assert_eq!(state["_esm"], serde_json::json!(esm));
+    assert_eq!(state["options"], options);
+    assert!(
+        state.get("value").is_none(),
+        "binary object fields should be removed from state and represented in buffers"
+    );
+    let buffers = model["buffers"].as_array().expect("buffers array");
+    assert_eq!(buffers.len(), 1);
+    assert_eq!(buffers[0]["encoding"], serde_json::json!("base64"));
+    assert_eq!(buffers[0]["path"], serde_json::json!(["value"]));
+    assert_eq!(
+        buffers[0]["data"],
+        serde_json::json!(base64::engine::general_purpose::STANDARD.encode(binary))
+    );
+}
+
+#[tokio::test]
 async fn test_save_notebook_to_disk_externalizes_arrow_stream_outputs() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, notebook_path) = test_room_with_path(&tmp, "arrow-output.ipynb");

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1548,6 +1548,65 @@ async fn test_save_notebook_to_disk_resolves_widget_state_content_refs() {
 }
 
 #[tokio::test]
+async fn test_save_notebook_to_disk_skips_only_widget_with_unresolved_state_blob() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "widget-state-partial.ipynb");
+
+    room.state
+        .with_doc(|sd| {
+            sd.put_comm(
+                "healthy-widget",
+                "jupyter.widget",
+                "@jupyter-widgets/controls",
+                "IntSliderModel",
+                &serde_json::json!({
+                    "_model_module": "@jupyter-widgets/controls",
+                    "_model_module_version": "2.0.0",
+                    "_model_name": "IntSliderModel",
+                    "value": 7
+                }),
+                0,
+            )?;
+            sd.put_comm(
+                "broken-widget",
+                "jupyter.widget",
+                "@jupyter-widgets/controls",
+                "ImageModel",
+                &serde_json::json!({
+                    "_model_module": "@jupyter-widgets/controls",
+                    "_model_module_version": "2.0.0",
+                    "_model_name": "ImageModel",
+                    "value": {
+                        "blob": "missing-widget-state-blob",
+                        "size": 6,
+                        "media_type": "application/octet-stream"
+                    }
+                }),
+                1,
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    let content = std::fs::read_to_string(&notebook_path).unwrap();
+    let saved: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let widget_models = saved["metadata"]["widgets"][WIDGET_STATE_MIME]["state"]
+        .as_object()
+        .expect("widget state map");
+    assert!(widget_models.contains_key("healthy-widget"));
+    assert!(
+        !widget_models.contains_key("broken-widget"),
+        "a single unresolved widget blob should not poison every other widget model"
+    );
+    assert_eq!(
+        widget_models["healthy-widget"]["state"]["value"],
+        serde_json::json!(7)
+    );
+}
+
+#[tokio::test]
 async fn test_save_notebook_to_disk_externalizes_arrow_stream_outputs() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, notebook_path) = test_room_with_path(&tmp, "arrow-output.ipynb");


### PR DESCRIPTION
## Summary

- Materialize live `RuntimeStateDoc.comms` into notebook-level Jupyter widget-state metadata during `.ipynb` save.
- Preserve the original widget-view output while writing `metadata.widgets["application/vnd.jupyter.widget-state+json"]` for live widget models.
- Resolve nteract `ContentRef` widget state blobs back into portable saved-widget JSON, including base64 `buffers` for binary traitlets.

## Verification

- `cargo xtask wasm`
- `cargo test -p runtimed test_save_notebook_to_disk`
- `cargo xtask lint --fix`
