### PR TITLE
fix(notebook-cloud): polish auth presence session handling

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -701,13 +701,19 @@ export function rewritePresenceFrame(
   return rewritePresenceIngress(
     frame.payload,
     peer.id,
-    peer.identity.principal,
+    presencePeerLabel(peer.identity),
     peer.identity.principal,
     peer.identity.operator,
   ).then((payload) => ({
     type: frame.type,
     payload,
   }));
+}
+
+export function presencePeerLabel(identity: AuthenticatedConnection): string {
+  return (
+    identity.metadata.displayName?.trim() || identity.metadata.email?.trim() || identity.principal
+  );
 }
 
 function notebookIdFromPath(pathname: string): string | undefined {

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -122,6 +122,42 @@ describe("cloud collaborator auth", () => {
     assert.match(prototypeAuthSummary(state), /Anil requesting viewer/);
   });
 
+  it("falls back to anonymous auth for expired non-refreshable OIDC sessions", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: jwt({
+          sub: "anaconda-user-expired",
+          email: "expired@example.com",
+          name: "Expired User",
+        }),
+        refreshToken: null,
+        expiresAt: Math.floor(Date.now() / 1000) - 3600,
+        claims: {
+          sub: "anaconda-user-expired",
+          email: "expired@example.com",
+          name: "Expired User",
+        },
+      }),
+    );
+    storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, "editor");
+
+    const state = readCloudPrototypeAuth(storage);
+
+    assert.equal(state.mode, "anonymous");
+    assert.equal(state.token, null);
+    assert.equal(state.problem, null);
+    assert.equal(prototypeAuthSummary(state), "Anonymous read-only viewer");
+    assert.deepEqual(cloudSyncAuthFromPrototypeAuthState(state), {
+      headers: {},
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: null,
+    });
+  });
+
   it("can request an editor role from a browser Access session without JS token material", () => {
     const storage = new MemoryStorage();
     storeCloudAccessAuth(storage, { scope: "editor" });

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   CloudWebSocketTransport,
+  cloudRoomReadyPeerLabel,
   normalizeConnectionScope,
   startCloudBootstrapSync,
   syncUrl,
@@ -108,6 +109,25 @@ describe("cloud live sync", () => {
 
     assert.equal(url.searchParams.get("viewer_session"), "anon-one");
     assert.equal(url.searchParams.has("operator"), false);
+  });
+
+  it("uses display name, email, then actor label for the local cloud room peer label", () => {
+    const ready = {
+      actor_label: "user:anaconda:uuid-123/browser:session-1",
+      display_name: "Alice Example",
+      email: "alice@example.com",
+    };
+
+    assert.equal(cloudRoomReadyPeerLabel(ready), "Alice Example");
+    assert.equal(
+      cloudRoomReadyPeerLabel({ ...ready, display_name: " ", email: "alice@example.com" }),
+      "alice@example.com",
+    );
+    const { display_name: _displayName, email: _email, ...actorOnlyReady } = ready;
+    assert.equal(
+      cloudRoomReadyPeerLabel(actorOnlyReady),
+      "user:anaconda:uuid-123/browser:session-1",
+    );
   });
 
   it("does not expose PoolDoc sync from the cloud viewer adapter", () => {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/identity.ts";
 import {
   NotebookRoom,
+  presencePeerLabel,
   rewritePresenceFrame,
   shouldBroadcastFrame,
   shouldPersistMaterializedSyncFrame,
@@ -38,7 +39,7 @@ before(async () => {
 });
 
 describe("NotebookRoom presence rewrite", () => {
-  it("rewrites canonical CBOR presence to the server peer and authenticated principal", async () => {
+  it("rewrites canonical CBOR presence to the server peer and friendly display label", async () => {
     const identity = authenticateDevRequest(
       new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
     );
@@ -57,8 +58,35 @@ describe("NotebookRoom presence rewrite", () => {
 
     assert.equal(rewritten.type, FrameType.PRESENCE);
     assert.equal(body.peer_id, "server-peer");
-    assert.equal(body.peer_label, "user:dev:alice");
+    assert.equal(body.peer_label, "alice");
     assert.equal(body.actor_label, "user:dev:alice/agent:codex:s1");
+  });
+
+  it("uses display name, email, then principal for rewritten presence peer labels", () => {
+    const baseIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+    );
+    const withoutDisplayName = {
+      ...baseIdentity,
+      metadata: {
+        provider: baseIdentity.metadata.provider,
+        transport: baseIdentity.metadata.transport,
+        principalNamespace: baseIdentity.metadata.principalNamespace,
+        email: "alice@example.com",
+      },
+    };
+    const withoutFriendlyMetadata = {
+      ...baseIdentity,
+      metadata: {
+        provider: baseIdentity.metadata.provider,
+        transport: baseIdentity.metadata.transport,
+        principalNamespace: baseIdentity.metadata.principalNamespace,
+      },
+    };
+
+    assert.equal(presencePeerLabel(baseIdentity), "alice");
+    assert.equal(presencePeerLabel(withoutDisplayName), "alice@example.com");
+    assert.equal(presencePeerLabel(withoutFriendlyMetadata), "user:dev:alice");
   });
 
   it("falls back to the authenticated operator for invalid presented actor labels", async () => {
@@ -80,7 +108,7 @@ describe("NotebookRoom presence rewrite", () => {
 
     assert.equal(rewritten.type, FrameType.PRESENCE);
     assert.equal(body.actor_label, "user:dev:alice/desktop:a");
-    assert.equal(body.peer_label, "user:dev:alice");
+    assert.equal(body.peer_label, "alice");
   });
 
   it("rejects non-CBOR presence payloads", async () => {

--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -200,6 +200,67 @@ describe("cloud OIDC browser auth", () => {
     assert.equal(readStoredOidcToken(storage, 100).token?.accessToken, refreshedAccessToken);
   });
 
+  it("treats expired non-refreshable OIDC tokens as unusable without invalidating auth", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: jwt({ sub: "anaconda-user-expired", name: "Expired User" }),
+        refreshToken: null,
+        expiresAt: 100,
+        claims: { sub: "anaconda-user-expired", name: "Expired User" },
+      }),
+    );
+
+    const stored = readStoredOidcToken(storage, 200);
+
+    assert.equal(stored.token, null);
+    assert.equal(stored.problem, null);
+    assert.equal(stored.expired, true);
+    assert.equal(storedOidcTokenNeedsRefresh(storage, 200), false);
+  });
+
+  it("coalesces concurrent refreshes for the same stored OIDC session", async () => {
+    const storage = new MemoryStorage();
+    const refreshedAccessToken = jwt({ sub: "anaconda-user-123", name: "Alice Refreshed" });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: jwt({ sub: "anaconda-user-123", name: "Alice" }),
+        refreshToken: "refresh-secret",
+        expiresAt: 100,
+        claims: { sub: "anaconda-user-123", name: "Alice" },
+      }),
+    );
+    let discoveryRequests = 0;
+    let tokenRequests = 0;
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/.well-known/openid-configuration")) {
+        discoveryRequests += 1;
+        return Response.json({
+          authorization_endpoint: "https://auth.stage.anaconda.com/api/auth/authorize",
+          token_endpoint: "https://auth.stage.anaconda.com/api/auth/token",
+        });
+      }
+      tokenRequests += 1;
+      return Response.json({
+        access_token: refreshedAccessToken,
+        expires_in: 300,
+      });
+    };
+
+    const [first, second] = await Promise.all([
+      refreshStoredOidcToken(authConfig, { storage, fetchImpl, nowSeconds: 200 }),
+      refreshStoredOidcToken(authConfig, { storage, fetchImpl, nowSeconds: 200 }),
+    ]);
+
+    assert.equal(first.accessToken, refreshedAccessToken);
+    assert.equal(second.accessToken, refreshedAccessToken);
+    assert.equal(discoveryRequests, 1);
+    assert.equal(tokenRequests, 1);
+  });
+
   it("preserves refresh token and profile claims when refresh responses omit them", async () => {
     const storage = new MemoryStorage();
     storage.setItem(

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -108,6 +108,9 @@ export function readCloudPrototypeAuth(
         problem: oidcSession.problem,
       };
     }
+    if (oidcSession.expired) {
+      return anonymousAuthState();
+    }
     if (requestedScope) {
       return {
         mode: "access",

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -80,7 +80,7 @@ export async function connectCloudSyncRuntime({
       new URL(runtimedWasmPath, location.href),
     );
     const syncHandle = syncableCloudHandle(handle);
-    const peerLabel = actorPeerLabel(ready.actor_label);
+    const peerLabel = cloudRoomReadyPeerLabel(ready);
     const heartbeatPeerId = ready.peer_id;
     const connectionScope = normalizeConnectionScope(ready.connection_scope);
     const engine = new SyncEngine({
@@ -403,9 +403,13 @@ async function bytesFromWebSocketMessage(data: unknown): Promise<Uint8Array> {
   throw new Error(`unsupported WebSocket message ${Object.prototype.toString.call(data)}`);
 }
 
-function actorPeerLabel(actorLabel: string): string {
-  const [principal, operator] = actorLabel.split("/", 2);
-  return operator ? `${principal} (${operator})` : actorLabel;
+export function cloudRoomReadyPeerLabel(
+  ready: Pick<
+    Extract<SessionControlMessage, { type: "cloud_room_ready" }>,
+    "actor_label" | "display_name" | "email"
+  >,
+): string {
+  return ready.display_name?.trim() || ready.email?.trim() || ready.actor_label;
 }
 
 const consoleSyncLogger = {

--- a/apps/notebook-cloud/viewer/oidc-auth.ts
+++ b/apps/notebook-cloud/viewer/oidc-auth.ts
@@ -71,17 +71,17 @@ export function normalizeOidcAuthConfig(
 export function readStoredOidcToken(
   storage: Pick<CloudOidcStorage, "getItem">,
   nowSeconds = currentEpochSeconds(),
-): { token: CloudOidcTokenState | null; problem: string | null } {
+): { token: CloudOidcTokenState | null; problem: string | null; expired: boolean } {
   const parsed = readStoredOidcTokenState(storage);
   if (!parsed.token) {
-    return parsed;
+    return { ...parsed, expired: false };
   }
   const { token } = parsed;
   if (token.expiresAt <= nowSeconds + EXPIRY_SKEW_SECONDS) {
-    return { token: null, problem: "Stored OIDC session is expired." };
+    return { token: null, problem: null, expired: true };
   }
 
-  return { token, problem: null };
+  return { token, problem: null, expired: false };
 }
 
 export function storedOidcTokenNeedsRefresh(
@@ -94,7 +94,38 @@ export function storedOidcTokenNeedsRefresh(
   );
 }
 
-export async function refreshStoredOidcToken(
+const refreshesByStorage = new WeakMap<
+  CloudOidcStorage,
+  Map<string, Promise<CloudOidcTokenState>>
+>();
+
+export function refreshStoredOidcToken(
+  config: CloudOidcAuthConfig,
+  input: {
+    storage: CloudOidcStorage;
+    fetchImpl?: typeof fetch;
+    nowSeconds?: number;
+  },
+): Promise<CloudOidcTokenState> {
+  const refreshKey = oidcRefreshKey(config);
+  let storageRefreshes = refreshesByStorage.get(input.storage);
+  if (!storageRefreshes) {
+    storageRefreshes = new Map();
+    refreshesByStorage.set(input.storage, storageRefreshes);
+  }
+  const existing = storageRefreshes.get(refreshKey);
+  if (existing) {
+    return existing;
+  }
+
+  const refresh = refreshStoredOidcTokenUncoalesced(config, input).finally(() => {
+    storageRefreshes.delete(refreshKey);
+  });
+  storageRefreshes.set(refreshKey, refresh);
+  return refresh;
+}
+
+async function refreshStoredOidcTokenUncoalesced(
   config: CloudOidcAuthConfig,
   input: {
     storage: CloudOidcStorage;
@@ -123,6 +154,15 @@ export async function refreshStoredOidcToken(
     input.nowSeconds ?? currentEpochSeconds(),
     current.token,
   );
+}
+
+function oidcRefreshKey(config: CloudOidcAuthConfig): string {
+  return [
+    config.issuer,
+    config.clientId,
+    config.redirectUri,
+    config.scope ?? DEFAULT_OIDC_SCOPE,
+  ].join("\n");
 }
 
 function readStoredOidcTokenState(storage: Pick<CloudOidcStorage, "getItem">): {


### PR DESCRIPTION
## Summary

- Use friendly display labels for cloud presence while preserving principals and actor labels for protocol identity.
- Prefer `display_name`, then `email`, then actor label for the browser's local peer label.
- Treat expired stored OIDC sessions as anonymous/sign-in-needed instead of invalid, and coalesce concurrent refreshes.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/live-sync.test.ts test/collaborator-auth.test.ts test/oidc-auth.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3063 --max-turns 120 --out .context/reviews/pr-3063.json`
  - Verdict: `clear`, no findings.

## Stack

Merge order:

1. `quod/notebook-cloud-auth-controls-surface`
2. `quod/notebook-cloud-auth-presence-polish`
