### PR TITLE
Fail fast on hosted notebook-cloud route preflight

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
@@ -1,0 +1,8 @@
+const PREFLIGHT_FAILURE_KINDS = new Set(["render-api", "catalog-api"]);
+
+export function hasPreflightFailures(failures) {
+  return (
+    Array.isArray(failures) &&
+    failures.some((failure) => PREFLIGHT_FAILURE_KINDS.has(failure?.kind))
+  );
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -10,6 +10,7 @@ import {
   isFatalIsolatedDiagnostic,
   parseIsolatedDiagnosticText,
 } from "./hosted-render-smoke-diagnostics.mjs";
+import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import { catalogApiUrlForViewer, renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL =
@@ -161,6 +162,9 @@ async function main() {
         expectedLatestRevisionNotebookHeadsHash,
         expectedLatestRevisionRuntimeHeadsHash,
       });
+    }
+    if (hasPreflightFailures(failures)) {
+      throw new SmokeFailure(failures);
     }
 
     await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });

--- a/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { hasPreflightFailures } from "../scripts/hosted-render-smoke-preflight.mjs";
+
+describe("hosted render smoke preflight", () => {
+  it("fails fast for route-level render and catalog API failures", () => {
+    assert.equal(hasPreflightFailures([{ kind: "render-api" }]), true);
+    assert.equal(hasPreflightFailures([{ kind: "catalog-api" }]), true);
+  });
+
+  it("does not treat later browser-render failures as preflight failures", () => {
+    assert.equal(hasPreflightFailures([{ kind: "console-error" }]), false);
+    assert.equal(hasPreflightFailures([{ kind: "sift-wasm" }]), false);
+    assert.equal(hasPreflightFailures([]), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Fail hosted render smoke immediately when render/catalog API preflight checks fail.
- Add a small helper and unit coverage for route-level preflight failure detection.

## Verification

- `node --test apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs`
- `node --test apps/notebook-cloud/test/hosted-smoke-*.test.mjs apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs`
- `git diff --check`
- `NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=20000 NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT= NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS= NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS= NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT= NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER=0 NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0 NOTEBOOK_CLOUD_REQUIRE_RUNTIMED_WASM=0 NOTEBOOK_CLOUD_SMOKE_THEME_MODES= node scripts/hosted-render-smoke.mjs https://nteract-notebook-cloud.rgbkrk.workers.dev/n/topic-viz`

The deployed `topic-viz` URL currently reports structured `render-api` and `catalog-api` 404 failures.
