### PR TITLE
feat(pi): render Arrow IPC tables in REPL

### DIFF
--- a/crates/nteract-predicate/src/parquet_summary.rs
+++ b/crates/nteract-predicate/src/parquet_summary.rs
@@ -13,7 +13,8 @@ use arrow::array::{
     TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
     UInt32Array, UInt64Array, UInt8Array,
 };
-use arrow::datatypes::{DataType, TimeUnit};
+use arrow::datatypes::{DataType, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -106,7 +107,26 @@ pub fn summarize_parquet(
         .collect();
     let column_hints = parse_parquet_column_hints(&column_names, footer_rows, &kv_metadata);
     let reader = builder.build()?;
+    let batches = reader.collect::<Result<Vec<_>, _>>()?;
 
+    Ok(summarize_record_batches(
+        schema.as_ref(),
+        &batches,
+        bytes.len() as u64,
+        column_hints,
+    ))
+}
+
+/// Summarize already-decoded Arrow record batches.
+///
+/// This is the format-neutral waist used by both Parquet and Arrow IPC table
+/// renderers. `schema` supplies column names/types even when `batches` is empty.
+pub fn summarize_record_batches(
+    schema: &Schema,
+    batches: &[RecordBatch],
+    num_bytes: u64,
+    column_hints: Vec<ParquetColumnHint>,
+) -> ParquetSummary {
     let num_cols = schema.fields().len();
     let mut null_counts: Vec<u64> = vec![0; num_cols];
     let mut numeric_accum: Vec<Option<(f64, f64)>> = vec![None; num_cols];
@@ -116,8 +136,7 @@ pub fn summarize_parquet(
     let mut temporal_accum: Vec<Option<(i64, i64, TimeUnit)>> = vec![None; num_cols];
     let mut total_rows: u64 = 0;
 
-    for batch in reader {
-        let batch = batch?;
+    for batch in batches {
         total_rows += batch.num_rows() as u64;
 
         for (col_idx, col) in batch.columns().iter().enumerate() {
@@ -155,12 +174,12 @@ pub fn summarize_parquet(
         })
         .collect();
 
-    Ok(ParquetSummary {
+    ParquetSummary {
         num_rows: total_rows,
-        num_bytes: bytes.len() as u64,
+        num_bytes,
         columns,
         column_hints,
-    })
+    }
 }
 
 /// Increment the count for a string value in a column's accumulator, bounded
@@ -560,7 +579,9 @@ fn format_data_type(dt: &DataType) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{BooleanArray, Float64Array, Int64Array, LargeStringArray, StringArray};
+    use arrow::array::{
+        BooleanArray, Float64Array, Int64Array, LargeStringArray, StringArray, StringViewArray,
+    };
     use arrow::datatypes::{Field, Schema};
     use arrow::record_batch::RecordBatch;
     use parquet::arrow::ArrowWriter;
@@ -659,6 +680,61 @@ mod tests {
                 assert_eq!(*false_count, 2);
             }
             _ => panic!("expected boolean stats"),
+        }
+    }
+
+    #[test]
+    fn summarize_record_batches_matches_parquet_scan() {
+        let batch = make_test_batch();
+        let bytes = batch_to_parquet_bytes(&batch);
+        let parquet_summary = summarize_parquet(&bytes).unwrap();
+        let batch_summary = summarize_record_batches(
+            batch.schema().as_ref(),
+            &[batch],
+            bytes.len() as u64,
+            parquet_summary.column_hints.clone(),
+        );
+
+        assert_eq!(batch_summary.num_rows, parquet_summary.num_rows);
+        assert_eq!(batch_summary.num_bytes, parquet_summary.num_bytes);
+        assert_eq!(
+            batch_summary
+                .columns
+                .iter()
+                .map(|column| (&column.name, &column.data_type, column.null_count))
+                .collect::<Vec<_>>(),
+            parquet_summary
+                .columns
+                .iter()
+                .map(|column| (&column.name, &column.data_type, column.null_count))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            serde_json::to_value(&batch_summary.columns).unwrap(),
+            serde_json::to_value(&parquet_summary.columns).unwrap()
+        );
+    }
+
+    #[test]
+    fn summarize_record_batches_counts_utf8_view_strings() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s", DataType::Utf8View, true)]));
+        let arr = StringViewArray::from(vec![Some("alpha"), None, Some("beta"), Some("alpha")]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap();
+        let summary = summarize_record_batches(schema.as_ref(), &[batch], 128, vec![]);
+
+        assert_eq!(summary.num_rows, 4);
+        assert_eq!(summary.columns[0].data_type, "string");
+        assert_eq!(summary.columns[0].null_count, 1);
+        match &summary.columns[0].stats {
+            ColumnStats::String {
+                distinct_count,
+                top,
+                ..
+            } => {
+                assert_eq!(*distinct_count, 2);
+                assert_eq!(top[0], ("alpha".to_string(), 2));
+            }
+            _ => panic!("expected Utf8View string stats"),
         }
     }
 

--- a/crates/runtimed-node/src/arrow_ipc.rs
+++ b/crates/runtimed-node/src/arrow_ipc.rs
@@ -1,0 +1,324 @@
+//! Arrow IPC stream summarization and row reading for the TUI table viewer.
+//!
+//! DataFrame outputs are emitted as Arrow IPC streams. These helpers mirror the
+//! Parquet N-API surface while sharing the same row/summary structs so the TUI
+//! renderer can stay format-blind.
+
+use std::io::Cursor;
+
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::ipc::reader::StreamReader;
+use arrow::record_batch::RecordBatch;
+use napi_derive::napi;
+use nteract_predicate::parquet_features::parse_parquet_column_hints;
+use nteract_predicate::parquet_summary;
+
+use crate::parquet::{
+    array_value_to_string, parquet_summary_to_result, ParquetRowPage, ParquetSummaryResult,
+};
+
+/// Summarize an Arrow IPC stream from a local blob/file path.
+#[napi]
+pub fn summarize_arrow_file(file_path: String) -> napi::Result<ParquetSummaryResult> {
+    summarize_arrow_chunks(vec![file_path])
+}
+
+/// Summarize ordered Arrow IPC chunk files as one logical table.
+#[napi]
+pub fn summarize_arrow_chunks(file_paths: Vec<String>) -> napi::Result<ParquetSummaryResult> {
+    summarize_arrow_paths(&file_paths).map_err(napi::Error::from_reason)
+}
+
+/// Read a page of rows from an Arrow IPC stream at a local blob/file path.
+#[napi]
+pub fn read_arrow_file(file_path: String, offset: i64, limit: i64) -> napi::Result<ParquetRowPage> {
+    read_arrow_chunks(vec![file_path], offset, limit)
+}
+
+/// Read a page of rows from ordered Arrow IPC chunk files as one logical table.
+#[napi]
+pub fn read_arrow_chunks(
+    file_paths: Vec<String>,
+    offset: i64,
+    limit: i64,
+) -> napi::Result<ParquetRowPage> {
+    read_arrow_rows_from_paths(&file_paths, offset, limit).map_err(napi::Error::from_reason)
+}
+
+fn summarize_arrow_paths(file_paths: &[String]) -> Result<ParquetSummaryResult, String> {
+    let (schema, batches, num_bytes) = read_arrow_record_batches_from_paths(file_paths)?;
+    let total_rows = batches.iter().map(|batch| batch.num_rows() as u64).sum();
+    let column_names: Vec<String> = schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    let column_hints = parse_parquet_column_hints(&column_names, total_rows, schema.metadata());
+    let summary = parquet_summary::summarize_record_batches(
+        schema.as_ref(),
+        &batches,
+        num_bytes,
+        column_hints,
+    );
+
+    Ok(parquet_summary_to_result(&summary))
+}
+
+fn read_arrow_rows_from_paths(
+    file_paths: &[String],
+    offset: i64,
+    limit: i64,
+) -> Result<ParquetRowPage, String> {
+    let (schema, batches, _) = read_arrow_record_batches_from_paths(file_paths)?;
+    Ok(read_arrow_rows_from_batches(
+        schema.as_ref(),
+        &batches,
+        offset,
+        limit,
+    ))
+}
+
+fn read_arrow_record_batches_from_paths(
+    file_paths: &[String],
+) -> Result<(SchemaRef, Vec<RecordBatch>, u64), String> {
+    if file_paths.is_empty() {
+        return Err("Arrow error: no chunk paths provided".to_string());
+    }
+
+    let mut schema: Option<SchemaRef> = None;
+    let mut batches = Vec::new();
+    let mut num_bytes = 0_u64;
+
+    for file_path in file_paths {
+        let bytes =
+            std::fs::read(file_path).map_err(|e| format!("Failed to read {file_path}: {e}"))?;
+        num_bytes += bytes.len() as u64;
+        let (chunk_schema, chunk_batches) = read_arrow_record_batches_from_bytes(bytes)?;
+        if let Some(existing_schema) = schema.as_ref() {
+            ensure_compatible_schema(existing_schema.as_ref(), chunk_schema.as_ref())?;
+        } else {
+            schema = Some(chunk_schema);
+        }
+        batches.extend(chunk_batches);
+    }
+
+    let schema = schema.ok_or_else(|| "Arrow error: no schema found".to_string())?;
+    Ok((schema, batches, num_bytes))
+}
+
+fn read_arrow_record_batches_from_bytes(
+    bytes: Vec<u8>,
+) -> Result<(SchemaRef, Vec<RecordBatch>), String> {
+    let mut reader = StreamReader::try_new(Cursor::new(bytes), None)
+        .map_err(|e| format!("Arrow IPC error: {e}"))?;
+    let schema = reader.schema();
+    let mut batches = Vec::new();
+    for batch in &mut reader {
+        batches.push(batch.map_err(|e| format!("Arrow IPC batch read error: {e}"))?);
+    }
+    Ok((schema, batches))
+}
+
+fn ensure_compatible_schema(expected: &Schema, actual: &Schema) -> Result<(), String> {
+    if expected.fields().len() != actual.fields().len() {
+        return Err(format!(
+            "Arrow error: chunk schema column count mismatch ({} != {})",
+            expected.fields().len(),
+            actual.fields().len()
+        ));
+    }
+
+    for (idx, (expected_field, actual_field)) in expected
+        .fields()
+        .iter()
+        .zip(actual.fields().iter())
+        .enumerate()
+    {
+        if expected_field.name() != actual_field.name()
+            || expected_field.data_type() != actual_field.data_type()
+            || expected_field.is_nullable() != actual_field.is_nullable()
+        {
+            return Err(format!(
+                "Arrow error: chunk schema mismatch at column {idx} (expected {}: {:?}, got {}: {:?})",
+                expected_field.name(),
+                expected_field.data_type(),
+                actual_field.name(),
+                actual_field.data_type()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn read_arrow_rows_from_batches(
+    schema: &Schema,
+    batches: &[RecordBatch],
+    offset: i64,
+    limit: i64,
+) -> ParquetRowPage {
+    let columns: Vec<String> = schema
+        .fields()
+        .iter()
+        .map(|field| field.name().clone())
+        .collect();
+    let offset = offset.max(0) as usize;
+    let limit = limit.max(0) as usize;
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    let mut total_rows: usize = 0;
+    let mut row_idx: usize = 0;
+
+    for batch in batches {
+        let batch_rows = batch.num_rows();
+        total_rows += batch_rows;
+
+        if row_idx + batch_rows <= offset {
+            row_idx += batch_rows;
+            continue;
+        }
+
+        let start = offset.saturating_sub(row_idx);
+        let end = batch_rows.min(start + limit.saturating_sub(rows.len()));
+
+        for r in start..end {
+            if rows.len() >= limit {
+                break;
+            }
+            let mut row: Vec<String> = Vec::with_capacity(batch.num_columns());
+            for col in batch.columns() {
+                row.push(array_value_to_string(col.as_ref(), r));
+            }
+            rows.push(row);
+        }
+
+        row_idx += batch_rows;
+    }
+
+    ParquetRowPage {
+        columns,
+        rows,
+        total_rows: total_rows as i64,
+        offset: offset as i64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use arrow::array::{BooleanArray, Float64Array, Int32Array, StringViewArray};
+    use arrow::datatypes::{DataType, Field};
+    use arrow::ipc::writer::StreamWriter;
+    use std::sync::Arc;
+
+    fn sample_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("label", DataType::Utf8View, true),
+            Field::new("score", DataType::Float64, false),
+            Field::new("flag", DataType::Boolean, false),
+        ]))
+    }
+
+    fn sample_batch(
+        ids: Vec<i32>,
+        labels: Vec<Option<&str>>,
+        scores: Vec<f64>,
+        flags: Vec<bool>,
+    ) -> RecordBatch {
+        RecordBatch::try_new(
+            sample_schema(),
+            vec![
+                Arc::new(Int32Array::from(ids)),
+                Arc::new(StringViewArray::from(labels)),
+                Arc::new(Float64Array::from(scores)),
+                Arc::new(BooleanArray::from(flags)),
+            ],
+        )
+        .expect("record batch")
+    }
+
+    fn batch_to_ipc_bytes(batch: &RecordBatch) -> Vec<u8> {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut writer =
+                StreamWriter::try_new(&mut cursor, batch.schema().as_ref()).expect("stream writer");
+            writer.write(batch).expect("write batch");
+            writer.finish().expect("finish stream");
+        }
+        cursor.into_inner()
+    }
+
+    fn write_temp_arrow(bytes: &[u8]) -> (std::path::PathBuf, String) {
+        let path = std::env::temp_dir().join(format!(
+            "runtimed-node-arrow-{}.arrow",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, bytes).expect("write arrow");
+        let path_string = path.to_string_lossy().to_string();
+        (path, path_string)
+    }
+
+    #[test]
+    fn arrow_file_helpers_read_utf8_view_rows_and_stats() {
+        let batch = sample_batch(
+            vec![1, 2, 3],
+            vec![Some("alpha"), None, Some("alpha")],
+            vec![1.25, 2.5, 3.75],
+            vec![true, false, true],
+        );
+        let bytes = batch_to_ipc_bytes(&batch);
+        let (path, path_string) = write_temp_arrow(&bytes);
+
+        let page = read_arrow_file(path_string.clone(), 0, 40).expect("rows");
+        let summary = summarize_arrow_file(path_string).expect("summary");
+        let _ = std::fs::remove_file(path);
+
+        assert_eq!(page.columns, vec!["id", "label", "score", "flag"]);
+        assert_eq!(page.total_rows, 3);
+        assert_eq!(page.rows[0][1], "alpha");
+        assert_eq!(page.rows[1][1], "null");
+        assert_eq!(summary.num_rows, 3);
+        assert_eq!(summary.columns[1].data_type, "string");
+        assert_eq!(summary.columns[1].null_count, 1);
+
+        let stats: serde_json::Value =
+            serde_json::from_str(&summary.columns[1].stats_json).unwrap();
+        assert_eq!(stats["kind"], "string");
+        assert_eq!(stats["distinct_count"], 1);
+    }
+
+    #[test]
+    fn arrow_chunks_paginate_across_ordered_streams() {
+        let first = sample_batch(
+            vec![1, 2],
+            vec![Some("alpha"), Some("beta")],
+            vec![1.0, 2.0],
+            vec![true, false],
+        );
+        let second = sample_batch(
+            vec![3, 4],
+            vec![Some("gamma"), Some("delta")],
+            vec![3.0, 4.0],
+            vec![true, true],
+        );
+        let (first_path, first_path_string) = write_temp_arrow(&batch_to_ipc_bytes(&first));
+        let (second_path, second_path_string) = write_temp_arrow(&batch_to_ipc_bytes(&second));
+
+        let page = read_arrow_chunks(vec![first_path_string, second_path_string], 1, 3)
+            .expect("chunked rows");
+        let _ = std::fs::remove_file(first_path);
+        let _ = std::fs::remove_file(second_path);
+
+        assert_eq!(page.total_rows, 4);
+        assert_eq!(page.offset, 1);
+        assert_eq!(
+            page.rows
+                .iter()
+                .map(|row| (row[0].as_str(), row[1].as_str()))
+                .collect::<Vec<_>>(),
+            vec![("2", "beta"), ("3", "gamma"), ("4", "delta")]
+        );
+    }
+}

--- a/crates/runtimed-node/src/lib.rs
+++ b/crates/runtimed-node/src/lib.rs
@@ -22,18 +22,22 @@
 
 use napi_derive::napi;
 
+mod arrow_ipc;
 mod error;
 mod parquet;
 mod session;
 
+pub use arrow_ipc::{
+    read_arrow_chunks, read_arrow_file, summarize_arrow_chunks, summarize_arrow_file,
+};
 pub use error::NodeError;
 pub use parquet::{read_parquet_file, summarize_parquet_file};
 pub use session::{
-    create_notebook, get_execution_result, list_active_notebooks, open_notebook,
-    open_notebook_path, show_notebook, shutdown_notebook, ActiveNotebook, CellResult,
-    CondaDependencyStatus, CreateCellOptions, CreateNotebookEnvironmentMode, CreateNotebookOptions,
-    DependencyEditOptions, DependencyStatus, DependencyTrustStatus, EventSubscription,
-    ExecuteCellOptions, GetExecutionResultOptions, JsCellSnapshot, JsOutput,
+    blob_store_path, create_notebook, get_execution_result, list_active_notebooks, open_notebook,
+    open_notebook_path, resolve_blob_path, show_notebook, shutdown_notebook, ActiveNotebook,
+    CellResult, CondaDependencyStatus, CreateCellOptions, CreateNotebookEnvironmentMode,
+    CreateNotebookOptions, DependencyEditOptions, DependencyStatus, DependencyTrustStatus,
+    EventSubscription, ExecuteCellOptions, GetExecutionResultOptions, JsCellSnapshot, JsOutput,
     ListActiveNotebooksOptions, MoveCellOptions, OpenNotebookOptions, PackageManager,
     PixiDependencyStatus, QueueCellOptions, QueuedExecution, RunCellOptions, RuntimeStatus,
     Session, SetCellOptions, ShowNotebookOptions, ShowNotebookResult, ShutdownNotebookOptions,

--- a/crates/runtimed-node/src/parquet.rs
+++ b/crates/runtimed-node/src/parquet.rs
@@ -49,6 +49,12 @@ fn summarize_parquet_from_bytes(bytes: &[u8]) -> Result<ParquetSummaryResult, St
     let summary =
         parquet_summary::summarize_parquet(bytes).map_err(|e| format!("Parquet error: {e}"))?;
 
+    Ok(parquet_summary_to_result(&summary))
+}
+
+pub(crate) fn parquet_summary_to_result(
+    summary: &parquet_summary::ParquetSummary,
+) -> ParquetSummaryResult {
     let columns = summary
         .columns
         .iter()
@@ -60,11 +66,11 @@ fn summarize_parquet_from_bytes(bytes: &[u8]) -> Result<ParquetSummaryResult, St
         })
         .collect();
 
-    Ok(ParquetSummaryResult {
+    ParquetSummaryResult {
         num_rows: summary.num_rows as i64,
         num_bytes: summary.num_bytes as i64,
         columns,
-    })
+    }
 }
 
 /// Read a page of rows from a local blob/file path.
@@ -142,7 +148,7 @@ fn read_parquet_rows_from_bytes(
 }
 
 /// Convert an Arrow array value at a given index to a display string.
-fn array_value_to_string(array: &dyn Array, idx: usize) -> String {
+pub(crate) fn array_value_to_string(array: &dyn Array, idx: usize) -> String {
     if array.is_null(idx) {
         return "null".to_string();
     }
@@ -161,6 +167,9 @@ fn array_value_to_string(array: &dyn Array, idx: usize) -> String {
             .downcast_ref::<LargeStringArray>()
             .map(|a| a.value(idx).to_string())
             .unwrap_or_default(),
+        DataType::Utf8View => {
+            nteract_predicate::arrow_utils::string_at(array, idx).unwrap_or_else(|| "?".to_string())
+        }
         DataType::Int64 => array
             .as_any()
             .downcast_ref::<Int64Array>()

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -4,7 +4,7 @@
 //! Phase 2 will extract the shared logic into a `runtimed-session` crate
 //! and collapse both `-py` and `-node` onto it.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1455,6 +1455,24 @@ fn resolve_socket_path(override_path: Option<String>) -> PathBuf {
         .unwrap_or_else(runt_workspace::default_socket_path)
 }
 
+/// Resolve a blob hash to the local on-disk blob path for the selected daemon.
+#[napi]
+pub fn resolve_blob_path(hash: String, socket_path: Option<String>) -> Option<String> {
+    let socket_path = resolve_socket_path(socket_path);
+    let store_path = blob_store_path_for_socket_path(&socket_path)?;
+    let blob_path = blob_file_path_for_hash(&store_path, &hash)?;
+    blob_path
+        .exists()
+        .then(|| blob_path.to_string_lossy().to_string())
+}
+
+/// Return the local blob store root for the selected daemon, when present.
+#[napi]
+pub fn blob_store_path(socket_path: Option<String>) -> Option<String> {
+    blob_store_path_for_socket_path(&resolve_socket_path(socket_path))
+        .map(|path| path.to_string_lossy().to_string())
+}
+
 async fn resolve_blob_paths(socket_path: &std::path::Path) -> (Option<String>, Option<PathBuf>) {
     if let Some(parent) = socket_path.parent() {
         let daemon_json = parent.join("daemon.json");
@@ -1468,16 +1486,23 @@ async fn resolve_blob_paths(socket_path: &std::path::Path) -> (Option<String>, O
         } else {
             None
         };
-        let store_path = parent.join("blobs");
-        let store_path = if store_path.exists() {
-            Some(store_path)
-        } else {
-            None
-        };
+        let store_path = blob_store_path_for_socket_path(socket_path);
         (base_url, store_path)
     } else {
         (None, None)
     }
+}
+
+fn blob_store_path_for_socket_path(socket_path: &Path) -> Option<PathBuf> {
+    let store_path = socket_path.parent()?.join("blobs");
+    store_path.exists().then_some(store_path)
+}
+
+fn blob_file_path_for_hash(store_path: &Path, hash: &str) -> Option<PathBuf> {
+    if hash.len() < 2 || !hash.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(store_path.join(&hash[..2]).join(&hash[2..]))
 }
 
 async fn session_handle(state: &Arc<Mutex<SessionState>>) -> Result<DocHandle> {
@@ -2234,6 +2259,39 @@ mod tests {
     fn resolve_socket_path_prefers_explicit_override() {
         let path = resolve_socket_path(Some("/tmp/runtimed-node-test.sock".to_string()));
         assert_eq!(path, PathBuf::from("/tmp/runtimed-node-test.sock"));
+    }
+
+    #[test]
+    fn resolve_blob_path_uses_daemon_blob_store_sharding() {
+        let root =
+            std::env::temp_dir().join(format!("runtimed-node-blob-path-{}", uuid::Uuid::new_v4()));
+        let blob_root = root.join("blobs");
+        let socket_path = root.join("daemon.sock");
+        let hash = "abcdef0123456789";
+        let blob_path = blob_root.join("ab").join("cdef0123456789");
+        std::fs::create_dir_all(blob_path.parent().unwrap()).unwrap();
+        std::fs::write(&blob_path, b"arrow").unwrap();
+
+        assert_eq!(
+            blob_store_path(Some(socket_path.to_string_lossy().to_string())),
+            Some(blob_root.to_string_lossy().to_string())
+        );
+        assert_eq!(
+            resolve_blob_path(
+                hash.to_string(),
+                Some(socket_path.to_string_lossy().to_string())
+            ),
+            Some(blob_path.to_string_lossy().to_string())
+        );
+        assert_eq!(
+            resolve_blob_path(
+                "not-a-hex-hash".to_string(),
+                Some(socket_path.to_string_lossy().to_string())
+            ),
+            None
+        );
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/packages/runtimed-node/src/index.d.ts
+++ b/packages/runtimed-node/src/index.d.ts
@@ -270,19 +270,40 @@ export function getExecutionResult(
   options?: { socketPath?: string },
 ): Promise<CellResult>;
 
-export function readParquetFile(
-  filePath: string,
-  offset: number,
-  limit: number,
-): {
+export interface ParquetColumnInfo {
+  name: string;
+  dataType: string;
+  nullCount: number;
+  statsJson: string;
+}
+
+export interface ParquetRowPage {
   columns: string[];
   rows: string[][];
   totalRows: number;
   offset: number;
-};
+}
 
-export function summarizeParquetFile(filePath: string): {
+export interface ParquetSummaryResult {
   numRows: number;
   numBytes: number;
-  columns: Array<{ name: string; dataType: string; nullCount: number; statsJson: string }>;
-};
+  columns: ParquetColumnInfo[];
+}
+
+export type TableRowPage = ParquetRowPage;
+export type TableSummaryResult = ParquetSummaryResult;
+
+export function blobStorePath(socketPath?: string | null): string | null;
+export function resolveBlobPath(hash: string, socketPath?: string | null): string | null;
+
+export function readParquetFile(filePath: string, offset: number, limit: number): ParquetRowPage;
+
+export function readArrowFile(filePath: string, offset: number, limit: number): ParquetRowPage;
+
+export function readArrowChunks(filePaths: string[], offset: number, limit: number): ParquetRowPage;
+
+export function summarizeParquetFile(filePath: string): ParquetSummaryResult;
+
+export function summarizeArrowFile(filePath: string): ParquetSummaryResult;
+
+export function summarizeArrowChunks(filePaths: string[]): ParquetSummaryResult;

--- a/packages/runtimed-node/tests/arrow-ipc.test.ts
+++ b/packages/runtimed-node/tests/arrow-ipc.test.ts
@@ -1,0 +1,103 @@
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+const require = createRequire(import.meta.url);
+
+let binding:
+  | {
+      readArrowFile: (
+        filePath: string,
+        offset: number,
+        limit: number,
+      ) => {
+        columns: string[];
+        rows: string[][];
+        totalRows: number;
+        offset: number;
+      };
+      readArrowChunks: (
+        filePaths: string[],
+        offset: number,
+        limit: number,
+      ) => {
+        columns: string[];
+        rows: string[][];
+        totalRows: number;
+        offset: number;
+      };
+      summarizeArrowFile: (filePath: string) => {
+        numRows: number;
+        columns: Array<{ name: string; dataType: string }>;
+      };
+      summarizeArrowChunks: (filePaths: string[]) => { numRows: number };
+      resolveBlobPath: (hash: string, socketPath?: string | null) => string | null;
+    }
+  | undefined;
+let loadError: unknown;
+
+try {
+  binding = require("../src/index.cjs");
+} catch (error) {
+  loadError = error;
+}
+
+const describeNative = binding?.readArrowFile ? describe : describe.skip;
+const fixture = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../sift/public/polars-utf8view.arrow",
+);
+
+describeNative("@runtimed/node Arrow IPC native integration", () => {
+  it("reads and summarizes a real Utf8View Arrow stream fixture", () => {
+    if (!binding) throw loadError;
+
+    const page = binding.readArrowFile(fixture, 0, 3);
+    const summary = binding.summarizeArrowFile(fixture);
+
+    expect(page.columns).toEqual(["id", "name", "note", "score", "event_ts"]);
+    expect(page.rows).toHaveLength(3);
+    expect(page.totalRows).toBe(100);
+    expect(summary.numRows).toBe(100);
+    expect(summary.columns.map((column) => column.dataType)).toEqual([
+      "int64",
+      "string",
+      "string",
+      "float64",
+      "timestamp[microsecond]",
+    ]);
+  });
+
+  it("paginates across multiple Arrow stream chunks", () => {
+    if (!binding) throw loadError;
+
+    const page = binding.readArrowChunks([fixture, fixture], 98, 5);
+    const summary = binding.summarizeArrowChunks([fixture, fixture]);
+
+    expect(page.totalRows).toBe(200);
+    expect(page.offset).toBe(98);
+    expect(page.rows.map((row) => row[0])).toEqual(["98", "99", "0", "1", "2"]);
+    expect(summary.numRows).toBe(200);
+  });
+
+  it("resolves blob hashes through the daemon blob-store sharding layout", () => {
+    if (!binding) throw loadError;
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "runtimed-node-arrow-"));
+    const socketPath = path.join(root, "daemon.sock");
+    const hash = "abcdef0123456789";
+    const blobPath = path.join(root, "blobs", "ab", "cdef0123456789");
+    fs.mkdirSync(path.dirname(blobPath), { recursive: true });
+    fs.writeFileSync(blobPath, "arrow");
+
+    try {
+      expect(binding.resolveBlobPath(hash, socketPath)).toBe(blobPath);
+      expect(binding.resolveBlobPath("not-a-hash", socketPath)).toBeNull();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/nteract/pi/extensions/repl.test.ts
+++ b/plugins/nteract/pi/extensions/repl.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { findTableSource, renderTableTextForSource } from "./repl";
+
+const ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream";
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+};
+
+function outputWithData(data: Record<string, unknown>) {
+  return {
+    outputType: "display_data",
+    dataJson: JSON.stringify(data),
+  };
+}
+
+function manifestOutput(manifest: unknown) {
+  return outputWithData({
+    [ARROW_STREAM_MANIFEST_MIME]: {
+      type: "json",
+      value: manifest,
+    },
+  });
+}
+
+describe("pi REPL Arrow table rendering", () => {
+  it("renders a regular Arrow display blob with the DataTable path", () => {
+    const source = findTableSource({
+      cellId: "cell-1",
+      executionId: "exec-1",
+      status: "done",
+      success: true,
+      outputs: [
+        {
+          outputType: "execute_result",
+          blobPathsJson: JSON.stringify({ [ARROW_STREAM_MIME]: "/tmp/table.arrow" }),
+        },
+      ],
+    });
+
+    expect(source).toEqual({ kind: "arrow", path: "/tmp/table.arrow" });
+
+    const text = renderTableTextForSource(
+      source,
+      7,
+      theme,
+      {
+        readParquetFile: vi.fn(),
+        readArrowFile: vi.fn(() => ({
+          columns: ["id", "label", "score"],
+          rows: [
+            ["1", "alpha", "1.0000"],
+            ["2", "beta", "3.0000"],
+          ],
+          totalRows: 2,
+          offset: 0,
+        })),
+        summarizeArrowFile: vi.fn(() => ({
+          numRows: 2,
+          numBytes: 256,
+          columns: [
+            {
+              name: "id",
+              dataType: "int32",
+              nullCount: 0,
+              statsJson: '{"kind":"numeric","min":1,"max":2}',
+            },
+            {
+              name: "label",
+              dataType: "string",
+              nullCount: 0,
+              statsJson: '{"kind":"string","distinct_count":2,"top":[["alpha",1],["beta",1]]}',
+            },
+            {
+              name: "score",
+              dataType: "float64",
+              nullCount: 0,
+              statsJson: '{"kind":"numeric","min":1,"max":3}',
+            },
+          ],
+        })),
+      } as any,
+      120,
+    );
+
+    expect(text).toContain("Out[7]:");
+    expect(text).toContain("label");
+    expect(text).toContain("alpha");
+    expect(text).toContain("1.0..3.0");
+  });
+
+  it("renders streamed display-update manifests as cheap skeletons while incomplete", () => {
+    const readArrowChunks = vi.fn();
+    const source = findTableSource(
+      {
+        cellId: "cell-1",
+        executionId: "exec-1",
+        status: "running",
+        success: true,
+        outputs: [
+          manifestOutput({
+            schema: {
+              columns: [
+                { name: "city", type: "string", nullable: false },
+                { name: "value", type: "int64", nullable: false },
+              ],
+            },
+            chunks: [{ index: 0, hash: "abcdef0123456789", row_count: 10 }],
+            complete: false,
+            summary: { total_rows: 100, included_rows: 10, sampled: false },
+          }),
+        ],
+      },
+      { resolveBlobPath: vi.fn(() => "/tmp/blobs/ab/cdef0123456789") },
+    );
+
+    expect(source).toEqual({
+      kind: "arrow-manifest",
+      manifest: expect.objectContaining({ complete: false }),
+      chunkPaths: ["/tmp/blobs/ab/cdef0123456789"],
+    });
+
+    const text = renderTableTextForSource(
+      source,
+      3,
+      theme,
+      { readParquetFile: vi.fn(), readArrowChunks } as any,
+      120,
+    );
+
+    expect(readArrowChunks).not.toHaveBeenCalled();
+    expect(text).toContain("city");
+    expect(text).toContain("value");
+    expect(text).toContain("loading 10/100 rows × 2 columns");
+  });
+
+  it("decodes completed display-update manifests from resolved chunk paths", () => {
+    const readArrowChunks = vi.fn(() => ({
+      columns: ["city", "value"],
+      rows: [
+        ["Akron", "1"],
+        ["Boise", "4"],
+      ],
+      totalRows: 2,
+      offset: 0,
+    }));
+    const summarizeArrowChunks = vi.fn(() => ({
+      numRows: 2,
+      numBytes: 512,
+      columns: [
+        {
+          name: "city",
+          dataType: "string",
+          nullCount: 0,
+          statsJson: '{"kind":"string","distinct_count":2,"top":[["Akron",1],["Boise",1]]}',
+        },
+        {
+          name: "value",
+          dataType: "int64",
+          nullCount: 0,
+          statsJson: '{"kind":"numeric","min":1,"max":4}',
+        },
+      ],
+    }));
+
+    const source = findTableSource(
+      {
+        cellId: "cell-1",
+        executionId: "exec-1",
+        status: "done",
+        success: true,
+        outputs: [
+          manifestOutput({
+            schema: {
+              columns: [
+                { name: "city", type: "string" },
+                { name: "value", type: "int64" },
+              ],
+            },
+            chunks: [
+              { index: 0, hash: "abcdef0123456789", row_count: 1 },
+              { index: 1, hash: "0123456789abcdef", row_count: 1 },
+            ],
+            complete: true,
+            summary: { total_rows: 2, included_rows: 2, sampled: false },
+          }),
+        ],
+      },
+      {
+        resolveBlobPath: vi.fn((hash: string) => `/tmp/blobs/${hash.slice(0, 2)}/${hash.slice(2)}`),
+      },
+    );
+
+    const text = renderTableTextForSource(
+      source,
+      4,
+      theme,
+      { readParquetFile: vi.fn(), readArrowChunks, summarizeArrowChunks } as any,
+      120,
+    );
+
+    expect(readArrowChunks).toHaveBeenCalledWith(
+      ["/tmp/blobs/ab/cdef0123456789", "/tmp/blobs/01/23456789abcdef"],
+      0,
+      40,
+    );
+    expect(text).toContain("Akron");
+    expect(text).toContain("1.0..4.0");
+  });
+});

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -45,21 +45,13 @@ type RuntimedNode = {
     notebookId: string,
     opts?: { socketPath?: string; peerLabel?: string; description?: string },
   ): Promise<Session>;
-  readParquetFile(
-    filePath: string,
-    offset: number,
-    limit: number,
-  ): {
-    columns: string[];
-    rows: string[][];
-    totalRows: number;
-    offset: number;
-  };
-  summarizeParquetFile?(filePath: string): {
-    numRows: number;
-    numBytes: number;
-    columns: Array<{ name: string; dataType: string; nullCount: number; statsJson: string }>;
-  };
+  readParquetFile(filePath: string, offset: number, limit: number): TableRowPage;
+  readArrowFile?(filePath: string, offset: number, limit: number): TableRowPage;
+  readArrowChunks?(filePaths: string[], offset: number, limit: number): TableRowPage;
+  summarizeParquetFile?(filePath: string): TableSummaryResult;
+  summarizeArrowFile?(filePath: string): TableSummaryResult;
+  summarizeArrowChunks?(filePaths: string[]): TableSummaryResult;
+  resolveBlobPath?(hash: string, socketPath?: string): string | null | undefined;
 };
 
 type JsOutput = {
@@ -82,6 +74,19 @@ type CellResult = {
   status: string; // "done" | "error" | "timeout" | "kernel_error"
   success: boolean;
   outputs?: JsOutput[];
+};
+
+type TableRowPage = {
+  columns: string[];
+  rows: string[][];
+  totalRows: number;
+  offset: number;
+};
+
+type TableSummaryResult = {
+  numRows: number;
+  numBytes: number;
+  columns: Array<{ name: string; dataType: string; nullCount: number; statsJson: string }>;
 };
 
 type QueuedExecution = {
@@ -217,6 +222,44 @@ type ColumnStats = {
   false_count?: number;
 };
 
+const PARQUET_MIME = "application/vnd.apache.parquet";
+const ARROW_STREAM_MIME = "application/vnd.apache.arrow.stream";
+const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
+
+type ArrowManifestColumn = {
+  name: string;
+  type?: string;
+  nullable?: boolean;
+};
+
+type ArrowManifestChunk = {
+  index?: number;
+  hash?: string;
+  size?: number;
+  row_count?: number;
+  record_batch_count?: number;
+  encoding?: string;
+};
+
+type ArrowStreamManifest = {
+  schema?: {
+    columns?: ArrowManifestColumn[];
+  };
+  chunks?: ArrowManifestChunk[];
+  complete?: boolean;
+  summary?: {
+    total_rows?: number;
+    included_rows?: number;
+    sampled?: boolean;
+    sample_strategy?: string;
+  };
+};
+
+type TableSource =
+  | { kind: "parquet"; path: string }
+  | { kind: "arrow"; path: string }
+  | { kind: "arrow-manifest"; manifest: ArrowStreamManifest; chunkPaths: string[] };
+
 function formatStat(stats: ColumnStats | null): string {
   if (!stats) return "";
   switch (stats.kind) {
@@ -312,6 +355,7 @@ class DataTable {
   private cachedWidth?: number;
 
   private indent: number;
+  private footerText?: string;
 
   constructor(
     columns: string[],
@@ -321,6 +365,7 @@ class DataTable {
     colStats: (ColumnStats | null)[],
     theme: Theme,
     indent: number = 0,
+    footerText?: string,
   ) {
     this.columns = columns;
     this.rows = rows;
@@ -329,6 +374,7 @@ class DataTable {
     this.colStats = colStats;
     this.theme = theme;
     this.indent = indent;
+    this.footerText = footerText;
   }
 
   invalidate(): void {
@@ -461,10 +507,9 @@ class DataTable {
     // ── Footer info ──
     const showingRows = numRows < this.totalRows ? `showing ${numRows} of ` : "";
     const hiddenSuffix = hiddenCols > 0 ? ` (${hiddenCols} more columns)` : "";
-    const info = t.fg(
-      "dim",
-      `${showingRows}${this.totalRows} rows × ${totalCols} columns${hiddenSuffix}`,
-    );
+    const infoText =
+      this.footerText ?? `${showingRows}${this.totalRows} rows × ${totalCols} columns`;
+    const info = t.fg("dim", `${infoText}${hiddenSuffix}`);
     lines.push(info);
 
     // Indent all lines to align with Out[n]: prompt
@@ -569,16 +614,234 @@ function formatResult(result: CellResult): {
   return { content: parts, isError };
 }
 
-function findParquetBlobPath(result: CellResult): string | undefined {
-  for (const o of result.outputs ?? []) {
-    if (!o.blobPathsJson) continue;
+function parseJsonObject(raw: string | undefined): Record<string, any> | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseArrowManifestEntry(entry: any): ArrowStreamManifest | undefined {
+  if (!entry || typeof entry !== "object") return undefined;
+  let value = entry.value;
+  if (entry.type === "text" && typeof value === "string") {
     try {
-      const paths = JSON.parse(o.blobPathsJson);
-      const pqPath = paths["application/vnd.apache.parquet"];
-      if (typeof pqPath === "string") return pqPath;
-    } catch {}
+      value = JSON.parse(value);
+    } catch {
+      return undefined;
+    }
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as ArrowStreamManifest;
+}
+
+function parseTableManifest(dataJson: string | undefined): ArrowStreamManifest | undefined {
+  const data = parseJsonObject(dataJson);
+  return parseArrowManifestEntry(data?.[ARROW_STREAM_MANIFEST_MIME]);
+}
+
+function resolveManifestChunkPaths(
+  manifest: ArrowStreamManifest,
+  rn: Pick<RuntimedNode, "resolveBlobPath"> | undefined,
+): string[] {
+  const resolveBlobPath = rn?.resolveBlobPath;
+  if (!resolveBlobPath) return [];
+  const paths: string[] = [];
+  for (const chunk of manifest.chunks ?? []) {
+    if (typeof chunk.hash !== "string") continue;
+    const resolved = resolveBlobPath(chunk.hash);
+    if (typeof resolved === "string" && resolved.length > 0) {
+      paths.push(resolved);
+    }
+  }
+  return paths;
+}
+
+function findLegacyParquetBlobPath(result: CellResult): string | undefined {
+  const source = findTableSource(result, undefined);
+  return source?.kind === "parquet" ? source.path : undefined;
+}
+
+export function findTableSource(
+  result: CellResult,
+  rn?: Pick<RuntimedNode, "resolveBlobPath">,
+): TableSource | undefined {
+  for (const o of result.outputs ?? []) {
+    const paths = parseJsonObject(o.blobPathsJson);
+    const parquetPath = paths?.[PARQUET_MIME];
+    if (typeof parquetPath === "string") return { kind: "parquet", path: parquetPath };
+
+    const arrowPath = paths?.[ARROW_STREAM_MIME];
+    if (typeof arrowPath === "string") return { kind: "arrow", path: arrowPath };
+  }
+
+  for (const o of result.outputs ?? []) {
+    const manifest = parseTableManifest(o.dataJson);
+    if (manifest) {
+      return {
+        kind: "arrow-manifest",
+        manifest,
+        chunkPaths: resolveManifestChunkPaths(manifest, rn),
+      };
+    }
   }
   return undefined;
+}
+
+function parseSummaryStats(summary: TableSummaryResult | undefined): {
+  colTypes: string[];
+  colStats: (ColumnStats | null)[];
+} {
+  if (!summary) return { colTypes: [], colStats: [] };
+  return {
+    colTypes: summary.columns.map((c) => c.dataType),
+    colStats: summary.columns.map((c) => {
+      try {
+        return JSON.parse(c.statsJson) as ColumnStats;
+      } catch {
+        return null;
+      }
+    }),
+  };
+}
+
+function renderDataTableText(
+  page: TableRowPage,
+  count: number | undefined,
+  theme: Theme,
+  width: number,
+  colTypes: string[],
+  colStats: (ColumnStats | null)[],
+  footerText?: string,
+): string {
+  const prompt = count != null ? `Out[${count}]:` : "Out:";
+  const promptStr = theme.fg("muted", prompt);
+  const indent = prompt.length + 1;
+  const dt = new DataTable(
+    page.columns,
+    page.rows,
+    page.totalRows,
+    page.columns.map((_, i) => colTypes[i] ?? ""),
+    page.columns.map((_, i) => colStats[i] ?? null),
+    theme,
+    indent,
+    footerText,
+  );
+  const tableLines = dt.render(width - indent);
+  const indentStr = " ".repeat(indent);
+  if (tableLines.length > 0 && tableLines[0].startsWith(indentStr)) {
+    tableLines[0] = `${promptStr} ${tableLines[0].slice(indent)}`;
+  }
+  return tableLines.join("\n");
+}
+
+function manifestColumns(manifest: ArrowStreamManifest): ArrowManifestColumn[] {
+  return (manifest.schema?.columns ?? []).filter(
+    (column) => column && typeof column.name === "string",
+  );
+}
+
+function manifestIncludedRows(manifest: ArrowStreamManifest): number {
+  const included = manifest.summary?.included_rows;
+  if (typeof included === "number") return included;
+  return (manifest.chunks ?? []).reduce((sum, chunk) => sum + (chunk.row_count ?? 0), 0);
+}
+
+function manifestTotalRows(manifest: ArrowStreamManifest): number {
+  const total = manifest.summary?.total_rows;
+  if (typeof total === "number") return total;
+  return manifestIncludedRows(manifest);
+}
+
+function manifestFooterText(manifest: ArrowStreamManifest, columnCount: number): string {
+  const included = manifestIncludedRows(manifest);
+  const total = manifestTotalRows(manifest);
+  const sampled = Boolean(manifest.summary?.sampled);
+  const rowText = manifest.complete
+    ? sampled && total > included
+      ? `sampled ${included} of ${total}`
+      : `${total}`
+    : total > 0
+      ? `loading ${included}/${total}`
+      : `loading ${included}`;
+  return `${rowText} rows × ${columnCount} columns`;
+}
+
+function renderManifestSkeletonText(
+  source: Extract<TableSource, { kind: "arrow-manifest" }>,
+  count: number | undefined,
+  theme: Theme,
+  width: number,
+): string | undefined {
+  const columns = manifestColumns(source.manifest);
+  if (!columns.length) return undefined;
+  const page: TableRowPage = {
+    columns: columns.map((column) => column.name),
+    rows: [],
+    totalRows: manifestTotalRows(source.manifest),
+    offset: 0,
+  };
+  return renderDataTableText(
+    page,
+    count,
+    theme,
+    width,
+    columns.map((column) => column.type ?? ""),
+    columns.map(() => null),
+    manifestFooterText(source.manifest, columns.length),
+  );
+}
+
+export function renderTableTextForSource(
+  source: TableSource | undefined,
+  count: number | undefined,
+  theme: Theme,
+  rn: RuntimedNode,
+  width: number = process.stdout.columns || 120,
+): string | undefined {
+  if (!source) return undefined;
+
+  try {
+    if (source.kind === "parquet") {
+      const page = rn.readParquetFile(source.path, 0, 40);
+      if (!page?.columns?.length) return undefined;
+      const { colTypes, colStats } = parseSummaryStats(rn.summarizeParquetFile?.(source.path));
+      return renderDataTableText(page, count, theme, width, colTypes, colStats);
+    }
+
+    if (source.kind === "arrow") {
+      const page = rn.readArrowFile?.(source.path, 0, 40);
+      if (!page?.columns?.length) return undefined;
+      const { colTypes, colStats } = parseSummaryStats(rn.summarizeArrowFile?.(source.path));
+      return renderDataTableText(page, count, theme, width, colTypes, colStats);
+    }
+
+    const expectedChunkCount = (source.manifest.chunks ?? []).filter(
+      (chunk) => typeof chunk.hash === "string",
+    ).length;
+    const hasAllChunkPaths =
+      expectedChunkCount > 0 && source.chunkPaths.length === expectedChunkCount;
+    if (source.manifest.complete && hasAllChunkPaths && rn.readArrowChunks) {
+      try {
+        const page = rn.readArrowChunks(source.chunkPaths, 0, 40);
+        if (page?.columns?.length) {
+          const { colTypes, colStats } = parseSummaryStats(
+            rn.summarizeArrowChunks?.(source.chunkPaths),
+          );
+          return renderDataTableText(page, count, theme, width, colTypes, colStats);
+        }
+      } catch {
+        // Fall through to the manifest skeleton if chunk files are unavailable.
+      }
+    }
+
+    return renderManifestSkeletonText(source, count, theme, width);
+  } catch {
+    return undefined;
+  }
 }
 
 // --- extension ---------------------------------------------------------------
@@ -813,56 +1076,18 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
         nextExecCount = count + 1;
       }
 
-      // If we have a parquet blob path, read it via napi and render as DataTable
-      const pqPath = details.parquet_blob_path;
-      if (pqPath && rn?.readParquetFile) {
-        try {
-          const page = rn.readParquetFile(pqPath, 0, 40);
-          if (page && page.rows.length > 0) {
-            // Get column types and stats from summary
-            let colTypes: string[] = page.columns.map(() => "");
-            let colStats: (ColumnStats | null)[] = page.columns.map(() => null);
-            if (rn.summarizeParquetFile) {
-              try {
-                const summary = rn.summarizeParquetFile(pqPath);
-                colTypes = summary.columns.map((c: any) => c.dataType);
-                colStats = summary.columns.map((c: any) => {
-                  try {
-                    return JSON.parse(c.statsJson);
-                  } catch {
-                    return null;
-                  }
-                });
-              } catch {}
-            }
-
-            // Render table with Out[n]: prompt
-            const prompt = count != null ? `Out[${count}]:` : "Out:";
-            const promptStr = theme.fg("muted", prompt);
-            const indent = prompt.length + 1;
-            const dt = new DataTable(
-              page.columns,
-              page.rows,
-              page.totalRows,
-              colTypes,
-              colStats,
-              theme,
-              indent,
-            );
-            const text =
-              (_context.lastComponent instanceof Text ? _context.lastComponent : undefined) ??
-              new Text("", 0, 0);
-            const termWidth = process.stdout.columns || 120;
-            const tableLines = dt.render(termWidth - indent);
-            // Put first table line on the Out[n]: line instead of below it
-            const indentStr = " ".repeat(indent);
-            if (tableLines.length > 0 && tableLines[0].startsWith(indentStr)) {
-              tableLines[0] = `${promptStr} ${tableLines[0].slice(indent)}`;
-            }
-            text.setText(tableLines.join("\n"));
-            return text;
-          }
-        } catch {}
+      const tableSource =
+        (details.table_source as TableSource | undefined) ??
+        (typeof details.parquet_blob_path === "string"
+          ? ({ kind: "parquet", path: details.parquet_blob_path } as TableSource)
+          : undefined);
+      const tableText = renderTableTextForSource(tableSource, count, theme, rn);
+      if (tableText) {
+        const text =
+          (_context.lastComponent instanceof Text ? _context.lastComponent : undefined) ??
+          new Text("", 0, 0);
+        text.setText(tableText);
+        return text;
       }
 
       // Extract text output from content
@@ -912,14 +1137,14 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
               status: progress.status,
               execution_count: progress.executionCount,
               is_error: isError,
-              parquet_blob_path: findParquetBlobPath(progress),
+              table_source: findTableSource(progress, rn),
+              parquet_blob_path: findLegacyParquetBlobPath(progress),
               streaming: true,
             },
           });
         },
       });
-      // Extract parquet blob path for human-side table rendering
-      const parquetBlobPath = findParquetBlobPath(result);
+      const tableSource = findTableSource(result, rn);
 
       const { content, isError } = formatResult(result);
       return {
@@ -931,7 +1156,8 @@ export default function nteractReplExtension(pi: ExtensionAPI) {
           status: result.status,
           execution_count: result.executionCount,
           is_error: isError,
-          parquet_blob_path: parquetBlobPath,
+          table_source: tableSource,
+          parquet_blob_path: tableSource?.kind === "parquet" ? tableSource.path : undefined,
           runtime: sess.getRuntimeStatus
             ? await sess.getRuntimeStatus().catch(() => undefined)
             : undefined,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "apps/notebook/src/**/__tests__/**/*.test.{ts,tsx}",
       "apps/mcp-app/src/**/__tests__/**/*.test.{js,ts,tsx}",
       "packages/**/tests/**/*.test.{ts,tsx}",
+      "plugins/nteract/pi/**/*.test.{ts,tsx}",
     ],
     globals: true,
     setupFiles: ["./src/test-setup.ts"],


### PR DESCRIPTION
## Summary
- add format-neutral RecordBatch table summarization shared by parquet and Arrow IPC
- expose Arrow IPC file/chunk readers plus blob hash resolution through @runtimed/node
- render direct Arrow blobs and streamed Arrow manifests in the pi REPL DataTable path

## Tests
- cargo test -p nteract-predicate parquet_summary --lib
- cargo check -p runtimed-node
- pnpm --dir packages/runtimed-node build
- pnpm test:run packages/runtimed-node/tests/arrow-ipc.test.ts plugins/nteract/pi/extensions/repl.test.ts
- cargo xtask lint --fix
