### PR TITLE
fix(notebook-cloud): make latest viewer live-first

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -4,7 +4,7 @@ This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It 
 
 The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata for sync frames that actually change a materialized document. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
 
-`/n/:notebookId` is a hosted notebook page. `/api/n/:id/render` can warm-start the page from a persisted `NotebookDoc` + `RuntimeStateDoc` snapshot pair in R2, but connected browsers join `/n/:id/sync` and render from the live materialized room once sync is ready. Snapshot-pair publishes also pre-materialize the render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
+`/n/:notebookId` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` and `/api/n/:id/renders/:headsHash` remain pinned snapshot surfaces for immutable revisions, publish validation, export/debug readback, and cache regeneration. Snapshot-pair publishes also pre-materialize the pinned render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
 ## Local dev
 
@@ -98,10 +98,10 @@ pnpm --dir apps/notebook-cloud smoke:hosted:install
 It verifies that the hosted viewer renders the live-published code cell with a
 runtime-derived execution count, that sandboxed output iframes expose expected
 markdown and Sift notebook content, and that Sift's WASM sidecar loads from the configured
-renderer asset origin with CORS. It also checks the backing `/api/n/:id/render`
-document reports `source: "snapshot-pair"` so the smoke proves the page is using
-a materialized NotebookDoc + RuntimeStateDoc snapshot pair, and checks the
-catalog owner/latest revision actor match the live publish path. Override the
+renderer asset origin with CORS. It also checks the latest catalog revision and
+its pinned `/api/n/:id/renders/:headsHash` document report `source: "snapshot-pair"`
+so publish validation still proves the persisted NotebookDoc + RuntimeStateDoc
+pair is complete. Override the
 target with `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a
 visual artifact.
@@ -585,11 +585,11 @@ curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
   --data-binary @output.bin
 ```
 
-Catalog and render readback:
+Catalog and pinned render readback:
 
 ```bash
 curl "http://127.0.0.1:8787/api/n/demo"
-curl "http://127.0.0.1:8787/api/n/demo/render"
+curl "http://127.0.0.1:8787/api/n/demo/renders/{notebookHeadsHash}"
 ```
 
 ## Next integration steps

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -1,9 +1,12 @@
-export function renderApiUrlForViewer(viewerUrl) {
+export function renderApiUrlForViewer(viewerUrl, headsHash) {
   const parsed = notebookViewerUrl(viewerUrl);
-  if (!parsed) {
+  if (!parsed || typeof headsHash !== "string" || headsHash.length === 0) {
     return null;
   }
-  return new URL(`/api/n/${parsed.notebookId}/render`, parsed.origin).href;
+  return new URL(
+    `/api/n/${parsed.notebookId}/renders/${encodeURIComponent(headsHash)}`,
+    parsed.origin,
+  ).href;
 }
 
 export function catalogApiUrlForViewer(viewerUrl) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -149,10 +149,8 @@ async function main() {
   });
 
   try {
-    if (expectedRenderSource) {
-      renderApiCheck = await checkHostedRenderApi(targetUrl, expectedRenderSource);
-    }
     if (
+      expectedRenderSource ||
       expectedCatalogOwnerPrincipal ||
       expectedLatestRevisionActorLabel ||
       expectedLatestRevisionNotebookHeadsHash ||
@@ -164,6 +162,13 @@ async function main() {
         expectedLatestRevisionNotebookHeadsHash,
         expectedLatestRevisionRuntimeHeadsHash,
       });
+    }
+    if (expectedRenderSource) {
+      renderApiCheck = await checkHostedRenderApi(
+        targetUrl,
+        expectedRenderSource,
+        catalogApiCheck?.latestRevisionNotebookHeadsHash ?? null,
+      );
     }
     if (hasPreflightFailures(failures)) {
       throw new SmokeFailure(failures);
@@ -670,12 +675,12 @@ function isRelevantRequestUrl(value) {
   }
 }
 
-async function checkHostedRenderApi(viewerUrl, expectedSource) {
-  const renderUrl = renderApiUrlForViewer(viewerUrl);
+async function checkHostedRenderApi(viewerUrl, expectedSource, headsHash) {
+  const renderUrl = renderApiUrlForViewer(viewerUrl, headsHash);
   if (!renderUrl) {
     failures.push({
       kind: "render-api",
-      text: `Could not derive /api/n/:id/render URL from ${viewerUrl}`,
+      text: `Could not derive pinned render URL from ${viewerUrl}`,
     });
     return null;
   }

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -28,10 +28,10 @@ handle.update_source(
   [
     "# nteract cloud notebook",
     "",
-    "This public viewer is rendering a persisted NotebookDoc snapshot.",
+    "This public viewer is backed by the live notebook room.",
     "",
     "- The NotebookDoc and RuntimeStateDoc .am snapshots are stored in R2.",
-    "- The read-only render is materialized by runtimed-wasm from those snapshots.",
+    "- Pinned revisions can still be materialized by runtimed-wasm from those snapshots.",
   ].join("\n"),
 );
 handle.add_cell_after("hello", "code", "intro");
@@ -64,11 +64,13 @@ await putBytes(
   },
 );
 
-const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
-assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+const rendered = await fetchJson(
+  `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
+);
+assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
 assert(
   rendered.cells.some((cell) => cell.id === "hello" && cell.source.includes("nteract cloud")),
-  "latest snapshot render did not include the demo code cell",
+  "pinned snapshot render did not include the demo code cell",
 );
 
 console.log(
@@ -85,7 +87,7 @@ console.log(
         "runtimed_wasm_snapshot_pair",
         "r2_runtime_snapshot_publish",
         "r2_snapshot_publish",
-        "latest_snapshot_materialization",
+        "pinned_snapshot_materialization",
       ],
     },
     null,

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -59,8 +59,10 @@ await putBytes(
   },
 );
 
-const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
-assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+const rendered = await fetchJson(
+  `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
+);
+assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
 for (const blob of fixtureBlobs) {
   assert(
     rendered.blob_urls?.[blob.hash],
@@ -87,7 +89,7 @@ console.log(
       checks: [
         "fixture_snapshot_pair_publish",
         "runtime_state_output_manifests",
-        "latest_snapshot_materialization",
+        "pinned_snapshot_materialization",
         ...(fixtureBlobs.length > 0 ? ["fixture_blob_uploads", "blob_resolver_urls"] : []),
       ],
     },

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -58,8 +58,10 @@ try {
     },
   );
 
-  const rendered = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/render`);
-  assert(rendered.source === "snapshot-pair", "latest render was not materialized from snapshots");
+  const rendered = await fetchJson(
+    `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
+  );
+  assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
 
   console.log(
     JSON.stringify(
@@ -79,7 +81,7 @@ try {
           "live_session_snapshot_pair",
           "runtime_state_output_manifests",
           "local_blob_uploads",
-          "latest_snapshot_materialization",
+          "pinned_snapshot_materialization",
         ],
       },
       null,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -167,11 +167,6 @@ const worker: ExportedHandler<Env> = {
       return routeCatalog(request, env, decodeURIComponent(catalogMatch[1]));
     }
 
-    const latestRenderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/render$/);
-    if (latestRenderMatch && request.method === "GET") {
-      return routeLatestRender(request, env, decodeURIComponent(latestRenderMatch[1]));
-    }
-
     const aclMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/acl\/?$/);
     if (aclMatch) {
       return routeNotebookAcl(request, env, decodeURIComponent(aclMatch[1]));
@@ -1073,34 +1068,6 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
   return json(catalog);
 }
 
-async function routeLatestRender(
-  request: Request,
-  env: Env,
-  notebookId: string,
-): Promise<Response> {
-  if (!env.DB) {
-    return json({ error: "D1 binding DB is not configured" }, 503);
-  }
-  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
-  if (identity instanceof Response) {
-    return identity;
-  }
-
-  const catalog = await getNotebookCatalog(env, notebookId);
-  if (!catalog) {
-    return json({ error: "notebook not found" }, 404);
-  }
-
-  const revision =
-    catalog.revisions.find((candidate) => candidate.id === catalog.notebook.latest_revision_id) ??
-    catalog.revisions[0];
-  if (!revision) {
-    return json({ error: "notebook has no published revisions" }, 404);
-  }
-
-  return getRenderObjectOrMaterialize(request, env, notebookId, revision, false);
-}
-
 async function routeRender(
   request: Request,
   env: Env,
@@ -1900,7 +1867,7 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const renderEndpoint = headsHash
     ? `${notebookApiBasePath}/renders/${encodeURIComponent(headsHash)}`
-    : `${notebookApiBasePath}/render`;
+    : null;
   const config = {
     notebookId,
     headsHash: headsHash ?? null,

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -8,19 +8,23 @@ import {
 } from "../scripts/hosted-render-smoke-routes.mjs";
 
 describe("hosted render smoke routes", () => {
-  it("derives the render API URL from a hosted notebook viewer URL", () => {
+  it("derives the pinned render API URL from a hosted notebook viewer URL", () => {
     assert.equal(
       renderApiUrlForViewer(
         "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
+        "heads-latest",
       ),
-      "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet/render",
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet/renders/heads-latest",
     );
   });
 
-  it("derives the render API URL from a hosted vanity notebook viewer URL", () => {
+  it("derives the pinned render API URL from a hosted vanity notebook viewer URL", () => {
     assert.equal(
-      renderApiUrlForViewer("https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit"),
-      "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/render",
+      renderApiUrlForViewer(
+        "https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit",
+        "heads-edit",
+      ),
+      "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/renders/heads-edit",
     );
   });
 
@@ -56,9 +60,10 @@ describe("hosted render smoke routes", () => {
 
   it("returns null for non-viewer URLs", () => {
     assert.equal(renderApiUrlForViewer("https://example.com/"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/debug"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/r/head123"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo", null), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync", "heads"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/debug", "heads"), null);
+    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/r/head123", "heads"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -79,6 +79,21 @@ describe("HTML script serialization", () => {
     assert.doesNotMatch(html, /id="notebook"/);
   });
 
+  it("serves latest notebook viewers as live-sync shells without a latest render endpoint", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo"),
+      fakeEnv(),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /id="nteract-cloud-viewer-config"/);
+    assert.match(html, /"headsHash":null/);
+    assert.match(html, /"renderEndpoint":null/);
+    assert.match(html, /"syncEndpoint":"\/n\/demo\/sync"/);
+  });
+
   it("serves the root path as the notebook-cloud sign-in shell", async () => {
     const response = await worker.fetch(
       new Request("https://preview.runt.run/"),

--- a/apps/notebook-cloud/test/output-document-worker.test.ts
+++ b/apps/notebook-cloud/test/output-document-worker.test.ts
@@ -66,7 +66,7 @@ describe("output document Worker", () => {
 
   it("does not expose app APIs, room sockets, viewer bundles, renderer assets, or blobs", async () => {
     const blockedRoutes = [
-      "/api/n/demo/render",
+      "/api/n/demo/renders/heads-demo",
       "/api/n/demo/blobs/sha256-demo",
       "/n/demo/sync",
       "/assets/notebook-cloud-viewer.js",

--- a/apps/notebook-cloud/test/viewer-loading-policy.test.ts
+++ b/apps/notebook-cloud/test/viewer-loading-policy.test.ts
@@ -31,4 +31,18 @@ describe("cloud viewer loading policy", () => {
       },
     );
   });
+
+  it("routes malformed pinned configs into the snapshot branch so the viewer can show an error", () => {
+    assert.deepEqual(
+      cloudViewerLoadingPolicy({
+        headsHash: "heads-123",
+        renderEndpoint: null,
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        shouldFetchSnapshotRender: true,
+        initialStatusMessage: "Loading pinned notebook snapshot...",
+      },
+    );
+  });
 });

--- a/apps/notebook-cloud/test/viewer-loading-policy.test.ts
+++ b/apps/notebook-cloud/test/viewer-loading-policy.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { cloudViewerLoadingPolicy } from "../viewer/loading-policy.ts";
+
+describe("cloud viewer loading policy", () => {
+  it("uses live room sync for latest notebook URLs", () => {
+    assert.deepEqual(
+      cloudViewerLoadingPolicy({
+        headsHash: null,
+        renderEndpoint: null,
+      }),
+      {
+        shouldConnectLiveRoom: true,
+        shouldFetchSnapshotRender: false,
+        initialStatusMessage: "Connecting to live notebook room...",
+      },
+    );
+  });
+
+  it("uses pinned snapshot rendering for immutable revision URLs", () => {
+    assert.deepEqual(
+      cloudViewerLoadingPolicy({
+        headsHash: "heads-123",
+        renderEndpoint: "/api/n/demo/renders/heads-123",
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        shouldFetchSnapshotRender: true,
+        initialStatusMessage: "Loading pinned notebook snapshot...",
+      },
+    );
+  });
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2656,7 +2656,7 @@ describe("Worker artifact routes", () => {
     );
 
     const response = await worker.fetch(
-      new Request("http://localhost/api/n/route-demo/render"),
+      new Request("http://localhost/api/n/route-demo/renders/heads-fixture"),
       env,
       fakeContext(),
     );
@@ -2681,6 +2681,13 @@ describe("Worker artifact routes", () => {
       true,
       "materialized render should be cached back into R2",
     );
+
+    const latestRenderRoute = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/render"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(latestRenderRoute.status, 404);
   });
 
   it("rejects snapshot publish when the referenced runtime snapshot is missing", async () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -70,6 +70,7 @@ import {
   emptyCloudLivePresenceSnapshot,
   type CloudLivePresenceSnapshot,
 } from "./live-presence";
+import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
   cloudViewerPresenceDisplay,
@@ -106,7 +107,7 @@ import "./index.css";
 interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
-  renderEndpoint: string;
+  renderEndpoint: string | null;
   aclEndpoint: string;
   invitesEndpoint: string;
   syncEndpoint: string;
@@ -165,7 +166,6 @@ function loadConfig(): CloudViewerConfig {
   const parsed = JSON.parse(element.textContent ?? "{}") as Partial<CloudViewerConfig>;
   if (
     !parsed.notebookId ||
-    !parsed.renderEndpoint ||
     !parsed.aclEndpoint ||
     !parsed.invitesEndpoint ||
     !parsed.syncEndpoint ||
@@ -179,7 +179,10 @@ function loadConfig(): CloudViewerConfig {
   return {
     notebookId: parsed.notebookId,
     headsHash: parsed.headsHash ?? null,
-    renderEndpoint: parsed.renderEndpoint,
+    renderEndpoint:
+      typeof parsed.renderEndpoint === "string" && parsed.renderEndpoint.length > 0
+        ? parsed.renderEndpoint
+        : null,
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
     syncEndpoint: parsed.syncEndpoint,
@@ -529,11 +532,12 @@ function NotebookViewer({
   authConfig: CloudViewerAuthConfig;
 }) {
   const { config } = runtime;
+  const loadingPolicy = cloudViewerLoadingPolicy(config);
   const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
-    message: "Loading notebook snapshot...",
+    message: loadingPolicy.initialStatusMessage,
   });
   const [cells, setCells] = useState<ResolvedCell[]>([]);
   const [showCode, setShowCode] = useState(true);
@@ -587,13 +591,23 @@ function NotebookViewer({
     if (authRenewal.kind === "refreshing") {
       return;
     }
+    if (!loadingPolicy.shouldFetchSnapshotRender) {
+      snapshotResolvedRef.current = true;
+      return;
+    }
+    if (!config.renderEndpoint) {
+      snapshotResolvedRef.current = true;
+      setStatus({ kind: "error", message: "Pinned notebook render endpoint is not configured." });
+      return;
+    }
 
     let cancelled = false;
+    const renderEndpoint = config.renderEndpoint;
 
     void (async () => {
       try {
         const response = await fetch(
-          config.renderEndpoint,
+          renderEndpoint,
           withCloudPrototypeAuthHeaders({ headers: { Accept: "application/json" } }, authState),
         );
         if (!response.ok) {
@@ -653,10 +667,22 @@ function NotebookViewer({
     return () => {
       cancelled = true;
     };
-  }, [authRenewal.kind, authState, blobResolver, config.renderEndpoint, widgetStore]);
+  }, [
+    authRenewal.kind,
+    authState,
+    blobResolver,
+    config.blobBasePath,
+    config.renderEndpoint,
+    config.rendererAssetsBasePath,
+    loadingPolicy.shouldFetchSnapshotRender,
+    widgetStore,
+  ]);
 
   useEffect(() => {
     if (authRenewal.kind === "refreshing") {
+      return;
+    }
+    if (!loadingPolicy.shouldConnectLiveRoom) {
       return;
     }
 
@@ -803,6 +829,14 @@ function NotebookViewer({
       })
       .catch((error: unknown) => {
         if (disposed) return;
+        if (cellsRef.current.length === 0) {
+          setStatus({
+            kind: "error",
+            message: `Unable to load live notebook room: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        }
         setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
         setConnectionScope(null);
         setConnectionActorLabel(null);
@@ -823,7 +857,19 @@ function NotebookViewer({
       setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
       setLivePresence(emptyCloudLivePresenceSnapshot());
     };
-  }, [authRenewal.kind, authState, blobResolver, config.syncEndpoint, connectAttempt, widgetStore]);
+  }, [
+    authRenewal.kind,
+    authState,
+    blobResolver,
+    config.blobBasePath,
+    config.rendererAssetsBasePath,
+    config.runtimedWasmModulePath,
+    config.runtimedWasmPath,
+    config.syncEndpoint,
+    connectAttempt,
+    loadingPolicy.shouldConnectLiveRoom,
+    widgetStore,
+  ]);
 
   const readOnlyCells = useMemo(
     () =>

--- a/apps/notebook-cloud/viewer/loading-policy.ts
+++ b/apps/notebook-cloud/viewer/loading-policy.ts
@@ -1,0 +1,29 @@
+export interface CloudViewerLoadingPolicyConfig {
+  headsHash: string | null;
+  renderEndpoint: string | null;
+}
+
+export interface CloudViewerLoadingPolicy {
+  shouldConnectLiveRoom: boolean;
+  shouldFetchSnapshotRender: boolean;
+  initialStatusMessage: string;
+}
+
+export function cloudViewerLoadingPolicy({
+  headsHash,
+  renderEndpoint,
+}: CloudViewerLoadingPolicyConfig): CloudViewerLoadingPolicy {
+  if (headsHash) {
+    return {
+      shouldConnectLiveRoom: false,
+      shouldFetchSnapshotRender: Boolean(renderEndpoint),
+      initialStatusMessage: "Loading pinned notebook snapshot...",
+    };
+  }
+
+  return {
+    shouldConnectLiveRoom: true,
+    shouldFetchSnapshotRender: false,
+    initialStatusMessage: "Connecting to live notebook room...",
+  };
+}

--- a/apps/notebook-cloud/viewer/loading-policy.ts
+++ b/apps/notebook-cloud/viewer/loading-policy.ts
@@ -11,12 +11,11 @@ export interface CloudViewerLoadingPolicy {
 
 export function cloudViewerLoadingPolicy({
   headsHash,
-  renderEndpoint,
 }: CloudViewerLoadingPolicyConfig): CloudViewerLoadingPolicy {
   if (headsHash) {
     return {
       shouldConnectLiveRoom: false,
-      shouldFetchSnapshotRender: Boolean(renderEndpoint),
+      shouldFetchSnapshotRender: true,
       initialStatusMessage: "Loading pinned notebook snapshot...",
     };
   }


### PR DESCRIPTION
## Summary

- make latest `/n/:id` and `/n/:id/:vanity` viewer shells sync-first by omitting a latest render endpoint
- delete the overlapping latest `/api/n/:id/render` route while keeping pinned `/api/n/:id/renders/:headsHash`
- update publish/smoke scripts, docs, and route tests to validate pinned render artifacts from catalog heads

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/worker-routes.test.ts test/hosted-smoke-routes.test.mjs test/viewer-loading-policy.test.ts test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

Current hosted notebook URLs now use the Automerge room as the authoritative document path for both read-only viewers and editor+ sessions. Snapshot render materialization remains for immutable revisions, publish validation, and smoke/export diagnostics.
