### PR TITLE
feat(notebook-cloud): add hosted sharing controls

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -49,14 +49,21 @@ import { collectBlobRefs } from "./blob-refs.ts";
 import { cloudLog, durationMs } from "./observability.ts";
 import {
   createPendingNotebookInvite,
+  getPrincipalProfiles,
   getPendingNotebookInvitesForLogin,
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
   revokePendingNotebookInvite,
   type ListedPendingNotebookInviteRow,
   type PendingNotebookInviteRow,
+  type PrincipalProfileRow,
 } from "./sharing-storage.ts";
-import { normalizeInviteEmail, normalizeProviderHint } from "./sharing.ts";
+import {
+  normalizeInviteEmail,
+  normalizeProviderHint,
+  shareTargetDisplay,
+  type PrincipalProfile,
+} from "./sharing.ts";
 import {
   viewerThemeBootstrapScript,
   viewerThemeFirstPaintStyle,
@@ -908,6 +915,54 @@ function inviteResponse(
   };
 }
 
+async function aclResponseRows(
+  env: Env,
+  rows: NotebookAclRow[],
+): Promise<Array<NotebookAclRow & { display: ReturnType<typeof shareTargetDisplay> }>> {
+  const principals = rows
+    .filter((row) => row.subject_kind === "principal")
+    .map((row) => row.subject);
+  const profilesByPrincipal = new Map(
+    (await getPrincipalProfiles(env, principals)).map((profile) => [profile.principal, profile]),
+  );
+  return rows.map((row) => aclRowResponse(row, profilesByPrincipal.get(row.subject)));
+}
+
+function aclRowResponse(
+  row: NotebookAclRow,
+  profile?: PrincipalProfileRow,
+): NotebookAclRow & { display: ReturnType<typeof shareTargetDisplay> } {
+  if (row.subject_kind === "public") {
+    return {
+      ...row,
+      display: shareTargetDisplay({ publicViewer: true }),
+    };
+  }
+
+  return {
+    ...row,
+    display: profile
+      ? shareTargetDisplay({ profile: principalProfileFromRow(profile) })
+      : {
+          kind: "principal",
+          label: row.subject,
+          principal: row.subject,
+          email: null,
+        },
+  };
+}
+
+function principalProfileFromRow(row: PrincipalProfileRow): PrincipalProfile {
+  return {
+    principal: row.principal,
+    provider: row.provider,
+    email: row.email_normalized,
+    displayName: row.display_name,
+    firstSeenAt: row.first_seen_at,
+    lastSeenAt: row.last_seen_at,
+  };
+}
+
 async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
@@ -926,9 +981,10 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
   }
 
   if (request.method === "GET") {
+    const acl = await getNotebookAclRows(env, notebookId);
     return json({
       notebook_id: notebookId,
-      acl: await getNotebookAclRows(env, notebookId),
+      acl: await aclResponseRows(env, acl),
     });
   }
 
@@ -969,7 +1025,7 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
     return json({
       ok: true,
       notebook_id: notebookId,
-      acl,
+      acl: await aclResponseRows(env, acl),
     });
   }
 
@@ -994,7 +1050,7 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
     {
       ok: true,
       notebook_id: notebookId,
-      acl: await getNotebookAclRows(env, notebookId),
+      acl: await aclResponseRows(env, await getNotebookAclRows(env, notebookId)),
     },
     201,
   );
@@ -1840,13 +1896,16 @@ function normalizedRuntimeHeadsHash(value: string | null): string | null {
 function viewer(notebookId: string, request: Request, env: Env, headsHash?: string): Response {
   const escaped = escapeHtml(notebookId);
   const title = headsHash ? `${escaped} @ ${escapeHtml(headsHash)}` : escaped;
+  const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const renderEndpoint = headsHash
-    ? `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`
-    : `/api/n/${encodeURIComponent(notebookId)}/render`;
+    ? `${notebookApiBasePath}/renders/${encodeURIComponent(headsHash)}`
+    : `${notebookApiBasePath}/render`;
   const config = {
     notebookId,
     headsHash: headsHash ?? null,
     renderEndpoint,
+    aclEndpoint: `${notebookApiBasePath}/acl`,
+    invitesEndpoint: `${notebookApiBasePath}/invites`,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),
     rendererAssetsBasePath: rendererAssetsBasePath(env),

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -9,6 +9,8 @@ import {
   type PendingNotebookInvite,
 } from "./sharing.ts";
 
+const PRINCIPAL_PROFILE_LOOKUP_BATCH_SIZE = 50;
+
 export interface PrincipalProfileRow {
   principal: string;
   provider: string;
@@ -143,6 +145,49 @@ export async function getPrincipalProfile(
   )
     .bind(principal)
     .first<PrincipalProfileRow>();
+}
+
+export async function getPrincipalProfiles(
+  env: Env,
+  principals: string[],
+): Promise<PrincipalProfileRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  const uniquePrincipals = Array.from(new Set(principals.filter((principal) => principal)));
+  if (uniquePrincipals.length === 0) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const profiles: PrincipalProfileRow[] = [];
+  for (
+    let index = 0;
+    index < uniquePrincipals.length;
+    index += PRINCIPAL_PROFILE_LOOKUP_BATCH_SIZE
+  ) {
+    const batch = uniquePrincipals.slice(index, index + PRINCIPAL_PROFILE_LOOKUP_BATCH_SIZE);
+    const placeholders = batch.map(() => "?").join(", ");
+    const rows = await env.DB.prepare(
+      `SELECT principal,
+              provider,
+              provider_subject,
+              email_normalized,
+              email_verified,
+              display_name,
+              avatar_url,
+              first_seen_at,
+              last_seen_at,
+              raw_claims_json
+         FROM principal_profiles
+         WHERE principal IN (${placeholders})`,
+    )
+      .bind(...batch)
+      .all<PrincipalProfileRow>();
+    profiles.push(...(rows.results ?? []));
+  }
+  return profiles;
 }
 
 export async function createPendingNotebookInvite(

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -69,6 +69,8 @@ describe("HTML script serialization", () => {
       "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
     );
     assert.match(html, /"renderEndpoint":"\/api\/n\/demo\/renders\/heads-123"/);
+    assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
+    assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "../src/cloudflare-types.ts";
 import {
   createPendingNotebookInvite,
+  getPrincipalProfiles,
   resolveNotebookInvitesForLogin,
   upsertPrincipalProfile,
   type PendingNotebookInviteRow,
@@ -47,6 +48,64 @@ describe("hosted sharing storage", () => {
     assert.equal(profile?.display_name, "Alice Updated");
     assert.equal(profile?.first_seen_at, "2026-05-24T12:00:00.000Z");
     assert.equal(profile?.last_seen_at, "2026-05-24T12:05:00.000Z");
+  });
+
+  it("loads multiple principal profiles in one batch", async () => {
+    const env = fakeEnv();
+    await upsertPrincipalProfile(env, {
+      principal: "user:cloudflare-access:access-sub-1",
+      provider: "cloudflare-access",
+      providerSubject: "access-sub-1",
+      email: "alice@example.com",
+      emailVerified: true,
+      displayName: "Alice Example",
+      timestamp: "2026-05-24T12:00:00.000Z",
+    });
+    await upsertPrincipalProfile(env, {
+      principal: "user:cloudflare-access:access-sub-2",
+      provider: "cloudflare-access",
+      providerSubject: "access-sub-2",
+      email: "bob@example.com",
+      emailVerified: true,
+      displayName: "Bob Example",
+      timestamp: "2026-05-24T12:01:00.000Z",
+    });
+
+    const profiles = await getPrincipalProfiles(env, [
+      "user:cloudflare-access:access-sub-1",
+      "user:cloudflare-access:access-sub-1",
+      "missing",
+      "user:cloudflare-access:access-sub-2",
+    ]);
+
+    assert.deepEqual(profiles.map((profile) => profile.principal).sort(), [
+      "user:cloudflare-access:access-sub-1",
+      "user:cloudflare-access:access-sub-2",
+    ]);
+  });
+
+  it("loads principal profiles in chunks below D1 bind limits", async () => {
+    const env = fakeEnv();
+    const principals = Array.from(
+      { length: 125 },
+      (_, index) => `user:cloudflare-access:access-sub-${index}`,
+    );
+    for (const [index, principal] of principals.entries()) {
+      await upsertPrincipalProfile(env, {
+        principal,
+        provider: "cloudflare-access",
+        providerSubject: `access-sub-${index}`,
+        email: `user-${index}@example.com`,
+        emailVerified: true,
+        displayName: `User ${index}`,
+        timestamp: "2026-05-24T12:00:00.000Z",
+      });
+    }
+
+    const profiles = await getPrincipalProfiles(env, principals);
+
+    assert.equal(profiles.length, 125);
+    assert.equal(env.DB.maxPrincipalProfileLookupBindCount, 50);
   });
 
   it("backfills provider subject when a profile was first seen without one", async () => {
@@ -576,6 +635,7 @@ class FakeD1 implements D1Database {
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly acl: NotebookAclRow[] = [];
   readonly deletedNotebookIds = new Set<string>();
+  maxPrincipalProfileLookupBindCount = 0;
   beforeInviteInsert?: (input: {
     notebookId: string;
     emailNormalized: string;
@@ -810,6 +870,21 @@ class FakeD1Statement implements D1PreparedStatement {
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (this.query.startsWith("PRAGMA table_info")) {
       return okResult([{ name: "runtime_snapshot_key" }] as T[]);
+    }
+    if (this.query.includes("FROM principal_profiles")) {
+      const principals = new Set(this.values as string[]);
+      this.db.maxPrincipalProfileLookupBindCount = Math.max(
+        this.db.maxPrincipalProfileLookupBindCount,
+        this.values.length,
+      );
+      if (this.values.length > 100) {
+        throw new Error("D1_ERROR: too many SQL variables");
+      }
+      return okResult(
+        [...this.db.profiles.values()].filter((profile) =>
+          principals.has(profile.principal),
+        ) as T[],
+      );
     }
     if (this.query.includes("FROM notebook_invites")) {
       const [email, provider, now] = this.values as [string, string, string];

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCloudShareAccessRows,
+  hasPublicViewerAccess,
+  normalizeShareInviteEmail,
+  scopeLabel,
+  type CloudNotebookAclRow,
+  type CloudNotebookInvite,
+} from "../viewer/sharing-client.ts";
+
+describe("cloud viewer sharing client", () => {
+  it("orders current access like the sharing dialog expects", () => {
+    const acl: CloudNotebookAclRow[] = [
+      aclRow({
+        subject_kind: "public",
+        subject: "anonymous",
+        scope: "viewer",
+        display: { kind: "public_viewer", label: "Anyone with the link" },
+      }),
+      aclRow({
+        subject: "user:anaconda:bob",
+        scope: "editor",
+        display: {
+          kind: "principal",
+          label: "Bob Example",
+          principal: "user:anaconda:bob",
+          email: "bob@example.com",
+        },
+      }),
+      aclRow({
+        subject: "user:anaconda:alice",
+        scope: "owner",
+        display: {
+          kind: "principal",
+          label: "Alice Owner",
+          principal: "user:anaconda:alice",
+          email: "alice@example.com",
+        },
+      }),
+    ];
+    const invites: CloudNotebookInvite[] = [
+      inviteRow({ id: "invite-1", email: "carol@example.com", scope: "viewer" }),
+      inviteRow({ id: "invite-2", email: "done@example.com", status: "accepted" }),
+    ];
+
+    const rows = buildCloudShareAccessRows({ acl, invites });
+
+    assert.deepEqual(
+      rows.map((row) => [row.kind, row.label, row.badge, row.removable]),
+      [
+        ["acl", "Alice Owner", "Owner", false],
+        ["acl", "Bob Example", "Can edit", true],
+        ["acl", "Anyone with the link", "Can view", true],
+        ["invite", "carol@example.com", "Can view", true],
+      ],
+    );
+  });
+
+  it("detects public viewer access from explicit public ACL rows", () => {
+    assert.equal(
+      hasPublicViewerAccess([
+        aclRow({ subject_kind: "public", subject: "anonymous", scope: "viewer" }),
+      ]),
+      true,
+    );
+    assert.equal(hasPublicViewerAccess([aclRow({ subject: "user:anaconda:alice" })]), false);
+  });
+
+  it("keeps share invite email validation in the viewer before owner mutations", () => {
+    assert.equal(normalizeShareInviteEmail(" Bob@Example.COM "), "bob@example.com");
+    assert.equal(normalizeShareInviteEmail("not an email"), null);
+    assert.equal(normalizeShareInviteEmail("bad/provider@example.com"), null);
+  });
+
+  it("labels supported cloud share scopes", () => {
+    assert.equal(scopeLabel("owner"), "Owner");
+    assert.equal(scopeLabel("editor"), "Can edit");
+    assert.equal(scopeLabel("runtime_peer"), "Runtime");
+    assert.equal(scopeLabel("viewer"), "Can view");
+  });
+});
+
+function aclRow(overrides: Partial<CloudNotebookAclRow> = {}): CloudNotebookAclRow {
+  return {
+    notebook_id: "topic-viz",
+    subject_kind: "principal",
+    subject: "user:anaconda:alice",
+    scope: "viewer",
+    created_at: "2026-05-28T00:00:00.000Z",
+    updated_at: "2026-05-28T00:00:00.000Z",
+    created_by_actor_label: "user:anaconda:alice/browser:viewer",
+    ...overrides,
+  };
+}
+
+function inviteRow(overrides: Partial<CloudNotebookInvite> = {}): CloudNotebookInvite {
+  return {
+    id: "invite-1",
+    notebook_id: "topic-viz",
+    email: "bob@example.com",
+    provider_hint: null,
+    scope: "editor",
+    status: "pending",
+    invited_by_actor_label: "user:anaconda:alice/browser:viewer",
+    accepted_by_principal: null,
+    created_at: "2026-05-28T00:00:00.000Z",
+    expires_at: null,
+    accepted_at: null,
+    revoked_at: null,
+    revoked_by_actor_label: null,
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1366,6 +1366,54 @@ describe("Worker artifact routes", () => {
     assert.equal(hiddenAgain.status, 404);
   });
 
+  it("returns display metadata for ACL sharing rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "acl-display-demo");
+    seedAcl(env, {
+      notebookId: "acl-display-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "acl-display-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    env.DB.profiles.set("user:dev:alice", {
+      principal: "user:dev:alice",
+      provider: "dev",
+      provider_subject: "alice",
+      email_normalized: "alice@example.com",
+      email_verified: 1,
+      display_name: "Alice Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const response = await aclRequest(env, "GET", undefined, "acl-display-demo");
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { acl: Array<Record<string, unknown>> };
+    assert.deepEqual(
+      body.acl.map((row) => row.display),
+      [
+        {
+          kind: "principal",
+          label: "Alice Example",
+          principal: "user:dev:alice",
+          email: "alice@example.com",
+        },
+        {
+          kind: "public_viewer",
+          label: "Anyone with the link",
+        },
+      ],
+    );
+  });
+
   it("keeps ACL management owner-only and public grants viewer-only", async () => {
     const env = fakeEnv();
     seedNotebook(env, "acl-private-demo");
@@ -3423,6 +3471,17 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("FROM principal_profiles")) {
+      const principals = new Set(this.values as string[]);
+      if (this.values.length > 100) {
+        throw new Error("D1_ERROR: too many SQL variables");
+      }
+      return okResult(
+        [...this.db.profiles.values()].filter((profile) =>
+          principals.has(profile.principal),
+        ) as T[],
+      );
+    }
     if (
       this.query.includes("FROM notebook_invites") &&
       this.query.includes("WHERE notebook_id = ?")

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -225,6 +225,11 @@ body {
   position: relative;
 }
 
+.cloud-share-menu {
+  position: relative;
+}
+
+.cloud-share-menu summary,
 .cloud-auth-menu summary {
   display: inline-flex;
   align-items: center;
@@ -248,16 +253,23 @@ body {
   display: none;
 }
 
+.cloud-share-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.cloud-share-menu summary:hover,
 .cloud-auth-menu summary:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
 }
 
+.cloud-share-menu summary:focus-visible,
 .cloud-auth-menu summary:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
+.cloud-share-menu svg,
 .cloud-auth-menu svg,
 .cloud-auth-state svg {
   width: 1rem;
@@ -265,6 +277,7 @@ body {
   flex: 0 0 auto;
 }
 
+.cloud-share-menu summary span,
 .cloud-auth-menu summary span {
   min-width: 0;
   overflow: hidden;
@@ -272,6 +285,211 @@ body {
   white-space: nowrap;
   font-size: 0.8125rem;
   line-height: 1;
+}
+
+.cloud-share-panel {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  z-index: 30;
+  display: grid;
+  gap: 0.875rem;
+  width: min(28rem, calc(100vw - 1.5rem));
+  max-height: min(42rem, calc(100vh - 5rem));
+  overflow: auto;
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 8px;
+  padding: 0.875rem;
+  color: var(--foreground);
+  background: var(--background);
+  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
+}
+
+.cloud-share-panel header,
+.cloud-share-public {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cloud-share-panel h2,
+.cloud-share-panel h3,
+.cloud-share-panel p {
+  margin: 0;
+}
+
+.cloud-share-panel h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.cloud-share-panel h3 {
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.cloud-share-panel p {
+  margin-top: 0.1875rem;
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-share-panel button,
+.cloud-share-invite input,
+.cloud-share-invite select {
+  min-width: 0;
+  height: 2rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font-size: 0.8125rem;
+}
+
+.cloud-share-panel button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding-inline: 0.625rem;
+}
+
+.cloud-share-panel button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 10%);
+}
+
+.cloud-share-panel button:disabled {
+  cursor: progress;
+  opacity: 0.62;
+}
+
+.cloud-share-public {
+  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+}
+
+.cloud-share-public > div {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.625rem;
+  align-items: start;
+  min-width: 0;
+}
+
+.cloud-share-public strong,
+.cloud-share-current strong {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.cloud-share-public span,
+.cloud-share-current li > div > span,
+.cloud-share-empty {
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.cloud-share-invite {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(6rem, 0.35fr) auto;
+  gap: 0.5rem;
+  align-items: end;
+}
+
+.cloud-share-invite label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.cloud-share-invite input,
+.cloud-share-invite select {
+  padding-inline: 0.625rem;
+}
+
+.cloud-share-invite .cloud-auth-form-error {
+  grid-column: 1 / -1;
+}
+
+.cloud-share-current {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.cloud-share-current ul {
+  display: grid;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.cloud-share-current li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  gap: 0.5rem;
+  align-items: center;
+  min-width: 0;
+  border: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+  border-radius: 8px;
+  padding: 0.5rem;
+  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+}
+
+.cloud-share-current li > svg,
+.cloud-share-public > div > svg {
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+}
+
+.cloud-share-current li > div {
+  min-width: 0;
+}
+
+.cloud-share-badge {
+  border-radius: 999px;
+  padding: 0.1875rem 0.5rem;
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--foreground) 9%, transparent);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.cloud-share-current li button {
+  width: 2rem;
+  padding-inline: 0;
+}
+
+.cloud-share-message {
+  border: 1px solid color-mix(in srgb, #0f766e 30%, transparent);
+  border-radius: 6px;
+  padding: 0.5rem 0.625rem;
+  color: #0f766e;
+  background: color-mix(in srgb, #0f766e 8%, var(--background));
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-share-message[data-kind="error"] {
+  border-color: color-mix(in srgb, #b42318 40%, transparent);
+  color: #b42318;
+  background: color-mix(in srgb, #b42318 8%, var(--background));
 }
 
 .cloud-auth-menu form {
@@ -428,6 +646,24 @@ body {
 .cloud-code-toggle svg {
   width: 1rem;
   height: 1rem;
+}
+
+@media (max-width: 640px) {
+  .cloud-share-invite {
+    grid-template-columns: 1fr;
+  }
+
+  .cloud-share-current li {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .cloud-share-current li button {
+    grid-column: 3;
+  }
+
+  .cloud-share-badge {
+    justify-self: end;
+  }
 }
 
 .cloud-report-notebook {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -5,10 +5,16 @@ import {
   Copy,
   Eye,
   EyeOff,
+  Globe2,
   KeyRound,
+  Link2,
   LogIn,
   LogOut,
+  Mail,
   RotateCcw,
+  Share2,
+  Trash2,
+  UserRound,
   UsersRound,
 } from "lucide-react";
 import {
@@ -69,6 +75,15 @@ import {
   reduceCloudViewerPresenceMessage,
 } from "./presence";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
+import {
+  buildCloudShareAccessRows,
+  hasPublicViewerAccess,
+  normalizeShareInviteEmail,
+  type CloudNotebookAclRow,
+  type CloudNotebookInvite,
+  type CloudShareAccessRow,
+  type CloudShareInviteScope,
+} from "./sharing-client";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import {
@@ -87,6 +102,8 @@ interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
   renderEndpoint: string;
+  aclEndpoint: string;
+  invitesEndpoint: string;
   syncEndpoint: string;
   blobBasePath: string;
   rendererAssetsBasePath: string;
@@ -139,6 +156,8 @@ function loadConfig(): CloudViewerConfig {
   if (
     !parsed.notebookId ||
     !parsed.renderEndpoint ||
+    !parsed.aclEndpoint ||
+    !parsed.invitesEndpoint ||
     !parsed.syncEndpoint ||
     !parsed.blobBasePath ||
     !parsed.rendererAssetsBasePath ||
@@ -151,6 +170,8 @@ function loadConfig(): CloudViewerConfig {
     notebookId: parsed.notebookId,
     headsHash: parsed.headsHash ?? null,
     renderEndpoint: parsed.renderEndpoint,
+    aclEndpoint: parsed.aclEndpoint,
+    invitesEndpoint: parsed.invitesEndpoint,
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
     rendererAssetsBasePath: parsed.rendererAssetsBasePath,
@@ -776,6 +797,14 @@ function NotebookViewer({
         <div className="cloud-toolbar-actions">
           <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
 
+          {connectionScope === "owner" ? (
+            <CloudSharingControls
+              aclEndpoint={config.aclEndpoint}
+              invitesEndpoint={config.invitesEndpoint}
+              authState={authState}
+            />
+          ) : null}
+
           <CloudAuthControls
             authConfig={authConfig}
             authState={authState}
@@ -866,6 +895,350 @@ function NotebookViewer({
       )}
     </main>
   );
+}
+
+function CloudSharingControls({
+  aclEndpoint,
+  invitesEndpoint,
+  authState,
+}: {
+  aclEndpoint: string;
+  invitesEndpoint: string;
+  authState: CloudPrototypeAuthState;
+}) {
+  const [open, setOpen] = useState(false);
+  const [acl, setAcl] = useState<CloudNotebookAclRow[]>([]);
+  const [invites, setInvites] = useState<CloudNotebookInvite[]>([]);
+  const [loadState, setLoadState] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageKind, setMessageKind] = useState<"info" | "error">("info");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteScope, setInviteScope] = useState<CloudShareInviteScope>("viewer");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const inviteSubmitLockRef = useRef(false);
+  const publicLink = new URL(window.location.pathname, window.location.origin).href;
+  const accessRows = useMemo(() => buildCloudShareAccessRows({ acl, invites }), [acl, invites]);
+  const publicEnabled = useMemo(() => hasPublicViewerAccess(acl), [acl]);
+  const inviteReady = normalizeShareInviteEmail(inviteEmail) !== null;
+
+  const loadSharingState = useCallback(
+    async (options?: { preserveMessage?: boolean; signal?: AbortSignal }) => {
+      setLoadState("loading");
+      if (!options?.preserveMessage) {
+        setMessage(null);
+      }
+      try {
+        const [aclResponse, invitesResponse] = await Promise.all([
+          fetchWithCloudPrototypeAuth(
+            aclEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            authState,
+          ),
+          fetchWithCloudPrototypeAuth(
+            invitesEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            authState,
+          ),
+        ]);
+        if (options?.signal?.aborted) {
+          return;
+        }
+        if (!aclResponse.ok) {
+          throw await cloudResponseError(aclResponse, "Unable to load access list");
+        }
+        if (!invitesResponse.ok) {
+          throw await cloudResponseError(invitesResponse, "Unable to load invites");
+        }
+        const aclBody = (await aclResponse.json()) as { acl?: CloudNotebookAclRow[] };
+        const invitesBody = (await invitesResponse.json()) as { invites?: CloudNotebookInvite[] };
+        setAcl(Array.isArray(aclBody.acl) ? aclBody.acl : []);
+        setInvites(Array.isArray(invitesBody.invites) ? invitesBody.invites : []);
+        setLoadState("ready");
+      } catch (error) {
+        if (options?.signal?.aborted) {
+          return;
+        }
+        setLoadState("error");
+        setMessageKind("error");
+        setMessage(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [aclEndpoint, authState, invitesEndpoint],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    void loadSharingState({ signal: controller.signal });
+    return () => controller.abort();
+  }, [loadSharingState, open]);
+
+  const copyPublicLink = async () => {
+    try {
+      await navigator.clipboard.writeText(publicLink);
+      setCopyState("copied");
+      setMessageKind("info");
+      setMessage("Link copied.");
+    } catch {
+      setCopyState("failed");
+      setMessageKind("error");
+      setMessage("Unable to copy the link.");
+    }
+  };
+
+  const submitInvite = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (inviteSubmitLockRef.current) {
+      return;
+    }
+    const email = normalizeShareInviteEmail(inviteEmail);
+    if (!email) {
+      setFormError("Enter a valid email address.");
+      return;
+    }
+
+    inviteSubmitLockRef.current = true;
+    setBusyAction("invite");
+    setFormError(null);
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        invitesEndpoint,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email, scope: inviteScope }),
+        },
+        authState,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to create invite");
+      }
+      setInviteEmail("");
+      setMessageKind("info");
+      setMessage(`Invite created for ${email}.`);
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      inviteSubmitLockRef.current = false;
+      setBusyAction(null);
+    }
+  };
+
+  const togglePublicAccess = async () => {
+    setBusyAction("public");
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        aclEndpoint,
+        {
+          method: publicEnabled ? "DELETE" : "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            subject_kind: "public",
+            subject: "anonymous",
+            scope: "viewer",
+          }),
+        },
+        authState,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(
+          response,
+          publicEnabled ? "Unable to disable public link" : "Unable to enable public link",
+        );
+      }
+      setMessageKind("info");
+      setMessage(publicEnabled ? "Public link disabled." : "Public link enabled.");
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const removeAccessRow = async (row: CloudShareAccessRow) => {
+    if (!row.removable) return;
+
+    setBusyAction(row.id);
+    setMessage(null);
+    try {
+      const response =
+        row.kind === "invite"
+          ? await fetchWithCloudPrototypeAuth(
+              appendEndpointPathSegment(invitesEndpoint, row.invite.id),
+              {
+                method: "DELETE",
+                headers: { Accept: "application/json" },
+              },
+              authState,
+            )
+          : await fetchWithCloudPrototypeAuth(
+              aclEndpoint,
+              {
+                method: "DELETE",
+                headers: {
+                  Accept: "application/json",
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  subject_kind: row.acl.subject_kind,
+                  subject: row.acl.subject,
+                  scope: row.acl.scope,
+                }),
+              },
+              authState,
+            );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to remove access");
+      }
+      setMessageKind("info");
+      setMessage(`${row.label} removed.`);
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  return (
+    <details
+      className="cloud-share-menu"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary title="Share notebook">
+        <Share2 aria-hidden="true" />
+        <span>Share</span>
+      </summary>
+      <div className="cloud-share-panel">
+        <header>
+          <div>
+            <h2>Share notebook</h2>
+            <p>Manage public read access and collaborator invites for this cloud notebook.</p>
+          </div>
+          <button type="button" onClick={() => void copyPublicLink()}>
+            <Link2 aria-hidden="true" />
+            {copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy failed" : "Copy"}
+          </button>
+        </header>
+
+        <section className="cloud-share-public" aria-label="Public link access">
+          <div>
+            <Globe2 aria-hidden="true" />
+            <div>
+              <strong>Anyone with the link</strong>
+              <span>{publicEnabled ? "Can view this notebook" : "No anonymous access"}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled={busyAction === "public" || loadState === "loading"}
+            onClick={() => void togglePublicAccess()}
+          >
+            {publicEnabled ? "Disable" : "Enable"}
+          </button>
+        </section>
+
+        <form className="cloud-share-invite" onSubmit={submitInvite}>
+          <label>
+            <span>Invite by email</span>
+            <input
+              type="email"
+              value={inviteEmail}
+              placeholder="name@example.com"
+              autoComplete="email"
+              onChange={(event) => {
+                setInviteEmail(event.target.value);
+                setFormError(null);
+              }}
+            />
+          </label>
+          <label>
+            <span>Access</span>
+            <select
+              value={inviteScope}
+              onChange={(event) => setInviteScope(event.target.value as CloudShareInviteScope)}
+            >
+              <option value="viewer">Can view</option>
+              <option value="editor">Can edit</option>
+            </select>
+          </label>
+          <button type="submit" disabled={!inviteReady || busyAction === "invite"}>
+            <Mail aria-hidden="true" />
+            Invite
+          </button>
+          {formError ? (
+            <div className="cloud-auth-form-error" role="alert">
+              {formError}
+            </div>
+          ) : null}
+        </form>
+
+        <section className="cloud-share-current" aria-label="Current notebook access">
+          <h3>Current access</h3>
+          {loadState === "loading" && accessRows.length === 0 ? (
+            <div className="cloud-share-empty">Loading access...</div>
+          ) : accessRows.length === 0 ? (
+            <div className="cloud-share-empty">Only the owner can access this notebook.</div>
+          ) : (
+            <ul>
+              {accessRows.map((row) => (
+                <li key={row.id}>
+                  <CloudShareRowIcon row={row} />
+                  <div>
+                    <strong>{row.label}</strong>
+                    <span>{row.detail}</span>
+                  </div>
+                  <span className="cloud-share-badge">{row.badge}</span>
+                  {row.removable ? (
+                    <button
+                      type="button"
+                      aria-label={`Remove ${row.label}`}
+                      title={`Remove ${row.label}`}
+                      disabled={busyAction === row.id}
+                      onClick={() => void removeAccessRow(row)}
+                    >
+                      <Trash2 aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {message ? (
+          <div className="cloud-share-message" data-kind={messageKind}>
+            {message}
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
+  if (row.kind === "invite") {
+    return <Mail aria-hidden="true" />;
+  }
+  if (row.acl.subject_kind === "public") {
+    return <Globe2 aria-hidden="true" />;
+  }
+  return <UserRound aria-hidden="true" />;
 }
 
 function CloudAuthControls({
@@ -1206,6 +1579,23 @@ const EMPTY_REMOTE_CELL_PRESENCE: RemoteCellPresence = {
 
 function canEditLiveNotebook(connectionScope: string | null): boolean {
   return connectionScope === "editor" || connectionScope === "owner";
+}
+
+function appendEndpointPathSegment(endpoint: string, segment: string): string {
+  const base = endpoint.endsWith("/") ? endpoint.slice(0, -1) : endpoint;
+  return `${base}/${encodeURIComponent(segment)}`;
+}
+
+async function cloudResponseError(response: Response, fallback: string): Promise<Error> {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    if (typeof body.error === "string" && body.error) {
+      return new Error(`${fallback}: ${body.error}`);
+    }
+  } catch {
+    // Ignore malformed error responses and fall back to the HTTP status.
+  }
+  return new Error(`${fallback}: ${response.status}`);
 }
 
 function ViewerStartupError({ message }: { message: string }) {

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -1,0 +1,176 @@
+export type CloudShareScope = "viewer" | "editor" | "runtime_peer" | "owner";
+export type CloudShareInviteScope = "viewer" | "editor";
+export type CloudInviteStatus = "pending" | "accepted" | "revoked" | "expired";
+
+export type CloudShareDisplay =
+  | {
+      kind: "principal";
+      label: string;
+      principal: string;
+      email: string | null;
+    }
+  | {
+      kind: "pending_invite";
+      label: string;
+      email: string;
+    }
+  | {
+      kind: "public_viewer";
+      label: string;
+    };
+
+export interface CloudNotebookAclRow {
+  notebook_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: CloudShareScope;
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+  display?: CloudShareDisplay;
+}
+
+export interface CloudNotebookInvite {
+  id: string;
+  notebook_id: string;
+  email: string;
+  provider_hint: string | null;
+  scope: CloudShareInviteScope;
+  status: CloudInviteStatus;
+  invited_by_actor_label: string;
+  accepted_by_principal: string | null;
+  created_at: string;
+  expires_at: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  revoked_by_actor_label: string | null;
+  display?: CloudShareDisplay;
+}
+
+export type CloudShareAccessRow =
+  | {
+      id: string;
+      kind: "acl";
+      acl: CloudNotebookAclRow;
+      label: string;
+      detail: string;
+      scope: CloudShareScope;
+      badge: string;
+      removable: boolean;
+    }
+  | {
+      id: string;
+      kind: "invite";
+      invite: CloudNotebookInvite;
+      label: string;
+      detail: string;
+      scope: CloudShareInviteScope;
+      badge: string;
+      removable: boolean;
+    };
+
+export function buildCloudShareAccessRows(input: {
+  acl: CloudNotebookAclRow[];
+  invites: CloudNotebookInvite[];
+}): CloudShareAccessRow[] {
+  const rows: CloudShareAccessRow[] = [];
+
+  for (const acl of [...input.acl].sort(compareAclRows)) {
+    rows.push({
+      id: `acl:${acl.subject_kind}:${acl.subject}:${acl.scope}`,
+      kind: "acl",
+      acl,
+      label: labelForAcl(acl),
+      detail: detailForAcl(acl),
+      scope: acl.scope,
+      badge: scopeLabel(acl.scope),
+      removable: acl.subject_kind === "public" || acl.scope !== "owner",
+    });
+  }
+
+  for (const invite of input.invites.filter((candidate) => candidate.status === "pending")) {
+    rows.push({
+      id: `invite:${invite.id}`,
+      kind: "invite",
+      invite,
+      label: invite.display?.label || invite.email,
+      detail: invite.provider_hint
+        ? `Pending invite via ${invite.provider_hint}`
+        : "Pending invite",
+      scope: invite.scope,
+      badge: scopeLabel(invite.scope),
+      removable: true,
+    });
+  }
+
+  return rows;
+}
+
+export function hasPublicViewerAccess(acl: CloudNotebookAclRow[]): boolean {
+  return acl.some(
+    (row) => row.subject_kind === "public" && row.subject === "anonymous" && row.scope === "viewer",
+  );
+}
+
+export function scopeLabel(scope: CloudShareScope): string {
+  switch (scope) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Can edit";
+    case "runtime_peer":
+      return "Runtime";
+    case "viewer":
+      return "Can view";
+  }
+}
+
+export function normalizeShareInviteEmail(value: string): string | null {
+  const email = value.trim().toLowerCase();
+  const parts = email.split("@");
+  if (
+    !email ||
+    email.includes("/") ||
+    /\s/.test(email) ||
+    parts.length !== 2 ||
+    !parts[0] ||
+    !parts[1] ||
+    !parts[1].includes(".")
+  ) {
+    return null;
+  }
+  return email;
+}
+
+function labelForAcl(row: CloudNotebookAclRow): string {
+  if (row.subject_kind === "public") {
+    return row.display?.label || "Anyone with the link";
+  }
+  return row.display?.label || row.subject;
+}
+
+function detailForAcl(row: CloudNotebookAclRow): string {
+  if (row.subject_kind === "public") {
+    return "Public read-only access";
+  }
+  const display = row.display;
+  if (display?.kind === "principal") {
+    const email = display.email?.trim();
+    if (email && email !== display.label) {
+      return email;
+    }
+    return display.principal;
+  }
+  return row.subject;
+}
+
+function compareAclRows(a: CloudNotebookAclRow, b: CloudNotebookAclRow): number {
+  const rank = (row: CloudNotebookAclRow): number => {
+    if (row.subject_kind === "principal" && row.scope === "owner") return 0;
+    if (row.subject_kind === "principal") return 1;
+    return 2;
+  };
+  const rankDelta = rank(a) - rank(b);
+  if (rankDelta !== 0) return rankDelta;
+  return `${labelForAcl(a)}:${a.scope}`.localeCompare(`${labelForAcl(b)}:${b.scope}`);
+}


### PR DESCRIPTION
## Summary

- Add an owner-only hosted viewer sharing popover for public read access, email invites, and current access rows.
- Surface ACL display metadata from the Worker so the viewer can render profile/public labels instead of raw subjects.
- Pass ACL and invite endpoints through the viewer config to keep cloud route knowledge out of shared renderer/viewer code.

## Notes

- This PR is based directly on `origin/main`; no stacked PR dependency.
- Invite creation intentionally omits `provider_hint` so verified email invites can resolve across configured identity providers.
- Public sharing continues to use the existing explicit `public/anonymous/viewer` ACL row.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/renderer-contract.test.ts test/html.test.ts test/viewer-sharing.test.ts test/worker-routes.test.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud test`
