### PR TITLE
fix(notebook-cloud): refresh auth after storage changes

### DIFF
--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -3,12 +3,14 @@ import assert from "node:assert/strict";
 import {
   NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
   NOTEBOOK_CLOUD_DEFAULT_SCOPE,
+  NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY,
   NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
   NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
   NOTEBOOK_CLOUD_USER_STORAGE_KEY,
   cloudHttpHeadersFromPrototypeAuthState,
   clearCloudPrototypeDevAuth,
   cloudSyncAuthFromPrototypeAuthState,
+  isCloudPrototypeAuthStorageKey,
   prepareCloudOidcViewerLogin,
   prototypeAuthDiagnostics,
   prototypeAuthSummary,
@@ -32,6 +34,16 @@ describe("cloud collaborator auth", () => {
       operator: null,
       requestedScope: null,
     });
+  });
+
+  it("identifies auth storage keys that should refresh stale browser tabs", () => {
+    assert.equal(isCloudPrototypeAuthStorageKey(NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY), true);
+    assert.equal(isCloudPrototypeAuthStorageKey(NOTEBOOK_CLOUD_USER_STORAGE_KEY), true);
+    assert.equal(isCloudPrototypeAuthStorageKey(NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY), true);
+    assert.equal(isCloudPrototypeAuthStorageKey(NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY), true);
+    assert.equal(isCloudPrototypeAuthStorageKey(NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY), true);
+    assert.equal(isCloudPrototypeAuthStorageKey(null), true);
+    assert.equal(isCloudPrototypeAuthStorageKey("nteract:notebook-cloud:theme"), false);
   });
 
   it("builds WebSocket subprotocol auth without putting the token in the URL", () => {

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -122,7 +122,7 @@ describe("cloud collaborator auth", () => {
     assert.match(prototypeAuthSummary(state), /Anil requesting viewer/);
   });
 
-  it("falls back to anonymous auth for expired non-refreshable OIDC sessions", () => {
+  it("keeps expired non-refreshable OIDC sessions visible for renewal", () => {
     const storage = new MemoryStorage();
     storage.setItem(
       NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
@@ -145,10 +145,12 @@ describe("cloud collaborator auth", () => {
 
     const state = readCloudPrototypeAuth(storage);
 
-    assert.equal(state.mode, "anonymous");
+    assert.equal(state.mode, "oidc_expired");
     assert.equal(state.token, null);
-    assert.equal(state.problem, null);
-    assert.equal(prototypeAuthSummary(state), "Anonymous read-only viewer");
+    assert.equal(state.user, "Expired User");
+    assert.equal(state.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
+    assert.equal(state.problem, "Stored OIDC session is expired. Sign in again.");
+    assert.equal(prototypeAuthSummary(state), "Expired User needs sign-in renewal.");
     assert.deepEqual(cloudSyncAuthFromPrototypeAuthState(state), {
       headers: {},
       protocols: [],
@@ -156,6 +158,39 @@ describe("cloud collaborator auth", () => {
       operator: null,
       requestedScope: null,
     });
+  });
+
+  it("diagnoses expired OIDC sessions without exposing stale bearer material", () => {
+    const storage = new MemoryStorage();
+    const accessToken = jwt({
+      sub: "anaconda-user-expired",
+      email: "expired@example.com",
+      name: "Expired User",
+    });
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken,
+        refreshToken: null,
+        expiresAt: Math.floor(Date.now() / 1000) - 3600,
+        claims: {
+          sub: "anaconda-user-expired",
+          email: "expired@example.com",
+          name: "Expired User",
+        },
+      }),
+    );
+
+    const diagnostics = prototypeAuthDiagnostics(readCloudPrototypeAuth(storage), {
+      actorLabel: null,
+      connectionError: null,
+      connectionScope: "viewer",
+    });
+
+    assert.match(diagnostics.copyText, /Stored identity: Expired User/);
+    assert.match(diagnostics.copyText, /Sign-in: Stored OIDC session is expired/);
+    assert.match(diagnostics.copyText, /Effective auth: No expired bearer token is sent/);
+    assert.doesNotMatch(diagnostics.copyText, new RegExp(accessToken.replaceAll(".", "\\.")));
   });
 
   it("can request an editor role from a browser Access session without JS token material", () => {

--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -217,6 +217,7 @@ describe("cloud OIDC browser auth", () => {
     assert.equal(stored.token, null);
     assert.equal(stored.problem, null);
     assert.equal(stored.expired, true);
+    assert.equal(stored.expiredClaims?.name, "Expired User");
     assert.equal(storedOidcTokenNeedsRefresh(storage, 200), false);
   });
 

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -21,6 +21,14 @@ export const NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY = "nteract:notebook-cloud:scope";
 export const NOTEBOOK_CLOUD_DEFAULT_SCOPE: ConnectionScope = "viewer";
 export { NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY, NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY };
 
+const NOTEBOOK_CLOUD_AUTH_STORAGE_KEYS = new Set<string>([
+  NOTEBOOK_CLOUD_DEV_TOKEN_STORAGE_KEY,
+  NOTEBOOK_CLOUD_USER_STORAGE_KEY,
+  NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
+  NOTEBOOK_CLOUD_OIDC_REQUEST_STORAGE_KEY,
+  NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+]);
+
 export interface CloudSyncAuth {
   headers: Record<string, string>;
   protocols: string[];
@@ -79,6 +87,10 @@ export function cloudPrototypeAuthFromWindow(): CloudPrototypeAuthState {
   } catch {
     return anonymousAuthState();
   }
+}
+
+export function isCloudPrototypeAuthStorageKey(key: string | null): boolean {
+  return key === null || NOTEBOOK_CLOUD_AUTH_STORAGE_KEYS.has(key);
 }
 
 export function readCloudPrototypeAuth(

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -30,7 +30,7 @@ export interface CloudSyncAuth {
 }
 
 export interface CloudPrototypeAuthState {
-  mode: "anonymous" | "access" | "dev" | "invalid" | "oidc";
+  mode: "anonymous" | "access" | "dev" | "invalid" | "oidc" | "oidc_expired";
   token: string | null;
   user: string | null;
   oidcClaims: CloudOidcClaims | null;
@@ -109,7 +109,14 @@ export function readCloudPrototypeAuth(
       };
     }
     if (oidcSession.expired) {
-      return anonymousAuthState();
+      return {
+        mode: "oidc_expired",
+        token: null,
+        user: oidcSession.expiredClaims ? oidcDisplayName(oidcSession.expiredClaims) : null,
+        oidcClaims: oidcSession.expiredClaims,
+        requestedScope: NOTEBOOK_CLOUD_DEFAULT_SCOPE,
+        problem: "Stored OIDC session is expired. Sign in again.",
+      };
     }
     if (requestedScope) {
       return {
@@ -289,11 +296,14 @@ export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
       state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE
     }`;
   }
+  if (state.mode === "oidc_expired") {
+    return `${state.user ?? "OIDC session"} needs sign-in renewal.`;
+  }
   if (state.mode === "access") {
     return `Browser session requesting ${state.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE}`;
   }
   if (state.mode === "invalid") {
-    return `${state.problem ?? "Stored collaborator token is invalid"} Connected anonymously.`;
+    return state.problem ?? "Stored collaborator token is invalid.";
   }
   return "Anonymous read-only viewer";
 }
@@ -338,6 +348,31 @@ export function prototypeAuthDiagnostics(
       rows.push({
         label: "Provider subject",
         value: state.oidcClaims.sub,
+      });
+    }
+  } else if (state.mode === "oidc_expired") {
+    rows.push(
+      {
+        label: "Stored identity",
+        value: state.user ?? "OIDC session",
+        tone: "warning",
+      },
+      {
+        label: "Sign-in",
+        value: state.problem ?? "Stored OIDC session is expired. Sign in again.",
+        tone: "warning",
+      },
+      {
+        label: "Effective auth",
+        value: "No expired bearer token is sent; public notebooks may still load as a viewer.",
+        tone: "warning",
+      },
+    );
+    if (state.oidcClaims?.sub) {
+      rows.push({
+        label: "Provider subject",
+        value: state.oidcClaims.sub,
+        tone: "warning",
       });
     }
   } else if (state.mode === "access") {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -45,6 +45,7 @@ import {
   cloudPrototypeAuthFromWindow,
   cloudSyncAuthFromPrototypeAuthState,
   fetchWithCloudPrototypeAuth,
+  isCloudPrototypeAuthStorageKey,
   NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   prepareCloudOidcViewerLogin,
   prototypeAuthDiagnostics,
@@ -294,15 +295,27 @@ function useCloudPrototypeAuth(authConfig: CloudViewerAuthConfig): {
         void refreshOidcIfNeeded();
       }
     };
+    const refreshOnStorage = (event: StorageEvent) => {
+      if (event.storageArea && event.storageArea !== window.localStorage) {
+        return;
+      }
+      if (!isCloudPrototypeAuthStorageKey(event.key)) {
+        return;
+      }
+      refreshAuthState();
+      void refreshOidcIfNeeded();
+    };
     window.addEventListener("focus", refreshOnFocus);
+    window.addEventListener("storage", refreshOnStorage);
     document.addEventListener("visibilitychange", refreshOnVisibility);
 
     return () => {
       window.clearInterval(interval);
       window.removeEventListener("focus", refreshOnFocus);
+      window.removeEventListener("storage", refreshOnStorage);
       document.removeEventListener("visibilitychange", refreshOnVisibility);
     };
-  }, [refreshOidcIfNeeded]);
+  }, [refreshAuthState, refreshOidcIfNeeded]);
 
   return { authState, authRenewal, refreshAuthState };
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -450,7 +450,9 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
             </button>
           )}
           <a href="/n/topic-viz">Open topic-viz</a>
-          {authState.mode === "invalid" || authState.mode === "access" ? (
+          {authState.mode === "invalid" ||
+          authState.mode === "access" ||
+          authState.mode === "oidc_expired" ? (
             <button type="button" onClick={resetAuth}>
               <RotateCcw aria-hidden="true" />
               Reset
@@ -998,7 +1000,7 @@ function NotebookViewer({
         </div>
       </div>
 
-      {authState.mode === "invalid" ? (
+      {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
         <div className="cloud-state cloud-auth-state mx-8 mr-4" data-kind="error">
           <span>{prototypeAuthSummary(authState)}</span>
           <button type="button" onClick={resetPrototypeAuth}>
@@ -1549,7 +1551,7 @@ function CloudAuthControls({
         ? (authState.user ?? "Signed in")
         : authState.mode === "access"
           ? "Browser session"
-          : authState.mode === "invalid"
+          : authState.mode === "invalid" || authState.mode === "oidc_expired"
             ? "Auth needs attention"
             : "Anonymous";
   const diagnostics = prototypeAuthDiagnostics(authState, {

--- a/apps/notebook-cloud/viewer/oidc-auth.ts
+++ b/apps/notebook-cloud/viewer/oidc-auth.ts
@@ -71,17 +71,22 @@ export function normalizeOidcAuthConfig(
 export function readStoredOidcToken(
   storage: Pick<CloudOidcStorage, "getItem">,
   nowSeconds = currentEpochSeconds(),
-): { token: CloudOidcTokenState | null; problem: string | null; expired: boolean } {
+): {
+  token: CloudOidcTokenState | null;
+  problem: string | null;
+  expired: boolean;
+  expiredClaims: CloudOidcClaims | null;
+} {
   const parsed = readStoredOidcTokenState(storage);
   if (!parsed.token) {
-    return { ...parsed, expired: false };
+    return { ...parsed, expired: false, expiredClaims: null };
   }
   const { token } = parsed;
   if (token.expiresAt <= nowSeconds + EXPIRY_SKEW_SECONDS) {
-    return { token: null, problem: null, expired: true };
+    return { token: null, problem: null, expired: true, expiredClaims: token.claims };
   }
 
-  return { token, problem: null, expired: false };
+  return { token, problem: null, expired: false, expiredClaims: null };
 }
 
 export function storedOidcTokenNeedsRefresh(


### PR DESCRIPTION
## Summary

- Refresh notebook-cloud browser auth state when another tab updates localStorage auth keys.
- Reuse the existing OIDC renewal path after storage events so stale tabs do not wait for the next one-minute timer/focus/visibility refresh.
- Centralize the auth storage-key allowlist and ignore unrelated viewer storage such as theme settings.

## Stack

- Depends on #3074 (`quod/notebook-cloud-oidc-renewal`).
- Merge #3074 first, then this PR after GitHub retargets the branch.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/oidc-auth.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
