### PR TITLE
docs(elements): add theme surface catalog

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
-@import "../../../src/styles/notebook-tokens.css";
+@import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";
 
 @source "../**/*.{ts,tsx,mdx}";
@@ -11,9 +11,4 @@
 
 :root {
   --fd-layout-width: 1320px;
-}
-
-body {
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
 }

--- a/apps/elements/app/layout.tsx
+++ b/apps/elements/app/layout.tsx
@@ -14,6 +14,20 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" data-color-theme="classic" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  try {
+    const value = localStorage.getItem("notebook-color-theme");
+    document.documentElement.setAttribute("data-color-theme", value === "cream" ? "cream" : "classic");
+  } catch {
+    document.documentElement.setAttribute("data-color-theme", "classic");
+  }
+})();`,
+          }}
+        />
+      </head>
       <body className="min-h-dvh bg-fd-background text-fd-foreground">
         <RootProvider search={{ enabled: false }}>{children}</RootProvider>
       </body>

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ArrowRight, Boxes, FileCode2, ListChecks, PanelLeft } from "lucide-react";
+import { ArrowRight, Boxes, FileCode2, ListChecks, Palette, PanelLeft } from "lucide-react";
 import { RailOutlineExample } from "@/components/rail-outline-example";
 
 const entries = [
@@ -26,6 +26,12 @@ const entries = [
     description: "Future home for markdown, output, and widget examples.",
     href: "/docs",
     icon: Boxes,
+  },
+  {
+    title: "Theme surfaces",
+    description: "Classic and cream notebook palettes under shared tokens.",
+    href: "/docs/theme-surfaces",
+    icon: Palette,
   },
 ];
 
@@ -62,7 +68,7 @@ export default function Home() {
       </section>
 
       <section className="border-t border-fd-border bg-fd-muted/20">
-        <div className="mx-auto grid max-w-6xl gap-4 px-6 py-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="mx-auto grid max-w-6xl gap-4 px-6 py-8 md:grid-cols-2 lg:grid-cols-5">
           {entries.map((entry) => (
             <Link
               key={entry.title}

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -4,6 +4,7 @@ import {
   Code2,
   FileCode2,
   ListChecks,
+  Palette,
   PanelLeft,
   Rows3,
   Search,
@@ -38,10 +39,9 @@ const phases = [
   },
   {
     title: "Expose notebook themes",
-    state: "next",
-    icon: ListChecks,
-    summary:
-      "Keep classic as the docs default, then add a deliberate classic/cream preview toggle.",
+    state: "active",
+    icon: Palette,
+    summary: "Classic and cream palette checks on top of the shared notebook base CSS.",
   },
   {
     title: "Document runtime surfaces",
@@ -83,11 +83,11 @@ const families = [
   },
   {
     family: "Theme surfaces",
-    source: "src/styles/{notebook-tokens,cream-theme}.css",
+    source: "src/styles/notebook-base.css + apps/elements/components/notebook-palette-toggle.tsx",
     target: "nteract shell",
-    status: "next",
+    status: "active",
     intent:
-      "The docs app defaults to classic while importing the shared theme tokens; add a catalog-level classic/cream switch once previews need side-by-side palette checks.",
+      "The docs app now imports the shared notebook base CSS and exposes a runtime-free classic/cream palette switch for previewing catalog components.",
   },
   {
     family: "Outputs",

--- a/apps/elements/components/notebook-palette-toggle.tsx
+++ b/apps/elements/components/notebook-palette-toggle.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Palette } from "lucide-react";
+
+type NotebookPalette = "classic" | "cream";
+
+const storageKey = "notebook-color-theme";
+
+const options: Array<{
+  value: NotebookPalette;
+  label: string;
+  swatch: string;
+}> = [
+  {
+    value: "classic",
+    label: "Classic",
+    swatch: "bg-white",
+  },
+  {
+    value: "cream",
+    label: "Cream",
+    swatch: "bg-[#f5f2ec]",
+  },
+];
+
+function isNotebookPalette(value: string | null): value is NotebookPalette {
+  return value === "classic" || value === "cream";
+}
+
+function readStoredPalette(): NotebookPalette {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    return isNotebookPalette(stored) ? stored : "classic";
+  } catch {
+    return "classic";
+  }
+}
+
+function applyPalette(value: NotebookPalette) {
+  document.documentElement.setAttribute("data-color-theme", value);
+}
+
+export function NotebookPaletteToggle() {
+  const [palette, setPalette] = useState<NotebookPalette>("classic");
+
+  useEffect(() => {
+    const stored = readStoredPalette();
+    setPalette(stored);
+    applyPalette(stored);
+  }, []);
+
+  const selectPalette = (value: NotebookPalette) => {
+    setPalette(value);
+    applyPalette(value);
+    try {
+      localStorage.setItem(storageKey, value);
+    } catch {
+      // localStorage can be unavailable in private or locked-down contexts.
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1 rounded-lg border border-fd-border bg-fd-secondary/50 p-0.5 text-fd-muted-foreground"
+      aria-label="Notebook palette"
+    >
+      <Palette className="ml-1 size-3.5" aria-hidden="true" />
+      {options.map((option) => {
+        const isActive = palette === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isActive}
+            title={`${option.label} notebook palette`}
+            onClick={() => selectPalette(option.value)}
+            className={[
+              "inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors",
+              isActive
+                ? "bg-fd-background text-fd-foreground shadow-sm"
+                : "hover:bg-fd-accent hover:text-fd-accent-foreground",
+            ].join(" ")}
+          >
+            <span
+              className={[
+                "size-2.5 rounded-full border",
+                option.swatch,
+                option.value === "cream" ? "border-[#d8cec3]" : "border-fd-border",
+              ].join(" ")}
+              aria-hidden="true"
+            />
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/elements/components/theme-surfaces-example.tsx
+++ b/apps/elements/components/theme-surfaces-example.tsx
@@ -1,0 +1,83 @@
+import { NotebookPaletteToggle } from "@/components/notebook-palette-toggle";
+
+const surfaces = [
+  {
+    label: "background",
+    className: "bg-background text-foreground",
+    value: "--background",
+  },
+  {
+    label: "card",
+    className: "bg-card text-card-foreground",
+    value: "--card",
+  },
+  {
+    label: "muted",
+    className: "bg-muted text-muted-foreground",
+    value: "--muted",
+  },
+  {
+    label: "primary",
+    className: "bg-primary text-primary-foreground",
+    value: "--primary",
+  },
+];
+
+const accents = [
+  { label: "python", className: "bg-sky-500" },
+  { label: "idle", className: "bg-green-500" },
+  { label: "deno", className: "bg-emerald-500" },
+  { label: "ai", className: "bg-purple-500" },
+  { label: "error", className: "bg-red-500" },
+];
+
+export function ThemeSurfacesExample() {
+  return (
+    <div className="not-prose space-y-4 rounded-lg border border-fd-border bg-fd-card p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-fd-foreground">Notebook palette</h2>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            Shared notebook tokens under the docs shell.
+          </p>
+        </div>
+        <NotebookPaletteToggle />
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-4">
+        {surfaces.map((surface) => (
+          <div
+            key={surface.label}
+            className={["min-h-24 rounded-lg border border-border p-3", surface.className].join(
+              " ",
+            )}
+          >
+            <div className="text-sm font-semibold">{surface.label}</div>
+            <div className="mt-6 font-mono text-[11px] opacity-70">{surface.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-2 rounded-lg border border-border bg-background p-3 text-foreground">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <div className="text-sm font-semibold">Notebook accents</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              Tailwind palette variables stay theme-aware for notebook states.
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {accents.map((accent) => (
+              <span
+                key={accent.label}
+                title={accent.label}
+                className={["size-3 rounded-full", accent.className].join(" ")}
+              />
+            ))}
+          </div>
+        </div>
+        <div className="h-2 rounded-full bg-gradient-to-r from-sky-500 via-emerald-500 to-purple-500" />
+      </div>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -36,3 +36,4 @@ generic shadcn primitives under the hood.
 - [Cell anatomy](/docs/cell-anatomy)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)
+- [Theme surfaces](/docs/theme-surfaces)

--- a/apps/elements/content/docs/theme-surfaces.mdx
+++ b/apps/elements/content/docs/theme-surfaces.mdx
@@ -1,0 +1,26 @@
+---
+title: Theme surfaces
+description: Shared notebook theme tokens in the elements catalog.
+---
+
+import { ThemeSurfacesExample } from "@/components/theme-surfaces-example";
+
+The catalog defaults to the classic notebook palette while keeping the cream
+palette available for component previews. This is separate from Fumadocs'
+light/dark mode switch: light/dark controls contrast, and the notebook palette
+controls the color system used by nteract-owned UI.
+
+<ThemeSurfacesExample />
+
+## Runtime boundary
+
+The palette switch is docs-local and writes the same `data-color-theme` contract
+that notebook components already read. It does not import synced settings,
+Tauri state, runtime hooks, generated WASM, or renderer iframe state.
+
+## Catalog rule
+
+Notebook components should render correctly in classic and cream before they
+are considered catalog-ready. If a component needs iframe, renderer, or runtime
+state to respond to the palette, document that adapter boundary on the page
+that introduces it.

--- a/apps/elements/lib/layout.shared.tsx
+++ b/apps/elements/lib/layout.shared.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
+import { NotebookPaletteToggle } from "@/components/notebook-palette-toggle";
 
 export function baseOptions(): BaseLayoutProps {
   return {
@@ -11,6 +12,11 @@ export function baseOptions(): BaseLayoutProps {
         text: "Catalog",
         url: "/docs",
         active: "nested-url",
+      },
+      {
+        type: "custom",
+        secondary: true,
+        children: <NotebookPaletteToggle />,
       },
     ],
   };


### PR DESCRIPTION
## Summary

- add a docs-local notebook palette toggle for `classic` and `cream`
- default `apps/elements` to the classic notebook palette while bootstrapping the saved palette before hydration
- add a fixture-backed theme surfaces page that exercises shared notebook token surfaces and accent colors
- switch `apps/elements/app/global.css` to import the shared notebook base CSS
- update the landing page, docs index, and component burn-down to track theme surfaces as an active catalog family

## Notes

- This branch is intentionally based on `origin/main`, so it does not include the still-open #3098 runtime-surfaces cleanup.
- The palette toggle only writes `data-color-theme` and `notebook-color-theme` in local storage. It does not import synced settings, Tauri, runtime hooks, generated WASM, iframes, or renderer state.
- Fumadocs still owns light/dark mode. This adds the notebook palette axis beside it.

## Verification

- `pnpm --dir apps/elements build`
- browser smoke against `http://127.0.0.1:5176/docs/theme-surfaces`
  - initial palette is `classic`
  - switching to `cream` sets `data-color-theme="cream"` and persists `notebook-color-theme=cream`
  - switching back to `classic` restores `data-color-theme="classic"`
  - dark mode plus cream palette resolves to the cream dark background
- `cargo xtask lint --fix`
