### PR TITLE
docs(elements): add component burn-down

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -3,12 +3,134 @@
 @import "fumadocs-ui/css/preset.css";
 
 @source "../**/*.{ts,tsx,mdx}";
+@source "../../../src/components/cell/**/*.{ts,tsx}";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
 
 :root {
   --fd-layout-width: 1320px;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
 }
 
 body {
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+}
+
+@keyframes queue-breathe {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.animate-queue-breathe {
+  animation: queue-breathe 3s ease-in-out infinite;
+}
+
+@keyframes exec-squish {
+  0% {
+    transform: scale(1, 1) rotate(0deg);
+    opacity: 1;
+  }
+  15% {
+    transform: scale(1.08, 0.92) rotate(-0.5deg);
+    opacity: 0.6;
+  }
+  30% {
+    transform: scale(0.94, 1.07) rotate(0.3deg);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.01, 0.99) rotate(0deg);
+    opacity: 0.65;
+  }
+  70% {
+    transform: scale(0.98, 1.02) rotate(-0.2deg);
+    opacity: 1;
+  }
+  85% {
+    transform: scale(1.005, 0.995) rotate(0deg);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1, 1) rotate(0deg);
+    opacity: 1;
+  }
+}
+
+.animate-exec-squish {
+  animation: exec-squish 3s cubic-bezier(0.34, 1.56, 0.64, 1) 1s infinite;
+  transform-origin: center center;
 }

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, BookOpen, Boxes, PanelLeft } from "lucide-react";
+import { ArrowRight, Boxes, FileCode2, ListChecks, PanelLeft } from "lucide-react";
 import { RailOutlineExample } from "@/components/rail-outline-example";
 
 const entries = [
@@ -10,16 +10,22 @@ const entries = [
     icon: PanelLeft,
   },
   {
+    title: "Component burn-down",
+    description: "Track notebook-specific components we should own.",
+    href: "/docs/component-burndown",
+    icon: ListChecks,
+  },
+  {
+    title: "Cell anatomy",
+    description: "Fixture-backed target shape for nteract cells.",
+    href: "/docs/cell-anatomy",
+    icon: FileCode2,
+  },
+  {
     title: "Rendering catalog",
     description: "Future home for markdown, output, and widget examples.",
     href: "/docs",
     icon: Boxes,
-  },
-  {
-    title: "Migration notes",
-    description: "Track what should move from the old elements repo.",
-    href: "/docs",
-    icon: BookOpen,
   },
 ];
 
@@ -56,7 +62,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-fd-border bg-fd-muted/20">
-        <div className="mx-auto grid max-w-6xl gap-4 px-6 py-8 md:grid-cols-3">
+        <div className="mx-auto grid max-w-6xl gap-4 px-6 py-8 md:grid-cols-2 lg:grid-cols-4">
           {entries.map((entry) => (
             <Link
               key={entry.title}

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -17,7 +17,7 @@ const entries = [
   },
   {
     title: "Cell anatomy",
-    description: "Fixture-backed target shape for nteract cells.",
+    description: "Inventory map for current nteract cells.",
     href: "/docs/cell-anatomy",
     icon: FileCode2,
   },

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -1,43 +1,108 @@
+"use client";
+
 import {
   Braces,
+  CheckCircle2,
   CircleDot,
   FileText,
-  GripVertical,
-  Play,
   Rows3,
   Search,
   ShieldCheck,
 } from "lucide-react";
+import { CellContainer } from "@/components/cell/CellContainer";
+import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 
 const layers = [
   {
     name: "CellContainer",
     source: "src/components/cell/CellContainer.tsx",
     role: "Frame, focus state, gutter ribbon, drag handle, and segmented source/output layout.",
+    status: "rendered",
   },
   {
     name: "CompactExecutionButton",
     source: "src/components/cell/CompactExecutionButton.tsx",
     role: "Run/interrupt affordance that belongs to code cells, not a generic button variant.",
+    status: "rendered",
   },
   {
     name: "CodeMirrorEditor",
     source: "src/components/editor/codemirror-editor.tsx",
     role: "Source editing, search highlighting, remote cursors, completion, and attribution.",
+    status: "adapter needed",
   },
   {
     name: "OutputArea",
     source: "src/components/cell/OutputArea.tsx",
     role: "Output focus, display mode controls, and frame-level output interaction.",
+    status: "adapter needed",
   },
 ];
 
 const contracts = [
-  "Catalog pages use existing components first; schematic markup is temporary and labeled.",
+  "Catalog examples import current components before using schematic markup.",
+  "Fixture content may stand in for runtime/editor/output systems until an adapter exists.",
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
-  "Source, output, gutter, and presence areas should be independently documented.",
 ];
+
+function SourceFixture() {
+  return (
+    <div className="min-w-0">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Rows3 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-semibold">Code cell frame</h3>
+            <p className="text-xs text-fd-muted-foreground">
+              Current CellContainer with fixture source content
+            </p>
+          </div>
+        </div>
+        <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+          existing component
+        </span>
+      </div>
+
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
+        <Braces className="size-4" aria-hidden="true" />
+        Source editor fixture
+      </div>
+      <pre className="overflow-x-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs leading-6 text-foreground">
+        <code>{`features = orders.assign(month=orders.date.dt.month)
+model.fit(features[columns], target)
+predictions = model.predict(features_holdout)`}</code>
+      </pre>
+    </div>
+  );
+}
+
+function OutputFixture() {
+  return (
+    <div className="px-3 py-2">
+      <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
+        <FileText className="size-4" aria-hidden="true" />
+        OutputArea fixture
+      </div>
+      <div className="rounded-md border border-border bg-background p-3">
+        <div className="grid gap-2 text-xs sm:grid-cols-3">
+          <div>
+            <div className="text-muted-foreground">MAE</div>
+            <div className="mt-1 text-sm font-semibold">8.42</div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">MAPE</div>
+            <div className="mt-1 text-sm font-semibold">6.8%</div>
+          </div>
+          <div>
+            <div className="text-muted-foreground">Backtest</div>
+            <div className="mt-1 text-sm font-semibold">16 weeks</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function CellAnatomyExample() {
   return (
@@ -48,96 +113,62 @@ export function CellAnatomyExample() {
           <div>
             <h2 className="text-sm font-semibold">Catalog fidelity rule</h2>
             <p className="mt-1 text-xs leading-5">
-              This page documents the current notebook cell components. The visual below is a
-              labeled schematic until the docs app can render the real `CodeCell`, `MarkdownCell`,
-              `CellContainer`, editor, and output components from fixtures without pulling in the
-              runtime.
+              This page now renders the current CellContainer and CompactExecutionButton directly
+              from the notebook component sources. Editor and output regions remain fixture-backed
+              until their runtime-free adapters exist.
             </p>
           </div>
         </div>
       </section>
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_160px]">
+        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_190px]">
           <div>gutter</div>
           <div>source and output</div>
-          <div className="hidden text-right sm:block">schematic only</div>
+          <div className="hidden text-right sm:block">real shell, fixture content</div>
         </div>
-        <div className="grid min-h-[360px] grid-cols-[52px_1fr]">
-          <aside className="flex flex-col items-center border-r border-fd-border bg-fd-muted/30 py-4">
-            <button
-              type="button"
-              className="flex size-8 items-center justify-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-              aria-label="Run cell"
-            >
-              <Play className="size-4" aria-hidden="true" />
-            </button>
-            <div className="mt-4 h-full w-1 rounded-full bg-sky-500/70" />
-            <GripVertical className="mt-3 size-4 text-fd-muted-foreground" aria-hidden="true" />
-          </aside>
-
-          <main className="min-w-0">
-            <div className="flex items-center justify-between gap-3 border-b border-fd-border px-4 py-3">
-              <div className="flex min-w-0 items-center gap-2">
-                <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-                <div className="min-w-0">
-                  <h3 className="truncate text-sm font-semibold">Code cell frame</h3>
-                  <p className="text-xs text-fd-muted-foreground">execution_count=12 · python</p>
-                </div>
+        <div className="bg-background py-4 pl-12 pr-2">
+          <CellContainer
+            id="fixture-code-cell"
+            cellType="code"
+            isFocused
+            className="mx-0 px-0"
+            gutterContent={<CompactExecutionButton count={12} />}
+            codeContent={<SourceFixture />}
+            outputContent={<OutputFixture />}
+            rightGutterContent={
+              <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
+                real
+              </span>
+            }
+            outputRightGutterContent={
+              <span className="rounded-full bg-fd-muted px-1.5 py-0.5 text-[10px] font-medium text-fd-muted-foreground">
+                fixture
+              </span>
+            }
+            presenceIndicators={
+              <div className="mt-1 flex flex-col gap-1" aria-label="Fixture presence markers">
+                <span className="size-1.5 rounded-full bg-rose-500" />
+                <span className="size-1.5 rounded-full bg-amber-500" />
+                <span className="size-1.5 rounded-full bg-sky-500" />
               </div>
-              <div className="flex items-center gap-1">
-                <span className="size-2 rounded-full bg-rose-500" />
-                <span className="size-2 rounded-full bg-amber-500" />
-                <span className="size-2 rounded-full bg-sky-500" />
-              </div>
-            </div>
-
-            <div className="border-b border-fd-border bg-fd-background p-4">
-              <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
-                <Braces className="size-4" aria-hidden="true" />
-                Source editor
-              </div>
-              <pre className="overflow-x-auto rounded-md border border-fd-border bg-fd-muted/40 p-3 font-mono text-xs leading-6 text-fd-foreground">
-                <code>{`features = orders.assign(month=orders.date.dt.month)
-model.fit(features[columns], target)
-predictions = model.predict(features_holdout)`}</code>
-              </pre>
-            </div>
-
-            <div className="bg-fd-muted/20 p-4">
-              <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
-                <FileText className="size-4" aria-hidden="true" />
-                Output area
-              </div>
-              <div className="rounded-md border border-fd-border bg-fd-background p-3">
-                <div className="grid gap-2 text-xs sm:grid-cols-3">
-                  <div>
-                    <div className="text-fd-muted-foreground">MAE</div>
-                    <div className="mt-1 text-sm font-semibold">8.42</div>
-                  </div>
-                  <div>
-                    <div className="text-fd-muted-foreground">MAPE</div>
-                    <div className="mt-1 text-sm font-semibold">6.8%</div>
-                  </div>
-                  <div>
-                    <div className="text-fd-muted-foreground">Backtest</div>
-                    <div className="mt-1 text-sm font-semibold">16 weeks</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </main>
+            }
+            dragHandleProps={{ "aria-label": "Fixture drag handle" }}
+          />
         </div>
       </section>
 
-      <section className="grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+      <section className="grid gap-3">
         <div className="rounded-lg border border-fd-border bg-fd-card">
           <div className="border-b border-fd-border p-4">
             <h2 className="text-sm font-semibold">Current Pieces</h2>
           </div>
           <div className="divide-y divide-fd-border">
             {layers.map((layer) => (
-              <div key={layer.name} className="grid gap-2 p-4 sm:grid-cols-[180px_1fr]">
+              <div
+                key={layer.name}
+                className="grid gap-3 p-4 md:grid-cols-[190px_minmax(0,1fr)_130px]"
+              >
                 <div>
                   <div className="text-sm font-semibold">{layer.name}</div>
                   <div className="mt-1 break-words font-mono text-xs text-fd-muted-foreground [overflow-wrap:anywhere]">
@@ -145,6 +176,14 @@ predictions = model.predict(features_holdout)`}</code>
                   </div>
                 </div>
                 <p className="text-xs leading-5 text-fd-muted-foreground">{layer.role}</p>
+                <div>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-fd-border bg-fd-background px-2 py-1 text-[11px] text-fd-muted-foreground">
+                    {layer.status === "rendered" && (
+                      <CheckCircle2 className="size-3 text-emerald-600" aria-hidden="true" />
+                    )}
+                    {layer.status}
+                  </span>
+                </div>
               </div>
             ))}
           </div>

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -1,4 +1,13 @@
-import { Braces, CircleDot, FileText, GripVertical, Play, Rows3, Search } from "lucide-react";
+import {
+  Braces,
+  CircleDot,
+  FileText,
+  GripVertical,
+  Play,
+  Rows3,
+  Search,
+  ShieldCheck,
+} from "lucide-react";
 
 const layers = [
   {
@@ -24,6 +33,7 @@ const layers = [
 ];
 
 const contracts = [
+  "Catalog pages use existing components first; schematic markup is temporary and labeled.",
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
   "Source, output, gutter, and presence areas should be independently documented.",
@@ -32,11 +42,26 @@ const contracts = [
 export function CellAnatomyExample() {
   return (
     <div className="not-prose space-y-6">
+      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Catalog fidelity rule</h2>
+            <p className="mt-1 text-xs leading-5">
+              This page documents the current notebook cell components. The visual below is a
+              labeled schematic until the docs app can render the real `CodeCell`, `MarkdownCell`,
+              `CellContainer`, editor, and output components from fixtures without pulling in the
+              runtime.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_120px]">
+        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_160px]">
           <div>gutter</div>
           <div>source and output</div>
-          <div className="hidden text-right sm:block">cell chrome</div>
+          <div className="hidden text-right sm:block">schematic only</div>
         </div>
         <div className="grid min-h-[360px] grid-cols-[52px_1fr]">
           <aside className="flex flex-col items-center border-r border-fd-border bg-fd-muted/30 py-4">

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -10,7 +10,10 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import { CellContainer } from "@/components/cell/CellContainer";
+import { CellHeader } from "@/components/cell/CellHeader";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
+import { ExecutionCount } from "@/components/cell/ExecutionCount";
+import { PlayButton } from "@/components/cell/PlayButton";
 
 const layers = [
   {
@@ -23,6 +26,24 @@ const layers = [
     name: "CompactExecutionButton",
     source: "src/components/cell/CompactExecutionButton.tsx",
     role: "Run/interrupt affordance that belongs to code cells, not a generic button variant.",
+    status: "rendered",
+  },
+  {
+    name: "CellHeader",
+    source: "src/components/cell/CellHeader.tsx",
+    role: "Header slot layout for cell controls without owning runtime state.",
+    status: "rendered",
+  },
+  {
+    name: "ExecutionCount",
+    source: "src/components/cell/ExecutionCount.tsx",
+    role: "Notebook execution prompt that preserves count and running-state display.",
+    status: "rendered",
+  },
+  {
+    name: "PlayButton",
+    source: "src/components/cell/PlayButton.tsx",
+    role: "Cell-specific execute/interrupt control for gutter and toolbar placements.",
     status: "rendered",
   },
   {
@@ -45,6 +66,8 @@ const contracts = [
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
 ];
+
+const noop = () => {};
 
 function SourceFixture() {
   return (
@@ -155,6 +178,71 @@ export function CellAnatomyExample() {
             }
             dragHandleProps={{ "aria-label": "Fixture drag handle" }}
           />
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <div className="mb-4">
+          <h2 className="text-sm font-semibold">Runtime-Free Imports</h2>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            These are current cell components rendered with inert fixture handlers.
+          </p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="mb-2 text-xs font-medium text-fd-muted-foreground">CellHeader</div>
+            <CellHeader
+              className="rounded border border-border bg-background"
+              leftContent={
+                <>
+                  <ExecutionCount count={12} />
+                  <span className="text-xs font-medium text-muted-foreground">python</span>
+                </>
+              }
+              rightContent={
+                <span className="rounded-full bg-fd-muted px-2 py-1 text-[11px] text-fd-muted-foreground">
+                  focused
+                </span>
+              }
+            />
+          </div>
+
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="mb-2 text-xs font-medium text-fd-muted-foreground">ExecutionCount</div>
+            <div className="flex flex-wrap items-center gap-4 rounded border border-border bg-background p-3">
+              <ExecutionCount count={null} />
+              <ExecutionCount count={7} />
+              <ExecutionCount count={24} isExecuting />
+            </div>
+          </div>
+
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="mb-2 text-xs font-medium text-fd-muted-foreground">PlayButton</div>
+            <div className="flex flex-wrap items-center gap-3 rounded border border-border bg-background p-3">
+              <PlayButton
+                executionState="idle"
+                cellType="code"
+                isFocused
+                onExecute={noop}
+                onInterrupt={noop}
+              />
+              <PlayButton
+                executionState="running"
+                cellType="code"
+                isFocused
+                onExecute={noop}
+                onInterrupt={noop}
+              />
+              <PlayButton
+                executionState="queued"
+                cellType="code"
+                isFocused
+                gutterMode
+                onExecute={noop}
+                onInterrupt={noop}
+              />
+            </div>
+          </div>
         </div>
       </section>
 

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -1,0 +1,145 @@
+import { Braces, CircleDot, FileText, GripVertical, Play, Rows3, Search } from "lucide-react";
+
+const layers = [
+  {
+    name: "CellContainer",
+    source: "src/components/cell/CellContainer.tsx",
+    role: "Frame, focus state, gutter ribbon, drag handle, and segmented source/output layout.",
+  },
+  {
+    name: "CompactExecutionButton",
+    source: "src/components/cell/CompactExecutionButton.tsx",
+    role: "Run/interrupt affordance that belongs to code cells, not a generic button variant.",
+  },
+  {
+    name: "CodeMirrorEditor",
+    source: "src/components/editor/codemirror-editor.tsx",
+    role: "Source editing, search highlighting, remote cursors, completion, and attribution.",
+  },
+  {
+    name: "OutputArea",
+    source: "src/components/cell/OutputArea.tsx",
+    role: "Output focus, display mode controls, and frame-level output interaction.",
+  },
+];
+
+const contracts = [
+  "Cell identity and stable DOM order stay outside the visual component.",
+  "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
+  "Source, output, gutter, and presence areas should be independently documented.",
+];
+
+export function CellAnatomyExample() {
+  return (
+    <div className="not-prose space-y-6">
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_120px]">
+          <div>gutter</div>
+          <div>source and output</div>
+          <div className="hidden text-right sm:block">cell chrome</div>
+        </div>
+        <div className="grid min-h-[360px] grid-cols-[52px_1fr]">
+          <aside className="flex flex-col items-center border-r border-fd-border bg-fd-muted/30 py-4">
+            <button
+              type="button"
+              className="flex size-8 items-center justify-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+              aria-label="Run cell"
+            >
+              <Play className="size-4" aria-hidden="true" />
+            </button>
+            <div className="mt-4 h-full w-1 rounded-full bg-sky-500/70" />
+            <GripVertical className="mt-3 size-4 text-fd-muted-foreground" aria-hidden="true" />
+          </aside>
+
+          <main className="min-w-0">
+            <div className="flex items-center justify-between gap-3 border-b border-fd-border px-4 py-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold">Code cell frame</h3>
+                  <p className="text-xs text-fd-muted-foreground">execution_count=12 · python</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                <span className="size-2 rounded-full bg-rose-500" />
+                <span className="size-2 rounded-full bg-amber-500" />
+                <span className="size-2 rounded-full bg-sky-500" />
+              </div>
+            </div>
+
+            <div className="border-b border-fd-border bg-fd-background p-4">
+              <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
+                <Braces className="size-4" aria-hidden="true" />
+                Source editor
+              </div>
+              <pre className="overflow-x-auto rounded-md border border-fd-border bg-fd-muted/40 p-3 font-mono text-xs leading-6 text-fd-foreground">
+                <code>{`features = orders.assign(month=orders.date.dt.month)
+model.fit(features[columns], target)
+predictions = model.predict(features_holdout)`}</code>
+              </pre>
+            </div>
+
+            <div className="bg-fd-muted/20 p-4">
+              <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
+                <FileText className="size-4" aria-hidden="true" />
+                Output area
+              </div>
+              <div className="rounded-md border border-fd-border bg-fd-background p-3">
+                <div className="grid gap-2 text-xs sm:grid-cols-3">
+                  <div>
+                    <div className="text-fd-muted-foreground">MAE</div>
+                    <div className="mt-1 text-sm font-semibold">8.42</div>
+                  </div>
+                  <div>
+                    <div className="text-fd-muted-foreground">MAPE</div>
+                    <div className="mt-1 text-sm font-semibold">6.8%</div>
+                  </div>
+                  <div>
+                    <div className="text-fd-muted-foreground">Backtest</div>
+                    <div className="mt-1 text-sm font-semibold">16 weeks</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <h2 className="text-sm font-semibold">Current Pieces</h2>
+          </div>
+          <div className="divide-y divide-fd-border">
+            {layers.map((layer) => (
+              <div key={layer.name} className="grid gap-2 p-4 sm:grid-cols-[180px_1fr]">
+                <div>
+                  <div className="text-sm font-semibold">{layer.name}</div>
+                  <div className="mt-1 break-words font-mono text-xs text-fd-muted-foreground [overflow-wrap:anywhere]">
+                    {layer.source}
+                  </div>
+                </div>
+                <p className="text-xs leading-5 text-fd-muted-foreground">{layer.role}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Search className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Extraction Contract</h2>
+          </div>
+          <div className="space-y-3">
+            {contracts.map((contract) => (
+              <div key={contract} className="flex gap-2 text-xs leading-5 text-fd-muted-foreground">
+                <CircleDot className="mt-0.5 size-3 flex-none" aria-hidden="true" />
+                <span>{contract}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -13,8 +13,8 @@ import {
 const stats = [
   { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
   { label: "notebook domains", value: "6", detail: "first catalog targets" },
-  { label: "component forks", value: "0", detail: "use current sources first" },
-  { label: "starter examples", value: "2", detail: "outline plus burn-down" },
+  { label: "component forks", value: "0", detail: "current sources stay canonical" },
+  { label: "current imports", value: "2", detail: "CellContainer plus execution button" },
 ];
 
 const phases = [
@@ -26,9 +26,9 @@ const phases = [
   },
   {
     title: "Document cell anatomy",
-    state: "next",
+    state: "active",
     icon: Rows3,
-    summary: "Map current code, markdown, raw cells, shared controls, presence, and status.",
+    summary: "Render current cell shell pieces, then add editor and output adapters.",
   },
   {
     title: "Separate renderers",
@@ -57,14 +57,15 @@ const families = [
     source: "apps/notebook/src/components/{CodeCell,MarkdownCell,RawCell}.tsx",
     target: "nteract cells",
     status: "next",
-    intent: "Document the current cell frame and action surface before extracting wrappers.",
+    intent: "Document code, markdown, and raw cells after their runtime hooks can be fixture-fed.",
   },
   {
     family: "Cell internals",
     source: "src/components/cell/**",
     target: "nteract cells",
-    status: "next",
-    intent: "Keep execution count, controls, status, and presence as notebook concepts.",
+    status: "active",
+    intent:
+      "CellContainer and CompactExecutionButton now render from current source in the catalog.",
   },
   {
     family: "Editors",
@@ -117,7 +118,7 @@ const rules = [
   {
     title: "Use current components first",
     icon: ShieldCheck,
-    body: "Catalog pages should render existing components through fixtures as soon as isolation allows. Schematic markup is temporary and must be labeled.",
+    body: "Catalog pages render existing components through fixtures as soon as isolation allows. The cell anatomy page now starts with the real cell shell.",
   },
   {
     title: "Own notebook semantics",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -1,0 +1,240 @@
+import {
+  Boxes,
+  CheckCircle2,
+  CircleDotDashed,
+  Code2,
+  FileCode2,
+  Layers3,
+  ListChecks,
+  PanelLeft,
+  Rows3,
+  ShieldCheck,
+} from "lucide-react";
+
+const stats = [
+  { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
+  { label: "notebook domains", value: "6", detail: "first catalog targets" },
+  { label: "old elements imports", value: "0", detail: "inspiration only" },
+  { label: "starter examples", value: "2", detail: "outline plus burn-down" },
+];
+
+const phases = [
+  {
+    title: "Catalog the notebook shell",
+    state: "active",
+    icon: PanelLeft,
+    summary: "Left rail, workspace chrome, toolbar, and notebook-level navigation.",
+  },
+  {
+    title: "Promote cell anatomy",
+    state: "next",
+    icon: Rows3,
+    summary: "Markdown, code, raw cells, execution controls, presence, and cell status.",
+  },
+  {
+    title: "Separate renderers",
+    state: "next",
+    icon: FileCode2,
+    summary: "Output frames, MIME routing, isolated renderers, and display metadata.",
+  },
+  {
+    title: "Document runtime surfaces",
+    state: "queued",
+    icon: ShieldCheck,
+    summary: "Trust, dependency headers, kernel errors, and environment decisions.",
+  },
+];
+
+const families = [
+  {
+    family: "Notebook workspace",
+    source: "apps/notebook/src/components/NotebookView.tsx",
+    target: "nteract shell",
+    status: "active",
+    intent: "Own the reading frame, sidebar rail, scroll handles, and top-level notebook chrome.",
+  },
+  {
+    family: "Cells",
+    source: "apps/notebook/src/components/{CodeCell,MarkdownCell,RawCell}.tsx",
+    target: "nteract cells",
+    status: "next",
+    intent: "Extract the cell frame and action surface before changing cell rendering behavior.",
+  },
+  {
+    family: "Cell internals",
+    source: "src/components/cell/**",
+    target: "nteract cells",
+    status: "next",
+    intent: "Keep execution count, controls, status, and presence as notebook concepts.",
+  },
+  {
+    family: "Editors",
+    source: "src/components/editor/**",
+    target: "nteract editor",
+    status: "planned",
+    intent: "Document CodeMirror wrappers, themes, keymaps, and source-editing affordances.",
+  },
+  {
+    family: "Outputs",
+    source: "src/components/outputs/**",
+    target: "nteract renderers",
+    status: "planned",
+    intent:
+      "Catalog MIME routing, media frames, text output, errors, and isolated renderer affordances.",
+  },
+  {
+    family: "Widgets",
+    source: "src/components/widgets/**",
+    target: "nteract widgets",
+    status: "planned",
+    intent: "Treat widget controls as notebook output components, not generic form widgets.",
+  },
+  {
+    family: "Runtime decisions",
+    source: "apps/notebook/src/components/*Dialog.tsx",
+    target: "nteract runtime",
+    status: "planned",
+    intent: "Make trust, environment, and launch decisions reusable catalog examples.",
+  },
+  {
+    family: "Generic primitives",
+    source: "src/components/ui/**",
+    target: "shadcn floor",
+    status: "hold",
+    intent:
+      "Keep low-level Button, Dialog, Select, Sheet, and form controls boring until a notebook semantic wrapper exists.",
+  },
+];
+
+const statusClasses = {
+  active: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  next: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  planned: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  queued: "border-fd-border bg-fd-muted text-fd-muted-foreground",
+  hold: "border-fd-border bg-fd-background text-fd-muted-foreground",
+};
+
+const rules = [
+  {
+    title: "Own notebook semantics",
+    icon: ListChecks,
+    body: "If a component knows about cells, outputs, kernels, trust, packages, variables, or notebook navigation, it belongs in the nteract catalog.",
+  },
+  {
+    title: "Wrap generic interactions",
+    icon: Layers3,
+    body: "Use shadcn primitives as implementation details behind domain names such as CellAction, RuntimeDialog, or NotebookRailButton.",
+  },
+  {
+    title: "Leave primitives generic",
+    icon: Boxes,
+    body: "Button, Select, Sheet, Popover, and similar controls should stay low-level until the notebook use case gives them a real contract.",
+  },
+];
+
+function statusLabel(status: keyof typeof statusClasses) {
+  if (status === "active") return "active";
+  if (status === "next") return "next";
+  if (status === "hold") return "hold";
+  return "planned";
+}
+
+export function ComponentBurndown() {
+  return (
+    <div className="not-prose space-y-8">
+      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {stats.map((item) => (
+          <div key={item.label} className="rounded-lg border border-fd-border bg-fd-card p-4">
+            <div className="text-2xl font-semibold text-fd-foreground">{item.value}</div>
+            <div className="mt-1 text-sm font-medium">{item.label}</div>
+            <div className="mt-2 text-xs leading-5 text-fd-muted-foreground">{item.detail}</div>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <div className="mb-4 flex items-center gap-2">
+          <CircleDotDashed className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Next Phases</h2>
+        </div>
+        <div className="grid gap-3 md:grid-cols-4">
+          {phases.map((phase, index) => (
+            <div
+              key={phase.title}
+              className="rounded-lg border border-fd-border bg-fd-background p-3"
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <phase.icon className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+                <span className="text-xs tabular-nums text-fd-muted-foreground">0{index + 1}</span>
+              </div>
+              <h3 className="text-sm font-semibold">{phase.title}</h3>
+              <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{phase.summary}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Code2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Component Burn-Down</h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The target is a catalog of nteract-owned notebook components. shadcn stays as the
+            interaction floor, not the public component identity.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border">
+          {families.map((item) => (
+            <div
+              key={item.family}
+              className="grid gap-3 p-4 md:grid-cols-[minmax(0,1.1fr)_minmax(0,1.2fr)_150px]"
+            >
+              <div>
+                <h3 className="text-sm font-semibold">{item.family}</h3>
+                <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">{item.intent}</p>
+              </div>
+              <div className="min-w-0">
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                  Current source
+                </div>
+                <div className="mt-1 break-words font-mono text-xs leading-5 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                  {item.source}
+                </div>
+              </div>
+              <div className="flex flex-wrap items-start gap-2 md:flex-col md:items-end">
+                <span className="rounded-full border border-fd-border bg-fd-background px-2 py-1 text-xs text-fd-muted-foreground">
+                  {item.target}
+                </span>
+                <span
+                  className={[
+                    "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium",
+                    statusClasses[item.status as keyof typeof statusClasses],
+                  ].join(" ")}
+                >
+                  {item.status === "active" ? (
+                    <CheckCircle2 className="size-3" aria-hidden="true" />
+                  ) : (
+                    <CircleDotDashed className="size-3" aria-hidden="true" />
+                  )}
+                  {statusLabel(item.status as keyof typeof statusClasses)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {rules.map((rule) => (
+          <div key={rule.title} className="rounded-lg border border-fd-border bg-fd-card p-4">
+            <rule.icon className="mb-3 size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h3 className="text-sm font-semibold">{rule.title}</h3>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{rule.body}</p>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -1,5 +1,4 @@
 import {
-  Boxes,
   CheckCircle2,
   CircleDotDashed,
   Code2,
@@ -14,7 +13,7 @@ import {
 const stats = [
   { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
   { label: "notebook domains", value: "6", detail: "first catalog targets" },
-  { label: "old elements imports", value: "0", detail: "inspiration only" },
+  { label: "component forks", value: "0", detail: "use current sources first" },
   { label: "starter examples", value: "2", detail: "outline plus burn-down" },
 ];
 
@@ -26,10 +25,10 @@ const phases = [
     summary: "Left rail, workspace chrome, toolbar, and notebook-level navigation.",
   },
   {
-    title: "Promote cell anatomy",
+    title: "Document cell anatomy",
     state: "next",
     icon: Rows3,
-    summary: "Markdown, code, raw cells, execution controls, presence, and cell status.",
+    summary: "Map current code, markdown, raw cells, shared controls, presence, and status.",
   },
   {
     title: "Separate renderers",
@@ -58,7 +57,7 @@ const families = [
     source: "apps/notebook/src/components/{CodeCell,MarkdownCell,RawCell}.tsx",
     target: "nteract cells",
     status: "next",
-    intent: "Extract the cell frame and action surface before changing cell rendering behavior.",
+    intent: "Document the current cell frame and action surface before extracting wrappers.",
   },
   {
     family: "Cell internals",
@@ -116,6 +115,11 @@ const statusClasses = {
 
 const rules = [
   {
+    title: "Use current components first",
+    icon: ShieldCheck,
+    body: "Catalog pages should render existing components through fixtures as soon as isolation allows. Schematic markup is temporary and must be labeled.",
+  },
+  {
     title: "Own notebook semantics",
     icon: ListChecks,
     body: "If a component knows about cells, outputs, kernels, trust, packages, variables, or notebook navigation, it belongs in the nteract catalog.",
@@ -124,11 +128,6 @@ const rules = [
     title: "Wrap generic interactions",
     icon: Layers3,
     body: "Use shadcn primitives as implementation details behind domain names such as CellAction, RuntimeDialog, or NotebookRailButton.",
-  },
-  {
-    title: "Leave primitives generic",
-    icon: Boxes,
-    body: "Button, Select, Sheet, Popover, and similar controls should stay low-level until the notebook use case gives them a real contract.",
   },
 ];
 
@@ -181,8 +180,9 @@ export function ComponentBurndown() {
             <h2 className="text-sm font-semibold">Component Burn-Down</h2>
           </div>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The target is a catalog of nteract-owned notebook components. shadcn stays as the
-            interaction floor, not the public component identity.
+            The target is a catalog of existing nteract-owned notebook components. shadcn stays as
+            the interaction floor, not the public component identity, and this app should not fork
+            production UI while cataloging it.
           </p>
         </div>
         <div className="divide-y divide-fd-border">

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -14,7 +14,7 @@ const stats = [
   { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
   { label: "notebook domains", value: "6", detail: "first catalog targets" },
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
-  { label: "current imports", value: "2", detail: "CellContainer plus execution button" },
+  { label: "current imports", value: "5", detail: "cell shell and runtime-free internals" },
 ];
 
 const phases = [
@@ -28,7 +28,7 @@ const phases = [
     title: "Document cell anatomy",
     state: "active",
     icon: Rows3,
-    summary: "Render current cell shell pieces, then add editor and output adapters.",
+    summary: "Render current cell shell pieces and runtime-free internals, then add adapters.",
   },
   {
     title: "Separate renderers",
@@ -65,7 +65,7 @@ const families = [
     target: "nteract cells",
     status: "active",
     intent:
-      "CellContainer and CompactExecutionButton now render from current source in the catalog.",
+      "CellContainer, CompactExecutionButton, CellHeader, ExecutionCount, and PlayButton now render from current source.",
   },
   {
     family: "Editors",
@@ -118,7 +118,7 @@ const rules = [
   {
     title: "Use current components first",
     icon: ShieldCheck,
-    body: "Catalog pages render existing components through fixtures as soon as isolation allows. The cell anatomy page now starts with the real cell shell.",
+    body: "Catalog pages render existing components through fixtures as soon as isolation allows. The cell anatomy page now starts with real cell pieces.",
   },
   {
     title: "Own notebook semantics",

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -5,9 +5,10 @@ description: A fixture-backed inventory map for existing nteract cell components
 
 import { CellAnatomyExample } from "@/components/cell-anatomy-example";
 
-The first component family to document is the existing cell frame. It is where
-generic buttons, editor wrappers, gutters, presence, outputs, and runtime state
-already become notebook semantics.
+The first component family to document is the existing cell frame. This page
+now renders the current `CellContainer` and `CompactExecutionButton` with
+fixture content, so the catalog starts from production pieces instead of a new
+visual fork.
 
 <CellAnatomyExample />
 
@@ -17,6 +18,6 @@ The sidebar outline should scroll to cells and reflect heading state, but it
 should not own cell rendering. A clear cell anatomy gives the sidebar a stable
 contract while preserving the existing `NotebookView` DOM-order invariant.
 
-This docs site should converge toward rendering current components with fixture
-data. New schematic UI is only a temporary map when direct imports would drag in
-runtime hooks, generated WASM, or notebook sync state.
+This docs site should keep moving component by component toward runtime-free
+fixtures. Editor and output examples still need adapters before they can safely
+render without generated WASM, iframe/plugin context, or notebook sync state.

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -6,9 +6,8 @@ description: A fixture-backed inventory map for existing nteract cell components
 import { CellAnatomyExample } from "@/components/cell-anatomy-example";
 
 The first component family to document is the existing cell frame. This page
-now renders the current `CellContainer` and `CompactExecutionButton` with
-fixture content, so the catalog starts from production pieces instead of a new
-visual fork.
+now renders current cell pieces with fixture content, so the catalog starts
+from production components instead of a new visual fork.
 
 <CellAnatomyExample />
 

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -1,0 +1,18 @@
+---
+title: Cell anatomy
+description: A fixture-backed target shape for nteract-owned cell components.
+---
+
+import { CellAnatomyExample } from "@/components/cell-anatomy-example";
+
+The first component family to promote is the cell frame. It is where generic
+buttons, editor wrappers, gutters, presence, outputs, and runtime state become
+notebook semantics.
+
+<CellAnatomyExample />
+
+## Why this comes first
+
+The sidebar outline should scroll to cells and reflect heading state, but it
+should not own cell rendering. A clean cell anatomy gives the sidebar a stable
+target while preserving the existing `NotebookView` DOM-order invariant.

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -1,18 +1,22 @@
 ---
 title: Cell anatomy
-description: A fixture-backed target shape for nteract-owned cell components.
+description: A fixture-backed inventory map for existing nteract cell components.
 ---
 
 import { CellAnatomyExample } from "@/components/cell-anatomy-example";
 
-The first component family to promote is the cell frame. It is where generic
-buttons, editor wrappers, gutters, presence, outputs, and runtime state become
-notebook semantics.
+The first component family to document is the existing cell frame. It is where
+generic buttons, editor wrappers, gutters, presence, outputs, and runtime state
+already become notebook semantics.
 
 <CellAnatomyExample />
 
 ## Why this comes first
 
 The sidebar outline should scroll to cells and reflect heading state, but it
-should not own cell rendering. A clean cell anatomy gives the sidebar a stable
-target while preserving the existing `NotebookView` DOM-order invariant.
+should not own cell rendering. A clear cell anatomy gives the sidebar a stable
+contract while preserving the existing `NotebookView` DOM-order invariant.
+
+This docs site should converge toward rendering current components with fixture
+data. New schematic UI is only a temporary map when direct imports would drag in
+runtime hooks, generated WASM, or notebook sync state.

--- a/apps/elements/content/docs/component-burndown.mdx
+++ b/apps/elements/content/docs/component-burndown.mdx
@@ -1,0 +1,20 @@
+---
+title: Component burn-down
+description: A working inventory for replacing generic primitives with nteract-owned notebook components.
+---
+
+import { ComponentBurndown } from "@/components/component-burndown";
+
+This page tracks the component work as a burn-down rather than a vague rewrite.
+The goal is not to hide shadcn. The goal is to make notebook concepts the
+public components and keep shadcn as the low-level implementation layer.
+
+<ComponentBurndown />
+
+## Current rule
+
+If a component has notebook semantics, it should eventually have an nteract
+component name, fixture, and docs page here. If it is only an interaction
+primitive, keep it generic until the notebook contract is clear.
+
+The first concrete family is [cell anatomy](/docs/cell-anatomy).

--- a/apps/elements/content/docs/component-burndown.mdx
+++ b/apps/elements/content/docs/component-burndown.mdx
@@ -1,13 +1,14 @@
 ---
 title: Component burn-down
-description: A working inventory for replacing generic primitives with nteract-owned notebook components.
+description: A working inventory for cataloging existing nteract-owned notebook components.
 ---
 
 import { ComponentBurndown } from "@/components/component-burndown";
 
 This page tracks the component work as a burn-down rather than a vague rewrite.
-The goal is not to hide shadcn. The goal is to make notebook concepts the
-public components and keep shadcn as the low-level implementation layer.
+The goal is not to fork the current UI. The goal is to catalog existing notebook
+components, make notebook concepts the public surface, and keep shadcn as the
+low-level implementation layer.
 
 <ComponentBurndown />
 
@@ -16,5 +17,9 @@ public components and keep shadcn as the low-level implementation layer.
 If a component has notebook semantics, it should eventually have an nteract
 component name, fixture, and docs page here. If it is only an interaction
 primitive, keep it generic until the notebook contract is clear.
+
+Every page should prefer importing current components behind fixture adapters.
+Any schematic UI must be labeled as temporary and tied back to the source files
+it is mapping.
 
 The first concrete family is [cell anatomy](/docs/cell-anatomy).

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -25,3 +25,13 @@ repo-level `docs/` tree.
 Start with the notebook outline rail. It exercises the same shape we want for
 future package, variable, renderer, and metadata panels without importing the
 desktop runtime, sync engine, or generated WASM bindings.
+
+## Next slice
+
+Move the component work through a burn-down. The catalog should make it obvious
+which surfaces are nteract-owned notebook concepts and which surfaces are still
+generic shadcn primitives under the hood.
+
+- [Component burn-down](/docs/component-burndown)
+- [Cell anatomy](/docs/cell-anatomy)
+- [Notebook outline rail](/docs/notebook-outline)

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -16,6 +16,8 @@ slots for packages, variables, renderers, and future notebook tools.
 - The real app should wrap `NotebookView` in a workspace shell rather than
   moving cells into the sidebar.
 - The outline should start from materialized markdown headings.
+- Keep the rail icon-led: outline, packages, variables, renderers, and future
+  side panels should scan as compact tools before a panel opens.
 - Package and variable panels should become sibling rail panels, not sections
   embedded inside the outline.
 - This example is fixture-backed and intentionally avoids `App.tsx`,

--- a/apps/elements/next.config.mjs
+++ b/apps/elements/next.config.mjs
@@ -3,6 +3,7 @@ import { createMDX } from "fumadocs-mdx/next";
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
+  allowedDevOrigins: ["127.0.0.1"],
   output: "export",
   images: {
     unoptimized: true,

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -6,6 +6,8 @@
     "incremental": true,
     "jsx": "preserve",
     "paths": {
+      "@/components/cell/*": ["../../src/components/cell/*"],
+      "@/lib/utils": ["../../src/lib/utils"],
       "@/*": ["./*"],
       "collections/*": ["./.source/*"]
     },


### PR DESCRIPTION
## Summary

- add a component burn-down page to `apps/elements`
- add a `Cell anatomy` page that renders existing runtime-free cell components with fixture content
- link the new docs pages from the elements landing page and catalog index

## Notes

- This is still runtime-free docs/prototype work.
- The burn-down separates notebook-specific components from generic shadcn primitives.
- The cell anatomy page now imports `CellContainer`, `CompactExecutionButton`, `CellHeader`, `ExecutionCount`, and `PlayButton`; editor and output examples remain adapter targets.
- The outline rail direction stays icon-led for outline, packages, variables, renderers, and future side panels.

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Playwright smoke against `/docs/cell-anatomy`, `/docs/component-burndown`, and `/docs/notebook-outline` at desktop and mobile widths
