### PR TITLE
fix(notebook-cloud): prevent output document edge transforms

### DIFF
--- a/apps/notebook-cloud/src/output-document-worker.ts
+++ b/apps/notebook-cloud/src/output-document-worker.ts
@@ -101,7 +101,7 @@ function withOutputDocumentHeaders(response: Response): Response {
   response.headers.delete("Set-Cookie");
   response.headers.delete("Access-Control-Allow-Credentials");
   if (response.ok && response.headers.get("Content-Type")?.includes("text/html")) {
-    response.headers.set("Cache-Control", "public, max-age=300, must-revalidate");
+    response.headers.set("Cache-Control", "public, max-age=300, must-revalidate, no-transform");
   } else if (!response.headers.has("Cache-Control")) {
     response.headers.set("Cache-Control", "no-store");
   }

--- a/apps/notebook-cloud/test/output-document-worker.test.ts
+++ b/apps/notebook-cloud/test/output-document-worker.test.ts
@@ -32,6 +32,7 @@ describe("output document Worker", () => {
     assert.match(response.headers.get("Content-Security-Policy") ?? "", /script-src/);
     assert.match(response.headers.get("Content-Security-Policy") ?? "", /frame-src 'none'/);
     assert.match(response.headers.get("Permissions-Policy") ?? "", /camera=\(\)/);
+    assert.match(response.headers.get("Cache-Control") ?? "", /\bno-transform\b/);
     assert.equal(response.headers.get("Set-Cookie"), null);
     assert.equal(response.headers.get("Access-Control-Allow-Credentials"), null);
     assert.match(await response.text(), /<!doctype html>/i);


### PR DESCRIPTION
## Summary

- add `no-transform` to cacheable output-document HTML responses
- assert the header in the output-document Worker test

## Why

After deploying #3047 to `preview.runt.run`, the hosted `topic-viz` notebook rendered, but the output-document iframe emitted repeated Cloudflare Web Analytics CORS errors from `/cdn-cgi/rum`. The iframe is intentionally sandboxed without `allow-same-origin`, so its origin is opaque (`null`). Cloudflare's auto-injected RUM beacon then attempts to POST to the output-document origin and fails CORS.

Cloudflare Web Analytics docs state that `Cache-Control: public, no-transform` prevents Cloudflare from modifying the original HTML payload during automatic setup. This keeps the dedicated output document shell free of edge-injected scripts while preserving the existing cacheability and sandbox posture.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/output-document-worker.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`

## Deploy note

Deploy only `apps/notebook-cloud/wrangler.output-document.toml` after merge, then rerun hosted smoke against `https://preview.runt.run/n/topic-viz`.
