### PR TITLE
docs(elements): render remaining notebook fixtures

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
+import { ExecutionCount } from "@/components/cell/ExecutionCount";
 
 const layers = [
   {
@@ -26,6 +27,12 @@ const layers = [
     status: "rendered",
   },
   {
+    name: "ExecutionCount",
+    source: "src/components/cell/ExecutionCount.tsx",
+    role: "Read-only gutter count used when notebook cells are rendered without execution controls.",
+    status: "rendered",
+  },
+  {
     name: "CodeMirrorEditor",
     source: "src/components/editor/codemirror-editor.tsx",
     role: "Source editing, search highlighting, remote cursors, completion, and attribution.",
@@ -36,6 +43,30 @@ const layers = [
     source: "src/components/cell/OutputArea.tsx",
     role: "Output focus, display mode controls, and frame-level output interaction.",
     status: "adapter needed",
+  },
+];
+
+const cellTypeFixtures = [
+  {
+    id: "fixture-code-count",
+    type: "code",
+    label: "Code cell",
+    count: 7,
+    body: "Read-only code cells use the execution count while editable code cells use the compact run control.",
+  },
+  {
+    id: "fixture-markdown-count",
+    type: "markdown",
+    label: "Markdown cell",
+    count: null,
+    body: "Markdown keeps the same container contract but shifts to the markdown gutter accent when focused.",
+  },
+  {
+    id: "fixture-raw-count",
+    type: "raw",
+    label: "Raw cell",
+    count: null,
+    body: "Raw cells use the raw gutter accent while sharing the same frame and drag affordance.",
   },
 ];
 
@@ -154,6 +185,67 @@ export function CellAnatomyExample() {
             }
             dragHandleProps={{ "aria-label": "Fixture drag handle" }}
           />
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Cell Type Gutters</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            These rows reuse the current CellContainer gutter colors and ExecutionCount component,
+            with fixture content standing in for the editor or renderer.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background py-2">
+          {cellTypeFixtures.map((cell) => (
+            <div key={cell.id} className="py-2 pl-12 pr-2">
+              <CellContainer
+                id={cell.id}
+                cellType={cell.type}
+                isFocused
+                className="mx-0 px-0"
+                gutterContent={
+                  cell.type === "code" ? (
+                    <ExecutionCount count={cell.count} />
+                  ) : (
+                    <ExecutionCount count={cell.count} className="opacity-50" />
+                  )
+                }
+              >
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center justify-between gap-3">
+                    <h3 className="truncate text-sm font-semibold">{cell.label}</h3>
+                    <span className="rounded-full border border-fd-border bg-fd-background px-2 py-1 font-mono text-[11px] text-fd-muted-foreground">
+                      {cell.type}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{cell.body}</p>
+                </div>
+              </CellContainer>
+            </div>
+          ))}
+          <div className="py-2 pl-12 pr-2">
+            <CellContainer
+              id="fixture-executing-count"
+              cellType="code"
+              isFocused
+              className="mx-0 px-0"
+              gutterContent={<ExecutionCount count={null} isExecuting />}
+            >
+              <div className="min-w-0">
+                <div className="flex min-w-0 items-center justify-between gap-3">
+                  <h3 className="truncate text-sm font-semibold">Executing count state</h3>
+                  <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-[11px] font-medium text-sky-700 dark:text-sky-300">
+                    running
+                  </span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+                  ExecutionCount renders the notebook convention for active read-only cells without
+                  requiring kernel state in the catalog.
+                </p>
+              </div>
+            </CellContainer>
+          </div>
         </div>
       </section>
 

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -17,8 +17,8 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "21",
-    detail: "used shell, runtime, theme, renderer, editor, and widget surfaces",
+    value: "22",
+    detail: "used shell toolbar, runtime, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -58,10 +58,11 @@ const phases = [
 const families = [
   {
     family: "Notebook workspace",
-    source: "apps/notebook/src/components/NotebookView.tsx",
+    source: "apps/notebook/src/components/{NotebookView,NotebookToolbar}.tsx",
     target: "nteract shell",
     status: "active",
-    intent: "Own the reading frame, sidebar rail, scroll handles, and top-level notebook chrome.",
+    intent:
+      "NotebookToolbar now renders from current source; the sidebar rail remains a fixture-backed adapter until the app owns that component.",
   },
   {
     family: "Cells",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -17,8 +17,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "22",
-    detail: "used shell toolbar, runtime, theme, renderer, editor, and widget surfaces",
+    value: "27",
+    detail:
+      "used shell toolbar, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -51,7 +52,7 @@ const phases = [
     title: "Document runtime surfaces",
     state: "active",
     icon: ShieldCheck,
-    summary: "Trust, dependency headers, environment decisions, and runtime adapter blockers.",
+    summary: "Trust, dependency headers, environment decisions, daemon state, and launch banners.",
   },
 ];
 
@@ -113,11 +114,11 @@ const families = [
   },
   {
     family: "Runtime decisions",
-    source: "apps/notebook/src/components/*Dialog.tsx",
+    source: "apps/notebook/src/components/{*Dialog,*Banner,DependencyHeader}.tsx",
     target: "nteract runtime",
     status: "active",
     intent:
-      "TrustDialog, RuntimeDecisionDialog, EnvBuildDecisionDialog, and DependencyHeader now render with fixture state; runtime-value banners still need adapters.",
+      "TrustDialog, RuntimeDecisionDialog, EnvBuildDecisionDialog, DependencyHeader, and runtime banners now render with fixture state and a host adapter for settings actions.",
   },
   {
     family: "Generic primitives",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -17,9 +17,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "27",
+    value: "28",
     detail:
-      "used shell toolbar, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -78,7 +78,7 @@ const families = [
     target: "nteract cells",
     status: "active",
     intent:
-      "CellContainer and CompactExecutionButton now render from current source; unused legacy helpers have been removed instead of cataloged.",
+      "CellContainer, CompactExecutionButton, and ExecutionCount now render from current source; unused legacy helpers have been removed instead of cataloged.",
   },
   {
     family: "Editors",

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -1,4 +1,15 @@
-import { Boxes, ListTree, Package, PanelLeft, Variable } from "lucide-react";
+"use client";
+
+import { Boxes, ListTree, Package, PanelLeft, ShieldCheck, Variable } from "lucide-react";
+import { KERNEL_STATUS, RUNTIME_STATUS, type RuntimeLifecycle } from "runtimed";
+import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
+
+const noop = () => {};
+
+const runningIdleLifecycle: RuntimeLifecycle = {
+  lifecycle: "Running",
+  activity: "Idle",
+};
 
 const outlineItems = [
   { title: "Load data", depth: 0, active: true },
@@ -29,6 +40,28 @@ const cells = [
 export function RailOutlineExample() {
   return (
     <div className="not-prose overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm">
+      <NotebookToolbar
+        kernelStatus={KERNEL_STATUS.IDLE}
+        statusKey={RUNTIME_STATUS.RUNNING_IDLE}
+        lifecycle={runningIdleLifecycle}
+        errorReason={null}
+        kernelErrorMessage={null}
+        envSource="uv:inline"
+        envTypeHint="uv"
+        envProgress={null}
+        runtime="python"
+        focusedCellId="cell-clean-columns"
+        lastCellId="cell-findings"
+        onStartKernel={noop}
+        onInterruptKernel={noop}
+        onRestartKernel={noop}
+        onRunAllCells={noop}
+        onRestartAndRunAll={noop}
+        onAddCell={noop}
+        onToggleDependencies={noop}
+        isDepsOpen={false}
+        depsOutOfSync={false}
+      />
       <div className="grid min-h-[420px] grid-cols-[48px_260px_minmax(420px,1fr)] overflow-x-auto">
         <aside className="flex flex-col items-center gap-2 border-r border-fd-border bg-fd-muted/40 px-2 py-3">
           <div className="mb-3 flex size-8 items-center justify-center rounded-md bg-fd-primary text-fd-primary-foreground">
@@ -86,6 +119,16 @@ export function RailOutlineExample() {
 
         <main className="bg-fd-muted/20 p-6">
           <div className="mx-auto max-w-2xl space-y-3">
+            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
+              <div className="mb-1 flex items-center gap-2 font-semibold">
+                <ShieldCheck className="size-3.5" aria-hidden="true" />
+                NotebookToolbar is rendered from the notebook app.
+              </div>
+              <p>
+                The rail and outline data remain fixture-backed until the app has a production rail
+                component and heading adapter.
+              </p>
+            </div>
             {cells.map((cell) => (
               <section
                 key={cell.title}

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -1,16 +1,43 @@
 "use client";
 
-import { AlertTriangle, CircleDot, PackageCheck, RotateCw, ShieldAlert } from "lucide-react";
-import { useState } from "react";
+import { NotebookHostProvider, type NotebookHost } from "@nteract/notebook-host";
+import {
+  AlertTriangle,
+  CircleDot,
+  GitBranch,
+  PackageCheck,
+  RotateCw,
+  Server,
+  ShieldAlert,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { DaemonStatusBanner } from "@/notebook-components/DaemonStatusBanner";
+import { DebugBanner } from "@/notebook-components/DebugBanner";
 import { DependencyHeader } from "@/notebook-components/DependencyHeader";
 import { EnvBuildDecisionDialog } from "@/notebook-components/EnvBuildDecisionDialog";
+import { KernelLaunchErrorBanner } from "@/notebook-components/KernelLaunchErrorBanner";
+import { PoolErrorBanner } from "@/notebook-components/PoolErrorBanner";
 import { RuntimeDecisionDialog } from "@/notebook-components/RuntimeDecisionDialog";
 import { TrustDialog } from "@/notebook-components/TrustDialog";
+import { UntrustedBanner } from "@/notebook-components/UntrustedBanner";
 
 const noop = () => {};
 const asyncNoop = async () => {};
 const asyncTrue = async () => true;
+const unlisten = () => {};
+const fixtureTransport: NotebookHost["transport"] = {
+  sendFrame: asyncNoop,
+  sendTypedRequest: async () => {
+    throw new Error("Fixture host does not send typed requests.");
+  },
+  onFrame: () => unlisten,
+  sendRequest: async () => {
+    throw new Error("Fixture host does not send requests.");
+  },
+  connected: true,
+  disconnect: noop,
+};
 
 const runtimePieces = [
   {
@@ -40,10 +67,111 @@ const runtimePieces = [
   {
     name: "KernelLaunchErrorBanner",
     source: "apps/notebook/src/components/KernelLaunchErrorBanner.tsx",
-    role: "Launch failure banner is adapter-blocked because it imports runtimed value constants.",
-    status: "adapter needed",
+    role: "Generic launch failure remediation with stderr details, copy, retry, and dismiss actions.",
+    status: "rendered",
+  },
+  {
+    name: "DaemonStatusBanner",
+    source: "apps/notebook/src/components/DaemonStatusBanner.tsx",
+    role: "Daemon progress and failure state surfaced before the notebook runtime is usable.",
+    status: "rendered",
+  },
+  {
+    name: "PoolErrorBanner",
+    source: "apps/notebook/src/components/PoolErrorBanner.tsx",
+    role: "Package manager pool warming failures with a host-provided settings action.",
+    status: "rendered",
+  },
+  {
+    name: "UntrustedBanner",
+    source: "apps/notebook/src/components/UntrustedBanner.tsx",
+    role: "Inline dependency approval gate that opens TrustDialog before kernel start.",
+    status: "rendered",
+  },
+  {
+    name: "DebugBanner",
+    source: "apps/notebook/src/components/DebugBanner.tsx",
+    role: "Development branch, commit, and daemon-version chrome for local notebook builds.",
+    status: "rendered",
   },
 ];
+
+const fixtureHost: NotebookHost = {
+  name: "elements-fixture",
+  transport: fixtureTransport,
+  daemon: {
+    isConnected: async () => true,
+    reconnect: asyncNoop,
+    getInfo: async () => null,
+    getReadyInfo: async () => null,
+  },
+  daemonEvents: {
+    onReadyLive: () => unlisten,
+    onReady: () => unlisten,
+    onProgress: () => unlisten,
+    onDisconnected: () => unlisten,
+    onUnavailable: () => unlisten,
+  },
+  relay: {
+    requiresReadyGeneration: false,
+    notifySyncReady: asyncNoop,
+  },
+  blobs: {
+    port: async () => 0,
+    resolver: async () => {
+      throw new Error("Fixture host does not resolve blobs.");
+    },
+  },
+  trust: {
+    approve: asyncNoop,
+  },
+  deps: {
+    checkTyposquats: async () => [],
+  },
+  notebook: {
+    applyPathChanged: asyncNoop,
+    getDefaultSaveDirectory: async () => "/Users/kyle/notebooks",
+    saveAs: asyncNoop,
+    openInNewWindow: asyncNoop,
+    cloneToEphemeral: async () => "fixture-room",
+  },
+  window: {
+    getTitle: async () => "fixture.ipynb",
+    setTitle: asyncNoop,
+    onFocusChange: () => unlisten,
+  },
+  system: {
+    getGitInfo: async () => null,
+    getUsername: async () => "kyle",
+  },
+  dialog: {
+    openFile: async () => null,
+    saveFile: async () => null,
+  },
+  externalLinks: {
+    open: asyncNoop,
+  },
+  updater: {
+    getSnapshot: () => ({ status: "idle", version: null, error: null }),
+    subscribe: () => unlisten,
+    check: async () => ({ status: "idle", version: null, error: null }),
+    beginUpgrade: asyncNoop,
+  },
+  settings: {
+    openWindow: asyncNoop,
+  },
+  commands: {
+    register: () => unlisten,
+    run: asyncNoop,
+    list: () => [],
+  },
+  log: {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+  },
+};
 
 const trustInfo = {
   status: "untrusted" as const,
@@ -74,6 +202,13 @@ const envBuildDetails = `Environment named "mathnet" was not found.
 conda env create -f /Users/kyle/notebooks/environment.yml
 
 The declared environment includes Python 3.13, pandas, scikit-learn, and matplotlib.`;
+
+const kernelLaunchError = [
+  "Kernel process exited immediately: exit status: 1",
+  "stderr tail:",
+  "/Users/kyle/notebooks/.venv/bin/python: No module named nteract_kernel_launcher",
+  "hint: rebuild the environment or verify the project interpreter.",
+].join("\n");
 
 function RuntimeDialogs() {
   const [trustOpen, setTrustOpen] = useState(false);
@@ -206,6 +341,137 @@ function DependencyHeaderFixture() {
   );
 }
 
+function RuntimeBanners() {
+  return (
+    <section
+      className="overflow-hidden rounded-lg border border-fd-border bg-fd-card"
+      data-elements-slot="runtime-banner-fixtures"
+    >
+      <div className="border-b border-fd-border p-4">
+        <h2 className="text-sm font-semibold">Runtime Banners</h2>
+        <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+          Rendered from notebook app components with inert callbacks and a fixture notebook host
+          where a settings action would otherwise reach the desktop shell.
+        </p>
+      </div>
+      <div className="divide-y divide-fd-border">
+        <BannerFixture
+          icon={<GitBranch className="size-4" aria-hidden="true" />}
+          name="DebugBanner"
+          description="Development build chrome for branch, commit, and daemon version."
+        >
+          <DebugBanner
+            branch="quod/elements-runtime-banners"
+            commit="755b6f6d"
+            description="docs catalog"
+            daemonVersion="2.5.2-nightly+755b6f6d"
+            isDevMode
+          />
+        </BannerFixture>
+
+        <BannerFixture
+          icon={<Server className="size-4" aria-hidden="true" />}
+          name="DaemonStatusBanner"
+          description="Startup progress and daemon failure states."
+        >
+          <div className="space-y-2">
+            <DaemonStatusBanner
+              status={{ status: "waiting_for_ready", attempt: 2, max_attempts: 8 }}
+            />
+            <DaemonStatusBanner
+              status={{
+                status: "failed",
+                error: "Socket connection timed out",
+                guidance: "Check that the dev daemon is running for this worktree.",
+              }}
+              onDismiss={noop}
+              onRetry={noop}
+            />
+          </div>
+        </BannerFixture>
+
+        <BannerFixture
+          icon={<AlertTriangle className="size-4" aria-hidden="true" />}
+          name="PoolErrorBanner"
+          description="Pool warming warnings for package manager defaults."
+        >
+          <NotebookHostProvider host={fixtureHost}>
+            <PoolErrorBanner
+              uvError={{
+                message: "Failed to warm uv environment",
+                failed_package: "reqeusts",
+                error_kind: "invalid_package",
+                consecutive_failures: 3,
+                retry_in_secs: 60,
+                receivedAt: Date.now(),
+              }}
+              condaError={{
+                message: "Conda solve timed out",
+                failed_package: "scikit-learn",
+                error_kind: "timeout",
+                consecutive_failures: 1,
+                retry_in_secs: 30,
+                receivedAt: Date.now(),
+              }}
+              pixiError={null}
+              onDismissUv={noop}
+              onDismissConda={noop}
+              onDismissPixi={noop}
+            />
+          </NotebookHostProvider>
+        </BannerFixture>
+
+        <BannerFixture
+          icon={<ShieldAlert className="size-4" aria-hidden="true" />}
+          name="UntrustedBanner"
+          description="Inline trust gate before dependency-backed kernel start."
+        >
+          <UntrustedBanner onReviewClick={noop} />
+        </BannerFixture>
+
+        <BannerFixture
+          icon={<AlertTriangle className="size-4" aria-hidden="true" />}
+          name="KernelLaunchErrorBanner"
+          description="Generic launch failure details after typed remediation cases are excluded."
+        >
+          <KernelLaunchErrorBanner
+            errorDetails={kernelLaunchError}
+            onRetry={noop}
+            onDismiss={noop}
+          />
+        </BannerFixture>
+      </div>
+    </section>
+  );
+}
+
+function BannerFixture({
+  children,
+  description,
+  icon,
+  name,
+}: {
+  children: ReactNode;
+  description: string;
+  icon: ReactNode;
+  name: string;
+}) {
+  return (
+    <div className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+      <div>
+        <div className="flex items-center gap-2 text-fd-muted-foreground">
+          {icon}
+          <h3 className="text-sm font-semibold text-fd-foreground">{name}</h3>
+        </div>
+        <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{description}</p>
+      </div>
+      <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export function RuntimeSurfacesExample() {
   return (
     <div className="not-prose space-y-6">
@@ -224,6 +490,8 @@ export function RuntimeSurfacesExample() {
       </section>
 
       <DependencyHeaderFixture />
+
+      <RuntimeBanners />
 
       <section className="rounded-lg border border-fd-border bg-fd-card p-4">
         <div className="mb-4">

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -19,9 +19,10 @@ should not own cell rendering. A clear cell anatomy gives the sidebar a stable
 contract while preserving the existing `NotebookView` DOM-order invariant.
 
 This docs site should keep moving component by component toward runtime-free
-fixtures. Editor, output, and full cell examples still need adapters before
-they can safely render without generated WASM, iframe/plugin context, notebook
-sync state, or runtime hooks.
+fixtures. The cell frame, compact execution button, execution count, and
+cell-type gutter accents now render from current source. Editor, output, and
+full cell examples still need adapters before they can safely render without
+generated WASM, iframe/plugin context, notebook sync state, or runtime hooks.
 
 Unused legacy cell helper components should be removed rather than cataloged.
 Catalog entries need to trace to notebook app usage, an active migration target,

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -9,12 +9,18 @@ The rail outline is the first production direction for a notebook table of
 contents. It keeps reading navigation available while leaving clear sibling
 slots for packages, variables, renderers, and future notebook tools.
 
+This fixture now renders the current notebook app toolbar directly. The rail
+itself stays catalog-owned until the notebook app has a production left-rail
+component to import.
+
 <RailOutlineExample />
 
 ## Implementation intent
 
 - The real app should wrap `NotebookView` in a workspace shell rather than
   moving cells into the sidebar.
+- `NotebookToolbar` is imported from `apps/notebook/src/components` with inert
+  fixture callbacks and runtime status props.
 - The outline should start from materialized markdown headings.
 - Keep the rail icon-led: outline, packages, variables, renderers, and future
   side panels should scan as compact tools before a panel opens.

--- a/apps/elements/content/docs/runtime-surfaces.mdx
+++ b/apps/elements/content/docs/runtime-surfaces.mdx
@@ -6,13 +6,13 @@ description: Fixture-backed runtime decision components from the notebook app.
 import { RuntimeSurfacesExample } from "@/components/runtime-surfaces-example";
 
 Runtime decisions are notebook UI, not generic dialogs. This page starts
-cataloging the existing dependency and launch decision surfaces with fixtures
-instead of host state.
+cataloging the existing dependency, daemon, pool, trust, and launch decision
+surfaces with fixtures instead of live runtime state.
 
 <RuntimeSurfacesExample />
 
 ## Adapter notes
 
-The current fixtures keep side effects inert. Components that import runtime
-value constants, daemon state, or host-backed hooks should get a thin adapter
-before they are rendered here.
+The current fixtures keep side effects inert. Components that need desktop host
+access, such as the pool settings action, render under a small fixture host
+adapter instead of importing notebook shell state into the docs app.

--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slider": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,6 +292,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
## Summary

- consolidate the remaining elements catalog slices into this PR: notebook toolbar, runtime banners, and cell gutter fixtures
- render the production `NotebookToolbar` inside the notebook outline fixture with inert callbacks and fixture runtime status props
- render notebook runtime banners with a fixture `NotebookHostProvider` for host actions instead of app shell/runtime state
- render `ExecutionCount` in the cell anatomy catalog alongside existing `CellContainer` and `CompactExecutionButton` fixtures
- update the component burn-down, docs pages, docs-app HoverCard dependency, and lockfile for the combined catalog state

## Notes

This replaces the separate runtime-banner and cell-gutter PRs with one combined elements PR so the stack pays one rebase/review/CI cycle.

Notebook app source is unchanged. The imported components stay canonical in `apps/notebook` and `src/components`; this PR only adds fixture-backed catalog usage under `apps/elements`.

## Verification

- `pnpm install`
- `pnpm --dir apps/elements build`
- Browser smoke against:
  - `http://127.0.0.1:5176/docs/notebook-outline`
  - `http://127.0.0.1:5176/docs/runtime-surfaces`
  - `http://127.0.0.1:5176/docs/cell-anatomy`
- `cargo xtask lint --fix`
- `git diff --check`
- `uv run pr-review https://github.com/nteract/nteract/pull/3107 --max-turns 120 --out .context/reviews/pr-3107-combined-20260529.json` (`verdict: clear`)
- GitHub CI: pending for `9a10936b344addcc2bb88b1b1d8f6c7db8449e12`
