### PR TITLE
perf(notebook-cloud): preload sift wasm for live views

### DIFF
--- a/apps/notebook-cloud/test/viewer-sift-preload.test.ts
+++ b/apps/notebook-cloud/test/viewer-sift-preload.test.ts
@@ -95,6 +95,33 @@ describe("cloud viewer Sift WASM preload", () => {
     assert.equal(targetDocument.links[0]?.crossOrigin, "anonymous");
     assert.equal(targetDocument.links[0]?.dataset.nteractPreload, "sift-wasm");
   });
+
+  it("keeps repeated live materialization preloads idempotent", () => {
+    const targetDocument = fakeDocument();
+    const cells = [
+      cell([
+        {
+          output_type: "display_data",
+          data: {
+            "application/vnd.nteract.arrow-stream-manifest+json": {
+              chunks: [{ url: "https://cloud.test/api/n/demo/blobs/sha256-table" }],
+            },
+          },
+          metadata: {},
+        },
+      ]),
+    ];
+
+    assert.equal(
+      preloadSiftWasmForCells(cells, preloadOptions(), targetDocument as unknown as Document),
+      "https://cloud.test/renderer-assets/sift_wasm.wasm?v=dev",
+    );
+    assert.equal(
+      preloadSiftWasmForCells(cells, preloadOptions(), targetDocument as unknown as Document),
+      "https://cloud.test/renderer-assets/sift_wasm.wasm?v=dev",
+    );
+    assert.equal(targetDocument.links.length, 1);
+  });
 });
 
 function cell(outputs: JupyterOutput[]): ResolvedCell {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -621,6 +621,16 @@ function NotebookViewer({
       }),
     [authState, config.blobBasePath],
   );
+  const preloadSiftWasm = useCallback(
+    (nextCells: readonly ResolvedCell[]) => {
+      preloadSiftWasmForCells(nextCells, {
+        blobBasePath: config.blobBasePath,
+        rendererAssetsBasePath: config.rendererAssetsBasePath,
+        pageUrl: location.href,
+      });
+    },
+    [config.blobBasePath, config.rendererAssetsBasePath],
+  );
   const outputHostContext = useMemo<NteractEmbedHostContextPatch>(
     () => ({
       nteract: {
@@ -707,11 +717,7 @@ function NotebookViewer({
           shouldContinue: () => !cancelled && !liveMaterializedRef.current,
         });
         if (cancelled || liveMaterializedRef.current) return;
-        preloadSiftWasmForCells(resolvedCells, {
-          blobBasePath: config.blobBasePath,
-          rendererAssetsBasePath: config.rendererAssetsBasePath,
-          pageUrl: location.href,
-        });
+        preloadSiftWasm(resolvedCells);
         setCells(resolvedCells);
         if (resolvedCells.length === 0) {
           setStatus({ kind: "empty", message: "This published notebook has no cells." });
@@ -741,8 +747,8 @@ function NotebookViewer({
     config.blobBasePath,
     config.headsHash,
     config.pinnedRenderBasePath,
-    config.rendererAssetsBasePath,
     loadingPolicy.shouldFetchSnapshotRender,
+    preloadSiftWasm,
     widgetStore,
   ]);
 
@@ -806,6 +812,7 @@ function NotebookViewer({
       if (disposed || sequence !== materializeSequence) return;
       if (syncCells.length > 0) {
         liveMaterializedRef.current = true;
+        preloadSiftWasm(syncCells);
         setCells(syncCells);
         setStatus({
           kind: "loading",
@@ -825,6 +832,7 @@ function NotebookViewer({
       });
       if (disposed || sequence !== materializeSequence) return;
       liveMaterializedRef.current = true;
+      preloadSiftWasm(resolvedCells);
       setCells(resolvedCells);
       setStatus(
         resolvedCells.length === 0
@@ -945,12 +953,12 @@ function NotebookViewer({
     authState,
     blobResolver,
     config.blobBasePath,
-    config.rendererAssetsBasePath,
     config.runtimedWasmModulePath,
     config.runtimedWasmPath,
     config.syncEndpoint,
     connectAttempt,
     loadingPolicy.shouldConnectLiveRoom,
+    preloadSiftWasm,
     widgetStore,
   ]);
 


### PR DESCRIPTION
## Summary

- preload Sift WASM from the live Automerge materialization path, not only pinned `/render` snapshots
- reuse the existing parent-page prefetch helper for sync-resolved and fully resolved live cells
- add idempotence coverage for repeated live materializations

## Context

This is the next small rendering-performance slice after #3097 and #3100 merged.
Latest notebook URLs now treat live sync as the primary source of truth, so
Sift/Arrow-heavy notebooks such as topic-viz should warm renderer sidecars from
the live path as soon as the parent page can identify Sift-backed outputs.

The output iframe sandbox remains unchanged.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-sift-preload.test.ts test/viewer-renderer-assets.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Follow-up

After merge/deploy, rerun `pnpm --dir apps/notebook-cloud smoke:hosted` against
preview.runt.run and compare `first_output_iframe` / `frame_texts` against the
previous topic-viz baseline.
