### PR TITLE
fix(notebook-cloud): refresh stale room checkpoints

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -9,7 +9,7 @@ const ROOM_HOST_ACTOR_LABEL = "system/schema:notebook-cloud-room";
 const CHECKPOINT_NOTEBOOK_KEY = "room-host:notebook-doc";
 const CHECKPOINT_RUNTIME_STATE_KEY = "room-host:runtime-state-doc";
 const CHECKPOINT_META_KEY = "room-host:checkpoint";
-const CHECKPOINT_VERSION = 2;
+const CHECKPOINT_VERSION = 4;
 
 interface RoomHostOutboundFrame {
   peer_id: string;
@@ -29,6 +29,9 @@ interface RoomCheckpointMetadata {
   notebook_heads: string[];
   runtime_state_heads: string[];
   saved_at: string;
+  published_revision_id: string | null;
+  published_notebook_heads: string[] | null;
+  published_runtime_state_heads: string[] | null;
 }
 
 interface RoomPeer {
@@ -39,6 +42,9 @@ interface RoomPeer {
 export class RoomMaterializer {
   private hostReady: Promise<RoomHostHandle> | undefined;
   private operationQueue: Promise<void> = Promise.resolve();
+  private loadedPublishedRevisionId: string | null = null;
+  private loadedPublishedNotebookHeads: string[] | null = null;
+  private loadedPublishedRuntimeStateHeads: string[] | null = null;
 
   constructor(
     private readonly notebookId: string,
@@ -84,6 +90,9 @@ export class RoomMaterializer {
         notebook_heads: Array.from(host.get_heads_hex()),
         runtime_state_heads: Array.from(host.get_runtime_state_heads_hex()),
         saved_at: new Date().toISOString(),
+        published_revision_id: this.loadedPublishedRevisionId,
+        published_notebook_heads: this.loadedPublishedNotebookHeads,
+        published_runtime_state_heads: this.loadedPublishedRuntimeStateHeads,
       };
       await Promise.all([
         this.state.storage.put(CHECKPOINT_NOTEBOOK_KEY, notebookBytes),
@@ -125,10 +134,65 @@ export class RoomMaterializer {
     try {
       const checkpoint = await this.loadCheckpoint();
       if (checkpoint) {
-        const host = loadRoomHostSnapshot(checkpoint.notebookBytes, checkpoint.runtimeStateBytes);
+        const latestPublished = await this.loadLatestPublishedSnapshotPairForCheckpoint();
+        if (
+          latestPublished &&
+          checkpoint.metadata.published_revision_id !== latestPublished.revisionId
+        ) {
+          const checkpointKeepReason = checkpointKeepReasonForRevisionMismatch(
+            checkpoint.metadata,
+            latestPublished.createdAt,
+          );
+          if (checkpointKeepReason) {
+            this.markLoadedCheckpoint(checkpoint.metadata);
+            const host = await loadRoomHostSnapshot(
+              checkpoint.notebookBytes,
+              checkpoint.runtimeStateBytes,
+            );
+            cloudLog("info", "room.materializer.loaded", {
+              notebook_id: this.notebookId,
+              source: "durable_object_checkpoint",
+              reason: checkpointKeepReason,
+              checkpoint_published_revision_id: checkpoint.metadata.published_revision_id,
+              published_revision_id: latestPublished.revisionId,
+              duration_ms: durationMs(startedAt),
+              notebook_byte_length: checkpoint.notebookBytes.byteLength,
+              runtime_state_byte_length: checkpoint.runtimeStateBytes.byteLength,
+              counter: "materializer_loads",
+              counter_delta: 1,
+            });
+            return host;
+          }
+
+          const host = await loadRoomHostSnapshot(
+            latestPublished.notebookBytes,
+            latestPublished.runtimeStateBytes,
+          );
+          this.markLoadedPublishedSnapshot(latestPublished.revisionId, host);
+          cloudLog("info", "room.materializer.loaded", {
+            notebook_id: this.notebookId,
+            source: "published_snapshot_pair",
+            reason: "checkpoint_seed_revision_mismatch",
+            checkpoint_published_revision_id: checkpoint.metadata.published_revision_id,
+            published_revision_id: latestPublished.revisionId,
+            duration_ms: durationMs(startedAt),
+            notebook_byte_length: latestPublished.notebookBytes.byteLength,
+            runtime_state_byte_length: latestPublished.runtimeStateBytes.byteLength,
+            counter: "materializer_loads",
+            counter_delta: 1,
+          });
+          return host;
+        }
+
+        this.markLoadedCheckpoint(checkpoint.metadata);
+        const host = await loadRoomHostSnapshot(
+          checkpoint.notebookBytes,
+          checkpoint.runtimeStateBytes,
+        );
         cloudLog("info", "room.materializer.loaded", {
           notebook_id: this.notebookId,
           source: "durable_object_checkpoint",
+          published_revision_id: checkpoint.metadata.published_revision_id,
           duration_ms: durationMs(startedAt),
           notebook_byte_length: checkpoint.notebookBytes.byteLength,
           runtime_state_byte_length: checkpoint.runtimeStateBytes.byteLength,
@@ -140,10 +204,15 @@ export class RoomMaterializer {
 
       const published = await this.loadLatestPublishedSnapshotPair();
       if (published) {
-        const host = loadRoomHostSnapshot(published.notebookBytes, published.runtimeStateBytes);
+        const host = await loadRoomHostSnapshot(
+          published.notebookBytes,
+          published.runtimeStateBytes,
+        );
+        this.markLoadedPublishedSnapshot(published.revisionId, host);
         cloudLog("info", "room.materializer.loaded", {
           notebook_id: this.notebookId,
           source: "published_snapshot_pair",
+          published_revision_id: published.revisionId,
           duration_ms: durationMs(startedAt),
           notebook_byte_length: published.notebookBytes.byteLength,
           runtime_state_byte_length: published.runtimeStateBytes.byteLength,
@@ -153,6 +222,9 @@ export class RoomMaterializer {
         return host;
       }
 
+      this.loadedPublishedRevisionId = null;
+      this.loadedPublishedNotebookHeads = null;
+      this.loadedPublishedRuntimeStateHeads = null;
       const host = createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
       cloudLog("info", "room.materializer.loaded", {
         notebook_id: this.notebookId,
@@ -177,6 +249,7 @@ export class RoomMaterializer {
   private async loadCheckpoint(): Promise<{
     notebookBytes: Uint8Array;
     runtimeStateBytes: Uint8Array;
+    metadata: RoomCheckpointMetadata;
   } | null> {
     const [notebookBytes, runtimeStateBytes] = await Promise.all([
       this.state.storage.get<ArrayBuffer>(CHECKPOINT_NOTEBOOK_KEY),
@@ -184,16 +257,73 @@ export class RoomMaterializer {
     ]);
     const metadata =
       await this.state.storage.get<Partial<RoomCheckpointMetadata>>(CHECKPOINT_META_KEY);
-    if (!notebookBytes || !runtimeStateBytes || metadata?.version !== CHECKPOINT_VERSION) {
+    if (
+      !notebookBytes ||
+      !runtimeStateBytes ||
+      (metadata?.version !== 2 &&
+        metadata?.version !== 3 &&
+        metadata?.version !== CHECKPOINT_VERSION)
+    ) {
       return null;
     }
     return {
       notebookBytes: new Uint8Array(notebookBytes),
       runtimeStateBytes: new Uint8Array(runtimeStateBytes),
+      metadata: {
+        version: typeof metadata.version === "number" ? metadata.version : CHECKPOINT_VERSION,
+        notebook_heads: Array.isArray(metadata.notebook_heads) ? metadata.notebook_heads : [],
+        runtime_state_heads: Array.isArray(metadata.runtime_state_heads)
+          ? metadata.runtime_state_heads
+          : [],
+        saved_at: typeof metadata.saved_at === "string" ? metadata.saved_at : "",
+        published_revision_id:
+          typeof metadata.published_revision_id === "string"
+            ? metadata.published_revision_id
+            : null,
+        published_notebook_heads: Array.isArray(metadata.published_notebook_heads)
+          ? metadata.published_notebook_heads
+          : null,
+        published_runtime_state_heads: Array.isArray(metadata.published_runtime_state_heads)
+          ? metadata.published_runtime_state_heads
+          : null,
+      },
     };
   }
 
+  private async loadLatestPublishedSnapshotPairForCheckpoint(): Promise<{
+    revisionId: string;
+    createdAt: string;
+    notebookBytes: Uint8Array;
+    runtimeStateBytes: Uint8Array;
+  } | null> {
+    try {
+      return await this.loadLatestPublishedSnapshotPair();
+    } catch (error) {
+      cloudLog("warn", "room.materializer.published_snapshot_lookup_failed", {
+        notebook_id: this.notebookId,
+        error: errorMessage(error),
+        counter: "materializer_published_snapshot_lookup_failures",
+        counter_delta: 1,
+      });
+      return null;
+    }
+  }
+
+  private markLoadedCheckpoint(metadata: RoomCheckpointMetadata): void {
+    this.loadedPublishedRevisionId = metadata.published_revision_id;
+    this.loadedPublishedNotebookHeads = metadata.published_notebook_heads;
+    this.loadedPublishedRuntimeStateHeads = metadata.published_runtime_state_heads;
+  }
+
+  private markLoadedPublishedSnapshot(revisionId: string, host: RoomHostHandle): void {
+    this.loadedPublishedRevisionId = revisionId;
+    this.loadedPublishedNotebookHeads = Array.from(host.get_heads_hex());
+    this.loadedPublishedRuntimeStateHeads = Array.from(host.get_runtime_state_heads_hex());
+  }
+
   private async loadLatestPublishedSnapshotPair(): Promise<{
+    revisionId: string;
+    createdAt: string;
     notebookBytes: Uint8Array;
     runtimeStateBytes: Uint8Array;
   } | null> {
@@ -225,6 +355,8 @@ export class RoomMaterializer {
     }
 
     return {
+      revisionId: latest.id,
+      createdAt: latest.created_at,
       notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
       runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
     };
@@ -247,6 +379,60 @@ function normalizeResult(value: unknown): RoomHostFrameResult {
     runtime_state_changed: result?.runtime_state_changed ?? false,
     outbound: result?.outbound ?? [],
   };
+}
+
+function checkpointKeepReasonForRevisionMismatch(
+  metadata: RoomCheckpointMetadata,
+  latestPublishedCreatedAt: string,
+): string | null {
+  if (hasUnpublishedCheckpointChanges(metadata)) {
+    return "checkpoint_has_unpublished_changes";
+  }
+  if (legacyCheckpointIsNewerThanPublished(metadata, latestPublishedCreatedAt)) {
+    return "legacy_checkpoint_newer_than_published";
+  }
+  return null;
+}
+
+function hasUnpublishedCheckpointChanges(metadata: RoomCheckpointMetadata): boolean {
+  if (
+    metadata.version >= CHECKPOINT_VERSION &&
+    metadata.published_revision_id === null &&
+    ((metadata.published_notebook_heads === null && metadata.notebook_heads.length > 0) ||
+      (metadata.published_runtime_state_heads === null && metadata.runtime_state_heads.length > 0))
+  ) {
+    return true;
+  }
+  return (
+    headsChanged(metadata.notebook_heads, metadata.published_notebook_heads) ||
+    headsChanged(metadata.runtime_state_heads, metadata.published_runtime_state_heads)
+  );
+}
+
+function legacyCheckpointIsNewerThanPublished(
+  metadata: RoomCheckpointMetadata,
+  latestPublishedCreatedAt: string,
+): boolean {
+  if (metadata.version >= CHECKPOINT_VERSION || metadata.published_revision_id) {
+    return false;
+  }
+  const checkpointSavedAt = Date.parse(metadata.saved_at);
+  const latestPublishedAt = Date.parse(latestPublishedCreatedAt);
+  if (!Number.isFinite(checkpointSavedAt) || !Number.isFinite(latestPublishedAt)) {
+    return false;
+  }
+  return checkpointSavedAt > latestPublishedAt;
+}
+
+function headsChanged(current: string[], baseline: string[] | null): boolean {
+  if (!baseline) {
+    return false;
+  }
+  if (current.length !== baseline.length) {
+    return true;
+  }
+  const currentSet = new Set(current);
+  return baseline.some((head) => !currentSet.has(head));
 }
 
 function toUint8Array(value: Uint8Array | number[]): Uint8Array {

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1,7 +1,18 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import type { DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import type {
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  D1Value,
+  DurableObjectState,
+  Env,
+  R2Bucket,
+  R2Object,
+  R2ObjectBody,
+  R2PutOptions,
+} from "../src/cloudflare-types.ts";
 import { authenticateDevRequest } from "../src/identity.ts";
 import { FrameType, encodeTypedFrame, type FrameTypeValue } from "../src/protocol.ts";
 import { RoomMaterializer } from "../src/room-materializer.ts";
@@ -495,6 +506,457 @@ describe("RoomMaterializer", () => {
     assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
   });
 
+  it("keeps legacy versioned checkpoints when no published snapshot is available", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "legacy-cell",
+      "Legacy versioned checkpoint\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 2,
+        notebook_heads: ["legacy"],
+        runtime_state_heads: ["legacy-runtime"],
+        saved_at: "2026-05-27T00:00:00.000Z",
+      }),
+    ]);
+
+    const reloaded = new RoomMaterializer("demo", state, {} as Env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["legacy-cell", "Legacy versioned checkpoint\n"]],
+    );
+  });
+
+  it("uses the latest published snapshot instead of legacy versioned checkpoints", async () => {
+    const state = fakeState();
+    const legacySnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "legacy-cell",
+      "Legacy checkpoint edit\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(legacySnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(legacySnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 2,
+        notebook_heads: ["legacy"],
+        runtime_state_heads: ["legacy-runtime"],
+        saved_at: "2026-05-27T00:00:00.000Z",
+      }),
+    ]);
+
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Published snapshot markdown\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Published snapshot markdown\n"]],
+    );
+  });
+
+  it("keeps legacy versioned checkpoints saved after the latest published snapshot", async () => {
+    const state = fakeState();
+    const legacySnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "legacy-cell",
+      "Legacy checkpoint edit after publish\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(legacySnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(legacySnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 2,
+        notebook_heads: legacySnapshot.notebookHeads,
+        runtime_state_heads: legacySnapshot.runtimeStateHeads,
+        saved_at: "2026-05-29T00:00:00.000Z",
+      }),
+    ]);
+
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Published snapshot markdown\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["legacy-cell", "Legacy checkpoint edit after publish\n"]],
+    );
+  });
+
+  it("keeps current checkpoints with no published baseline when a snapshot appears later", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "local-cell",
+      "Local room edit before first publish\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: null,
+        published_notebook_heads: null,
+        published_runtime_state_heads: null,
+      }),
+    ]);
+
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Later published snapshot\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["local-cell", "Local room edit before first publish\n"]],
+    );
+  });
+
+  it("uses the latest published snapshot instead of stale revision checkpoints", async () => {
+    const state = fakeState();
+    const staleSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "stale-cell",
+      "Stale room checkpoint\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(staleSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(staleSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: staleSnapshot.notebookHeads,
+        runtime_state_heads: staleSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-27T00:00:00.000Z",
+        published_revision_id: "revision-old",
+        published_notebook_heads: staleSnapshot.notebookHeads,
+        published_runtime_state_heads: staleSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Published snapshot markdown\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-new",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Published snapshot markdown\n"]],
+    );
+  });
+
+  it("keeps checkpoints with unpublished changes when a newer revision exists", async () => {
+    const state = fakeState();
+    const seedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "edited-cell",
+      "Original checkpoint seed\n",
+    );
+    const editedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "edited-cell",
+      "Unpublished live edit\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(editedSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(editedSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: editedSnapshot.notebookHeads,
+        runtime_state_heads: editedSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-old",
+        published_notebook_heads: seedSnapshot.notebookHeads,
+        published_runtime_state_heads: seedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Newer published snapshot\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-new",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["edited-cell", "Unpublished live edit\n"]],
+    );
+  });
+
+  it("falls back to a valid checkpoint when published snapshot lookup fails", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Checkpoint survives catalog outage\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: checkpointSnapshot.notebookHeads,
+        published_runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const env = failingPublishedSnapshotEnv();
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["checkpoint-cell", "Checkpoint survives catalog outage\n"]],
+    );
+  });
+
+  it("keeps a checkpoint seeded from the current published revision", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "edited-cell",
+      "Live edited checkpoint\n",
+    );
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Original published snapshot\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: publishedSnapshot.notebookHeads,
+        published_runtime_state_heads: publishedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["edited-cell", "Live edited checkpoint\n"]],
+    );
+  });
+
   it("rejects runtime peer and editor execution creation over runtime-state sync", async () => {
     const state = fakeState();
     const materializer = new RoomMaterializer("demo", state, {} as Env);
@@ -792,6 +1254,30 @@ async function createRoomHostWithAcceptedExecution(
   return loadRoomHostSnapshot(seedHost.save_notebook(), runtimeSeed.save());
 }
 
+async function createNotebookRoomSnapshot(
+  notebookId: string,
+  cellId: string,
+  source: string,
+): Promise<{
+  notebookBytes: Uint8Array;
+  runtimeStateBytes: Uint8Array;
+  notebookHeads: string[];
+  runtimeStateHeads: string[];
+}> {
+  const host = await createEmptyRoomHost(notebookId, "system/schema:notebook-cloud-room");
+  const owner = NotebookHandle.create_bootstrap("user:dev:publisher/agent:runt-publish");
+  syncHostWithClient(host, "peer-owner", "user:dev:publisher", true, true, owner);
+  owner.add_cell(0, cellId, "markdown");
+  owner.update_source(cellId, source);
+  applyClientChangesToHost(host, "peer-owner", "user:dev:publisher", true, true, owner);
+  return {
+    notebookBytes: host.save_notebook(),
+    runtimeStateBytes: host.save_runtime_state_doc(),
+    notebookHeads: Array.from(host.get_heads_hex()),
+    runtimeStateHeads: Array.from(host.get_runtime_state_heads_hex()),
+  };
+}
+
 async function syncMaterializerWithRuntimePeer(
   materializer: RoomMaterializer,
   peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
@@ -1054,4 +1540,212 @@ function fakeState(): DurableObjectState {
     },
     waitUntil: () => undefined,
   };
+}
+
+function fakePublishedSnapshotEnv(input: {
+  notebookId: string;
+  revisionId: string;
+  actorLabel: string;
+  notebookBytes: Uint8Array;
+  runtimeStateBytes: Uint8Array;
+}): Env {
+  const snapshotKey = "test:notebook-snapshot";
+  const runtimeSnapshotKey = "test:runtime-state-snapshot";
+  const bucket = new FakeR2Bucket();
+  bucket.objects.set(snapshotKey, arrayBufferFromBytes(input.notebookBytes));
+  bucket.objects.set(runtimeSnapshotKey, arrayBufferFromBytes(input.runtimeStateBytes));
+  return {
+    DB: new FakeCatalogD1({
+      notebook: {
+        id: input.notebookId,
+        owner_principal: "user:dev:publisher",
+        title: null,
+        created_at: "2026-05-28T00:00:00.000Z",
+        updated_at: "2026-05-28T00:00:00.000Z",
+        latest_revision_id: input.revisionId,
+      },
+      revision: {
+        id: input.revisionId,
+        notebook_id: input.notebookId,
+        notebook_heads_hash: "heads-published",
+        runtime_heads_hash: "runtime-published",
+        snapshot_key: snapshotKey,
+        runtime_snapshot_key: runtimeSnapshotKey,
+        actor_label: input.actorLabel,
+        created_at: "2026-05-28T00:00:00.000Z",
+      },
+    }),
+    NOTEBOOK_SNAPSHOTS: bucket,
+  } as unknown as Env;
+}
+
+function failingPublishedSnapshotEnv(): Env {
+  const dbError = new Error("catalog unavailable");
+  return {
+    DB: {
+      prepare(): D1PreparedStatement {
+        throw dbError;
+      },
+      async exec(): Promise<D1Result> {
+        throw dbError;
+      },
+      async batch<T = unknown>(): Promise<D1Result<T>[]> {
+        throw dbError;
+      },
+    },
+    NOTEBOOK_SNAPSHOTS: new FakeR2Bucket(),
+  } as unknown as Env;
+}
+
+function arrayBufferFromBytes(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+class FakeCatalogD1 implements D1Database {
+  constructor(
+    readonly catalog: {
+      notebook: {
+        id: string;
+        owner_principal: string;
+        title: string | null;
+        created_at: string;
+        updated_at: string;
+        latest_revision_id: string;
+      };
+      revision: {
+        id: string;
+        notebook_id: string;
+        notebook_heads_hash: string;
+        runtime_heads_hash: string;
+        snapshot_key: string;
+        runtime_snapshot_key: string;
+        actor_label: string;
+        created_at: string;
+      };
+    },
+  ) {}
+
+  prepare(query: string): D1PreparedStatement {
+    return new FakeCatalogStatement(this, query);
+  }
+
+  async exec(): Promise<D1Result> {
+    return okResult();
+  }
+
+  async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    return Promise.all(statements.map((statement) => statement.run<T>()));
+  }
+}
+
+class FakeCatalogStatement implements D1PreparedStatement {
+  private values: D1Value[] = [];
+
+  constructor(
+    private readonly db: FakeCatalogD1,
+    private readonly query: string,
+  ) {}
+
+  bind(...values: D1Value[]): D1PreparedStatement {
+    this.values = values;
+    return this;
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    if (/FROM notebooks\s+WHERE id = \?/s.test(this.query)) {
+      const notebookId = this.values[0];
+      return notebookId === this.db.catalog.notebook.id ? (this.db.catalog.notebook as T) : null;
+    }
+    return null;
+  }
+
+  async run<T = unknown>(): Promise<D1Result<T>> {
+    return okResult<T>();
+  }
+
+  async all<T = unknown>(): Promise<D1Result<T>> {
+    if (/PRAGMA table_info\(notebook_revisions\)/.test(this.query)) {
+      return okResult([{ name: "runtime_snapshot_key" }] as T[]);
+    }
+    if (/FROM notebook_revisions/s.test(this.query)) {
+      const notebookId = this.values[0];
+      const results = notebookId === this.db.catalog.notebook.id ? [this.db.catalog.revision] : [];
+      return okResult(results as T[]);
+    }
+    if (/FROM notebook_blobs/s.test(this.query)) {
+      return okResult([]);
+    }
+    return okResult([]);
+  }
+}
+
+function okResult<T = unknown>(results: T[] = []): D1Result<T> {
+  return { results, success: true, meta: { changes: 0 } };
+}
+
+class FakeR2Bucket implements R2Bucket {
+  readonly objects = new Map<string, ArrayBuffer>();
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    const value = this.objects.get(key);
+    return value ? new FakeR2Object(key, value) : null;
+  }
+
+  async head(key: string): Promise<R2Object | null> {
+    const value = this.objects.get(key);
+    return value ? new FakeR2Object(key, value) : null;
+  }
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
+    _options?: R2PutOptions,
+  ): Promise<R2Object> {
+    const bytes =
+      typeof value === "string"
+        ? new TextEncoder().encode(value).buffer
+        : value instanceof ArrayBuffer
+          ? value
+          : ArrayBuffer.isView(value)
+            ? value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)
+            : new ArrayBuffer(0);
+    this.objects.set(key, bytes);
+    return new FakeR2Object(key, bytes);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
+}
+
+class FakeR2Object implements R2ObjectBody {
+  readonly version = "test";
+  readonly etag = "etag";
+  readonly httpEtag = "etag";
+  readonly uploaded = new Date("2026-05-28T00:00:00.000Z");
+  readonly httpMetadata = undefined;
+  readonly customMetadata = undefined;
+
+  constructor(
+    readonly key: string,
+    private readonly value: ArrayBuffer,
+  ) {}
+
+  get size(): number {
+    return this.value.byteLength;
+  }
+
+  get body(): ReadableStream {
+    return new Response(this.value).body!;
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    return this.value.slice(0);
+  }
+
+  async text(): Promise<string> {
+    return new TextDecoder().decode(this.value);
+  }
+
+  writeHttpMetadata(_headers: Headers): void {}
 }


### PR DESCRIPTION
## Summary

- make notebook-cloud room checkpoints remember the published revision that seeded them
- prefer the latest published snapshot pair when an older room checkpoint would shadow a newer publish
- cover both stale-checkpoint replacement and current-revision checkpoint preservation in room materializer tests

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/worker-routes.test.ts test/snapshot-render.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

This addresses the `topic-viz` preview failure where the render API had the current markdown intro but the hydrated live room materialized from stale Durable Object checkpoint data.
