### PR TITLE
fix(notebook): remove needless diagnostics path borrow

### DIFF
--- a/crates/notebook/src/diagnostics_upload.rs
+++ b/crates/notebook/src/diagnostics_upload.rs
@@ -198,7 +198,7 @@ fn prepare_archive_in_dir(runt_path: &Path, output_dir: &Path) -> Result<Prepare
         ));
     }
 
-    let archive_path = find_diagnostics_archive(&output_dir)?;
+    let archive_path = find_diagnostics_archive(output_dir)?;
     let metadata = fs::metadata(&archive_path).map_err(|e| {
         format!(
             "Failed to inspect diagnostics archive {}: {e}",


### PR DESCRIPTION
## Summary

- Remove an unnecessary borrow when finding the prepared diagnostics archive.
- Keep the diagnostics upload path behavior unchanged while satisfying Clippy's `needless_borrow` lint.

## Verification

- `cargo clippy -p notebook --lib --tests -- -D warnings`
- `cargo xtask lint --fix`
- `git diff --check`
