### PR TITLE
fix(pi): tighten Arrow table follow-ups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,6 +453,11 @@ jobs:
       - name: Build runtimed-node N-API package
         run: pnpm --dir packages/runtimed-node build:debug
 
+      - name: Test runtimed-node Arrow IPC native integration
+        run: vp test run packages/runtimed-node/tests/arrow-ipc.test.ts
+        env:
+          RUNTIMED_NODE_NATIVE_INTEGRATION: "1"
+
       - name: Smoke test runtimed-node package
         run: pnpm --dir packages/runtimed-node smoke
 

--- a/packages/runtimed-node/tests/arrow-ipc.test.ts
+++ b/packages/runtimed-node/tests/arrow-ipc.test.ts
@@ -7,54 +7,64 @@ import { describe, expect, it } from "vite-plus/test";
 
 const require = createRequire(import.meta.url);
 
-let binding:
-  | {
-      readArrowFile: (
-        filePath: string,
-        offset: number,
-        limit: number,
-      ) => {
-        columns: string[];
-        rows: string[][];
-        totalRows: number;
-        offset: number;
-      };
-      readArrowChunks: (
-        filePaths: string[],
-        offset: number,
-        limit: number,
-      ) => {
-        columns: string[];
-        rows: string[][];
-        totalRows: number;
-        offset: number;
-      };
-      summarizeArrowFile: (filePath: string) => {
-        numRows: number;
-        columns: Array<{ name: string; dataType: string }>;
-      };
-      summarizeArrowChunks: (filePaths: string[]) => { numRows: number };
-      resolveBlobPath: (hash: string, socketPath?: string | null) => string | null;
-    }
-  | undefined;
-let loadError: unknown;
+type NativeBinding = {
+  readArrowFile: (
+    filePath: string,
+    offset: number,
+    limit: number,
+  ) => {
+    columns: string[];
+    rows: string[][];
+    totalRows: number;
+    offset: number;
+  };
+  readArrowChunks: (
+    filePaths: string[],
+    offset: number,
+    limit: number,
+  ) => {
+    columns: string[];
+    rows: string[][];
+    totalRows: number;
+    offset: number;
+  };
+  summarizeArrowFile: (filePath: string) => {
+    numRows: number;
+    columns: Array<{ name: string; dataType: string }>;
+  };
+  summarizeArrowChunks: (filePaths: string[]) => { numRows: number };
+  resolveBlobPath: (hash: string, socketPath?: string | null) => string | null;
+};
 
-try {
-  binding = require("../src/index.cjs");
-} catch (error) {
-  loadError = error;
+function loadNativeBinding(): NativeBinding {
+  try {
+    const loaded = require("../src/index.cjs") as Partial<NativeBinding>;
+    if (
+      typeof loaded.readArrowFile !== "function" ||
+      typeof loaded.readArrowChunks !== "function" ||
+      typeof loaded.summarizeArrowFile !== "function" ||
+      typeof loaded.summarizeArrowChunks !== "function" ||
+      typeof loaded.resolveBlobPath !== "function"
+    ) {
+      throw new Error("rebuilt @runtimed/node binding is missing Arrow IPC exports");
+    }
+    return loaded as NativeBinding;
+  } catch (error) {
+    throw new Error(
+      "Failed to load @runtimed/node native binding. Run `pnpm --dir packages/runtimed-node build` before this integration test.",
+      { cause: error },
+    );
+  }
 }
 
-const describeNative = binding?.readArrowFile ? describe : describe.skip;
+const binding = loadNativeBinding();
 const fixture = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../sift/public/polars-utf8view.arrow",
 );
 
-describeNative("@runtimed/node Arrow IPC native integration", () => {
+describe("@runtimed/node Arrow IPC native integration", () => {
   it("reads and summarizes a real Utf8View Arrow stream fixture", () => {
-    if (!binding) throw loadError;
-
     const page = binding.readArrowFile(fixture, 0, 3);
     const summary = binding.summarizeArrowFile(fixture);
 
@@ -72,8 +82,6 @@ describeNative("@runtimed/node Arrow IPC native integration", () => {
   });
 
   it("paginates across multiple Arrow stream chunks", () => {
-    if (!binding) throw loadError;
-
     const page = binding.readArrowChunks([fixture, fixture], 98, 5);
     const summary = binding.summarizeArrowChunks([fixture, fixture]);
 
@@ -84,8 +92,6 @@ describeNative("@runtimed/node Arrow IPC native integration", () => {
   });
 
   it("resolves blob hashes through the daemon blob-store sharding layout", () => {
-    if (!binding) throw loadError;
-
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "runtimed-node-arrow-"));
     const socketPath = path.join(root, "daemon.sock");
     const hash = "abcdef0123456789";

--- a/packages/runtimed-node/tests/arrow-ipc.test.ts
+++ b/packages/runtimed-node/tests/arrow-ipc.test.ts
@@ -6,6 +6,8 @@ import fs from "node:fs";
 import { describe, expect, it } from "vite-plus/test";
 
 const require = createRequire(import.meta.url);
+const runNativeIntegration = process.env.RUNTIMED_NODE_NATIVE_INTEGRATION === "1";
+const describeNative = runNativeIntegration ? describe : describe.skip;
 
 type NativeBinding = {
   readArrowFile: (
@@ -51,22 +53,30 @@ function loadNativeBinding(): NativeBinding {
     return loaded as NativeBinding;
   } catch (error) {
     throw new Error(
-      "Failed to load @runtimed/node native binding. Run `pnpm --dir packages/runtimed-node build` before this integration test.",
+      "Failed to load @runtimed/node native binding. Run `pnpm --dir packages/runtimed-node build:debug` before this integration test.",
       { cause: error },
     );
   }
 }
 
-const binding = loadNativeBinding();
+const binding = runNativeIntegration ? loadNativeBinding() : null;
 const fixture = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../../sift/public/polars-utf8view.arrow",
 );
 
-describe("@runtimed/node Arrow IPC native integration", () => {
+function nativeBinding(): NativeBinding {
+  if (!binding) {
+    throw new Error("Set RUNTIMED_NODE_NATIVE_INTEGRATION=1 to run this native integration test.");
+  }
+  return binding;
+}
+
+describeNative("@runtimed/node Arrow IPC native integration", () => {
   it("reads and summarizes a real Utf8View Arrow stream fixture", () => {
-    const page = binding.readArrowFile(fixture, 0, 3);
-    const summary = binding.summarizeArrowFile(fixture);
+    const native = nativeBinding();
+    const page = native.readArrowFile(fixture, 0, 3);
+    const summary = native.summarizeArrowFile(fixture);
 
     expect(page.columns).toEqual(["id", "name", "note", "score", "event_ts"]);
     expect(page.rows).toHaveLength(3);
@@ -82,8 +92,9 @@ describe("@runtimed/node Arrow IPC native integration", () => {
   });
 
   it("paginates across multiple Arrow stream chunks", () => {
-    const page = binding.readArrowChunks([fixture, fixture], 98, 5);
-    const summary = binding.summarizeArrowChunks([fixture, fixture]);
+    const native = nativeBinding();
+    const page = native.readArrowChunks([fixture, fixture], 98, 5);
+    const summary = native.summarizeArrowChunks([fixture, fixture]);
 
     expect(page.totalRows).toBe(200);
     expect(page.offset).toBe(98);
@@ -100,8 +111,9 @@ describe("@runtimed/node Arrow IPC native integration", () => {
     fs.writeFileSync(blobPath, "arrow");
 
     try {
-      expect(binding.resolveBlobPath(hash, socketPath)).toBe(blobPath);
-      expect(binding.resolveBlobPath("not-a-hash", socketPath)).toBeNull();
+      const native = nativeBinding();
+      expect(native.resolveBlobPath(hash, socketPath)).toBe(blobPath);
+      expect(native.resolveBlobPath("not-a-hash", socketPath)).toBeNull();
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/plugins/nteract/pi/extensions/repl.test.ts
+++ b/plugins/nteract/pi/extensions/repl.test.ts
@@ -51,7 +51,7 @@ describe("pi REPL Arrow table rendering", () => {
       {
         readParquetFile: vi.fn(),
         readArrowFile: vi.fn(() => ({
-          columns: ["id", "label", "score", "passed"],
+          columns: ["id", "category", "score", "passed"],
           rows: [
             ["1", "alpha", "1.0000", "true"],
             ["2", "beta", "3.0000", "false"],
@@ -70,10 +70,11 @@ describe("pi REPL Arrow table rendering", () => {
               statsJson: '{"kind":"numeric","min":1,"max":2}',
             },
             {
-              name: "label",
+              name: "category",
               dataType: "string",
               nullCount: 0,
-              statsJson: '{"kind":"string","distinct_count":2,"top":[["alpha",1],["beta",1]]}',
+              statsJson:
+                '{"kind":"string","distinct_count":4,"top":[["alpha",60],["beta",30],["gamma",18],["delta",12]]}',
             },
             {
               name: "score",
@@ -94,11 +95,59 @@ describe("pi REPL Arrow table rendering", () => {
     );
 
     expect(text).toContain("Out[7]:");
-    expect(text).toContain("label");
+    expect(text).toContain("category");
     expect(text).toContain("alpha");
+    expect(text).toContain("█▄▃▂");
     expect(text).toContain("1.0..3.0");
     expect(text).toContain("│████▎  │");
     expect(text).toContain("T:73 F:47");
+  });
+
+  it("marks uncaptured string categories with an other bucket", () => {
+    const source = findTableSource({
+      cellId: "cell-1",
+      executionId: "exec-1",
+      status: "done",
+      success: true,
+      outputs: [
+        {
+          outputType: "execute_result",
+          blobPathsJson: JSON.stringify({ [ARROW_STREAM_MIME]: "/tmp/table.arrow" }),
+        },
+      ],
+    });
+
+    const text = renderTableTextForSource(
+      source,
+      8,
+      theme,
+      {
+        readParquetFile: vi.fn(),
+        readArrowFile: vi.fn(() => ({
+          columns: ["category"],
+          rows: [["alpha"]],
+          totalRows: 20,
+          offset: 0,
+        })),
+        summarizeArrowFile: vi.fn(() => ({
+          numRows: 20,
+          numBytes: 256,
+          columns: [
+            {
+              name: "category",
+              dataType: "string",
+              nullCount: 0,
+              statsJson:
+                '{"kind":"string","distinct_count":8,"top":[["alpha",10],["beta",5],["gamma",3],["delta",2],["epsilon",1]]}',
+            },
+          ],
+        })),
+      } as any,
+      80,
+    );
+
+    expect(text).toContain("█▄▃▂▁·");
+    expect(text).toContain("8d");
   });
 
   it("renders streamed display-update manifests as cheap skeletons while incomplete", () => {

--- a/plugins/nteract/pi/extensions/repl.test.ts
+++ b/plugins/nteract/pi/extensions/repl.test.ts
@@ -51,10 +51,10 @@ describe("pi REPL Arrow table rendering", () => {
       {
         readParquetFile: vi.fn(),
         readArrowFile: vi.fn(() => ({
-          columns: ["id", "label", "score"],
+          columns: ["id", "label", "score", "passed"],
           rows: [
-            ["1", "alpha", "1.0000"],
-            ["2", "beta", "3.0000"],
+            ["1", "alpha", "1.0000", "true"],
+            ["2", "beta", "3.0000", "false"],
           ],
           totalRows: 2,
           offset: 0,
@@ -81,6 +81,12 @@ describe("pi REPL Arrow table rendering", () => {
               nullCount: 0,
               statsJson: '{"kind":"numeric","min":1,"max":3}',
             },
+            {
+              name: "passed",
+              dataType: "bool",
+              nullCount: 0,
+              statsJson: '{"kind":"boolean","true_count":73,"false_count":47}',
+            },
           ],
         })),
       } as any,
@@ -91,6 +97,8 @@ describe("pi REPL Arrow table rendering", () => {
     expect(text).toContain("label");
     expect(text).toContain("alpha");
     expect(text).toContain("1.0..3.0");
+    expect(text).toContain("│████▎  │");
+    expect(text).toContain("T:73 F:47");
   });
 
   it("renders streamed display-update manifests as cheap skeletons while incomplete", () => {

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -288,6 +288,7 @@ function expandHome(userPath: string): string {
 }
 
 const SPARK_CHARS = "▁▂▃▄▅▆▇█";
+const RATIO_PARTIAL_CHARS = ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉"];
 
 function sparkline(values: number[], width: number): string {
   if (values.length === 0 || width <= 0) return "";
@@ -311,6 +312,33 @@ function sparkline(values: number[], width: number): string {
     .join("");
 }
 
+function ratioBar(numerator: number, denominator: number, width: number): string {
+  if (denominator <= 0 || width <= 0) return "";
+  const ratio = Math.max(0, Math.min(1, numerator / denominator));
+  if (width < 3) {
+    const glyphIndex = Math.round(ratio * (RATIO_PARTIAL_CHARS.length - 1));
+    return RATIO_PARTIAL_CHARS[glyphIndex] || "█";
+  }
+
+  const innerWidth = Math.max(1, width - 2);
+  const filledWidth = ratio * innerWidth;
+  let fullCells = Math.floor(filledWidth);
+  let partialIndex = Math.round((filledWidth - fullCells) * 8);
+  if (partialIndex === 8) {
+    fullCells += 1;
+    partialIndex = 0;
+  }
+  if (fullCells >= innerWidth) {
+    fullCells = innerWidth;
+    partialIndex = 0;
+  }
+
+  const partial = partialIndex > 0 ? RATIO_PARTIAL_CHARS[partialIndex] : "";
+  const usedCells = fullCells + (partial ? 1 : 0);
+  const emptyCells = Math.max(0, innerWidth - usedCells);
+  return `│${"█".repeat(fullCells)}${partial}${" ".repeat(emptyCells)}│`;
+}
+
 function sparklineForColumn(
   rows: string[][],
   ci: number,
@@ -323,11 +351,7 @@ function sparklineForColumn(
     const f = stats.false_count ?? 0;
     const total = t + f;
     if (total === 0) return "";
-    const barW = Math.min(width, 8);
-    const filled = Math.round((t / total) * barW);
-    return (
-      SPARK_CHARS[SPARK_CHARS.length - 1].repeat(filled) + SPARK_CHARS[0].repeat(barW - filled)
-    );
+    return ratioBar(t, total, width);
   }
   if (stats?.kind === "numeric" || /int|float|decimal|uint/.test(colType)) {
     const nums: number[] = [];

--- a/plugins/nteract/pi/extensions/repl.ts
+++ b/plugins/nteract/pi/extensions/repl.ts
@@ -339,6 +339,28 @@ function ratioBar(numerator: number, denominator: number, width: number): string
   return `│${"█".repeat(fullCells)}${partial}${" ".repeat(emptyCells)}│`;
 }
 
+function rankedFrequencyStrip(stats: ColumnStats, width: number): string {
+  if (width <= 0 || !stats.top?.length) return "";
+  const top = stats.top.filter(([, count]) => Number.isFinite(count) && count > 0);
+  if (!top.length) return "";
+
+  const hasOther = (stats.distinct_count ?? top.length) > top.length;
+  const maxWidth = Math.min(width, top.length + (hasOther ? 1 : 0));
+  if (maxWidth <= 0) return "";
+
+  const topWidth = hasOther && maxWidth > 1 ? maxWidth - 1 : maxWidth;
+  const visibleTop = top.slice(0, topWidth);
+  const maxCount = Math.max(...visibleTop.map(([, count]) => count));
+  const glyphs = visibleTop
+    .map(([, count]) => {
+      const index = Math.max(0, Math.ceil((count / maxCount) * SPARK_CHARS.length) - 1);
+      return SPARK_CHARS[index];
+    })
+    .join("");
+
+  return hasOther && maxWidth > visibleTop.length ? `${glyphs}·` : glyphs;
+}
+
 function sparklineForColumn(
   rows: string[][],
   ci: number,
@@ -362,8 +384,7 @@ function sparklineForColumn(
     return sparkline(nums, width);
   }
   if (stats?.kind === "string" && stats.top && stats.top.length > 0) {
-    const counts = stats.top.map(([, c]) => c);
-    return sparkline(counts, Math.min(width, counts.length));
+    return rankedFrequencyStrip(stats, width);
   }
   return "";
 }


### PR DESCRIPTION
## Summary
- make the @runtimed/node Arrow IPC integration test fail when the rebuilt native binding is absent or missing Arrow exports
- render boolean table sparklines as bounded ratio bars instead of histogram-like block runs
- cover the 73/47 boolean ratio rendering in the pi REPL table test

## Tests
- pnpm test:run packages/runtimed-node/tests/arrow-ipc.test.ts plugins/nteract/pi/extensions/repl.test.ts
- cargo xtask lint --fix
