### PR TITLE
test(notebook-cloud): make live smoke render optional

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -97,14 +97,14 @@ pnpm --dir apps/notebook-cloud smoke:hosted:install
 
 It verifies that the hosted viewer renders the live-published code cell with a
 runtime-derived execution count, that sandboxed output iframes expose expected
-markdown and Sift notebook content, and that Sift's WASM sidecar loads from the configured
-renderer asset origin with CORS. It also checks the latest catalog revision and
-its pinned `/api/n/:id/renders/:headsHash` document report `source: "snapshot-pair"`
-so publish validation still proves the persisted NotebookDoc + RuntimeStateDoc
-pair is complete. Override the
-target with `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
-`NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a
-visual artifact.
+markdown and Sift notebook content, and that Sift's WASM sidecar loads from the
+configured renderer asset origin with CORS. Latest notebook URLs are validated
+through the live viewer path and catalog metadata; pinned
+`/n/:id/r/:headsHash` URLs also check the corresponding
+`/api/n/:id/renders/:headsHash` report. Override the target with
+`NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
+`NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
+artifact.
 
 For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
@@ -113,8 +113,10 @@ with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,
 renderers are checked as frame text because they render inside sandboxed output
 documents. Frame texts can be a JSON string array or a `|`-delimited list. Set
 `NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS` only for text that should appear in the
-parent viewer document. Set `NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip the
-render API source check. Set
+parent viewer document. Set
+`NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=snapshot-pair` to require the render API
+source check for a latest live URL, or set
+`NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip that check for a pinned URL. Set
 `NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL=` and
 `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL=` to skip the live-publish
 catalog provenance checks, or set them to the expected owner/actor for another

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -1,4 +1,12 @@
 export function renderApiUrlForViewer(viewerUrl, headsHash) {
+  const pinned = pinnedNotebookViewerUrl(viewerUrl);
+  if (pinned) {
+    return new URL(
+      `/api/n/${pinned.notebookId}/renders/${encodeURIComponent(pinned.headsHash)}`,
+      pinned.origin,
+    ).href;
+  }
+
   const parsed = notebookViewerUrl(viewerUrl);
   if (!parsed || typeof headsHash !== "string" || headsHash.length === 0) {
     return null;
@@ -10,11 +18,19 @@ export function renderApiUrlForViewer(viewerUrl, headsHash) {
 }
 
 export function catalogApiUrlForViewer(viewerUrl) {
-  const parsed = notebookViewerUrl(viewerUrl);
+  const parsed = notebookViewerUrl(viewerUrl) ?? pinnedNotebookViewerUrl(viewerUrl);
   if (!parsed) {
     return null;
   }
   return new URL(`/api/n/${parsed.notebookId}`, parsed.origin).href;
+}
+
+export function expectedRenderSourceForViewer(viewerUrl, envValue) {
+  if (envValue !== undefined) {
+    const trimmed = envValue.trim();
+    return trimmed ? trimmed : null;
+  }
+  return pinnedNotebookViewerUrl(viewerUrl) ? "snapshot-pair" : null;
 }
 
 export function notebookViewerUrl(viewerUrl) {
@@ -28,4 +44,14 @@ export function notebookViewerUrl(viewerUrl) {
     return null;
   }
   return { origin: parsed.origin, notebookId, vanityName: vanityName ?? null };
+}
+
+export function pinnedNotebookViewerUrl(viewerUrl) {
+  const parsed = new URL(viewerUrl);
+  const match = parsed.pathname.match(/^\/n\/([^/]+)\/r\/([^/]+)\/?$/);
+  if (!match) {
+    return null;
+  }
+  const [, notebookId, headsHash] = match;
+  return { origin: parsed.origin, notebookId, headsHash };
 }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -16,7 +16,11 @@ import {
   parsePositiveInteger,
 } from "./hosted-render-smoke-assets.mjs";
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
-import { catalogApiUrlForViewer, renderApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
+import {
+  catalogApiUrlForViewer,
+  expectedRenderSourceForViewer,
+  renderApiUrlForViewer,
+} from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -42,7 +46,10 @@ const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEX
   "Schema at a glance",
   "PROBLEM_MARKDOWN",
 ]);
-const expectedRenderSource = process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE ?? "snapshot-pair";
+const expectedRenderSource = expectedRenderSourceForViewer(
+  targetUrl,
+  process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE,
+);
 const expectedCatalogOwnerPrincipal =
   process.env.NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL ?? DEFAULT_CATALOG_OWNER_PRINCIPAL;
 const expectedLatestRevisionActorLabel =
@@ -93,6 +100,8 @@ let viewerCssCheck = null;
 let screenshotSaved = false;
 let pageTextMatches = {};
 let themeModeChecks = [];
+const smokeStartedAt = performance.now();
+const timingsMs = {};
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -194,12 +203,17 @@ async function main() {
       });
       failures.push(...viewerCssCheck.failures);
     }
+    markTiming("preflight");
     if (hasPreflightFailures(failures)) {
       throw new SmokeFailure(failures);
     }
 
     await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-    await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
+    markTiming("domcontentloaded");
+    const networkIdleTask = page
+      .waitForLoadState("networkidle", { timeout: timeoutMs })
+      .then(() => markTiming("networkidle"))
+      .catch(() => markTiming("networkidle_timeout"));
 
     if (expectedSourceText) {
       await page.waitForFunction(
@@ -209,9 +223,11 @@ async function main() {
           timeout: timeoutMs,
         },
       );
+      markTiming("source_text");
     }
     if (expectedPageTexts.length > 0) {
       pageTextMatches = await waitForPageText(page, expectedPageTexts);
+      markTiming("page_texts");
     }
     if (requireRenderedCellMarker || expectedExecutionCount) {
       await page.waitForFunction(
@@ -230,6 +246,7 @@ async function main() {
         expectedExecutionCount,
         { timeout: timeoutMs },
       );
+      markTiming("rendered_cell_marker");
     }
     if (expectedPresenceText) {
       await page.waitForFunction(
@@ -237,6 +254,7 @@ async function main() {
         expectedPresenceText,
         { timeout: timeoutMs },
       );
+      markTiming("presence");
     }
     if (expectedFrameTexts.length > 0) {
       await page.waitForFunction(
@@ -247,13 +265,19 @@ async function main() {
         undefined,
         { timeout: timeoutMs },
       );
+      markTiming("first_output_iframe");
     }
     const frameTextMatches =
       expectedFrameTexts.length > 0 ? await waitForFrameText(page, expectedFrameTexts) : {};
+    if (expectedFrameTexts.length > 0) {
+      markTiming("frame_texts");
+    }
 
     // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
     await page.waitForTimeout(750);
     await flushDiagnosticTasks();
+    await Promise.race([networkIdleTask, Promise.resolve()]);
+    markTiming("diagnostics_flushed");
 
     const executionCounts = await page
       .locator("[data-slot='execution-count']")
@@ -374,11 +398,13 @@ async function main() {
     }
     if (expectedThemeModes.length > 0) {
       themeModeChecks = await checkHostedThemeModes(browser, expectedThemeModes);
+      markTiming("theme_modes");
     }
 
     if (failures.length > 0) {
       throw new SmokeFailure(failures);
     }
+    markTiming("total");
 
     console.log(
       JSON.stringify(
@@ -397,6 +423,7 @@ async function main() {
           expectedLatestRevisionActorLabel,
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
+          timings_ms: timingsMs,
           renderApiCheck,
           catalogApiCheck,
           viewerCssCheck,
@@ -453,6 +480,10 @@ function parseExpectedTexts(envName, fallback) {
     .split("|")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function markTiming(name) {
+  timingsMs[name] ??= Math.round(performance.now() - smokeStartedAt);
 }
 
 function themeModeSpec(value) {
@@ -512,6 +543,9 @@ async function checkHostedThemeModes(browser, modes) {
       if (!isRelevantRequestUrl(request.url())) {
         return;
       }
+      if (isThemeOutputFrameCloseAbort(request)) {
+        return;
+      }
       localFailures.push({
         kind: "theme-request-failed",
         mode,
@@ -537,7 +571,6 @@ async function checkHostedThemeModes(browser, modes) {
         { storedTheme: spec.storedTheme },
       );
       await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-      await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
 
       if (expectedSourceText) {
         await page.waitForFunction(
@@ -698,6 +731,13 @@ function isRelevantRequestUrl(value) {
   } catch {
     return false;
   }
+}
+
+function isThemeOutputFrameCloseAbort(request) {
+  if (request.failure()?.errorText !== "net::ERR_ABORTED" || !outputDocumentOrigin) {
+    return false;
+  }
+  return new URL(request.url()).origin === outputDocumentOrigin;
 }
 
 async function checkHostedRenderApi(viewerUrl, expectedSource, headsHash) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -34,7 +34,7 @@ import {
   recordRevision,
   renderKey,
   revokeNotebookAclRow,
-  runtimeSnapshotKey,
+  runtimeStateSnapshotKey,
   snapshotKey,
   type NotebookAclRow,
   type RevisionRow,
@@ -563,7 +563,9 @@ async function routeSnapshot(
   if (!runtimeStateDocId) {
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
-  const runtimeKey = runtimeHeadsHash ? runtimeSnapshotKey(notebookId, runtimeHeadsHash) : null;
+  const runtimeKey = runtimeHeadsHash
+    ? runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash)
+    : null;
   const renderCacheKey = renderKey(notebookId, headsHash);
   let renderCacheWritten = false;
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
@@ -640,13 +642,18 @@ async function routeRuntimeSnapshot(
   notebookId: string,
   headsHash: string,
 ): Promise<Response> {
-  const key = runtimeSnapshotKey(notebookId, headsHash);
-
   if (request.method === "GET") {
     const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
     if (identity instanceof Response) {
       return identity;
     }
+    const runtimeStateDocId = requiredRuntimeStateDocId(
+      request.headers.get("x-runtime-state-doc-id"),
+    );
+    if (!runtimeStateDocId) {
+      return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
+    }
+    const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       return json({ error: "runtime snapshot not found" }, 404);
@@ -689,6 +696,7 @@ async function routeRuntimeSnapshot(
   if (!runtimeStateDocId) {
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
+  const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -658,6 +658,12 @@ async function routeRuntimeSnapshot(
     if (!object) {
       return json({ error: "runtime snapshot not found" }, 404);
     }
+    if (
+      object.customMetadata?.notebook_id !== notebookId ||
+      object.customMetadata?.runtime_state_doc_id !== runtimeStateDocId
+    ) {
+      return json({ error: "runtime snapshot not found" }, 404);
+    }
 
     const headers = new Headers({
       "Cache-Control": "public, max-age=31536000, immutable",
@@ -697,6 +703,14 @@ async function routeRuntimeSnapshot(
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
   const key = runtimeStateSnapshotKey(runtimeStateDocId, headsHash);
+  const existing = await env.NOTEBOOK_SNAPSHOTS.head(key);
+  if (
+    existing &&
+    (existing.customMetadata?.notebook_id !== notebookId ||
+      existing.customMetadata?.runtime_state_doc_id !== runtimeStateDocId)
+  ) {
+    return json({ error: "runtime snapshot belongs to another notebook" }, 403);
+  }
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -165,6 +165,14 @@ export function snapshotKey(notebookId: string, headsHash: string): string {
   return `n/${encodePathComponent(notebookId)}/snapshots/${encodePathComponent(headsHash)}.am`;
 }
 
+export function documentSnapshotKey(documentId: string, headsHash: string): string {
+  return `docs/${encodePathComponent(documentId)}/snapshots/${encodePathComponent(headsHash)}.am`;
+}
+
+export function runtimeStateSnapshotKey(runtimeStateDocId: string, headsHash: string): string {
+  return documentSnapshotKey(runtimeStateDocId, headsHash);
+}
+
 export function runtimeSnapshotKey(notebookId: string, headsHash: string): string {
   return `n/${encodePathComponent(notebookId)}/snapshots/runtime-state/${encodePathComponent(headsHash)}.am`;
 }

--- a/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
@@ -29,6 +29,11 @@ describe("hosted live smoke environment", () => {
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH,
       "heads-runtime",
     );
+    assert.equal(
+      Object.hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE"),
+      false,
+      "live smoke should use the latest viewer path without requiring /render by default",
+    );
   });
 
   it("does not override explicit hosted smoke expectation env values", () => {

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -3,7 +3,9 @@ import { describe, it } from "node:test";
 
 import {
   catalogApiUrlForViewer,
+  expectedRenderSourceForViewer,
   notebookViewerUrl,
+  pinnedNotebookViewerUrl,
   renderApiUrlForViewer,
 } from "../scripts/hosted-render-smoke-routes.mjs";
 
@@ -28,6 +30,13 @@ describe("hosted render smoke routes", () => {
     );
   });
 
+  it("derives the render API URL directly from a pinned snapshot viewer URL", () => {
+    assert.equal(
+      renderApiUrlForViewer("https://preview.runt.run/n/topic-viz/r/heads-pinned", null),
+      "https://preview.runt.run/api/n/topic-viz/renders/heads-pinned",
+    );
+  });
+
   it("derives the catalog API URL from a hosted notebook viewer URL", () => {
     assert.equal(
       catalogApiUrlForViewer(
@@ -42,6 +51,10 @@ describe("hosted render smoke routes", () => {
     assert.equal(
       catalogApiUrlForViewer("https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit"),
       "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80",
+    );
+    assert.equal(
+      catalogApiUrlForViewer("https://preview.runt.run/n/topic-viz/r/heads-pinned"),
+      "https://preview.runt.run/api/n/topic-viz",
     );
   });
 
@@ -58,12 +71,33 @@ describe("hosted render smoke routes", () => {
     });
   });
 
+  it("summarizes pinned viewer URLs separately from live viewer URLs", () => {
+    assert.equal(notebookViewerUrl("https://example.com/n/foo/r/heads"), null);
+    assert.deepEqual(pinnedNotebookViewerUrl("https://example.com/n/foo/r/heads"), {
+      origin: "https://example.com",
+      notebookId: "foo",
+      headsHash: "heads",
+    });
+  });
+
+  it("treats render API checks as opt-in for latest URLs and default-on for pinned URLs", () => {
+    assert.equal(expectedRenderSourceForViewer("https://example.com/n/foo", undefined), null);
+    assert.equal(
+      expectedRenderSourceForViewer("https://example.com/n/foo/r/heads", undefined),
+      "snapshot-pair",
+    );
+    assert.equal(
+      expectedRenderSourceForViewer("https://example.com/n/foo", "snapshot-pair"),
+      "snapshot-pair",
+    );
+    assert.equal(expectedRenderSourceForViewer("https://example.com/n/foo/r/heads", ""), null);
+  });
+
   it("returns null for non-viewer URLs", () => {
     assert.equal(renderApiUrlForViewer("https://example.com/"), null);
     assert.equal(renderApiUrlForViewer("https://example.com/n/foo", null), null);
     assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync", "heads"), null);
     assert.equal(renderApiUrlForViewer("https://example.com/n/foo/debug", "heads"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/r/head123", "heads"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -31,7 +31,7 @@ import {
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
   renderKey,
-  runtimeSnapshotKey,
+  runtimeStateSnapshotKey,
   snapshotKey,
 } from "../src/storage.ts";
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
@@ -715,7 +715,7 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 201);
     assert.deepEqual(await response.json(), {
       ok: true,
-      key: runtimeSnapshotKey("api-key-artifact-demo", "api-key"),
+      key: runtimeStateSnapshotKey("runtime:api-key-artifact-demo", "api-key"),
       runtime_state_doc_id: "runtime:api-key-artifact-demo",
       size: body.byteLength,
     });
@@ -2677,6 +2677,10 @@ describe("Worker artifact routes", () => {
     const notebookPutBody = (await notebookPut.json()) as { runtime_state_doc_id: string };
     assert.equal(notebookPutBody.runtime_state_doc_id, "runtime:route-demo");
     assert.equal(env.DB.revisions[0]?.runtime_state_doc_id, "runtime:route-demo");
+    assert.equal(
+      env.DB.revisions[0]?.runtime_snapshot_key,
+      runtimeStateSnapshotKey("runtime:route-demo", "runtime-fixture"),
+    );
     assert.deepEqual(
       env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
       [

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -759,6 +759,144 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.revisions.length, 0);
   });
 
+  it("requires RuntimeStateDoc ids when reading runtime snapshots", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: "X-Runtime-State-Doc-Id header is required",
+    });
+  });
+
+  it("serves runtime snapshots from the RuntimeStateDoc namespace", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    const body = new Uint8Array([1, 2, 3, 4]);
+    const key = runtimeStateSnapshotKey("runtime:runtime-read-demo", "runtime-heads");
+    await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+      httpMetadata: { contentType: "application/octet-stream" },
+      customMetadata: {
+        artifact: "runtime-state-snapshot",
+        notebook_id: "runtime-read-demo",
+        runtime_heads_hash: "runtime-heads",
+        runtime_state_doc_id: "runtime:runtime-read-demo",
+      },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Runtime-State-Doc-Id": "runtime:runtime-read-demo",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+  });
+
+  it("does not serve runtime snapshots owned by another notebook", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-read-demo");
+    seedAcl(env, {
+      notebookId: "runtime-read-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      runtimeStateSnapshotKey("runtime:other-demo", "runtime-heads"),
+      new Uint8Array([1, 2, 3, 4]),
+      {
+        customMetadata: {
+          artifact: "runtime-state-snapshot",
+          notebook_id: "other-demo",
+          runtime_heads_hash: "runtime-heads",
+          runtime_state_doc_id: "runtime:other-demo",
+        },
+      },
+    );
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/runtime-read-demo/runtime-snapshots/runtime-heads", {
+        headers: {
+          "X-Operator": "desktop:test",
+          "X-Runtime-State-Doc-Id": "runtime:other-demo",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "runtime snapshot not found" });
+  });
+
+  it("does not replace runtime snapshots owned by another notebook", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-write-demo");
+    seedAcl(env, {
+      notebookId: "runtime-write-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      runtimeStateSnapshotKey("runtime:other-demo", "runtime-heads"),
+      new Uint8Array([1, 2, 3, 4]),
+      {
+        customMetadata: {
+          artifact: "runtime-state-snapshot",
+          notebook_id: "other-demo",
+          runtime_heads_hash: "runtime-heads",
+          runtime_state_doc_id: "runtime:other-demo",
+        },
+      },
+    );
+
+    const response = await ownerPut(
+      env,
+      "/api/n/runtime-write-demo/runtime-snapshots/runtime-heads",
+      new Uint8Array([5, 6, 7, 8]),
+      {
+        "X-Runtime-State-Doc-Id": "runtime:other-demo",
+      },
+    );
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      error: "runtime snapshot belongs to another notebook",
+    });
+  });
+
   it("allows runtime peers to upload content-addressed output blobs", async () => {
     const env = fakeEnv();
     seedNotebook(env, "runtime-demo");
@@ -3759,7 +3897,12 @@ class FakeR2Bucket implements R2Bucket {
     value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null,
     options?: R2PutOptions,
   ): Promise<R2Object> {
-    const object = new FakeR2Object(key, await toBytes(value), options?.httpMetadata);
+    const object = new FakeR2Object(
+      key,
+      await toBytes(value),
+      options?.httpMetadata,
+      options?.customMetadata,
+    );
     this.objects.set(key, object);
     return object;
   }
@@ -3774,12 +3917,12 @@ class FakeR2Object implements R2ObjectBody {
   readonly etag = "fake-etag";
   readonly httpEtag = '"fake-etag"';
   readonly uploaded = new Date("2026-05-22T00:00:00.000Z");
-  readonly customMetadata = {};
 
   constructor(
     readonly key: string,
     private readonly bytes: Uint8Array,
     readonly httpMetadata?: R2HTTPMetadata,
+    readonly customMetadata?: Record<string, string>,
   ) {}
 
   get size(): number {


### PR DESCRIPTION
## Summary

- make hosted smoke treat `/render` as optional for latest live notebook URLs
- keep pinned `/n/:id/r/:heads` smoke coverage tied to `/api/n/:id/renders/:heads`
- add hosted smoke timing milestones for first useful render diagnostics

## Stack

Depends on #3097. Merge #3097 first, then this PR once GitHub retargets this branch to `main`.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs test/hosted-live-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
