### PR TITLE
docs(architecture): define runtime state document identity

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,6 +31,7 @@ These entries define the center of gravity for the system:
 | Identity, actors, scopes | [Identity and Trust](identity-and-trust.md) | Accepted |
 | Wire format | [Typed-frame v4 wire protocol](typed-frame-v4-wire-protocol.md) | Draft |
 | Document boundaries | [The Three-Document Split](three-document-split.md) | Draft |
+| Runtime-state identity | [Runtime State Document Identity](runtime-state-document-identity.md) | Draft |
 | Execution ordering | [Cell Execution Pipeline and Control-Plane Separation](execution-pipeline.md) | Draft |
 | Blob storage | [Blob Storage and Content Addressing](blob-storage-and-content-addressing.md) | Draft |
 | Sharing product requirements | [Hosted Notebook Sharing and Invites](hosted-sharing-invites.md) | PRD draft |
@@ -44,6 +45,7 @@ These entries define the center of gravity for the system:
 |-------|--------|-------|
 | [Typed-frame v4 wire protocol](typed-frame-v4-wire-protocol.md) | Draft | Frame bytes, channels, caps, and compatibility. |
 | [The Three-Document Split](three-document-split.md) | Draft | NotebookDoc, RuntimeStateDoc, and PoolDoc responsibility boundaries. |
+| [Runtime State Document Identity](runtime-state-document-identity.md) | Draft | NotebookDoc-owned pointer to the RuntimeStateDoc identity and checkpoint-head split. |
 | [Cell Execution Pipeline and Control-Plane Separation](execution-pipeline.md) | Draft | Execution state, output ordering, and lifecycle priority. |
 | [Execution Liveness](execution-liveness.md) | Design memo | Divergence-detection framing; not a recovery decision yet. |
 | [Tokio Mutex Discipline](tokio-mutex-discipline.md) | Draft | Async lock and cancel-safety invariants. |

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -77,14 +77,16 @@ New storage work should move toward the first-class document namespace in
 `runtime-state-document-identity.md`:
 
 ```text
-docs/{docId}/snapshot/{headsHash}.am
-docs/{docId}/incremental/{chunkHash}.amdelta
+docs/{docId}/snapshot/{headsHash}
+docs/{docId}/incremental/{chunkHash}
 blobs/{sha256}
 ```
 
-The render path is derived. The first three paths are the durable publish
-artifact set, but hosts can precompute the render path at publish time to prove
-the snapshot pair and blob set are complete.
+The render path is derived. Snapshot paths and blob paths are the durable
+publish artifact set; incremental paths are an optional future optimization that
+should follow Automerge Repo's logical storage shape rather than introduce a
+new file-extension convention. Hosts can precompute the render path at publish
+time to prove the snapshot pair and blob set are complete.
 
 For connected notebook pages, the live room supersedes the render path. `/render`
 is a warm-start cache and static/export read model, not a separate state lane.

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -27,6 +27,9 @@ The shared runtime work now gives us a cleaner path:
   separate origin boundaries; see `hosted-output-origin-isolation.md`.
 - Mixed output lists are segmented by the shared output renderer, not by the
   cloud viewer; see `output-rendering-segmentation.md`.
+- `runtime-state-document-identity.md` makes the `RuntimeStateDoc` a
+  first-class document identified from `NotebookDoc`, rather than only an
+  object nested under a notebook artifact path.
 
 ## Decision 1: Durable publish artifacts are snapshot pairs
 
@@ -44,6 +47,7 @@ A published revision is durable when these artifacts exist:
 The revision row records:
 
 - `notebook_heads_hash`
+- `runtime_state_doc_id`
 - `runtime_heads_hash`
 - `snapshot_key`
 - `runtime_snapshot_key`
@@ -60,13 +64,22 @@ leaves no revision row.
 
 ## Decision 2: R2 layout is deterministic
 
-For a notebook `n/:id`:
+The current compatibility layout for a notebook `n/:id` is:
 
 ```text
 n/{id}/snapshots/{notebookHeadsHash}.am
 n/{id}/snapshots/runtime-state/{runtimeHeadsHash}.am
 n/{id}/blobs/{sha256}
 n/{id}/renders/{notebookHeadsHash}.json
+```
+
+New storage work should move toward the first-class document namespace in
+`runtime-state-document-identity.md`:
+
+```text
+docs/{docId}/snapshot/{headsHash}.am
+docs/{docId}/incremental/{chunkHash}.amdelta
+blobs/{sha256}
 ```
 
 The render path is derived. The first three paths are the durable publish

--- a/docs/architecture/runtime-state-document-identity.md
+++ b/docs/architecture/runtime-state-document-identity.md
@@ -79,9 +79,11 @@ The canonical lookup direction is:
 NotebookDoc -> RuntimeStateDoc
 ```
 
-`RuntimeStateDoc` may carry `notebook_id` and `runtime_state_doc_id` as
-self-identifying validation fields, but those fields are not the authorization
-root. Authorization flows through the notebook and its ACL.
+`RuntimeStateDoc` may carry `runtime_state_doc_id` as its self identity and an
+optional `notebook_id` backlink when it is attached to a notebook. The backlink
+is provenance and validation context, not a required part of runtime-state
+identity. Authorization for notebook-attached runtime state flows through the
+notebook and its ACL.
 
 ## Consequences
 
@@ -99,14 +101,16 @@ daemon/system actor.
 
 ### RuntimeStateDoc schema changes
 
-`RuntimeStateDoc` should gain root self-identifying fields:
+`RuntimeStateDoc` should gain root identity fields:
 
 - `runtime_state_doc_id`
-- `notebook_id`
+- `notebook_id` (optional backlink for notebook-attached runtime state)
 
 These fields make storage, diagnostics, and cloud bootstrap validation cheaper.
-They are advisory checks against loading the wrong pair; they do not make
-runtime state independently shareable.
+The runtime-state id is the document's own identity. The notebook backlink is an
+advisory check against loading the wrong pair and must remain optional so the
+same document shape can support markdown-associated runtime state or standalone
+runtime state.
 
 ### Desktop room construction changes
 
@@ -117,7 +121,7 @@ notebook document:
 2. Read `NotebookDoc.runtime_state_doc_id`.
 3. If missing, mint a runtime-state document id and write it into `NotebookDoc`.
 4. Load the matching `RuntimeStateDoc` if present; otherwise create one with the
-   same id and backlink fields.
+   same runtime-state id and the optional notebook backlink.
 5. Continue syncing `NotebookDoc` on frame `0x00` and `RuntimeStateDoc` on frame
    `0x05`.
 
@@ -139,7 +143,9 @@ Bootstrap resolves the pair this way:
 3. Load the latest authorized `NotebookDoc` snapshot.
 4. Read `runtime_state_doc_id` from `NotebookDoc`.
 5. Load the checkpointed `RuntimeStateDoc` snapshot with that id and matching
-   recorded heads.
+   recorded heads. If the runtime-state snapshot has a `notebook_id` backlink,
+   validate it against the loaded notebook; if it does not, treat the
+   `NotebookDoc.runtime_state_doc_id` pointer as the association.
 6. Render from the two local Automerge documents.
 7. Open live sync for both documents.
 

--- a/docs/architecture/runtime-state-document-identity.md
+++ b/docs/architecture/runtime-state-document-identity.md
@@ -158,14 +158,20 @@ state is the pair of document ids plus their heads.
 Object storage should move toward document-id namespaces:
 
 ```text
-docs/{docId}/snapshot/{headsHash}.am
-docs/{docId}/incremental/{chunkHash}.amdelta
+docs/{docId}/snapshot/{headsHash}
+docs/{docId}/incremental/{chunkHash}
 blobs/{sha256}
 ```
 
-This mirrors the upstream `automerge-repo` storage shape: storage is organized
-by document id, snapshot chunks are loaded before incremental chunks, and
-`loadIncremental` can materialize the document from that byte stream.
+This mirrors the upstream `automerge-repo` logical storage shape: storage is
+organized by document id, snapshot chunks are loaded before incremental chunks,
+and Automerge can materialize the document from that byte stream. The path
+segments are the convention; this ADR does not define a new `.amdelta` file
+extension.
+
+The first hosted implementation can write only compact snapshots. Incremental
+object chunks are an optimization to evaluate after snapshot-pair bootstrap is
+measured; live deltas can remain in the room's sync protocol memory until then.
 
 The current cloud R2 layout remains a compatibility path:
 
@@ -231,7 +237,7 @@ The identity pointer fixes association without erasing the boundary.
 5. Add `runtime_state_doc_id` to cloud revision/catalog metadata.
 6. Teach cloud materialization to prefer the pointer and retain legacy nested
    runtime-state snapshot fallback.
-7. Move new object snapshots toward `docs/{docId}/snapshot/{headsHash}.am`.
+7. Move new object snapshots toward `docs/{docId}/snapshot/{headsHash}`.
 8. Evaluate incremental object chunks only after snapshot-pair bootstrap is
    measured.
 
@@ -249,9 +255,11 @@ and runtime-state doc over separate frame types.
 
 ## Open Questions
 
-1. Should document ids use the existing nteract UUID/ULID style or Automerge's
-   base58check document id format? The first implementation should choose one
-   typed `RuntimeStateDocId` wrapper and avoid exposing storage paths as ids.
+1. Should public notebook routes keep the existing nteract UUID/ULID style while
+   Automerge document references accept or normalize Automerge's base58check
+   `automerge:` URL format at API boundaries? The first implementation should
+   choose one typed `RuntimeStateDocId` wrapper and avoid exposing storage paths
+   as ids.
 2. Does "clear outputs/runtime state" clear the existing runtime-state document
    or rotate `runtime_state_doc_id`? Restarting a kernel should not rotate it.
 3. Should duplicate/fork notebook flows copy the runtime-state document for a

--- a/docs/architecture/runtime-state-document-identity.md
+++ b/docs/architecture/runtime-state-document-identity.md
@@ -1,0 +1,267 @@
+# Runtime State Document Identity
+
+**Status:** Draft, 2026-05-29.
+
+## Context
+
+nteract already keeps notebook state and runtime state in separate Automerge
+documents:
+
+- `NotebookDoc` carries cells, source text, durable metadata, attachments, and
+  the current per-cell `execution_id` pointer.
+- `RuntimeStateDoc` carries kernel lifecycle, queue state, executions, outputs,
+  widget comm state, environment state, trust state, and project context.
+
+That split is still the right boundary. The missing piece is identity.
+
+Desktop currently creates a `RuntimeStateDoc` because a `NotebookRoom` exists.
+The room owns `doc: NotebookDoc` and `state: RuntimeStateDoc` as sibling fields.
+Cloud similarly records a published snapshot pair by notebook id, notebook heads,
+runtime-state heads, and object keys. In both cases, the runtime-state document is
+paired operationally, but the notebook document itself does not identify the
+runtime-state document that belongs with it.
+
+That becomes brittle once hosted notebooks load Automerge directly:
+
+- A browser bootstrap should not need a separate "outer document" just to know
+  which runtime-state document resolves outputs and widgets for a notebook.
+- Object storage wants document-id namespaces for snapshots and incrementals,
+  not runtime-state snapshots nested forever under a notebook path.
+- Auth and sharing remain notebook-oriented, but the host needs to fetch two
+  Automerge documents as one authorized renderable pair.
+- Desktop needs the same vocabulary before runtime state becomes more durable.
+
+## Decision
+
+`NotebookDoc` carries the authoritative pointer to its current runtime-state
+document.
+
+```text
+NotebookDoc/
+  schema_version
+  notebook_id
+  runtime_state_doc_id
+  cells/
+  metadata/
+
+RuntimeStateDoc/
+  schema_version
+  runtime_state_doc_id
+  notebook_id
+  kernel/
+  queue/
+  executions/
+  env/
+  trust/
+  project_context/
+  display_index/
+  comms/
+```
+
+The pointer is document identity. It is not a heads hash and it is not a storage
+object key.
+
+Heads remain version coordinates owned by checkpoint, publish, and storage
+metadata:
+
+```text
+notebook_doc_id
+notebook_heads_hash
+runtime_state_doc_id
+runtime_state_heads_hash
+notebook_snapshot_key
+runtime_state_snapshot_key
+```
+
+The canonical lookup direction is:
+
+```text
+NotebookDoc -> RuntimeStateDoc
+```
+
+`RuntimeStateDoc` may carry `notebook_id` and `runtime_state_doc_id` as
+self-identifying validation fields, but those fields are not the authorization
+root. Authorization flows through the notebook and its ACL.
+
+## Consequences
+
+### NotebookDoc schema changes
+
+`NotebookDoc` needs a schema bump for `runtime_state_doc_id`.
+
+The field belongs at the root next to `notebook_id`, not under user-facing
+Jupyter metadata. It is CRDT topology: the identity of the second document
+needed to render the first document's current runtime state.
+
+Older `NotebookDoc` values that do not contain the field are migrated by minting
+a runtime-state document id and writing it into the notebook document with the
+daemon/system actor.
+
+### RuntimeStateDoc schema changes
+
+`RuntimeStateDoc` should gain root self-identifying fields:
+
+- `runtime_state_doc_id`
+- `notebook_id`
+
+These fields make storage, diagnostics, and cloud bootstrap validation cheaper.
+They are advisory checks against loading the wrong pair; they do not make
+runtime state independently shareable.
+
+### Desktop room construction changes
+
+Desktop keeps `NotebookRoom { doc, state }`, but `state` is resolved through the
+notebook document:
+
+1. Load or create `NotebookDoc`.
+2. Read `NotebookDoc.runtime_state_doc_id`.
+3. If missing, mint a runtime-state document id and write it into `NotebookDoc`.
+4. Load the matching `RuntimeStateDoc` if present; otherwise create one with the
+   same id and backlink fields.
+5. Continue syncing `NotebookDoc` on frame `0x00` and `RuntimeStateDoc` on frame
+   `0x05`.
+
+This does not require combining the documents or changing the typed-frame
+protocol.
+
+### Cloud bootstrap changes
+
+The hosted route remains notebook-oriented:
+
+```text
+/n/{notebookDocId}/{vanityName}
+```
+
+Bootstrap resolves the pair this way:
+
+1. Authenticate the user.
+2. Authorize the user against the notebook ACL.
+3. Load the latest authorized `NotebookDoc` snapshot.
+4. Read `runtime_state_doc_id` from `NotebookDoc`.
+5. Load the checkpointed `RuntimeStateDoc` snapshot with that id and matching
+   recorded heads.
+6. Render from the two local Automerge documents.
+7. Open live sync for both documents.
+
+The checkpoint/catalog row is still necessary because a runtime-state document
+id alone does not identify a point-in-time rendering. The coherent renderable
+state is the pair of document ids plus their heads.
+
+### Object storage changes
+
+Object storage should move toward document-id namespaces:
+
+```text
+docs/{docId}/snapshot/{headsHash}.am
+docs/{docId}/incremental/{chunkHash}.amdelta
+blobs/{sha256}
+```
+
+This mirrors the upstream `automerge-repo` storage shape: storage is organized
+by document id, snapshot chunks are loaded before incremental chunks, and
+`loadIncremental` can materialize the document from that byte stream.
+
+The current cloud R2 layout remains a compatibility path:
+
+```text
+n/{notebookId}/snapshots/{notebookHeadsHash}.am
+n/{notebookId}/snapshots/runtime-state/{runtimeHeadsHash}.am
+```
+
+New code should not deepen that nesting. It makes the runtime-state document
+look like a file inside the notebook instead of a first-class Automerge document
+associated by the notebook model.
+
+## Rejected Alternatives
+
+### Keep the association only in the cloud catalog
+
+Rejected. It keeps desktop and cloud terminology divergent and requires an
+outer bootstrap record to answer a model question the notebook document should
+own.
+
+The catalog still records exact checkpoint heads and storage keys, but it should
+not be the only place that knows which runtime-state document belongs to a
+notebook.
+
+### Store runtime-state heads in NotebookDoc
+
+Rejected. Heads change whenever runtime state changes. Storing runtime heads in
+`NotebookDoc` would create write amplification and would make every progress
+bar, output stream, widget update, and execution-status transition potentially
+dirty the notebook document.
+
+The notebook needs to know the document id. Checkpoints need to know heads.
+
+### Use Automerge refs as the association
+
+Rejected for now. Automerge refs are useful for paths inside an Automerge
+document and for fixed-head views, but the notebook/runtime association is a
+typed cross-document relationship with authorization consequences. A plain root
+field is easier to validate, migrate, and expose across Rust, WASM, Python, and
+cloud workers.
+
+### Combine NotebookDoc and RuntimeStateDoc
+
+Rejected. The split is load-bearing:
+
+- notebook edits and runtime outputs have different write cadence;
+- notebook fields and runtime fields have different write authorities;
+- `.ipynb` export needs durable cell/source metadata without queue/kernel state;
+- hosted authorization needs editors to write notebook fields without gaining
+  runtime authority.
+
+The identity pointer fixes association without erasing the boundary.
+
+## Migration Plan
+
+1. Add typed accessors for `NotebookDoc.runtime_state_doc_id` and bump the
+   notebook schema.
+2. Add typed self-identifying fields to `RuntimeStateDoc`.
+3. During room creation/load, mint and persist a runtime-state document id when
+   opening an older notebook document.
+4. Keep the existing sync streams and room shape while changing how
+   `NotebookRoom.state` is initialized.
+5. Add `runtime_state_doc_id` to cloud revision/catalog metadata.
+6. Teach cloud materialization to prefer the pointer and retain legacy nested
+   runtime-state snapshot fallback.
+7. Move new object snapshots toward `docs/{docId}/snapshot/{headsHash}.am`.
+8. Evaluate incremental object chunks only after snapshot-pair bootstrap is
+   measured.
+
+## Compatibility
+
+Older notebooks without `runtime_state_doc_id` remain valid. The daemon mints
+and writes the missing id before peers rely on runtime state.
+
+Existing cloud revisions remain readable by synthesizing a stable legacy
+runtime-state id from the notebook id while continuing to read the old nested R2
+keys. New revisions should write the explicit id.
+
+The typed-frame wire format does not change. Peers still sync the notebook doc
+and runtime-state doc over separate frame types.
+
+## Open Questions
+
+1. Should document ids use the existing nteract UUID/ULID style or Automerge's
+   base58check document id format? The first implementation should choose one
+   typed `RuntimeStateDocId` wrapper and avoid exposing storage paths as ids.
+2. Does "clear outputs/runtime state" clear the existing runtime-state document
+   or rotate `runtime_state_doc_id`? Restarting a kernel should not rotate it.
+3. Should duplicate/fork notebook flows copy the runtime-state document for a
+   snapshot fork or mint a fresh runtime-state document for a clean working
+   copy? This likely needs explicit product behavior.
+4. How durable should desktop runtime state become? This ADR makes identity
+   durable first; persistence can follow without changing the association model.
+
+## References
+
+- [The Three-Document Split](three-document-split.md)
+- [Hosted Notebook Artifacts](hosted-notebook-artifacts.md)
+- [Blob Storage and Content Addressing](blob-storage-and-content-addressing.md)
+- [Typed-frame v4 wire protocol](typed-frame-v4-wire-protocol.md)
+- `crates/notebook-doc/src/lib.rs`
+- `crates/runtime-doc/src/doc.rs`
+- `crates/runtimed/src/notebook_sync_server/room.rs`
+- `apps/notebook-cloud/src/storage.ts`
+- `apps/notebook-cloud/src/room-materializer.ts`

--- a/docs/architecture/three-document-split.md
+++ b/docs/architecture/three-document-split.md
@@ -7,7 +7,7 @@
 nteract syncs state through Automerge CRDTs. Three separate documents carry that state today, not one:
 
 - **`NotebookDoc`** (`crates/notebook-doc/src/lib.rs`) - one per notebook room. Carries cells, source text, notebook metadata, attachments. Schema version 4. Wire frame `0x00` (AutomergeSync).
-- **`RuntimeStateDoc`** (`crates/runtime-doc/src/doc.rs`) - one per notebook room. Carries kernel lifecycle, execution queue, executions and their outputs, env-sync state, trust state, project-file context, widget comm state. Schema version 2. Wire frame `0x05` (RuntimeStateSync).
+- **`RuntimeStateDoc`** (`crates/runtime-doc/src/doc.rs`) - one per runtime state surface; today each notebook room creates one. Carries kernel lifecycle, execution queue, executions and their outputs, env-sync state, trust state, project-file context, widget comm state. Schema version 2. Wire frame `0x05` (RuntimeStateSync).
 - **`PoolDoc`** (`crates/notebook-doc/src/pool_state.rs`) - one per daemon (not per room). Carries UV / Conda / Pixi prewarm pool counters, errors, retry timers. No schema version. Wire frame `0x06` (PoolStateSync).
 
 A connecting peer subscribes through one of the typed-frame handshake channels. `NotebookSync` (and the related `OpenNotebook` / `CreateNotebook` paths) brings up all three documents on one socket: `NotebookDoc` and `RuntimeStateDoc` per the joined room, plus `PoolDoc` fanned out to that peer because the peer loop subscribes to `pool_doc_changed` regardless of room. The `Pool` handshake is a JSON-IPC channel for pool status, env claims, and daemon admin; it does not carry typed-frame Automerge sync at all. Frame caps differ per type (see `crates/notebook-wire/src/lib.rs:59-102`).
@@ -92,10 +92,11 @@ This is currently the only structural link between the two documents. Everything
 The choice to store the pointer in `NotebookDoc` and the body in `RuntimeStateDoc` was driven by save semantics. The pointer is the part that survives a `.ipynb` export. The body is the part that gets thrown away.
 
 `runtime-state-document-identity.md` adds a second, document-level association:
-`NotebookDoc.runtime_state_doc_id`. That pointer identifies which
-`RuntimeStateDoc` belongs with the notebook. It does not replace
-`cell.execution_id`, and it does not store runtime-state heads in
-`NotebookDoc`.
+`NotebookDoc.runtime_state_doc_id`. For notebook rooms, that pointer identifies
+which `RuntimeStateDoc` belongs with the notebook. The association is optional
+from the runtime-state document's point of view so the same schema can support
+markdown-associated or standalone runtime state later. It does not replace
+`cell.execution_id`, and it does not store runtime-state heads in `NotebookDoc`.
 
 ## Decision 3: Write authority is per-document, and `RuntimeStateDoc` separates runtime authority from widget state
 

--- a/docs/architecture/three-document-split.md
+++ b/docs/architecture/three-document-split.md
@@ -21,6 +21,9 @@ what changes when the split runs in a multi-user deployment.
 Neighbors:
 
 - `docs/architecture/typed-frame-v4-wire-protocol.md` — the byte protocol that carries each doc's sync stream.
+- `docs/architecture/runtime-state-document-identity.md` — the follow-on
+  identity decision that makes `NotebookDoc` point at its associated
+  `RuntimeStateDoc`.
 - `docs/architecture/execution-pipeline.md` — how `RuntimeStateDoc` is written during cell execution.
 - `docs/architecture/blob-storage-and-content-addressing.md` — how output payloads are stored separately from the doc itself.
 - `docs/architecture/identity-and-trust.md` — the trust scopes the three-doc split makes expressible.
@@ -80,13 +83,19 @@ The placement test: if executing a cell would have to wait on this field before 
 
 This matches nbformat semantics. `.ipynb` files carry cell source, cell type, metadata, and (legacy) static output snapshots. They do not carry queue state, kernel status, env-sync diff. The .ipynb load path imports legacy outputs into a single synthetic execution in `RuntimeStateDoc`; live outputs sit there from the start.
 
-### One pointer crosses the boundary: `cell.execution_id`
+### The cell-level pointer crosses the boundary: `cell.execution_id`
 
 A cell's "current outputs" are looked up by following the `cells/{cell_id}/execution_id` pointer in `NotebookDoc` into the `executions/{execution_id}/outputs` map in `RuntimeStateDoc`. The daemon stamps this pointer at queue time (`NotebookDoc::set_execution_id`, `lib.rs:1707`). `clear_outputs` sets the pointer to null and resets the legacy `execution_count` field; it never deletes the execution entry in `RuntimeStateDoc` (`lib.rs:1736`).
 
-This is the only structural link between the two documents. Everything else is keyed entirely within one or the other. Output history sits in `RuntimeStateDoc` indefinitely; the cell just looks at one of the entries.
+This is currently the only structural link between the two documents. Everything else is keyed entirely within one or the other. Output history sits in `RuntimeStateDoc` indefinitely; the cell just looks at one of the entries.
 
 The choice to store the pointer in `NotebookDoc` and the body in `RuntimeStateDoc` was driven by save semantics. The pointer is the part that survives a `.ipynb` export. The body is the part that gets thrown away.
+
+`runtime-state-document-identity.md` adds a second, document-level association:
+`NotebookDoc.runtime_state_doc_id`. That pointer identifies which
+`RuntimeStateDoc` belongs with the notebook. It does not replace
+`cell.execution_id`, and it does not store runtime-state heads in
+`NotebookDoc`.
 
 ## Decision 3: Write authority is per-document, and `RuntimeStateDoc` separates runtime authority from widget state
 


### PR DESCRIPTION
## Summary

- adds a draft ADR for `NotebookDoc.runtime_state_doc_id` as the authoritative link to the associated `RuntimeStateDoc`
- clarifies that `RuntimeStateDoc.notebook_id` is an optional backlink for notebook-attached runtime state, not a required identity field
- records that heads remain checkpoint/catalog metadata rather than live document fields
- updates the architecture register plus adjacent hosted artifact and three-document split docs

## Stack

This is the base ADR PR for the runtime-state identity stack. Follow-up implementation PRs should target this branch until the ADR lands, then be retargeted by GitHub in merge order.

Planned follow-ups:

1. Add `RuntimeStateDocId` accessors and NotebookDoc schema migration.
2. Add RuntimeStateDoc self-identifying fields.
3. Resolve desktop `NotebookRoom.state` from the NotebookDoc pointer.
4. Carry the id through hosted publish/catalog/materialization and migrate storage layout.

## Verification

- `cargo xtask lint --fix`

## Review Notes

This is intentionally docs-only. The next PR in the stack will start the schema work.
