### PR TITLE
perf(notebook-cloud): defer supplemental viewer css

### DIFF
--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -1,6 +1,7 @@
 import { copyFile, mkdir } from "node:fs/promises";
 import { access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { writeViewerCssManifest } from "./viewer-css-assets.mjs";
 
 const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
 const outputUrl = new URL("../dist/plugins/sift_wasm.wasm", import.meta.url);
@@ -55,6 +56,9 @@ await copyFile(runtimedWasmUrl, runtimedPluginOutputUrl);
 await copyFile(isolatedRendererModuleUrl, isolatedRendererModuleOutputUrl);
 await copyFile(isolatedRendererCssUrl, isolatedRendererCssOutputUrl);
 await copyFile(outputDocumentFrameUrl, outputDocumentOutputUrl);
+const { manifest, manifestUrl } = await writeViewerCssManifest(
+  new URL("../dist/assets/", import.meta.url),
+);
 
 console.log(`copied ${fileURLToPath(siftWasmUrl)} -> ${fileURLToPath(outputUrl)}`);
 console.log(
@@ -76,6 +80,8 @@ console.log(
 console.log(
   `copied ${fileURLToPath(outputDocumentFrameUrl)} -> ${fileURLToPath(outputDocumentOutputUrl)}`,
 );
+console.log(`wrote viewer CSS manifest ${fileURLToPath(manifestUrl)}`);
+console.log(`viewer CSS assets: ${JSON.stringify(manifest)}`);
 
 async function assertExists(url) {
   try {

--- a/apps/notebook-cloud/scripts/viewer-css-assets.mjs
+++ b/apps/notebook-cloud/scripts/viewer-css-assets.mjs
@@ -1,0 +1,25 @@
+import { readdir, writeFile } from "node:fs/promises";
+
+export const VIEWER_PRIMARY_CSS = "notebook-cloud-viewer.css";
+export const VIEWER_CSS_MANIFEST = "notebook-cloud-viewer-css.json";
+
+export async function collectViewerCssAssets(assetsDirUrl, { publicPrefix = "/assets/" } = {}) {
+  const entries = await readdir(assetsDirUrl);
+  const stylesheets = entries.filter((entry) => entry.endsWith(".css")).sort();
+
+  return {
+    primary: stylesheets.includes(VIEWER_PRIMARY_CSS)
+      ? `${publicPrefix}${VIEWER_PRIMARY_CSS}`
+      : null,
+    supplemental: stylesheets
+      .filter((entry) => entry !== VIEWER_PRIMARY_CSS)
+      .map((entry) => `${publicPrefix}${entry}`),
+  };
+}
+
+export async function writeViewerCssManifest(assetsDirUrl) {
+  const manifest = await collectViewerCssAssets(assetsDirUrl);
+  const manifestUrl = new URL(VIEWER_CSS_MANIFEST, assetsDirUrl);
+  await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { manifest, manifestUrl };
+}

--- a/apps/notebook-cloud/test/viewer-css-assets.test.mjs
+++ b/apps/notebook-cloud/test/viewer-css-assets.test.mjs
@@ -1,0 +1,41 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { collectViewerCssAssets, writeViewerCssManifest } from "../scripts/viewer-css-assets.mjs";
+
+describe("viewer CSS asset manifest", () => {
+  it("keeps the primary viewer stylesheet separate from supplemental lazy CSS", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-css-assets-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("notebook-cloud-viewer.css", assetsUrl), "");
+    await writeFile(new URL("notebook-cloud-viewer2.css", assetsUrl), "");
+    await writeFile(new URL("markdown-output.css", assetsUrl), "");
+    await writeFile(new URL("notebook-cloud-viewer.js", assetsUrl), "");
+
+    assert.deepEqual(await collectViewerCssAssets(assetsUrl), {
+      primary: "/assets/notebook-cloud-viewer.css",
+      supplemental: ["/assets/markdown-output.css", "/assets/notebook-cloud-viewer2.css"],
+    });
+  });
+
+  it("writes a generated manifest beside the built viewer assets", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-css-manifest-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("notebook-cloud-viewer.css", assetsUrl), "");
+    await writeFile(new URL("notebook-cloud-viewer2.css", assetsUrl), "");
+
+    const { manifest, manifestUrl } = await writeViewerCssManifest(assetsUrl);
+    const written = JSON.parse(await readFile(manifestUrl, "utf8"));
+
+    assert.deepEqual(written, manifest);
+    assert.deepEqual(written, {
+      primary: "/assets/notebook-cloud-viewer.css",
+      supplemental: ["/assets/notebook-cloud-viewer2.css"],
+    });
+  });
+});

--- a/apps/notebook-cloud/test/viewer-supplemental-css.test.ts
+++ b/apps/notebook-cloud/test/viewer-supplemental-css.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { supplementalStylesheetsFromManifest } from "../viewer/supplemental-css.ts";
+
+describe("viewer supplemental CSS loader", () => {
+  it("accepts same-origin built viewer CSS assets", () => {
+    assert.deepEqual(
+      supplementalStylesheetsFromManifest({
+        supplemental: ["/assets/notebook-cloud-viewer2.css", "/assets/markdown-output.css"],
+      }),
+      ["/assets/notebook-cloud-viewer2.css", "/assets/markdown-output.css"],
+    );
+  });
+
+  it("ignores malformed or remote stylesheet hrefs", () => {
+    assert.deepEqual(
+      supplementalStylesheetsFromManifest({
+        supplemental: [
+          "https://example.test/remote.css",
+          "/renderer-assets/isolated-renderer.css",
+          "/assets/../secret.css",
+          "/assets/%2e%2e/secret.css",
+          "/assets/not-css.txt",
+          null,
+        ],
+      }),
+      [],
+    );
+  });
+});

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -108,6 +108,7 @@ import {
 } from "./sharing-client";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
+import { loadSupplementalViewerCss } from "./supplemental-css";
 import {
   applyDocumentTheme,
   CLOUD_VIEWER_THEME_STORAGE_KEY,
@@ -119,6 +120,8 @@ import {
   projectCloudWidgetComms,
 } from "./widget-runtime";
 import "./index.css";
+
+loadSupplementalViewerCss();
 
 interface CloudViewerConfig {
   notebookId: string;

--- a/apps/notebook-cloud/viewer/supplemental-css.ts
+++ b/apps/notebook-cloud/viewer/supplemental-css.ts
@@ -1,0 +1,67 @@
+const VIEWER_CSS_MANIFEST_PATH = "/assets/notebook-cloud-viewer-css.json";
+
+let supplementalCssLoadStarted = false;
+
+interface ViewerCssManifest {
+  supplemental?: unknown;
+}
+
+export function supplementalStylesheetsFromManifest(manifest: unknown): string[] {
+  if (!manifest || typeof manifest !== "object") return [];
+
+  const { supplemental } = manifest as ViewerCssManifest;
+  if (!Array.isArray(supplemental)) return [];
+
+  return supplemental.filter(isSafeViewerStylesheet);
+}
+
+export function loadSupplementalViewerCss(): void {
+  if (typeof document === "undefined" || typeof fetch === "undefined") return;
+  if (supplementalCssLoadStarted) return;
+  supplementalCssLoadStarted = true;
+
+  const load = () => {
+    void fetch(VIEWER_CSS_MANIFEST_PATH, { credentials: "same-origin" })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((manifest) => {
+        for (const href of supplementalStylesheetsFromManifest(manifest)) {
+          appendStylesheetOnce(href);
+        }
+      })
+      .catch(() => {
+        // Supplemental CSS only affects lazy output surfaces. Missing manifests
+        // should not block the notebook shell from rendering.
+      });
+  };
+
+  if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+    window.requestIdleCallback(load, { timeout: 1000 });
+    return;
+  }
+
+  setTimeout(load, 0);
+}
+
+function appendStylesheetOnce(href: string): void {
+  for (const link of Array.from(
+    document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]'),
+  )) {
+    if (link.getAttribute("href") === href) return;
+  }
+
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  link.dataset.nteractCloudSupplementalCss = "true";
+  document.head.appendChild(link);
+}
+
+function isSafeViewerStylesheet(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith("/assets/") &&
+    value.endsWith(".css") &&
+    !value.includes("..") &&
+    !value.includes("%")
+  );
+}

--- a/apps/notebook-cloud/vite.config.ts
+++ b/apps/notebook-cloud/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     outDir: "dist",
     emptyOutDir: true,
     assetsInlineLimit: 0,
+    cssCodeSplit: true,
     sourcemap: false,
     lib: {
       entry: path.join(appDir, "viewer/index.tsx"),
@@ -32,10 +33,13 @@ export default defineConfig({
       output: {
         entryFileNames: "assets/notebook-cloud-viewer.js",
         chunkFileNames: "assets/[name]-[hash].js",
-        assetFileNames: (assetInfo) =>
-          assetInfo.name?.endsWith(".css")
-            ? "assets/notebook-cloud-viewer.css"
-            : "assets/[name]-[hash].[ext]",
+        assetFileNames: (assetInfo) => {
+          if (!assetInfo.name?.endsWith(".css")) return "assets/[name]-[hash].[ext]";
+          if (assetInfo.name === "index.css" || assetInfo.name === "notebook-cloud-viewer.css") {
+            return "assets/notebook-cloud-viewer.css";
+          }
+          return "assets/[name]-[hash].[ext]";
+        },
       },
       onwarn(warning, warn) {
         if (


### PR DESCRIPTION
## Summary

- enables Vite CSS code splitting for the notebook-cloud viewer bundle
- writes a generated viewer CSS manifest next to built `/assets/*`
- loads supplemental viewer CSS after the shell starts so the first stylesheet is no longer blocked by lazy output CSS

## Why

The cloud viewer was still shipping about 1.6 MB of CSS as the render-blocking `notebook-cloud-viewer.css` even after renderer sidecars moved out of the main bundle. With CSS splitting enabled, the critical stylesheet drops to about 167 kB, while the large lazy output CSS moves to a supplemental stylesheet loaded from the hosted asset origin after startup.

This is deliberately a first-paint optimization, not a total-byte optimization. Output CSS still loads for the notebook experience, but it no longer blocks the initial shell and early notebook content.

## Asset-hosting note

Cloud can use Worker/CDN-hosted sidecars for large renderer/runtime assets. Desktop/Tauri still needs a bootstrap-safe critical shell path because the runtime daemon may not be up yet. Once the daemon is healthy, it can become another asset host for renderer/runtime chunks. Shared component work should model this as an output/renderer asset-host adapter rather than requiring cloud CDN, Tauri bootstrap, and daemon-served assets to share one packaging path.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-css-assets.test.mjs test/viewer-supplemental-css.test.ts test/html.test.ts test/worker-routes.test.ts test/renderer-assets-worker.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud test:renderer-parity`
- `cargo xtask lint --fix`

Build output:

- `dist/assets/notebook-cloud-viewer.css`: 167.43 kB, gzip 25.24 kB
- supplemental output CSS, `dist/assets/katex-options-D_EmowkL.css` in the verified build: 1,458.32 kB, gzip 947.02 kB
- `dist/assets/notebook-cloud-viewer.js`: 770.01 kB, gzip 196.64 kB

## Reviewer Follow-up

- pinned only the Vite primary `index.css` asset to `notebook-cloud-viewer.css`, leaving split CSS chunks on distinct hashed asset names
- hardened supplemental stylesheet filtering against percent-encoded traversal-shaped paths

## Stack Order

Independent branch off current `origin/main`; no stacked PR dependency.
