### PR TITLE
feat(runtimed): seed runtime state document identity in rooms

### DIFF
--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -70,7 +70,6 @@
 //!       seq: Int           (insertion order)
 //!       capture_msg_id: Str (Output widget capture routing, "" if not capturing)
 //!   runtime_state_doc_id: Str|null
-//!   notebook_id: Str|null
 //!   last_saved: Str|null   (ISO timestamp of last save)
 //! ```
 
@@ -307,9 +306,6 @@ pub struct RuntimeState {
     /// `runtime_state_doc_id` pointer when known.
     #[serde(default)]
     pub runtime_state_doc_id: Option<String>,
-    /// NotebookDoc identity this runtime state belongs to when known.
-    #[serde(default)]
-    pub notebook_id: Option<String>,
     pub kernel: KernelState,
     pub queue: QueueState,
     pub env: EnvState,
@@ -2271,33 +2267,12 @@ impl RuntimeStateDoc {
         self.read_opt_str(&ROOT, "runtime_state_doc_id")
     }
 
-    /// NotebookDoc identity this runtime state belongs to, if known.
-    pub fn notebook_id(&self) -> Option<String> {
-        self.read_opt_str(&ROOT, "notebook_id")
-    }
-
     /// Set the RuntimeStateDoc identity.
     pub fn set_runtime_state_doc_id(
         &mut self,
         runtime_state_doc_id: Option<&str>,
     ) -> Result<(), RuntimeStateError> {
         self.set_optional_str("runtime_state_doc_id", runtime_state_doc_id)
-    }
-
-    /// Set the NotebookDoc identity this runtime state belongs to.
-    pub fn set_notebook_id(&mut self, notebook_id: Option<&str>) -> Result<(), RuntimeStateError> {
-        self.set_optional_str("notebook_id", notebook_id)
-    }
-
-    /// Set both document identity fields together.
-    pub fn set_document_identity(
-        &mut self,
-        runtime_state_doc_id: Option<&str>,
-        notebook_id: Option<&str>,
-    ) -> Result<(), RuntimeStateError> {
-        self.set_runtime_state_doc_id(runtime_state_doc_id)?;
-        self.set_notebook_id(notebook_id)?;
-        Ok(())
     }
 
     // ── Project context ─────────────────────────────────────────────
@@ -2861,7 +2836,6 @@ impl RuntimeStateDoc {
         let last_saved = self.read_opt_str(&ROOT, "last_saved");
         let path = self.read_opt_str(&ROOT, "path");
         let runtime_state_doc_id = self.runtime_state_doc_id();
-        let notebook_id = self.notebook_id();
 
         let trust_state = trust
             .as_ref()
@@ -2882,7 +2856,6 @@ impl RuntimeStateDoc {
 
         RuntimeState {
             runtime_state_doc_id,
-            notebook_id,
             kernel: kernel_state,
             queue: queue_state,
             env: env_state,
@@ -3909,24 +3882,19 @@ mod tests {
     }
 
     #[test]
-    fn test_set_document_identity() {
+    fn test_set_runtime_state_doc_id() {
         let mut doc = RuntimeStateDoc::new();
         assert_eq!(doc.runtime_state_doc_id(), None);
-        assert_eq!(doc.notebook_id(), None);
 
-        doc.set_document_identity(Some("runtime:nb-1"), Some("nb-1"))
-            .unwrap();
+        doc.set_runtime_state_doc_id(Some("runtime:nb-1")).unwrap();
         assert_eq!(doc.runtime_state_doc_id().as_deref(), Some("runtime:nb-1"));
-        assert_eq!(doc.notebook_id().as_deref(), Some("nb-1"));
 
         let state = doc.read_state();
         assert_eq!(state.runtime_state_doc_id.as_deref(), Some("runtime:nb-1"));
-        assert_eq!(state.notebook_id.as_deref(), Some("nb-1"));
 
-        doc.set_document_identity(None, None).unwrap();
+        doc.set_runtime_state_doc_id(None).unwrap();
         let state = doc.read_state();
         assert_eq!(state.runtime_state_doc_id, None);
-        assert_eq!(state.notebook_id, None);
     }
 
     #[test]

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -187,13 +187,6 @@ fn validate_runtime_peer_room_host_owned_delta(
             "room-host/daemon-owned",
         ));
     }
-    if before.state.notebook_id != after.state.notebook_id {
-        return Err(runtime_state_policy_error(
-            scope,
-            "notebook_id",
-            "room-host/daemon-owned",
-        ));
-    }
     if before.state.last_saved != after.state.last_saved {
         return Err(runtime_state_policy_error(
             scope,
@@ -433,13 +426,6 @@ fn validate_comm_state_only_runtime_delta(
             "daemon-owned",
         ));
     }
-    if before.state.notebook_id != after.state.notebook_id {
-        return Err(runtime_state_policy_error(
-            scope,
-            "notebook_id",
-            "daemon-owned",
-        ));
-    }
     if before.state.last_saved != after.state.last_saved {
         return Err(runtime_state_policy_error(
             scope,
@@ -632,13 +618,13 @@ mod tests {
     fn owner_runtime_state_policy_rejects_identity_rewrites() {
         let mut before_doc = RuntimeStateDoc::new();
         before_doc
-            .set_document_identity(Some("runtime:nb-1"), Some("nb-1"))
+            .set_runtime_state_doc_id(Some("runtime:nb-1"))
             .unwrap();
         let before = runtime_state_policy_snapshot(&before_doc);
 
         let mut after_doc = RuntimeStateDoc::new();
         after_doc
-            .set_document_identity(Some("runtime:nb-2"), Some("nb-1"))
+            .set_runtime_state_doc_id(Some("runtime:nb-2"))
             .unwrap();
         let after = runtime_state_policy_snapshot(&after_doc);
 

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1256,8 +1256,6 @@ impl PyCommDocEntry {
 pub struct PyRuntimeState {
     /// RuntimeStateDoc identity, if known.
     pub runtime_state_doc_id: Option<String>,
-    /// NotebookDoc identity this runtime state belongs to, if known.
-    pub notebook_id: Option<String>,
     /// Kernel state (status, name, language, env_source).
     pub kernel: PyKernelState,
     /// Execution queue state.
@@ -1316,7 +1314,6 @@ impl From<runtime_doc::RuntimeState> for PyRuntimeState {
         };
         Self {
             runtime_state_doc_id: rs.runtime_state_doc_id,
-            notebook_id: rs.notebook_id,
             kernel: PyKernelState {
                 status: legacy_status.to_string(),
                 starting_phase: legacy_phase.to_string(),
@@ -1504,7 +1501,6 @@ mod tests {
 
         let runtime = RuntimeState {
             runtime_state_doc_id: Some("runtime:notebook-a".to_string()),
-            notebook_id: Some("notebook-a".to_string()),
             kernel: KernelState {
                 name: "kernel-a".to_string(),
                 language: "python".to_string(),
@@ -1546,7 +1542,6 @@ mod tests {
             py_state.runtime_state_doc_id.as_deref(),
             Some("runtime:notebook-a")
         );
-        assert_eq!(py_state.notebook_id.as_deref(), Some("notebook-a"));
         assert_eq!(py_state.kernel.status, "busy");
         assert_eq!(py_state.kernel.lifecycle, "Running");
         assert_eq!(py_state.kernel.activity, "Busy");

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -790,6 +790,7 @@ impl NotebookRoom {
         if ephemeral {
             let _ = doc.set_metadata("ephemeral", "true");
         }
+        let runtime_state_doc_id = doc.ensure_runtime_state_doc_id(&notebook_id_str)?;
 
         let (persist_tx, flush_request_tx) = if ephemeral {
             (None, None)
@@ -862,11 +863,10 @@ impl NotebookRoom {
         );
 
         let (state_changed_tx, _) = broadcast::channel(16);
-        let state = runtime_doc::RuntimeStateHandle::new(
-            RuntimeStateDoc::try_new()
-                .map_err(|e| anyhow::anyhow!("create runtime state doc: {e}"))?,
-            state_changed_tx,
-        );
+        let mut state_doc = RuntimeStateDoc::try_new()
+            .map_err(|e| anyhow::anyhow!("create runtime state doc: {e}"))?;
+        state_doc.set_runtime_state_doc_id(Some(&runtime_state_doc_id))?;
+        let state = runtime_doc::RuntimeStateHandle::new(state_doc, state_changed_tx);
 
         // Seed path on the runtime-state doc so connecting peers see it via sync.
         if let Some(p) = path.as_ref() {
@@ -914,7 +914,10 @@ impl NotebookRoom {
 
         let filename = notebook_doc_filename(notebook_id);
         let persist_path = docs_dir.join(filename);
-        let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
+        let mut doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
+        let runtime_state_doc_id = doc
+            .ensure_runtime_state_doc_id(notebook_id)
+            .expect("seed runtime state document id");
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         let (flush_request_tx, flush_rx) = mpsc::unbounded_channel::<FlushRequest>();
         spawn_persist_debouncer(persist_rx, flush_rx, persist_path.clone());
@@ -965,7 +968,11 @@ impl NotebookRoom {
             }
         };
         let (state_changed_tx, _) = broadcast::channel(16);
-        let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
+        let mut state_doc = RuntimeStateDoc::new();
+        state_doc
+            .set_runtime_state_doc_id(Some(&runtime_state_doc_id))
+            .expect("seed runtime state document identity");
+        let state = runtime_doc::RuntimeStateHandle::new(state_doc, state_changed_tx);
         if let Some(p) = path.as_ref() {
             let path_str = p.to_string_lossy().into_owned();
             let _ = state.with_doc(|sd| sd.set_path(Some(&path_str)));

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -313,8 +313,19 @@ async fn test_room_load_or_create_new() {
 
     let doc = room.doc.try_read().unwrap();
     assert_eq!(doc.notebook_id(), Some("test-nb".to_string()));
+    assert_eq!(
+        doc.runtime_state_doc_id(),
+        Some(notebook_doc::default_runtime_state_doc_id("test-nb"))
+    );
     assert_eq!(doc.cell_count(), 0);
     assert_eq!(room.connections.active_peers.load(Ordering::Relaxed), 0);
+    drop(doc);
+
+    let runtime_state = room.state.read(|doc| doc.read_state()).unwrap();
+    assert_eq!(
+        runtime_state.runtime_state_doc_id.as_deref(),
+        Some(notebook_doc::default_runtime_state_doc_id("test-nb").as_str())
+    );
 }
 
 #[tokio::test]
@@ -451,8 +462,21 @@ async fn test_new_fresh_creates_empty_doc() {
     let room = NotebookRoom::new_fresh(uuid, None, tmp.path(), blob_store, false);
 
     let doc = room.doc.try_read().unwrap();
-    assert_eq!(doc.notebook_id(), Some(uuid.to_string()));
+    let notebook_id = uuid.to_string();
+    let runtime_state_doc_id = notebook_doc::default_runtime_state_doc_id(&notebook_id);
+    assert_eq!(doc.notebook_id(), Some(notebook_id.clone()));
+    assert_eq!(
+        doc.runtime_state_doc_id(),
+        Some(runtime_state_doc_id.clone())
+    );
     assert_eq!(doc.cell_count(), 0);
+    drop(doc);
+
+    let runtime_state = room.state.read(|doc| doc.read_state()).unwrap();
+    assert_eq!(
+        runtime_state.runtime_state_doc_id.as_deref(),
+        Some(runtime_state_doc_id.as_str())
+    );
 }
 
 #[tokio::test]

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -278,10 +278,6 @@ export interface RuntimeState {
    * pointer when known.
    */
   runtime_state_doc_id: string | null;
-  /**
-   * NotebookDoc identity this runtime state belongs to when known.
-   */
-  notebook_id: string | null;
   kernel: KernelState;
   queue: QueueState;
   env: EnvState;
@@ -305,7 +301,6 @@ export interface RuntimeState {
 
 export const DEFAULT_RUNTIME_STATE: RuntimeState = {
   runtime_state_doc_id: null,
-  notebook_id: null,
   kernel: {
     lifecycle: { lifecycle: "NotStarted" },
     error_reason: "",


### PR DESCRIPTION
## Summary

- seed each daemon `NotebookRoom` with `NotebookDoc.runtime_state_doc_id`
- initialize the room's daemon-owned `RuntimeStateDoc` with only its self id
- remove the `notebook_id` backlink from the RuntimeStateDoc format and generated bindings
- keep the notebook association owned by `NotebookDoc.runtime_state_doc_id`
- extend room creation tests so both fresh and load/create paths assert the NotebookDoc -> RuntimeStateDoc pointer and document-agnostic RuntimeStateDoc identity

## Stack order

The prerequisite ADR/schema/runtime-doc PRs have merged. This PR is now rebased directly on `main`.

## Verification

- `cargo test -p runtimed test_room_load_or_create_new`
- `cargo test -p runtimed test_new_fresh_creates_empty_doc`
- `cargo test -p runtime-doc test_set_runtime_state_doc_id`
- `cargo test -p runtime-doc owner_runtime_state_policy_rejects_identity_rewrites`
- `cargo xtask lint --fix`
