### PR TITLE
perf(notebook-cloud): load renderer from sidecar assets

### DIFF
--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -16,6 +16,22 @@ const runtimedWasmUrl = new URL(
 );
 const runtimedOutputUrl = new URL("../dist/assets/runtimed_wasm_bg.wasm", import.meta.url);
 const runtimedPluginOutputUrl = new URL("../dist/plugins/runtimed_wasm_bg.wasm", import.meta.url);
+const isolatedRendererModuleUrl = new URL(
+  "../../notebook/src/renderer-plugins/isolated-renderer.js",
+  import.meta.url,
+);
+const isolatedRendererCssUrl = new URL(
+  "../../notebook/src/renderer-plugins/isolated-renderer.css",
+  import.meta.url,
+);
+const isolatedRendererModuleOutputUrl = new URL(
+  "../dist/plugins/isolated-renderer.js",
+  import.meta.url,
+);
+const isolatedRendererCssOutputUrl = new URL(
+  "../dist/plugins/isolated-renderer.css",
+  import.meta.url,
+);
 const outputDocumentFrameUrl = new URL(
   "../../../src/components/isolated/frame.html",
   import.meta.url,
@@ -25,6 +41,8 @@ const outputDocumentOutputUrl = new URL("../dist-output-document/index.html", im
 await assertExists(siftWasmUrl);
 await assertExists(runtimedWasmModuleUrl);
 await assertExists(runtimedWasmUrl);
+await assertExists(isolatedRendererModuleUrl);
+await assertExists(isolatedRendererCssUrl);
 await assertExists(outputDocumentFrameUrl);
 await mkdir(new URL("../dist/plugins/", import.meta.url), { recursive: true });
 await mkdir(new URL("../dist/assets/", import.meta.url), { recursive: true });
@@ -34,6 +52,8 @@ await copyFile(runtimedWasmModuleUrl, runtimedModuleOutputUrl);
 await copyFile(runtimedWasmUrl, runtimedOutputUrl);
 await copyFile(runtimedWasmModuleUrl, runtimedModulePluginOutputUrl);
 await copyFile(runtimedWasmUrl, runtimedPluginOutputUrl);
+await copyFile(isolatedRendererModuleUrl, isolatedRendererModuleOutputUrl);
+await copyFile(isolatedRendererCssUrl, isolatedRendererCssOutputUrl);
 await copyFile(outputDocumentFrameUrl, outputDocumentOutputUrl);
 
 console.log(`copied ${fileURLToPath(siftWasmUrl)} -> ${fileURLToPath(outputUrl)}`);
@@ -46,6 +66,12 @@ console.log(
 );
 console.log(
   `copied ${fileURLToPath(runtimedWasmUrl)} -> ${fileURLToPath(runtimedPluginOutputUrl)}`,
+);
+console.log(
+  `copied ${fileURLToPath(isolatedRendererModuleUrl)} -> ${fileURLToPath(isolatedRendererModuleOutputUrl)}`,
+);
+console.log(
+  `copied ${fileURLToPath(isolatedRendererCssUrl)} -> ${fileURLToPath(isolatedRendererCssOutputUrl)}`,
 );
 console.log(
   `copied ${fileURLToPath(outputDocumentFrameUrl)} -> ${fileURLToPath(outputDocumentOutputUrl)}`,

--- a/apps/notebook-cloud/test/viewer-renderer-assets.test.ts
+++ b/apps/notebook-cloud/test/viewer-renderer-assets.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { rendererAssetBasePathForProvider } from "../viewer/renderer-assets.ts";
+
+describe("cloud viewer renderer asset helpers", () => {
+  it("normalizes configured renderer asset bases for IsolatedRendererProvider fetches", () => {
+    assert.equal(rendererAssetBasePathForProvider("/renderer-assets/"), "/renderer-assets");
+    assert.equal(
+      rendererAssetBasePathForProvider("https://assets.example/renderer-assets/"),
+      "https://assets.example/renderer-assets",
+    );
+  });
+
+  it("preserves already-normalized relative and absolute bases", () => {
+    assert.equal(rendererAssetBasePathForProvider("/renderer-assets"), "/renderer-assets");
+    assert.equal(
+      rendererAssetBasePathForProvider("https://assets.example/renderer-assets"),
+      "https://assets.example/renderer-assets",
+    );
+  });
+});

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import { createRoot } from "react-dom/client";
 import {
   BookOpen,
@@ -88,6 +96,7 @@ import {
   type RenderCell,
   type ResolvedCell,
 } from "./render-resolution";
+import { rendererAssetBasePathForProvider } from "./renderer-assets";
 import {
   buildCloudShareAccessRows,
   hasPublicViewerAccess,
@@ -155,8 +164,6 @@ interface ViewerRuntime {
 type ViewerRuntimeState =
   | { kind: "ready"; runtime: ViewerRuntime }
   | { kind: "error"; message: string };
-
-const rendererBundle = () => import("virtual:isolated-renderer");
 
 installDocumentThemeSync();
 
@@ -355,7 +362,31 @@ function App() {
     return <ViewerStartupError message={`Unable to start cloud viewer: ${runtimeState.message}`} />;
   }
 
-  return <NotebookViewer runtime={runtimeState.runtime} authConfig={authConfig} />;
+  return (
+    <CloudNotebookProviders config={runtimeState.runtime.config}>
+      <NotebookViewer runtime={runtimeState.runtime} authConfig={authConfig} />
+    </CloudNotebookProviders>
+  );
+}
+
+function CloudNotebookProviders({
+  children,
+  config,
+}: {
+  children: ReactNode;
+  config: CloudViewerConfig;
+}) {
+  return (
+    <IsolatedRendererProvider
+      basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}
+    >
+      <CloudWidgetStoreProvider>
+        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
+          {children}
+        </MediaProvider>
+      </CloudWidgetStoreProvider>
+    </IsolatedRendererProvider>
+  );
 }
 
 function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
@@ -1990,12 +2021,6 @@ createRoot(requireElement("#root")).render(
   <ErrorBoundary
     fallback={(error) => <ViewerStartupError message={`Cloud viewer crashed: ${error.message}`} />}
   >
-    <IsolatedRendererProvider loader={rendererBundle}>
-      <CloudWidgetStoreProvider>
-        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
-          <App />
-        </MediaProvider>
-      </CloudWidgetStoreProvider>
-    </IsolatedRendererProvider>
+    <App />
   </ErrorBoundary>,
 );

--- a/apps/notebook-cloud/viewer/renderer-assets.ts
+++ b/apps/notebook-cloud/viewer/renderer-assets.ts
@@ -1,0 +1,3 @@
+export function rendererAssetBasePathForProvider(basePath: string): string {
+  return basePath.trim().replace(/\/+$/, "");
+}


### PR DESCRIPTION
## Summary

- Load notebook-cloud's shared isolated renderer through configured sidecar assets instead of importing `virtual:isolated-renderer` into the viewer entry.
- Copy `isolated-renderer.js` and `isolated-renderer.css` into `dist/plugins` so `/renderer-assets/*` can serve the provider fetches on preview/prod.
- Add a small helper/test for normalizing trailing-slash renderer asset base paths before they reach `IsolatedRendererProvider`.

## Rendering Performance Goal

This is the first rendering-performance slice for the updated notebook-cloud goal: make first useful render lighter by shrinking the cloud viewer app shell and using the same shared isolated output runtime from sidecar assets. It keeps output iframe sandboxing intact and does not add cloud-specific renderer forks.

Build evidence from this branch:

- `notebook-cloud-viewer.js`: 768.97 kB, gzip 196.33 kB
- no `assets/_virtual_isolated-renderer-*.js` chunk emitted
- `dist/plugins/isolated-renderer.js` and `dist/plugins/isolated-renderer.css` copied for `/renderer-assets/*`

The viewer CSS is still large because renderer/plugin CSS is still hoisted into the app CSS bundle. I left that as the next focused optimization rather than mixing CSS bundling changes into this sidecar-loader PR.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-renderer-assets.test.ts test/html.test.ts test/worker-routes.test.ts test/renderer-assets-worker.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `cargo xtask lint --fix`
