### PR TITLE
fix(notebook-cloud): use shared markdown cell surface

### DIFF
--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -66,6 +66,7 @@ export interface AuthenticatedConnectionMetadata {
   principalNamespace: string;
   displayName?: string;
   email?: string;
+  emailVerified?: boolean;
 }
 
 const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
@@ -156,6 +157,7 @@ interface JwtPayload {
   aud?: string | string[];
   azp?: string;
   email?: string;
+  email_verified?: boolean;
   exp?: number;
   iss?: string;
   name?: string;
@@ -328,6 +330,7 @@ export async function authenticateCloudflareAccessRequest(
         ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
         : {}),
       ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
+      ...(payload.email?.trim() ? { emailVerified: true } : {}),
     },
   };
   return credential.webSocketProtocol
@@ -379,6 +382,7 @@ export async function authenticateOidcRequest(
         ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
         : {}),
       ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
+      ...(payload.email?.trim() ? { emailVerified: payload.email_verified === true } : {}),
     },
   };
   return credential.webSocketProtocol
@@ -424,6 +428,7 @@ export async function authenticateAnacondaApiKeyRequest(
       principalNamespace: config.principalNamespace,
       ...(userInfo.displayName ? { displayName: userInfo.displayName } : {}),
       ...(userInfo.email ? { email: userInfo.email } : {}),
+      ...(userInfo.email ? { emailVerified: true } : {}),
     },
   };
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1660,18 +1660,19 @@ async function authenticateRequestOrResponse(
 }
 
 async function resolveLoginInvites(env: Env, identity: AuthenticatedConnection): Promise<void> {
-  if (identity.metadata.provider !== "cloudflare-access") {
+  if (identity.metadata.provider !== "cloudflare-access" && identity.metadata.provider !== "oidc") {
     return;
   }
 
   try {
-    // Access has already authenticated this email claim; use it only to resolve
-    // pending invite rows into principal ACL rows before authorization.
+    // The identity provider has already authenticated this email claim; use it
+    // only to resolve pending invite rows into principal ACL rows before
+    // authorization.
     const login = {
       principal: identity.principal,
       provider: identity.metadata.provider,
       email: identity.metadata.email ?? null,
-      emailVerified: Boolean(identity.metadata.email),
+      emailVerified: identity.metadata.emailVerified === true,
       displayName: identity.metadata.displayName ?? null,
     };
     const pendingInvites = await getPendingNotebookInvitesForLogin(env, login);

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -15,6 +15,7 @@ import {
   readCloudPrototypeAuth,
   storeCloudAccessAuth,
   storeCloudPrototypeDevAuth,
+  storeCloudRequestedScope,
   validatePrototypeToken,
   type CloudPrototypeAuthStorage,
 } from "../viewer/collaborator-auth.ts";
@@ -137,6 +138,40 @@ describe("cloud collaborator auth", () => {
     assert.match(prototypeAuthSummary(state), /Browser session requesting editor/);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
     assert.equal(storage.getItem(NOTEBOOK_CLOUD_USER_STORAGE_KEY), null);
+  });
+
+  it("switches requested scope without replacing stored OIDC token material", () => {
+    const storage = new MemoryStorage();
+    const accessToken = jwt({
+      sub: "anaconda-user-789",
+      email: "kyle@example.com",
+      email_verified: true,
+      name: "Kyle",
+    });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken,
+        refreshToken: "refresh-token",
+        expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        claims: {
+          sub: "anaconda-user-789",
+          email: "kyle@example.com",
+          email_verified: true,
+          name: "Kyle",
+        },
+      }),
+    );
+
+    storeCloudRequestedScope(storage, "editor");
+    assert.equal(readCloudPrototypeAuth(storage).requestedScope, "editor");
+
+    storeCloudRequestedScope(storage, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    const state = readCloudPrototypeAuth(storage);
+    assert.equal(state.mode, "oidc");
+    assert.equal(state.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.equal(state.token, accessToken);
+    assert.equal(storage.getItem(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), null);
   });
 
   it("starts OIDC sign-in as a viewer without stale prototype identity", () => {

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -362,6 +362,7 @@ describe("Cloudflare Access identity", () => {
         principalNamespace: "user:cloudflare-access",
         displayName: "Alice Demo",
         email: "alice@example.com",
+        emailVerified: true,
       },
     });
   });
@@ -796,6 +797,7 @@ describe("Anaconda API key identity", () => {
         principalNamespace: "user:anaconda",
         displayName: "Kyle Kelley",
         email: "rgbkrk@gmail.com",
+        emailVerified: true,
       },
     });
     assert.deepEqual(calls, [
@@ -1101,6 +1103,7 @@ describe("OIDC identity", () => {
     const { env, token } = await oidcTokenFixture({
       subject: "user/123",
       email: "alice@example.com",
+      extraPayload: { email_verified: true },
       name: "Alice Demo",
     });
 
@@ -1124,6 +1127,7 @@ describe("OIDC identity", () => {
         principalNamespace: "user:anaconda",
         displayName: "Alice Demo",
         email: "alice@example.com",
+        emailVerified: true,
       },
     });
   });

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -4,6 +4,7 @@ import {
   CloudWebSocketTransport,
   normalizeConnectionScope,
   startCloudBootstrapSync,
+  syncUrl,
   syncableCloudHandle,
   withReadyTimeout,
 } from "../viewer/live-sync.ts";
@@ -79,6 +80,34 @@ describe("cloud live sync", () => {
     });
 
     assert.deepEqual(calls, ["start", "resetForBootstrap", "flush"]);
+  });
+
+  it("labels authenticated browser sync connections as browser operators", () => {
+    const url = syncUrl("https://cloud.test/n/demo/sync", "session/one", {
+      headers: { Authorization: "Bearer token" },
+      protocols: ["nteract-bearer.dG9rZW4", "nteract.v4"],
+      user: null,
+      operator: null,
+      requestedScope: "editor",
+    });
+
+    assert.equal(
+      url.href,
+      "wss://cloud.test/n/demo/sync?viewer_session=session%2Fone&operator=browser%3Asession%252Fone&scope=editor",
+    );
+  });
+
+  it("does not present an operator for anonymous viewer sync", () => {
+    const url = syncUrl("https://cloud.test/n/demo/sync", "anon-one", {
+      headers: {},
+      protocols: [],
+      user: null,
+      operator: null,
+      requestedScope: null,
+    });
+
+    assert.equal(url.searchParams.get("viewer_session"), "anon-one");
+    assert.equal(url.searchParams.has("operator"), false);
   });
 
   it("does not expose PoolDoc sync from the cloud viewer adapter", () => {

--- a/apps/notebook-cloud/test/prototype-dev-controls.test.ts
+++ b/apps/notebook-cloud/test/prototype-dev-controls.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { shouldShowPrototypeDevControls } from "../viewer/prototype-dev-controls.ts";
+
+describe("prototype dev controls visibility", () => {
+  it("keeps dev controls visible when OIDC is not configured", () => {
+    assert.equal(
+      shouldShowPrototypeDevControls({
+        oidcConfigured: false,
+        hostname: "preview.runt.run",
+        search: "",
+      }),
+      true,
+    );
+  });
+
+  it("hides dev controls on deployed OIDC hosts by default", () => {
+    assert.equal(
+      shouldShowPrototypeDevControls({
+        oidcConfigured: true,
+        hostname: "preview.runt.run",
+        search: "",
+      }),
+      false,
+    );
+  });
+
+  it("allows explicit dev controls on deployed OIDC hosts", () => {
+    for (const search of ["?notebook_cloud_dev_auth=1", "?dev_auth=true"]) {
+      assert.equal(
+        shouldShowPrototypeDevControls({
+          oidcConfigured: true,
+          hostname: "preview.runt.run",
+          search,
+        }),
+        true,
+      );
+    }
+  });
+
+  it("keeps dev controls visible on local hosts", () => {
+    for (const hostname of ["localhost", "app.localhost", "127.0.0.1", "::1"]) {
+      assert.equal(
+        shouldShowPrototypeDevControls({
+          oidcConfigured: true,
+          hostname,
+          search: "",
+        }),
+        true,
+      );
+    }
+  });
+});

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -16,6 +16,16 @@ test("cloud editable markdown cells use shared cell and output rendering surface
   assert.match(sourceText, /<CodeMirrorEditor/);
 });
 
+test("cloud markdown edit toggle avoids blur and stale-source races", () => {
+  const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /editorRef\.current\?\.getEditor\(\)\?\.state\.doc\.toString\(\)/);
+  assert.match(sourceText, /suppressNextToggleClickRef/);
+  assert.match(sourceText, /onMouseDown=\{handleActionMouseDown\}/);
+  assert.match(sourceText, /onClick=\{handleActionClick\}/);
+});
+
 test("cloud live notebook passes renderer policy into editable markdown cells", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -26,6 +26,14 @@ test("cloud markdown edit toggle avoids blur and stale-source races", () => {
   assert.match(sourceText, /onClick=\{handleActionClick\}/);
 });
 
+test("cloud markdown editor remounts with latest source state", () => {
+  const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /if \(!editing\) return;\s+bridge\.applyFullSource\(cell\.source\);/);
+  assert.match(sourceText, /cell\.source\.trim\(\)\.length === 0 && !editing/);
+});
+
 test("cloud live notebook passes renderer policy into editable markdown cells", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+test("cloud editable markdown cells use shared cell and output rendering surfaces", () => {
+  const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /import \{ CellContainer \} from "@\/components\/cell\/CellContainer";/);
+  assert.match(sourceText, /import \{ OutputArea \} from "@\/components\/cell\/OutputArea";/);
+  assert.match(sourceText, /<CellContainer/);
+  assert.match(sourceText, /<OutputArea/);
+  assert.match(sourceText, /isolated="auto"/);
+  assert.match(sourceText, /priority=\{priority\}/);
+  assert.match(sourceText, /hostContext=\{hostContext\}/);
+  assert.match(sourceText, /<CodeMirrorEditor/);
+});
+
+test("cloud live notebook passes renderer policy into editable markdown cells", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
+  assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2395,6 +2395,109 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("resolves pending email invites for OIDC editor WebSocket requests", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      email: "kkelley@anaconda.com",
+      extraPayload: { email_verified: true },
+      name: "Kyle Kelley",
+    });
+    let forwardedRequest: Request | undefined;
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "oidc-invite-demo");
+    seedPendingInvite(env, {
+      id: "invite-oidc-editor",
+      notebookId: "oidc-invite-demo",
+      email: "kkelley@anaconda.com",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/oidc-invite-demo/sync?operator=browser:tab&scope=editor", {
+        headers: {
+          Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+            token,
+          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
+    assert.ok(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "oidc-invite-demo" &&
+          row.subject_kind === "principal" &&
+          row.subject === "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375" &&
+          row.scope === "editor",
+      ),
+    );
+    assert.equal(env.DB.invites.get("invite-oidc-editor")?.status, "accepted");
+  });
+
+  it("does not resolve pending OIDC invites for unverified emails", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "unverified-oidc-user",
+      email: "unverified@anaconda.com",
+      extraPayload: { email_verified: false },
+    });
+    const env = fakeEnv(oidcEnv);
+    seedNotebook(env, "oidc-unverified-invite-demo");
+    seedPendingInvite(env, {
+      id: "invite-unverified-oidc-editor",
+      notebookId: "oidc-unverified-invite-demo",
+      email: "unverified@anaconda.com",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request(
+        "https://cloud.test/n/oidc-unverified-invite-demo/sync?operator=browser:tab&scope=editor",
+        {
+          headers: {
+            Origin: "https://cloud.test",
+            "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+              token,
+            )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+            Upgrade: "websocket",
+          },
+        },
+      ),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.equal(env.DB.invites.get("invite-unverified-oidc-editor")?.status, "pending");
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "oidc-unverified-invite-demo" &&
+          row.subject === "user:anaconda:unverified-oidc-user",
+      ),
+      false,
+    );
+  });
+
   it("requires Origin for OIDC bearer subprotocol WebSocket credentials", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "alice" });
     let roomFetches = 0;

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -236,6 +236,13 @@ export function storeCloudAccessAuth(
   storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, input.scope);
 }
 
+export function storeCloudRequestedScope(
+  storage: Pick<CloudPrototypeAuthStorage, "setItem">,
+  scope: ConnectionScope,
+): void {
+  storage.setItem(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY, scope);
+}
+
 export function prepareCloudOidcViewerLogin(
   storage: Pick<CloudPrototypeAuthStorage, "removeItem" | "setItem">,
 ): void {

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -1,4 +1,16 @@
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { Check, Pencil } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { CellContainer } from "@/components/cell/CellContainer";
+import { OutputArea } from "@/components/cell/OutputArea";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import {
@@ -7,6 +19,8 @@ import {
   setRemoteSelections,
 } from "@/components/editor/remote-cursors";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { cn } from "@/lib/utils";
 import {
   createCrdtBridge,
   remoteChangesFromTextAttributions,
@@ -29,6 +43,8 @@ export interface EditableMarkdownCellProps {
   cell: ResolvedCell;
   className?: string;
   sourceClassName?: string;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
   onSourceChange: (cellId: string, source: string) => void;
   onSyncNeeded: () => void;
   getHandle: () => NotebookHandle | null;
@@ -49,6 +65,8 @@ export function EditableMarkdownCell({
   cell,
   className,
   sourceClassName,
+  priority,
+  hostContext,
   onSourceChange,
   onSyncNeeded,
   getHandle,
@@ -58,6 +76,7 @@ export function EditableMarkdownCell({
   onPresenceCursor,
   onPresenceSelection,
 }: EditableMarkdownCellProps) {
+  const [editing, setEditing] = useState(cell.source.trim().length === 0);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const getHandleRef = useRef(getHandle);
   const onSourceChangeRef = useRef(onSourceChange);
@@ -95,6 +114,36 @@ export function EditableMarkdownCell({
     return editorExtensions;
   }, [bridge.extension, cell.id, onPresenceCursor, onPresenceSelection]);
 
+  const markdownOutput = useMemo<JupyterOutput>(
+    () => ({
+      output_id: `markdown-source:${cell.id}`,
+      output_type: "display_data",
+      data: { "text/markdown": cell.source },
+      metadata: {},
+    }),
+    [cell.id, cell.source],
+  );
+
+  const enterEditing = useCallback(() => {
+    setEditing(true);
+  }, []);
+
+  const exitEditing = useCallback(() => {
+    if (cell.source.trim().length > 0) {
+      setEditing(false);
+    }
+  }, [cell.source]);
+
+  const handlePreviewKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        enterEditing();
+      }
+    },
+    [enterEditing],
+  );
+
   useLayoutEffect(() => {
     if (!textAttributionQueue) return;
 
@@ -116,29 +165,108 @@ export function EditableMarkdownCell({
   }, [bridge, cell.source]);
 
   useEffect(() => {
+    if (!editing) return;
+    const frame = requestAnimationFrame(() => {
+      editorRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editing]);
+
+  useEffect(() => {
     const view = editorRef.current?.getEditor();
     if (!view) return;
     setRemoteCursors(view, remotePresence?.cursors ?? []);
     setRemoteSelections(view, remotePresence?.selections ?? []);
-  }, [remotePresence]);
+  }, [editing, remotePresence]);
 
   return (
-    <article
+    <CellContainer
+      id={cell.id}
+      cellType="markdown"
       className={className}
-      data-cell-id={cell.id}
-      data-cell-type="markdown"
-      data-slot="cloud-editable-markdown-cell"
-    >
-      <div className={sourceClassName} data-slot="cloud-editable-markdown-source">
-        <CodeMirrorEditor
-          ref={editorRef}
-          initialValue={cell.source}
-          language="markdown"
-          lineWrapping
-          extensions={extensions}
-          className="cloud-markdown-editor min-h-[2rem]"
+      presenceIndicators={<CloudMarkdownPresenceIndicators presence={remotePresence} />}
+      rightGutterContent={
+        <button
+          type="button"
+          className="cloud-markdown-cell-action"
+          aria-label={editing ? "Render markdown" : "Edit markdown"}
+          title={editing ? "Render markdown" : "Edit markdown"}
+          onClick={editing ? exitEditing : enterEditing}
+        >
+          {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+        </button>
+      }
+      codeContent={
+        editing ? (
+          <div className={sourceClassName} data-slot="cloud-editable-markdown-source">
+            <CodeMirrorEditor
+              ref={editorRef}
+              initialValue={cell.source}
+              language="markdown"
+              lineWrapping
+              onBlur={exitEditing}
+              extensions={extensions}
+              placeholder="Markdown"
+              className="cloud-markdown-editor min-h-[2rem]"
+            />
+          </div>
+        ) : (
+          <div
+            className={cn("cloud-markdown-preview", sourceClassName)}
+            data-slot="cloud-editable-markdown-preview"
+            role="textbox"
+            aria-readonly
+            tabIndex={0}
+            onDoubleClick={enterEditing}
+            onKeyDown={handlePreviewKeyDown}
+          >
+            <OutputArea
+              cellId={cell.id}
+              outputs={[markdownOutput]}
+              isolated="auto"
+              priority={priority}
+              hostContext={hostContext}
+              className="cloud-markdown-preview-output"
+            />
+          </div>
+        )
+      }
+    />
+  );
+}
+
+function CloudMarkdownPresenceIndicators({ presence }: { presence?: RemoteCellPresence }) {
+  const peers = useMemo(() => {
+    const byPeer = new Map<string, { label: string; color: string }>();
+    for (const cursor of presence?.cursors ?? []) {
+      byPeer.set(cursor.peerId, {
+        label: cursor.peerLabel,
+        color: cursor.color,
+      });
+    }
+    for (const selection of presence?.selections ?? []) {
+      byPeer.set(selection.peerId, {
+        label: selection.peerLabel,
+        color: selection.color,
+      });
+    }
+    return Array.from(byPeer.entries()).map(([peerId, peer]) => ({ peerId, ...peer }));
+  }, [presence]);
+
+  if (peers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="cloud-markdown-presence" aria-label="Remote editors">
+      {peers.slice(0, 4).map((peer) => (
+        <span
+          key={peer.peerId}
+          style={{ backgroundColor: peer.color }}
+          title={peer.label}
+          aria-label={peer.label}
         />
-      </div>
-    </article>
+      ))}
+    </div>
   );
 }

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { OutputArea } from "@/components/cell/OutputArea";
@@ -78,6 +79,7 @@ export function EditableMarkdownCell({
 }: EditableMarkdownCellProps) {
   const [editing, setEditing] = useState(cell.source.trim().length === 0);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const suppressNextToggleClickRef = useRef(false);
   const getHandleRef = useRef(getHandle);
   const onSourceChangeRef = useRef(onSourceChange);
   const onSyncNeededRef = useRef(onSyncNeeded);
@@ -129,10 +131,37 @@ export function EditableMarkdownCell({
   }, []);
 
   const exitEditing = useCallback(() => {
-    if (cell.source.trim().length > 0) {
+    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? cell.source;
+    if (currentSource.trim().length > 0) {
       setEditing(false);
     }
   }, [cell.source]);
+
+  const handleActionMouseDown = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (!editing) return;
+      event.preventDefault();
+      suppressNextToggleClickRef.current = true;
+      exitEditing();
+    },
+    [editing, exitEditing],
+  );
+
+  const handleActionClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (suppressNextToggleClickRef.current) {
+        suppressNextToggleClickRef.current = false;
+        event.preventDefault();
+        return;
+      }
+      if (editing) {
+        exitEditing();
+      } else {
+        enterEditing();
+      }
+    },
+    [editing, enterEditing, exitEditing],
+  );
 
   const handlePreviewKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -191,7 +220,8 @@ export function EditableMarkdownCell({
           className="cloud-markdown-cell-action"
           aria-label={editing ? "Render markdown" : "Edit markdown"}
           title={editing ? "Render markdown" : "Edit markdown"}
-          onClick={editing ? exitEditing : enterEditing}
+          onMouseDown={handleActionMouseDown}
+          onClick={handleActionClick}
         >
           {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
         </button>

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -190,8 +190,15 @@ export function EditableMarkdownCell({
   }, [bridge, cell.id, localActorLabel, textAttributionQueue]);
 
   useLayoutEffect(() => {
+    if (!editing) return;
     bridge.applyFullSource(cell.source);
-  }, [bridge, cell.source]);
+  }, [bridge, cell.source, editing]);
+
+  useEffect(() => {
+    if (cell.source.trim().length === 0 && !editing) {
+      setEditing(true);
+    }
+  }, [cell.source, editing]);
 
   useEffect(() => {
     if (!editing) return;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -729,6 +729,64 @@ body {
   padding-block: 0.25rem 1rem;
 }
 
+.cloud-editable-markdown-cell[data-slot="cell-container"] {
+  padding-block: 0.25rem 1rem;
+}
+
+.cloud-markdown-preview {
+  min-width: 0;
+  cursor: text;
+  outline: none;
+}
+
+.cloud-markdown-preview:focus-visible {
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ring) 60%, transparent);
+}
+
+.cloud-markdown-preview-output {
+  padding-inline: 0 !important;
+}
+
+.cloud-markdown-cell-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  background: transparent;
+}
+
+.cloud-markdown-cell-action:hover,
+.cloud-markdown-cell-action:focus-visible {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+  outline: none;
+}
+
+.cloud-markdown-cell-action svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-markdown-presence {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: center;
+  padding-top: 0.25rem;
+}
+
+.cloud-markdown-presence span {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--background) 80%, transparent);
+}
+
 .cloud-editable-markdown-cell .cm-editor {
   border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 6px;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -230,7 +230,9 @@ body {
 }
 
 .cloud-share-menu summary,
-.cloud-auth-menu summary {
+.cloud-auth-menu summary,
+.cloud-scope-toggle-button,
+.cloud-sign-in-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -258,19 +260,23 @@ body {
 }
 
 .cloud-share-menu summary:hover,
-.cloud-auth-menu summary:hover {
+.cloud-auth-menu summary:hover,
+.cloud-scope-toggle-button:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
 }
 
 .cloud-share-menu summary:focus-visible,
-.cloud-auth-menu summary:focus-visible {
+.cloud-auth-menu summary:focus-visible,
+.cloud-scope-toggle-button:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
 .cloud-share-menu svg,
 .cloud-auth-menu svg,
+.cloud-scope-toggle-button svg,
+.cloud-sign-in-button svg,
 .cloud-auth-state svg {
   width: 1rem;
   height: 1rem;
@@ -278,13 +284,48 @@ body {
 }
 
 .cloud-share-menu summary span,
-.cloud-auth-menu summary span {
+.cloud-auth-menu summary span,
+.cloud-scope-toggle-button span,
+.cloud-sign-in-button span {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.8125rem;
   line-height: 1;
+}
+
+.cloud-sign-in-button {
+  cursor: pointer;
+}
+
+.cloud-scope-toggle-button[data-state="editing"] {
+  border-color: color-mix(in srgb, #16a34a 52%, transparent);
+  color: color-mix(in srgb, #16a34a 80%, var(--foreground) 20%);
+}
+
+.cloud-scope-toggle-button[data-state="requested"] {
+  border-color: color-mix(in srgb, var(--ring) 48%, transparent);
+}
+
+.cloud-sign-in-button:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
+}
+
+.cloud-sign-in-button:disabled {
+  cursor: progress;
+  opacity: 0.72;
+}
+
+.cloud-sign-in-button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-sign-in-button[data-state="error"] {
+  border-color: color-mix(in srgb, #dc2626 48%, transparent);
+  color: #dc2626;
 }
 
 .cloud-share-panel {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1742,6 +1742,8 @@ function CloudLiveNotebook({
               cell={cell}
               className="cloud-cell cloud-editable-markdown-cell"
               sourceClassName="cloud-source-block"
+              priority={priority}
+              hostContext={hostContext}
               onSourceChange={onMarkdownSourceChange}
               onSyncNeeded={onMarkdownSyncNeeded}
               getHandle={getHandle}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { createRoot } from "react-dom/client";
 import {
+  BookOpen,
   Code2,
   Copy,
   Eye,
@@ -11,6 +12,7 @@ import {
   LogIn,
   LogOut,
   Mail,
+  Pencil,
   RotateCcw,
   Share2,
   Trash2,
@@ -48,6 +50,7 @@ import {
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
   storeCloudPrototypeDevAuth,
+  storeCloudRequestedScope,
   validatePrototypeToken,
   withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
@@ -75,6 +78,7 @@ import {
   reduceCloudViewerConnection,
   reduceCloudViewerPresenceMessage,
 } from "./presence";
+import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
 import {
   buildCloudShareAccessRows,
@@ -342,6 +346,11 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   );
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
+  const showPrototypeDevControls = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  });
 
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
@@ -391,18 +400,20 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
           </div>
         </div>
 
-        <label className="cloud-home-scope">
-          <span>Scope</span>
-          <select
-            value={scope}
-            onChange={(event) => setScope(event.target.value as ConnectionScope)}
-          >
-            <option value="editor">editor</option>
-            <option value="owner">owner</option>
-            <option value="runtime_peer">runtime_peer</option>
-            <option value="viewer">viewer</option>
-          </select>
-        </label>
+        {showPrototypeDevControls ? (
+          <label className="cloud-home-scope">
+            <span>Scope</span>
+            <select
+              value={scope}
+              onChange={(event) => setScope(event.target.value as ConnectionScope)}
+            >
+              <option value="editor">editor</option>
+              <option value="owner">owner</option>
+              <option value="runtime_peer">runtime_peer</option>
+              <option value="viewer">viewer</option>
+            </select>
+          </label>
+        ) : null}
 
         {formError ? (
           <div className="cloud-auth-form-error" role="alert">
@@ -909,6 +920,14 @@ function NotebookViewer({
             />
           ) : null}
 
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+
+          <CloudNotebookEditModeButton
+            authState={authState}
+            connectionScope={connectionScope}
+            onAuthStateChange={refreshAuthState}
+          />
+
           <CloudAuthControls
             authConfig={authConfig}
             authState={authState}
@@ -1350,6 +1369,96 @@ function CloudSharingControls({
   );
 }
 
+function CloudNotebookEditModeButton({
+  authState,
+  connectionScope,
+  onAuthStateChange,
+}: {
+  authState: CloudPrototypeAuthState;
+  connectionScope: string | null;
+  onAuthStateChange: () => void;
+}) {
+  if (authState.mode !== "oidc") {
+    return null;
+  }
+
+  const requestedScope = authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
+  const requestingEdit = requestedScope === "editor" || requestedScope === "owner";
+  const editing = connectionScope === "editor" || connectionScope === "owner";
+  const label = requestingEdit ? "View" : "Edit";
+  const title = requestingEdit
+    ? editing
+      ? "Return to read-only viewing"
+      : "Stop requesting edit access"
+    : "Request edit access";
+
+  return (
+    <button
+      type="button"
+      className="cloud-scope-toggle-button"
+      aria-pressed={requestingEdit}
+      data-state={editing ? "editing" : requestingEdit ? "requested" : "viewing"}
+      title={title}
+      onClick={() => {
+        storeCloudRequestedScope(
+          window.localStorage,
+          requestingEdit ? NOTEBOOK_CLOUD_DEFAULT_SCOPE : "editor",
+        );
+        onAuthStateChange();
+      }}
+    >
+      {requestingEdit ? <BookOpen aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function CloudNotebookSignInButton({
+  authConfig,
+  authState,
+}: {
+  authConfig: CloudViewerAuthConfig;
+  authState: CloudPrototypeAuthState;
+}) {
+  const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  if (!authConfig.oidc || authState.mode === "oidc") {
+    return null;
+  }
+
+  const beginOidcAuth = async () => {
+    if (!authConfig.oidc) return;
+    try {
+      setAuthAction("starting");
+      setError(null);
+      prepareCloudOidcViewerLogin(window.localStorage);
+      const url = await beginOidcLogin(authConfig.oidc, {
+        currentUrl: window.location.href,
+        storage: window.localStorage,
+      });
+      window.location.assign(url.href);
+    } catch (caught) {
+      setAuthAction("idle");
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className="cloud-sign-in-button"
+      data-state={error ? "error" : authAction}
+      disabled={authAction === "starting"}
+      title={error ?? "Sign in with Anaconda"}
+      onClick={beginOidcAuth}
+    >
+      <LogIn aria-hidden="true" />
+      <span>{error ? "Sign-in failed" : authAction === "starting" ? "Signing in" : "Sign in"}</span>
+    </button>
+  );
+}
+
 function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
   if (row.kind === "invite") {
     return <Mail aria-hidden="true" />;
@@ -1383,6 +1492,11 @@ function CloudAuthControls({
   const [formError, setFormError] = useState<string | null>(null);
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const showPrototypeDevControls = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  });
   const summary =
     authState.mode === "dev"
       ? `Dev ${authState.user ?? "browser-editor"}`
@@ -1467,37 +1581,41 @@ function CloudAuthControls({
             </div>
           ))}
         </dl>
-        <label>
-          <span>Dev token</span>
-          <input
-            type="password"
-            value={token}
-            placeholder="Worker dev token"
-            autoComplete="off"
-            onChange={(event) => setToken(event.target.value)}
-          />
-        </label>
-        <label>
-          <span>User</span>
-          <input
-            type="text"
-            value={user}
-            autoComplete="off"
-            onChange={(event) => setUser(event.target.value)}
-          />
-        </label>
-        <label>
-          <span>Scope</span>
-          <select
-            value={scope}
-            onChange={(event) => setScope(event.target.value as ConnectionScope)}
-          >
-            <option value="editor">editor</option>
-            <option value="owner">owner</option>
-            <option value="runtime_peer">runtime_peer</option>
-            <option value="viewer">viewer</option>
-          </select>
-        </label>
+        {showPrototypeDevControls ? (
+          <>
+            <label>
+              <span>Dev token</span>
+              <input
+                type="password"
+                value={token}
+                placeholder="Worker dev token"
+                autoComplete="off"
+                onChange={(event) => setToken(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>User</span>
+              <input
+                type="text"
+                value={user}
+                autoComplete="off"
+                onChange={(event) => setUser(event.target.value)}
+              />
+            </label>
+            <label>
+              <span>Scope</span>
+              <select
+                value={scope}
+                onChange={(event) => setScope(event.target.value as ConnectionScope)}
+              >
+                <option value="editor">editor</option>
+                <option value="owner">owner</option>
+                <option value="runtime_peer">runtime_peer</option>
+                <option value="viewer">viewer</option>
+              </select>
+            </label>
+          </>
+        ) : null}
         {formError ? (
           <div className="cloud-auth-form-error" role="alert">
             {formError}
@@ -1521,10 +1639,12 @@ function CloudAuthControls({
               {authAction === "starting" ? "Starting sign-in" : "Sign in"}
             </button>
           ) : null}
-          <button type="submit">
-            <KeyRound aria-hidden="true" />
-            Use dev identity
-          </button>
+          {showPrototypeDevControls ? (
+            <button type="submit">
+              <KeyRound aria-hidden="true" />
+              Use dev identity
+            </button>
+          ) : null}
           <button type="button" onClick={() => void copyDiagnostics()}>
             <Copy aria-hidden="true" />
             {copyState === "copied"

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -363,8 +363,8 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 }
 
-function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): URL {
-  const url = new URL(syncEndpoint, location.href);
+export function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): URL {
+  const url = new URL(syncEndpoint, pageHref());
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
   if (auth.user) {
     url.searchParams.set("user", auth.user);
@@ -373,11 +373,21 @@ function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): 
   }
   if (auth.operator) {
     url.searchParams.set("operator", auth.operator);
+  } else if (hasAuthenticatedBrowserCredential(auth)) {
+    url.searchParams.set("operator", `browser:${encodeURIComponent(sessionId)}`);
   }
   if (auth.requestedScope) {
     url.searchParams.set("scope", auth.requestedScope);
   }
   return url;
+}
+
+function pageHref(): string {
+  return typeof location === "undefined" ? "http://localhost/" : location.href;
+}
+
+function hasAuthenticatedBrowserCredential(auth: CloudSyncAuth): boolean {
+  return Boolean(auth.user || auth.protocols.length > 0 || auth.headers.Authorization);
 }
 
 async function bytesFromWebSocketMessage(data: unknown): Promise<Uint8Array> {

--- a/apps/notebook-cloud/viewer/prototype-dev-controls.ts
+++ b/apps/notebook-cloud/viewer/prototype-dev-controls.ts
@@ -1,0 +1,29 @@
+export interface PrototypeDevControlsVisibilityInput {
+  oidcConfigured: boolean;
+  hostname: string;
+  search: string;
+}
+
+export function shouldShowPrototypeDevControls({
+  oidcConfigured,
+  hostname,
+  search,
+}: PrototypeDevControlsVisibilityInput): boolean {
+  if (!oidcConfigured) {
+    return true;
+  }
+
+  const params = new URLSearchParams(search);
+  const explicit = params.get("notebook_cloud_dev_auth") ?? params.get("dev_auth");
+  if (explicit === "1" || explicit === "true") {
+    return true;
+  }
+
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized.endsWith(".localhost")
+  );
+}


### PR DESCRIPTION
## Summary

- route cloud editable markdown preview rendering through the shared `CellContainer` and `OutputArea`
- keep the cloud-specific CRDT bridge, live presence, and editor sync glue in the cloud viewer
- pass the notebook-cloud MIME priority and isolated host context into the shared output renderer

## Stack order

This PR targets `quod/notebook-cloud-auth-controls-surface` / #3062.

Merge order:

1. Merge #3062 first.
2. Merge this PR after GitHub retargets it, or retarget it to `main` after #3062 lands.

It is independent of the follow-on auth/presence polish and viewer live-update regression PRs, but it intentionally builds on the auth controls surface so the same hosted editor entry point can use the shared markdown rendering path.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
