### PR TITLE
Emit compact table previews for Arrow outputs

### DIFF
--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -54,9 +54,12 @@ from nteract_kernel_launcher._format import (
     ARROW_STREAM_MANIFEST_MIME,
     ARROW_STREAM_MIME,
     DEFAULT_ARROW_CHUNK_BYTES,
+    TABLE_PREVIEW_MIME,
+    ArrowStreamChunk,
     arrow_stream_row_count,
     build_arrow_stream_manifest,
     build_arrow_stream_manifest_from_chunks,
+    build_arrow_table_preview_from_chunks,
     has_arrow_stream_protocol,
     iter_arrow_stream_chunks,
 )
@@ -138,6 +141,25 @@ class ArrowStreamManifestFormatter(BaseFormatter):
         return printer(obj)
 
 
+class ArrowTablePreviewFormatter(BaseFormatter):
+    """Per-MIME formatter that emits compact table preview JSON."""
+
+    format_type = Unicode(TABLE_PREVIEW_MIME)
+
+    def __init__(self, *args, arrow_state: _ArrowFormatterState, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._arrow_state = arrow_state
+
+    def __call__(self, obj: Any) -> Any:
+        if not self.enabled:
+            return None
+        try:
+            printer = self.lookup(obj)
+        except KeyError:
+            return self._arrow_state.value_for(obj, TABLE_PREVIEW_MIME)
+        return printer(obj)
+
+
 class _ArrowFormatterState:
     """Share one serialized Arrow bundle across per-MIME formatter calls."""
 
@@ -157,7 +179,12 @@ class _ArrowFormatterState:
             "bundle": bundle,
             "remaining": {
                 mime
-                for mime in (BLOB_REF_MIME, ARROW_STREAM_MANIFEST_MIME, "text/llm+plain")
+                for mime in (
+                    BLOB_REF_MIME,
+                    ARROW_STREAM_MANIFEST_MIME,
+                    TABLE_PREVIEW_MIME,
+                    "text/llm+plain",
+                )
                 if mime in bundle
             },
         }
@@ -319,6 +346,7 @@ def _emit_arrow_stream_chunks(
             complete=True,
             summary=summary_hints,
         ),
+        TABLE_PREVIEW_MIME: build_arrow_table_preview_from_chunks(chunks),
     }
     if llm_text is not None:
         bundle["text/llm+plain"] = llm_text
@@ -446,6 +474,18 @@ def _emit_table_bytes(
                 record_batch_count=record_batch_count,
                 summary=summary_hints,
             )
+            bundle[TABLE_PREVIEW_MIME] = build_arrow_table_preview_from_chunks(
+                [
+                    ArrowStreamChunk(
+                        index=0,
+                        data=data,
+                        content_hash=h,
+                        size=len(data),
+                        row_count=included_rows,
+                        record_batch_count=record_batch_count or 0,
+                    ),
+                ]
+            )
         except Exception as exc:  # noqa: BLE001
             log.debug("arrow manifest build failed: %s", exc)
     if llm_text is not None:
@@ -493,6 +533,11 @@ def _install_dataframe_formatters(ip: Any) -> None:
             ArrowStreamManifestFormatter,
         ):
             formatters[ARROW_STREAM_MANIFEST_MIME] = ArrowStreamManifestFormatter(
+                parent=display_formatter,
+                arrow_state=arrow_state,
+            )
+        if not isinstance(formatters.get(TABLE_PREVIEW_MIME), ArrowTablePreviewFormatter):
+            formatters[TABLE_PREVIEW_MIME] = ArrowTablePreviewFormatter(
                 parent=display_formatter,
                 arrow_state=arrow_state,
             )

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py
@@ -11,13 +11,16 @@ from __future__ import annotations
 import datetime as _dt
 import hashlib
 import sys
+from collections import Counter
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
 ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream"
 ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json"
+TABLE_PREVIEW_MIME = "application/vnd.nteract.table-preview+json"
 DEFAULT_ARROW_CHUNK_BYTES = 8 * 1024 * 1024
+DEFAULT_TABLE_PREVIEW_ROWS = 30
 
 
 @dataclass(frozen=True)
@@ -349,6 +352,167 @@ def build_arrow_stream_manifest_from_chunks(
         "summary": summary or {},
     }
     return manifest
+
+
+def build_arrow_table_preview_from_chunks(
+    chunks: list[ArrowStreamChunk],
+    *,
+    max_rows: int = DEFAULT_TABLE_PREVIEW_ROWS,
+) -> dict[str, Any]:
+    """Build a compact row/profile preview from Arrow stream chunks."""
+    import pyarrow as pa
+
+    rows: list[list[str]] = []
+    profilers: list[_ColumnPreviewProfile] | None = None
+
+    for chunk in chunks:
+        table = pa.ipc.open_stream(pa.BufferReader(chunk.data)).read_all()
+        if profilers is None:
+            profilers = [_ColumnPreviewProfile(field.type) for field in table.schema]
+
+        for row_index in range(table.num_rows):
+            row: list[str] = []
+            for column_index, column in enumerate(table.columns):
+                value = column[row_index].as_py()
+                if profilers is not None:
+                    profilers[column_index].add(value)
+                row.append(_compact_preview_cell(value))
+            if len(rows) < max_rows:
+                rows.append(row)
+
+    return {
+        "rows": rows,
+        "profiles": [profiler.finish() for profiler in profilers or []],
+    }
+
+
+class _ColumnPreviewProfile:
+    def __init__(self, data_type: Any) -> None:
+        import pyarrow as pa
+
+        if pa.types.is_boolean(data_type):
+            self.kind = "boolean"
+            self.true_count = 0
+            self.false_count = 0
+        elif (
+            pa.types.is_integer(data_type)
+            or pa.types.is_floating(data_type)
+            or pa.types.is_decimal(data_type)
+        ):
+            self.kind = "numeric"
+            self.values: list[float] = []
+            self.unique_values: set[str] = set()
+        else:
+            self.kind = "categorical"
+            self.counts: Counter[str] = Counter()
+        self.null_count = 0
+
+    def add(self, value: Any) -> None:
+        if value is None:
+            self.null_count += 1
+            return
+        if self.kind == "boolean":
+            if value is True:
+                self.true_count += 1
+            elif value is False:
+                self.false_count += 1
+            else:
+                self.null_count += 1
+            return
+        if self.kind == "numeric":
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                self.null_count += 1
+                return
+            if parsed != parsed or parsed in (float("inf"), float("-inf")):
+                self.null_count += 1
+                return
+            self.values.append(parsed)
+            if len(self.unique_values) <= 20:
+                self.unique_values.add(_compact_preview_cell(value))
+            return
+        self.counts[_compact_preview_cell(value)] += 1
+
+    def finish(self) -> dict[str, Any]:
+        if self.kind == "boolean":
+            return {
+                "kind": "boolean",
+                "detail": _profile_detail(
+                    [f"{self.true_count} true", f"{self.false_count} false"],
+                    self.null_count,
+                ),
+                "bars": [self.true_count, self.false_count],
+            }
+        if self.kind == "numeric":
+            return _finish_numeric_profile(self.values, self.unique_values, self.null_count)
+
+        sorted_counts = sorted(self.counts.items(), key=lambda item: (-item[1], item[0]))
+        return {
+            "kind": "categorical",
+            "detail": _profile_detail([f"{len(self.counts)} distinct"], self.null_count),
+            "bars": [count for _label, count in sorted_counts[:8]],
+        }
+
+
+def _finish_numeric_profile(
+    values: list[float],
+    unique_values: set[str],
+    null_count: int,
+) -> dict[str, Any]:
+    if not values:
+        return {
+            "kind": "numeric",
+            "detail": _profile_detail(["no values"], null_count),
+            "bars": [],
+        }
+
+    minimum = min(values)
+    maximum = max(values)
+    bin_count = 8
+    width = (maximum - minimum) / bin_count if maximum > minimum else 1.0
+    bars = [0] * bin_count
+    for value in values:
+        index = int((value - minimum) // width) if width > 0 else 0
+        if index >= bin_count:
+            index = bin_count - 1
+        bars[index] += 1
+
+    detail_parts = [f"{_compact_number(minimum)}-{_compact_number(maximum)}"]
+    if len(unique_values) <= 20:
+        detail_parts.append(f"{len(unique_values)} distinct")
+    return {
+        "kind": "numeric",
+        "detail": _profile_detail(detail_parts, null_count),
+        "bars": bars,
+    }
+
+
+def _profile_detail(parts: list[str], null_count: int) -> str:
+    if null_count:
+        parts = [*parts, f"{null_count} null"]
+    return " ".join(parts)
+
+
+def _compact_number(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _compact_preview_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        text = f"<bytes {len(value)}>"
+    elif hasattr(value, "isoformat"):
+        text = value.isoformat()
+    else:
+        text = str(value)
+    compact = " ".join(text.split())
+    if len(compact) <= 96:
+        return compact
+    return compact[:93] + "..."
 
 
 def serialize_arrow_stream(source: Any, *, max_bytes: int) -> tuple[bytes, str, int, int]:

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -640,7 +640,7 @@ def test_arrow_stream_formatter_stashes_bytes_and_returns_bundle():
     pytest.importorskip("pyarrow")
 
     from nteract_kernel_launcher import _bootstrap, _buffer_hook
-    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME, TABLE_PREVIEW_MIME
     from nteract_kernel_launcher._refs import BLOB_REF_MIME
 
     _buffer_hook.pending_buffers().clear()
@@ -659,6 +659,11 @@ def test_arrow_stream_formatter_stashes_bytes_and_returns_bundle():
     assert bundle[ARROW_STREAM_MANIFEST_MIME]["schema"]["columns"] == [
         {"name": "a", "type": "int64", "nullable": True},
         {"name": "b", "type": "large_string", "nullable": True},
+    ]
+    assert bundle[TABLE_PREVIEW_MIME]["rows"] == [["1", "x"], ["2", "y"], ["3", "z"]]
+    assert [profile["kind"] for profile in bundle[TABLE_PREVIEW_MIME]["profiles"]] == [
+        "numeric",
+        "categorical",
     ]
 
 

--- a/python/nteract-kernel-launcher/tests/test_format.py
+++ b/python/nteract-kernel-launcher/tests/test_format.py
@@ -402,6 +402,36 @@ def test_iter_arrow_stream_chunks_yields_decodable_mini_streams():
     ]
 
 
+def test_build_arrow_table_preview_from_chunks_is_compact():
+    pa = pytest.importorskip("pyarrow")
+    from nteract_kernel_launcher._format import (
+        build_arrow_table_preview_from_chunks,
+        iter_arrow_stream_chunks,
+    )
+
+    table = pa.table(
+        {
+            "name": ["Ada", "Grace", "Ada"],
+            "score": [9.5, 8.25, 10.0],
+            "rank": [2, None, 1],
+        }
+    )
+    reader = pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=2))
+    chunks = list(iter_arrow_stream_chunks(reader))
+
+    preview = build_arrow_table_preview_from_chunks(chunks, max_rows=2)
+
+    assert preview["rows"] == [["Ada", "9.5", "2"], ["Grace", "8.25", ""]]
+    assert preview["profiles"][0]["kind"] == "categorical"
+    assert preview["profiles"][0]["detail"] == "2 distinct"
+    assert preview["profiles"][0]["bars"] == [2, 1]
+    assert preview["profiles"][1]["kind"] == "numeric"
+    assert "8.25-10" in preview["profiles"][1]["detail"]
+    assert sum(preview["profiles"][1]["bars"]) == 3
+    assert preview["profiles"][2]["kind"] == "numeric"
+    assert "1 null" in preview["profiles"][2]["detail"]
+
+
 def test_iter_arrow_stream_chunks_preserves_schema_metadata():
     pa = pytest.importorskip("pyarrow")
     from nteract_kernel_launcher._format import iter_arrow_stream_chunks


### PR DESCRIPTION
## Summary

- emit `application/vnd.nteract.table-preview+json` alongside Arrow stream outputs
- build compact row previews plus lightweight column profiles from Arrow IPC chunks
- register a shared formatter so blob refs, Arrow manifests, previews, and `text/llm+plain` reuse one serialization pass

## Verification

- `uv run --project python/nteract-kernel-launcher pytest python/nteract-kernel-launcher/tests/test_format.py::test_build_arrow_table_preview_from_chunks_is_compact python/nteract-kernel-launcher/tests/test_bootstrap.py::test_arrow_stream_formatter_stashes_bytes_and_returns_bundle`
- `uv run --project python/nteract-kernel-launcher pytest python/nteract-kernel-launcher/tests/test_format.py python/nteract-kernel-launcher/tests/test_bootstrap.py`
- `uv run ruff check python/nteract-kernel-launcher/nteract_kernel_launcher/_format.py python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py python/nteract-kernel-launcher/tests/test_format.py python/nteract-kernel-launcher/tests/test_bootstrap.py`
