### PR TITLE
test(e2e): gate execution on session readiness

### DIFF
--- a/e2e/helpers-contract.test.mjs
+++ b/e2e/helpers-contract.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const helpersSource = readFileSync(new URL("./helpers.js", import.meta.url), "utf8");
+
+function exportedFunctionBody(name) {
+  const start = helpersSource.indexOf(`export async function ${name}`);
+  assert.notEqual(start, -1, `${name} should be exported`);
+  const nextExport = helpersSource.indexOf("\nexport async function ", start + 1);
+  return helpersSource.slice(start, nextExport === -1 ? undefined : nextExport);
+}
+
+test("waitForKernelReady gates execution on session runtime readiness", () => {
+  const body = exportedFunctionBody("waitForKernelReady");
+
+  assert.match(body, /getKernelStatus\(/);
+  assert.match(body, /getSessionRuntimeState\(/);
+  assert.match(body, /sessionState === "ready"/);
+  assert.doesNotMatch(body, /waitForNotebookSynced\(/);
+});
+
+test("waitForCellOutput stays scoped to the requested cell", () => {
+  const body = exportedFunctionBody("waitForCellOutput");
+
+  assert.doesNotMatch(body, /global output/i);
+  assert.doesNotMatch(body, /\$\(\s*selector\s*\)/);
+});

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -11,6 +11,46 @@ import { browser } from "@wdio/globals";
 // macOS uses Cmd (Meta) for shortcuts, Linux uses Ctrl
 const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
 
+function cellSelectorForId(cellId) {
+  return `[data-cell-id="${cellId.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"]`;
+}
+
+async function resolveCellElement(cell, cellId) {
+  try {
+    if (await cell.isExisting()) {
+      return cell;
+    }
+  } catch {
+    // The original element can go stale when the cell re-renders.
+  }
+
+  if (!cellId) {
+    return null;
+  }
+
+  const freshCell = await $(cellSelectorForId(cellId));
+  if (await freshCell.isExisting()) {
+    return freshCell;
+  }
+  return null;
+}
+
+async function findCellOutputElement(cell, cellId, outputSelectors) {
+  const currentCell = await resolveCellElement(cell, cellId);
+  if (!currentCell) {
+    return null;
+  }
+
+  for (const selector of outputSelectors) {
+    const output = await currentCell.$(selector);
+    if (await output.isExisting()) {
+      return output;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Wait for the app to be fully loaded (toolbar visible).
  * Uses browser.execute() (executeScript) which goes through the JS bridge
@@ -64,14 +104,11 @@ export async function waitForNotebookSynced(timeout = 15000) {
  * fail-closed until SessionControl reports runtime_state=ready.
  */
 export async function waitForSessionReady(timeout = 30000) {
-  await waitForNotebookSynced(timeout);
+  await waitForAppReady();
   try {
     await browser.waitUntil(
       async () => {
-        return await browser.execute(() => {
-          const el = document.querySelector("[data-session-ready]");
-          return el?.getAttribute("data-session-ready") === "true";
-        });
+        return (await getSessionRuntimeState()) === "ready";
       },
       {
         timeout,
@@ -80,10 +117,7 @@ export async function waitForSessionReady(timeout = 30000) {
       },
     );
   } catch (error) {
-    const state = await browser.execute(() => {
-      const el = document.querySelector("[data-session-runtime-state]");
-      return el?.getAttribute("data-session-runtime-state") ?? "missing";
-    });
+    const state = await getSessionRuntimeState();
     throw new Error(
       error instanceof Error
         ? `${error.message} (state=${state})`
@@ -114,19 +148,36 @@ export async function waitForCodeCells(expectedCount, timeout = 15000) {
 }
 
 /**
- * Wait for the kernel to reach idle or busy state.
- * Use this in specs that execute code — replaces both the 5000ms before()
- * pause AND the first kernel startup wait.
+ * Wait for the kernel to reach idle or busy state and for the session-control
+ * runtime gate to allow ExecuteCell.
  */
 export async function waitForKernelReady(timeout = 60000) {
   await waitForAppReady();
-  await browser.waitUntil(
-    async () => {
-      const text = await getKernelStatus();
-      return text === "idle" || text === "busy";
-    },
-    { timeout, interval: 200, timeoutMsg: "Kernel not ready" },
-  );
+  try {
+    await browser.waitUntil(
+      async () => {
+        const status = await getKernelStatus();
+        const sessionState = await getSessionRuntimeState();
+        return (
+          (status === "idle" || status === "busy") &&
+          sessionState === "ready"
+        );
+      },
+      {
+        timeout,
+        interval: 200,
+        timeoutMsg: "Kernel/session runtime not ready",
+      },
+    );
+  } catch (error) {
+    const status = await getKernelStatus();
+    const sessionState = await getSessionRuntimeState();
+    throw new Error(
+      error instanceof Error
+        ? `${error.message} (kernel=${status}, session=${sessionState})`
+        : `Kernel/session runtime not ready (kernel=${status}, session=${sessionState})`,
+    );
+  }
 }
 
 /**
@@ -135,8 +186,7 @@ export async function waitForKernelReady(timeout = 60000) {
  * Returns the cell element for further assertions.
  */
 export async function executeFirstCell() {
-  // Wait for the notebook to finish Automerge sync and render cells.
-  await waitForNotebookSynced();
+  await waitForSessionReady();
 
   const codeCell = await $('[data-cell-type="code"]');
   await codeCell.waitForExist({ timeout: 5000 });
@@ -166,8 +216,9 @@ export async function executeFirstCell() {
  * Wait for stream output to appear in a cell.
  * Returns the output text.
  *
- * Note: In daemon mode, the DOM may re-render after trust approval,
- * so we use a global selector if the cell-scoped one fails.
+ * The DOM may re-render after trust approval, so stale cell references are
+ * refreshed by `data-cell-id`. We deliberately do not accept any page output:
+ * a global output fallback can pass the wrong execution.
  */
 export async function waitForCellOutput(cell, timeout = 120000) {
   const outputSelectors = [
@@ -175,30 +226,12 @@ export async function waitForCellOutput(cell, timeout = 120000) {
     '[data-slot="ansi-error-output"]',
     '[data-slot="output-item"]',
   ];
+  const cellId = await cell.getAttribute("data-cell-id").catch(() => null);
 
   await browser.waitUntil(
     async () => {
-      // Try cell-scoped selectors first.
-      for (const selector of outputSelectors) {
-        try {
-          const output = await cell.$(selector);
-          if (await output.isExisting()) {
-            return true;
-          }
-        } catch {
-          // Cell reference may be stale, continue to global check.
-        }
-      }
-
-      // Fall back to global selectors (any output on page).
-      for (const selector of outputSelectors) {
-        const globalOutput = await $(selector);
-        if (await globalOutput.isExisting()) {
-          return true;
-        }
-      }
-
-      return false;
+      const output = await findCellOutputElement(cell, cellId, outputSelectors);
+      return output !== null;
     },
     {
       timeout,
@@ -207,23 +240,9 @@ export async function waitForCellOutput(cell, timeout = 120000) {
     },
   );
 
-  // Try cell-scoped first, then fall back to global.
-  for (const selector of outputSelectors) {
-    try {
-      const cellOutput = await cell.$(selector);
-      if (await cellOutput.isExisting()) {
-        return await cellOutput.getText();
-      }
-    } catch {
-      // Cell reference stale, use global check below.
-    }
-  }
-
-  for (const selector of outputSelectors) {
-    const globalOutput = await $(selector);
-    if (await globalOutput.isExisting()) {
-      return await globalOutput.getText();
-    }
+  const output = await findCellOutputElement(cell, cellId, outputSelectors);
+  if (output) {
+    return await output.getText();
   }
 
   return "";
@@ -384,6 +403,7 @@ export async function waitForKernelReadyWithTrust(timeout = 300000) {
 
   // Check if kernel is already ready (trusted notebook, or daemon auto-trust)
   if (initialStatus === "idle" || initialStatus === "busy") {
+    await waitForSessionReady(timeout);
     console.log("[trust] Kernel already ready, no trust needed");
     return false;
   }
@@ -468,10 +488,21 @@ export async function waitForKernelReadyWithTrust(timeout = 300000) {
   );
 
   const finalStatus = await getKernelStatus();
+  await waitForSessionReady(timeout);
   console.log(
     `[trust] Kernel ready: status=${finalStatus}, trustApproved=${trustApproved}`,
   );
   return trustApproved;
+}
+
+/**
+ * Get the current session-control runtime state.
+ */
+export async function getSessionRuntimeState() {
+  return await browser.execute(() => {
+    const el = document.querySelector("[data-session-runtime-state]");
+    return el?.getAttribute("data-session-runtime-state") ?? "missing";
+  });
 }
 
 /**

--- a/e2e/specs/dx-bootstrap-repr-llm.spec.js
+++ b/e2e/specs/dx-bootstrap-repr-llm.spec.js
@@ -13,6 +13,7 @@ import {
   waitForCellOutputMatching,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForSessionReady,
 } from "../helpers.js";
 
 const LLM_REPR_SENTINEL = "llm-e2e: dx bootstrap repr";
@@ -44,6 +45,7 @@ print("HAS_LLM_MIME", "text/llm+plain" in data)
 print("LLM_VALUE", data.get("text/llm+plain"))
 `.trim(),
     );
+    await waitForSessionReady();
 
     const executeButton = await codeCell.$('[data-testid="execute-button"]');
     if (await executeButton.isExisting()) {

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -16,6 +16,7 @@ import {
   waitForCellOutput,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForSessionReady,
 } from "../helpers.js";
 
 describe("Prewarmed Environment Pool", () => {
@@ -55,6 +56,7 @@ describe("Prewarmed Environment Pool", () => {
     // Ensure the cell has the right source via CodeMirror dispatch API.
     // The fixture has source but CRDT sync may not have delivered it yet.
     await setCellSource(codeCell, "import sys; print(sys.executable)");
+    await waitForSessionReady();
 
     // Execute via button click (reliable with tauri-plugin-webdriver)
     const executeButton = await codeCell.$('[data-testid="execute-button"]');

--- a/e2e/specs/smoke.spec.js
+++ b/e2e/specs/smoke.spec.js
@@ -17,6 +17,7 @@ import {
   waitForCellOutput,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForSessionReady,
 } from "../helpers.js";
 
 describe("E2E Smoke Test", () => {
@@ -43,6 +44,7 @@ describe("E2E Smoke Test", () => {
 
     // Set cell source via CodeMirror dispatch API (reliable with any WebDriver)
     await setCellSource(codeCell, "print('hello from e2e')");
+    await waitForSessionReady();
 
     // Execute via the execute button (more reliable than Shift+Enter with synthetic events)
     const executeButton = await codeCell.$('[data-testid="execute-button"]');
@@ -57,7 +59,7 @@ describe("E2E Smoke Test", () => {
       await browser.keys(["Shift", "Enter"]);
     }
 
-    // Wait for output to appear (uses global fallback for WRY compatibility)
+    // Wait for output to appear in the executed cell.
     const outputText = await waitForCellOutput(codeCell, 30000);
 
     // Verify output contains expected text

--- a/e2e/specs/untitled-pyproject.spec.js
+++ b/e2e/specs/untitled-pyproject.spec.js
@@ -20,6 +20,7 @@ import {
   waitForCellOutput,
   waitForKernelReady,
   waitForNotebookSynced,
+  waitForSessionReady,
 } from "../helpers.js";
 
 describe("Untitled Notebook with pyproject.toml", () => {
@@ -55,6 +56,7 @@ describe("Untitled Notebook with pyproject.toml", () => {
     const code = "import httpx; print(httpx.__version__)";
     console.log(`[untitled-pyproject] Setting cell source: ${code}`);
     await setCellSource(codeCell, code);
+    await waitForSessionReady();
 
     // Click the execute button explicitly
     const executeButton = await codeCell.$('[data-testid="execute-button"]');

--- a/e2e/specs/uv-pyproject.spec.js
+++ b/e2e/specs/uv-pyproject.spec.js
@@ -18,6 +18,7 @@ import {
   waitForKernelReady,
   waitForNotebookSynced,
   waitForOutputContaining,
+  waitForSessionReady,
 } from "../helpers.js";
 
 describe("UV pyproject.toml Detection", () => {
@@ -60,6 +61,7 @@ describe("UV pyproject.toml Detection", () => {
     // Set source via CodeMirror dispatch (no keyboard events)
     await setCellSource(codeCell, "import sys; print(sys.executable)");
     console.log("[uv-pyproject] Set cell source to print sys.executable.");
+    await waitForSessionReady();
 
     // Click the execute button
     const executeButton = await codeCell.$('[data-testid="execute-button"]');
@@ -86,6 +88,7 @@ describe("UV pyproject.toml Detection", () => {
     // Set source via CodeMirror dispatch (replaces typeSlowly + keyboard shortcuts)
     await setCellSource(cell, "import httpx; print(httpx.__version__)");
     console.log("[uv-pyproject] Set cell source to import httpx.");
+    await waitForSessionReady();
 
     // Click the execute button
     const executeButton = await cell.$('[data-testid="execute-button"]');


### PR DESCRIPTION
## Summary

- Tightens E2E readiness semantics so `waitForKernelReady` requires both toolbar kernel readiness and `SessionControl` runtime readiness before tests execute cells.
- Keeps output waits scoped to the requested cell by refreshing stale cell references through `data-cell-id` instead of accepting any output on the page.
- Adds explicit `waitForSessionReady()` calls before manual execute clicks in broad fixture specs.
- Adds a lightweight helper contract test covering the flake-prone readiness and output-scoping invariants.

## Verification

- `node --test e2e/helpers-contract.test.mjs`
- `node --check e2e/helpers.js`
- `node --check e2e/helpers-contract.test.mjs`
- `node --check e2e/specs/smoke.spec.js`
- `node --check e2e/specs/uv-pyproject.spec.js`
- `node --check e2e/specs/prewarmed-uv.spec.js`
- `node --check e2e/specs/dx-bootstrap-repr-llm.spec.js`
- `node --check e2e/specs/untitled-pyproject.spec.js`
- `cargo xtask lint --fix`

## Notes

- Draft because I did not run the full native WebDriver E2E suite locally.
- The original Actions link investigated here was a runtimed-py integration timeout cascade rather than a browser E2E failure, so this PR addresses the separate E2E helper flake risk from the project audit.
