### PR TITLE
test(notebook-cloud): guard live smoke routes

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -2,7 +2,7 @@ export function renderApiUrlForViewer(viewerUrl, headsHash) {
   const pinned = pinnedNotebookViewerUrl(viewerUrl);
   if (pinned) {
     return new URL(
-      `/api/n/${pinned.notebookId}/renders/${encodeURIComponent(pinned.headsHash)}`,
+      `/api/n/${encodeURIComponent(pinned.notebookId)}/renders/${encodeURIComponent(pinned.headsHash)}`,
       pinned.origin,
     ).href;
   }
@@ -12,9 +12,59 @@ export function renderApiUrlForViewer(viewerUrl, headsHash) {
     return null;
   }
   return new URL(
-    `/api/n/${parsed.notebookId}/renders/${encodeURIComponent(headsHash)}`,
+    `/api/n/${encodeURIComponent(parsed.notebookId)}/renders/${encodeURIComponent(headsHash)}`,
     parsed.origin,
   ).href;
+}
+
+export function hostedNotebookRequestKind(viewerUrl, requestUrl) {
+  const target = notebookViewerUrl(viewerUrl) ?? pinnedNotebookViewerUrl(viewerUrl);
+  if (!target) {
+    return null;
+  }
+
+  const parsedRequest = new URL(requestUrl);
+  if (!sameHostedOrigin(parsedRequest, target.origin)) {
+    return null;
+  }
+
+  const liveSyncMatch = parsedRequest.pathname.match(/^\/n\/([^/]+)\/sync\/?$/);
+  if (liveSyncMatch && decodeURIComponent(liveSyncMatch[1]) === target.notebookId) {
+    return { kind: "live-sync" };
+  }
+
+  const catalogMatch = parsedRequest.pathname.match(/^\/api\/n\/([^/]+)\/?$/);
+  if (catalogMatch && decodeURIComponent(catalogMatch[1]) === target.notebookId) {
+    return { kind: "catalog" };
+  }
+
+  const renderMatch = parsedRequest.pathname.match(/^\/api\/n\/([^/]+)\/renders\/([^/]+)$/);
+  if (renderMatch && decodeURIComponent(renderMatch[1]) === target.notebookId) {
+    return { kind: "render-cache", headsHash: decodeURIComponent(renderMatch[2]) };
+  }
+
+  const legacyRenderMatch = parsedRequest.pathname.match(/^\/api\/n\/([^/]+)\/render\/?$/);
+  if (legacyRenderMatch && decodeURIComponent(legacyRenderMatch[1]) === target.notebookId) {
+    return { kind: "legacy-render" };
+  }
+
+  return null;
+}
+
+function sameHostedOrigin(parsedRequest, targetOrigin) {
+  const target = new URL(targetOrigin);
+  const requestProtocol =
+    parsedRequest.protocol === "wss:"
+      ? "https:"
+      : parsedRequest.protocol === "ws:"
+        ? "http:"
+        : parsedRequest.protocol;
+
+  return (
+    parsedRequest.hostname === target.hostname &&
+    parsedRequest.port === target.port &&
+    requestProtocol === target.protocol
+  );
 }
 
 export function catalogApiUrlForViewer(viewerUrl) {
@@ -22,7 +72,7 @@ export function catalogApiUrlForViewer(viewerUrl) {
   if (!parsed) {
     return null;
   }
-  return new URL(`/api/n/${parsed.notebookId}`, parsed.origin).href;
+  return new URL(`/api/n/${encodeURIComponent(parsed.notebookId)}`, parsed.origin).href;
 }
 
 export function expectedRenderSourceForViewer(viewerUrl, envValue) {
@@ -43,7 +93,11 @@ export function notebookViewerUrl(viewerUrl) {
   if (vanityName && ["debug", "r", "sync"].includes(vanityName)) {
     return null;
   }
-  return { origin: parsed.origin, notebookId, vanityName: vanityName ?? null };
+  return {
+    origin: parsed.origin,
+    notebookId: decodeURIComponent(notebookId),
+    vanityName: vanityName ? decodeURIComponent(vanityName) : null,
+  };
 }
 
 export function pinnedNotebookViewerUrl(viewerUrl) {
@@ -53,5 +107,9 @@ export function pinnedNotebookViewerUrl(viewerUrl) {
     return null;
   }
   const [, notebookId, headsHash] = match;
-  return { origin: parsed.origin, notebookId, headsHash };
+  return {
+    origin: parsed.origin,
+    notebookId: decodeURIComponent(notebookId),
+    headsHash: decodeURIComponent(headsHash),
+  };
 }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -19,6 +19,8 @@ import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import {
   catalogApiUrlForViewer,
   expectedRenderSourceForViewer,
+  hostedNotebookRequestKind,
+  notebookViewerUrl,
   renderApiUrlForViewer,
 } from "./hosted-render-smoke-routes.mjs";
 
@@ -59,6 +61,15 @@ const expectedLatestRevisionNotebookHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH ?? "";
 const expectedLatestRevisionRuntimeHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH ?? "";
+const latestViewerTarget = notebookViewerUrl(targetUrl);
+const expectLiveSync =
+  process.env.NOTEBOOK_CLOUD_EXPECT_LIVE_SYNC === undefined
+    ? latestViewerTarget !== null
+    : process.env.NOTEBOOK_CLOUD_EXPECT_LIVE_SYNC !== "0";
+const forbidLegacyRenderRoute = process.env.NOTEBOOK_CLOUD_FORBID_LEGACY_RENDER !== "0";
+const expectedWarmStartRenderHeadsHash =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_WARM_START_RENDER_HEADS_HASH ??
+  (latestViewerTarget ? expectedLatestRevisionNotebookHeadsHash : "");
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const requireRuntimedWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_RUNTIMED_WASM !== "0";
 const requireViewerCssSplit = process.env.NOTEBOOK_CLOUD_REQUIRE_VIEWER_CSS_SPLIT !== "0";
@@ -91,6 +102,12 @@ const failures = [];
 const warnings = [];
 const siftWasmRequests = [];
 const runtimedWasmRequests = [];
+const notebookRouteRequests = {
+  catalog: [],
+  liveSync: [],
+  renderCache: [],
+  legacyRender: [],
+};
 const rendererCompletions = [];
 const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
@@ -141,6 +158,14 @@ async function main() {
 
   page.on("pageerror", (error) => {
     failures.push({ kind: "page-error", text: error.message });
+  });
+
+  page.on("request", (request) => {
+    captureNotebookRouteRequest(request.url());
+  });
+
+  page.on("websocket", (socket) => {
+    captureNotebookRouteRequest(socket.url());
   });
 
   page.on("requestfailed", (request) => {
@@ -307,6 +332,32 @@ async function main() {
     if (requireRuntimedWasm && runtimedWasmRequests.length === 0) {
       failures.push({ kind: "runtimed-wasm", text: "runtimed WASM was not requested" });
     }
+    if (expectLiveSync && notebookRouteRequests.liveSync.length === 0) {
+      failures.push({
+        kind: "live-sync-route",
+        text: "Latest notebook viewer did not open the live sync route",
+        observedRoutes: notebookRouteRequests,
+      });
+    }
+    if (forbidLegacyRenderRoute && notebookRouteRequests.legacyRender.length > 0) {
+      failures.push({
+        kind: "legacy-render-route",
+        text: "Hosted viewer requested the deprecated latest render route",
+        observedRoutes: notebookRouteRequests,
+      });
+    }
+    if (
+      expectedWarmStartRenderHeadsHash &&
+      !notebookRouteRequests.renderCache.some(
+        (request) => request.headsHash === expectedWarmStartRenderHeadsHash,
+      )
+    ) {
+      failures.push({
+        kind: "warm-start-render-route",
+        text: `Latest notebook viewer did not warm start from /renders/${expectedWarmStartRenderHeadsHash}`,
+        observedRoutes: notebookRouteRequests,
+      });
+    }
     failures.push(...fatalIsolatedDiagnostics.map(isolatedDiagnosticFailure));
     for (const request of siftWasmRequests) {
       if (request.status >= 400) {
@@ -423,6 +474,9 @@ async function main() {
           expectedLatestRevisionActorLabel,
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
+          expectLiveSync,
+          forbidLegacyRenderRoute,
+          expectedWarmStartRenderHeadsHash,
           timings_ms: timingsMs,
           renderApiCheck,
           catalogApiCheck,
@@ -434,6 +488,7 @@ async function main() {
           pageTextMatches,
           themeModeChecks,
           iframeMetrics,
+          notebookRouteRequests,
           siftWasmRequests,
           runtimedWasmRequests,
           rendererCompletions: rendererCompletions.length,
@@ -484,6 +539,28 @@ function parseExpectedTexts(envName, fallback) {
 
 function markTiming(name) {
   timingsMs[name] ??= Math.round(performance.now() - smokeStartedAt);
+}
+
+function captureNotebookRouteRequest(url) {
+  const route = hostedNotebookRequestKind(targetUrl, url);
+  if (!route) {
+    return;
+  }
+
+  switch (route.kind) {
+    case "catalog":
+      notebookRouteRequests.catalog.push({ url });
+      break;
+    case "live-sync":
+      notebookRouteRequests.liveSync.push({ url });
+      break;
+    case "render-cache":
+      notebookRouteRequests.renderCache.push({ url, headsHash: route.headsHash });
+      break;
+    case "legacy-render":
+      notebookRouteRequests.legacyRender.push({ url });
+      break;
+  }
 }
 
 function themeModeSpec(value) {

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   catalogApiUrlForViewer,
   expectedRenderSourceForViewer,
+  hostedNotebookRequestKind,
   notebookViewerUrl,
   pinnedNotebookViewerUrl,
   renderApiUrlForViewer,
@@ -71,6 +72,34 @@ describe("hosted render smoke routes", () => {
     });
   });
 
+  it("decodes viewer URL path segments before matching hosted requests", () => {
+    assert.deepEqual(notebookViewerUrl("https://example.com/n/folder%2Fdemo/lets%20edit"), {
+      origin: "https://example.com",
+      notebookId: "folder/demo",
+      vanityName: "lets edit",
+    });
+    assert.deepEqual(pinnedNotebookViewerUrl("https://example.com/n/folder%2Fdemo/r/heads%2F1"), {
+      origin: "https://example.com",
+      notebookId: "folder/demo",
+      headsHash: "heads/1",
+    });
+    assert.deepEqual(
+      hostedNotebookRequestKind(
+        "https://example.com/n/folder%2Fdemo/lets%20edit",
+        "wss://example.com/n/folder%2Fdemo/sync",
+      ),
+      { kind: "live-sync" },
+    );
+    assert.equal(
+      catalogApiUrlForViewer("https://example.com/n/folder%2Fdemo/lets%20edit"),
+      "https://example.com/api/n/folder%2Fdemo",
+    );
+    assert.equal(
+      renderApiUrlForViewer("https://example.com/n/folder%2Fdemo/lets%20edit", "heads/2"),
+      "https://example.com/api/n/folder%2Fdemo/renders/heads%2F2",
+    );
+  });
+
   it("summarizes pinned viewer URLs separately from live viewer URLs", () => {
     assert.equal(notebookViewerUrl("https://example.com/n/foo/r/heads"), null);
     assert.deepEqual(pinnedNotebookViewerUrl("https://example.com/n/foo/r/heads"), {
@@ -91,6 +120,52 @@ describe("hosted render smoke routes", () => {
       "snapshot-pair",
     );
     assert.equal(expectedRenderSourceForViewer("https://example.com/n/foo/r/heads", ""), null);
+  });
+
+  it("classifies live notebook route requests for hosted smoke assertions", () => {
+    const viewerUrl = "https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit";
+
+    assert.deepEqual(
+      hostedNotebookRequestKind(
+        viewerUrl,
+        "wss://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/sync?viewer_session=abc",
+      ),
+      { kind: "live-sync" },
+    );
+    assert.deepEqual(
+      hostedNotebookRequestKind(
+        viewerUrl,
+        "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80",
+      ),
+      { kind: "catalog" },
+    );
+    assert.deepEqual(
+      hostedNotebookRequestKind(
+        viewerUrl,
+        "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/renders/heads-edit",
+      ),
+      { kind: "render-cache", headsHash: "heads-edit" },
+    );
+    assert.deepEqual(
+      hostedNotebookRequestKind(
+        viewerUrl,
+        "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/render",
+      ),
+      { kind: "legacy-render" },
+    );
+  });
+
+  it("ignores route requests for other origins or notebooks", () => {
+    const viewerUrl = "https://preview.runt.run/n/topic-viz";
+
+    assert.equal(
+      hostedNotebookRequestKind(viewerUrl, "https://preview.runt.run/api/n/other/render"),
+      null,
+    );
+    assert.equal(
+      hostedNotebookRequestKind(viewerUrl, "https://example.com/api/n/topic-viz/render"),
+      null,
+    );
   });
 
   it("returns null for non-viewer URLs", () => {


### PR DESCRIPTION
## Summary

- add hosted smoke request classification for catalog, live sync, render-cache, and legacy render routes
- require latest notebook viewer smoke runs to observe `/n/:id/sync`
- fail hosted smoke if the page regresses to deprecated `/api/n/:id/render`
- verify known latest heads warm-start through immutable `/api/n/:id/renders/:heads`

## Stack Order

Merge in order:

1. #3103
2. #3106
3. #3108
4. this PR

This PR targets `quod/notebook-cloud-live-render-warmstart`; retarget to `main` after #3108 lands.

## Verification

```bash
pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs test/hosted-live-smoke-env.test.mjs
pnpm --dir apps/notebook-cloud typecheck
cargo xtask lint --fix
NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/topic-viz/topic-viz \
NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH=heads-037146a50878e53c5d705848 \
NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH=heads-9f1268a1532cbb67a68c53fa \
pnpm --dir apps/notebook-cloud smoke:hosted
```

Hosted route evidence from the smoke:

- observed live sync: `wss://preview.runt.run/n/topic-viz/sync?...`
- observed warm-start cache: `/api/n/topic-viz/renders/heads-037146a50878e53c5d705848`
- observed legacy render requests: none
