### PR TITLE
fix(notebook-cloud): renew browser oidc sessions

### DIFF
--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -8,6 +8,8 @@ import {
   normalizeOidcAuthConfig,
   oidcDiscoveryUrl,
   readStoredOidcToken,
+  refreshStoredOidcToken,
+  storedOidcTokenNeedsRefresh,
   type CloudOidcAuthConfig,
   type CloudOidcRequestState,
   type CloudOidcStorage,
@@ -121,12 +123,158 @@ describe("cloud OIDC browser auth", () => {
     ]);
     assert.equal(result.returnUrl, "/n/private-demo");
     assert.equal(result.token.claims.sub, "anaconda-user-123");
+    assert.equal(result.token.refreshToken, "refresh-secret");
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY), null);
     assert.equal(readStoredOidcToken(storage).token?.accessToken, accessToken);
-    assert.doesNotMatch(
-      storage.getItem(NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY) ?? "",
-      /refresh-secret/,
+  });
+
+  it("refreshes stored OIDC tokens before falling back to anonymous auth", async () => {
+    const storage = new MemoryStorage();
+    const oldAccessToken = jwt({
+      sub: "anaconda-user-123",
+      email: "alice@example.com",
+      email_verified: true,
+      name: "Alice",
+    });
+    const refreshedAccessToken = jwt({
+      sub: "anaconda-user-123",
+      email: "alice@example.com",
+      email_verified: true,
+      name: "Alice Updated",
+    });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: oldAccessToken,
+        refreshToken: "refresh-secret",
+        expiresAt: 100,
+        claims: {
+          sub: "anaconda-user-123",
+          email: "alice@example.com",
+          email_verified: true,
+          name: "Alice",
+        },
+      }),
     );
+    const seenRequests: string[] = [];
+
+    assert.equal(storedOidcTokenNeedsRefresh(storage, 100), true);
+
+    const token = await refreshStoredOidcToken(authConfig, {
+      storage,
+      nowSeconds: 200,
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        seenRequests.push(url);
+        if (url.endsWith("/.well-known/openid-configuration")) {
+          return Response.json({
+            authorization_endpoint: "https://auth.stage.anaconda.com/api/auth/authorize",
+            token_endpoint: "https://auth.stage.anaconda.com/api/auth/token",
+          });
+        }
+        assert.equal(url, "https://auth.stage.anaconda.com/api/auth/token");
+        assert.equal(init?.method, "POST");
+        const body = new URLSearchParams(String(init?.body));
+        assert.equal(body.get("client_id"), "client-id");
+        assert.equal(body.get("grant_type"), "refresh_token");
+        assert.equal(body.get("refresh_token"), "refresh-secret");
+        assert.equal(body.get("scope"), "openid email profile offline_access");
+        return Response.json({
+          access_token: refreshedAccessToken,
+          expires_in: 300,
+          refresh_token: "rotated-refresh-secret",
+        });
+      },
+    });
+
+    assert.deepEqual(seenRequests, [
+      "https://auth.stage.anaconda.com/api/auth/.well-known/openid-configuration",
+      "https://auth.stage.anaconda.com/api/auth/token",
+    ]);
+    assert.equal(token.accessToken, refreshedAccessToken);
+    assert.equal(token.refreshToken, "rotated-refresh-secret");
+    assert.equal(token.expiresAt, 500);
+    assert.equal(token.claims.name, "Alice Updated");
+    assert.equal(storedOidcTokenNeedsRefresh(storage, 450), true);
+    assert.equal(storedOidcTokenNeedsRefresh(storage, 100), false);
+    assert.equal(readStoredOidcToken(storage, 100).token?.accessToken, refreshedAccessToken);
+  });
+
+  it("preserves refresh token and profile claims when refresh responses omit them", async () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: jwt({ sub: "anaconda-user-123", email: "alice@example.com", name: "Alice" }),
+        refreshToken: "refresh-secret",
+        expiresAt: 100,
+        claims: {
+          sub: "anaconda-user-123",
+          email: "alice@example.com",
+          email_verified: true,
+          name: "Alice",
+        },
+      }),
+    );
+
+    const token = await refreshStoredOidcToken(authConfig, {
+      storage,
+      nowSeconds: 200,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.endsWith("/.well-known/openid-configuration")) {
+          return Response.json({
+            authorization_endpoint: "https://auth.stage.anaconda.com/api/auth/authorize",
+            token_endpoint: "https://auth.stage.anaconda.com/api/auth/token",
+          });
+        }
+        return Response.json({
+          access_token: jwt({ sub: "anaconda-user-123" }),
+          expires_in: 300,
+        });
+      },
+    });
+
+    assert.equal(token.refreshToken, "refresh-secret");
+    assert.equal(token.claims.email, "alice@example.com");
+    assert.equal(token.claims.name, "Alice");
+  });
+
+  it("rejects refresh responses for a different subject without replacing stored tokens", async () => {
+    const storage = new MemoryStorage();
+    const oldAccessToken = jwt({ sub: "anaconda-user-123", name: "Alice" });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: oldAccessToken,
+        refreshToken: "refresh-secret",
+        expiresAt: 100,
+        claims: { sub: "anaconda-user-123", name: "Alice" },
+      }),
+    );
+
+    await assert.rejects(
+      () =>
+        refreshStoredOidcToken(authConfig, {
+          storage,
+          fetchImpl: async (input) => {
+            const url = String(input);
+            if (url.endsWith("/.well-known/openid-configuration")) {
+              return Response.json({
+                authorization_endpoint: "https://auth.stage.anaconda.com/api/auth/authorize",
+                token_endpoint: "https://auth.stage.anaconda.com/api/auth/token",
+              });
+            }
+            return Response.json({
+              access_token: jwt({ sub: "anaconda-user-456" }),
+              expires_in: 300,
+            });
+          },
+        }),
+      /different subject/,
+    );
+
+    assert.equal(readStoredOidcToken(storage, 0).token?.accessToken, oldAccessToken);
   });
 
   it("rejects callback state mismatches without storing token material", async () => {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -366,6 +366,12 @@ body {
   line-height: 1.35;
 }
 
+.cloud-auth-form-error[data-kind="info"] {
+  border-color: color-mix(in srgb, var(--foreground) 16%, transparent);
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+}
+
 .cloud-auth-actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -52,6 +52,8 @@ import {
   clearCloudOidcAuth,
   completeOidcRedirect,
   normalizeOidcAuthConfig,
+  refreshStoredOidcToken,
+  storedOidcTokenNeedsRefresh,
   type CloudOidcAuthConfig,
 } from "./oidc-auth";
 import type { ConnectionScope } from "../src/auth-shared";
@@ -98,6 +100,11 @@ interface CloudViewerConfig {
 interface CloudViewerAuthConfig {
   oidc: CloudOidcAuthConfig | null;
 }
+
+type CloudAuthRenewalState =
+  | { kind: "idle"; message: null }
+  | { kind: "refreshing"; message: string }
+  | { kind: "failed"; message: string };
 
 interface SnapshotRender {
   heads_hash?: string;
@@ -199,6 +206,90 @@ function isHomePath(): boolean {
   return pathname === "" || pathname === "/index.html";
 }
 
+function useCloudPrototypeAuth(authConfig: CloudViewerAuthConfig): {
+  authState: CloudPrototypeAuthState;
+  authRenewal: CloudAuthRenewalState;
+  refreshAuthState: () => void;
+} {
+  const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
+    cloudPrototypeAuthFromWindow(),
+  );
+  const [authRenewal, setAuthRenewal] = useState<CloudAuthRenewalState>(() =>
+    shouldRefreshStoredOidcToken()
+      ? { kind: "refreshing", message: "Refreshing sign-in..." }
+      : { kind: "idle", message: null },
+  );
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const refreshAuthState = useCallback(() => {
+    setAuthState(cloudPrototypeAuthFromWindow());
+    if (!shouldRefreshStoredOidcToken()) {
+      setAuthRenewal({ kind: "idle", message: null });
+    }
+  }, []);
+
+  const refreshOidcIfNeeded = useCallback(async () => {
+    const oidc = authConfig.oidc;
+    if (!oidc || !shouldRefreshStoredOidcToken()) {
+      return;
+    }
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    const refreshPromise = (async () => {
+      setAuthRenewal({ kind: "refreshing", message: "Refreshing sign-in..." });
+      try {
+        await refreshStoredOidcToken(oidc, { storage: window.localStorage });
+        refreshAuthState();
+        setAuthRenewal({ kind: "idle", message: null });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn("[notebook-cloud] OIDC session refresh failed", error);
+        refreshAuthState();
+        setAuthRenewal({ kind: "failed", message: `Unable to refresh sign-in: ${message}` });
+      } finally {
+        refreshPromiseRef.current = null;
+      }
+    })();
+    refreshPromiseRef.current = refreshPromise;
+    return refreshPromise;
+  }, [authConfig.oidc, refreshAuthState]);
+
+  useEffect(() => {
+    void refreshOidcIfNeeded();
+
+    const interval = window.setInterval(() => {
+      void refreshOidcIfNeeded();
+    }, 60_000);
+    const refreshOnFocus = () => {
+      void refreshOidcIfNeeded();
+    };
+    const refreshOnVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void refreshOidcIfNeeded();
+      }
+    };
+    window.addEventListener("focus", refreshOnFocus);
+    document.addEventListener("visibilitychange", refreshOnVisibility);
+
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", refreshOnFocus);
+      document.removeEventListener("visibilitychange", refreshOnVisibility);
+    };
+  }, [refreshOidcIfNeeded]);
+
+  return { authState, authRenewal, refreshAuthState };
+}
+
+function shouldRefreshStoredOidcToken(): boolean {
+  try {
+    return Boolean(window.localStorage && storedOidcTokenNeedsRefresh(window.localStorage));
+  } catch {
+    return false;
+  }
+}
+
 function App() {
   const [authConfig] = useState<CloudViewerAuthConfig>(() => loadAuthConfig());
   const [runtimeState] = useState<ViewerRuntimeState | null>(() =>
@@ -225,9 +316,7 @@ function App() {
 
 function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
-  const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
-    cloudPrototypeAuthFromWindow(),
-  );
+  const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const [scope, setScope] = useState<ConnectionScope>(
     authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   );
@@ -260,7 +349,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const resetAuth = () => {
     clearCloudPrototypeDevAuth(window.localStorage);
     setFormError(null);
-    setAuthState(cloudPrototypeAuthFromWindow());
+    refreshAuthState();
   };
 
   const signedIn = authState.mode === "oidc";
@@ -299,6 +388,15 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
             {formError}
           </div>
         ) : null}
+        {authRenewal.kind !== "idle" ? (
+          <div
+            className="cloud-auth-form-error"
+            data-kind={authRenewal.kind === "failed" ? "error" : "info"}
+            role={authRenewal.kind === "failed" ? "alert" : "status"}
+          >
+            {authRenewal.message}
+          </div>
+        ) : null}
 
         <div className="cloud-home-actions">
           {signedIn ? (
@@ -306,7 +404,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
               type="button"
               onClick={() => {
                 clearCloudOidcAuth(window.localStorage);
-                setAuthState(cloudPrototypeAuthFromWindow());
+                refreshAuthState();
               }}
             >
               <LogOut aria-hidden="true" />
@@ -422,9 +520,7 @@ function NotebookViewer({
     () => ({ batches: [] }),
   );
   const [connectAttempt, setConnectAttempt] = useState(0);
-  const [authState, setAuthState] = useState<CloudPrototypeAuthState>(() =>
-    cloudPrototypeAuthFromWindow(),
-  );
+  const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const textAttributionSequenceRef = useRef(0);
   const blobResolver = useMemo(
     () =>
@@ -456,6 +552,10 @@ function NotebookViewer({
   }, [cells]);
 
   useEffect(() => {
+    if (authRenewal.kind === "refreshing") {
+      return;
+    }
+
     let cancelled = false;
 
     void (async () => {
@@ -521,9 +621,13 @@ function NotebookViewer({
     return () => {
       cancelled = true;
     };
-  }, [authState, blobResolver, config.renderEndpoint, widgetStore]);
+  }, [authRenewal.kind, authState, blobResolver, config.renderEndpoint, widgetStore]);
 
   useEffect(() => {
+    if (authRenewal.kind === "refreshing") {
+      return;
+    }
+
     let disposed = false;
     let subscriptions: Array<{ unsubscribe: () => void }> = [];
     let materializeSequence = 0;
@@ -687,7 +791,7 @@ function NotebookViewer({
       setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
       setLivePresence(emptyCloudLivePresenceSnapshot());
     };
-  }, [authState, blobResolver, config.syncEndpoint, connectAttempt, widgetStore]);
+  }, [authRenewal.kind, authState, blobResolver, config.syncEndpoint, connectAttempt, widgetStore]);
 
   const readOnlyCells = useMemo(
     () =>
@@ -763,8 +867,8 @@ function NotebookViewer({
   );
   const resetPrototypeAuth = useCallback(() => {
     clearCloudPrototypeDevAuth(window.localStorage);
-    setAuthState(cloudPrototypeAuthFromWindow());
-  }, []);
+    refreshAuthState();
+  }, [refreshAuthState]);
 
   return (
     <main className="flex min-h-screen w-full flex-col py-6">
@@ -782,7 +886,7 @@ function NotebookViewer({
             connectionActorLabel={connectionActorLabel}
             connectionError={connectionError}
             connectionScope={connectionScope}
-            onAuthStateChange={() => setAuthState(cloudPrototypeAuthFromWindow())}
+            onAuthStateChange={refreshAuthState}
           />
 
           {status.kind === "ready" && codeCellCount > 0 ? (
@@ -808,6 +912,21 @@ function NotebookViewer({
             <RotateCcw aria-hidden="true" />
             Reset to anonymous
           </button>
+        </div>
+      ) : null}
+
+      {authRenewal.kind !== "idle" ? (
+        <div
+          className="cloud-state cloud-auth-state mx-8 mr-4"
+          data-kind={authRenewal.kind === "failed" ? "error" : "loading"}
+        >
+          <span>{authRenewal.message}</span>
+          {authRenewal.kind === "failed" ? (
+            <button type="button" onClick={resetPrototypeAuth}>
+              <RotateCcw aria-hidden="true" />
+              Reset to anonymous
+            </button>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/notebook-cloud/viewer/oidc-auth.ts
+++ b/apps/notebook-cloud/viewer/oidc-auth.ts
@@ -72,6 +72,63 @@ export function readStoredOidcToken(
   storage: Pick<CloudOidcStorage, "getItem">,
   nowSeconds = currentEpochSeconds(),
 ): { token: CloudOidcTokenState | null; problem: string | null } {
+  const parsed = readStoredOidcTokenState(storage);
+  if (!parsed.token) {
+    return parsed;
+  }
+  const { token } = parsed;
+  if (token.expiresAt <= nowSeconds + EXPIRY_SKEW_SECONDS) {
+    return { token: null, problem: "Stored OIDC session is expired." };
+  }
+
+  return { token, problem: null };
+}
+
+export function storedOidcTokenNeedsRefresh(
+  storage: Pick<CloudOidcStorage, "getItem">,
+  nowSeconds = currentEpochSeconds(),
+): boolean {
+  const parsed = readStoredOidcTokenState(storage);
+  return Boolean(
+    parsed.token?.refreshToken && parsed.token.expiresAt <= nowSeconds + EXPIRY_SKEW_SECONDS,
+  );
+}
+
+export async function refreshStoredOidcToken(
+  config: CloudOidcAuthConfig,
+  input: {
+    storage: CloudOidcStorage;
+    fetchImpl?: typeof fetch;
+    nowSeconds?: number;
+  },
+): Promise<CloudOidcTokenState> {
+  const current = readStoredOidcTokenState(input.storage);
+  if (!current.token) {
+    throw new Error(current.problem ?? "Stored OIDC session is missing.");
+  }
+  if (!current.token.refreshToken) {
+    throw new Error("Stored OIDC session cannot be refreshed.");
+  }
+
+  const endpoints = await discoverOidcEndpoints(config, input.fetchImpl);
+  const response = await exchangeRefreshToken(
+    config,
+    endpoints,
+    current.token.refreshToken,
+    input.fetchImpl,
+  );
+  return storeOidcTokenResponse(
+    input.storage,
+    response,
+    input.nowSeconds ?? currentEpochSeconds(),
+    current.token,
+  );
+}
+
+function readStoredOidcTokenState(storage: Pick<CloudOidcStorage, "getItem">): {
+  token: CloudOidcTokenState | null;
+  problem: string | null;
+} {
   const raw = storage.getItem(NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY);
   if (!raw) {
     return { token: null, problem: null };
@@ -89,10 +146,6 @@ export function readStoredOidcToken(
   if (!accessToken || !claims || !Number.isFinite(expiresAt)) {
     return { token: null, problem: "Stored OIDC session is invalid." };
   }
-  if (expiresAt <= nowSeconds + EXPIRY_SKEW_SECONDS) {
-    return { token: null, problem: "Stored OIDC session is expired." };
-  }
-
   return {
     token: {
       accessToken,
@@ -108,19 +161,24 @@ export function storeOidcTokenResponse(
   storage: CloudOidcStorage,
   response: CloudOidcTokenResponse,
   nowSeconds = currentEpochSeconds(),
+  previousToken: CloudOidcTokenState | null = null,
 ): CloudOidcTokenState {
   const accessToken = typeof response.access_token === "string" ? response.access_token : "";
   if (!accessToken) {
     throw new Error("OIDC token response did not include an access token");
   }
-  const claims = claimsFromTokenResponse(response, accessToken);
+  const claims = claimsFromTokenResponse(response, accessToken, previousToken);
   const expiresIn =
     typeof response.expires_in === "number" && Number.isFinite(response.expires_in)
       ? response.expires_in
       : 3600;
+  const responseRefreshToken =
+    typeof response.refresh_token === "string" && response.refresh_token.trim()
+      ? response.refresh_token.trim()
+      : null;
   const token: CloudOidcTokenState = {
     accessToken,
-    refreshToken: null,
+    refreshToken: responseRefreshToken ?? previousToken?.refreshToken ?? null,
     expiresAt: nowSeconds + expiresIn,
     claims,
   };
@@ -272,6 +330,34 @@ async function exchangeAuthorizationCode(
   return (await response.json()) as CloudOidcTokenResponse;
 }
 
+async function exchangeRefreshToken(
+  config: CloudOidcAuthConfig,
+  endpoints: CloudOidcEndpoints,
+  refreshToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CloudOidcTokenResponse> {
+  const form = new URLSearchParams();
+  form.set("client_id", config.clientId);
+  form.set("grant_type", "refresh_token");
+  form.set("refresh_token", refreshToken);
+  if (config.scope) {
+    form.set("scope", config.scope);
+  }
+
+  const response = await fetchImpl(endpoints.tokenEndpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: form,
+  });
+  if (!response.ok) {
+    throw new Error(`OIDC token refresh failed: ${response.status}`);
+  }
+  return (await response.json()) as CloudOidcTokenResponse;
+}
+
 function readOidcRequestState(
   storage: Pick<CloudOidcStorage, "getItem">,
 ): CloudOidcRequestState | null {
@@ -327,12 +413,23 @@ function base64UrlEncodeBytes(bytes: Uint8Array): string {
 function claimsFromTokenResponse(
   response: CloudOidcTokenResponse,
   accessToken: string,
+  previousToken: CloudOidcTokenState | null = null,
 ): CloudOidcClaims {
   const claimsSource =
     typeof response.id_token === "string" && response.id_token ? response.id_token : accessToken;
   const claims = normalizeClaims(decodeJwtPayload(claimsSource));
   if (!claims) {
     throw new Error("OIDC token response did not include a usable subject claim");
+  }
+  if (previousToken && claims.sub !== previousToken.claims.sub) {
+    throw new Error("OIDC token refresh returned a different subject");
+  }
+  if (previousToken && claimsSource === accessToken) {
+    return {
+      ...previousToken.claims,
+      ...claims,
+      sub: claims.sub,
+    };
   }
   return claims;
 }


### PR DESCRIPTION
## Summary

- Persist the OIDC refresh token from the browser authorization-code exchange so `offline_access` sessions can actually renew.
- Refresh stored browser OIDC sessions before render fetches or live-room sync fall back to anonymous viewer auth.
- Coalesce renewal attempts and preserve stable profile/display claims across providers that rotate refresh tokens or omit ID tokens during refresh.

## Notes

- This PR is based directly on `origin/main`; no stacked PR dependency.
- intheloop was used as product/context precedent, not as code to port wholesale. The implementation here is a small notebook-cloud-native OIDC renewal path.
- Sharing/permissions UI remains a separate track in #3059.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/oidc-auth.test.ts test/collaborator-auth.test.ts test/html.test.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud test`
