### PR TITLE
test(notebook-cloud): target preview hosted smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -81,11 +81,11 @@ http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
 `NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair.
 
-`smoke:hosted` runs a headless Chromium check against the deployed canonical
-MathNet notebook by default:
+`smoke:hosted` runs a headless Chromium check against the deployed
+`preview.runt.run` topic-viz notebook by default:
 
 ```text
-https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet
+https://preview.runt.run/n/topic-viz
 ```
 
 Install the Chromium browser once before running the hosted smoke from a fresh
@@ -131,10 +131,9 @@ to publish an already-open live notebook room instead.
 `smoke:hosted:live` composes the two live checks: it runs `publish:live`, reads
 the returned viewer URL and exported notebook/runtime heads, then runs
 `smoke:hosted` against that exact notebook while asserting the catalog latest
-revision still points at those heads. Use
-`NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev` and
-`NOTEBOOK_CLOUD_DEV_TOKEN=...` to target the deployed prototype, or leave the
-defaults to target local Wrangler.
+revision still points at those heads. Use `NOTEBOOK_CLOUD_URL=https://preview.runt.run`
+and `NOTEBOOK_CLOUD_DEV_TOKEN=...` to target the deployed prototype, or leave
+the defaults to target local Wrangler.
 
 `smoke:hosted:source-room` covers the already-open room path. It creates and
 executes the same live MathNet notebook first, then calls `smoke:hosted:live`
@@ -409,9 +408,9 @@ Disposable Cloudflare resources currently wired in `wrangler.toml`:
 - Worker: `nteract-notebook-cloud`
 - Renderer asset Worker: `nteract-notebook-cloud-assets`
 - Output document Worker: `nteract-notebook-cloud-outputs`
-- URL: `https://nteract-notebook-cloud.rgbkrk.workers.dev`
+- URL: `https://preview.runt.run`
 - Renderer assets URL: `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/`
-- Output document URL: `https://nteract-notebook-cloud-outputs.rgbkrk.workers.dev/frame/`
+- Output document URL: `https://preview.runtusercontent.com/frame/`
 - D1: `nteract-notebook-cloud-prototype-db`
 - R2: `nteract-notebook-cloud-prototype`
 
@@ -481,19 +480,19 @@ Useful events while debugging collaboration:
 Quick deployed runbook:
 
 ```bash
-NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
+NOTEBOOK_CLOUD_URL=https://preview.runt.run \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud smoke
 
-NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
+NOTEBOOK_CLOUD_URL=https://preview.runt.run \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud wasm:roundtrip
 
-NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
+NOTEBOOK_CLOUD_URL=https://preview.runt.run \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud smoke:hosted:live
 
-NOTEBOOK_CLOUD_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev \
+NOTEBOOK_CLOUD_URL=https://preview.runt.run \
 NOTEBOOK_CLOUD_DEV_TOKEN=... \
 pnpm --dir apps/notebook-cloud smoke:hosted:collab
 
@@ -502,7 +501,7 @@ NOTEBOOK_CLOUD_ACCESS_ORIGIN=https://<access-protected-notebook-host> \
 NOTEBOOK_CLOUD_ACCESS_JWT="$(cloudflared access token -app=https://<access-protected-notebook-host>)" \
 pnpm --dir apps/notebook-cloud smoke:hosted:access
 
-NOTEBOOK_CLOUD_HOSTED_URL=https://nteract-notebook-cloud.rgbkrk.workers.dev/n/<id> \
+NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/<id>/<vanity-name> \
 NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0 \
 pnpm --dir apps/notebook-cloud smoke:hosted
 ```

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -97,7 +97,7 @@ pnpm --dir apps/notebook-cloud smoke:hosted:install
 
 It verifies that the hosted viewer renders the live-published code cell with a
 runtime-derived execution count, that sandboxed output iframes expose expected
-notebook content, and that Sift's WASM sidecar loads from the configured
+markdown and Sift notebook content, and that Sift's WASM sidecar loads from the configured
 renderer asset origin with CORS. It also checks the backing `/api/n/:id/render`
 document reports `source: "snapshot-pair"` so the smoke proves the page is using
 a materialized NotebookDoc + RuntimeStateDoc snapshot pair, and checks the
@@ -109,8 +109,11 @@ visual artifact.
 For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
 `NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT`, and
-`NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS`. Frame texts can be a JSON string array or
-a `|`-delimited list. Set `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip the
+`NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS`. Markdown cells and isolated output
+renderers are checked as frame text because they render inside sandboxed output
+documents. Frame texts can be a JSON string array or a `|`-delimited list. Set
+`NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS` only for text that should appear in the
+parent viewer document. Set `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip the
 render API source check. Set
 `NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL=` and
 `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL=` to skip the live-publish

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -1,17 +1,28 @@
 export function renderApiUrlForViewer(viewerUrl) {
-  const parsed = new URL(viewerUrl);
-  const match = parsed.pathname.match(/^\/n\/([^/]+)\/?$/);
-  if (!match) {
+  const parsed = notebookViewerUrl(viewerUrl);
+  if (!parsed) {
     return null;
   }
-  return new URL(`/api/n/${match[1]}/render`, parsed.origin).href;
+  return new URL(`/api/n/${parsed.notebookId}/render`, parsed.origin).href;
 }
 
 export function catalogApiUrlForViewer(viewerUrl) {
+  const parsed = notebookViewerUrl(viewerUrl);
+  if (!parsed) {
+    return null;
+  }
+  return new URL(`/api/n/${parsed.notebookId}`, parsed.origin).href;
+}
+
+export function notebookViewerUrl(viewerUrl) {
   const parsed = new URL(viewerUrl);
-  const match = parsed.pathname.match(/^\/n\/([^/]+)\/?$/);
+  const match = parsed.pathname.match(/^\/n\/([^/]+)(?:\/([^/]+))?\/?$/);
   if (!match) {
     return null;
   }
-  return new URL(`/api/n/${match[1]}`, parsed.origin).href;
+  const [, notebookId, vanityName] = match;
+  if (vanityName && ["debug", "r", "sync"].includes(vanityName)) {
+    return null;
+  }
+  return { origin: parsed.origin, notebookId, vanityName: vanityName ?? null };
 }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -30,12 +30,11 @@ const expectedSourceText =
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
 const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "viewing";
-const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", [
+const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", []);
+const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "MathNet topic visualization",
   "Loading the slice",
   "Schema at a glance",
-]);
-const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "PROBLEM_MARKDOWN",
 ]);
 const expectedRenderSource = process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE ?? "snapshot-pair";

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -13,24 +13,27 @@ import {
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import { catalogApiUrlForViewer, renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
-const DEFAULT_URL =
-  "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet";
+const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
-const DEFAULT_OUTPUT_DOCUMENT_ORIGIN = "https://nteract-notebook-cloud-outputs.rgbkrk.workers.dev";
-const DEFAULT_CATALOG_OWNER_PRINCIPAL = "user:dev:live-publish";
-const DEFAULT_LATEST_REVISION_ACTOR_LABEL = "user:dev:live-publish/agent:publish-live";
+const DEFAULT_OUTPUT_DOCUMENT_ORIGIN = "https://preview.runtusercontent.com";
+const DEFAULT_CATALOG_OWNER_PRINCIPAL = "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375";
+const DEFAULT_LATEST_REVISION_ACTOR_LABEL =
+  "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0/agent:runt-publish";
 
 const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
 const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
 const expectedOutputDocumentOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_OUTPUT_DOCUMENT_ORIGIN ?? DEFAULT_OUTPUT_DOCUMENT_ORIGIN;
-const expectedSourceText = process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "import polars as pl";
+const expectedSourceText =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
 const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "viewing";
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", [
-  "Loaded 25 rows",
+  "MathNet topic visualization",
+  "Loading the slice",
+  "Schema at a glance",
 ]);
 const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "PROBLEM_MARKDOWN",

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   catalogApiUrlForViewer,
+  notebookViewerUrl,
   renderApiUrlForViewer,
 } from "../scripts/hosted-render-smoke-routes.mjs";
 
@@ -13,6 +14,13 @@ describe("hosted render smoke routes", () => {
         "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
       ),
       "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet/render",
+    );
+  });
+
+  it("derives the render API URL from a hosted vanity notebook viewer URL", () => {
+    assert.equal(
+      renderApiUrlForViewer("https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit"),
+      "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/render",
     );
   });
 
@@ -27,11 +35,30 @@ describe("hosted render smoke routes", () => {
       catalogApiUrlForViewer("https://example.com/n/foo/"),
       "https://example.com/api/n/foo",
     );
+    assert.equal(
+      catalogApiUrlForViewer("https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit"),
+      "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80",
+    );
+  });
+
+  it("summarizes plain and vanity viewer URLs", () => {
+    assert.deepEqual(notebookViewerUrl("https://example.com/n/foo"), {
+      origin: "https://example.com",
+      notebookId: "foo",
+      vanityName: null,
+    });
+    assert.deepEqual(notebookViewerUrl("https://example.com/n/foo/lets-edit"), {
+      origin: "https://example.com",
+      notebookId: "foo",
+      vanityName: "lets-edit",
+    });
   });
 
   it("returns null for non-viewer URLs", () => {
     assert.equal(renderApiUrlForViewer("https://example.com/"), null);
     assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/debug"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/r/head123"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });


### PR DESCRIPTION
## Summary

- point the default hosted render smoke at `https://preview.runt.run/n/topic-viz`
- update hosted smoke expectations for the current preview output origin and published topic-viz provenance
- check topic-viz markdown headings in sandboxed output frames, matching the shared markdown renderer path
- derive render/catalog API preflight URLs from vanity viewer paths like `/n/{id}/{vanity-name}`
- refresh the notebook-cloud README deployment and smoke snippets for `preview.runt.run`

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-routes.test.mjs test/hosted-smoke-catalog.test.mjs test/hosted-smoke-preflight.test.mjs`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`

## Notes

The previous preview run reached anonymous render/catalog preflight but timed out waiting for topic-viz markdown text in the parent page. After deploying merged #3067, the default hosted smoke now passes by checking markdown headings and Sift table text inside sandboxed output frames.
