### PR TITLE
fix(notebook-cloud): hydrate widget progress views

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Frame, type Locator, type Page } from "@playwright/test";
 import { cloudOutputParityExpectedMarkers } from "../../test/fixtures/cloud-output-parity";
 
 test.describe("cloud renderer parity harness", () => {
@@ -123,9 +123,20 @@ test.describe("cloud renderer parity harness", () => {
 
     const siftCell = page.locator('[data-cell-id="sift-arrow-output"]');
     await expect(siftCell).toContainText(cloudOutputParityExpectedMarkers.siftStream);
-    await expect(siftCell).toContainText("Cloud Sift widget progress marker");
+    await expect(siftCell).not.toContainText("Cloud Sift widget progress marker");
+    await expect(siftCell.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
+      timeout: 60_000,
+    });
+    const widgetFrame = await findFrameContaining(
+      page,
+      siftCell,
+      'iframe[data-slot="isolated-frame"]',
+      '[data-widget-type="IntProgress"]',
+    );
+    await expect(widgetFrame.locator('[data-widget-type="IntProgress"]')).toBeVisible({
+      timeout: 30_000,
+    });
     await expect(siftCell.locator('[data-sift-output="true"]')).toBeVisible({ timeout: 60_000 });
-    await expect(siftCell.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(1);
     await expect(siftCell.locator('[data-sift-output="true"] iframe')).toHaveCSS(
       "pointer-events",
       "none",
@@ -135,7 +146,9 @@ test.describe("cloud renderer parity harness", () => {
       /\/output-document\/frame\.html\?nteract_theme=light$/,
     );
     await expect(
-      page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
+      page
+        .frameLocator('[data-cell-id="sift-arrow-output"] [data-sift-output="true"] iframe')
+        .locator("body"),
     ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
   });
 
@@ -220,7 +233,9 @@ test.describe("cloud renderer parity harness", () => {
 
     const siftCell = page.locator('[data-cell-id="sift-arrow-output"]');
     await expect(
-      page.frameLocator('[data-cell-id="sift-arrow-output"] iframe').locator("body"),
+      page
+        .frameLocator('[data-cell-id="sift-arrow-output"] [data-sift-output="true"] iframe')
+        .locator("body"),
     ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
 
     await page.evaluate(() => {
@@ -240,7 +255,7 @@ test.describe("cloud renderer parity harness", () => {
     );
 
     const viewport = page
-      .frameLocator('[data-cell-id="sift-arrow-output"] iframe')
+      .frameLocator('[data-cell-id="sift-arrow-output"] [data-sift-output="true"] iframe')
       .locator(".sift-viewport");
     await viewport.waitFor({ timeout: 30_000 });
     await expect(viewport).toHaveCSS("overscroll-behavior-y", "auto");
@@ -260,4 +275,30 @@ async function openParityHarness(page: Page) {
   await expect(page.getByTestId("cloud-render-parity")).toHaveAttribute("data-ready", "true", {
     timeout: 60_000,
   });
+}
+
+async function findFrameContaining(
+  page: Page,
+  root: Locator,
+  frameSelector: string,
+  innerSelector: string,
+  timeoutMs = 30_000,
+): Promise<Frame> {
+  const deadline = Date.now() + timeoutMs;
+  let frameCount = 0;
+
+  while (Date.now() < deadline) {
+    const frameHandles = await root.locator(frameSelector).elementHandles();
+    frameCount = frameHandles.length;
+    for (const handle of frameHandles) {
+      const frame = await handle.contentFrame();
+      if (!frame) continue;
+      if ((await frame.locator(innerSelector).count()) > 0) {
+        return frame;
+      }
+    }
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(`No iframe containing ${innerSelector} found among ${frameCount} frames`);
 }

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -1,6 +1,7 @@
 import type { BlobResolver } from "runtimed";
 import { collectBlobUrls } from "./blob-refs.ts";
 import { loadSnapshotPair } from "./runtimed-wasm.ts";
+import { snapshotWidgetCommsFromRuntimeState, type SnapshotWidgetComm } from "./widget-comms.ts";
 
 export interface SnapshotRender {
   schema_version: 1;
@@ -13,6 +14,7 @@ export interface SnapshotRender {
   source: "snapshot-pair";
   cells: unknown;
   blob_urls: Record<string, string>;
+  widget_comms: SnapshotWidgetComm[];
 }
 
 export async function materializeSnapshotPairRender(input: {
@@ -27,6 +29,7 @@ export async function materializeSnapshotPairRender(input: {
   const handle = await loadSnapshotPair(input.notebookBytes, input.runtimeStateBytes);
   try {
     const cells = JSON.parse(handle.get_cells_json()) as unknown;
+    const runtimeState = handle.get_runtime_state();
     const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json());
     return {
       schema_version: 1,
@@ -39,6 +42,7 @@ export async function materializeSnapshotPairRender(input: {
       source: "snapshot-pair",
       cells,
       blob_urls: input.blobResolver ? collectBlobUrls(cells, input.blobResolver) : {},
+      widget_comms: snapshotWidgetCommsFromRuntimeState(runtimeState),
     };
   } finally {
     handle.free();

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -1,0 +1,85 @@
+export interface SnapshotWidgetComm {
+  comm_id: string;
+  target_name: string;
+  model_module: string;
+  model_name: string;
+  state: Record<string, unknown>;
+  buffer_paths?: string[][];
+  seq: number;
+}
+
+export function snapshotWidgetCommsFromRuntimeState(runtimeState: unknown): SnapshotWidgetComm[] {
+  const comms = asRecord(asRecord(runtimeState).comms);
+  return normalizeSnapshotWidgetComms(
+    Object.entries(comms).map(([commId, entry]) => ({
+      ...asRecord(entry),
+      comm_id: commId,
+    })),
+  );
+}
+
+export function normalizeSnapshotWidgetComms(value: unknown): SnapshotWidgetComm[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeSnapshotWidgetComm(entry))
+    .filter((entry): entry is SnapshotWidgetComm => entry !== null)
+    .sort((a, b) => a.seq - b.seq);
+}
+
+export function widgetCommStoreState(comm: SnapshotWidgetComm): Record<string, unknown> {
+  return {
+    ...comm.state,
+    _model_module: stringValue(comm.state._model_module) ?? optionalString(comm.model_module),
+    _model_name: stringValue(comm.state._model_name) ?? optionalString(comm.model_name),
+  };
+}
+
+function normalizeSnapshotWidgetComm(value: unknown): SnapshotWidgetComm | null {
+  const entry = asRecord(value);
+  const commId = stringValue(entry.comm_id) ?? stringValue(entry.commId);
+  if (!commId) return null;
+
+  const modelModule = stringValue(entry.model_module) ?? stringValue(entry.modelModule) ?? "";
+  const modelName = stringValue(entry.model_name) ?? stringValue(entry.modelName) ?? "UnknownModel";
+  const state = asRecord(entry.state);
+
+  const bufferPaths = normalizeBufferPaths(entry.buffer_paths ?? entry.bufferPaths);
+
+  return {
+    comm_id: commId,
+    target_name:
+      stringValue(entry.target_name) ?? stringValue(entry.targetName) ?? "jupyter.widget",
+    model_module: modelModule,
+    model_name: modelName,
+    state,
+    ...(bufferPaths ? { buffer_paths: bufferPaths } : {}),
+    seq: numberValue(entry.seq) ?? 0,
+  };
+}
+
+function normalizeBufferPaths(value: unknown): string[][] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const paths = value.filter(
+    (path): path is string[] =>
+      Array.isArray(path) && path.every((part) => typeof part === "string"),
+  );
+  return paths.length > 0 ? paths : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function optionalString(value: string): string | undefined {
+  return value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -3,6 +3,7 @@ import type { ReadOnlyNotebookCellData } from "../../../../src/components/cell/R
 import type { SupportedLanguage } from "../../../../src/components/editor/languages";
 import type { NteractEmbedHostContextPatch } from "../../../../src/components/isolated/host-context";
 import { resolveCell, type RenderCell, type ResolvedCell } from "../../viewer/render-resolution.ts";
+import type { SnapshotWidgetComm } from "../../src/widget-comms.ts";
 
 const ARROW_BLOB_HASH = "sha256:10bda18795f19e46bee92a2bb34606f89f089868c6b121b7f0526761c913b77f";
 
@@ -301,6 +302,26 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
         metadata: {},
       },
     ],
+  },
+];
+
+export const cloudOutputParityWidgetComms: readonly SnapshotWidgetComm[] = [
+  {
+    comm_id: "cloud-sift-progress",
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "IntProgressModel",
+    state: {
+      _model_module: "@jupyter-widgets/controls",
+      _model_name: "IntProgressModel",
+      description: "Resolving data files:",
+      value: 56,
+      min: 0,
+      max: 56,
+      bar_style: "success",
+      orientation: "horizontal",
+    },
+    seq: 1,
   },
 ];
 

--- a/apps/notebook-cloud/test/mime-policy.test.ts
+++ b/apps/notebook-cloud/test/mime-policy.test.ts
@@ -8,14 +8,14 @@ const WIDGET_VIEW_MIME = "application/vnd.jupyter.widget-view+json";
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
 describe("cloud viewer MIME policy", () => {
-  it("prefers text fallbacks over unhydrated widget views", () => {
+  it("keeps widget views aligned with the shared notebook priority", () => {
     const data = {
       [WIDGET_VIEW_MIME]: { version_major: 2, version_minor: 0, model_id: "progress" },
       "text/plain": "Resolving data files: 100%",
     };
 
     assert.equal(selectMimeType(data, DEFAULT_PRIORITY), WIDGET_VIEW_MIME);
-    assert.equal(selectMimeType(data, CLOUD_VIEWER_PRIORITY), "text/plain");
+    assert.equal(selectMimeType(data, CLOUD_VIEWER_PRIORITY), WIDGET_VIEW_MIME);
 
     const payload = jupyterOutputToRenderPayload(
       {
@@ -28,8 +28,12 @@ describe("cloud viewer MIME policy", () => {
       { priority: CLOUD_VIEWER_PRIORITY },
     );
 
-    assert.equal(payload?.mimeType, "text/plain");
-    assert.equal(payload?.data, "Resolving data files: 100%");
+    assert.equal(payload?.mimeType, WIDGET_VIEW_MIME);
+    assert.deepEqual(payload?.data, {
+      version_major: 2,
+      version_minor: 0,
+      model_id: "progress",
+    });
   });
 
   it("keeps Arrow stream manifests ahead of table text and HTML fallbacks", () => {

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -1,16 +1,23 @@
-import { StrictMode, useEffect, useMemo, useState } from "react";
+import { StrictMode, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { OutputArea } from "../../../../../src/components/cell/OutputArea";
 import { ReadOnlyNotebook } from "../../../../../src/components/cell/ReadOnlyNotebook";
 import { IsolatedRendererProvider } from "../../../../../src/components/isolated/isolated-renderer-context";
 import { MediaProvider } from "../../../../../src/components/outputs/media-provider";
 import { ThemeToggle } from "../../../../../src/components/ui/theme-toggle";
+import { useWidgetStoreRequired } from "../../../../../src/components/widgets/widget-store-context";
 import { useTheme } from "../../../../../src/hooks/useTheme";
 import { CLOUD_VIEWER_PRIORITY } from "../../../viewer/mime-policy";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "../../../viewer/theme";
 import {
+  CLOUD_WIDGET_RENDERERS,
+  CloudWidgetStoreProvider,
+  projectCloudWidgetComms,
+} from "../../../viewer/widget-runtime";
+import {
   cloudOutputParityExpectedMarkers,
   cloudOutputParityHostContext,
+  cloudOutputParityWidgetComms,
   resolveCloudOutputParityCells,
 } from "../../fixtures/cloud-output-parity";
 import "../../../viewer/index.css";
@@ -20,6 +27,8 @@ const rendererBundle = () => import("virtual:isolated-renderer");
 
 function CloudRendererParityHarness() {
   const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { store: widgetStore } = useWidgetStoreRequired();
+  const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const [cells, setCells] = useState<Awaited<ReturnType<typeof resolveCloudOutputParityCells>>>([]);
   const [boundaryCollapsed, setBoundaryCollapsed] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,6 +41,10 @@ function CloudRendererParityHarness() {
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
+
+  useEffect(() => {
+    projectCloudWidgetComms(widgetStore, cloudOutputParityWidgetComms, projectedWidgetCommIdsRef);
+  }, [widgetStore]);
 
   useEffect(() => {
     let cancelled = false;
@@ -76,7 +89,7 @@ function CloudRendererParityHarness() {
         {Object.values(cloudOutputParityExpectedMarkers).join("\n")}
       </div>
       <IsolatedRendererProvider loader={rendererBundle}>
-        <MediaProvider priority={CLOUD_VIEWER_PRIORITY}>
+        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
           <ReadOnlyNotebook
             cells={cells}
             priority={CLOUD_VIEWER_PRIORITY}
@@ -122,6 +135,8 @@ if (!root) {
 
 createRoot(root).render(
   <StrictMode>
-    <CloudRendererParityHarness />
+    <CloudWidgetStoreProvider>
+      <CloudRendererParityHarness />
+    </CloudWidgetStoreProvider>
   </StrictMode>,
 );

--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -4,7 +4,7 @@ import type { BlobResolver } from "runtimed";
 import { resolveCell, resolveOutputs } from "../viewer/render-resolution.ts";
 
 describe("cloud viewer render resolution", () => {
-  it("turns static widget views into text fallbacks", async () => {
+  it("preserves widget views so RuntimeStateDoc models can hydrate them", async () => {
     const outputs = await resolveOutputs(
       [
         {
@@ -25,13 +25,14 @@ describe("cloud viewer render resolution", () => {
     assert.equal(outputs.length, 1);
     assert.equal(outputs[0].output_type, "display_data");
     if (outputs[0].output_type === "display_data") {
-      assert.equal(outputs[0].data["application/vnd.jupyter.widget-view+json"], undefined);
-      assert.equal(outputs[0].data["text/plain"], "IntSlider slider: 7 (0-10)");
+      assert.deepEqual(outputs[0].data["application/vnd.jupyter.widget-view+json"], {
+        model_id: "slider-1",
+      });
       assert.equal(outputs[0].data["text/llm+plain"], "IntSlider slider: 7 (0-10)");
     }
   });
 
-  it("does not leave widget-only outputs on a loading state", async () => {
+  it("keeps widget-only outputs instead of inventing static fallbacks", async () => {
     const outputs = await resolveOutputs(
       [
         {
@@ -51,8 +52,10 @@ describe("cloud viewer render resolution", () => {
     assert.equal(outputs.length, 1);
     assert.equal(outputs[0].output_type, "display_data");
     if (outputs[0].output_type === "display_data") {
-      assert.equal(outputs[0].data["application/vnd.jupyter.widget-view+json"], undefined);
-      assert.equal(outputs[0].data["text/plain"], "Widget state unavailable");
+      assert.deepEqual(outputs[0].data["application/vnd.jupyter.widget-view+json"], {
+        model_id: "slider-1",
+      });
+      assert.equal(outputs[0].data["text/plain"], undefined);
     }
   });
 

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -1,7 +1,7 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
+import { initializeRuntimedWasm, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import { materializeSnapshotPairRender } from "../src/snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -146,6 +146,60 @@ describe("snapshot pair render materialization", () => {
       render.blob_urls[blobHash],
       `https://cloud.test/api/n/fixture-sift-arrow/blobs/${encodeURIComponent(blobHash)}`,
     );
+  });
+
+  it("materializes RuntimeStateDoc widget comms for hosted widget views", async () => {
+    const notebookBytes = await readFile(
+      new URL(
+        "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+        import.meta.url,
+      ),
+    );
+    const peer = new RuntimeStatePeerHandle("runtime");
+    peer.put_comm_json(
+      "progress-widget",
+      "jupyter.widget",
+      "@jupyter-widgets/controls",
+      "IntProgressModel",
+      JSON.stringify({
+        description: "Resolving data files:",
+        value: 56,
+        min: 0,
+        max: 56,
+        bar_style: "success",
+        orientation: "horizontal",
+      }),
+      4,
+    );
+    const runtimeStateBytes = peer.save();
+    peer.free();
+
+    const render = await materializeSnapshotPairRender({
+      notebookId: "fixture-widget-progress",
+      notebookHeadsHash: "heads-fixture",
+      runtimeHeadsHash: "runtime-fixture",
+      notebookBytes,
+      runtimeStateBytes,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+    });
+
+    assert.deepEqual(render.widget_comms, [
+      {
+        comm_id: "progress-widget",
+        target_name: "jupyter.widget",
+        model_module: "@jupyter-widgets/controls",
+        model_name: "IntProgressModel",
+        state: {
+          description: "Resolving data files:",
+          value: 56,
+          min: 0,
+          max: 56,
+          bar_style: "success",
+          orientation: "horizontal",
+        },
+        seq: 4,
+      },
+    ]);
   });
 });
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -11,10 +11,15 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
+import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { isTextAttributionEvent } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
+import {
+  normalizeSnapshotWidgetComms,
+  snapshotWidgetCommsFromRuntimeState,
+} from "../src/widget-comms";
 import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable-markdown-cell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import {
@@ -51,6 +56,11 @@ import {
   CLOUD_VIEWER_THEME_STORAGE_KEY,
   installDocumentThemeSync,
 } from "./theme";
+import {
+  CLOUD_WIDGET_RENDERERS,
+  CloudWidgetStoreProvider,
+  projectCloudWidgetComms,
+} from "./widget-runtime";
 import "./index.css";
 
 interface CloudViewerConfig {
@@ -70,6 +80,7 @@ interface SnapshotRender {
   metadata?: unknown;
   source?: string;
   cells?: unknown;
+  widget_comms?: unknown;
 }
 
 type ViewerStatus =
@@ -160,6 +171,7 @@ function App() {
 function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   const { config, blobResolver } = runtime;
   const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { store: widgetStore } = useWidgetStoreRequired();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: "Loading notebook snapshot...",
@@ -171,6 +183,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
   const liveMaterializedRef = useRef(false);
   const snapshotResolvedRef = useRef(false);
+  const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const [presence, setPresence] = useState(initialCloudViewerPresence);
   const [livePresence, setLivePresence] = useState(emptyCloudLivePresenceSnapshot);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
@@ -228,6 +241,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
 
         const render = (await response.json()) as SnapshotRender;
         const rawCells = Array.isArray(render.cells) ? (render.cells as RenderCell[]) : [];
+        const widgetComms = normalizeSnapshotWidgetComms(render.widget_comms);
         const notebookLanguage = languageFromNotebookMetadata(render.metadata) ?? "python";
         notebookLanguageRef.current = notebookLanguage;
         const resolvedCells = await Promise.all(
@@ -236,6 +250,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         if (cancelled || liveMaterializedRef.current) return;
 
         snapshotResolvedRef.current = true;
+        projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
         preloadSiftWasmForCells(resolvedCells, {
           blobBasePath: config.blobBasePath,
           rendererAssetsBasePath: config.rendererAssetsBasePath,
@@ -263,7 +278,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
     return () => {
       cancelled = true;
     };
-  }, [blobResolver, config.renderEndpoint]);
+  }, [blobResolver, config.renderEndpoint, widgetStore]);
 
   useEffect(() => {
     let disposed = false;
@@ -303,6 +318,9 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
           return;
         }
       }
+      const widgetComms = snapshotWidgetCommsFromRuntimeState(
+        liveRuntime.handle.get_runtime_state(),
+      );
       const metadata = parseJsonOrNull(liveRuntime.handle.get_metadata_snapshot_json?.());
       const notebookLanguage =
         languageFromNotebookMetadata(metadata) ?? notebookLanguageRef.current ?? "python";
@@ -313,6 +331,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       if (disposed || sequence !== materializeSequence) return;
 
       liveMaterializedRef.current = true;
+      projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
       setCells(resolvedCells);
       setStatus(
         resolvedCells.length === 0
@@ -413,7 +432,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
       setLivePresence(emptyCloudLivePresenceSnapshot());
     };
-  }, [authState, blobResolver, config.syncEndpoint, connectAttempt]);
+  }, [authState, blobResolver, config.syncEndpoint, connectAttempt, widgetStore]);
 
   const readOnlyCells = useMemo(
     () =>
@@ -936,9 +955,11 @@ createRoot(requireElement("#root")).render(
     fallback={(error) => <ViewerStartupError message={`Cloud viewer crashed: ${error.message}`} />}
   >
     <IsolatedRendererProvider loader={rendererBundle}>
-      <MediaProvider priority={CLOUD_VIEWER_PRIORITY}>
-        <App />
-      </MediaProvider>
+      <CloudWidgetStoreProvider>
+        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
+          <App />
+        </MediaProvider>
+      </CloudWidgetStoreProvider>
     </IsolatedRendererProvider>
   </ErrorBoundary>,
 );

--- a/apps/notebook-cloud/viewer/mime-policy.ts
+++ b/apps/notebook-cloud/viewer/mime-policy.ts
@@ -1,12 +1,8 @@
 import { DEFAULT_PRIORITY } from "@/components/outputs/mime-priority";
 
-const WIDGET_VIEW_MIME = "application/vnd.jupyter.widget-view+json";
-
 /**
- * The published cloud viewer does not hydrate RuntimeStateDoc widget models
- * yet. Prefer a widget output's text/plain fallback when it exists, while
- * keeping every other shared nteract MIME priority unchanged.
+ * Keep cloud output selection aligned with the shared notebook renderer.
+ * Cloud hydrates RuntimeStateDoc widget models before rendering, so widget
+ * views should win over stale text fallbacks just like desktop.
  */
-export const CLOUD_VIEWER_PRIORITY = DEFAULT_PRIORITY.filter(
-  (mimeType) => mimeType !== WIDGET_VIEW_MIME,
-);
+export const CLOUD_VIEWER_PRIORITY = DEFAULT_PRIORITY;

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -4,7 +4,6 @@ import {
   resolveManifest,
   type OutputManifest,
 } from "@/components/isolated/output-manifest";
-import { WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import type { BlobResolver } from "runtimed";
 
 export interface RenderCell {
@@ -90,7 +89,7 @@ async function resolveOutput(
       output as OutputManifest,
       blobResolver,
     )) as JupyterOutput;
-    return normalizeStaticWidgetOutput(resolved);
+    return resolved;
   }
 
   if (isManifestWithMissingOutputId(output)) {
@@ -98,25 +97,10 @@ async function resolveOutput(
   }
 
   if (isJupyterOutput(output)) {
-    return normalizeStaticWidgetOutput(identifyJupyterOutput(output, syntheticOutputId));
+    return identifyJupyterOutput(output, syntheticOutputId);
   }
 
   return null;
-}
-
-function normalizeStaticWidgetOutput(output: JupyterOutput): JupyterOutput {
-  if (output.output_type !== "display_data" && output.output_type !== "execute_result") {
-    return output;
-  }
-  if (!(WIDGET_VIEW_MIME in output.data)) return output;
-
-  const fallback = output.data["text/plain"] ?? output.data["text/llm+plain"];
-
-  const data = { ...output.data };
-  delete data[WIDGET_VIEW_MIME];
-  if (!("text/plain" in data)) data["text/plain"] = String(fallback ?? "Widget state unavailable");
-
-  return { ...output, data };
 }
 
 function identifyJupyterOutput(output: JupyterOutput, outputId: string): JupyterOutput {

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -1,0 +1,71 @@
+import { type ReactNode, useEffect, useMemo, useRef } from "react";
+import { createCanvasManagerRouter } from "@/components/widgets/canvas-manager-subscriptions";
+import { createLinkManager } from "@/components/widgets/link-subscriptions";
+import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
+import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
+import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
+import { WidgetView } from "@/components/widgets/widget-view";
+import { widgetCommStoreState, type SnapshotWidgetComm } from "../src/widget-comms";
+import "@/components/widgets/controls";
+
+export const CLOUD_WIDGET_RENDERERS = {
+  [WIDGET_VIEW_MIME]: CloudWidgetViewRenderer,
+};
+
+export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) {
+  const storeRef = useRef<WidgetStore | null>(null);
+  if (!storeRef.current) {
+    storeRef.current = createWidgetStore();
+  }
+  const store = storeRef.current;
+
+  useEffect(() => createLinkManager(store), [store]);
+  useEffect(() => createCanvasManagerRouter(store), [store]);
+
+  const value = useMemo(
+    () => ({
+      store,
+      sendUpdate: async (commId: string, state: Record<string, unknown>) => {
+        store.updateModel(commId, state);
+      },
+      sendCustom: () => {},
+      closeComm: (commId: string) => {
+        store.deleteModel(commId);
+      },
+    }),
+    [store],
+  );
+
+  return <WidgetStoreContext.Provider value={value}>{children}</WidgetStoreContext.Provider>;
+}
+
+export function projectCloudWidgetComms(
+  store: WidgetStore,
+  comms: readonly SnapshotWidgetComm[],
+  projectedCommIdsRef: { current: Set<string> },
+): void {
+  const nextCommIds = new Set<string>();
+
+  for (const comm of comms) {
+    const commId = comm.comm_id;
+    nextCommIds.add(commId);
+    const state = widgetCommStoreState(comm);
+    if (store.getModel(commId)) {
+      store.updateModel(commId, state, comm.buffer_paths);
+    } else {
+      store.createModel(commId, state, comm.buffer_paths);
+    }
+  }
+
+  for (const commId of projectedCommIdsRef.current) {
+    if (!nextCommIds.has(commId)) {
+      store.deleteModel(commId);
+    }
+  }
+  projectedCommIdsRef.current = nextCommIds;
+}
+
+function CloudWidgetViewRenderer({ data }: { data: unknown }) {
+  const modelId = parseWidgetViewModelId(data);
+  return modelId ? <WidgetView modelId={modelId} /> : null;
+}


### PR DESCRIPTION
## Summary
- materialize RuntimeStateDoc widget comms into notebook-cloud render JSON
- hydrate the cloud viewer widget store and restore shared widget MIME priority
- extend renderer parity coverage to require real IntProgress rendering while keeping Sift isolated

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/render-resolution.test.ts test/mime-policy.test.ts test/snapshot-render.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud test:renderer-parity
- cargo xtask lint --fix
- pnpm --dir apps/notebook-cloud test
- pnpm --dir apps/notebook-cloud build