### PR TITLE
fix(notebook-cloud): allow public auth read fallback

### DIFF
--- a/apps/notebook-cloud/src/authorization.ts
+++ b/apps/notebook-cloud/src/authorization.ts
@@ -28,11 +28,22 @@ export class AuthorizationError extends Error {
   }
 }
 
+export interface AuthorizeNotebookAccessOptions {
+  /**
+   * Browser viewers can arrive with a stale or over-eager requested scope while
+   * still only being allowed to use the notebook's public read grant. Use this
+   * only on the live room connection path so mutation routes do not continue
+   * after a silent scope downgrade.
+   */
+  allowPublicViewerDowngrade?: boolean;
+}
+
 export async function authorizeNotebookAccess(
   env: Env,
   notebookId: string,
   identity: AuthenticatedConnection,
   requestedScope: ConnectionScope = identity.scope,
+  options: AuthorizeNotebookAccessOptions = {},
 ): Promise<AuthenticatedConnection> {
   if (!env.DB) {
     throw new AuthorizationError("D1 binding DB is not configured", 503);
@@ -58,11 +69,21 @@ export async function authorizeNotebookAccess(
   }
 
   const principalRows = await getNotebookAclRowsForPrincipal(env, notebookId, identity.principal);
-  if (!aclRowsCoverScope(principalRows, requestedScope)) {
-    throw new AuthorizationError(`${identity.principal} cannot access ${notebookId}`, 403);
+  if (aclRowsCoverScope(principalRows, requestedScope)) {
+    return { ...identity, scope: requestedScope };
   }
 
-  return { ...identity, scope: requestedScope };
+  const publicRows = await getPublicNotebookAclRows(env, notebookId);
+  if (aclRowsCoverScope(publicRows, "viewer")) {
+    if (requestedScope === "viewer") {
+      return { ...identity, scope: "viewer" };
+    }
+    if (options.allowPublicViewerDowngrade && requestedScope === "editor") {
+      return { ...identity, scope: "viewer" };
+    }
+  }
+
+  throw new AuthorizationError(`${identity.principal} cannot access ${notebookId}`, 403);
 }
 
 export function aclRowsCoverScope(

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -17,7 +17,11 @@ import {
   type ConnectionScope,
   validatePrincipal,
 } from "./identity.ts";
-import { AuthorizationError, authorizeNotebookAccess } from "./authorization.ts";
+import {
+  AuthorizationError,
+  authorizeNotebookAccess,
+  type AuthorizeNotebookAccessOptions,
+} from "./authorization.ts";
 import {
   blobKey,
   createNotebookWithOwnerAcl,
@@ -319,7 +323,15 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   if (!notebookId) {
     return json({ error: "notebook id is required" }, 400);
   }
-  const authorizedIdentity = await authorizeIdentityOrResponse(env, notebookId, identity);
+  const authorizedIdentity = await authorizeIdentityOrResponse(
+    env,
+    notebookId,
+    identity,
+    identity.scope,
+    {
+      allowPublicViewerDowngrade: true,
+    },
+  );
   if (authorizedIdentity instanceof Response) {
     return authorizedIdentity;
   }
@@ -1651,9 +1663,10 @@ async function authorizeIdentityOrResponse(
   notebookId: string,
   identity: AuthenticatedConnection,
   requestedScope: ConnectionScope = identity.scope,
+  options?: AuthorizeNotebookAccessOptions,
 ): Promise<AuthenticatedConnection | Response> {
   try {
-    return await authorizeNotebookAccess(env, notebookId, identity, requestedScope);
+    return await authorizeNotebookAccess(env, notebookId, identity, requestedScope, options);
   } catch (error) {
     if (error instanceof AuthorizationError) {
       cloudLog(error.status >= 500 ? "warn" : "info", "authz.denied", {

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
+  NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
   NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
   NOTEBOOK_CLOUD_USER_STORAGE_KEY,
@@ -85,6 +86,38 @@ describe("cloud collaborator auth", () => {
     assert.deepEqual(cloudHttpHeadersFromPrototypeAuthState(state), {
       Authorization: `Bearer ${accessToken}`,
     });
+  });
+
+  it("defaults OIDC browser sessions to viewer scope", () => {
+    const storage = new MemoryStorage();
+    const accessToken = jwt({
+      sub: "anaconda-user-456",
+      email: "anil@example.com",
+      email_verified: true,
+      name: "Anil",
+    });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken,
+        refreshToken: null,
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        claims: {
+          sub: "anaconda-user-456",
+          email: "anil@example.com",
+          email_verified: true,
+          name: "Anil",
+        },
+      }),
+    );
+
+    const state = readCloudPrototypeAuth(storage);
+    const auth = cloudSyncAuthFromPrototypeAuthState(state);
+
+    assert.equal(state.mode, "oidc");
+    assert.equal(state.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.equal(auth.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.match(prototypeAuthSummary(state), /Anil requesting viewer/);
   });
 
   it("can request an editor role from a browser Access session without JS token material", () => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -7,6 +7,7 @@ import {
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+  TRUSTED_SCOPE_HEADER,
   TRUSTED_WEBSOCKET_PROTOCOL_HEADER,
   authenticateDevRequest,
 } from "../src/identity.ts";
@@ -808,7 +809,7 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), { error: "notebook not found" });
   });
 
-  it("does not let authenticated principals fall back to public ACL rows", async () => {
+  it("lets authenticated principals read through public viewer ACL rows", async () => {
     const env = fakeEnv();
     seedNotebook(env, "public-demo");
     seedAcl(env, {
@@ -830,10 +831,14 @@ describe("Worker artifact routes", () => {
       env,
       fakeContext(),
     );
-    assert.equal(authenticated.status, 403);
-    assert.deepEqual(await authenticated.json(), {
-      error: "user:dev:bob cannot access public-demo",
-    });
+    assert.equal(authenticated.status, 200);
+
+    const ownerRoute = await worker.fetch(
+      new Request("http://localhost/api/n/public-demo/acl?user=bob&operator=desktop:b&scope=owner"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(ownerRoute.status, 403);
   });
 
   it("authorizes Cloudflare Access principals through notebook ACL rows", async () => {
@@ -2290,6 +2295,52 @@ describe("Worker artifact routes", () => {
       forwardedRequest.headers.get("Sec-WebSocket-Protocol"),
       NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
     );
+    assert.equal(
+      forwardedRequest.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER),
+      NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+    );
+  });
+
+  it("downgrades OIDC editor WebSocket requests to public viewer access", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "anil" });
+    let forwardedRequest: Request | undefined;
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "public-oidc-demo");
+    seedAcl(env, {
+      notebookId: "public-oidc-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/public-oidc-demo/sync?operator=browser:tab&scope=editor", {
+        headers: {
+          Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+            token,
+          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "viewer");
     assert.equal(
       forwardedRequest.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER),
       NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -18,6 +18,7 @@ import {
 export const NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY = "nteract:notebook-cloud:dev-token";
 export const NOTEBOOK_CLOUD_USER_STORAGE_KEY = "nteract:notebook-cloud:user";
 export const NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY = "nteract:notebook-cloud:scope";
+export const NOTEBOOK_CLOUD_DEFAULT_SCOPE: ConnectionScope = "viewer";
 export { NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY, NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY };
 
 export interface CloudSyncAuth {
@@ -93,7 +94,7 @@ export function readCloudPrototypeAuth(
         token: oidcSession.token.accessToken,
         user: oidcDisplayName(oidcSession.token.claims),
         oidcClaims: oidcSession.token.claims,
-        requestedScope: requestedScope ?? "editor",
+        requestedScope: requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
         problem: null,
       };
     }
@@ -103,7 +104,7 @@ export function readCloudPrototypeAuth(
         token: null,
         user: null,
         oidcClaims: null,
-        requestedScope: requestedScope ?? "editor",
+        requestedScope: requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
         problem: oidcSession.problem,
       };
     }
@@ -128,7 +129,7 @@ export function readCloudPrototypeAuth(
       token,
       user,
       oidcClaims: null,
-      requestedScope: requestedScope ?? "editor",
+      requestedScope: requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
       problem,
     };
   }
@@ -138,7 +139,7 @@ export function readCloudPrototypeAuth(
     token,
     user,
     oidcClaims: null,
-    requestedScope: requestedScope ?? "editor",
+    requestedScope: requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
     problem: null,
   };
 }
@@ -150,7 +151,7 @@ export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthSta
       protocols: [],
       user: null,
       operator: null,
-      requestedScope: state.requestedScope ?? "editor",
+      requestedScope: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
     };
   }
   if (state.mode === "oidc" && state.token) {
@@ -162,7 +163,7 @@ export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthSta
       ],
       user: null,
       operator: null,
-      requestedScope: state.requestedScope ?? "editor",
+      requestedScope: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
     };
   }
   if (state.mode !== "dev" || !state.token) {
@@ -177,7 +178,7 @@ export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthSta
     ],
     user: state.user ?? "browser-editor",
     operator: null,
-    requestedScope: state.requestedScope ?? "editor",
+    requestedScope: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   };
 }
 
@@ -260,13 +261,17 @@ export function validatePrototypeToken(token: string): string | null {
 
 export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
   if (state.mode === "dev") {
-    return `${state.user ?? "browser-editor"} requesting ${state.requestedScope ?? "editor"}`;
+    return `${state.user ?? "browser-editor"} requesting ${
+      state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE
+    }`;
   }
   if (state.mode === "oidc") {
-    return `${state.user ?? "OIDC session"} requesting ${state.requestedScope ?? "editor"}`;
+    return `${state.user ?? "OIDC session"} requesting ${
+      state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE
+    }`;
   }
   if (state.mode === "access") {
-    return `Browser session requesting ${state.requestedScope ?? "editor"}`;
+    return `Browser session requesting ${state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE}`;
   }
   if (state.mode === "invalid") {
     return `${state.problem ?? "Stored collaborator token is invalid"} Connected anonymously.`;
@@ -287,7 +292,7 @@ export function prototypeAuthDiagnostics(
       },
       {
         label: "Requested scope",
-        value: state.requestedScope ?? "editor",
+        value: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
       },
       {
         label: "Dev token",
@@ -302,7 +307,7 @@ export function prototypeAuthDiagnostics(
       },
       {
         label: "Requested scope",
-        value: state.requestedScope ?? "editor",
+        value: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
       },
       {
         label: "Credential",
@@ -324,7 +329,7 @@ export function prototypeAuthDiagnostics(
       },
       {
         label: "Requested scope",
-        value: state.requestedScope ?? "editor",
+        value: state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
       },
       {
         label: "Credential",
@@ -336,7 +341,7 @@ export function prototypeAuthDiagnostics(
       {
         label: "Stored identity",
         value: `${devPrincipalLabel(state.user ?? "browser-editor")} requesting ${
-          state.requestedScope ?? "editor"
+          state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE
         }`,
         tone: "warning",
       },

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -37,6 +37,7 @@ import {
   cloudPrototypeAuthFromWindow,
   cloudSyncAuthFromPrototypeAuthState,
   fetchWithCloudPrototypeAuth,
+  NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
@@ -227,7 +228,9 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
     cloudPrototypeAuthFromWindow(),
   );
-  const [scope, setScope] = useState<ConnectionScope>(authState.requestedScope ?? "editor");
+  const [scope, setScope] = useState<ConnectionScope>(
+    authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
+  );
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -882,7 +885,9 @@ function CloudAuthControls({
 }) {
   const [token, setToken] = useState("");
   const [user, setUser] = useState(authState.user ?? "alice");
-  const [scope, setScope] = useState<ConnectionScope>(authState.requestedScope ?? "editor");
+  const [scope, setScope] = useState<ConnectionScope>(
+    authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
+  );
   const [formError, setFormError] = useState<string | null>(null);
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");


### PR DESCRIPTION
## Summary

- let authenticated OIDC/dev principals read public notebooks through the explicit public viewer ACL row
- downgrade live-room `editor` WebSocket requests to `viewer` only when the notebook is public and only on the room route
- default first-time browser/OIDC prototype sessions to `viewer` instead of `editor`

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/worker-routes.test.ts test/authorization.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Hosted deployment

- deployed this branch to `preview.runt.run`
- `https://preview.runt.run/api/n/topic-viz/render` returns `200` anonymously
- hosted smoke against `https://preview.runt.run/n/topic-viz` passed with 23 rendered cells, Sift iframe text, theme checks, and isolated output frames on `preview.runtusercontent.com`
- `pr-review` report: `.context/reviews/pr-3058.json`, verdict `clear`
