### PR TITLE
feat(notebook-cloud): record runtime state document id

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -557,6 +557,12 @@ async function routeSnapshot(
 
   const body = await request.arrayBuffer();
   const runtimeHeadsHash = normalizedRuntimeHeadsHash(request.headers.get("x-runtime-heads-hash"));
+  const runtimeStateDocId = requiredRuntimeStateDocId(
+    request.headers.get("x-runtime-state-doc-id"),
+  );
+  if (!runtimeStateDocId) {
+    return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
+  }
   const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
   const renderCacheKey = renderKey(notebookId, headsHash);
   let renderCacheWritten = false;
@@ -567,6 +573,7 @@ async function routeSnapshot(
     },
     customMetadata: {
       notebook_id: notebookId,
+      runtime_state_doc_id: runtimeStateDocId,
       notebook_heads_hash: headsHash,
     },
   });
@@ -605,6 +612,7 @@ async function routeSnapshot(
   try {
     revisionId = await recordRevision(env, {
       notebookId,
+      runtimeStateDocId,
       notebookHeadsHash: headsHash,
       runtimeHeadsHash,
       snapshotKey: key,
@@ -620,7 +628,10 @@ async function routeSnapshot(
     throw error;
   }
 
-  return json({ ok: true, revision_id: revisionId, key }, 201);
+  return json(
+    { ok: true, revision_id: revisionId, key, runtime_state_doc_id: runtimeStateDocId },
+    201,
+  );
 }
 
 async function routeRuntimeSnapshot(
@@ -672,6 +683,12 @@ async function routeRuntimeSnapshot(
   }
 
   const body = await request.arrayBuffer();
+  const runtimeStateDocId = requiredRuntimeStateDocId(
+    request.headers.get("x-runtime-state-doc-id"),
+  );
+  if (!runtimeStateDocId) {
+    return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
+  }
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -679,12 +696,16 @@ async function routeRuntimeSnapshot(
     },
     customMetadata: {
       notebook_id: notebookId,
+      runtime_state_doc_id: runtimeStateDocId,
       runtime_heads_hash: headsHash,
       artifact: "runtime-state-snapshot",
     },
   });
 
-  return json({ ok: true, key, size: body.byteLength }, 201);
+  return json(
+    { ok: true, key, size: body.byteLength, runtime_state_doc_id: runtimeStateDocId },
+    201,
+  );
 }
 
 interface PendingInvitePayload {
@@ -1857,6 +1878,11 @@ function absoluteOrigin(value: string): string | null {
 }
 
 function normalizedRuntimeHeadsHash(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed !== "none" ? trimmed : null;
+}
+
+function requiredRuntimeStateDocId(value: string | null): string | null {
   const trimmed = value?.trim();
   return trimmed && trimmed !== "none" ? trimmed : null;
 }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -19,6 +19,7 @@ export interface NotebookRow {
 export interface RevisionRow {
   id: string;
   notebook_id: string;
+  runtime_state_doc_id: string | null;
   notebook_heads_hash: string;
   runtime_heads_hash: string | null;
   snapshot_key: string;
@@ -66,6 +67,7 @@ const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebook_revisions (
     id TEXT PRIMARY KEY,
     notebook_id TEXT NOT NULL,
+    runtime_state_doc_id TEXT,
     notebook_heads_hash TEXT NOT NULL,
     runtime_heads_hash TEXT,
     snapshot_key TEXT NOT NULL,
@@ -147,6 +149,11 @@ const SCHEMA_MIGRATIONS = [
     table: "notebook_revisions",
     column: "runtime_snapshot_key",
     statement: `ALTER TABLE notebook_revisions ADD COLUMN runtime_snapshot_key TEXT`,
+  },
+  {
+    table: "notebook_revisions",
+    column: "runtime_state_doc_id",
+    statement: `ALTER TABLE notebook_revisions ADD COLUMN runtime_state_doc_id TEXT`,
   },
 ];
 
@@ -503,6 +510,7 @@ export async function recordRevision(
   env: Env,
   revision: {
     notebookId: string;
+    runtimeStateDocId: string;
     notebookHeadsHash: string;
     runtimeHeadsHash: string | null;
     snapshotKey: string;
@@ -523,15 +531,17 @@ export async function recordRevision(
       `INSERT INTO notebook_revisions (
        id,
        notebook_id,
+       runtime_state_doc_id,
        notebook_heads_hash,
        runtime_heads_hash,
        snapshot_key,
        runtime_snapshot_key,
        actor_label
-     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).bind(
       revisionId,
       revision.notebookId,
+      revision.runtimeStateDocId,
       revision.notebookHeadsHash,
       revision.runtimeHeadsHash,
       revision.snapshotKey,
@@ -616,6 +626,7 @@ export async function getNotebookCatalog(
   const revisions = await env.DB.prepare(
     `SELECT id,
             notebook_id,
+            runtime_state_doc_id,
             notebook_heads_hash,
             runtime_heads_hash,
             snapshot_key,

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1567,6 +1567,7 @@ function fakePublishedSnapshotEnv(input: {
       revision: {
         id: input.revisionId,
         notebook_id: input.notebookId,
+        runtime_state_doc_id: `runtime:${input.notebookId}`,
         notebook_heads_hash: "heads-published",
         runtime_heads_hash: "runtime-published",
         snapshot_key: snapshotKey,
@@ -1615,6 +1616,7 @@ class FakeCatalogD1 implements D1Database {
       revision: {
         id: string;
         notebook_id: string;
+        runtime_state_doc_id: string;
         notebook_heads_hash: string;
         runtime_heads_hash: string;
         snapshot_key: string;
@@ -1665,7 +1667,7 @@ class FakeCatalogStatement implements D1PreparedStatement {
 
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (/PRAGMA table_info\(notebook_revisions\)/.test(this.query)) {
-      return okResult([{ name: "runtime_snapshot_key" }] as T[]);
+      return okResult([{ name: "runtime_snapshot_key" }, { name: "runtime_state_doc_id" }] as T[]);
     }
     if (/FROM notebook_revisions/s.test(this.query)) {
       const notebookId = this.values[0];

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -869,7 +869,7 @@ class FakeD1Statement implements D1PreparedStatement {
 
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (this.query.startsWith("PRAGMA table_info")) {
-      return okResult([{ name: "runtime_snapshot_key" }] as T[]);
+      return okResult([{ name: "runtime_snapshot_key" }, { name: "runtime_state_doc_id" }] as T[]);
     }
     if (this.query.includes("FROM principal_profiles")) {
       const principals = new Set(this.values as string[]);

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -651,6 +651,7 @@ describe("Worker artifact routes", () => {
           Cookie: `CF_Authorization=${token}`,
           Origin: "https://cloud.test",
           "X-Operator": "browser:tab",
+          "X-Runtime-State-Doc-Id": "runtime:access-artifact-demo",
           "X-Scope": "owner",
         },
         body,
@@ -667,6 +668,7 @@ describe("Worker artifact routes", () => {
           "Content-Type": "application/octet-stream",
           "CF-Access-Token": token,
           "X-Operator": "cli:smoke",
+          "X-Runtime-State-Doc-Id": "runtime:access-artifact-demo",
           "X-Scope": "owner",
         },
         body,
@@ -701,6 +703,7 @@ describe("Worker artifact routes", () => {
           Authorization: `Bearer ${token}`,
           "Content-Type": "application/octet-stream",
           "X-Operator": "agent:runt-publish",
+          "X-Runtime-State-Doc-Id": "runtime:api-key-artifact-demo",
           "X-Scope": "owner",
         },
         body,
@@ -713,6 +716,7 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), {
       ok: true,
       key: runtimeSnapshotKey("api-key-artifact-demo", "api-key"),
+      runtime_state_doc_id: "runtime:api-key-artifact-demo",
       size: body.byteLength,
     });
     assert.deepEqual(seenAuthorizations, [`Bearer ${token}`]);
@@ -729,6 +733,30 @@ describe("Worker artifact routes", () => {
       ),
       true,
     );
+  });
+
+  it("requires RuntimeStateDoc ids for snapshot publishes", async () => {
+    const env = fakeEnv();
+    const body = new Uint8Array([1, 2, 3, 4]);
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/runtime-id-required/runtime-snapshots/runtime-heads",
+      body,
+    );
+    assert.equal(runtimePut.status, 400);
+    assert.deepEqual(await runtimePut.json(), {
+      error: "X-Runtime-State-Doc-Id header is required",
+    });
+
+    const notebookPut = await ownerPut(env, "/api/n/runtime-id-required/snapshots/heads", body);
+    assert.equal(notebookPut.status, 400);
+    assert.deepEqual(await notebookPut.json(), {
+      error: "X-Runtime-State-Doc-Id header is required",
+    });
+
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
+    assert.equal(env.DB.revisions.length, 0);
   });
 
   it("allows runtime peers to upload content-addressed output blobs", async () => {
@@ -2626,6 +2654,9 @@ describe("Worker artifact routes", () => {
       env,
       "/api/n/route-demo/runtime-snapshots/runtime-fixture",
       runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:route-demo",
+      },
     );
     assert.equal(runtimePut.status, 201);
     assert.deepEqual(
@@ -2639,9 +2670,13 @@ describe("Worker artifact routes", () => {
       notebookBytes,
       {
         "X-Runtime-Heads-Hash": "runtime-fixture",
+        "X-Runtime-State-Doc-Id": "runtime:route-demo",
       },
     );
     assert.equal(notebookPut.status, 201);
+    const notebookPutBody = (await notebookPut.json()) as { runtime_state_doc_id: string };
+    assert.equal(notebookPutBody.runtime_state_doc_id, "runtime:route-demo");
+    assert.equal(env.DB.revisions[0]?.runtime_state_doc_id, "runtime:route-demo");
     assert.deepEqual(
       env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
       [
@@ -2705,6 +2740,7 @@ describe("Worker artifact routes", () => {
       notebookBytes,
       {
         "X-Runtime-Heads-Hash": "runtime-missing",
+        "X-Runtime-State-Doc-Id": "runtime:missing-runtime-demo",
       },
     );
 
@@ -2728,6 +2764,9 @@ describe("Worker artifact routes", () => {
       env,
       "/api/n/corrupt-demo/runtime-snapshots/runtime-corrupt",
       corruptBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:corrupt-demo",
+      },
     );
     assert.equal(runtimePut.status, 201);
 
@@ -2740,6 +2779,7 @@ describe("Worker artifact routes", () => {
     try {
       response = await ownerPut(env, "/api/n/corrupt-demo/snapshots/heads-corrupt", corruptBytes, {
         "X-Runtime-Heads-Hash": "runtime-corrupt",
+        "X-Runtime-State-Doc-Id": "runtime:corrupt-demo",
       });
     } finally {
       console.warn = originalWarn;
@@ -2797,6 +2837,9 @@ describe("Worker artifact routes", () => {
       env,
       "/api/n/missing-blob-demo/runtime-snapshots/runtime-fixture",
       runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:missing-blob-demo",
+      },
     );
     assert.equal(runtimePut.status, 201);
 
@@ -2813,6 +2856,7 @@ describe("Worker artifact routes", () => {
         notebookBytes,
         {
           "X-Runtime-Heads-Hash": "runtime-fixture",
+          "X-Runtime-State-Doc-Id": "runtime:missing-blob-demo",
         },
       );
     } finally {
@@ -3129,6 +3173,7 @@ interface NotebookAclRow {
 interface RevisionRow {
   id: string;
   notebook_id: string;
+  runtime_state_doc_id: string | null;
   notebook_heads_hash: string;
   runtime_heads_hash: string | null;
   snapshot_key: string;
@@ -3420,15 +3465,26 @@ class FakeD1Statement implements D1PreparedStatement {
       const [
         id,
         notebookId,
+        runtimeStateDocId,
         notebookHeadsHash,
         runtimeHeadsHash,
         snapshotKey,
         runtimeSnapshotKey,
         actorLabel,
-      ] = this.values as [string, string, string, string | null, string, string | null, string];
+      ] = this.values as [
+        string,
+        string,
+        string | null,
+        string,
+        string | null,
+        string,
+        string | null,
+        string,
+      ];
       this.db.revisions.push({
         id,
         notebook_id: notebookId,
+        runtime_state_doc_id: runtimeStateDocId,
         notebook_heads_hash: notebookHeadsHash,
         runtime_heads_hash: runtimeHeadsHash,
         snapshot_key: snapshotKey,

--- a/crates/runt-publish/src/main.rs
+++ b/crates/runt-publish/src/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use automerge::AutoCommit;
 use clap::Parser;
-use notebook_doc::NotebookDoc;
+use notebook_doc::{default_runtime_state_doc_id, NotebookDoc};
 use notebook_sync::connect;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use runtime_doc::RuntimeStateDoc;
@@ -145,12 +145,21 @@ async fn main() -> Result<()> {
     let mut refs =
         collect_snapshot_blob_refs(&snapshot.notebook_bytes, &snapshot.runtime_state_bytes)?;
     let initial_ref_count = refs.len();
+    let runtime_state_doc_id =
+        runtime_state_doc_id_from_notebook_snapshot(&snapshot.notebook_bytes, &notebook_id)?;
 
     let publisher = Publisher::new(args, notebook_id, blob_base_url, blob_store_path)?;
     let uploaded_blobs = publisher.upload_blob_closure(&mut refs).await?;
 
     let runtime_heads_hash = heads_digest(&snapshot.runtime_state_heads);
     let notebook_heads_hash = heads_digest(&snapshot.notebook_heads);
+    let runtime_state_doc_id_header = HeaderValue::from_str(&runtime_state_doc_id)
+        .context("runtime state document id is not a valid header value")?;
+    let mut runtime_snapshot_headers = HeaderMap::new();
+    runtime_snapshot_headers.insert(
+        "X-Runtime-State-Doc-Id",
+        runtime_state_doc_id_header.clone(),
+    );
     publisher
         .put_bytes(
             &[
@@ -162,7 +171,7 @@ async fn main() -> Result<()> {
             ],
             snapshot.runtime_state_bytes,
             DEFAULT_BLOB_CONTENT_TYPE,
-            HeaderMap::new(),
+            runtime_snapshot_headers,
         )
         .await?;
 
@@ -172,6 +181,7 @@ async fn main() -> Result<()> {
         HeaderValue::from_str(&runtime_heads_hash)
             .context("runtime heads hash is not a valid header value")?,
     );
+    snapshot_headers.insert("X-Runtime-State-Doc-Id", runtime_state_doc_id_header);
     publisher
         .put_bytes(
             &[
@@ -201,6 +211,7 @@ async fn main() -> Result<()> {
             "notebook_id": publisher.notebook_id,
             "source_notebook_id": open.info.notebook_id,
             "viewer_url": publisher.viewer_url(),
+            "runtime_state_doc_id": runtime_state_doc_id,
             "notebook_heads_hash": notebook_heads_hash,
             "runtime_heads_hash": runtime_heads_hash,
             "initial_blob_refs": initial_ref_count,
@@ -419,6 +430,17 @@ fn collect_snapshot_blob_refs(
     collect_runtime_snapshot_blob_refs(runtime_state_bytes, &mut refs)?;
     collect_notebook_snapshot_blob_refs(notebook_bytes, &mut refs)?;
     Ok(refs)
+}
+
+fn runtime_state_doc_id_from_notebook_snapshot(
+    notebook_bytes: &[u8],
+    fallback_notebook_id: &str,
+) -> Result<String> {
+    let notebook_doc = NotebookDoc::load(notebook_bytes)
+        .context("load NotebookDoc from exported snapshot bytes")?;
+    Ok(notebook_doc
+        .runtime_state_doc_id()
+        .unwrap_or_else(|| default_runtime_state_doc_id(fallback_notebook_id)))
 }
 
 fn collect_runtime_snapshot_blob_refs(


### PR DESCRIPTION
## Summary
- adds `runtime_state_doc_id` to notebook-cloud revision metadata without inventing a cloud-side fallback for new publishes
- requires `X-Runtime-State-Doc-Id` on notebook/runtime snapshot publish routes and stores it in R2 metadata/catalog rows
- teaches `runt-publish` to send the RuntimeStateDoc id from the NotebookDoc snapshot with both uploads

## Verification
```bash
pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/sharing-storage.test.ts test/room-materializer.test.ts
pnpm --dir apps/notebook-cloud typecheck
cargo test -p runt-publish
cargo xtask lint --fix
```

## Notes
`notebook-cloud` and `runt-publish` are still preview/internal surfaces. This PR intentionally does not preserve old publish behavior for missing RuntimeStateDoc ids; existing preview data can be republished or migrated as needed.

## Stack
Independent of #3094, which has merged. It keeps the existing notebook-scoped runtime R2 key for now; document-id storage is handled by the stacked follow-up #3097.
