### PR TITLE
docs(architecture): remove runtime state notebook backlink

### DIFF
--- a/docs/architecture/runtime-state-document-identity.md
+++ b/docs/architecture/runtime-state-document-identity.md
@@ -47,7 +47,6 @@ NotebookDoc/
 RuntimeStateDoc/
   schema_version
   runtime_state_doc_id
-  notebook_id
   kernel/
   queue/
   executions/
@@ -79,11 +78,10 @@ The canonical lookup direction is:
 NotebookDoc -> RuntimeStateDoc
 ```
 
-`RuntimeStateDoc` may carry `runtime_state_doc_id` as its self identity and an
-optional `notebook_id` backlink when it is attached to a notebook. The backlink
-is provenance and validation context, not a required part of runtime-state
-identity. Authorization for notebook-attached runtime state flows through the
-notebook and its ACL.
+`RuntimeStateDoc` carries `runtime_state_doc_id` as its self identity when
+known. The runtime-state document does not carry a notebook backlink.
+Authorization for notebook-attached runtime state flows through the notebook and
+its ACL because the notebook document owns the association.
 
 ## Consequences
 
@@ -101,16 +99,15 @@ daemon/system actor.
 
 ### RuntimeStateDoc schema changes
 
-`RuntimeStateDoc` should gain root identity fields:
+`RuntimeStateDoc` should gain a root identity field:
 
 - `runtime_state_doc_id`
-- `notebook_id` (optional backlink for notebook-attached runtime state)
 
-These fields make storage, diagnostics, and cloud bootstrap validation cheaper.
-The runtime-state id is the document's own identity. The notebook backlink is an
-advisory check against loading the wrong pair and must remain optional so the
-same document shape can support markdown-associated runtime state or standalone
-runtime state.
+This makes storage, diagnostics, and cloud bootstrap validation cheaper. The
+runtime-state id is the document's own identity. Notebook association remains a
+property of the `NotebookDoc.runtime_state_doc_id` pointer and catalog/checkpoint
+metadata so the same runtime-state document shape can support markdown-associated
+or standalone runtime state later.
 
 ### Desktop room construction changes
 
@@ -121,7 +118,7 @@ notebook document:
 2. Read `NotebookDoc.runtime_state_doc_id`.
 3. If missing, mint a runtime-state document id and write it into `NotebookDoc`.
 4. Load the matching `RuntimeStateDoc` if present; otherwise create one with the
-   same runtime-state id and the optional notebook backlink.
+   same runtime-state id.
 5. Continue syncing `NotebookDoc` on frame `0x00` and `RuntimeStateDoc` on frame
    `0x05`.
 
@@ -143,9 +140,8 @@ Bootstrap resolves the pair this way:
 3. Load the latest authorized `NotebookDoc` snapshot.
 4. Read `runtime_state_doc_id` from `NotebookDoc`.
 5. Load the checkpointed `RuntimeStateDoc` snapshot with that id and matching
-   recorded heads. If the runtime-state snapshot has a `notebook_id` backlink,
-   validate it against the loaded notebook; if it does not, treat the
-   `NotebookDoc.runtime_state_doc_id` pointer as the association.
+   recorded heads. Treat the `NotebookDoc.runtime_state_doc_id` pointer as the
+   association; do not require or write a runtime-state notebook backlink.
 6. Render from the two local Automerge documents.
 7. Open live sync for both documents.
 
@@ -229,7 +225,7 @@ The identity pointer fixes association without erasing the boundary.
 
 1. Add typed accessors for `NotebookDoc.runtime_state_doc_id` and bump the
    notebook schema.
-2. Add typed self-identifying fields to `RuntimeStateDoc`.
+2. Add a typed self-identifying field to `RuntimeStateDoc`.
 3. During room creation/load, mint and persist a runtime-state document id when
    opening an older notebook document.
 4. Keep the existing sync streams and room shape while changing how

--- a/docs/architecture/three-document-split.md
+++ b/docs/architecture/three-document-split.md
@@ -93,10 +93,11 @@ The choice to store the pointer in `NotebookDoc` and the body in `RuntimeStateDo
 
 `runtime-state-document-identity.md` adds a second, document-level association:
 `NotebookDoc.runtime_state_doc_id`. For notebook rooms, that pointer identifies
-which `RuntimeStateDoc` belongs with the notebook. The association is optional
-from the runtime-state document's point of view so the same schema can support
-markdown-associated or standalone runtime state later. It does not replace
-`cell.execution_id`, and it does not store runtime-state heads in `NotebookDoc`.
+which `RuntimeStateDoc` belongs with the notebook. The runtime-state document
+itself remains document-agnostic: it carries its own `runtime_state_doc_id`, not
+a notebook backlink, so the same schema can support markdown-associated or
+standalone runtime state later. It does not replace `cell.execution_id`, and it
+does not store runtime-state heads in `NotebookDoc`.
 
 ## Decision 3: Write authority is per-document, and `RuntimeStateDoc` separates runtime authority from widget state
 
@@ -143,11 +144,11 @@ So the durable footprint of one notebook is: the `.ipynb` (or untitled `.automer
 
 | Document | Created when | Identity | GC'd when |
 |---|---|---|---|
-| `NotebookDoc` | On room load (either from `.ipynb` or fresh) | Per-notebook UUID; schema seed actor `nteract:notebook-schema:v4` | On room eviction; persisted file deleted on save-as transition |
-| `RuntimeStateDoc` | On room load (fresh from schema seed; load code populates synthetic executions when the `.ipynb` carries legacy outputs, `crates/runtimed/src/notebook_sync_server/load.rs:709, :731, :741`) | Per-notebook (lives next to its NotebookDoc); schema seed actor `nteract:runtime-state-schema:v2`; daemon writes under actor `runtimed:state`; runtime-agent peer writes under its own actor (`crates/runtimed/src/runtime_agent.rs:96`) | On room eviction |
+| `NotebookDoc` | On room load (either from `.ipynb` or fresh) | Per-notebook UUID; schema seed actor `nteract:notebook-schema:v5` | On room eviction; persisted file deleted on save-as transition |
+| `RuntimeStateDoc` | On room load (fresh from schema seed; load code populates synthetic executions when the `.ipynb` carries legacy outputs, `crates/runtimed/src/notebook_sync_server/load.rs:709, :731, :741`) | Runtime-state document id referenced by `NotebookDoc.runtime_state_doc_id`; schema seed actor `nteract:runtime-state-schema:v2`; daemon writes under actor `runtimed:state`; runtime-agent peer writes under its own actor (`crates/runtimed/src/runtime_agent.rs:96`) | On room eviction |
 | `PoolDoc` | On daemon startup | Singleton; daemon writes under actor `runtimed:pool` | On daemon shutdown |
 
-The schema seed actor is what makes initial sync correct. Every peer scaffolds from the same frozen genesis bytes (`assets/notebook_genesis_v4.am`, `assets/runtime_state_genesis_v2.am`) so the top-level object IDs (`cells`, `metadata`, `kernel`, `queue`, `executions`, ...) agree before the first sync round. The `notebook-doc/AGENTS.md` invariant "exactly one peer creates document structure" applies inside `NotebookDoc` for any non-genesis structure (so the daemon owns `cells` creation when scaffolding from empty); for `RuntimeStateDoc`, the daemon owns everything by convention because the genesis already scaffolds the runtime tree.
+The schema seed actor is what makes initial sync correct. Every peer scaffolds from the same frozen genesis bytes (`assets/notebook_genesis_v5.am`, `assets/runtime_state_genesis_v2.am`) so the top-level object IDs (`cells`, `metadata`, `kernel`, `queue`, `executions`, ...) agree before the first sync round. The `notebook-doc/AGENTS.md` invariant "exactly one peer creates document structure" applies inside `NotebookDoc` for any non-genesis structure (so the daemon owns `cells` creation when scaffolding from empty); for `RuntimeStateDoc`, the daemon owns everything by convention because the genesis already scaffolds the runtime tree.
 
 Room eviction is driven by "last peer disconnected." `peer_eviction.rs` runs the teardown: stop kernel, optionally clean up env, save `.ipynb` if file-backed and dirty, drop the room from the registry. Both notebook docs go out of scope. Re-opening the room recreates `RuntimeStateDoc` fresh from seed.
 


### PR DESCRIPTION
## Summary

- removes the stale RuntimeStateDoc `notebook_id` backlink from the runtime-state identity ADR
- clarifies that NotebookDoc owns the runtime-state association through `runtime_state_doc_id`
- updates the three-document split doc to describe RuntimeStateDoc as document-agnostic and align NotebookDoc schema seed references with v5

## Verification

```bash
cargo xtask lint --fix
```

## Stack

Independent of #3093. This is the first architecture cleanup slice from the
Automerge-first cloud plan and can merge on its own.
