### PR TITLE
refactor(notebook-cloud): derive pinned render URLs

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1865,13 +1865,10 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
   const escaped = escapeHtml(notebookId);
   const title = headsHash ? `${escaped} @ ${escapeHtml(headsHash)}` : escaped;
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
-  const renderEndpoint = headsHash
-    ? `${notebookApiBasePath}/renders/${encodeURIComponent(headsHash)}`
-    : null;
   const config = {
     notebookId,
     headsHash: headsHash ?? null,
-    renderEndpoint,
+    pinnedRenderBasePath: `${notebookApiBasePath}/renders/`,
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -68,7 +68,8 @@ describe("HTML script serialization", () => {
         html.indexOf("/assets/notebook-cloud-viewer.css"),
       "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
     );
-    assert.match(html, /"renderEndpoint":"\/api\/n\/demo\/renders\/heads-123"/);
+    assert.doesNotMatch(html, /"renderEndpoint"/);
+    assert.match(html, /"pinnedRenderBasePath":"\/api\/n\/demo\/renders\/"/);
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
@@ -90,7 +91,8 @@ describe("HTML script serialization", () => {
     assert.equal(response.status, 200);
     assert.match(html, /id="nteract-cloud-viewer-config"/);
     assert.match(html, /"headsHash":null/);
-    assert.match(html, /"renderEndpoint":null/);
+    assert.doesNotMatch(html, /"renderEndpoint"/);
+    assert.match(html, /"pinnedRenderBasePath":"\/api\/n\/demo\/renders\/"/);
     assert.match(html, /"syncEndpoint":"\/n\/demo\/sync"/);
   });
 

--- a/apps/notebook-cloud/test/viewer-loading-policy.test.ts
+++ b/apps/notebook-cloud/test/viewer-loading-policy.test.ts
@@ -8,7 +8,6 @@ describe("cloud viewer loading policy", () => {
     assert.deepEqual(
       cloudViewerLoadingPolicy({
         headsHash: null,
-        renderEndpoint: null,
       }),
       {
         shouldConnectLiveRoom: true,
@@ -22,21 +21,6 @@ describe("cloud viewer loading policy", () => {
     assert.deepEqual(
       cloudViewerLoadingPolicy({
         headsHash: "heads-123",
-        renderEndpoint: "/api/n/demo/renders/heads-123",
-      }),
-      {
-        shouldConnectLiveRoom: false,
-        shouldFetchSnapshotRender: true,
-        initialStatusMessage: "Loading pinned notebook snapshot...",
-      },
-    );
-  });
-
-  it("routes malformed pinned configs into the snapshot branch so the viewer can show an error", () => {
-    assert.deepEqual(
-      cloudViewerLoadingPolicy({
-        headsHash: "heads-123",
-        renderEndpoint: null,
       }),
       {
         shouldConnectLiveRoom: false,

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -107,7 +107,7 @@ import "./index.css";
 interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
-  renderEndpoint: string | null;
+  pinnedRenderBasePath: string;
   aclEndpoint: string;
   invitesEndpoint: string;
   syncEndpoint: string;
@@ -166,6 +166,7 @@ function loadConfig(): CloudViewerConfig {
   const parsed = JSON.parse(element.textContent ?? "{}") as Partial<CloudViewerConfig>;
   if (
     !parsed.notebookId ||
+    !parsed.pinnedRenderBasePath ||
     !parsed.aclEndpoint ||
     !parsed.invitesEndpoint ||
     !parsed.syncEndpoint ||
@@ -179,10 +180,7 @@ function loadConfig(): CloudViewerConfig {
   return {
     notebookId: parsed.notebookId,
     headsHash: parsed.headsHash ?? null,
-    renderEndpoint:
-      typeof parsed.renderEndpoint === "string" && parsed.renderEndpoint.length > 0
-        ? parsed.renderEndpoint
-        : null,
+    pinnedRenderBasePath: parsed.pinnedRenderBasePath,
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
     syncEndpoint: parsed.syncEndpoint,
@@ -595,14 +593,14 @@ function NotebookViewer({
       snapshotResolvedRef.current = true;
       return;
     }
-    if (!config.renderEndpoint) {
+    const renderEndpoint = pinnedRenderEndpoint(config);
+    if (!renderEndpoint) {
       snapshotResolvedRef.current = true;
-      setStatus({ kind: "error", message: "Pinned notebook render endpoint is not configured." });
+      setStatus({ kind: "error", message: "Pinned notebook heads are not configured." });
       return;
     }
 
     let cancelled = false;
-    const renderEndpoint = config.renderEndpoint;
 
     void (async () => {
       try {
@@ -672,7 +670,8 @@ function NotebookViewer({
     authState,
     blobResolver,
     config.blobBasePath,
-    config.renderEndpoint,
+    config.headsHash,
+    config.pinnedRenderBasePath,
     config.rendererAssetsBasePath,
     loadingPolicy.shouldFetchSnapshotRender,
     widgetStore,
@@ -1925,6 +1924,16 @@ function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {
   } catch {
     return false;
   }
+}
+
+function pinnedRenderEndpoint(config: CloudViewerConfig): string | null {
+  if (!config.headsHash) {
+    return null;
+  }
+  const basePath = config.pinnedRenderBasePath.endsWith("/")
+    ? config.pinnedRenderBasePath
+    : `${config.pinnedRenderBasePath}/`;
+  return `${basePath}${encodeURIComponent(config.headsHash)}`;
 }
 
 createRoot(requireElement("#root")).render(

--- a/apps/notebook-cloud/viewer/loading-policy.ts
+++ b/apps/notebook-cloud/viewer/loading-policy.ts
@@ -1,6 +1,5 @@
 export interface CloudViewerLoadingPolicyConfig {
   headsHash: string | null;
-  renderEndpoint: string | null;
 }
 
 export interface CloudViewerLoadingPolicy {


### PR DESCRIPTION
## Summary

- Rebased on `main` after #3072 merged.
- Removes the per-revision `renderEndpoint` field from the cloud viewer shell config.
- Keeps cloud route ownership in the Worker by passing `pinnedRenderBasePath`, then lets the viewer append the pinned heads hash locally.
- Simplifies the latest-vs-pinned loading policy so it only branches on `headsHash`.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-loading-policy.test.ts test/html.test.ts test/renderer-contract.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `git diff --check`
