### PR TITLE
docs(architecture): update publish render boundaries

### DIFF
--- a/apps/notebook-cloud/src/blob-refs.ts
+++ b/apps/notebook-cloud/src/blob-refs.ts
@@ -29,6 +29,7 @@ function visitBlobRefs(value: unknown, refs: Record<string, BlobRef>): void {
   if (typeof record.blob === "string") {
     addBlobRef(record, refs);
   }
+  addNotebookCellBlobRefs(record, refs);
 
   const arrowManifestRef = record[ARROW_STREAM_MANIFEST_MIME];
   if (isInlineContentRef(arrowManifestRef)) {
@@ -40,12 +41,45 @@ function visitBlobRefs(value: unknown, refs: Record<string, BlobRef>): void {
   }
 }
 
+function addNotebookCellBlobRefs(
+  record: Record<string, unknown>,
+  refs: Record<string, BlobRef>,
+): void {
+  const resolvedAssets = record.resolved_assets;
+  if (isRecord(resolvedAssets)) {
+    for (const hash of Object.values(resolvedAssets)) {
+      if (typeof hash === "string") {
+        mergeBlobRef(refs, { blob: hash });
+      }
+    }
+  }
+
+  const attachments = record.attachments;
+  if (!isRecord(attachments)) return;
+  for (const bundle of Object.values(attachments)) {
+    if (!isRecord(bundle)) continue;
+    for (const [mediaType, ref] of Object.entries(bundle)) {
+      if (!isRecord(ref) || typeof ref.blob_hash !== "string") continue;
+      mergeBlobRef(refs, { blob: ref.blob_hash, media_type: mediaType });
+    }
+  }
+}
+
 function addBlobRef(record: Record<string, unknown>, refs: Record<string, BlobRef>): void {
   if (typeof record.blob !== "string") return;
-  refs[record.blob] = {
+  mergeBlobRef(refs, {
     blob: record.blob,
     size: typeof record.size === "number" ? record.size : undefined,
     media_type: typeof record.media_type === "string" ? record.media_type : undefined,
+  });
+}
+
+function mergeBlobRef(refs: Record<string, BlobRef>, ref: BlobRef): void {
+  const existing = refs[ref.blob];
+  refs[ref.blob] = {
+    blob: ref.blob,
+    size: existing?.size ?? ref.size,
+    media_type: existing?.media_type ?? ref.media_type,
   };
 }
 
@@ -65,17 +99,42 @@ function visitArrowStreamManifest(content: string, refs: Record<string, BlobRef>
     return;
   }
   if (typeof manifest !== "object" || manifest === null) return;
-  const chunks = (manifest as Record<string, unknown>).chunks;
-  if (!Array.isArray(chunks)) return;
+  const record = manifest as Record<string, unknown>;
+  const chunks = record.chunks;
 
-  for (const chunk of chunks) {
-    if (typeof chunk !== "object" || chunk === null) continue;
-    const record = chunk as Record<string, unknown>;
-    if (typeof record.hash !== "string") continue;
-    refs[record.hash] = {
-      blob: record.hash,
-      size: typeof record.size === "number" ? record.size : undefined,
-      media_type: typeof record.media_type === "string" ? record.media_type : undefined,
-    };
+  if (Array.isArray(chunks)) {
+    for (const chunk of chunks) {
+      addManifestBlobRef(chunk, refs);
+    }
   }
+
+  const blobs = record.blobs;
+  if (Array.isArray(blobs)) {
+    for (const blob of blobs) {
+      addManifestBlobRef(blob, refs);
+    }
+  }
+
+  addManifestBlobRef(record.coalesced, refs);
+  const segments = isRecord(record.coalesced) ? record.coalesced.segments : undefined;
+  if (Array.isArray(segments)) {
+    for (const segment of segments) {
+      addManifestBlobRef(segment, refs);
+    }
+  }
+}
+
+function addManifestBlobRef(value: unknown, refs: Record<string, BlobRef>): void {
+  if (!isRecord(value)) return;
+  const hash = typeof value.blob === "string" ? value.blob : value.hash;
+  if (typeof hash !== "string") return;
+  mergeBlobRef(refs, {
+    blob: hash,
+    size: typeof value.size === "number" ? value.size : undefined,
+    media_type: typeof value.media_type === "string" ? value.media_type : undefined,
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,4 +1,5 @@
 import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
+import type { BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
   ACCESS_AUTH_TOKEN_PROTOCOL_PREFIX,
@@ -1238,7 +1239,7 @@ async function findMissingRenderBlobs(
   notebookId: string,
   render: unknown,
 ): Promise<MissingRenderBlob[]> {
-  const refs = Object.values(collectBlobRefs(render));
+  const refs = collectRenderBlobRefs(render);
   const missing: Array<MissingRenderBlob | null> = [];
 
   for (let index = 0; index < refs.length; index += RENDER_BLOB_HEAD_CONCURRENCY) {
@@ -1262,6 +1263,21 @@ async function findMissingRenderBlobs(
   return missing
     .filter((entry): entry is MissingRenderBlob => entry !== null)
     .sort((left, right) => left.hash.localeCompare(right.hash));
+}
+
+function collectRenderBlobRefs(render: unknown): BlobRef[] {
+  const refs = collectBlobRefs(render);
+  const blobUrls = isRecord(render) ? render.blob_urls : undefined;
+  if (isRecord(blobUrls)) {
+    for (const hash of Object.keys(blobUrls)) {
+      refs[hash] ??= { blob: hash };
+    }
+  }
+  return Object.values(refs);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 async function routeBlob(

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1182,7 +1182,7 @@ async function materializeSnapshotRenderCache(options: {
     };
   }
 
-  const missingBlobs = await findMissingRenderBlobs(bucket, options.notebookId, render.cells);
+  const missingBlobs = await findMissingRenderBlobs(bucket, options.notebookId, render);
   if (missingBlobs.length > 0) {
     cloudLog("warn", "render.materialization.missing_blobs", {
       notebook_id: options.notebookId,
@@ -1236,9 +1236,9 @@ async function materializeSnapshotRenderCache(options: {
 async function findMissingRenderBlobs(
   bucket: NonNullable<Env["NOTEBOOK_SNAPSHOTS"]>,
   notebookId: string,
-  cells: unknown,
+  render: unknown,
 ): Promise<MissingRenderBlob[]> {
-  const refs = Object.values(collectBlobRefs(cells));
+  const refs = Object.values(collectBlobRefs(render));
   const missing: Array<MissingRenderBlob | null> = [];
 
   for (let index = 0; index < refs.length; index += RENDER_BLOB_HEAD_CONCURRENCY) {

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -1,7 +1,11 @@
 import type { BlobResolver } from "runtimed";
 import { collectBlobUrls } from "./blob-refs.ts";
 import { loadSnapshotPair } from "./runtimed-wasm.ts";
-import { snapshotWidgetCommsFromRuntimeState, type SnapshotWidgetComm } from "./widget-comms.ts";
+import {
+  resolveSnapshotWidgetComms,
+  snapshotWidgetCommsFromRuntimeState,
+  type SnapshotWidgetComm,
+} from "./widget-comms.ts";
 
 export interface SnapshotRender {
   schema_version: 1;
@@ -31,6 +35,10 @@ export async function materializeSnapshotPairRender(input: {
     const cells = JSON.parse(handle.get_cells_json()) as unknown;
     const runtimeState = handle.get_runtime_state();
     const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json());
+    const rawWidgetComms = snapshotWidgetCommsFromRuntimeState(runtimeState);
+    const widgetComms = input.blobResolver
+      ? resolveSnapshotWidgetComms(rawWidgetComms, input.blobResolver)
+      : rawWidgetComms;
     return {
       schema_version: 1,
       generated_from: "runtimed-wasm:load_snapshot",
@@ -41,8 +49,10 @@ export async function materializeSnapshotPairRender(input: {
       metadata,
       source: "snapshot-pair",
       cells,
-      blob_urls: input.blobResolver ? collectBlobUrls(cells, input.blobResolver) : {},
-      widget_comms: snapshotWidgetCommsFromRuntimeState(runtimeState),
+      blob_urls: input.blobResolver
+        ? collectBlobUrls({ cells, widget_comms: rawWidgetComms }, input.blobResolver)
+        : {},
+      widget_comms: widgetComms,
     };
   } finally {
     handle.free();

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -1,3 +1,5 @@
+import type { BlobRef, BlobResolver } from "runtimed";
+
 export interface SnapshotWidgetComm {
   comm_id: string;
   target_name: string;
@@ -5,17 +7,39 @@ export interface SnapshotWidgetComm {
   model_name: string;
   state: Record<string, unknown>;
   buffer_paths?: string[][];
+  text_paths?: string[][];
   seq: number;
 }
 
-export function snapshotWidgetCommsFromRuntimeState(runtimeState: unknown): SnapshotWidgetComm[] {
+export function snapshotWidgetCommsFromRuntimeState(
+  runtimeState: unknown,
+  blobResolver?: BlobResolver,
+): SnapshotWidgetComm[] {
   const comms = asRecord(asRecord(runtimeState).comms);
-  return normalizeSnapshotWidgetComms(
+  const normalized = normalizeSnapshotWidgetComms(
     Object.entries(comms).map(([commId, entry]) => ({
       ...asRecord(entry),
       comm_id: commId,
     })),
   );
+  return blobResolver ? resolveSnapshotWidgetComms(normalized, blobResolver) : normalized;
+}
+
+export function resolveSnapshotWidgetComms(
+  comms: readonly SnapshotWidgetComm[],
+  blobResolver: BlobResolver,
+): SnapshotWidgetComm[] {
+  return comms.map((comm) => {
+    const bufferPaths: string[][] = [];
+    const textPaths: string[][] = [];
+    const state = resolveCommStateValue(comm.state, blobResolver, [], bufferPaths, textPaths);
+    return {
+      ...comm,
+      state: asRecord(state),
+      ...(bufferPaths.length > 0 ? { buffer_paths: bufferPaths } : {}),
+      ...(textPaths.length > 0 ? { text_paths: textPaths } : {}),
+    };
+  });
 }
 
 export function normalizeSnapshotWidgetComms(value: unknown): SnapshotWidgetComm[] {
@@ -44,6 +68,7 @@ function normalizeSnapshotWidgetComm(value: unknown): SnapshotWidgetComm | null 
   const state = asRecord(entry.state);
 
   const bufferPaths = normalizeBufferPaths(entry.buffer_paths ?? entry.bufferPaths);
+  const textPaths = normalizeBufferPaths(entry.text_paths ?? entry.textPaths);
 
   return {
     comm_id: commId,
@@ -53,8 +78,86 @@ function normalizeSnapshotWidgetComm(value: unknown): SnapshotWidgetComm | null 
     model_name: modelName,
     state,
     ...(bufferPaths ? { buffer_paths: bufferPaths } : {}),
+    ...(textPaths ? { text_paths: textPaths } : {}),
     seq: numberValue(entry.seq) ?? 0,
   };
+}
+
+function resolveCommStateValue(
+  value: unknown,
+  blobResolver: BlobResolver,
+  path: string[],
+  bufferPaths: string[][],
+  textPaths: string[][],
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) =>
+      resolveCommStateValue(item, blobResolver, [...path, String(index)], bufferPaths, textPaths),
+    );
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if ("inline" in record) {
+    return record.inline;
+  }
+
+  const blobRef = blobRefFromRecord(record);
+  if (blobRef) {
+    const lastKey = path[path.length - 1];
+    const url = blobResolver.url(blobRef);
+    if (lastKey !== "_esm" && lastKey !== "_css") {
+      if (isTextMediaType(blobRef.media_type)) {
+        textPaths.push(path);
+      } else {
+        bufferPaths.push(path);
+      }
+    }
+    return url;
+  }
+
+  const resolved: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    resolved[key] = resolveCommStateValue(
+      child,
+      blobResolver,
+      [...path, key],
+      bufferPaths,
+      textPaths,
+    );
+  }
+  return resolved;
+}
+
+function blobRefFromRecord(value: Record<string, unknown>): BlobRef | null {
+  if (typeof value.blob !== "string") return null;
+  return {
+    blob: value.blob,
+    size: typeof value.size === "number" ? value.size : undefined,
+    media_type: typeof value.media_type === "string" ? value.media_type : undefined,
+  };
+}
+
+function isTextMediaType(mediaType: unknown): boolean {
+  return typeof mediaType === "string" && !isBinaryMimeType(mediaType);
+}
+
+function isBinaryMimeType(mediaType: string): boolean {
+  const normalized = mediaType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return (
+    normalized === "application/octet-stream" ||
+    normalized.startsWith("image/") ||
+    normalized.startsWith("audio/") ||
+    normalized.startsWith("video/") ||
+    normalized === "application/pdf" ||
+    normalized === "application/zip" ||
+    normalized === "application/gzip" ||
+    normalized === "application/x-gzip" ||
+    normalized === "application/vnd.apache.arrow.file" ||
+    normalized === "application/vnd.apache.arrow.stream"
+  );
 }
 
 function normalizeBufferPaths(value: unknown): string[][] | undefined {

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -33,11 +33,13 @@ export function resolveSnapshotWidgetComms(
     const bufferPaths: string[][] = [];
     const textPaths: string[][] = [];
     const state = resolveCommStateValue(comm.state, blobResolver, [], bufferPaths, textPaths);
+    const mergedBufferPaths = [...(comm.buffer_paths ?? []), ...bufferPaths];
+    const mergedTextPaths = [...(comm.text_paths ?? []), ...textPaths];
     return {
       ...comm,
       state: asRecord(state),
-      ...(bufferPaths.length > 0 ? { buffer_paths: bufferPaths } : {}),
-      ...(textPaths.length > 0 ? { text_paths: textPaths } : {}),
+      ...(mergedBufferPaths.length > 0 ? { buffer_paths: mergedBufferPaths } : {}),
+      ...(mergedTextPaths.length > 0 ? { text_paths: mergedTextPaths } : {}),
     };
   });
 }

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -103,9 +103,9 @@ function resolveCommStateValue(
 
   const record = value as Record<string, unknown>;
   // Runtime ContentRef inline wrappers are exclusive: `{ inline: value }`.
-  // Treating this key as structural keeps cloud projection aligned with the
-  // WASM comm-state resolver used by desktop.
-  if ("inline" in record) {
+  // Require the exact wrapper shape so ordinary widget state objects that use
+  // an `inline` property are preserved.
+  if (isInlineContentRef(record)) {
     return record.inline;
   }
 
@@ -136,13 +136,31 @@ function resolveCommStateValue(
   return resolved;
 }
 
+function isInlineContentRef(value: Record<string, unknown>): boolean {
+  return hasOwn(value, "inline") && Object.keys(value).length === 1;
+}
+
 function blobRefFromRecord(value: Record<string, unknown>): BlobRef | null {
-  if (typeof value.blob !== "string") return null;
+  if (!isBlobContentRef(value)) return null;
   return {
     blob: value.blob,
-    size: typeof value.size === "number" ? value.size : undefined,
+    size: value.size,
     media_type: typeof value.media_type === "string" ? value.media_type : undefined,
   };
+}
+
+function isBlobContentRef(
+  value: Record<string, unknown>,
+): value is { blob: string; size: number; media_type?: unknown } {
+  if (!hasOwn(value, "blob") || !hasOwn(value, "size")) return false;
+  if (typeof value.blob !== "string" || typeof value.size !== "number") return false;
+  return Object.keys(value).every(
+    (key) => key === "blob" || key === "size" || key === "media_type",
+  );
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function isTextMediaType(mediaType: unknown): boolean {

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -141,6 +141,8 @@ function blobRefFromRecord(value: Record<string, unknown>): BlobRef | null {
 }
 
 function isTextMediaType(mediaType: unknown): boolean {
+  // Match runtimed-wasm's resolver: missing or unknown media_type stays on the
+  // binary path so legacy refs remain URL/DataView-compatible.
   return typeof mediaType === "string" && !isBinaryMimeType(mediaType);
 }
 

--- a/apps/notebook-cloud/src/widget-comms.ts
+++ b/apps/notebook-cloud/src/widget-comms.ts
@@ -102,6 +102,9 @@ function resolveCommStateValue(
   }
 
   const record = value as Record<string, unknown>;
+  // Runtime ContentRef inline wrappers are exclusive: `{ inline: value }`.
+  // Treating this key as structural keeps cloud projection aligned with the
+  // WASM comm-state resolver used by desktop.
   if ("inline" in record) {
     return record.inline;
   }

--- a/apps/notebook-cloud/test/blob-refs.test.ts
+++ b/apps/notebook-cloud/test/blob-refs.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { collectBlobRefs } from "../src/blob-refs.ts";
+
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+describe("cloud blob ref collection", () => {
+  it("collects NotebookDoc asset and attachment ref shapes", () => {
+    const refs = collectBlobRefs({
+      cells: [
+        {
+          resolved_assets: {
+            "attachment:plot.png": "resolved-asset-hash",
+          },
+          attachments: {
+            "plot.png": {
+              "image/png": {
+                blob_hash: "attachment-hash",
+                encoding: "base64",
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    assert.equal(refs["resolved-asset-hash"]?.blob, "resolved-asset-hash");
+    assert.equal(refs["attachment-hash"]?.blob, "attachment-hash");
+    assert.equal(refs["attachment-hash"]?.media_type, "image/png");
+  });
+
+  it("collects known Arrow manifest child ref shapes without schema fingerprints", () => {
+    const refs = collectBlobRefs({
+      data: {
+        [ARROW_STREAM_MANIFEST_MIME]: {
+          inline: JSON.stringify({
+            chunks: [
+              { hash: "chunk-hash", size: 10 },
+              { blob: "chunk-blob", media_type: "application/vnd.apache.arrow.stream" },
+            ],
+            blobs: [{ hash: "sidecar-hash" }],
+            coalesced: {
+              hash: "coalesced-hash",
+              segments: [{ hash: "segment-hash" }],
+            },
+            schema: { hash: "schema-fingerprint" },
+          }),
+        },
+      },
+    });
+
+    assert.equal(refs["chunk-hash"]?.size, 10);
+    assert.equal(refs["chunk-blob"]?.media_type, "application/vnd.apache.arrow.stream");
+    assert.ok(refs["sidecar-hash"]);
+    assert.ok(refs["coalesced-hash"]);
+    assert.ok(refs["segment-hash"]);
+    assert.equal(refs["schema-fingerprint"], undefined);
+  });
+});

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -43,7 +43,13 @@ function CloudRendererParityHarness() {
   }, [resolvedTheme]);
 
   useEffect(() => {
-    projectCloudWidgetComms(widgetStore, cloudOutputParityWidgetComms, projectedWidgetCommIdsRef);
+    void projectCloudWidgetComms(
+      widgetStore,
+      cloudOutputParityWidgetComms,
+      projectedWidgetCommIdsRef,
+    ).catch((err: unknown) => {
+      setError(err instanceof Error ? err.message : String(err));
+    });
   }, [widgetStore]);
 
   useEffect(() => {

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -223,6 +223,16 @@ describe("snapshot pair render materialization", () => {
           size: 24,
           media_type: "text/javascript",
         },
+        _css: {
+          blob: "css-hash",
+          size: 18,
+          media_type: "text/css",
+        },
+        label: {
+          blob: "label-hash",
+          size: 11,
+          media_type: "text/plain",
+        },
         value: {
           blob: "binary-hash",
           size: 12,
@@ -252,13 +262,30 @@ describe("snapshot pair render materialization", () => {
       "https://cloud.test/api/n/fixture-widget-anywidget/blobs/esm-hash",
     );
     assert.equal(
+      render.widget_comms[0]?.state._css,
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/css-hash",
+    );
+    assert.equal(
+      render.widget_comms[0]?.state.label,
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/label-hash",
+    );
+    assert.equal(
       render.widget_comms[0]?.state.value,
       "https://cloud.test/api/n/fixture-widget-anywidget/blobs/binary-hash",
     );
     assert.deepEqual(render.widget_comms[0]?.buffer_paths, [["value"]]);
+    assert.deepEqual(render.widget_comms[0]?.text_paths, [["label"]]);
     assert.equal(
       render.blob_urls["esm-hash"],
       "https://cloud.test/api/n/fixture-widget-anywidget/blobs/esm-hash",
+    );
+    assert.equal(
+      render.blob_urls["css-hash"],
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/css-hash",
+    );
+    assert.equal(
+      render.blob_urls["label-hash"],
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/label-hash",
     );
     assert.equal(
       render.blob_urls["binary-hash"],

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -201,6 +201,70 @@ describe("snapshot pair render materialization", () => {
       },
     ]);
   });
+
+  it("resolves widget comm ContentRefs through hosted blob URLs", async () => {
+    const notebookBytes = await readFile(
+      new URL(
+        "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+        import.meta.url,
+      ),
+    );
+    const peer = new RuntimeStatePeerHandle("runtime");
+    peer.put_comm_json(
+      "anywidget-model",
+      "jupyter.widget",
+      "anywidget",
+      "AnyModel",
+      JSON.stringify({
+        _model_module: "anywidget",
+        _model_name: "AnyModel",
+        _esm: {
+          blob: "esm-hash",
+          size: 24,
+          media_type: "text/javascript",
+        },
+        value: {
+          blob: "binary-hash",
+          size: 12,
+          media_type: "application/octet-stream",
+        },
+      }),
+      7,
+    );
+    const runtimeStateBytes = peer.save();
+    peer.free();
+
+    const render = await materializeSnapshotPairRender({
+      notebookId: "fixture-widget-anywidget",
+      notebookHeadsHash: "heads-fixture",
+      runtimeHeadsHash: "runtime-fixture",
+      notebookBytes,
+      runtimeStateBytes,
+      generatedAt: "2026-05-22T00:00:00.000Z",
+      blobResolver: createNotebookCloudBlobResolver({
+        baseUrl: "https://cloud.test/n/fixture-widget-anywidget",
+        blobBasePath: notebookCloudBlobBasePath("fixture-widget-anywidget"),
+      }),
+    });
+
+    assert.equal(
+      render.widget_comms[0]?.state._esm,
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/esm-hash",
+    );
+    assert.equal(
+      render.widget_comms[0]?.state.value,
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/binary-hash",
+    );
+    assert.deepEqual(render.widget_comms[0]?.buffer_paths, [["value"]]);
+    assert.equal(
+      render.blob_urls["esm-hash"],
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/esm-hash",
+    );
+    assert.equal(
+      render.blob_urls["binary-hash"],
+      "https://cloud.test/api/n/fixture-widget-anywidget/blobs/binary-hash",
+    );
+  });
 });
 
 async function readJson(url: URL): Promise<Record<string, unknown>> {

--- a/apps/notebook-cloud/test/widget-blob-inlining.test.ts
+++ b/apps/notebook-cloud/test/widget-blob-inlining.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { inlineWidgetBlobUrls } from "../viewer/widget-blob-inlining.ts";
+
+describe("cloud widget blob inlining", () => {
+  it("inlines allowed text blob URLs and binary blob URLs", async () => {
+    const state: Record<string, unknown> & { nested: Record<string, unknown> } = {
+      code: "https://cloud.test/api/n/demo/blobs/text-hash",
+      nested: {
+        value: "https://cloud.test/api/n/demo/blobs/binary-hash",
+      },
+    };
+    const fetches: string[] = [];
+
+    await inlineWidgetBlobUrls(
+      state,
+      { textPaths: [["code"]], bufferPaths: [["nested", "value"]] },
+      {
+        isAllowedBlobUrl: (url) => url.startsWith("https://cloud.test/api/n/demo/blobs/"),
+        fetchImpl: async (url) => {
+          fetches.push(String(url));
+          if (String(url).endsWith("text-hash")) {
+            return new Response("export default {}");
+          }
+          return new Response(new Uint8Array([1, 2, 3]));
+        },
+      },
+    );
+
+    assert.equal(state.code, "export default {}");
+    assert.ok(state.nested.value instanceof DataView);
+    assert.equal(state.nested.value.byteLength, 3);
+    assert.deepEqual(fetches, [
+      "https://cloud.test/api/n/demo/blobs/text-hash",
+      "https://cloud.test/api/n/demo/blobs/binary-hash",
+    ]);
+  });
+
+  it("leaves rejected or failed fetch paths unchanged", async () => {
+    const state = {
+      allowed: "https://cloud.test/api/n/demo/blobs/missing",
+      rejected: "https://example.invalid/track",
+      missingParent: "unchanged",
+    };
+
+    await inlineWidgetBlobUrls(
+      state,
+      {
+        textPaths: [["allowed"], ["rejected"], ["missing", "child"], []],
+      },
+      {
+        isAllowedBlobUrl: (url) => url.startsWith("https://cloud.test/api/n/demo/blobs/"),
+        fetchImpl: async () => new Response("not found", { status: 404 }),
+      },
+    );
+
+    assert.equal(state.allowed, "https://cloud.test/api/n/demo/blobs/missing");
+    assert.equal(state.rejected, "https://example.invalid/track");
+    assert.equal(state.missingParent, "unchanged");
+  });
+});

--- a/apps/notebook-cloud/test/widget-blob-inlining.test.ts
+++ b/apps/notebook-cloud/test/widget-blob-inlining.test.ts
@@ -58,4 +58,38 @@ describe("cloud widget blob inlining", () => {
     assert.equal(state.rejected, "https://example.invalid/track");
     assert.equal(state.missingParent, "unchanged");
   });
+
+  it("leaves paths unchanged when response body reads fail", async () => {
+    const state: Record<string, unknown> & { nested: Record<string, unknown> } = {
+      text: "https://cloud.test/api/n/demo/blobs/text",
+      nested: {
+        binary: "https://cloud.test/api/n/demo/blobs/binary",
+      },
+    };
+
+    await inlineWidgetBlobUrls(
+      state,
+      { textPaths: [["text"]], bufferPaths: [["nested", "binary"]] },
+      {
+        isAllowedBlobUrl: () => true,
+        fetchImpl: async (url) =>
+          String(url).endsWith("text")
+            ? failingBodyResponse("text body failed")
+            : failingBodyResponse("binary body failed"),
+      },
+    );
+
+    assert.equal(state.text, "https://cloud.test/api/n/demo/blobs/text");
+    assert.equal(state.nested.binary, "https://cloud.test/api/n/demo/blobs/binary");
+  });
 });
+
+function failingBodyResponse(message: string): Response {
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(new Error(message));
+      },
+    }),
+  );
+}

--- a/apps/notebook-cloud/test/widget-comms.test.ts
+++ b/apps/notebook-cloud/test/widget-comms.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { BlobRef, BlobResolver } from "runtimed";
+import { resolveSnapshotWidgetComms, type SnapshotWidgetComm } from "../src/widget-comms.ts";
+
+describe("cloud widget comm projection", () => {
+  it("preserves ordinary widget state objects with inline or blob properties", () => {
+    const [comm] = resolveSnapshotWidgetComms(
+      [
+        widgetComm({
+          layout: {
+            inline: true,
+            display: "flex",
+          },
+          marker: {
+            blob: "not-a-content-ref",
+          },
+          payload: {
+            blob: "also-not-a-content-ref",
+            size: 3,
+            extra: "state",
+          },
+        }),
+      ],
+      testBlobResolver,
+    );
+
+    assert.deepEqual(comm.state.layout, { inline: true, display: "flex" });
+    assert.deepEqual(comm.state.marker, { blob: "not-a-content-ref" });
+    assert.deepEqual(comm.state.payload, {
+      blob: "also-not-a-content-ref",
+      size: 3,
+      extra: "state",
+    });
+    assert.equal(comm.buffer_paths, undefined);
+    assert.equal(comm.text_paths, undefined);
+  });
+
+  it("resolves exact inline and blob ContentRef wrapper shapes", () => {
+    const [comm] = resolveSnapshotWidgetComms(
+      [
+        widgetComm({
+          label: { inline: "ready" },
+          image: {
+            blob: "image-hash",
+            size: 24,
+            media_type: "image/png",
+          },
+        }),
+      ],
+      testBlobResolver,
+    );
+
+    assert.equal(comm.state.label, "ready");
+    assert.equal(comm.state.image, "https://cloud.test/blobs/image-hash");
+    assert.deepEqual(comm.buffer_paths, [["image"]]);
+  });
+});
+
+const testBlobResolver: BlobResolver = {
+  url: (ref: BlobRef) => `https://cloud.test/blobs/${ref.blob}`,
+  fetch: async (ref: BlobRef) => new Response(ref.blob),
+};
+
+function widgetComm(state: Record<string, unknown>): SnapshotWidgetComm {
+  return {
+    comm_id: "comm",
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "IntSliderModel",
+    state,
+    seq: 0,
+  };
+}

--- a/apps/notebook-cloud/test/widget-runtime.test.ts
+++ b/apps/notebook-cloud/test/widget-runtime.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createWidgetStore } from "../../../src/components/widgets/widget-store.ts";
+import {
+  projectCloudWidgetComms,
+  type ProjectCloudWidgetCommsOptions,
+} from "../viewer/widget-comm-projection.ts";
+import type { SnapshotWidgetComm } from "../src/widget-comms.ts";
+
+describe("cloud widget runtime projection", () => {
+  it("does not delete previously projected models when async projection is cancelled", async () => {
+    const store = createWidgetStore();
+    store.createModel("comm-a", widgetState({ value: "old", payload: "old-payload" }));
+    store.createModel("comm-b", widgetState({ value: "keep" }));
+    const projectedCommIdsRef = { current: new Set(["comm-a", "comm-b"]) };
+    const originalFetch = globalThis.fetch;
+    let shouldContinue = true;
+
+    globalThis.fetch = (async () => {
+      shouldContinue = false;
+      return new Response("new-payload");
+    }) as typeof fetch;
+
+    try {
+      await projectCloudWidgetComms(
+        store,
+        [
+          widgetComm("comm-a", {
+            value: "new",
+            payload: "https://cloud.test/api/n/demo/blobs/payload",
+          }),
+        ],
+        projectedCommIdsRef,
+        {
+          isAllowedBlobUrl: (url) => url.startsWith("https://cloud.test/api/n/demo/blobs/"),
+          shouldContinue: () => shouldContinue,
+        },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(store.getModel("comm-a")?.state.value, "old");
+    assert.equal(store.getModel("comm-a")?.state.payload, "old-payload");
+    assert.equal(store.getModel("comm-b")?.state.value, "keep");
+    assert.deepEqual([...projectedCommIdsRef.current].sort(), ["comm-a", "comm-b"]);
+  });
+
+  it("reconciles stale models after a complete projection pass", async () => {
+    const store = createWidgetStore();
+    store.createModel("comm-a", widgetState({ value: "old" }));
+    store.createModel("comm-b", widgetState({ value: "stale" }));
+    const projectedCommIdsRef = { current: new Set(["comm-a", "comm-b"]) };
+
+    await projectCloudWidgetComms(
+      store,
+      [widgetComm("comm-a", { value: "new" })],
+      projectedCommIdsRef,
+      noBlobFetches(),
+    );
+
+    assert.equal(store.getModel("comm-a")?.state.value, "new");
+    assert.equal(store.getModel("comm-b"), undefined);
+    assert.deepEqual([...projectedCommIdsRef.current], ["comm-a"]);
+  });
+});
+
+function widgetComm(commId: string, state: Record<string, unknown>): SnapshotWidgetComm {
+  return {
+    comm_id: commId,
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "IntSliderModel",
+    state: widgetState(state),
+    text_paths: [["payload"]],
+    seq: 0,
+  };
+}
+
+function widgetState(state: Record<string, unknown>): Record<string, unknown> {
+  return {
+    _model_module: "@jupyter-widgets/controls",
+    _model_name: "IntSliderModel",
+    ...state,
+  };
+}
+
+function noBlobFetches(): ProjectCloudWidgetCommsOptions {
+  return {
+    isAllowedBlobUrl: () => false,
+  };
+}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -320,6 +320,7 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       }
       const widgetComms = snapshotWidgetCommsFromRuntimeState(
         liveRuntime.handle.get_runtime_state(),
+        blobResolver,
       );
       const metadata = parseJsonOrNull(liveRuntime.handle.get_metadata_snapshot_json?.());
       const notebookLanguage =

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -352,6 +352,13 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       );
     };
 
+    const materializeLiveCellsSafely = (liveRuntime: CloudSyncRuntime) => {
+      void materializeLiveCells(liveRuntime).catch((error: unknown) => {
+        if (disposed) return;
+        console.warn("[notebook-cloud] live room materialization failed", error);
+      });
+    };
+
     setPresence(initialCloudViewerPresence());
     setLivePresence(emptyCloudLivePresenceSnapshot());
     setConnectionError(null);
@@ -411,13 +418,13 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
             }
           }),
           liveRuntime.engine.cellChanges$.subscribe(() => {
-            void materializeLiveCells(liveRuntime);
+            materializeLiveCellsSafely(liveRuntime);
           }),
           liveRuntime.engine.runtimeState$.subscribe(() => {
-            void materializeLiveCells(liveRuntime);
+            materializeLiveCellsSafely(liveRuntime);
           }),
         ];
-        void materializeLiveCells(liveRuntime);
+        materializeLiveCellsSafely(liveRuntime);
       })
       .catch((error: unknown) => {
         if (disposed) return;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -250,7 +250,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         if (cancelled || liveMaterializedRef.current) return;
 
         snapshotResolvedRef.current = true;
-        projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
+        await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
+        if (cancelled || liveMaterializedRef.current) return;
         preloadSiftWasmForCells(resolvedCells, {
           blobBasePath: config.blobBasePath,
           rendererAssetsBasePath: config.rendererAssetsBasePath,
@@ -331,8 +332,9 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       );
       if (disposed || sequence !== materializeSequence) return;
 
+      await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
+      if (disposed || sequence !== materializeSequence) return;
       liveMaterializedRef.current = true;
-      projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
       setCells(resolvedCells);
       setStatus(
         resolvedCells.length === 0

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -250,7 +250,9 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
         if (cancelled || liveMaterializedRef.current) return;
 
         snapshotResolvedRef.current = true;
-        await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
+        await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef, {
+          isAllowedTextBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+        });
         if (cancelled || liveMaterializedRef.current) return;
         preloadSiftWasmForCells(resolvedCells, {
           blobBasePath: config.blobBasePath,
@@ -332,7 +334,9 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       );
       if (disposed || sequence !== materializeSequence) return;
 
-      await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef);
+      await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef, {
+        isAllowedTextBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+      });
       if (disposed || sequence !== materializeSequence) return;
       liveMaterializedRef.current = true;
       setCells(resolvedCells);
@@ -950,6 +954,17 @@ function parseJsonOrNull(value: string | undefined): unknown {
     return JSON.parse(value) as unknown;
   } catch {
     return null;
+  }
+}
+
+function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {
+  try {
+    const url = new URL(value, location.href);
+    const base = new URL(blobBasePath, location.href);
+    const basePath = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+    return url.origin === base.origin && url.pathname.startsWith(basePath);
+  } catch {
+    return false;
   }
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -251,7 +251,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
 
         snapshotResolvedRef.current = true;
         await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef, {
-          isAllowedTextBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+          isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+          shouldContinue: () => !cancelled && !liveMaterializedRef.current,
         });
         if (cancelled || liveMaterializedRef.current) return;
         preloadSiftWasmForCells(resolvedCells, {
@@ -335,7 +336,8 @@ function NotebookViewer({ runtime }: { runtime: ViewerRuntime }) {
       if (disposed || sequence !== materializeSequence) return;
 
       await projectCloudWidgetComms(widgetStore, widgetComms, projectedWidgetCommIdsRef, {
-        isAllowedTextBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+        isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+        shouldContinue: () => !disposed && sequence === materializeSequence,
       });
       if (disposed || sequence !== materializeSequence) return;
       liveMaterializedRef.current = true;

--- a/apps/notebook-cloud/viewer/widget-blob-inlining.ts
+++ b/apps/notebook-cloud/viewer/widget-blob-inlining.ts
@@ -1,0 +1,84 @@
+export interface WidgetBlobInliningOptions {
+  isAllowedBlobUrl?: (url: string) => boolean;
+  fetchImpl?: typeof fetch;
+}
+
+export async function inlineWidgetBlobUrls(
+  state: Record<string, unknown>,
+  paths: {
+    textPaths?: string[][];
+    bufferPaths?: string[][];
+  },
+  options: WidgetBlobInliningOptions = {},
+): Promise<void> {
+  await Promise.all([
+    inlineTextBlobUrls(state, paths.textPaths, options),
+    inlineBufferBlobUrls(state, paths.bufferPaths, options),
+  ]);
+}
+
+async function inlineTextBlobUrls(
+  state: Record<string, unknown>,
+  textPaths: string[][] | undefined,
+  options: WidgetBlobInliningOptions,
+): Promise<void> {
+  if (!textPaths || textPaths.length === 0) return;
+  await Promise.all(
+    textPaths.map(async (path) => {
+      const response = await fetchPath(state, path, options);
+      if (!response) return;
+      writePath(state, path, await response.text());
+    }),
+  );
+}
+
+async function inlineBufferBlobUrls(
+  state: Record<string, unknown>,
+  bufferPaths: string[][] | undefined,
+  options: WidgetBlobInliningOptions,
+): Promise<void> {
+  if (!bufferPaths || bufferPaths.length === 0) return;
+  await Promise.all(
+    bufferPaths.map(async (path) => {
+      const response = await fetchPath(state, path, options);
+      if (!response) return;
+      writePath(state, path, new DataView(await response.arrayBuffer()));
+    }),
+  );
+}
+
+async function fetchPath(
+  state: Record<string, unknown>,
+  path: string[],
+  options: WidgetBlobInliningOptions,
+): Promise<Response | null> {
+  const url = readPath(state, path);
+  if (typeof url !== "string") return null;
+  if (!options.isAllowedBlobUrl?.(url)) return null;
+  try {
+    const response = await (options.fetchImpl ?? fetch)(url);
+    return response.ok ? response : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const segment of path) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function writePath(value: Record<string, unknown>, path: string[], next: unknown): void {
+  if (path.length === 0) return;
+  let current: Record<string, unknown> = value;
+  for (const segment of path.slice(0, -1)) {
+    const child = current[segment];
+    if (typeof child !== "object" || child === null) return;
+    current = child as Record<string, unknown>;
+  }
+  current[path[path.length - 1]] = next;
+}

--- a/apps/notebook-cloud/viewer/widget-blob-inlining.ts
+++ b/apps/notebook-cloud/viewer/widget-blob-inlining.ts
@@ -27,7 +27,11 @@ async function inlineTextBlobUrls(
     textPaths.map(async (path) => {
       const response = await fetchPath(state, path, options);
       if (!response) return;
-      writePath(state, path, await response.text());
+      try {
+        writePath(state, path, await response.text());
+      } catch {
+        return;
+      }
     }),
   );
 }
@@ -42,7 +46,11 @@ async function inlineBufferBlobUrls(
     bufferPaths.map(async (path) => {
       const response = await fetchPath(state, path, options);
       if (!response) return;
-      writePath(state, path, new DataView(await response.arrayBuffer()));
+      try {
+        writePath(state, path, new DataView(await response.arrayBuffer()));
+      } catch {
+        return;
+      }
     }),
   );
 }

--- a/apps/notebook-cloud/viewer/widget-blob-inlining.ts
+++ b/apps/notebook-cloud/viewer/widget-blob-inlining.ts
@@ -1,5 +1,5 @@
 export interface WidgetBlobInliningOptions {
-  isAllowedBlobUrl?: (url: string) => boolean;
+  isAllowedBlobUrl: (url: string) => boolean;
   fetchImpl?: typeof fetch;
 }
 
@@ -9,7 +9,7 @@ export async function inlineWidgetBlobUrls(
     textPaths?: string[][];
     bufferPaths?: string[][];
   },
-  options: WidgetBlobInliningOptions = {},
+  options: WidgetBlobInliningOptions,
 ): Promise<void> {
   await Promise.all([
     inlineTextBlobUrls(state, paths.textPaths, options),
@@ -54,7 +54,7 @@ async function fetchPath(
 ): Promise<Response | null> {
   const url = readPath(state, path);
   if (typeof url !== "string") return null;
-  if (!options.isAllowedBlobUrl?.(url)) return null;
+  if (!options.isAllowedBlobUrl(url)) return null;
   try {
     const response = await (options.fetchImpl ?? fetch)(url);
     return response.ok ? response : null;

--- a/apps/notebook-cloud/viewer/widget-comm-projection.ts
+++ b/apps/notebook-cloud/viewer/widget-comm-projection.ts
@@ -1,0 +1,60 @@
+import type { WidgetStore } from "@/components/widgets/widget-store";
+import { widgetCommStoreState, type SnapshotWidgetComm } from "../src/widget-comms";
+import { inlineWidgetBlobUrls } from "./widget-blob-inlining";
+
+export interface ProjectCloudWidgetCommsOptions {
+  isAllowedBlobUrl?: (url: string) => boolean;
+  shouldContinue?: () => boolean;
+}
+
+export async function projectCloudWidgetComms(
+  store: WidgetStore,
+  comms: readonly SnapshotWidgetComm[],
+  projectedCommIdsRef: { current: Set<string> },
+  options: ProjectCloudWidgetCommsOptions = {},
+): Promise<void> {
+  if (options.shouldContinue && !options.shouldContinue()) return;
+
+  const projected = await Promise.all(
+    comms.map(async (comm) => {
+      const state = widgetCommStoreState(comm);
+      await inlineWidgetBlobUrls(
+        state,
+        { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
+        { isAllowedBlobUrl: options.isAllowedBlobUrl ?? (() => false) },
+      );
+      return {
+        bufferPaths: comm.buffer_paths,
+        commId: comm.comm_id,
+        state,
+      };
+    }),
+  );
+
+  if (options.shouldContinue && !options.shouldContinue()) return;
+
+  const projectedCommIds = new Set<string>();
+  for (const { bufferPaths, commId, state } of projected) {
+    if (store.getModel(commId)) {
+      store.updateModel(commId, state, bufferPaths);
+    } else {
+      store.createModel(commId, state, bufferPaths);
+    }
+    projectedCommIds.add(commId);
+  }
+
+  reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
+}
+
+function reconcileProjectedWidgetComms(
+  store: WidgetStore,
+  projectedCommIdsRef: { current: Set<string> },
+  nextCommIds: Set<string>,
+): void {
+  for (const commId of projectedCommIdsRef.current) {
+    if (!nextCommIds.has(commId)) {
+      store.deleteModel(commId);
+    }
+  }
+  projectedCommIdsRef.current = nextCommIds;
+}

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -51,28 +51,32 @@ export async function projectCloudWidgetComms(
   projectedCommIdsRef: { current: Set<string> },
   options: ProjectCloudWidgetCommsOptions = {},
 ): Promise<void> {
-  const projectedCommIds = new Set<string>();
+  if (options.shouldContinue && !options.shouldContinue()) return;
 
-  for (const comm of comms) {
-    if (options.shouldContinue && !options.shouldContinue()) {
-      reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
-      return;
-    }
-    const commId = comm.comm_id;
-    const state = widgetCommStoreState(comm);
-    await inlineWidgetBlobUrls(
-      state,
-      { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
-      { isAllowedBlobUrl: options.isAllowedBlobUrl },
-    );
-    if (options.shouldContinue && !options.shouldContinue()) {
-      reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
-      return;
-    }
+  const projected = await Promise.all(
+    comms.map(async (comm) => {
+      const state = widgetCommStoreState(comm);
+      await inlineWidgetBlobUrls(
+        state,
+        { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
+        { isAllowedBlobUrl: options.isAllowedBlobUrl ?? (() => false) },
+      );
+      return {
+        bufferPaths: comm.buffer_paths,
+        commId: comm.comm_id,
+        state,
+      };
+    }),
+  );
+
+  if (options.shouldContinue && !options.shouldContinue()) return;
+
+  const projectedCommIds = new Set<string>();
+  for (const { bufferPaths, commId, state } of projected) {
     if (store.getModel(commId)) {
-      store.updateModel(commId, state, comm.buffer_paths);
+      store.updateModel(commId, state, bufferPaths);
     } else {
-      store.createModel(commId, state, comm.buffer_paths);
+      store.createModel(commId, state, bufferPaths);
     }
     projectedCommIds.add(commId);
   }

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -12,6 +12,10 @@ export const CLOUD_WIDGET_RENDERERS = {
   [WIDGET_VIEW_MIME]: CloudWidgetViewRenderer,
 };
 
+export interface ProjectCloudWidgetCommsOptions {
+  isAllowedTextBlobUrl?: (url: string) => boolean;
+}
+
 export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) {
   const storeRef = useRef<WidgetStore | null>(null);
   if (!storeRef.current) {
@@ -43,6 +47,7 @@ export async function projectCloudWidgetComms(
   store: WidgetStore,
   comms: readonly SnapshotWidgetComm[],
   projectedCommIdsRef: { current: Set<string> },
+  options: ProjectCloudWidgetCommsOptions = {},
 ): Promise<void> {
   const nextCommIds = new Set<string>();
 
@@ -50,7 +55,7 @@ export async function projectCloudWidgetComms(
     const commId = comm.comm_id;
     nextCommIds.add(commId);
     const state = widgetCommStoreState(comm);
-    await inlineTextBlobUrls(state, comm.text_paths);
+    await inlineTextBlobUrls(state, comm.text_paths, options.isAllowedTextBlobUrl);
     if (store.getModel(commId)) {
       store.updateModel(commId, state, comm.buffer_paths);
     } else {
@@ -69,12 +74,14 @@ export async function projectCloudWidgetComms(
 async function inlineTextBlobUrls(
   state: Record<string, unknown>,
   textPaths: string[][] | undefined,
+  isAllowedTextBlobUrl: ((url: string) => boolean) | undefined,
 ): Promise<void> {
   if (!textPaths || textPaths.length === 0) return;
   await Promise.all(
     textPaths.map(async (path) => {
       const url = readPath(state, path);
       if (typeof url !== "string") return;
+      if (!isAllowedTextBlobUrl?.(url)) return;
       try {
         const response = await fetch(url);
         if (!response.ok) return;

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -6,6 +6,7 @@ import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { widgetCommStoreState, type SnapshotWidgetComm } from "../src/widget-comms";
+import { inlineWidgetBlobUrls } from "./widget-blob-inlining";
 import "@/components/widgets/controls";
 
 export const CLOUD_WIDGET_RENDERERS = {
@@ -13,7 +14,8 @@ export const CLOUD_WIDGET_RENDERERS = {
 };
 
 export interface ProjectCloudWidgetCommsOptions {
-  isAllowedTextBlobUrl?: (url: string) => boolean;
+  isAllowedBlobUrl?: (url: string) => boolean;
+  shouldContinue?: () => boolean;
 }
 
 export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) {
@@ -52,10 +54,16 @@ export async function projectCloudWidgetComms(
   const nextCommIds = new Set<string>();
 
   for (const comm of comms) {
+    if (options.shouldContinue && !options.shouldContinue()) return;
     const commId = comm.comm_id;
     nextCommIds.add(commId);
     const state = widgetCommStoreState(comm);
-    await inlineTextBlobUrls(state, comm.text_paths, options.isAllowedTextBlobUrl);
+    await inlineWidgetBlobUrls(
+      state,
+      { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
+      { isAllowedBlobUrl: options.isAllowedBlobUrl },
+    );
+    if (options.shouldContinue && !options.shouldContinue()) return;
     if (store.getModel(commId)) {
       store.updateModel(commId, state, comm.buffer_paths);
     } else {
@@ -69,49 +77,6 @@ export async function projectCloudWidgetComms(
     }
   }
   projectedCommIdsRef.current = nextCommIds;
-}
-
-async function inlineTextBlobUrls(
-  state: Record<string, unknown>,
-  textPaths: string[][] | undefined,
-  isAllowedTextBlobUrl: ((url: string) => boolean) | undefined,
-): Promise<void> {
-  if (!textPaths || textPaths.length === 0) return;
-  await Promise.all(
-    textPaths.map(async (path) => {
-      const url = readPath(state, path);
-      if (typeof url !== "string") return;
-      if (!isAllowedTextBlobUrl?.(url)) return;
-      try {
-        const response = await fetch(url);
-        if (!response.ok) return;
-        writePath(state, path, await response.text());
-      } catch {
-        // Keep the URL string; the widget will fail locally without blocking
-        // unrelated comms from rendering.
-      }
-    }),
-  );
-}
-
-function readPath(value: unknown, path: string[]): unknown {
-  let current = value;
-  for (const segment of path) {
-    if (typeof current !== "object" || current === null) return undefined;
-    current = (current as Record<string, unknown>)[segment];
-  }
-  return current;
-}
-
-function writePath(value: Record<string, unknown>, path: string[], next: unknown): void {
-  if (path.length === 0) return;
-  let current: Record<string, unknown> = value;
-  for (const segment of path.slice(0, -1)) {
-    const child = current[segment];
-    if (typeof child !== "object" || child === null) return;
-    current = child as Record<string, unknown>;
-  }
-  current[path[path.length - 1]] = next;
 }
 
 function CloudWidgetViewRenderer({ data }: { data: unknown }) {

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -39,17 +39,18 @@ export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) 
   return <WidgetStoreContext.Provider value={value}>{children}</WidgetStoreContext.Provider>;
 }
 
-export function projectCloudWidgetComms(
+export async function projectCloudWidgetComms(
   store: WidgetStore,
   comms: readonly SnapshotWidgetComm[],
   projectedCommIdsRef: { current: Set<string> },
-): void {
+): Promise<void> {
   const nextCommIds = new Set<string>();
 
   for (const comm of comms) {
     const commId = comm.comm_id;
     nextCommIds.add(commId);
     const state = widgetCommStoreState(comm);
+    await inlineTextBlobUrls(state, comm.text_paths);
     if (store.getModel(commId)) {
       store.updateModel(commId, state, comm.buffer_paths);
     } else {
@@ -63,6 +64,47 @@ export function projectCloudWidgetComms(
     }
   }
   projectedCommIdsRef.current = nextCommIds;
+}
+
+async function inlineTextBlobUrls(
+  state: Record<string, unknown>,
+  textPaths: string[][] | undefined,
+): Promise<void> {
+  if (!textPaths || textPaths.length === 0) return;
+  await Promise.all(
+    textPaths.map(async (path) => {
+      const url = readPath(state, path);
+      if (typeof url !== "string") return;
+      try {
+        const response = await fetch(url);
+        if (!response.ok) return;
+        writePath(state, path, await response.text());
+      } catch {
+        // Keep the URL string; the widget will fail locally without blocking
+        // unrelated comms from rendering.
+      }
+    }),
+  );
+}
+
+function readPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const segment of path) {
+    if (typeof current !== "object" || current === null) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function writePath(value: Record<string, unknown>, path: string[], next: unknown): void {
+  if (path.length === 0) return;
+  let current: Record<string, unknown> = value;
+  for (const segment of path.slice(0, -1)) {
+    const child = current[segment];
+    if (typeof child !== "object" || child === null) return;
+    current = child as Record<string, unknown>;
+  }
+  current[path[path.length - 1]] = next;
 }
 
 function CloudWidgetViewRenderer({ data }: { data: unknown }) {

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -5,18 +5,15 @@ import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { WidgetView } from "@/components/widgets/widget-view";
-import { widgetCommStoreState, type SnapshotWidgetComm } from "../src/widget-comms";
-import { inlineWidgetBlobUrls } from "./widget-blob-inlining";
+export {
+  projectCloudWidgetComms,
+  type ProjectCloudWidgetCommsOptions,
+} from "./widget-comm-projection";
 import "@/components/widgets/controls";
 
 export const CLOUD_WIDGET_RENDERERS = {
   [WIDGET_VIEW_MIME]: CloudWidgetViewRenderer,
 };
-
-export interface ProjectCloudWidgetCommsOptions {
-  isAllowedBlobUrl?: (url: string) => boolean;
-  shouldContinue?: () => boolean;
-}
 
 export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) {
   const storeRef = useRef<WidgetStore | null>(null);
@@ -43,58 +40,6 @@ export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) 
   );
 
   return <WidgetStoreContext.Provider value={value}>{children}</WidgetStoreContext.Provider>;
-}
-
-export async function projectCloudWidgetComms(
-  store: WidgetStore,
-  comms: readonly SnapshotWidgetComm[],
-  projectedCommIdsRef: { current: Set<string> },
-  options: ProjectCloudWidgetCommsOptions = {},
-): Promise<void> {
-  if (options.shouldContinue && !options.shouldContinue()) return;
-
-  const projected = await Promise.all(
-    comms.map(async (comm) => {
-      const state = widgetCommStoreState(comm);
-      await inlineWidgetBlobUrls(
-        state,
-        { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
-        { isAllowedBlobUrl: options.isAllowedBlobUrl ?? (() => false) },
-      );
-      return {
-        bufferPaths: comm.buffer_paths,
-        commId: comm.comm_id,
-        state,
-      };
-    }),
-  );
-
-  if (options.shouldContinue && !options.shouldContinue()) return;
-
-  const projectedCommIds = new Set<string>();
-  for (const { bufferPaths, commId, state } of projected) {
-    if (store.getModel(commId)) {
-      store.updateModel(commId, state, bufferPaths);
-    } else {
-      store.createModel(commId, state, bufferPaths);
-    }
-    projectedCommIds.add(commId);
-  }
-
-  reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
-}
-
-function reconcileProjectedWidgetComms(
-  store: WidgetStore,
-  projectedCommIdsRef: { current: Set<string> },
-  nextCommIds: Set<string>,
-): void {
-  for (const commId of projectedCommIdsRef.current) {
-    if (!nextCommIds.has(commId)) {
-      store.deleteModel(commId);
-    }
-  }
-  projectedCommIdsRef.current = nextCommIds;
 }
 
 function CloudWidgetViewRenderer({ data }: { data: unknown }) {

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -51,26 +51,40 @@ export async function projectCloudWidgetComms(
   projectedCommIdsRef: { current: Set<string> },
   options: ProjectCloudWidgetCommsOptions = {},
 ): Promise<void> {
-  const nextCommIds = new Set<string>();
+  const projectedCommIds = new Set<string>();
 
   for (const comm of comms) {
-    if (options.shouldContinue && !options.shouldContinue()) return;
+    if (options.shouldContinue && !options.shouldContinue()) {
+      reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
+      return;
+    }
     const commId = comm.comm_id;
-    nextCommIds.add(commId);
     const state = widgetCommStoreState(comm);
     await inlineWidgetBlobUrls(
       state,
       { textPaths: comm.text_paths, bufferPaths: comm.buffer_paths },
       { isAllowedBlobUrl: options.isAllowedBlobUrl },
     );
-    if (options.shouldContinue && !options.shouldContinue()) return;
+    if (options.shouldContinue && !options.shouldContinue()) {
+      reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
+      return;
+    }
     if (store.getModel(commId)) {
       store.updateModel(commId, state, comm.buffer_paths);
     } else {
       store.createModel(commId, state, comm.buffer_paths);
     }
+    projectedCommIds.add(commId);
   }
 
+  reconcileProjectedWidgetComms(store, projectedCommIdsRef, projectedCommIds);
+}
+
+function reconcileProjectedWidgetComms(
+  store: WidgetStore,
+  projectedCommIdsRef: { current: Set<string> },
+  nextCommIds: Set<string>,
+): void {
   for (const commId of projectedCommIdsRef.current) {
     if (!nextCommIds.has(commId)) {
       store.deleteModel(commId);

--- a/docs/architecture/blob-storage-and-content-addressing.md
+++ b/docs/architecture/blob-storage-and-content-addressing.md
@@ -121,10 +121,14 @@ Why this split:
 2. **Binary as bytes, not base64.** Storing PNGs as base64 inside Automerge
    text fields would 1.33x the size, defeat OS-level filesystem caching, and
    misclassify the data for HTTP serving.
-3. **One classification source.** MIME classification lives in
-   `notebook_doc::mime` (`is_binary_mime`, `mime_kind`). No per-crate copies.
-   The frontend does not classify; WASM resolves `ContentRef`s into one of
-   `Inline | Url | Blob` via `notebook-doc::mime::ResolvedContentRef`.
+3. **One classification source for output manifests.** MIME classification
+   lives in `notebook_doc::mime` (`is_binary_mime`, `mime_kind`). Rust output
+   paths and WASM output resolution use that source to resolve `ContentRef`s
+   into one of `Inline | Url | Blob` via
+   `notebook-doc::mime::ResolvedContentRef`. The hosted widget-comm bridge
+   currently mirrors the same binary/text split in TypeScript when projecting
+   `RuntimeStateDoc.comms`; that is a host adapter for read-only widget state,
+   not a second durable output-manifest policy.
 
 The threshold is a constant rather than a runtime-configurable knob today.
 Anything load-bearing on its value (test fixtures, the comm-state externalizer
@@ -384,11 +388,13 @@ blob reachable.
    maps to `/api/n/:id/blobs/:hash` or a future signed origin. The desktop
    resolver maps to `http://127.0.0.1:<port>/blob/<hash>`.
 3. **Snapshot pairing.** `NotebookHandle.load_snapshot(notebookBytes,
-   runtimeStateBytes)` (the `25e14bf3` change) materializes a snapshot pair
-   into a single handle. Outputs decode to `ContentRef`s; the host plugs in a
-   `BlobResolver` against whichever origin owns the bytes (local daemon for a
-   desktop viewer, cloud origin for a hosted viewer). The snapshot pair plus
-   the resolver is enough to render; no intermediate JSON projection.
+   runtimeStateBytes)` materializes a snapshot pair into a single handle.
+   Outputs decode to `ContentRef`s; the host plugs in a `BlobResolver` against
+   whichever origin owns the bytes (local daemon for a desktop viewer, cloud
+   origin for a hosted viewer). The snapshot pair plus the resolver is the
+   durable source of truth. Hosts may still build derived JSON render caches at
+   publish/request time, but those caches are regenerable validation artifacts,
+   not a second notebook format.
 
 The snapshot pair invariant: a saved `RuntimeStateDoc` is only renderable if
 every `ContentRef::Blob` it carries is reachable through the resolver. Publish
@@ -491,17 +497,14 @@ elsewhere, some are surfaced here for the first time.
    pandas reprs) that a value-aware threshold (e.g., higher for
    `text/plain` traceback, lower for `application/json`) might cut sync
    bandwidth materially. No data captured to drive that choice.
-6. **Snapshot publish does not check blob reachability.** The snapshot pair
-   load path assumes the host supplies a resolver that can reach every ref.
-   No tool today walks a saved `RuntimeStateDoc`, enumerates its
-   `ContentRef::Blob` entries, and verifies they exist in the destination
-   blob store before declaring a publish complete. A publisher that forgets
-   a blob produces a snapshot that loads but renders with broken outputs.
-   The natural home for the fix is the hosted-artifacts publish flow
-   (`hosted-notebook-artifacts.md`): `latest_revision_id` should not advance
-   until every reachable `ContentRef::Blob` exists in the destination store.
-   The desktop ADR keeps this as an open question because desktop save does
-   not have a publish boundary; the room either has the blobs or it doesn't.
+6. **Publish ref collectors must stay schema-complete.** The publish boundary
+   now walks saved snapshot documents and rejects hosted revisions when
+   materialized render refs are missing from the destination blob store. The
+   remaining risk is schema drift: every new ref shape in `RuntimeStateDoc`
+   outputs/comms, `NotebookDoc` assets/attachments, or inline manifest children
+   must be added to the publisher, hosted validator, and GC inventory together.
+   Desktop save still does not have a separate publish boundary; the room either
+   has the blobs or it does not.
 7. **MIME mutation on re-put.** A repeat put with the same bytes but a
    different `media_type` overwrites the sidecar (`put_disk` fast path).
    That is intentional for the `application/json` -> `text/javascript`

--- a/docs/architecture/execution-pipeline.md
+++ b/docs/architecture/execution-pipeline.md
@@ -184,7 +184,7 @@ The committer therefore holds a `HashMap<String, PendingDisplayUpdate>` keyed by
 
 ### The flush before `ExecutionDone`
 
-When `status: idle` arrives from the kernel, `jupyter_kernel.rs:1419` calls:
+When `status: idle` arrives from the kernel, `jupyter_kernel.rs:1458-1479` calls:
 
 ```rust
 display_update_committer.flush_for_ordering().await;

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -34,7 +34,11 @@ A published revision is durable when these artifacts exist:
 
 - Notebook snapshot: saved `NotebookDoc` bytes.
 - Runtime snapshot: saved `RuntimeStateDoc` bytes.
-- Blob objects: content-addressed output bytes referenced by output manifests.
+- Blob objects: every content-addressed byte object reachable from the
+  snapshot pair. This includes `RuntimeStateDoc` execution output manifests,
+  widget comm state and comm outputs, `NotebookDoc.resolved_assets`,
+  `NotebookDoc.attachments`, and child refs named by inline manifests such as
+  Arrow/Sift chunks.
 - Catalog row: D1 metadata tying the above artifacts to a notebook id and heads.
 
 The revision row records:
@@ -50,8 +54,9 @@ truth and can be regenerated from the snapshot pair.
 
 The publish API may materialize that cache before recording the catalog row.
 This is a validation step, not a change in durability: if the `NotebookDoc` /
-`RuntimeStateDoc` pair cannot load, or if any rendered output manifest points at
-a missing blob object, the host rejects the publish and leaves no revision row.
+`RuntimeStateDoc` pair cannot load, or if any rendered cell, widget comm, or
+manifest child points at a missing blob object, the host rejects the publish and
+leaves no revision row.
 
 ## Decision 2: R2 layout is deterministic
 
@@ -88,6 +93,15 @@ stack as desktop: `ReadOnlyNotebook` → `ReadOnlyNotebookCell` → `OutputArea`
 `MediaRouter` / isolated iframe. The framework-agnostic
 `createNteractOutputEmbed()` surface remains the non-React embedding contract,
 but the cloud notebook viewer itself should not fork a separate DOM renderer.
+
+Widget comm state has one additional host-specific projection step. The Worker
+serializes `widget_comms` alongside rendered cells, resolving comm
+`ContentRef`s through the hosted `BlobResolver`. The viewer then seeds a
+read-only `WidgetStore`: `_esm` / `_css` stay URL strings for browser loading,
+text refs listed in `text_paths` are fetched and inlined by the viewer, and
+binary refs listed in `buffer_paths` are installed as `DataView`s. This keeps
+the rendered widget components shared while making the blob authority boundary
+explicit in the host.
 
 ## Decision 4: Blob refs stay host-neutral
 

--- a/docs/architecture/three-document-split.md
+++ b/docs/architecture/three-document-split.md
@@ -14,7 +14,9 @@ A connecting peer subscribes through one of the typed-frame handshake channels. 
 
 The split is load-bearing for sync bandwidth, write-frequency isolation, fan-out scope, persistence, and trust. It is not written down in one place. This ADR records the decision so the boundaries become visible to anyone changing them.
 
-This ADR describes the real desktop application. The hosted prototype at `apps/notebook-cloud/` is parked and outside scope. A closing section sketches what changes when the same split runs in a multi-user deployment.
+This ADR is desktop-first, but the hosted publish/cloud viewer now consumes the
+same `NotebookDoc` + `RuntimeStateDoc` snapshot pair. A closing section sketches
+what changes when the split runs in a multi-user deployment.
 
 Neighbors:
 
@@ -164,6 +166,7 @@ This is three different ingress shapes for what looks like one protocol. `PoolDo
 2. Daemon sets `RuntimeStateDoc.last_saved` to the ISO timestamp.
 3. User quits. Room evicts. Both notebook docs are dropped. `.automerge` for untitled paths is not used here because the doc is file-backed.
 4. User reopens the notebook. Daemon loads `.ipynb` into a fresh `NotebookDoc`. `RuntimeStateDoc` is rebuilt from schema seed, then the loader walks cells that carry legacy `execution_count` or outputs and creates **one synthetic execution entry per such cell** so the new `RuntimeStateDoc` can route them through the same `executions/*/outputs` shape (`crates/runtimed/src/notebook_sync_server/load.rs:709-741`). The cell's `execution_id` is set to the synthetic entry's id at the same time.
+5. If the `.ipynb` carries `metadata.widgets["application/vnd.jupyter.widget-state+json"]`, the loader also imports those widget models into `RuntimeStateDoc.comms`. Large widget buffers are externalized through the blob store before the comm state is written. That means a publish snapshot can carry widget models even when no live kernel has reopened those comms.
 
 ### Kernel crash and relaunch
 

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -35,6 +35,8 @@ function isLocalDaemonBlobUrl(value: string): boolean {
       (url.protocol === "http:" || url.protocol === "https:") &&
       url.hostname === "127.0.0.1" &&
       url.port.length > 0 &&
+      url.search === "" &&
+      url.hash === "" &&
       /^\/blob\/[a-f0-9]+$/.test(url.pathname)
     );
   } catch {

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -28,8 +28,14 @@ import {
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 
-/** Blob URL pattern for host-provided ContentRef URLs. */
-const BLOB_URL_RE = /^https?:\/\/.+/;
+function isHttpBlobUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Fetch the blob URL at each `bufferPaths` position in `state` and replace
@@ -53,7 +59,7 @@ async function resolveBlobUrlsInPlace(
         if (typeof current !== "object" || current === null) return;
         current = (current as Record<string, unknown>)[segment];
       }
-      if (typeof current !== "string" || !BLOB_URL_RE.test(current)) return;
+      if (typeof current !== "string" || !isHttpBlobUrl(current)) return;
       try {
         const resp = await fetch(current);
         if (!resp.ok) return;

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -28,10 +28,14 @@ import {
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 
-function isHttpBlobUrl(value: string): boolean {
+function isLocalDaemonBlobUrl(value: string): boolean {
   try {
     const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:";
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.hostname === "127.0.0.1" &&
+      url.pathname.startsWith("/blob/")
+    );
   } catch {
     return false;
   }
@@ -59,7 +63,7 @@ async function resolveBlobUrlsInPlace(
         if (typeof current !== "object" || current === null) return;
         current = (current as Record<string, unknown>)[segment];
       }
-      if (typeof current !== "string" || !isHttpBlobUrl(current)) return;
+      if (typeof current !== "string" || !isLocalDaemonBlobUrl(current)) return;
       try {
         const resp = await fetch(current);
         if (!resp.ok) return;

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -34,7 +34,8 @@ function isLocalDaemonBlobUrl(value: string): boolean {
     return (
       (url.protocol === "http:" || url.protocol === "https:") &&
       url.hostname === "127.0.0.1" &&
-      url.pathname.startsWith("/blob/")
+      url.port.length > 0 &&
+      /^\/blob\/[a-f0-9]+$/.test(url.pathname)
     );
   } catch {
     return false;

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -28,8 +28,8 @@ import {
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 
-/** Blob URL pattern: http://127.0.0.1:{port}/blob/{hash} */
-const BLOB_URL_RE = /^https?:\/\/127\.0\.0\.1:\d+\/blob\/[a-f0-9]+$/;
+/** Blob URL pattern for host-provided ContentRef URLs. */
+const BLOB_URL_RE = /^https?:\/\/.+/;
 
 /**
  * Fetch the blob URL at each `bufferPaths` position in `state` and replace


### PR DESCRIPTION
## Summary

- document publish completeness as the full snapshot-pair blob closure, including NotebookDoc assets/attachments, RuntimeStateDoc comms, and manifest child refs
- describe the hosted widget comm projection boundary added by #3046 without claiming full render-surface convergence
- refresh stale architecture notes around derived render caches, widget metadata hydration, and display-update line references

## Stack

Draft stacked on #3046. This is documentation-only follow-up from the audit notes under `.context/audits/`.

## Test plan

- `cargo xtask lint --fix`
