### PR TITLE
fix(notebook-cloud): default oidc sign-in to viewer

### DIFF
--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -9,6 +9,7 @@ import {
   cloudHttpHeadersFromPrototypeAuthState,
   clearCloudPrototypeDevAuth,
   cloudSyncAuthFromPrototypeAuthState,
+  prepareCloudOidcViewerLogin,
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
   readCloudPrototypeAuth,
@@ -136,6 +137,21 @@ describe("cloud collaborator auth", () => {
     assert.match(prototypeAuthSummary(state), /Browser session requesting editor/);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
+  });
+
+  it("starts OIDC sign-in as a viewer without stale prototype identity", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY, "secret");
+    storage.setItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY, "browser-editor");
+    storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, "editor");
+    storage.setItem(NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY, "stale");
+
+    prepareCloudOidcViewerLogin(storage);
+
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY), NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY), null);
   });
 
   it("preserves every explicit connection scope supported by the protocol", () => {

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -236,6 +236,15 @@ export function storeCloudAccessAuth(
   storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
 }
 
+export function prepareCloudOidcViewerLogin(
+  storage: Pick<CloudPrototypeAuthStorage, "removeItem" | "setItem">,
+): void {
+  clearCloudOidcAuth(storage);
+  storage.removeItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY);
+  storage.removeItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY);
+  storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+}
+
 export function clearCloudPrototypeDevAuth(
   storage: Pick<CloudPrototypeAuthStorage, "removeItem">,
 ): void {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -44,7 +44,7 @@ import {
   cloudSyncAuthFromPrototypeAuthState,
   fetchWithCloudPrototypeAuth,
   NOTEBOOK_CLOUD_DEFAULT_SCOPE,
-  NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
+  prepareCloudOidcViewerLogin,
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
   storeCloudPrototypeDevAuth,
@@ -55,7 +55,6 @@ import {
 import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
 import {
   beginOidcLogin,
-  clearCloudOidcAuth,
   completeOidcRedirect,
   normalizeOidcAuthConfig,
   refreshStoredOidcToken,
@@ -355,7 +354,8 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
     }
     try {
       setAuthAction("starting");
-      window.localStorage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, scope);
+      prepareCloudOidcViewerLogin(window.localStorage);
+      setScope(NOTEBOOK_CLOUD_DEFAULT_SCOPE);
       const url = await beginOidcLogin(authConfig.oidc, {
         currentUrl: window.location.href,
         storage: window.localStorage,
@@ -424,7 +424,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
             <button
               type="button"
               onClick={() => {
-                clearCloudOidcAuth(window.localStorage);
+                clearCloudPrototypeDevAuth(window.localStorage);
                 refreshAuthState();
               }}
             >
@@ -1422,7 +1422,8 @@ function CloudAuthControls({
     }
     try {
       setAuthAction("starting");
-      window.localStorage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, scope);
+      prepareCloudOidcViewerLogin(window.localStorage);
+      setScope(NOTEBOOK_CLOUD_DEFAULT_SCOPE);
       const url = await beginOidcLogin(authConfig.oidc, {
         currentUrl: window.location.href,
         storage: window.localStorage,
@@ -1507,7 +1508,7 @@ function CloudAuthControls({
             <button
               type="button"
               onClick={() => {
-                clearCloudOidcAuth(window.localStorage);
+                clearCloudPrototypeDevAuth(window.localStorage);
                 onAuthStateChange();
               }}
             >


### PR DESCRIPTION
## Summary

- Start OIDC sign-in as a viewer instead of reusing stale prototype editor/owner scope from localStorage.
- Clear stale dev identity and OIDC token state before beginning a new OIDC login.
- Clear the stored prototype scope on OIDC sign-out so the next anonymous/public visit is not labeled as an edit request.

## Notes

- This PR is based directly on `origin/main`; no stacked PR dependency.
- This complements #3058's server-side public viewer downgrade by making the browser ask for viewer scope up front.
- It keeps explicit dev-token scope selection available for local/prototype debugging.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/oidc-auth.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud test`
