### PR TITLE
fix(notebook-cloud): resolve published output refs

### DIFF
--- a/apps/notebook-cloud/src/blob-refs.ts
+++ b/apps/notebook-cloud/src/blob-refs.ts
@@ -102,6 +102,8 @@ function visitArrowStreamManifest(content: string, refs: Record<string, BlobRef>
   const record = manifest as Record<string, unknown>;
   const chunks = record.chunks;
 
+  addManifestBlobRef(record, refs);
+
   if (Array.isArray(chunks)) {
     for (const chunk of chunks) {
       addManifestBlobRef(chunk, refs);

--- a/apps/notebook-cloud/test/blob-refs.test.ts
+++ b/apps/notebook-cloud/test/blob-refs.test.ts
@@ -34,6 +34,9 @@ describe("cloud blob ref collection", () => {
       data: {
         [ARROW_STREAM_MANIFEST_MIME]: {
           inline: JSON.stringify({
+            blob: "single-stream-hash",
+            size: 99,
+            content_type: "application/vnd.apache.arrow.stream",
             chunks: [
               { hash: "chunk-hash", size: 10 },
               { blob: "chunk-blob", media_type: "application/vnd.apache.arrow.stream" },
@@ -49,6 +52,7 @@ describe("cloud blob ref collection", () => {
       },
     });
 
+    assert.equal(refs["single-stream-hash"]?.size, 99);
     assert.equal(refs["chunk-hash"]?.size, 10);
     assert.equal(refs["chunk-blob"]?.media_type, "application/vnd.apache.arrow.stream");
     assert.ok(refs["sidecar-hash"]);

--- a/apps/notebook-cloud/test/render-resolution.test.ts
+++ b/apps/notebook-cloud/test/render-resolution.test.ts
@@ -536,6 +536,33 @@ describe("cloud viewer render resolution", () => {
     }
   });
 
+  it("resolves mixed Jupyter output content refs without requiring full manifests", async () => {
+    const outputs = await resolveOutputs(
+      [
+        {
+          output_id: "mixed-image-ref",
+          output_type: "display_data",
+          data: {
+            "image/png": {
+              blob: "sha256:image",
+              size: 4096,
+            },
+            "text/plain": "<Figure size 1000x500 with 1 Axes>",
+          },
+          metadata: {},
+        },
+      ],
+      rejectingBlobResolver(),
+    );
+
+    assert.equal(outputs.length, 1);
+    assert.equal(outputs[0].output_type, "display_data");
+    if (outputs[0].output_type === "display_data") {
+      assert.equal(outputs[0].data["image/png"], "https://cloud.test/blobs/sha256%3Aimage");
+      assert.equal(outputs[0].data["text/plain"], "<Figure size 1000x500 with 1 Axes>");
+    }
+  });
+
   it("keeps an explicit cell execution count over output fallbacks", async () => {
     const cell = await resolveCell(
       {

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -1,8 +1,10 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import {
   isOutputManifest,
+  resolveContentRef,
   resolveManifest,
   resolveManifestSync,
+  type ContentRef,
   type OutputManifest,
 } from "@/components/isolated/output-manifest";
 import type { BlobResolver } from "runtimed";
@@ -207,6 +209,7 @@ function resolveOutputSync(
   }
 
   if (isJupyterOutput(output)) {
+    if (jupyterOutputNeedsAsyncResolution(output)) return ASYNC_OUTPUT_REQUIRED;
     const resolved = identifyJupyterOutput(output, syntheticOutputId);
     if (cacheKey) setOutputResolutionCacheEntry(cache, cacheKey, resolved);
     return resolved;
@@ -245,10 +248,50 @@ async function resolveOutputAsyncUncached(
   }
 
   if (isJupyterOutput(output)) {
-    return identifyJupyterOutput(output, syntheticOutputId);
+    return resolveJupyterOutput(output, blobResolver, syntheticOutputId);
   }
 
   return null;
+}
+
+async function resolveJupyterOutput(
+  output: JupyterOutput,
+  blobResolver: BlobResolver,
+  outputId: string,
+): Promise<JupyterOutput> {
+  const identified = identifyJupyterOutput(output, outputId);
+
+  if (identified.output_type === "display_data" || identified.output_type === "execute_result") {
+    const data = { ...identified.data };
+    let changed = false;
+    for (const [mimeType, value] of Object.entries(data)) {
+      if (!isContentRefLike(value, mimeType)) continue;
+      data[mimeType] = await resolveContentRef(value as ContentRef, blobResolver, mimeType);
+      changed = true;
+    }
+    return changed ? { ...identified, data } : identified;
+  }
+
+  if (identified.output_type === "stream" && isContentRefLike(identified.text)) {
+    return {
+      ...identified,
+      text: await resolveContentRef(identified.text as ContentRef, blobResolver),
+    };
+  }
+
+  return identified;
+}
+
+function jupyterOutputNeedsAsyncResolution(output: JupyterOutput): boolean {
+  if (output.output_type === "display_data" || output.output_type === "execute_result") {
+    return Object.entries(output.data).some(([mimeType, value]) =>
+      isContentRefLike(value, mimeType),
+    );
+  }
+  if (output.output_type === "stream") {
+    return isContentRefLike(output.text);
+  }
+  return false;
 }
 
 function outputResolutionCacheKey(output: unknown, syntheticOutputId: string): string | null {

--- a/crates/runt-publish/src/main.rs
+++ b/crates/runt-publish/src/main.rs
@@ -14,6 +14,7 @@ use runtime_doc::RuntimeStateDoc;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use tokio::time::{sleep, Duration, Instant};
 use url::Url;
 
 const ARROW_STREAM_MANIFEST_MIME: &str = "application/vnd.nteract.arrow-stream-manifest+json";
@@ -71,7 +72,7 @@ struct Args {
     user: String,
 
     /// Operator label sent to notebook-cloud and used as the daemon peer label.
-    #[arg(long, default_value = "runt-publish")]
+    #[arg(long, default_value = "agent:runt-publish")]
     operator: String,
 }
 
@@ -138,8 +139,18 @@ async fn main() -> Result<()> {
     open.handle.await_session_ready().await?;
     open.handle.confirm_sync().await?;
     open.handle.confirm_state_sync().await?;
+    let expected_cell_count = expected_ipynb_cell_count(&notebook_path)?;
+    wait_for_imported_cells(&open.handle, expected_cell_count).await?;
+    open.handle.confirm_sync().await?;
+    open.handle.confirm_state_sync().await?;
 
     let snapshot = open.handle.save_snapshot_pair()?;
+    let exported_cell_count = notebook_snapshot_cell_count(&snapshot.notebook_bytes)?;
+    if expected_cell_count > 0 && exported_cell_count == 0 {
+        bail!(
+            "exported NotebookDoc snapshot has no cells after importing {expected_cell_count} .ipynb cells"
+        );
+    }
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
     let mut refs =
@@ -197,9 +208,7 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    let render = publisher
-        .get_json(&["api", "n", &publisher.notebook_id, "render"])
-        .await?;
+    let render = publisher.get_render(&notebook_heads_hash).await?;
     if render.get("source").and_then(Value::as_str) != Some("snapshot-pair") {
         bail!("latest render was not materialized from the uploaded snapshot pair");
     }
@@ -214,6 +223,7 @@ async fn main() -> Result<()> {
             "runtime_state_doc_id": runtime_state_doc_id,
             "notebook_heads_hash": notebook_heads_hash,
             "runtime_heads_hash": runtime_heads_hash,
+            "cell_count": exported_cell_count,
             "initial_blob_refs": initial_ref_count,
             "total_blob_refs": refs.len(),
             "uploaded_blobs": uploaded_blobs,
@@ -266,6 +276,9 @@ impl Publisher {
                 .get(&hash)
                 .cloned()
                 .with_context(|| format!("missing queued blob ref {hash}"))?;
+            if self.remote_blob_exists(&blob_ref.hash).await? {
+                continue;
+            }
             let local_blob = self.read_local_blob(&blob_ref.hash).await?;
             let content_type = blob_ref
                 .media_type
@@ -293,6 +306,28 @@ impl Publisher {
         }
 
         Ok(uploaded)
+    }
+
+    async fn remote_blob_exists(&self, hash: &str) -> Result<bool> {
+        let url = self.endpoint(&["api", "n", &self.notebook_id, "blobs", hash])?;
+        let response = self
+            .add_identity_headers(self.client.head(url.clone()))
+            .send()
+            .await?;
+        if response.status().is_success() {
+            return Ok(true);
+        }
+        if response.status().as_u16() == 404 {
+            return Ok(false);
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!(
+            "{} returned {} while checking blob existence: {}",
+            url,
+            status,
+            text
+        );
     }
 
     async fn read_local_blob(&self, hash: &str) -> Result<LocalBlob> {
@@ -373,6 +408,17 @@ impl Publisher {
         serde_json::from_str(&text).with_context(|| format!("decode JSON response from {url}"))
     }
 
+    async fn get_render(&self, notebook_heads_hash: &str) -> Result<Value> {
+        self.get_json(&[
+            "api",
+            "n",
+            &self.notebook_id,
+            "renders",
+            notebook_heads_hash,
+        ])
+        .await
+    }
+
     fn add_identity_headers(
         &self,
         mut request: reqwest::RequestBuilder,
@@ -430,6 +476,46 @@ fn collect_snapshot_blob_refs(
     collect_runtime_snapshot_blob_refs(runtime_state_bytes, &mut refs)?;
     collect_notebook_snapshot_blob_refs(notebook_bytes, &mut refs)?;
     Ok(refs)
+}
+
+fn notebook_snapshot_cell_count(notebook_bytes: &[u8]) -> Result<usize> {
+    let notebook_doc = NotebookDoc::load(notebook_bytes)
+        .context("load NotebookDoc from exported snapshot bytes")?;
+    Ok(notebook_doc.get_cells().len())
+}
+
+fn expected_ipynb_cell_count(path: &Path) -> Result<usize> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let json: Value =
+        serde_json::from_slice(&bytes).with_context(|| format!("parse {}", path.display()))?;
+    Ok(json
+        .get("cells")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len))
+}
+
+async fn wait_for_imported_cells(
+    handle: &notebook_sync::handle::DocHandle,
+    expected_cell_count: usize,
+) -> Result<()> {
+    if expected_cell_count == 0 {
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        let observed = handle.get_cells().len();
+        if observed >= expected_cell_count {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for notebook import: expected at least {expected_cell_count} cells, observed {observed}"
+            );
+        }
+        handle.confirm_sync().await?;
+        sleep(Duration::from_millis(250)).await;
+    }
 }
 
 fn runtime_state_doc_id_from_notebook_snapshot(
@@ -548,41 +634,53 @@ fn collect_blob_manifest_dependencies(value: &Value) -> Vec<BlobRef> {
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
 
+    collect_manifest_blob_ref(value, manifest_content_type.clone(), true, &mut refs);
+
     if let Some(chunks) = value.get("chunks").and_then(Value::as_array) {
         for chunk in chunks {
-            if let Some(hash) = chunk
-                .get("blob")
-                .or_else(|| chunk.get("hash"))
-                .and_then(Value::as_str)
-            {
-                refs.push(BlobRef {
-                    hash: hash.to_string(),
-                    size: size_from_value(chunk),
-                    media_type: media_type_from_value(chunk)
-                        .or_else(|| manifest_content_type.clone())
-                        .or_else(|| Some(ARROW_STREAM_CONTENT_TYPE.to_string())),
-                });
-            }
+            collect_manifest_blob_ref(chunk, manifest_content_type.clone(), true, &mut refs);
         }
     }
 
     if let Some(blobs) = value.get("blobs").and_then(Value::as_array) {
         for blob in blobs {
-            if let Some(hash) = blob
-                .get("blob")
-                .or_else(|| blob.get("hash"))
-                .and_then(Value::as_str)
-            {
-                refs.push(BlobRef {
-                    hash: hash.to_string(),
-                    size: size_from_value(blob),
-                    media_type: media_type_from_value(blob),
-                });
+            collect_manifest_blob_ref(blob, None, false, &mut refs);
+        }
+    }
+
+    if let Some(coalesced) = value.get("coalesced") {
+        collect_manifest_blob_ref(coalesced, manifest_content_type.clone(), true, &mut refs);
+        if let Some(segments) = coalesced.get("segments").and_then(Value::as_array) {
+            for segment in segments {
+                collect_manifest_blob_ref(segment, manifest_content_type.clone(), true, &mut refs);
             }
         }
     }
 
     refs
+}
+
+fn collect_manifest_blob_ref(
+    value: &Value,
+    fallback_media_type: Option<String>,
+    default_to_arrow_stream: bool,
+    refs: &mut Vec<BlobRef>,
+) {
+    let Some(hash) = value
+        .get("blob")
+        .or_else(|| value.get("hash"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+
+    refs.push(BlobRef {
+        hash: hash.to_string(),
+        size: size_from_value(value),
+        media_type: media_type_from_value(value)
+            .or(fallback_media_type)
+            .or_else(|| default_to_arrow_stream.then(|| ARROW_STREAM_CONTENT_TYPE.to_string())),
+    });
 }
 
 fn insert_blob_ref(
@@ -743,14 +841,33 @@ mod tests {
     #[test]
     fn expands_blob_manifest_dependencies() {
         let manifest = json!({
+            "blob": "single-stream",
+            "size": 99,
+            "content_type": ARROW_STREAM_CONTENT_TYPE,
             "chunks": [{"hash": "chunk-a", "size": 12}],
-            "blobs": [{"hash": "sidecar", "content_type": "text/plain"}]
+            "blobs": [{"hash": "sidecar", "content_type": "text/plain"}],
+            "coalesced": {
+                "hash": "coalesced-stream",
+                "segments": [{"hash": "coalesced-segment"}]
+            },
+            "schema": {"hash": "schema-fingerprint-only"}
         });
 
         let deps = collect_blob_manifest_dependencies(&manifest);
         assert_eq!(
             deps.iter().map(|dep| dep.hash.as_str()).collect::<Vec<_>>(),
-            vec!["chunk-a", "sidecar"]
+            vec![
+                "single-stream",
+                "chunk-a",
+                "sidecar",
+                "coalesced-stream",
+                "coalesced-segment"
+            ]
+        );
+        assert_eq!(deps[0].size, Some(99));
+        assert_eq!(
+            deps[0].media_type.as_deref(),
+            Some(ARROW_STREAM_CONTENT_TYPE)
         );
     }
 
@@ -875,6 +992,37 @@ mod tests {
         assert_eq!(
             sharded_blob_path(Path::new("/tmp/blobs"), "abcd"),
             Some(Path::new("/tmp/blobs").join("ab").join("cd"))
+        );
+    }
+
+    #[test]
+    fn publisher_verifies_materialized_render_by_heads_hash() {
+        let publisher = Publisher {
+            client: reqwest::Client::new(),
+            base_url: Url::parse("https://cloud.test/").unwrap(),
+            notebook_id: "topic-viz".to_string(),
+            vanity_name: None,
+            dev_token: None,
+            bearer_token: None,
+            auth_provider: None,
+            user: "runt-publish".to_string(),
+            operator: "agent:runt-publish".to_string(),
+            blob_base_url: None,
+            blob_store_path: None,
+        };
+
+        assert_eq!(
+            publisher
+                .endpoint(&[
+                    "api",
+                    "n",
+                    &publisher.notebook_id,
+                    "renders",
+                    "heads-fixture"
+                ])
+                .unwrap()
+                .as_str(),
+            "https://cloud.test/api/n/topic-viz/renders/heads-fixture"
         );
     }
 }

--- a/src/components/isolated/__tests__/embeddable-output.test.ts
+++ b/src/components/isolated/__tests__/embeddable-output.test.ts
@@ -102,6 +102,44 @@ describe("resolveEmbeddableOutputs", () => {
     expect(blobResolver.fetch).toHaveBeenCalledWith({ blob: "html", size: 26 });
   });
 
+  it("resolves Arrow stream manifest pointers for Sift", async () => {
+    const manifest: OutputManifest = {
+      output_id: "arrow-stream",
+      output_type: "execute_result",
+      execution_count: 1,
+      data: {
+        "application/vnd.nteract.arrow-stream-manifest+json": {
+          inline: JSON.stringify({
+            blob: "arrow-stream-hash",
+            size: 1615,
+            row_count: 200,
+          }),
+        },
+      },
+    };
+
+    const [payload] = await resolveEmbeddableOutputs(manifest, {
+      blobResolver: fakeBlobResolver({
+        "arrow-stream-hash": JSON.stringify({
+          chunks: [{ hash: "arrow-chunk-hash", row_count: 200 }],
+          complete: true,
+        }),
+      }),
+      cellId: "cell-arrow",
+    });
+
+    expect(payload?.mimeType).toBe("application/vnd.nteract.arrow-stream-manifest+json");
+    expect(payload?.data).toMatchObject({
+      complete: true,
+      chunks: [
+        {
+          url: "https://outputs.example.test/blob/arrow-chunk-hash",
+          row_count: 200,
+        },
+      ],
+    });
+  });
+
   it("requires a blob resolver for manifests", async () => {
     const manifest: OutputManifest = {
       output_id: "missing-blob-resolver",

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -157,20 +157,30 @@ function attachArrowManifestChunkUrls(
 ): unknown {
   if (typeof value !== "object" || value === null) return value;
   const manifest = value as Record<string, unknown>;
-  if (!Array.isArray(manifest.chunks)) return value;
-
   const blobResolver = normalizeBlobResolver(blobResolverInput);
+
+  if (!Array.isArray(manifest.chunks)) {
+    return value;
+  }
+
   let changed = false;
   const chunks = manifest.chunks.map((chunk) => {
     if (typeof chunk !== "object" || chunk === null) return chunk;
     const record = chunk as Record<string, unknown>;
     if (typeof record.url === "string") return chunk;
-    if (typeof record.hash !== "string") return chunk;
+    const hash = manifestBlobHash(record);
+    if (!hash) return chunk;
     changed = true;
-    return { ...record, url: blobResolver.url({ blob: record.hash }) };
+    return { ...record, url: blobResolver.url({ blob: hash }) };
   });
 
   return changed ? { ...manifest, chunks } : value;
+}
+
+function manifestBlobHash(record: Record<string, unknown>): string | null {
+  if (typeof record.blob === "string") return record.blob;
+  if (typeof record.hash === "string") return record.hash;
+  return null;
 }
 
 function parseMimeContent(mimeType: string, content: string, blobResolver: BlobResolverInput) {
@@ -185,6 +195,41 @@ function parseMimeContent(mimeType: string, content: string, blobResolver: BlobR
   }
 }
 
+async function parseMimeContentAsync(
+  mimeType: string,
+  content: string,
+  blobResolver: BlobResolverInput,
+) {
+  if (!mimeType.includes("json")) return content;
+  try {
+    const parsed = JSON.parse(content);
+    if (mimeType !== ARROW_STREAM_MANIFEST_MIME) return parsed;
+    if (isArrowManifestPointer(parsed)) {
+      const manifestContent = await resolveContentRef(parsed, blobResolver);
+      return parseMimeContent(mimeType, manifestContent, blobResolver);
+    }
+    return attachArrowManifestChunkUrls(parsed, blobResolver);
+  } catch {
+    return content;
+  }
+}
+
+function needsAsyncMimeResolution(mimeType: string, content: string): boolean {
+  if (mimeType !== ARROW_STREAM_MANIFEST_MIME) return false;
+  try {
+    return isArrowManifestPointer(JSON.parse(content));
+  } catch {
+    return false;
+  }
+}
+
+function isArrowManifestPointer(value: unknown): value is ContentRef {
+  if (!isContentRef(value)) return false;
+  if ("inline" in value) return false;
+  const record = value as Record<string, unknown>;
+  return !Array.isArray(record.chunks);
+}
+
 export async function resolveDataBundle(
   data: Record<string, ContentRef>,
   blobResolver: BlobResolverInput,
@@ -193,12 +238,13 @@ export async function resolveDataBundle(
   const contents = await Promise.all(
     entries.map(([mimeType, ref]) => resolveContentRef(ref, blobResolver, mimeType)),
   );
-  return Object.fromEntries(
-    entries.map(([mimeType], index) => [
+  const resolved = await Promise.all(
+    entries.map(async ([mimeType], index) => [
       mimeType,
-      parseMimeContent(mimeType, contents[index], blobResolver),
+      await parseMimeContentAsync(mimeType, contents[index], blobResolver),
     ]),
   );
+  return Object.fromEntries(resolved);
 }
 
 function resolveDataBundleSync(
@@ -209,6 +255,7 @@ function resolveDataBundleSync(
   for (const [mimeType, ref] of Object.entries(data)) {
     const content = resolveContentRefSync(ref, blobResolver, mimeType);
     if (content === null) return null;
+    if (needsAsyncMimeResolution(mimeType, content)) return null;
     resolved[mimeType] = parseMimeContent(mimeType, content, blobResolver);
   }
   return resolved;


### PR DESCRIPTION
## Summary

- update `runt-publish` for the Automerge-first cloud path: verify `/renders/{notebookHeadsHash}`, default to the agent operator label, wait for imported `.ipynb` cells before snapshotting, and fail instead of publishing empty snapshots
- reuse already-uploaded cloud blobs during publish and collect top-level Arrow manifest refs so recovered snapshot pairs can republish without local daemon blob copies
- resolve hosted output ContentRefs that appear inside materialized Jupyter outputs, including Arrow manifest pointers and image blobs, so topic-viz renders Sift tables/images from the published snapshot pair

## Stack

- Stacked on #3103 (`quod/notebook-cloud-live-sift-preload`). Merge #3103 first, then this PR after GitHub retargets or we rebase onto `main`.

## Verification

- `cargo test -p runt-publish`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/render-resolution.test.ts test/blob-refs.test.ts test/snapshot-render.test.ts`
- `pnpm --workspace-root exec vp test run src/components/isolated/__tests__/embeddable-output.test.ts`
- `cargo xtask lint --fix`
- `git diff --check`
- `pnpm --dir apps/notebook-cloud build`
- deployed preview workers:
  - assets: `6a55a87e-7811-4038-8e1e-0346a450ee05`
  - output document: `e971cac1-8b70-4726-9139-b16d4390031c`
  - main worker: `c9438b7a-da43-4cb3-805d-94644dde11f1`
- republished `topic-viz` with `runt-publish` using a local Anaconda API key:
  - notebook heads: `heads-037146a50878e53c5d705848`
  - runtime heads: `heads-9f1268a1532cbb67a68c53fa`
  - cells: 23
  - outputs: 24
  - blob refs: 9
- `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH=heads-037146a50878e53c5d705848 NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH=heads-9f1268a1532cbb67a68c53fa pnpm --dir apps/notebook-cloud smoke:hosted`

