### PR TITLE
chore(release): bump patch versions

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "nteract",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "source": {
         "source": "local",
         "path": "./plugins/nteract"
@@ -19,7 +19,7 @@
     },
     {
       "name": "nightly",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "source": {
         "source": "local",
         "path": "./plugins/nightly"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.3.1"
+      "version": "0.3.2"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "automerge-recovery"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "automerge",
  "thiserror 2.0.18",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "automerge",
  "serde_json",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "build-metadata"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "bumpalo"
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4444,11 +4444,11 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-client-branding"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dirs",
  "libc",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-wire"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "serde",
 ]
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-identity"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "jsonwebtoken",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-telemetry"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "log",
  "reqwest 0.12.28",
@@ -5960,7 +5960,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "playdate-image"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "image",
  "thiserror 2.0.18",
@@ -7061,7 +7061,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -7370,7 +7370,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -7404,7 +7404,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7432,7 +7432,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -7443,7 +7443,7 @@ dependencies = [
 
 [[package]]
 name = "runt-publish"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "automerge",
@@ -7466,7 +7466,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7474,7 +7474,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7487,7 +7487,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7501,7 +7501,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "aho-corasick",
  "alacritty_terminal",
@@ -7574,7 +7574,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7600,7 +7600,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7626,7 +7626,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-outputs"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "base64 0.22.1",
  "notebook-doc",
@@ -7641,7 +7641,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "kernel-env",
  "log",
@@ -7662,7 +7662,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-service"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "dirs",
  "log",
@@ -7673,7 +7673,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-settings-sync"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "automerge",
  "log",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "automerge",
  "console_error_panic_hook",
@@ -8401,7 +8401,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11656,7 +11656,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a78a0727fe6643f3ca47e72216fdc29f3143fe62f4ae82da2193f9151c249243
-size 1601509
+oid sha256:7480cf490432ffd6e7929f2adc105893d37f17cc82865e0ae0e0f36f89ead5d0
+size 1602722

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e46f0919b5bb28b07a4b55662c8d7201f41aeb3b4304c87b5547cb746a75bca
-size 1487204
+oid sha256:ce9745fa2799abba237e566f3b32b5f7a6a109a94a0bb524916da76301fa80d9
+size 1489305

--- a/crates/automerge-recovery/Cargo.toml
+++ b/crates/automerge-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge-recovery"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Small panic recovery helpers for Automerge operations"
 repository.workspace = true

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/build-metadata/Cargo.toml
+++ b/crates/build-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-metadata"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Shared build-script metadata helpers for nteract desktop"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-client-branding/Cargo.toml
+++ b/crates/mcp-client-branding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-client-branding"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Canonical display names for known MCP clients"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook-wire/Cargo.toml
+++ b/crates/notebook-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-wire"
-version = "0.2.7"
+version = "0.2.8"
 edition.workspace = true
 description = "Low-level notebook wire constants, frame limits, and session-control types"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-identity/Cargo.toml
+++ b/crates/nteract-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-identity"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Identity and authorization primitives for nteract notebook rooms"
 repository.workspace = true

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/nteract-telemetry/Cargo.toml
+++ b/crates/nteract-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-telemetry"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Anonymous phone-home telemetry for nteract Rust binaries"
 repository.workspace = true

--- a/crates/playdate-image/Cargo.toml
+++ b/crates/playdate-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-image"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-publish/Cargo.toml
+++ b/crates/runt-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-publish"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 description = "Prototype publisher for hosted nteract notebook-cloud demos"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Notebook trust extraction for the per-machine package allowlist"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for daemon-authoritative runtime state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-outputs/Cargo.toml
+++ b/crates/runtimed-outputs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-outputs"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Output resolution and LLM-friendly output formatting for runtimed"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-service/Cargo.toml
+++ b/crates/runtimed-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-service"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Cross-platform service management for the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-settings-sync/Cargo.toml
+++ b/crates/runtimed-settings-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-settings-sync"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Live settings sync client over the runtimed UDS protocol"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license = "BSD-3-Clause"
 repository = "https://github.com/nteract/nteract"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.5.1"
+version = "2.5.2"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository = "https://github.com/nteract/nteract"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -43,12 +43,22 @@ struct Target {
 const TARGETS: &[Target] = &[
     // Rust workspace crates (keep in sync with [workspace.members] in /Cargo.toml)
     Target {
+        path: "crates/build-metadata/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/runt/Cargo.toml",
         format: Format::Toml,
         matches: 1,
     },
     Target {
         path: "crates/runtimed/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/runt-publish/Cargo.toml",
         format: Format::Toml,
         matches: 1,
     },
@@ -89,7 +99,17 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "crates/nteract-identity/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/notebook-doc/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/notebook-wire/Cargo.toml",
         format: Format::Toml,
         matches: 1,
     },
@@ -119,6 +139,16 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "crates/mcp-client-branding/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/playdate-image/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/runt-trust/Cargo.toml",
         format: Format::Toml,
         matches: 1,
@@ -135,6 +165,11 @@ const TARGETS: &[Target] = &[
     },
     Target {
         path: "crates/kernel-env/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
+        path: "crates/automerge-recovery/Cargo.toml",
         format: Format::Toml,
         matches: 1,
     },
@@ -483,6 +518,8 @@ fn bump_str(version: &str, kind: BumpKind) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::*;
 
     #[test]
@@ -567,5 +604,56 @@ mod tests {
             "crates/sift-wasm/pkg/package.json: expected 1 version line(s), found 0",
             "crates/sift-wasm/pkg/package.json"
         ));
+    }
+
+    #[test]
+    fn rust_workspace_crate_versions_are_bump_targets() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let repo_root = manifest_dir
+            .parent()
+            .and_then(Path::parent)
+            .expect("xtask crate should live under crates/xtask");
+        let crates_dir = repo_root.join("crates");
+
+        let versioned_crates: BTreeSet<String> = fs::read_dir(&crates_dir)
+            .expect("read crates directory")
+            .map(|entry| entry.expect("read crate directory entry").path())
+            .filter(|path| path.is_dir())
+            .filter_map(|path| {
+                let cargo_toml = path.join("Cargo.toml");
+                let contents = fs::read_to_string(&cargo_toml).ok()?;
+                if contents.lines().any(|line| line.starts_with("version = ")) {
+                    Some(
+                        cargo_toml
+                            .strip_prefix(repo_root)
+                            .expect("crate manifest should be under repo root")
+                            .to_string_lossy()
+                            .replace('\\', "/"),
+                    )
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let bump_targets: BTreeSet<String> = TARGETS
+            .iter()
+            .filter_map(|target| match target.format {
+                Format::Toml
+                    if target.path.starts_with("crates/")
+                        && target.path.ends_with("/Cargo.toml") =>
+                {
+                    Some(target.path.to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        let missing_targets: Vec<&String> = versioned_crates.difference(&bump_targets).collect();
+
+        assert!(
+            missing_targets.is_empty(),
+            "versioned crate manifests missing from bump TARGETS: {missing_targets:#?}"
+        );
     }
 }

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Persistent notebook-backed Python REPL for Pi coding agents. Stateful execution, hot dependency sync, zero cold starts.",
   "author": "nteract contributors",
   "icon": "icon.png",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.2.1"
+version = "2.2.2"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.4.1"
+version = "0.4.2"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.5.1"
+version = "2.5.2"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.2.1"
+version = "0.2.2"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.5.1"
+version = "2.5.2"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- Bumps the coordinated release surfaces by one patch version.
- Adds the missing versioned Rust crates to `cargo xtask bump`.
- Adds an xtask regression test so future versioned crate manifests cannot drift out of `TARGETS` silently.
- Rebuilds the generated WASM/renderer plugin artifacts with `cargo xtask wasm`.

## Verification

- `cargo test -p xtask bump -- --nocapture`
- `cargo xtask wasm`
- `cargo xtask verify-plugins`
- `cargo check`
- `cargo xtask lint --fix`
