### PR TITLE
fix(notebook-cloud): surface oidc sign-in controls

### DIFF
--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -66,6 +66,7 @@ export interface AuthenticatedConnectionMetadata {
   principalNamespace: string;
   displayName?: string;
   email?: string;
+  emailVerified?: boolean;
 }
 
 const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
@@ -156,6 +157,7 @@ interface JwtPayload {
   aud?: string | string[];
   azp?: string;
   email?: string;
+  email_verified?: boolean;
   exp?: number;
   iss?: string;
   name?: string;
@@ -328,6 +330,7 @@ export async function authenticateCloudflareAccessRequest(
         ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
         : {}),
       ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
+      ...(payload.email?.trim() ? { emailVerified: true } : {}),
     },
   };
   return credential.webSocketProtocol
@@ -379,6 +382,7 @@ export async function authenticateOidcRequest(
         ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
         : {}),
       ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
+      ...(payload.email?.trim() ? { emailVerified: payload.email_verified === true } : {}),
     },
   };
   return credential.webSocketProtocol
@@ -424,6 +428,7 @@ export async function authenticateAnacondaApiKeyRequest(
       principalNamespace: config.principalNamespace,
       ...(userInfo.displayName ? { displayName: userInfo.displayName } : {}),
       ...(userInfo.email ? { email: userInfo.email } : {}),
+      ...(userInfo.email ? { emailVerified: true } : {}),
     },
   };
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1660,18 +1660,19 @@ async function authenticateRequestOrResponse(
 }
 
 async function resolveLoginInvites(env: Env, identity: AuthenticatedConnection): Promise<void> {
-  if (identity.metadata.provider !== "cloudflare-access") {
+  if (identity.metadata.provider !== "cloudflare-access" && identity.metadata.provider !== "oidc") {
     return;
   }
 
   try {
-    // Access has already authenticated this email claim; use it only to resolve
-    // pending invite rows into principal ACL rows before authorization.
+    // The identity provider has already authenticated this email claim; use it
+    // only to resolve pending invite rows into principal ACL rows before
+    // authorization.
     const login = {
       principal: identity.principal,
       provider: identity.metadata.provider,
       email: identity.metadata.email ?? null,
-      emailVerified: Boolean(identity.metadata.email),
+      emailVerified: identity.metadata.emailVerified === true,
       displayName: identity.metadata.displayName ?? null,
     };
     const pendingInvites = await getPendingNotebookInvitesForLogin(env, login);

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -15,6 +15,7 @@ import {
   readCloudPrototypeAuth,
   storeCloudAccessAuth,
   storeCloudPrototypeDevAuth,
+  storeCloudRequestedScope,
   validatePrototypeToken,
   type CloudPrototypeAuthStorage,
 } from "../viewer/collaborator-auth.ts";
@@ -137,6 +138,40 @@ describe("cloud collaborator auth", () => {
     assert.match(prototypeAuthSummary(state), /Browser session requesting editor/);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
+  });
+
+  it("switches requested scope without replacing stored OIDC token material", () => {
+    const storage = new MemoryStorage();
+    const accessToken = jwt({
+      sub: "anaconda-user-789",
+      email: "kyle@example.com",
+      email_verified: true,
+      name: "Kyle",
+    });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken,
+        refreshToken: "refresh-token",
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        claims: {
+          sub: "anaconda-user-789",
+          email: "kyle@example.com",
+          email_verified: true,
+          name: "Kyle",
+        },
+      }),
+    );
+
+    storeCloudRequestedScope(storage, "editor");
+    assert.equal(readCloudPrototypeAuth(storage).requestedScope, "editor");
+
+    storeCloudRequestedScope(storage, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    const state = readCloudPrototypeAuth(storage);
+    assert.equal(state.mode, "oidc");
+    assert.equal(state.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.equal(state.token, accessToken);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
   });
 
   it("starts OIDC sign-in as a viewer without stale prototype identity", () => {

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -362,6 +362,7 @@ describe("Cloudflare Access identity", () => {
         principalNamespace: "user:cloudflare-access",
         displayName: "Alice Demo",
         email: "alice@example.com",
+        emailVerified: true,
       },
     });
   });
@@ -796,6 +797,7 @@ describe("Anaconda API key identity", () => {
         principalNamespace: "user:anaconda",
         displayName: "Kyle Kelley",
         email: "rgbkrk@gmail.com",
+        emailVerified: true,
       },
     });
     assert.deepEqual(calls, [
@@ -1101,6 +1103,7 @@ describe("OIDC identity", () => {
     const { env, token } = await oidcTokenFixture({
       subject: "user/123",
       email: "alice@example.com",
+      extraPayload: { email_verified: true },
       name: "Alice Demo",
     });
 
@@ -1124,6 +1127,7 @@ describe("OIDC identity", () => {
         principalNamespace: "user:anaconda",
         displayName: "Alice Demo",
         email: "alice@example.com",
+        emailVerified: true,
       },
     });
   });

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -4,6 +4,7 @@ import {
   CloudWebSocketTransport,
   normalizeConnectionScope,
   startCloudBootstrapSync,
+  syncUrl,
   syncableCloudHandle,
   withReadyTimeout,
 } from "../viewer/live-sync.ts";
@@ -79,6 +80,34 @@ describe("cloud live sync", () => {
     });
 
     assert.deepEqual(calls, ["start", "resetForBootstrap", "flush"]);
+  });
+
+  it("labels authenticated browser sync connections as browser operators", () => {
+    const url = syncUrl("https://cloud.test/n/demo/sync", "session/one", {
+      headers: { Authorization: "Bearer token" },
+      protocols: ["nteract-bearer.dG9rZW4", "nteract.v4"],
+      user: null,
+      operator: null,
+      requestedScope: "editor",
+    });
+
+    assert.equal(
+      url.href,
+      "wss://cloud.test/n/demo/sync?viewer_session=session%2Fone&operator=browser%3Asession%252Fone&scope=editor",
+    );
+  });
+
+  it("does not present an operator for anonymous viewer sync", () => {
+    const url = syncUrl("https://cloud.test/n/demo/sync", "anon-one", {
+      headers: {},
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: null,
+    });
+
+    assert.equal(url.searchParams.get("viewer_session"), "anon-one");
+    assert.equal(url.searchParams.has("operator"), false);
   });
 
   it("does not expose PoolDoc sync from the cloud viewer adapter", () => {

--- a/apps/notebook-cloud/test/prototype-dev-controls.test.ts
+++ b/apps/notebook-cloud/test/prototype-dev-controls.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { shouldShowPrototypeDevControls } from "../viewer/prototype-dev-controls.ts";
+
+describe("prototype dev controls visibility", () => {
+  it("keeps dev controls visible when OIDC is not configured", () => {
+    assert.equal(
+      shouldShowPrototypeDevControls({
+        oidcConfigured: false,
+        hostname: "preview.runt.run",
+        search: "",
+      }),
+      true,
+    );
+  });
+
+  it("hides dev controls on deployed OIDC hosts by default", () => {
+    assert.equal(
+      shouldShowPrototypeDevControls({
+        oidcConfigured: true,
+        hostname: "preview.runt.run",
+        search: "",
+      }),
+      false,
+    );
+  });
+
+  it("allows explicit dev controls on deployed OIDC hosts", () => {
+    for (const search of ["?notebook_cloud_dev_auth=1", "?dev_auth=true"]) {
+      assert.equal(
+        shouldShowPrototypeDevControls({
+          oidcConfigured: true,
+          hostname: "preview.runt.run",
+          search,
+        }),
+        true,
+      );
+    }
+  });
+
+  it("keeps dev controls visible on local hosts", () => {
+    for (const hostname of ["localhost", "app.localhost", "127.0.0.1", "::1"]) {
+      assert.equal(
+        shouldShowPrototypeDevControls({
+          oidcConfigured: true,
+          hostname,
+          search: "",
+        }),
+        true,
+      );
+    }
+  });
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2395,6 +2395,109 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("resolves pending email invites for OIDC editor WebSocket requests", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      email: "kkelley@anaconda.com",
+      extraPayload: { email_verified: true },
+      name: "Kyle Kelley",
+    });
+    let forwardedRequest: Request | undefined;
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "oidc-invite-demo");
+    seedPendingInvite(env, {
+      id: "invite-oidc-editor",
+      notebookId: "oidc-invite-demo",
+      email: "kkelley@anaconda.com",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/oidc-invite-demo/sync?operator=browser:tab&scope=editor", {
+        headers: {
+          Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+            token,
+          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
+    assert.ok(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "oidc-invite-demo" &&
+          row.subject_kind === "principal" &&
+          row.subject === "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375" &&
+          row.scope === "editor",
+      ),
+    );
+    assert.equal(env.DB.invites.get("invite-oidc-editor")?.status, "accepted");
+  });
+
+  it("does not resolve pending OIDC invites for unverified emails", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "unverified-oidc-user",
+      email: "unverified@anaconda.com",
+      extraPayload: { email_verified: false },
+    });
+    const env = fakeEnv(oidcEnv);
+    seedNotebook(env, "oidc-unverified-invite-demo");
+    seedPendingInvite(env, {
+      id: "invite-unverified-oidc-editor",
+      notebookId: "oidc-unverified-invite-demo",
+      email: "unverified@anaconda.com",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://cloud.test/n/oidc-unverified-invite-demo/sync?operator=browser:tab&scope=editor",
+        {
+          headers: {
+            Origin: "https://cloud.test",
+            "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+              token,
+            )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.equal(env.DB.invites.get("invite-unverified-oidc-editor")?.status, "pending");
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "oidc-unverified-invite-demo" &&
+          row.subject === "user:anaconda:unverified-oidc-user",
+      ),
+      false,
+    );
+  });
+
   it("requires Origin for OIDC bearer subprotocol WebSocket credentials", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "alice" });
     let roomFetches = 0;

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -236,6 +236,13 @@ export function storeCloudAccessAuth(
   storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
 }
 
+export function storeCloudRequestedScope(
+  storage: Pick<CloudPrototypeAuthStorage, "setItem">,
+  scope: ConnectionScope,
+): void {
+  storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, scope);
+}
+
 export function prepareCloudOidcViewerLogin(
   storage: Pick<CloudPrototypeAuthStorage, "removeItem" | "setItem">,
 ): void {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -230,7 +230,9 @@ body {
 }
 
 .cloud-share-menu summary,
-.cloud-auth-menu summary {
+.cloud-auth-menu summary,
+.cloud-scope-toggle-button,
+.cloud-sign-in-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -258,19 +260,23 @@ body {
 }
 
 .cloud-share-menu summary:hover,
-.cloud-auth-menu summary:hover {
+.cloud-auth-menu summary:hover,
+.cloud-scope-toggle-button:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
 }
 
 .cloud-share-menu summary:focus-visible,
-.cloud-auth-menu summary:focus-visible {
+.cloud-auth-menu summary:focus-visible,
+.cloud-scope-toggle-button:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
 .cloud-share-menu svg,
 .cloud-auth-menu svg,
+.cloud-scope-toggle-button svg,
+.cloud-sign-in-button svg,
 .cloud-auth-state svg {
   width: 1rem;
   height: 1rem;
@@ -278,13 +284,48 @@ body {
 }
 
 .cloud-share-menu summary span,
-.cloud-auth-menu summary span {
+.cloud-auth-menu summary span,
+.cloud-scope-toggle-button span,
+.cloud-sign-in-button span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.8125rem;
   line-height: 1;
+}
+
+.cloud-sign-in-button {
+  cursor: pointer;
+}
+
+.cloud-scope-toggle-button[data-state="editing"] {
+  border-color: color-mix(in srgb, #16a34a 52%, transparent);
+  color: color-mix(in srgb, #16a34a 80%, var(--foreground) 20%);
+}
+
+.cloud-scope-toggle-button[data-state="requested"] {
+  border-color: color-mix(in srgb, var(--ring) 48%, transparent);
+}
+
+.cloud-sign-in-button:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
+}
+
+.cloud-sign-in-button:disabled {
+  cursor: progress;
+  opacity: 0.72;
+}
+
+.cloud-sign-in-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-sign-in-button[data-state="error"] {
+  border-color: color-mix(in srgb, #dc2626 48%, transparent);
+  color: #dc2626;
 }
 
 .cloud-share-panel {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { createRoot } from "react-dom/client";
 import {
+  BookOpen,
   Code2,
   Copy,
   Eye,
@@ -11,6 +12,7 @@ import {
   LogIn,
   LogOut,
   Mail,
+  Pencil,
   RotateCcw,
   Share2,
   Trash2,
@@ -48,6 +50,7 @@ import {
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
   storeCloudPrototypeDevAuth,
+  storeCloudRequestedScope,
   validatePrototypeToken,
   withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
@@ -75,6 +78,7 @@ import {
   reduceCloudViewerConnection,
   reduceCloudViewerPresenceMessage,
 } from "./presence";
+import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import {
   buildCloudShareAccessRows,
@@ -342,6 +346,11 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   );
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
+  const showPrototypeDevControls = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  });
 
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
@@ -391,18 +400,20 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
           </div>
         </div>
 
-        <label className="cloud-home-scope">
-          <span>Scope</span>
-          <select
-            value={scope}
-            onChange={(event) => setScope(event.target.value as ConnectionScope)}
-          >
-            <option value="editor">editor</option>
-            <option value="owner">owner</option>
-            <option value="runtime_peer">runtime_peer</option>
-            <option value="viewer">viewer</option>
-          </select>
-        </label>
+        {showPrototypeDevControls ? (
+          <label className="cloud-home-scope">
+            <span>Scope</span>
+            <select
+              value={scope}
+              onChange={(event) => setScope(event.target.value as ConnectionScope)}
+            >
+              <option value="editor">editor</option>
+              <option value="owner">owner</option>
+              <option value="runtime_peer">runtime_peer</option>
+              <option value="viewer">viewer</option>
+            </select>
+          </label>
+        ) : null}
 
         {formError ? (
           <div className="cloud-auth-form-error" role="alert">
@@ -909,6 +920,14 @@ function NotebookViewer({
             />
           ) : null}
 
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+
+          <CloudNotebookEditModeButton
+            authState={authState}
+            connectionScope={connectionScope}
+            onAuthStateChange={refreshAuthState}
+          />
+
           <CloudAuthControls
             authConfig={authConfig}
             authState={authState}
@@ -1350,6 +1369,96 @@ function CloudSharingControls({
   );
 }
 
+function CloudNotebookEditModeButton({
+  authState,
+  connectionScope,
+  onAuthStateChange,
+}: {
+  authState: CloudPrototypeAuthState;
+  connectionScope: string | null;
+  onAuthStateChange: () => void;
+}) {
+  if (authState.mode !== "oidc") {
+    return null;
+  }
+
+  const requestedScope = authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
+  const requestingEdit = requestedScope === "editor" || requestedScope === "owner";
+  const editing = connectionScope === "editor" || connectionScope === "owner";
+  const label = requestingEdit ? "View" : "Edit";
+  const title = requestingEdit
+    ? editing
+      ? "Return to read-only viewing"
+      : "Stop requesting edit access"
+    : "Request edit access";
+
+  return (
+    <button
+      type="button"
+      className="cloud-scope-toggle-button"
+      aria-pressed={requestingEdit}
+      data-state={editing ? "editing" : requestingEdit ? "requested" : "viewing"}
+      title={title}
+      onClick={() => {
+        storeCloudRequestedScope(
+          window.localStorage,
+          requestingEdit ? NOTEBOOK_CLOUD_DEFAULT_SCOPE : "editor",
+        );
+        onAuthStateChange();
+      }}
+    >
+      {requestingEdit ? <BookOpen aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function CloudNotebookSignInButton({
+  authConfig,
+  authState,
+}: {
+  authConfig: CloudViewerAuthConfig;
+  authState: CloudPrototypeAuthState;
+}) {
+  const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  if (!authConfig.oidc || authState.mode === "oidc") {
+    return null;
+  }
+
+  const beginOidcAuth = async () => {
+    if (!authConfig.oidc) return;
+    try {
+      setAuthAction("starting");
+      setError(null);
+      prepareCloudOidcViewerLogin(window.localStorage);
+      const url = await beginOidcLogin(authConfig.oidc, {
+        currentUrl: window.location.href,
+        storage: window.localStorage,
+      });
+      window.location.assign(url.href);
+    } catch (caught) {
+      setAuthAction("idle");
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="cloud-sign-in-button"
+      data-state={error ? "error" : authAction}
+      disabled={authAction === "starting"}
+      title={error ?? "Sign in with Anaconda"}
+      onClick={beginOidcAuth}
+    >
+      <LogIn aria-hidden="true" />
+      <span>{error ? "Sign-in failed" : authAction === "starting" ? "Signing in" : "Sign in"}</span>
+    </button>
+  );
+}
+
 function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
   if (row.kind === "invite") {
     return <Mail aria-hidden="true" />;
@@ -1383,6 +1492,11 @@ function CloudAuthControls({
   const [formError, setFormError] = useState<string | null>(null);
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const showPrototypeDevControls = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  });
   const summary =
     authState.mode === "dev"
       ? `Dev ${authState.user ?? "browser-editor"}`
@@ -1467,37 +1581,41 @@ function CloudAuthControls({
             </div>
           ))}
         </dl>
-        <label>
-          <span>Dev token</span>
-          <input
-            type="password"
-            value={token}
-            placeholder="Worker dev token"
-            autoComplete="off"
-            onChange={(event) => setToken(event.target.value)}
-          />
-        </label>
-        <label>
-          <span>User</span>
-          <input
-            type="text"
-            value={user}
-            autoComplete="off"
-            onChange={(event) => setUser(event.target.value)}
-          />
-        </label>
-        <label>
-          <span>Scope</span>
-          <select
-            value={scope}
-            onChange={(event) => setScope(event.target.value as ConnectionScope)}
-          >
-            <option value="editor">editor</option>
-            <option value="owner">owner</option>
-            <option value="runtime_peer">runtime_peer</option>
-            <option value="viewer">viewer</option>
-          </select>
-        </label>
+        {showPrototypeDevControls ? (
+          <>
+            <label>
+              <span>Dev token</span>
+              <input
+                type="password"
+                value={token}
+                placeholder="Worker dev token"
+                autoComplete="off"
+                onChange={(event) => setToken(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>User</span>
+              <input
+                type="text"
+                value={user}
+                autoComplete="off"
+                onChange={(event) => setUser(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>Scope</span>
+              <select
+                value={scope}
+                onChange={(event) => setScope(event.target.value as ConnectionScope)}
+              >
+                <option value="editor">editor</option>
+                <option value="owner">owner</option>
+                <option value="runtime_peer">runtime_peer</option>
+                <option value="viewer">viewer</option>
+              </select>
+            </label>
+          </>
+        ) : null}
         {formError ? (
           <div className="cloud-auth-form-error" role="alert">
             {formError}
@@ -1521,10 +1639,12 @@ function CloudAuthControls({
               {authAction === "starting" ? "Starting sign-in" : "Sign in"}
             </button>
           ) : null}
-          <button type="submit">
-            <KeyRound aria-hidden="true" />
-            Use dev identity
-          </button>
+          {showPrototypeDevControls ? (
+            <button type="submit">
+              <KeyRound aria-hidden="true" />
+              Use dev identity
+            </button>
+          ) : null}
           <button type="button" onClick={() => void copyDiagnostics()}>
             <Copy aria-hidden="true" />
             {copyState === "copied"

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -363,8 +363,8 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 }
 
-function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): URL {
-  const url = new URL(syncEndpoint, location.href);
+export function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): URL {
+  const url = new URL(syncEndpoint, pageHref());
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
   if (auth.user) {
     url.searchParams.set("user", auth.user);
@@ -373,11 +373,21 @@ function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): 
   }
   if (auth.operator) {
     url.searchParams.set("operator", auth.operator);
+  } else if (hasAuthenticatedBrowserCredential(auth)) {
+    url.searchParams.set("operator", `browser:${encodeURIComponent(sessionId)}`);
   }
   if (auth.requestedScope) {
     url.searchParams.set("scope", auth.requestedScope);
   }
   return url;
+}
+
+function pageHref(): string {
+  return typeof location === "undefined" ? "http://localhost/" : location.href;
+}
+
+function hasAuthenticatedBrowserCredential(auth: CloudSyncAuth): boolean {
+  return Boolean(auth.user || auth.protocols.length > 0 || auth.headers.Authorization);
 }
 
 async function bytesFromWebSocketMessage(data: unknown): Promise<Uint8Array> {

--- a/apps/notebook-cloud/viewer/prototype-dev-controls.ts
+++ b/apps/notebook-cloud/viewer/prototype-dev-controls.ts
@@ -1,0 +1,29 @@
+export interface PrototypeDevControlsVisibilityInput {
+  oidcConfigured: boolean;
+  hostname: string;
+  search: string;
+}
+
+export function shouldShowPrototypeDevControls({
+  oidcConfigured,
+  hostname,
+  search,
+}: PrototypeDevControlsVisibilityInput): boolean {
+  if (!oidcConfigured) {
+    return true;
+  }
+
+  const params = new URLSearchParams(search);
+  const explicit = params.get("notebook_cloud_dev_auth") ?? params.get("dev_auth");
+  if (explicit === "1" || explicit === "true") {
+    return true;
+  }
+
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized.endsWith(".localhost")
+  );
+}


### PR DESCRIPTION
## Summary

- Add a direct notebook toolbar sign-in button for OIDC-configured viewers.
- Add a signed-in `Edit` / `View` toggle so OIDC users can request editor scope without opening the prototype auth diagnostics.
- Hide prototype dev-token/user/scope controls on deployed OIDC-configured notebook-cloud hosts.
- Keep those controls available for local development, non-OIDC deployments, or explicit `?notebook_cloud_dev_auth=1` / `?dev_auth=true` sessions.
- Label authenticated cloud browser room connections as `browser:*` operators instead of falling back to `desktop:*`.
- Resolve pending email invites for direct OIDC identities before WebSocket authorization when the OIDC token reports a verified email, matching the Access invite flow without trusting unverified email claims.
- Add focused tests for visibility, scope toggling, browser operator labels, and OIDC invite resolution.

## Stack

- #3061 has merged.
- This PR now targets `main` directly.

## Notes

- This keeps the normal preview surface focused on OIDC sign-in/sign-out, diagnostics, and anonymous reset without routing users through the debug menu first.
- It preserves the local prototype dev identity path for debugging.
- This is the demo-readiness follow-up from testing `https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit`: the published notebook was fine, but signed-in users needed a real edit-mode entry point, OIDC invite resolution, and browser-origin actor labels.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/live-sync.test.ts test/worker-routes.test.ts test/prototype-dev-controls.test.ts test/oidc-auth.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `git diff --check`
- `pnpm --dir apps/notebook-cloud test`
