### PR TITLE
perf(notebook-cloud): hydrate outputs progressively

### DIFF
--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { BlobResolver } from "runtimed";
-import { resolveCell, resolveOutputs } from "../viewer/render-resolution.ts";
+import {
+  OUTPUT_RESOLUTION_CACHE_MAX_ENTRIES,
+  createOutputResolutionCache,
+  resolveCell,
+  resolveCellSync,
+  resolveOutputs,
+} from "../viewer/render-resolution.ts";
 
 describe("cloud viewer render resolution", () => {
   it("preserves widget views so RuntimeStateDoc models can hydrate them", async () => {
@@ -146,6 +152,125 @@ describe("cloud viewer render resolution", () => {
     assert.equal(healthyCell.outputs[0].output_type, "stream");
     assert.equal(brokenCell.outputs.length, 1);
     assert.equal(brokenCell.outputs[0].output_type, "error");
+  });
+
+  it("materializes source and sync-resolvable outputs before blob-backed outputs", async () => {
+    const cell = resolveCellSync(
+      {
+        id: "progressive-cell",
+        cell_type: "code",
+        source: "display(df)",
+        execution_count: 1,
+        outputs: [
+          {
+            output_id: "inline-stream",
+            output_type: "stream",
+            name: "stdout",
+            text: { inline: "loaded\n" },
+          },
+          {
+            output_id: "blob-text",
+            output_type: "display_data",
+            data: {
+              "text/plain": { blob: "sha256:text" },
+            },
+            metadata: {},
+          },
+        ],
+      },
+      textBlobResolver({ "sha256:text": "shape: (25, 8)" }),
+      0,
+      "python",
+    );
+
+    assert.equal(cell.source, "display(df)");
+    assert.equal(cell.outputs.length, 1);
+    assert.equal(cell.outputs[0].output_id, "inline-stream");
+  });
+
+  it("deduplicates concurrent blob-backed output resolution", async () => {
+    const cache = createOutputResolutionCache();
+    const resolver = textBlobResolver({ "sha256:text": "resolved once" });
+    const manifest = {
+      output_id: "blob-text",
+      output_type: "display_data",
+      data: {
+        "text/plain": { blob: "sha256:text" },
+      },
+      metadata: {},
+    };
+
+    const [first, second] = await Promise.all([
+      resolveOutputs([manifest], resolver, "cell", cache),
+      resolveOutputs([manifest], resolver, "cell", cache),
+    ]);
+
+    assert.equal(resolver.fetchCount(), 1);
+    assert.deepEqual(first, second);
+    assert.equal(first[0].output_type, "display_data");
+    if (first[0].output_type === "display_data") {
+      assert.equal(first[0].data["text/plain"], "resolved once");
+    }
+  });
+
+  it("keeps synthetic output ids unique when cached raw outputs omit output_id", async () => {
+    const cache = createOutputResolutionCache();
+    const output = {
+      output_type: "stream",
+      name: "stdout",
+      text: "same text\n",
+    };
+
+    const [first, second] = await Promise.all([
+      resolveOutputs([output], rejectingBlobResolver(), "cell-a", cache),
+      resolveOutputs([output], rejectingBlobResolver(), "cell-b", cache),
+    ]);
+
+    assert.equal(first[0].output_id, "cloud-output:cell-a:0");
+    assert.equal(second[0].output_id, "cloud-output:cell-b:0");
+  });
+
+  it("skips cache collisions for non-serializable raw outputs", async () => {
+    const cache = createOutputResolutionCache();
+    const firstOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "first\n",
+      value: 1n,
+    };
+    const secondOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "second\n",
+      value: 2n,
+    };
+
+    const first = await resolveOutputs([firstOutput], rejectingBlobResolver(), "cell-a", cache);
+    const second = await resolveOutputs([secondOutput], rejectingBlobResolver(), "cell-b", cache);
+
+    assert.equal(first[0].output_type, "stream");
+    assert.equal(second[0].output_type, "stream");
+    if (first[0].output_type === "stream" && second[0].output_type === "stream") {
+      assert.equal(first[0].text, "first\n");
+      assert.equal(second[0].text, "second\n");
+    }
+  });
+
+  it("bounds the output resolution cache across many distinct outputs", async () => {
+    const cache = createOutputResolutionCache();
+    const outputs = Array.from(
+      { length: OUTPUT_RESOLUTION_CACHE_MAX_ENTRIES + 10 },
+      (_, index) => ({
+        output_id: `output-${index}`,
+        output_type: "stream",
+        name: "stdout",
+        text: `output ${index}\n`,
+      }),
+    );
+
+    await resolveOutputs(outputs, rejectingBlobResolver(), "many-outputs", cache);
+
+    assert.equal(cache.size, OUTPUT_RESOLUTION_CACHE_MAX_ENTRIES);
   });
 
   it("derives code cell language from cell metadata before notebook metadata", async () => {
@@ -443,6 +568,23 @@ function rejectingBlobResolver(): BlobResolver {
     },
     async fetch() {
       return new Response("missing", { status: 404 });
+    },
+  };
+}
+
+function textBlobResolver(values: Record<string, string>): BlobResolver & { fetchCount(): number } {
+  let count = 0;
+  return {
+    url(ref) {
+      return `https://cloud.test/blobs/${encodeURIComponent(ref.blob)}`;
+    },
+    async fetch(ref) {
+      count += 1;
+      const value = values[ref.blob];
+      return value === undefined ? new Response("missing", { status: 404 }) : new Response(value);
+    },
+    fetchCount() {
+      return count;
     },
   };
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -81,7 +81,13 @@ import {
   reduceCloudViewerPresenceMessage,
 } from "./presence";
 import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
-import { resolveCell, type RenderCell, type ResolvedCell } from "./render-resolution";
+import {
+  createOutputResolutionCache,
+  resolveCell,
+  resolveCellSync,
+  type RenderCell,
+  type ResolvedCell,
+} from "./render-resolution";
 import {
   buildCloudShareAccessRows,
   hasPublicViewerAccess,
@@ -560,6 +566,7 @@ function NotebookViewer({
   const liveMaterializedRef = useRef(false);
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
+  const outputResolutionCacheRef = useRef(createOutputResolutionCache());
   const [presence, setPresence] = useState(initialCloudViewerPresence);
   const [livePresence, setLivePresence] = useState(emptyCloudLivePresenceSnapshot);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
@@ -642,8 +649,21 @@ function NotebookViewer({
         const widgetComms = normalizeSnapshotWidgetComms(render.widget_comms);
         const notebookLanguage = languageFromNotebookMetadata(render.metadata) ?? "python";
         notebookLanguageRef.current = notebookLanguage;
+        const outputResolutionCache = outputResolutionCacheRef.current;
+        const syncCells = rawCells.map((cell, index) =>
+          resolveCellSync(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
+        );
+        if (!cancelled && !liveMaterializedRef.current && syncCells.length > 0) {
+          setCells(syncCells);
+          setStatus({
+            kind: "loading",
+            message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
+          });
+        }
         const resolvedCells = await Promise.all(
-          rawCells.map((cell, index) => resolveCell(cell, blobResolver, index, notebookLanguage)),
+          rawCells.map((cell, index) =>
+            resolveCell(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
+          ),
         );
         if (cancelled || liveMaterializedRef.current) return;
 
@@ -745,8 +765,23 @@ function NotebookViewer({
       const notebookLanguage =
         languageFromNotebookMetadata(metadata) ?? notebookLanguageRef.current ?? "python";
       notebookLanguageRef.current = notebookLanguage;
+      const outputResolutionCache = outputResolutionCacheRef.current;
+      const syncCells = rawCells.map((cell, index) =>
+        resolveCellSync(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
+      );
+      if (disposed || sequence !== materializeSequence) return;
+      if (syncCells.length > 0) {
+        liveMaterializedRef.current = true;
+        setCells(syncCells);
+        setStatus({
+          kind: "loading",
+          message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
+        });
+      }
       const resolvedCells = await Promise.all(
-        rawCells.map((cell, index) => resolveCell(cell, blobResolver, index, notebookLanguage)),
+        rawCells.map((cell, index) =>
+          resolveCell(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
+        ),
       );
       if (disposed || sequence !== materializeSequence) return;
 

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -2,6 +2,7 @@ import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import {
   isOutputManifest,
   resolveManifest,
+  resolveManifestSync,
   type OutputManifest,
 } from "@/components/isolated/output-manifest";
 import type { BlobResolver } from "runtimed";
@@ -27,17 +28,59 @@ export interface ResolvedCell {
   metadata: Record<string, unknown>;
 }
 
+type OutputResolutionCacheEntry = JupyterOutput | Promise<JupyterOutput | null>;
+
+export type OutputResolutionCache = Map<string, OutputResolutionCacheEntry>;
+
+export const OUTPUT_RESOLUTION_CACHE_MAX_ENTRIES = 1024;
+
+const ASYNC_OUTPUT_REQUIRED = Symbol("async-output-required");
+
+type SyncOutputResolution = JupyterOutput | null | typeof ASYNC_OUTPUT_REQUIRED;
+
+export function createOutputResolutionCache(): OutputResolutionCache {
+  return new Map();
+}
+
 export async function resolveCell(
   cell: RenderCell,
   blobResolver: BlobResolver,
   index: number,
   defaultLanguage: string | null = null,
+  cache?: OutputResolutionCache,
 ): Promise<ResolvedCell> {
   const cellType = normalizeCellType(cell.cell_type);
   const metadata = normalizeMetadata(cell.metadata);
   const cellId = typeof cell.id === "string" ? cell.id : `cell-${index + 1}`;
   const outputs = Array.isArray(cell.outputs)
-    ? await resolveOutputs(cell.outputs, blobResolver, cellId)
+    ? await resolveOutputs(cell.outputs, blobResolver, cellId, cache)
+    : [];
+  const executionCount =
+    normalizeExecutionCount(cell.execution_count) ?? executionCountFromOutputs(outputs);
+  return {
+    id: cellId,
+    cellType,
+    source: typeof cell.source === "string" ? cell.source : "",
+    language: cellType === "code" ? (normalizeCellLanguage(metadata) ?? defaultLanguage) : null,
+    executionId: normalizeExecutionId(cell.execution_id),
+    executionCount,
+    outputs,
+    metadata,
+  };
+}
+
+export function resolveCellSync(
+  cell: RenderCell,
+  blobResolver: BlobResolver,
+  index: number,
+  defaultLanguage: string | null = null,
+  cache?: OutputResolutionCache,
+): ResolvedCell {
+  const cellType = normalizeCellType(cell.cell_type);
+  const metadata = normalizeMetadata(cell.metadata);
+  const cellId = typeof cell.id === "string" ? cell.id : `cell-${index + 1}`;
+  const outputs = Array.isArray(cell.outputs)
+    ? resolveOutputsSync(cell.outputs, blobResolver, cellId, cache)
     : [];
   const executionCount =
     normalizeExecutionCount(cell.execution_count) ?? executionCountFromOutputs(outputs);
@@ -57,12 +100,13 @@ export async function resolveOutputs(
   outputs: unknown[],
   blobResolver: BlobResolver,
   cellId: string = "output",
+  cache?: OutputResolutionCache,
 ): Promise<JupyterOutput[]> {
   const resolved = await Promise.all(
     outputs.map(async (output, index) => {
       const syntheticOutputId = `cloud-output:${cellId}:${index}`;
       try {
-        return await resolveOutput(output, blobResolver, syntheticOutputId);
+        return await resolveOutput(output, blobResolver, syntheticOutputId, cache);
       } catch (error) {
         return outputResolutionError(error, output, syntheticOutputId);
       }
@@ -71,14 +115,118 @@ export async function resolveOutputs(
   return resolved.filter((output): output is JupyterOutput => output !== null);
 }
 
+export function resolveOutputsSync(
+  outputs: unknown[],
+  blobResolver: BlobResolver,
+  cellId: string = "output",
+  cache?: OutputResolutionCache,
+): JupyterOutput[] {
+  return outputs
+    .map((output, index) => {
+      const syntheticOutputId = `cloud-output:${cellId}:${index}`;
+      try {
+        const resolved = resolveOutputSync(output, blobResolver, syntheticOutputId, cache);
+        return resolved === ASYNC_OUTPUT_REQUIRED ? null : resolved;
+      } catch {
+        return null;
+      }
+    })
+    .filter((output): output is JupyterOutput => output !== null);
+}
+
 async function resolveOutput(
+  output: unknown,
+  blobResolver: BlobResolver,
+  syntheticOutputId: string,
+  cache?: OutputResolutionCache,
+): Promise<JupyterOutput | null> {
+  const cacheKey = cache ? outputResolutionCacheKey(output, syntheticOutputId) : null;
+  const cached = cache && cacheKey ? cache.get(cacheKey) : undefined;
+  if (cached) {
+    return isPromiseLike(cached) ? await cached : cached;
+  }
+
+  const syncResolved = resolveOutputSync(output, blobResolver, syntheticOutputId, cache);
+  if (syncResolved !== ASYNC_OUTPUT_REQUIRED) {
+    return syncResolved;
+  }
+
+  const resolution = resolveOutputAsyncUncached(output, blobResolver, syntheticOutputId)
+    .then((resolved) => {
+      if (cacheKey) {
+        if (resolved) {
+          setOutputResolutionCacheEntry(cache, cacheKey, resolved);
+        } else {
+          cache?.delete(cacheKey);
+        }
+      }
+      return resolved;
+    })
+    .catch((error) => {
+      if (cacheKey) cache?.delete(cacheKey);
+      throw error;
+    });
+  if (cacheKey) setOutputResolutionCacheEntry(cache, cacheKey, resolution);
+  return resolution;
+}
+
+function resolveOutputSync(
+  output: unknown,
+  blobResolver: BlobResolver,
+  syntheticOutputId: string,
+  cache?: OutputResolutionCache,
+): SyncOutputResolution {
+  const cacheKey = cache ? outputResolutionCacheKey(output, syntheticOutputId) : null;
+  const cached = cache && cacheKey ? cache.get(cacheKey) : undefined;
+  if (cached) {
+    return isPromiseLike(cached) ? ASYNC_OUTPUT_REQUIRED : cached;
+  }
+
+  if (typeof output === "string") {
+    try {
+      return resolveOutputSync(
+        JSON.parse(output) as unknown,
+        blobResolver,
+        syntheticOutputId,
+        cache,
+      );
+    } catch {
+      return null;
+    }
+  }
+
+  if (isOutputManifest(output)) {
+    const resolved = resolveManifestSync(output as OutputManifest, blobResolver) as JupyterOutput;
+    if (!resolved) return ASYNC_OUTPUT_REQUIRED;
+    if (cacheKey) setOutputResolutionCacheEntry(cache, cacheKey, resolved);
+    return resolved;
+  }
+
+  if (isManifestWithMissingOutputId(output)) {
+    throw new Error("Cannot resolve output manifest without output_id");
+  }
+
+  if (isJupyterOutput(output)) {
+    const resolved = identifyJupyterOutput(output, syntheticOutputId);
+    if (cacheKey) setOutputResolutionCacheEntry(cache, cacheKey, resolved);
+    return resolved;
+  }
+
+  return null;
+}
+
+async function resolveOutputAsyncUncached(
   output: unknown,
   blobResolver: BlobResolver,
   syntheticOutputId: string,
 ): Promise<JupyterOutput | null> {
   if (typeof output === "string") {
     try {
-      return resolveOutput(JSON.parse(output) as unknown, blobResolver, syntheticOutputId);
+      return resolveOutputAsyncUncached(
+        JSON.parse(output) as unknown,
+        blobResolver,
+        syntheticOutputId,
+      );
     } catch {
       return null;
     }
@@ -101,6 +249,54 @@ async function resolveOutput(
   }
 
   return null;
+}
+
+function outputResolutionCacheKey(output: unknown, syntheticOutputId: string): string | null {
+  const serialized = serializedOutputCacheKey(output);
+  if (serialized === null) return null;
+  return outputNeedsSyntheticOutputId(output) ? `${syntheticOutputId}:${serialized}` : serialized;
+}
+
+function serializedOutputCacheKey(output: unknown): string | null {
+  if (typeof output === "string") return output;
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return null;
+  }
+}
+
+function outputNeedsSyntheticOutputId(output: unknown): boolean {
+  if (typeof output === "string") {
+    try {
+      return outputNeedsSyntheticOutputId(JSON.parse(output) as unknown);
+    } catch {
+      return false;
+    }
+  }
+  if (!isJupyterOutput(output)) {
+    return false;
+  }
+  return typeof output.output_id !== "string" || output.output_id.length === 0;
+}
+
+function isPromiseLike(value: OutputResolutionCacheEntry): value is Promise<JupyterOutput | null> {
+  return typeof (value as Promise<JupyterOutput | null>).then === "function";
+}
+
+function setOutputResolutionCacheEntry(
+  cache: OutputResolutionCache | undefined,
+  key: string,
+  value: OutputResolutionCacheEntry,
+): void {
+  if (!cache) return;
+  if (!cache.has(key) && cache.size >= OUTPUT_RESOLUTION_CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey === "string") {
+      cache.delete(oldestKey);
+    }
+  }
+  cache.set(key, value);
 }
 
 function identifyJupyterOutput(output: JupyterOutput, outputId: string): JupyterOutput {


### PR DESCRIPTION
## Summary

- add a cloud output-resolution cache with in-flight deduplication
- render a synchronous first pass for hosted snapshot/live cells before blob-backed outputs finish hydrating
- cover progressive materialization and duplicate blob suppression in render-resolution tests

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/render-resolution.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud smoke:hosted`

## Preview

Deployed this branch to `preview.runt.run`:

- main worker version: `0edb369d-ece6-47b8-aa86-278d9dc8dd26`
- renderer assets worker version: `c6e962cb-cdf8-4885-9996-25a738720b3f`
- output document worker version: `9617682a-1b44-437c-a4b3-98a7bd74a0c7`

Focused hosted measurement after deploy:

- duplicate `/api/n/topic-viz/blobs/...` fetches observed before this branch are gone
- remaining repeated requests are output document frames and the expected Sift WASM prefetch/fetch pair
- topic-viz still mounts 18 output frames; markdown cells are still iframe-gated via the shared read-only markdown/output path

## Follow-up

This PR improves hydration and duplicate work without changing output isolation. The larger remaining load costs are asset/frame shape: markdown cells render as isolated frames, `notebook-cloud-viewer.css` is still large, and the isolated renderer virtual chunk still loads up front.
