### PR TITLE
test(notebook-cloud): cover progress widget parity

### DIFF
--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -25,7 +25,7 @@ test.describe("cloud renderer parity harness", () => {
 
     await expect(page.locator('[data-slot="read-only-notebook"]')).toHaveAttribute(
       "data-cell-count",
-      "10",
+      "11",
     );
     await expect(page.locator('[data-cell-id="code-streams"]')).toContainText(
       cloudOutputParityExpectedMarkers.stdout,
@@ -150,6 +150,41 @@ test.describe("cloud renderer parity harness", () => {
         .frameLocator('[data-cell-id="sift-arrow-output"] [data-sift-output="true"] iframe')
         .locator("body"),
     ).toContainText(cloudOutputParityExpectedMarkers.siftColumn, { timeout: 90_000 });
+  });
+
+  test("renders multiple progress widget views without falling back to plain text", async ({
+    page,
+  }) => {
+    await openParityHarness(page);
+
+    const progressCell = page.locator('[data-cell-id="widget-progress-output"]');
+    await expect(progressCell).not.toContainText("Cloud IntProgress fallback marker");
+    await expect(progressCell).not.toContainText("Cloud FloatProgress fallback marker");
+    await expect(progressCell.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(1, {
+      timeout: 30_000,
+    });
+
+    const frame = await findFrameContaining(
+      page,
+      progressCell,
+      'iframe[data-slot="isolated-frame"]',
+      '[data-widget-type="FloatProgress"]',
+    );
+    await expect(frame.locator('[data-widget-type="IntProgress"]')).toContainText(
+      cloudOutputParityExpectedMarkers.intProgress,
+    );
+    await expect(frame.locator('[data-widget-type="FloatProgress"]')).toContainText(
+      cloudOutputParityExpectedMarkers.floatProgress,
+    );
+    await expect(
+      frame.locator('[data-widget-type="IntProgress"] [role="progressbar"]'),
+    ).toHaveAttribute("aria-valuenow", "100");
+    await expect(
+      frame.locator('[data-widget-type="FloatProgress"] [role="progressbar"]'),
+    ).toHaveAttribute("aria-valuenow", "62.5");
+    await expect(
+      frame.locator('[data-widget-type="FloatProgress"] [role="progressbar"]'),
+    ).toHaveAttribute("style", /--progress-bar-color:\s*#f97316/);
   });
 
   test("segments DOM output, interactive plugins, and Sift into separate lanes", async ({

--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -199,6 +199,38 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
     ],
   },
   {
+    id: "widget-progress-output",
+    cell_type: "code",
+    source: [
+      "from tqdm.auto import tqdm",
+      "for _ in tqdm(range(56), desc='Resolving data files:'):",
+      "    pass",
+      "for _ in tqdm(range(8), desc='Loading shard:'):",
+      "    pass",
+    ].join("\n"),
+    execution_count: 8,
+    outputs: [
+      {
+        output_id: "widget-progress-int",
+        output_type: "display_data",
+        data: {
+          "application/vnd.jupyter.widget-view+json": { model_id: "cloud-topic-progress-int" },
+          "text/plain": "Cloud IntProgress fallback marker",
+        },
+        metadata: {},
+      },
+      {
+        output_id: "widget-progress-float",
+        output_type: "display_data",
+        data: {
+          "application/vnd.jupyter.widget-view+json": { model_id: "cloud-topic-progress-float" },
+          "text/plain": "Cloud FloatProgress fallback marker",
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
     id: "mixed-interactive-sift-output",
     cell_type: "code",
     source: [
@@ -206,7 +238,7 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
       "display(df)",
       "# Plotly and Sift should not share one isolated frame.",
     ].join("\n"),
-    execution_count: 8,
+    execution_count: 9,
     outputs: [
       {
         output_id: "mixed-output-stream",
@@ -267,7 +299,7 @@ export const cloudOutputParityRenderCells: readonly RenderCell[] = [
       "display(HTML('<strong>Cloud boundary HTML marker</strong>'))",
       "display(df)",
     ].join("\n"),
-    execution_count: 9,
+    execution_count: 10,
     outputs: [
       {
         output_id: "boundary-output-stream",
@@ -323,6 +355,53 @@ export const cloudOutputParityWidgetComms: readonly SnapshotWidgetComm[] = [
     },
     seq: 1,
   },
+  {
+    comm_id: "cloud-topic-progress-int",
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "IntProgressModel",
+    state: {
+      _model_module: "@jupyter-widgets/controls",
+      _model_name: "IntProgressModel",
+      description: "Resolving data files:",
+      value: 56,
+      min: 0,
+      max: 56,
+      bar_style: "success",
+      orientation: "horizontal",
+    },
+    seq: 2,
+  },
+  {
+    comm_id: "cloud-topic-progress-float",
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "FloatProgressModel",
+    state: {
+      _model_module: "@jupyter-widgets/controls",
+      _model_name: "FloatProgressModel",
+      description: "Loading shard:",
+      value: 0.625,
+      min: 0,
+      max: 1,
+      bar_style: "",
+      style: "IPY_MODEL_cloud-topic-progress-style",
+      orientation: "horizontal",
+    },
+    seq: 3,
+  },
+  {
+    comm_id: "cloud-topic-progress-style",
+    target_name: "jupyter.widget",
+    model_module: "@jupyter-widgets/controls",
+    model_name: "ProgressStyleModel",
+    state: {
+      _model_module: "@jupyter-widgets/controls",
+      _model_name: "ProgressStyleModel",
+      bar_color: "#f97316",
+    },
+    seq: 4,
+  },
 ];
 
 export const cloudOutputParityExpectedMarkers = {
@@ -336,6 +415,8 @@ export const cloudOutputParityExpectedMarkers = {
   fallback: "Plain text fallback marker",
   siftStream: "Preparing Cloud Sift Arrow fixture",
   siftColumn: "score",
+  intProgress: "Resolving data files:",
+  floatProgress: "Loading shard:",
   mixedStream: "Cloud mixed stream marker",
   boundaryStream: "Cloud boundary stream marker",
   boundaryHtml: "Cloud boundary HTML marker",


### PR DESCRIPTION
## Summary

- extends the notebook-cloud render parity fixture with a standalone tqdm-style progress widget cell
- covers both `IntProgressModel` and `FloatProgressModel`, including style-model `bar_color` resolution
- asserts the cloud renderer uses widget views instead of `text/plain` fallbacks

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/widget-runtime.test.ts test/widget-comms.test.ts test/renderer-contract.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
