### PR TITLE
test(notebook-cloud): assert hosted viewer css split

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-assets.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-assets.mjs
@@ -1,0 +1,178 @@
+export const VIEWER_CSS_MANIFEST_PATH = "/assets/notebook-cloud-viewer-css.json";
+export const DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES = 250_000;
+
+export function parsePositiveInteger(value, fallback, name) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+export function isViewerCssAssetPath(value) {
+  return (
+    typeof value === "string" &&
+    value.startsWith("/assets/") &&
+    value.endsWith(".css") &&
+    !value.includes("..") &&
+    !value.includes("%")
+  );
+}
+
+export function validateViewerCssManifestPayload(manifest, { minSupplementalCount = 1 } = {}) {
+  const failures = [];
+
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    return {
+      primary: null,
+      supplemental: [],
+      failures: [{ kind: "viewer-css", text: "viewer CSS manifest was not an object" }],
+    };
+  }
+
+  const primary = isViewerCssAssetPath(manifest.primary) ? manifest.primary : null;
+  if (!primary) {
+    failures.push({
+      kind: "viewer-css",
+      text: "viewer CSS manifest is missing a safe primary stylesheet path",
+      value: manifest.primary ?? null,
+    });
+  }
+
+  const supplementalInput = Array.isArray(manifest.supplemental) ? manifest.supplemental : [];
+  if (!Array.isArray(manifest.supplemental)) {
+    failures.push({
+      kind: "viewer-css",
+      text: "viewer CSS manifest is missing a supplemental stylesheet array",
+    });
+  }
+
+  const supplemental = [];
+  for (const value of supplementalInput) {
+    if (isViewerCssAssetPath(value)) {
+      supplemental.push(value);
+      continue;
+    }
+    failures.push({
+      kind: "viewer-css",
+      text: "viewer CSS manifest included an unsafe supplemental stylesheet path",
+      value,
+    });
+  }
+
+  if (primary && supplemental.includes(primary)) {
+    failures.push({
+      kind: "viewer-css",
+      text: "viewer CSS manifest listed the primary stylesheet as supplemental",
+      value: primary,
+    });
+  }
+
+  if (supplemental.length < minSupplementalCount) {
+    failures.push({
+      kind: "viewer-css",
+      text: `expected at least ${minSupplementalCount} supplemental viewer CSS asset(s), got ${supplemental.length}`,
+    });
+  }
+
+  return { primary, supplemental, failures };
+}
+
+export async function checkViewerCssSplit(
+  viewerUrl,
+  {
+    fetchImpl = fetch,
+    manifestPath = VIEWER_CSS_MANIFEST_PATH,
+    maxPrimaryBytes = DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES,
+    minSupplementalCount = 1,
+  } = {},
+) {
+  const origin = new URL(viewerUrl).origin;
+  const manifestUrl = new URL(manifestPath, origin).href;
+  const failures = [];
+
+  const manifestResponse = await fetchImpl(manifestUrl);
+  if (!manifestResponse.ok) {
+    return {
+      manifestUrl,
+      manifestStatus: manifestResponse.status,
+      primary: null,
+      supplemental: [],
+      primaryBytes: null,
+      failures: [
+        {
+          kind: "viewer-css",
+          text: `${manifestUrl} returned ${manifestResponse.status}`,
+        },
+      ],
+    };
+  }
+
+  const manifest = await manifestResponse.json();
+  const manifestCheck = validateViewerCssManifestPayload(manifest, { minSupplementalCount });
+  failures.push(...manifestCheck.failures);
+
+  let primaryBytes = null;
+  let primaryStatus = null;
+  let primaryContentType = null;
+  if (manifestCheck.primary) {
+    const primaryUrl = new URL(manifestCheck.primary, origin).href;
+    const primaryResponse = await fetchImpl(primaryUrl);
+    primaryStatus = primaryResponse.status;
+    primaryContentType = primaryResponse.headers.get("content-type");
+    if (!primaryResponse.ok) {
+      failures.push({
+        kind: "viewer-css",
+        text: `${primaryUrl} returned ${primaryResponse.status}`,
+      });
+    } else {
+      primaryBytes = (await primaryResponse.arrayBuffer()).byteLength;
+      if (primaryBytes > maxPrimaryBytes) {
+        failures.push({
+          kind: "viewer-css",
+          text: `primary viewer CSS was ${primaryBytes} bytes, expected <= ${maxPrimaryBytes}`,
+          url: primaryUrl,
+        });
+      }
+    }
+    if (!primaryContentType?.includes("text/css")) {
+      failures.push({
+        kind: "viewer-css",
+        text: `primary viewer CSS content type was ${primaryContentType ?? "missing"}`,
+        url: primaryUrl,
+      });
+    }
+  }
+
+  const supplemental = [];
+  for (const href of manifestCheck.supplemental) {
+    const url = new URL(href, origin).href;
+    const response = await fetchImpl(url, { method: "HEAD" });
+    const status = response.status;
+    const contentType = response.headers.get("content-type");
+    supplemental.push({ href, url, status, contentType });
+    if (!response.ok) {
+      failures.push({ kind: "viewer-css", text: `${url} returned ${status}` });
+    }
+    if (!contentType?.includes("text/css")) {
+      failures.push({
+        kind: "viewer-css",
+        text: `supplemental viewer CSS content type was ${contentType ?? "missing"}`,
+        url,
+      });
+    }
+  }
+
+  return {
+    manifestUrl,
+    manifestStatus: manifestResponse.status,
+    primary: manifestCheck.primary,
+    primaryStatus,
+    primaryContentType,
+    primaryBytes,
+    maxPrimaryBytes,
+    supplemental,
+    failures,
+  };
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
@@ -1,4 +1,4 @@
-const PREFLIGHT_FAILURE_KINDS = new Set(["render-api", "catalog-api"]);
+const PREFLIGHT_FAILURE_KINDS = new Set(["render-api", "catalog-api", "viewer-css"]);
 
 export function hasPreflightFailures(failures) {
   return (

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -10,6 +10,11 @@ import {
   isFatalIsolatedDiagnostic,
   parseIsolatedDiagnosticText,
 } from "./hosted-render-smoke-diagnostics.mjs";
+import {
+  DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES,
+  checkViewerCssSplit,
+  parsePositiveInteger,
+} from "./hosted-render-smoke-assets.mjs";
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import { catalogApiUrlForViewer, renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
@@ -49,6 +54,17 @@ const expectedLatestRevisionRuntimeHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH ?? "";
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const requireRuntimedWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_RUNTIMED_WASM !== "0";
+const requireViewerCssSplit = process.env.NOTEBOOK_CLOUD_REQUIRE_VIEWER_CSS_SPLIT !== "0";
+const maxPrimaryViewerCssBytes = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_MAX_PRIMARY_VIEWER_CSS_BYTES,
+  DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES,
+  "NOTEBOOK_CLOUD_MAX_PRIMARY_VIEWER_CSS_BYTES",
+);
+const minSupplementalViewerCssCount = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_MIN_SUPPLEMENTAL_VIEWER_CSS_COUNT,
+  1,
+  "NOTEBOOK_CLOUD_MIN_SUPPLEMENTAL_VIEWER_CSS_COUNT",
+);
 const expectedThemeModes = parseExpectedTexts("NOTEBOOK_CLOUD_SMOKE_THEME_MODES", [
   "light",
   "dark",
@@ -73,6 +89,7 @@ const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
 let renderApiCheck = null;
 let catalogApiCheck = null;
+let viewerCssCheck = null;
 let screenshotSaved = false;
 let pageTextMatches = {};
 let themeModeChecks = [];
@@ -169,6 +186,13 @@ async function main() {
         expectedRenderSource,
         catalogApiCheck?.latestRevisionNotebookHeadsHash ?? null,
       );
+    }
+    if (requireViewerCssSplit) {
+      viewerCssCheck = await checkViewerCssSplit(targetUrl, {
+        maxPrimaryBytes: maxPrimaryViewerCssBytes,
+        minSupplementalCount: minSupplementalViewerCssCount,
+      });
+      failures.push(...viewerCssCheck.failures);
     }
     if (hasPreflightFailures(failures)) {
       throw new SmokeFailure(failures);
@@ -375,6 +399,7 @@ async function main() {
           expectedLatestRevisionRuntimeHeadsHash,
           renderApiCheck,
           catalogApiCheck,
+          viewerCssCheck,
           executionCounts,
           reportCellCount,
           presenceText,

--- a/apps/notebook-cloud/test/hosted-smoke-assets.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-assets.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  checkViewerCssSplit,
+  isViewerCssAssetPath,
+  validateViewerCssManifestPayload,
+} from "../scripts/hosted-render-smoke-assets.mjs";
+
+describe("hosted render smoke viewer CSS assets", () => {
+  it("accepts only same-origin viewer CSS asset paths", () => {
+    assert.equal(isViewerCssAssetPath("/assets/notebook-cloud-viewer.css"), true);
+    assert.equal(isViewerCssAssetPath("/assets/katex-options-D_EmowkL.css"), true);
+    assert.equal(isViewerCssAssetPath("https://example.test/style.css"), false);
+    assert.equal(isViewerCssAssetPath("/renderer-assets/isolated-renderer.css"), false);
+    assert.equal(isViewerCssAssetPath("/assets/../secret.css"), false);
+    assert.equal(isViewerCssAssetPath("/assets/%2e%2e/secret.css"), false);
+    assert.equal(isViewerCssAssetPath("/assets/not-css.txt"), false);
+  });
+
+  it("requires a primary stylesheet and supplemental split CSS", () => {
+    assert.deepEqual(
+      validateViewerCssManifestPayload({
+        primary: "/assets/notebook-cloud-viewer.css",
+        supplemental: ["/assets/katex-options-D_EmowkL.css"],
+      }),
+      {
+        primary: "/assets/notebook-cloud-viewer.css",
+        supplemental: ["/assets/katex-options-D_EmowkL.css"],
+        failures: [],
+      },
+    );
+
+    const collapsed = validateViewerCssManifestPayload({
+      primary: "/assets/notebook-cloud-viewer.css",
+      supplemental: [],
+    });
+    assert.equal(collapsed.failures.length, 1);
+    assert.match(collapsed.failures[0].text, /expected at least 1 supplemental/);
+  });
+
+  it("checks the hosted manifest, primary stylesheet size, and supplemental headers", async () => {
+    const responses = new Map([
+      [
+        "https://preview.runt.run/assets/notebook-cloud-viewer-css.json",
+        Response.json({
+          primary: "/assets/notebook-cloud-viewer.css",
+          supplemental: ["/assets/katex-options-D_EmowkL.css"],
+        }),
+      ],
+      [
+        "https://preview.runt.run/assets/notebook-cloud-viewer.css",
+        new Response("css", {
+          headers: { "content-type": "text/css" },
+        }),
+      ],
+      [
+        "HEAD https://preview.runt.run/assets/katex-options-D_EmowkL.css",
+        new Response(null, {
+          headers: { "content-type": "text/css" },
+        }),
+      ],
+    ]);
+
+    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz", {
+      fetchImpl: fakeFetch(responses),
+      maxPrimaryBytes: 250_000,
+    });
+
+    assert.equal(check.manifestStatus, 200);
+    assert.equal(check.primaryBytes, 3);
+    assert.equal(check.supplemental.length, 1);
+    assert.deepEqual(check.failures, []);
+  });
+
+  it("reports when the primary stylesheet grows back into the large render-blocking bundle", async () => {
+    const responses = new Map([
+      [
+        "https://preview.runt.run/assets/notebook-cloud-viewer-css.json",
+        Response.json({
+          primary: "/assets/notebook-cloud-viewer.css",
+          supplemental: ["/assets/katex-options-D_EmowkL.css"],
+        }),
+      ],
+      [
+        "https://preview.runt.run/assets/notebook-cloud-viewer.css",
+        new Response("x".repeat(251_000), {
+          headers: { "content-type": "text/css" },
+        }),
+      ],
+      [
+        "HEAD https://preview.runt.run/assets/katex-options-D_EmowkL.css",
+        new Response(null, {
+          headers: { "content-type": "text/css" },
+        }),
+      ],
+    ]);
+
+    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz", {
+      fetchImpl: fakeFetch(responses),
+      maxPrimaryBytes: 250_000,
+    });
+
+    assert.equal(check.primaryBytes, 251_000);
+    assert.equal(check.failures.length, 1);
+    assert.match(check.failures[0].text, /primary viewer CSS was 251000 bytes/);
+  });
+});
+
+function fakeFetch(responses) {
+  return async (url, init = {}) => {
+    const key = init.method === "HEAD" ? `HEAD ${url}` : url;
+    const response = responses.get(key);
+    if (!response) {
+      return new Response("missing", { status: 404 });
+    }
+    return response.clone();
+  };
+}

--- a/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
@@ -4,9 +4,10 @@ import { describe, it } from "node:test";
 import { hasPreflightFailures } from "../scripts/hosted-render-smoke-preflight.mjs";
 
 describe("hosted render smoke preflight", () => {
-  it("fails fast for route-level render and catalog API failures", () => {
+  it("fails fast for route-level render, catalog API, and viewer CSS failures", () => {
     assert.equal(hasPreflightFailures([{ kind: "render-api" }]), true);
     assert.equal(hasPreflightFailures([{ kind: "catalog-api" }]), true);
+    assert.equal(hasPreflightFailures([{ kind: "viewer-css" }]), true);
   });
 
   it("does not treat later browser-render failures as preflight failures", () => {


### PR DESCRIPTION
## Summary

- adds hosted smoke coverage for the notebook-cloud viewer CSS split
- fails smoke when the primary render-blocking viewer CSS grows above 250 kB
- reports the live CSS manifest, primary byte size, and supplemental CSS assets in smoke output

## Why

#3082 moves lazy output CSS into a supplemental asset. This PR turns that into a hosted regression guard so preview smoke catches stale assets or config drift that collapses CSS back into the initial stylesheet.

This keeps the performance goal concrete: hosted notebooks should show useful document structure quickly while larger renderer/output assets remain sidecar-loaded through the asset host.

## Stack Status

#3082 has merged. This PR is now rebased and targeted directly at `main`.

## Asset-Hosting Note

Cloud can use Worker/CDN-hosted sidecar assets for large renderer/runtime payloads. Desktop/Tauri still needs a bootstrap-safe critical shell because the runtime daemon may not be up yet. Once the daemon is healthy, it can become another asset host for renderer/runtime chunks. Shared component work should model this as an output/renderer asset-host adapter rather than forcing cloud CDN, Tauri bootstrap, and daemon-served assets into one packaging path.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-assets.test.mjs test/hosted-smoke-preflight.test.mjs test/hosted-smoke-routes.test.mjs test/viewer-css-assets.test.mjs test/viewer-supplemental-css.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`

Hosted smoke evidence from `https://preview.runt.run/n/topic-viz`:

- manifest URL: `https://preview.runt.run/assets/notebook-cloud-viewer-css.json`
- primary CSS: `/assets/notebook-cloud-viewer.css`, `167437` bytes, limit `250000`
- supplemental CSS: `/assets/katex-options-D_EmowkL.css`, `200 text/css`
- output iframe sandbox remained `allow-scripts allow-downloads allow-forms allow-pointer-lock` without `allow-same-origin`
