### PR TITLE
docs(notebook-cloud): align hosted auth path

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -1,10 +1,10 @@
 # nteract notebook cloud prototype
 
-This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates a dev, currently implemented Cloudflare Access, future direct OIDC, or anonymous viewer connection, authorizes that principal through the D1 room ACL, stamps a trusted `<principal>/<operator>` actor label, and routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id.
+This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates dev credentials, direct OIDC browser sessions, Anaconda API-key publishing requests, optional Cloudflare Access credentials, or anonymous viewer connections, authorizes the principal through the D1 room ACL, stamps a trusted `<principal>/<operator>` actor label, and routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id.
 
 The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata for sync frames that actually change a materialized document. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
 
-`/n/:notebookId` is now a public read-only notebook viewer. The durable source of truth is a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2; `/api/n/:id/render` materializes that pair with `NotebookHandle.load_snapshot()` when a render cache is absent. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
+`/n/:notebookId` is a hosted notebook page. `/api/n/:id/render` can warm-start the page from a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2, but connected browsers join `/n/:id/sync` and render from the live materialized room once sync is ready. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
 ## Local dev
 
@@ -212,13 +212,37 @@ browser to anonymous viewer mode. If the stored token is still a placeholder
 such as `<NOTEBOOK_CLOUD_DEV_TOKEN>`, the viewer refuses to use it, connects as
 an anonymous viewer instead, and shows a visible diagnostic with a reset button.
 
-## Cloudflare Access auth
+## Direct OIDC auth
 
-This is the currently implemented deployed-auth prototype path, but it is no
-longer the intended default production path. The architecture now points
-notebook-cloud at direct OIDC on `preview.runt.run`, reusing the retired
-`runtimed/intheloop` Anaconda stage OIDC lane. See
-`docs/architecture/hosted-direct-oidc-demo-runbook.md`.
+`preview.runt.run` uses direct OIDC against Anaconda stage. The Worker injects
+the issuer, client id, and redirect URI into the first-party viewer shell, and
+the browser completes an Authorization Code + PKCE flow through `/oidc`.
+Authenticated browser HTTP requests use `Authorization: Bearer`; browser
+WebSockets send the token through a non-echoed bearer subprotocol. The Worker
+validates the JWT issuer, audience/client id, signature, time claims, and
+principal namespace before consulting the D1 room ACL.
+
+Signed-in users can still read public notebooks when they do not have explicit
+collaborator rows. Viewer-scope HTTP reads authorize through the public
+`notebook_acl` row, and same-origin browser live-room connections may fall back
+from a stale `editor` request to stamped `viewer` scope for public notebooks.
+Mutation routes do not use that downgrade.
+
+Non-browser publishing uses Anaconda API keys with:
+
+```text
+Authorization: Bearer <ANACONDA_API_KEY>
+X-Notebook-Cloud-Auth-Provider: anaconda-api-key
+```
+
+See `docs/architecture/hosted-direct-oidc-demo-runbook.md`.
+
+## Optional Cloudflare Access auth
+
+This is an implemented prototype path, but it is not the intended default
+production path. The architecture points notebook-cloud at direct OIDC on
+`preview.runt.run`, reusing the retired `runtimed/intheloop` Anaconda stage
+OIDC lane.
 
 When `NOTEBOOK_CLOUD_ACCESS_TEAM_DOMAIN` and `NOTEBOOK_CLOUD_ACCESS_AUD`
 are configured, the Worker can authenticate Cloudflare Access/OIDC-style JWTs
@@ -568,13 +592,16 @@ curl "http://127.0.0.1:8787/api/n/demo/render"
 
 ## Next integration steps
 
-1. Verify the deployed Alice/Bob/anonymous viewer trial against the current
-   Worker after each live-sync change.
-2. Implement direct OIDC and take over `preview.runt.run` from the retired
-   `runtimed/intheloop` preview app.
-3. Replace flat ACL rows with the relationship model chosen for hosted
+1. Verify `preview.runt.run` topic-viz, lets-edit, and hosted smoke paths after
+   each live-sync or auth change.
+2. Keep the notebook page viewer-first: sign-in should not request edit by
+   default, and public-read fallback should keep signed-in users out of
+   anonymous-reset loops.
+3. Move the cloud viewer/editor toward shared desktop notebook controller and
+   cell/editor components instead of expanding cloud-only forks.
+4. Replace flat ACL rows with the relationship model chosen for hosted
    notebooks.
-4. Decide the runtime-peer upload flow for presigned blob writes and remote
+5. Decide the runtime-peer upload flow for presigned blob writes and remote
    runtime agents.
-5. Move notebook-specific output blobs to signed URLs or a dedicated private
+6. Move notebook-specific output blobs to signed URLs or a dedicated private
    output origin before hosting private notebooks at scale.

--- a/docs/architecture/deployment-topology.md
+++ b/docs/architecture/deployment-topology.md
@@ -113,12 +113,12 @@ whether a user or token can access a service or single-user server. Those Hub
 scopes authorize access to Hub compute. They do not grant nteract room roles;
 the nteract room ACL still grants `runtime_peer`, `editor`, or `owner`.
 
-Anaconda auth fits the hosted room side as an OIDC identity source. For the
-first Anaconda-friendly deployment, the notebook app should use direct OIDC
-against Anaconda stage on `preview.runt.run`, and the Worker should validate
-Anaconda-issued bearer JWTs before consulting the room ACL. Cloudflare Access
-can remain an optional outer perimeter for deployments that deliberately want
-it, but it is not the default notebook-cloud login path.
+Anaconda auth fits the hosted room side as an OIDC identity source. The
+Anaconda-friendly deployment uses direct OIDC against Anaconda stage on
+`preview.runt.run`, and the Worker validates Anaconda-issued bearer JWTs before
+consulting the room ACL. Cloudflare Access can remain an optional outer
+perimeter for deployments that deliberately want it, but it is not the default
+notebook-cloud login path.
 
 References:
 

--- a/docs/architecture/hosted-credential-transport.md
+++ b/docs/architecture/hosted-credential-transport.md
@@ -78,7 +78,7 @@ The room ACL still derives final connection scope. A provider claim or group may
 cap what the credential can do globally, but it does not grant per-notebook
 editor or owner access by itself.
 
-## Decision 2: Direct OIDC is the first hosted browser path
+## Decision 2: Direct OIDC is the hosted browser path for preview
 
 For the Anaconda-friendly hosted demo, the notebook application owns the OIDC
 browser flow directly:
@@ -117,10 +117,10 @@ we should reuse:
 | Staging takeover | `preview.runt.run` | `https://auth.stage.anaconda.com/api/auth` | `cec4781f-853c-4267-bf09-4bc59a2a3750` | `https://preview.runt.run/oidc` | `https://preview.runtusercontent.com` |
 | Production precedent | `app.runt.run` | `https://auth.anaconda.com/api/auth` | `74a51ff4-5814-48fa-9ae7-6d3ef0aca3e2` | `https://app.runt.run/oidc` | `https://runtusercontent.com` |
 
-Notebook-cloud should take over `preview.runt.run` first. The route transfer
-requires removing or replacing the old `runtimed/intheloop` preview Worker route
-and deploying notebook-cloud with the same OIDC redirect URI. The production
-`app.runt.run` lane is precedent, not the first target for notebook-cloud.
+Notebook-cloud uses `preview.runt.run` as the staging route. The route transfer
+from the old `runtimed/intheloop` preview Worker is historical context; current
+work should keep the same OIDC redirect URI and deployment variables. The
+production `app.runt.run` lane is precedent, not the notebook-cloud target.
 
 ### Principal namespace for direct OIDC login
 
@@ -133,16 +133,10 @@ Anaconda-scoped:
 user:anaconda:<encoded-anaconda-sub>
 ```
 
-If we deploy a first-party WorkOS app for a public `runtimed.com` viewer before
-Anaconda direct OIDC is available, the principal is WorkOS-scoped:
-
-```text
-user:workos:<encoded-workos-sub>
-```
-
 Email is display metadata and invite UX material; it is not the stable
-principal key. If a later migration links WorkOS users to Anaconda subjects, it
-must include an explicit subject mapping or ACL-row backfill plan.
+principal key. If a later deployment validates another OIDC provider, it must
+use a provider-specific namespace and include an explicit subject mapping or
+ACL-row backfill plan before linking those users to Anaconda subjects.
 
 ## Decision 3: Browser WebSocket bearer tokens use subprotocols
 
@@ -284,9 +278,19 @@ allowed if capabilities(requested_role)
   and subset_of acl_capabilities_for_principal
 ```
 
-If the check fails, reject the upgrade or HTTP request. Do not silently
-downgrade authenticated clients to viewer, because a downgraded editor fails
+If the check fails, reject mutation routes and non-browser system clients. Do
+not silently downgrade write APIs to viewer, because a downgraded editor fails
 later in harder-to-debug ways.
+
+The browser notebook page has one narrow exception for public notebooks:
+same-origin live-room WebSocket requests may fall back from a stale or eager
+`editor` request to `viewer` when the notebook has an explicit public-read ACL
+row and the authenticated principal lacks editor ACL rows. This keeps signed-in
+users able to read public notebooks without logging out. The connected scope is
+still stamped as `viewer`, viewer-authored document/runtime mutations are still
+rejected by the room host, and HTTP mutation routes do not use this downgrade.
+The intended UI is to connect as `viewer` by default and reconnect with
+`editor` only after the user requests editing.
 
 Anonymous requests have provider maximum capabilities of exactly viewer and are
 accepted only if the room has a public-read ACL row.
@@ -366,9 +370,9 @@ namespace, and optional perimeter configuration.
    `runtimed/intheloop` PKCE/localStorage shape initially. Before private
    notebooks become broad production surface, decide whether tokens should move
    behind a same-site BFF/session-cookie layer.
-2. **WorkOS fallback.** If we run a public `runtimed.com` viewer through WorkOS
-   before Anaconda direct OIDC is fully available, define the principal
-   namespace and future subject-linking story up front.
+2. **Additional OIDC providers.** If a public `runtimed.com` viewer validates a
+   different OIDC provider, define the principal namespace and future
+   subject-linking story up front.
 3. **Invite-by-email.** D1 ACLs key by principal, but people share by email.
    `docs/architecture/hosted-sharing-invites.md` sketches the pending-invite
    table, first-login resolution, display metadata, and public viewer UX.
@@ -380,8 +384,8 @@ namespace, and optional perimeter configuration.
    Admin revocation and provider sign-out need the future `SESSION_CONTROL`
    close path.
 6. **Service-token runtime peers.** Runtime sidecars need a clean credential
-   story, likely Anaconda scoped credentials, WorkOS machine credentials, or a
-   notebook-host-issued runtime ticket.
+   story, likely Anaconda scoped credentials, another configured OIDC machine
+   credential, or a notebook-host-issued runtime ticket.
 
 ## References
 

--- a/docs/architecture/hosted-direct-oidc-demo-runbook.md
+++ b/docs/architecture/hosted-direct-oidc-demo-runbook.md
@@ -1,8 +1,8 @@
 # Hosted Direct OIDC Anaconda Demo Runbook
 
-**Status:** Runbook, 2026-05-27.
-**Review trigger:** Re-check before any `preview.runt.run` route takeover,
-direct-OIDC Worker deployment, or Anaconda-backed hosted demo.
+**Status:** Runbook, updated 2026-05-28.
+**Review trigger:** Re-check before changing the `preview.runt.run` route,
+direct-OIDC Worker variables, or Anaconda-backed hosted demo.
 
 This is the operational path for the notebook-cloud direct OIDC demo:
 Cloudflare hosts the Worker, Durable Object, D1, R2, and custom domain, while
@@ -36,9 +36,9 @@ name = "anode-docworker-preview"
 routes = [{ pattern = "preview.runt.run", custom_domain = true }]
 ```
 
-Notebook-cloud should own that route after the direct-OIDC Worker path lands.
-Do not move the production `app.runt.run` route for this demo; it remains a
-production precedent and existing OIDC lane.
+Notebook-cloud now owns the staging lane for the hosted demo. Do not move the
+production `app.runt.run` route for this demo; it remains a production
+precedent and existing OIDC lane.
 
 ## Worker Runtime Variables
 
@@ -62,9 +62,9 @@ be replaced gradually. Use
 `NOTEBOOK_CLOUD_OIDC_JWKS_JSON` only for pinned/offline tests or an emergency
 where fetching the provider JWKS is intentionally disabled.
 
-`NOTEBOOK_CLOUD_DEV_TOKEN` may remain for scripted demo publishing and smoke
-tests until publish tooling has a first-class OIDC/API-key credential path. It
-is not the browser auth path.
+`NOTEBOOK_CLOUD_DEV_TOKEN` may remain for local-only smoke tests and emergency
+prototype diagnostics. It is not the browser auth path and it is not the
+publishing credential path.
 
 ## API-key Publishing
 
@@ -121,22 +121,19 @@ user:anaconda:<encoded-sub>
 Email, name, and avatar are display/audit metadata. They must not become
 `notebook_acl.subject` values.
 
-If a public `runtimed.com` viewer uses WorkOS first, that deployment should use
-`user:workos:<encoded-sub>` until a deliberate account-linking migration maps
-those users to Anaconda principals.
+If a future public `runtimed.com` viewer uses a different OIDC provider, that
+deployment must use a provider-specific principal namespace until a deliberate
+account-linking migration maps those users to Anaconda principals. Do not reuse
+email addresses as ACL subjects across providers.
 
-## Route Takeover Sequence
+## Deployment Validation Sequence
 
-1. Land and deploy the direct-OIDC Worker support behind the existing
-   `workers.dev` hostname.
+1. Deploy notebook-cloud's main Worker to `preview.runt.run`.
 2. Verify token validation and ACL behavior with a scripted bearer token or
-   local callback flow.
-3. Add notebook-cloud preview deployment config for `preview.runt.run`.
-4. Remove or replace the retired `runtimed/intheloop` `preview.runt.run` route.
-5. Deploy notebook-cloud's main Worker to `preview.runt.run`.
-6. Deploy/verify renderer asset and output-document Workers. Do not put the
+   browser callback flow.
+3. Deploy/verify renderer asset and output-document Workers. Do not put the
    renderer or output origins behind notebook app credentials.
-7. Run hosted smoke against:
+4. Run hosted smoke against:
    - anonymous public viewer;
    - authenticated viewer;
    - authenticated editor markdown edit;
@@ -145,8 +142,8 @@ those users to Anaconda principals.
 
 ## Expected Health Shape
 
-After direct OIDC is configured, `/api/health` should expose a non-secret OIDC
-readiness field, for example:
+With direct OIDC configured, `/api/health` exposes a non-secret OIDC readiness
+field:
 
 ```json
 {

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -73,6 +73,12 @@ The render path is derived. The first three paths are the durable publish
 artifact set, but hosts can precompute the render path at publish time to prove
 the snapshot pair and blob set are complete.
 
+For connected notebook pages, the live room supersedes the render path. `/render`
+is a warm-start cache and static/export read model, not a separate state lane.
+After the WebSocket materializes, viewers and editors render the same live
+`NotebookDoc` + `RuntimeStateDoc`; permission differences only change which
+frames the client may author.
+
 ## Decision 3: Materialization uses runtimed-wasm
 
 Hosted viewers and room hosts materialize published revisions by calling:
@@ -154,8 +160,9 @@ The bundle imports the shared isolated output embed API and the existing
 renderer plugin virtual modules. It receives notebook-specific configuration
 from the Worker HTML shell as JSON:
 
-- render endpoint (`/api/n/:id/render` or pinned `/renders/:headsHash`);
-- sync endpoint for anonymous viewer-scope presence;
+- render endpoint (`/api/n/:id/render` or pinned `/renders/:headsHash`) for
+  warm start;
+- sync endpoint for the live notebook room;
 - blob base path (`/api/n/:id/blobs/`);
 - renderer asset base URL;
 - runtimed WASM base URL;

--- a/docs/architecture/hosted-room-authorization.md
+++ b/docs/architecture/hosted-room-authorization.md
@@ -155,7 +155,8 @@ The authorization algorithm is deliberately rejection-oriented:
    capabilities and ACL capabilities. Anonymous public reads have provider
    capabilities of exactly `viewer`.
 6. If the check passes, the connection scope is exactly the requested role.
-   If it fails, reject the connection instead of silently downgrading.
+   If it fails, reject the connection instead of silently downgrading, except
+   for the browser live-room public-read case below.
 
 This keeps a WebSocket connection's scope scalar (`viewer`, `editor`,
 `runtime_peer`, or `owner`) while still allowing one principal to open multiple
@@ -169,6 +170,14 @@ maximum of `owner` when the request is local-loopback or carries the deployed de
 token. Real OIDC/JupyterHub providers should map credential claims to provider
 maximum capabilities before the ACL lookup.
 
+Browser notebook pages get one public-read compatibility path: if an
+authenticated user asks the live room for `editor` but has no editor ACL row,
+and the notebook has an explicit public `viewer` ACL row, the Worker may stamp
+the connection as `viewer`. This is allowed only for the same-origin live-room
+WebSocket path so stale tabs and over-eager UI defaults do not block signed-in
+users from reading public notebooks. HTTP mutation routes, publish routes, blob
+uploads, and system/native clients still fail rather than downgrade.
+
 ## Decision 4: Public viewers are authorized, not fallback guests
 
 Requests with no authenticated credential become anonymous principals only
@@ -179,9 +188,11 @@ anonymous:<session>/browser:<session>
 ```
 
 If a room has no public ACL row, an unauthenticated WebSocket upgrade or render
-API read gets `401`/`403`, not an implicit viewer session. Local Wrangler demo
-routes may seed a public-read ACL for the demo notebook, but deployed behavior
-must be explicit.
+API read gets `401`/`403`, not an implicit viewer session. A signed-in user who
+lacks a principal ACL row can still read through that public row when they
+request `viewer`, and browser live-room connections may use the public-read
+downgrade described above. Local Wrangler demo routes may seed a public-read
+ACL for the demo notebook, but deployed behavior must be explicit.
 
 Anonymous viewers are always read-only. They may receive room state and send
 presence. They may not send non-empty `NotebookDoc` or `RuntimeStateDoc` sync,
@@ -241,6 +252,13 @@ the request path that creates execution intent.
 Durable Object storage is not the source of truth for notebook content. It may
 hold hibernation metadata and a small amount of transient room state. R2
 snapshot pairs and D1 catalog/ACL rows are durable.
+
+For a connected browser page, the materialized live room is the active source
+of truth. A render cache or `/api/n/:id/render` response may warm-start first
+paint, but it must not become a separate read lane once the live room
+materializes. Read-only viewers and editors consume the same live
+`NotebookDoc`/`RuntimeStateDoc`; scope only limits what each connection may
+author.
 
 ## Decision 7: Markdown-only collaboration needs a semantic gate
 

--- a/docs/architecture/hosted-sharing-invites.md
+++ b/docs/architecture/hosted-sharing-invites.md
@@ -341,12 +341,12 @@ we choose the final share API names.
 ## Open Questions
 
 1. **Provider subject source.** For the first direct-OIDC demo, the principal is
-   `user:anaconda:<sub>`. If a WorkOS public viewer ships first, decide the
-   subject-linking migration before granting cross-provider ACL rows.
+   `user:anaconda:<sub>`. If another OIDC-backed public viewer ships first,
+   decide the subject-linking migration before granting cross-provider ACL rows.
 2. **Invite delivery.** Email delivery, invite-token links, and resend behavior
    are product work. ACL resolution does not depend on delivery mechanism.
 3. **Organization policy.** Some deployments may restrict invites to an
-   Anaconda org, email domain, or WorkOS/IdP group. That should be a share API
+   Anaconda org, email domain, or IdP group. That should be a share API
    validation rule, not a different ACL subject type.
 4. **Owner transfer.** Owner transfer needs confirmation and orphan protection.
    It should not be hidden inside invite-by-email.


### PR DESCRIPTION
# Summary

- update notebook-cloud docs to make direct Anaconda OIDC on `preview.runt.run` the active browser auth path
- demote Cloudflare Access to an optional/historical perimeter path
- document Anaconda API keys as the non-browser publishing credential path
- state that connected notebook pages use the live room as source of truth and `/render` is a warm-start/static-export cache
- document the public-read behavior for signed-in users, including the narrow browser live-room downgrade from stale `editor` requests to stamped `viewer` scope

# Verification

- `cargo xtask lint --fix`
- `git diff --check`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/html.test.ts test/oidc-auth.test.ts`

# Context

Local handoff: `.context/notebook-cloud-auth-adr-handoff-2026-05-28.md`

This is docs-only and targets the Track 0 ADR/docs alignment from the notebook-cloud parity plan. It intentionally does not change Worker auth behavior.
