### PR TITLE
feat(notebook-cloud): namespace runtime snapshots by document

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -34,7 +34,7 @@ import {
   recordRevision,
   renderKey,
   revokeNotebookAclRow,
-  runtimeSnapshotKey,
+  runtimeStateSnapshotKey,
   snapshotKey,
   type NotebookAclRow,
   type RevisionRow,
@@ -563,7 +563,9 @@ async function routeSnapshot(
   if (!runtimeStateDocId) {
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
-  const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
+  const runtimeKey = runtimeHeadsHash
+    ? runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash)
+    : null;
   const renderCacheKey = renderKey(notebookId, headsHash);
   let renderCacheWritten = false;
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
@@ -640,13 +642,18 @@ async function routeRuntimeSnapshot(
   notebookId: string,
   headsHash: string,
 ): Promise<Response> {
-  const key = runtimeSnapshotKey(notebookId, headsHash);
-
   if (request.method === "GET") {
     const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
     if (identity instanceof Response) {
       return identity;
     }
+    const runtimeStateDocId = requiredRuntimeStateDocId(
+      request.headers.get("x-runtime-state-doc-id"),
+    );
+    if (!runtimeStateDocId) {
+      return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
+    }
+    const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       return json({ error: "runtime snapshot not found" }, 404);
@@ -689,6 +696,7 @@ async function routeRuntimeSnapshot(
   if (!runtimeStateDocId) {
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
+  const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -658,6 +658,12 @@ async function routeRuntimeSnapshot(
     if (!object) {
       return json({ error: "runtime snapshot not found" }, 404);
     }
+    if (
+      object.customMetadata?.notebook_id !== notebookId ||
+      object.customMetadata?.runtime_state_doc_id !== runtimeStateDocId
+    ) {
+      return json({ error: "runtime snapshot not found" }, 404);
+    }
 
     const headers = new Headers({
       "Cache-Control": "public, max-age=31536000, immutable",
@@ -697,6 +703,14 @@ async function routeRuntimeSnapshot(
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
   const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
+  const existing = await env.NOTEBOOK_SNAPSHOTS.head(key);
+  if (
+    existing &&
+    (existing.customMetadata?.notebook_id !== notebookId ||
+      existing.customMetadata?.runtime_state_doc_id !== runtimeStateDocId)
+  ) {
+    return json({ error: "runtime snapshot belongs to another notebook" }, 403);
+  }
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -165,6 +165,14 @@ export function snapshotKey(notebookId: string, headsHash: string): string {
   return `n/${encodePathComponent(notebookId)}/snapshots/${encodePathComponent(headsHash)}.am`;
 }
 
+export function documentSnapshotKey(documentId: string, headsHash: string): string {
+  return `docs/${encodePathComponent(documentId)}/snapshots/${encodePathComponent(headsHash)}.am`;
+}
+
+export function runtimeStateSnapshotKey(runtimeStateDocId: string, headsHash: string): string {
+  return documentSnapshotKey(runtimeStateDocId, headsHash);
+}
+
 export function runtimeSnapshotKey(notebookId: string, headsHash: string): string {
   return `n/${encodePathComponent(notebookId)}/snapshots/runtime-state/${encodePathComponent(headsHash)}.am`;
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -31,7 +31,7 @@ import {
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
   renderKey,
-  runtimeSnapshotKey,
+  runtimeStateSnapshotKey,
   snapshotKey,
 } from "../src/storage.ts";
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
@@ -715,7 +715,7 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 201);
     assert.deepEqual(await response.json(), {
       ok: true,
-      key: runtimeSnapshotKey("api-key-artifact-demo", "api-key"),
+      key: runtimeStateSnapshotKey("runtime:api-key-artifact-demo", "api-key"),
       runtime_state_doc_id: "runtime:api-key-artifact-demo",
       size: body.byteLength,
     });
@@ -2677,6 +2677,10 @@ describe("Worker artifact routes", () => {
     const notebookPutBody = (await notebookPut.json()) as { runtime_state_doc_id: string };
     assert.equal(notebookPutBody.runtime_state_doc_id, "runtime:route-demo");
     assert.equal(env.DB.revisions[0]?.runtime_state_doc_id, "runtime:route-demo");
+    assert.equal(
+      env.DB.revisions[0]?.runtime_snapshot_key,
+      runtimeStateSnapshotKey("runtime:route-demo", "runtime-fixture"),
+    );
     assert.deepEqual(
       env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
       [

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -759,6 +759,144 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.revisions.length, 0);
   });
 
+  it("requires RuntimeStateDoc ids when reading runtime snapshots", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: "X-Runtime-State-Doc-Id header is required",
+    });
+  });
+
+  it("serves runtime snapshots from the RuntimeStateDoc namespace", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    const body = new Uint8Array([1, 2, 3, 4]);
+    const key = runtimeStateSnapshotKey("runtime:runtime-read-demo", "runtime-heads");
+    await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+      httpMetadata: { contentType: "application/octet-stream" },
+      customMetadata: {
+        artifact: "runtime-state-snapshot",
+        notebook_id: "runtime-read-demo",
+        runtime_heads_hash: "runtime-heads",
+        runtime_state_doc_id: "runtime:runtime-read-demo",
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Runtime-State-Doc-Id": "runtime:runtime-read-demo",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+  });
+
+  it("does not serve runtime snapshots owned by another notebook", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      runtimeStateSnapshotKey("runtime:other-demo", "runtime-heads"),
+      new Uint8Array([1, 2, 3, 4]),
+      {
+        customMetadata: {
+          artifact: "runtime-state-snapshot",
+          notebook_id: "other-demo",
+          runtime_heads_hash: "runtime-heads",
+          runtime_state_doc_id: "runtime:other-demo",
+        },
+      },
+    );
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Runtime-State-Doc-Id": "runtime:other-demo",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "runtime snapshot not found" });
+  });
+
+  it("does not replace runtime snapshots owned by another notebook", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-write-demo");
+    seedAcl(env, {
+      notebookId: "runtime-write-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      runtimeStateSnapshotKey("runtime:other-demo", "runtime-heads"),
+      new Uint8Array([1, 2, 3, 4]),
+      {
+        customMetadata: {
+          artifact: "runtime-state-snapshot",
+          notebook_id: "other-demo",
+          runtime_heads_hash: "runtime-heads",
+          runtime_state_doc_id: "runtime:other-demo",
+        },
+      },
+    );
+
+    const response = await ownerPut(
+      env,
+      "/api/n/runtime-write-demo/runtime-snapshots/runtime-heads",
+      new Uint8Array([5, 6, 7, 8]),
+      {
+        "X-Runtime-State-Doc-Id": "runtime:other-demo",
+      },
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      error: "runtime snapshot belongs to another notebook",
+    });
+  });
+
   it("allows runtime peers to upload content-addressed output blobs", async () => {
     const env = fakeEnv();
     seedNotebook(env, "runtime-demo");
@@ -3759,7 +3897,12 @@ class FakeR2Bucket implements R2Bucket {
     value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
     options?: R2PutOptions,
   ): Promise<R2Object> {
-    const object = new FakeR2Object(key, await toBytes(value), options?.httpMetadata);
+    const object = new FakeR2Object(
+      key,
+      await toBytes(value),
+      options?.httpMetadata,
+      options?.customMetadata,
+    );
     this.objects.set(key, object);
     return object;
   }
@@ -3774,12 +3917,12 @@ class FakeR2Object implements R2ObjectBody {
   readonly etag = "fake-etag";
   readonly httpEtag = '"fake-etag"';
   readonly uploaded = new Date("2026-05-22T00:00:00.000Z");
-  readonly customMetadata = {};
 
   constructor(
     readonly key: string,
     private readonly bytes: Uint8Array,
     readonly httpMetadata?: R2HTTPMetadata,
+    readonly customMetadata?: Record<string, string>,
   ) {}
 
   get size(): number {


### PR DESCRIPTION
## Summary
- stores RuntimeStateDoc snapshots under `docs/{runtimeStateDocId}/snapshots/{heads}.am`
- makes notebook snapshot publish lookup use the RuntimeStateDoc id sent by `runt-publish`
- requires `X-Runtime-State-Doc-Id` for direct runtime snapshot reads/writes instead of falling back to notebook-scoped storage
- verifies runtime snapshot R2 metadata matches the notebook route before serving or replacing a snapshot

## Verification
```bash
pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/sharing-storage.test.ts test/room-materializer.test.ts
pnpm --dir apps/notebook-cloud typecheck
cargo xtask lint --fix
```

## Notes
`notebook-cloud` and `runt-publish` are preview/internal surfaces. This intentionally does not include a legacy R2 key fallback; current preview content should be republished or migrated forward.
