### PR TITLE
docs(elements): add editor surface catalog

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -7,6 +7,7 @@ import {
   Palette,
   PanelLeft,
   ShieldCheck,
+  TextCursorInput,
 } from "lucide-react";
 import { RailOutlineExample } from "@/components/rail-outline-example";
 
@@ -28,6 +29,12 @@ const entries = [
     description: "Inventory map for current nteract cells.",
     href: "/docs/cell-anatomy",
     icon: FileCode2,
+  },
+  {
+    title: "Editor surfaces",
+    description: "CodeMirror fixtures for notebook source editing.",
+    href: "/docs/editor-surfaces",
+    icon: TextCursorInput,
   },
   {
     title: "Output renderers",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -17,8 +17,8 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "10",
-    detail: "used shell, runtime, theme, and renderer surfaces",
+    value: "15",
+    detail: "used shell, runtime, theme, renderer, and editor surfaces",
   },
 ];
 
@@ -82,8 +82,9 @@ const families = [
     family: "Editors",
     source: "src/components/editor/**",
     target: "nteract editor",
-    status: "planned",
-    intent: "Document CodeMirror wrappers, themes, keymaps, and source-editing affordances.",
+    status: "active",
+    intent:
+      "CodeMirrorEditor, ReadOnlyCodeMirror, StaticCodeBlock, search highlighting, remote cursors, text attribution, languages, and themes now render from fixtures.",
   },
   {
     family: "Theme surfaces",
@@ -138,7 +139,7 @@ const rules = [
   {
     title: "Use current components first",
     icon: ShieldCheck,
-    body: "Catalog pages render existing components through fixtures as soon as isolation allows. Cell, runtime, theme, and output pages now start with real notebook pieces.",
+    body: "Catalog pages render existing components through fixtures as soon as isolation allows. Cell, runtime, theme, editor, and output pages now start with real notebook pieces.",
   },
   {
     title: "Audit before cataloging",

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Braces,
+  Code2,
+  FileCode2,
+  GitPullRequestArrow,
+  Languages,
+  Search,
+  Sparkles,
+  TextCursorInput,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ColorTheme } from "@/components/editor/static-highlight";
+import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import { detectCellMagic, getCellMagicLanguage } from "@/components/editor/ipython";
+import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
+import { ReadOnlyCodeMirror } from "@/components/editor/readonly-codemirror";
+import {
+  peerColor,
+  remoteCursorsExtension,
+  setRemoteCursors,
+  setRemoteSelections,
+} from "@/components/editor/remote-cursors";
+import { searchHighlight } from "@/components/editor/search-highlight";
+import { StaticCodeBlock } from "@/components/editor/static-highlight";
+import {
+  addTextAttributions,
+  textAttributionExtension,
+} from "@/components/editor/text-attribution";
+
+type SampleKey = "python" | "sql" | "markdown" | "json";
+
+const codeSamples: Record<
+  SampleKey,
+  { label: string; language: SupportedLanguage; search: string; source: string }
+> = {
+  python: {
+    label: "Python",
+    language: "python",
+    search: "features",
+    source: `features = orders.assign(month=orders.date.dt.month)
+model.fit(features[columns], target)
+predictions = model.predict(features_holdout)
+display(predictions.head())`,
+  },
+  sql: {
+    label: "SQL",
+    language: "sql",
+    search: "revenue",
+    source: `select
+  date_trunc('week', order_date) as week,
+  sum(revenue) as revenue
+from mart.orders
+group by 1
+order by 1`,
+  },
+  markdown: {
+    label: "Markdown",
+    language: "markdown",
+    search: "forecast",
+    source: `## Forecast notes
+
+- Hold out the most recent 16 weeks.
+- Compare forecast drift by product line.
+- Keep the notebook narrative close to the output.`,
+  },
+  json: {
+    label: "JSON",
+    language: "json",
+    search: "metrics",
+    source: `{
+  "run": "forecast-042",
+  "status": "complete",
+  "metrics": {
+    "mae": 8.42,
+    "mape": 0.068
+  }
+}`,
+  },
+};
+
+const renderedPieces = [
+  {
+    name: "CodeMirrorEditor",
+    source: "src/components/editor/codemirror-editor.tsx",
+    detail:
+      "Editable notebook source surface with current language, theme, keymap, and extension compartments.",
+  },
+  {
+    name: "ReadOnlyCodeMirror",
+    source: "src/components/editor/readonly-codemirror.tsx",
+    detail: "Read-only source view used by notebook/report surfaces through the same editor shell.",
+  },
+  {
+    name: "StaticCodeBlock",
+    source: "src/components/editor/static-highlight.tsx",
+    detail: "Lezer-backed static highlighting for contexts that cannot own a live EditorView.",
+  },
+  {
+    name: "searchHighlight",
+    source: "src/components/editor/search-highlight.ts",
+    detail: "Current global-find highlight decorations rendered against fixture source.",
+  },
+  {
+    name: "remoteCursorsExtension",
+    source: "src/components/editor/remote-cursors.ts",
+    detail: "Runtime-free peer cursor and selection decorations pushed into the EditorView.",
+  },
+  {
+    name: "textAttributionExtension",
+    source: "src/components/editor/text-attribution.ts",
+    detail: "Imperative attribution marks for notebook source ownership and agent edits.",
+  },
+];
+
+const adapterBoundaries = [
+  {
+    name: "useCrdtBridge",
+    reason:
+      "Requires generated WASM and notebook sync state; the catalog should receive fixture source changes instead.",
+  },
+  {
+    name: "kernelCompletionExtension",
+    reason:
+      "Queries the active runtime for completions and needs a kernel-backed adapter before rendering here.",
+  },
+  {
+    name: "presenceSenderExtension",
+    reason:
+      "Publishes local selection frames through the presence bus; this page only renders static peer state.",
+  },
+  {
+    name: "editor registry",
+    reason:
+      "Coordinates app-level focus navigation and should stay outside standalone docs examples.",
+  },
+];
+
+const magicSource = `%%sql
+select country, count(*) as notebooks
+from public_sessions
+group by country
+order by notebooks desc`;
+
+const languageMatrix: { filename: string; language: SupportedLanguage; note: string }[] = [
+  { filename: "analysis.py", language: "python", note: "PEP 8 indentation and Python parser" },
+  { filename: "query.sql", language: "sql", note: "SQL parser for cell magics and database cells" },
+  { filename: "notes.md", language: "markdown", note: "Markdown parser for source previews" },
+  { filename: "state.json", language: "json", note: "Structured metadata and renderer fixtures" },
+];
+
+function range(source: string, needle: string) {
+  const from = source.indexOf(needle);
+  return from === -1 ? { from: 0, to: 0 } : { from, to: from + needle.length };
+}
+
+function SectionHeader({
+  title,
+  source,
+  icon: Icon,
+}: {
+  title: string;
+  source: string;
+  icon: LucideIcon;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
+      <div className="flex min-w-0 items-center gap-2">
+        <Icon className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">{title}</h2>
+          <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+            {source}
+          </div>
+        </div>
+      </div>
+      <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+        rendered
+      </span>
+    </div>
+  );
+}
+
+export function EditorSurfacesExample() {
+  const [sampleKey, setSampleKey] = useState<SampleKey>("python");
+  const [mode, setMode] = useState<"light" | "dark">("light");
+  const [colorTheme, setColorTheme] = useState<ColorTheme>("classic");
+  const [draftSource, setDraftSource] = useState(codeSamples.python.source);
+  const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const sample = codeSamples[sampleKey];
+  const activeOffset = useMemo(
+    () => sample.source.toLowerCase().indexOf(sample.search.toLowerCase()),
+    [sample.search, sample.source],
+  );
+  const editorExtensions = useMemo(
+    () => [
+      ...searchHighlight(sample.search, activeOffset),
+      ...remoteCursorsExtension(),
+      ...textAttributionExtension(),
+    ],
+    [activeOffset, sample.search],
+  );
+
+  useEffect(() => {
+    setDraftSource(sample.source);
+  }, [sample.source]);
+
+  useEffect(() => {
+    let frame = 0;
+    let attempts = 0;
+
+    const applyFixtureState = () => {
+      const view = editorRef.current?.getEditor();
+      if (!view) {
+        attempts += 1;
+        if (attempts < 20) {
+          frame = window.requestAnimationFrame(applyFixtureState);
+        }
+        return;
+      }
+
+      setRemoteCursors(view, [
+        {
+          peerId: "designer",
+          peerLabel: "Ari",
+          line: 1,
+          column: 10,
+          color: peerColor("designer"),
+        },
+        {
+          peerId: "agent",
+          peerLabel: "Codex",
+          line: 2,
+          column: 14,
+          color: peerColor("agent"),
+        },
+      ]);
+      setRemoteSelections(view, [
+        {
+          peerId: "reviewer",
+          peerLabel: "Review",
+          anchorLine: 0,
+          anchorCol: 0,
+          headLine: 0,
+          headCol: Math.min(20, sample.source.split("\n")[0]?.length ?? 0),
+          color: peerColor("reviewer"),
+        },
+      ]);
+
+      const featureRange = range(sample.source, sample.search);
+      if (featureRange.to > featureRange.from) {
+        addTextAttributions(view, [
+          {
+            ...featureRange,
+            actors: ["fixture peer"],
+            color: peerColor("fixture peer"),
+          },
+        ]);
+      }
+    };
+
+    frame = window.requestAnimationFrame(applyFixtureState);
+    return () => window.cancelAnimationFrame(frame);
+  }, [colorTheme, mode, sample.search, sample.source]);
+
+  const detectedMagic = detectCellMagic(magicSource);
+  const magicLanguage = detectedMagic ? getCellMagicLanguage(detectedMagic) : "plain";
+
+  return (
+    <div className="not-prose space-y-6" data-testid="editor-surfaces-example">
+      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+        <div className="flex items-start gap-3">
+          <TextCursorInput className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Editor fixture adapter</h2>
+            <p className="mt-1 text-xs leading-5">
+              This page renders current editor components with static source fixtures. Runtime sync,
+              presence sending, kernel completion, and focus registry behavior stay documented as
+              adapter boundaries until they can be fed without notebook host state.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <SectionHeader
+          title="Live source editor"
+          source="src/components/editor/codemirror-editor.tsx"
+          icon={Code2}
+        />
+        <div className="space-y-4 p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {Object.entries(codeSamples).map(([key, value]) => (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={sampleKey === key}
+                onClick={() => setSampleKey(key as SampleKey)}
+                className={[
+                  "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                  sampleKey === key
+                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
+                ].join(" ")}
+              >
+                {value.label}
+              </button>
+            ))}
+            <span className="mx-1 h-5 w-px bg-fd-border" aria-hidden="true" />
+            {(["light", "dark"] as const).map((nextMode) => (
+              <button
+                key={nextMode}
+                type="button"
+                aria-pressed={mode === nextMode}
+                onClick={() => setMode(nextMode)}
+                className={[
+                  "rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors",
+                  mode === nextMode
+                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
+                ].join(" ")}
+              >
+                {nextMode}
+              </button>
+            ))}
+            {(["classic", "cream"] as const).map((nextTheme) => (
+              <button
+                key={nextTheme}
+                type="button"
+                aria-pressed={colorTheme === nextTheme}
+                onClick={() => setColorTheme(nextTheme)}
+                className={[
+                  "rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors",
+                  colorTheme === nextTheme
+                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
+                ].join(" ")}
+              >
+                {nextTheme}
+              </button>
+            ))}
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-border bg-background">
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Languages className="size-3.5" aria-hidden="true" />
+                <span>{languageDisplayNames[sample.language]}</span>
+                <span aria-hidden="true">·</span>
+                <span>search: {sample.search}</span>
+              </div>
+              <div className="text-xs tabular-nums text-muted-foreground">
+                {draftSource.length} chars
+              </div>
+            </div>
+            <CodeMirrorEditor
+              key={`${sampleKey}-${mode}-${colorTheme}`}
+              ref={editorRef}
+              initialValue={sample.source}
+              language={sample.language}
+              theme={mode}
+              colorTheme={colorTheme}
+              lineWrapping
+              extensions={editorExtensions}
+              onValueChange={setDraftSource}
+              className="min-h-52"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <SectionHeader
+            title="Read-only source"
+            source="src/components/editor/readonly-codemirror.tsx"
+            icon={FileCode2}
+          />
+          <div className="p-4">
+            <div className="overflow-hidden rounded-lg border border-border bg-background">
+              <ReadOnlyCodeMirror
+                value={`# Report cell
+print("source is visible but not editable")
+display(summary_table)`}
+                language="python"
+                lineWrapping
+                className="min-h-36"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <SectionHeader
+            title="Static highlighting"
+            source="src/components/editor/static-highlight.tsx"
+            icon={Braces}
+          />
+          <div className="space-y-3 p-4">
+            <StaticCodeBlock
+              code={magicSource}
+              language={magicLanguage}
+              isDark={mode === "dark"}
+              colorTheme={colorTheme}
+            />
+            <div className="rounded-md border border-fd-border bg-fd-background px-3 py-2 text-xs text-fd-muted-foreground">
+              IPython cell magic <span className="font-mono">%%{detectedMagic}</span> resolves to{" "}
+              <span className="font-mono">{magicLanguage}</span> for static preview.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <Sparkles className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">Rendered Editor Pieces</h2>
+            </div>
+          </div>
+          <div className="divide-y divide-fd-border">
+            {renderedPieces.map((piece) => (
+              <div key={piece.name} className="p-4">
+                <div className="text-sm font-semibold">{piece.name}</div>
+                <div className="mt-1 break-words font-mono text-[11px] text-fd-muted-foreground [overflow-wrap:anywhere]">
+                  {piece.source}
+                </div>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{piece.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <GitPullRequestArrow className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">Adapter Boundaries</h2>
+            </div>
+          </div>
+          <div className="divide-y divide-fd-border">
+            {adapterBoundaries.map((boundary) => (
+              <div key={boundary.name} className="p-4">
+                <div className="text-sm font-semibold">{boundary.name}</div>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{boundary.reason}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Search className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Language Matrix</h2>
+          </div>
+        </div>
+        <div className="divide-y divide-fd-border">
+          {languageMatrix.map((item) => (
+            <div
+              key={item.filename}
+              className="grid gap-2 p-4 md:grid-cols-[160px_150px_minmax(0,1fr)]"
+            >
+              <div className="font-mono text-xs text-fd-muted-foreground">{item.filename}</div>
+              <div className="text-xs font-medium">{languageDisplayNames[item.language]}</div>
+              <div className="text-xs leading-5 text-fd-muted-foreground">{item.note}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/editor-surfaces.mdx
+++ b/apps/elements/content/docs/editor-surfaces.mdx
@@ -1,0 +1,20 @@
+---
+title: Editor surfaces
+description: Runtime-free CodeMirror fixtures for notebook source editing.
+---
+
+import { EditorSurfacesExample } from "@/components/editor-surfaces-example";
+
+Notebook source editing is a major nteract-owned surface. The notebook app
+uses the shared editor package for live cell source, read-only source previews,
+static syntax highlighting, search marks, remote cursors, attribution, language
+extensions, and notebook palettes.
+
+<EditorSurfacesExample />
+
+## Adapter notes
+
+This page renders current editor components and pure CodeMirror extensions with
+static fixture state. Runtime-backed behavior stays outside the docs app until
+there are thin adapters for CRDT source sync, kernel completion, presence
+sending, and app-level editor focus registration.

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -34,6 +34,7 @@ generic shadcn primitives under the hood.
 
 - [Component burn-down](/docs/component-burndown)
 - [Cell anatomy](/docs/cell-anatomy)
+- [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Output renderers](/docs/output-renderers)
 - [Notebook outline rail](/docs/notebook-outline)

--- a/apps/elements/types/lezer-toml.d.ts
+++ b/apps/elements/types/lezer-toml.d.ts
@@ -1,0 +1,5 @@
+declare module "lezer-toml" {
+  import type { LRParser } from "@lezer/lr";
+
+  export const parser: LRParser;
+}


### PR DESCRIPTION
## Summary

- add a runtime-free editor surfaces page under `apps/elements`
- render current editor components and pure extensions from fixtures: `CodeMirrorEditor`, `ReadOnlyCodeMirror`, `StaticCodeBlock`, `searchHighlight`, `remoteCursorsExtension`, and `textAttributionExtension`
- document CRDT sync, kernel completion, presence sending, and editor registry behavior as adapter boundaries instead of importing notebook runtime state
- update the home page, docs index, Tailwind sources, path aliases, and component burn-down for the editor family

## Notes

This branch has been rebased onto current `origin/main` after the output renderer slice landed, so the catalog navigation and burn-down now include both output and editor surfaces.

The local `apps/elements/types/lezer-toml.d.ts` mirrors the existing repo declaration in `src/vite-env.d.ts` so the Next docs app can type-check the shared editor language helper without changing notebook app code.

## Verification

- `pnpm --dir apps/elements build`
- HTTP smoke against `http://127.0.0.1:5176/docs/editor-surfaces`
- Playwright hydration smoke for `/docs/editor-surfaces`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3104 --max-turns 120 --out .context/reviews/pr-3104-rebase-20260529.json` (`verdict: clear`)
- GitHub CI passed for `bdc11cea4adfec4b10f53092a463c836a5c71236`
