### PR TITLE
refactor(notebook-cloud): load pinned snapshots directly

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -4,7 +4,7 @@ This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It 
 
 The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata for sync frames that actually change a materialized document. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
 
-`/n/:notebookId` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` and `/api/n/:id/renders/:headsHash` remain pinned snapshot surfaces for immutable revisions, publish validation, export/debug readback, and cache regeneration. Snapshot-pair publishes also pre-materialize the pinned render cache before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
+`/n/:notebookId` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` is an immutable pinned viewer that loads the persisted `NotebookDoc` + `RuntimeStateDoc` Automerge snapshot pair directly through `/api/n/:id/snapshots/:headsHash`, `/api/n/:id/runtime-snapshots/:runtimeHeadsHash`, and catalog revision metadata. Snapshot-pair publishes validate that the pair can be loaded and that referenced output blobs exist before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
 ## Local dev
 
@@ -100,8 +100,8 @@ runtime-derived execution count, that sandboxed output iframes expose expected
 markdown and Sift notebook content, and that Sift's WASM sidecar loads from the
 configured renderer asset origin with CORS. Latest notebook URLs are validated
 through the live viewer path and catalog metadata; pinned
-`/n/:id/r/:headsHash` URLs also check the corresponding
-`/api/n/:id/renders/:headsHash` report. Override the target with
+`/n/:id/r/:headsHash` URLs load persisted Automerge snapshot bytes rather than a
+materialized render API. Override the target with
 `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
 artifact.
@@ -114,9 +114,6 @@ renderers are checked as frame text because they render inside sandboxed output
 documents. Frame texts can be a JSON string array or a `|`-delimited list. Set
 `NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS` only for text that should appear in the
 parent viewer document. Set
-`NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=snapshot-pair` to require the render API
-source check for a latest live URL, or set
-`NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE=` to skip that check for a pinned URL. Set
 `NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL=` and
 `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL=` to skip the live-publish
 catalog provenance checks, or set them to the expected owner/actor for another
@@ -127,9 +124,9 @@ catalog check to a specific exported snapshot pair. Set
 Sift output.
 
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
-uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the rendered
+uploads its `NotebookDoc` + `RuntimeStateDoc` snapshot pair, walks the exported
 output manifests for blob refs, uploads the matching local daemon blobs, and
-materializes the hosted render. By default it creates and executes a small
+verifies the catalog revision. By default it creates and executes a small
 `ShadenA/MathNet` Polars notebook. Set `NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID=<id>`
 to publish an already-open live notebook room instead.
 
@@ -401,7 +398,7 @@ Bindings in `wrangler.toml`:
 
 - `NOTEBOOK_ROOMS`: Durable Object namespace, one object per notebook id.
 - `DB`: D1 catalog for notebooks, revisions, and blobs.
-- `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, generated render caches, and blobs.
+- `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc` snapshots, `RuntimeStateDoc` snapshots, and blobs.
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 - `RUNTIMED_WASM_BASE_URL` (optional): base URL for `runtimed_wasm.js` and `runtimed_wasm_bg.wasm`. The prototype deployment also points this at the dedicated asset Worker so the large WASM module is loaded as a CDN cacheable file instead of being inlined into the viewer bundle.
@@ -420,15 +417,12 @@ Published revision artifacts follow `docs/architecture/hosted-notebook-artifacts
 n/{id}/snapshots/{notebookHeadsHash}.am
 n/{id}/snapshots/runtime-state/{runtimeHeadsHash}.am
 n/{id}/blobs/{sha256}
-n/{id}/renders/{notebookHeadsHash}.json
 ```
 
-The render path is derived. Snapshot-pair publishes pre-materialize it to prove
-the pair and all referenced blobs are complete before recording a revision. If
-the render object is later missing, the Worker can load the snapshot pair
-through `runtimed-wasm` and regenerate the materialized render response. Clients
-cannot upload render-cache JSON directly; the Worker only writes render caches
-from persisted snapshot pairs.
+Snapshot-pair publishes validate that the pair can be loaded through
+`runtimed-wasm` and that all referenced blobs are present before recording a
+revision. The hosted viewer reads the snapshot pair directly for pinned
+revisions and uses `/n/:id/sync` for live latest views.
 
 ## Prototype deployment
 
@@ -496,9 +490,9 @@ Useful events while debugging collaboration:
 - `room.materializer.loaded`, `room.materializer.checkpoint.saved`, and
   `room.materializer.snapshot_pair_missing` - Durable Object materialization and
   persisted snapshot health.
-- `render.materialization.completed`, `render.materialization.failed`, and
-  `render.materialization.missing_blobs` - render-cache generation health and
-  missing output blob diagnosis.
+- `snapshot_pair.validation.completed`, `snapshot_pair.validation.failed`, and
+  `snapshot_pair.validation.missing_blobs` - publish-time snapshot-pair health
+  and missing output blob diagnosis.
 - `asset.fetch.completed` - viewer, `runtimed-wasm`, and renderer-plugin sidecar
   asset delivery. Filter by `asset_kind=renderer_plugin` for Sift WASM loading.
 - `blob.read.missing`, `blob.upload.completed`, and `blob.upload.rejected` -
@@ -587,11 +581,13 @@ curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
   --data-binary @output.bin
 ```
 
-Catalog and pinned render readback:
+Catalog and pinned snapshot readback:
 
 ```bash
 curl "http://127.0.0.1:8787/api/n/demo"
-curl "http://127.0.0.1:8787/api/n/demo/renders/{notebookHeadsHash}"
+curl "http://127.0.0.1:8787/api/n/demo/snapshots/{notebookHeadsHash}"
+curl "http://127.0.0.1:8787/api/n/demo/runtime-snapshots/{runtimeHeadsHash}" \
+  -H "X-Runtime-State-Doc-Id: {runtimeStateDocId}"
 ```
 
 ## Next integration steps

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-preflight.mjs
@@ -1,4 +1,4 @@
-const PREFLIGHT_FAILURE_KINDS = new Set(["render-api", "catalog-api", "viewer-css"]);
+const PREFLIGHT_FAILURE_KINDS = new Set(["catalog-api", "viewer-css"]);
 
 export function hasPreflightFailures(failures) {
   return (

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -1,36 +1,9 @@
-export function renderApiUrlForViewer(viewerUrl, headsHash) {
-  const pinned = pinnedNotebookViewerUrl(viewerUrl);
-  if (pinned) {
-    return new URL(
-      `/api/n/${pinned.notebookId}/renders/${encodeURIComponent(pinned.headsHash)}`,
-      pinned.origin,
-    ).href;
-  }
-
-  const parsed = notebookViewerUrl(viewerUrl);
-  if (!parsed || typeof headsHash !== "string" || headsHash.length === 0) {
-    return null;
-  }
-  return new URL(
-    `/api/n/${parsed.notebookId}/renders/${encodeURIComponent(headsHash)}`,
-    parsed.origin,
-  ).href;
-}
-
 export function catalogApiUrlForViewer(viewerUrl) {
   const parsed = notebookViewerUrl(viewerUrl) ?? pinnedNotebookViewerUrl(viewerUrl);
   if (!parsed) {
     return null;
   }
   return new URL(`/api/n/${parsed.notebookId}`, parsed.origin).href;
-}
-
-export function expectedRenderSourceForViewer(viewerUrl, envValue) {
-  if (envValue !== undefined) {
-    const trimmed = envValue.trim();
-    return trimmed ? trimmed : null;
-  }
-  return pinnedNotebookViewerUrl(viewerUrl) ? "snapshot-pair" : null;
 }
 
 export function notebookViewerUrl(viewerUrl) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -16,11 +16,7 @@ import {
   parsePositiveInteger,
 } from "./hosted-render-smoke-assets.mjs";
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
-import {
-  catalogApiUrlForViewer,
-  expectedRenderSourceForViewer,
-  renderApiUrlForViewer,
-} from "./hosted-render-smoke-routes.mjs";
+import { catalogApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -46,10 +42,6 @@ const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEX
   "Schema at a glance",
   "PROBLEM_MARKDOWN",
 ]);
-const expectedRenderSource = expectedRenderSourceForViewer(
-  targetUrl,
-  process.env.NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE,
-);
 const expectedCatalogOwnerPrincipal =
   process.env.NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL ?? DEFAULT_CATALOG_OWNER_PRINCIPAL;
 const expectedLatestRevisionActorLabel =
@@ -94,7 +86,6 @@ const runtimedWasmRequests = [];
 const rendererCompletions = [];
 const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
-let renderApiCheck = null;
 let catalogApiCheck = null;
 let viewerCssCheck = null;
 let screenshotSaved = false;
@@ -176,7 +167,6 @@ async function main() {
 
   try {
     if (
-      expectedRenderSource ||
       expectedCatalogOwnerPrincipal ||
       expectedLatestRevisionActorLabel ||
       expectedLatestRevisionNotebookHeadsHash ||
@@ -188,13 +178,6 @@ async function main() {
         expectedLatestRevisionNotebookHeadsHash,
         expectedLatestRevisionRuntimeHeadsHash,
       });
-    }
-    if (expectedRenderSource) {
-      renderApiCheck = await checkHostedRenderApi(
-        targetUrl,
-        expectedRenderSource,
-        catalogApiCheck?.latestRevisionNotebookHeadsHash ?? null,
-      );
     }
     if (requireViewerCssSplit) {
       viewerCssCheck = await checkViewerCssSplit(targetUrl, {
@@ -418,13 +401,11 @@ async function main() {
           expectedPresenceText,
           expectedFrameTexts,
           expectedOutputDocumentOrigin,
-          expectedRenderSource,
           expectedCatalogOwnerPrincipal,
           expectedLatestRevisionActorLabel,
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
           timings_ms: timingsMs,
-          renderApiCheck,
           catalogApiCheck,
           viewerCssCheck,
           executionCounts,
@@ -738,43 +719,6 @@ function isThemeOutputFrameCloseAbort(request) {
     return false;
   }
   return new URL(request.url()).origin === outputDocumentOrigin;
-}
-
-async function checkHostedRenderApi(viewerUrl, expectedSource, headsHash) {
-  const renderUrl = renderApiUrlForViewer(viewerUrl, headsHash);
-  if (!renderUrl) {
-    failures.push({
-      kind: "render-api",
-      text: `Could not derive pinned render URL from ${viewerUrl}`,
-    });
-    return null;
-  }
-
-  const response = await fetch(renderUrl);
-  if (!response.ok) {
-    failures.push({
-      kind: "render-api",
-      text: `${renderUrl} returned ${response.status}`,
-    });
-    return { url: renderUrl, status: response.status };
-  }
-
-  const json = await response.json();
-  const source = typeof json.source === "string" ? json.source : null;
-  const cellCount = Array.isArray(json.cells) ? json.cells.length : null;
-  if (source !== expectedSource) {
-    failures.push({
-      kind: "render-api",
-      text: `expected render source ${expectedSource}, got ${source ?? "missing"}`,
-      url: renderUrl,
-    });
-  }
-  return {
-    url: renderUrl,
-    status: response.status,
-    source,
-    cellCount,
-  };
 }
 
 async function checkHostedCatalogApi(

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -31,7 +31,7 @@ handle.update_source(
     "This public viewer is backed by the live notebook room.",
     "",
     "- The NotebookDoc and RuntimeStateDoc .am snapshots are stored in R2.",
-    "- Pinned revisions can still be materialized by runtimed-wasm from those snapshots.",
+    "- Pinned revisions are loaded from Automerge snapshots and the live room uses sync.",
   ].join("\n"),
 );
 handle.add_cell_after("hello", "code", "intro");
@@ -64,13 +64,14 @@ await putBytes(
   },
 );
 
-const rendered = await fetchJson(
-  `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
-);
-assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
+const catalog = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}`);
 assert(
-  rendered.cells.some((cell) => cell.id === "hello" && cell.source.includes("nteract cloud")),
-  "pinned snapshot render did not include the demo code cell",
+  catalog.revisions?.some(
+    (revision) =>
+      revision.notebook_heads_hash === headsHash &&
+      revision.runtime_heads_hash === runtimeHeadsHash,
+  ),
+  "published catalog did not include the demo snapshot pair",
 );
 
 console.log(
@@ -87,7 +88,7 @@ console.log(
         "runtimed_wasm_snapshot_pair",
         "r2_runtime_snapshot_publish",
         "r2_snapshot_publish",
-        "pinned_snapshot_materialization",
+        "published_snapshot_catalog",
       ],
     },
     null,

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -59,16 +59,15 @@ await putBytes(
   },
 );
 
-const rendered = await fetchJson(
-  `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
+const catalog = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}`);
+assert(
+  catalog.revisions?.some(
+    (revision) =>
+      revision.notebook_heads_hash === headsHash &&
+      revision.runtime_heads_hash === runtimeHeadsHash,
+  ),
+  "published catalog did not include the fixture snapshot pair",
 );
-assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
-for (const blob of fixtureBlobs) {
-  assert(
-    rendered.blob_urls?.[blob.hash],
-    `materialized render did not include blob URL for ${blob.hash}`,
-  );
-}
 
 console.log(
   JSON.stringify(
@@ -89,7 +88,7 @@ console.log(
       checks: [
         "fixture_snapshot_pair_publish",
         "runtime_state_output_manifests",
-        "pinned_snapshot_materialization",
+        "published_snapshot_catalog",
         ...(fixtureBlobs.length > 0 ? ["fixture_blob_uploads", "blob_resolver_urls"] : []),
       ],
     },

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -58,10 +58,15 @@ try {
     },
   );
 
-  const rendered = await fetchJson(
-    `/api/n/${encodeURIComponent(notebookId)}/renders/${encodeURIComponent(headsHash)}`,
+  const catalog = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}`);
+  assert(
+    catalog.revisions?.some(
+      (revision) =>
+        revision.notebook_heads_hash === headsHash &&
+        revision.runtime_heads_hash === runtimeHeadsHash,
+    ),
+    "published catalog did not include the snapshot pair",
   );
-  assert(rendered.source === "snapshot-pair", "pinned render was not materialized from snapshots");
 
   console.log(
     JSON.stringify(
@@ -81,7 +86,7 @@ try {
           "live_session_snapshot_pair",
           "runtime_state_output_manifests",
           "local_blob_uploads",
-          "pinned_snapshot_materialization",
+          "published_snapshot_catalog",
         ],
       },
       null,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -32,12 +32,10 @@ import {
   grantNotebookAclRow,
   recordBlob,
   recordRevision,
-  renderKey,
   revokeNotebookAclRow,
   runtimeStateSnapshotKey,
   snapshotKey,
   type NotebookAclRow,
-  type RevisionRow,
 } from "./storage.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import {
@@ -78,18 +76,17 @@ const DEFAULT_RENDERER_ASSETS_BASE_PATH = "/renderer-assets/";
 const DEFAULT_RUNTIMED_WASM_BASE_PATH = "/assets/";
 const VIEWER_RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
 const VIEWER_RUNTIMED_WASM_NAME = "runtimed_wasm_bg.wasm";
-const RENDER_BLOB_HEAD_CONCURRENCY = 16;
+const SNAPSHOT_BLOB_HEAD_CONCURRENCY = 16;
 
-interface MissingRenderBlob {
+interface MissingSnapshotBlob {
   hash: string;
   size: number | null;
   media_type: string | null;
 }
 
-type RenderMaterializationResult =
+type SnapshotPairValidationResult =
   | {
       ok: true;
-      body: string;
     }
   | {
       ok: false;
@@ -184,16 +181,6 @@ const worker: ExportedHandler<Env> = {
         env,
         decodeURIComponent(inviteItemMatch[1]),
         decodeURIComponent(inviteItemMatch[2]),
-      );
-    }
-
-    const renderMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/renders\/([^/]+)$/);
-    if (renderMatch) {
-      return routeRender(
-        request,
-        env,
-        decodeURIComponent(renderMatch[1]),
-        decodeURIComponent(renderMatch[2]),
       );
     }
 
@@ -566,8 +553,6 @@ async function routeSnapshot(
   const runtimeKey = runtimeHeadsHash
     ? runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash)
     : null;
-  const renderCacheKey = renderKey(notebookId, headsHash);
-  let renderCacheWritten = false;
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -593,7 +578,7 @@ async function routeSnapshot(
       );
     }
 
-    const materialized = await materializeSnapshotRenderCache({
+    const validated = await validateSnapshotPair({
       request,
       env,
       notebookId,
@@ -601,13 +586,11 @@ async function routeSnapshot(
       runtimeHeadsHash,
       notebookBytes: new Uint8Array(body),
       runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
-      immutable: true,
     });
-    if (!materialized.ok) {
+    if (!validated.ok) {
       await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
-      return json(materialized.body, materialized.status);
+      return json(validated.body, validated.status);
     }
-    renderCacheWritten = true;
   }
 
   let revisionId: string;
@@ -624,9 +607,6 @@ async function routeSnapshot(
     });
   } catch (error) {
     await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
-    if (renderCacheWritten) {
-      await env.NOTEBOOK_SNAPSHOTS.delete(renderCacheKey).catch(() => undefined);
-    }
     throw error;
   }
 
@@ -1111,118 +1091,7 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
   return json(catalog);
 }
 
-async function routeRender(
-  request: Request,
-  env: Env,
-  notebookId: string,
-  headsHash: string,
-): Promise<Response> {
-  if (request.method === "GET") {
-    const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "viewer");
-    if (identity instanceof Response) {
-      return identity;
-    }
-    const catalog = await getNotebookCatalog(env, notebookId);
-    const revision = catalog?.revisions.find(
-      (candidate) => candidate.notebook_heads_hash === headsHash,
-    );
-    return revision
-      ? getRenderObjectOrMaterialize(request, env, notebookId, revision, true)
-      : getRenderObject(env, notebookId, headsHash, true);
-  }
-
-  return json({ error: "method not allowed" }, 405);
-}
-
-async function getRenderObjectOrMaterialize(
-  request: Request,
-  env: Env,
-  notebookId: string,
-  revision: RevisionRow,
-  immutable: boolean,
-): Promise<Response> {
-  const cached = await getRenderObject(env, notebookId, revision.notebook_heads_hash, immutable);
-  if (cached.status !== 404) {
-    return cached;
-  }
-
-  return materializeSnapshotRender(request, env, notebookId, revision, immutable);
-}
-
-async function getRenderObject(
-  env: Env,
-  notebookId: string,
-  headsHash: string,
-  immutable: boolean,
-): Promise<Response> {
-  const key = renderKey(notebookId, headsHash);
-  const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
-  if (!object) {
-    return json({ error: "render cache not found" }, 404);
-  }
-
-  const headers = new Headers({
-    "Cache-Control": immutable
-      ? "public, max-age=31536000, immutable"
-      : "public, max-age=30, stale-while-revalidate=300",
-    "Content-Type": object.httpMetadata?.contentType ?? "application/json; charset=utf-8",
-    ETag: object.httpEtag,
-  });
-  return withCors(new Response(object.body, { headers }));
-}
-
-async function materializeSnapshotRender(
-  request: Request,
-  env: Env,
-  notebookId: string,
-  revision: RevisionRow,
-  immutable: boolean,
-): Promise<Response> {
-  if (!env.NOTEBOOK_SNAPSHOTS) {
-    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
-  }
-  if (!revision.runtime_snapshot_key) {
-    return json({ error: "revision has no runtime-state snapshot" }, 404);
-  }
-
-  const [notebookObject, runtimeObject] = await Promise.all([
-    env.NOTEBOOK_SNAPSHOTS.get(revision.snapshot_key),
-    env.NOTEBOOK_SNAPSHOTS.get(revision.runtime_snapshot_key),
-  ]);
-  if (!notebookObject) {
-    return json({ error: "notebook snapshot not found" }, 404);
-  }
-  if (!runtimeObject) {
-    return json({ error: "runtime snapshot not found" }, 404);
-  }
-
-  const materialized = await materializeSnapshotRenderCache({
-    request,
-    env,
-    notebookId,
-    notebookHeadsHash: revision.notebook_heads_hash,
-    runtimeHeadsHash: revision.runtime_heads_hash,
-    notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
-    runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
-    immutable,
-  });
-  if (!materialized.ok) {
-    return json(materialized.body, materialized.status);
-  }
-
-  return withCors(
-    new Response(materialized.body, {
-      headers: {
-        "Cache-Control": immutable
-          ? "public, max-age=31536000, immutable"
-          : "public, max-age=30, stale-while-revalidate=300",
-        "Content-Type": "application/json; charset=utf-8",
-      },
-    }),
-  );
-}
-
-async function materializeSnapshotRenderCache(options: {
+async function validateSnapshotPair(options: {
   request: Request;
   env: Env;
   notebookId: string;
@@ -1230,8 +1099,7 @@ async function materializeSnapshotRenderCache(options: {
   runtimeHeadsHash: string | null;
   notebookBytes: Uint8Array;
   runtimeStateBytes: Uint8Array;
-  immutable: boolean;
-}): Promise<RenderMaterializationResult> {
+}): Promise<SnapshotPairValidationResult> {
   const startedAt = Date.now();
   const bucket = options.env.NOTEBOOK_SNAPSHOTS;
   if (!bucket) {
@@ -1256,86 +1124,70 @@ async function materializeSnapshotRenderCache(options: {
       }),
     });
   } catch (error) {
-    cloudLog("warn", "render.materialization.failed", {
+    cloudLog("warn", "snapshot_pair.validation.failed", {
       notebook_id: options.notebookId,
       notebook_heads_hash: options.notebookHeadsHash,
       runtime_heads_hash: options.runtimeHeadsHash,
       duration_ms: durationMs(startedAt),
       error: errorMessage(error),
-      counter: "render_materialization_failures",
+      counter: "snapshot_pair_validation_failures",
       counter_delta: 1,
     });
     return {
       ok: false,
       status: 422,
       body: {
-        error: "render materialization failed",
+        error: "snapshot pair validation failed",
         details: errorMessage(error),
       },
     };
   }
 
-  const missingBlobs = await findMissingRenderBlobs(bucket, options.notebookId, render);
+  const missingBlobs = await findMissingSnapshotBlobs(bucket, options.notebookId, render);
   if (missingBlobs.length > 0) {
-    cloudLog("warn", "render.materialization.missing_blobs", {
+    cloudLog("warn", "snapshot_pair.validation.missing_blobs", {
       notebook_id: options.notebookId,
       notebook_heads_hash: options.notebookHeadsHash,
       runtime_heads_hash: options.runtimeHeadsHash,
       duration_ms: durationMs(startedAt),
       missing_blob_count: missingBlobs.length,
       missing_blob_hashes: missingBlobs.map((blob) => blob.hash).slice(0, 20),
-      counter: "render_materialization_missing_blobs",
+      counter: "snapshot_pair_validation_missing_blobs",
       counter_delta: 1,
     });
     return {
       ok: false,
       status: 424,
       body: {
-        error: "render materialization missing blobs",
+        error: "snapshot pair validation missing blobs",
         missing_blobs: missingBlobs,
       },
     };
   }
 
-  const body = JSON.stringify(render);
-  await bucket.put(renderKey(options.notebookId, options.notebookHeadsHash), body, {
-    httpMetadata: {
-      contentType: "application/json; charset=utf-8",
-      cacheControl: options.immutable
-        ? "public, max-age=31536000, immutable"
-        : "public, max-age=30, stale-while-revalidate=300",
-    },
-    customMetadata: {
-      notebook_id: options.notebookId,
-      notebook_heads_hash: options.notebookHeadsHash,
-      runtime_heads_hash: options.runtimeHeadsHash ?? "",
-      artifact: "materialized-render",
-    },
-  });
-  cloudLog("info", "render.materialization.completed", {
+  cloudLog("info", "snapshot_pair.validation.completed", {
     notebook_id: options.notebookId,
     notebook_heads_hash: options.notebookHeadsHash,
     runtime_heads_hash: options.runtimeHeadsHash,
     duration_ms: durationMs(startedAt),
     cell_count: Array.isArray(render.cells) ? render.cells.length : undefined,
     blob_ref_count: Object.keys(render.blob_urls).length,
-    byte_length: body.length,
-    counter: "render_materializations",
+    counter: "snapshot_pair_validations",
     counter_delta: 1,
   });
-  return { ok: true, body };
+  return { ok: true };
 }
 
-async function findMissingRenderBlobs(
+async function findMissingSnapshotBlobs(
   bucket: NonNullable<Env["NOTEBOOK_SNAPSHOTS"]>,
   notebookId: string,
   render: unknown,
-): Promise<MissingRenderBlob[]> {
-  const refs = collectRenderBlobRefs(render);
-  const missing: Array<MissingRenderBlob | null> = [];
+): Promise<MissingSnapshotBlob[]> {
+  const refs = collectSnapshotBlobRefs(render);
+  const missing: Array<MissingSnapshotBlob | null> = [];
 
-  for (let index = 0; index < refs.length; index += RENDER_BLOB_HEAD_CONCURRENCY) {
-    const batch = refs.slice(index, index + RENDER_BLOB_HEAD_CONCURRENCY);
+  for (let index = 0; index < refs.length; index += SNAPSHOT_BLOB_HEAD_CONCURRENCY) {
+    const batch = refs.slice(index, index + SNAPSHOT_BLOB_HEAD_CONCURRENCY);
     missing.push(
       ...(await Promise.all(
         batch.map(async (ref) => {
@@ -1353,11 +1205,11 @@ async function findMissingRenderBlobs(
   }
 
   return missing
-    .filter((entry): entry is MissingRenderBlob => entry !== null)
+    .filter((entry): entry is MissingSnapshotBlob => entry !== null)
     .sort((left, right) => left.hash.localeCompare(right.hash));
 }
 
-function collectRenderBlobRefs(render: unknown): BlobRef[] {
+function collectSnapshotBlobRefs(render: unknown): BlobRef[] {
   const refs = collectBlobRefs(render);
   const blobUrls = isRecord(render) ? render.blob_urls : undefined;
   if (isRecord(blobUrls)) {
@@ -1816,7 +1668,7 @@ function withCors(response: Response): Response {
   response.headers.set("Access-Control-Allow-Methods", "DELETE, GET, HEAD, POST, PUT, OPTIONS");
   response.headers.set(
     "Access-Control-Allow-Headers",
-    `Authorization, Cf-Access-Jwt-Assertion, CF-Access-Token, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, ${DEV_AUTH_TOKEN_HEADER}`,
+    `Authorization, Cf-Access-Jwt-Assertion, CF-Access-Token, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, X-Runtime-State-Doc-Id, ${DEV_AUTH_TOKEN_HEADER}`,
   );
   return response;
 }
@@ -1916,7 +1768,9 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
   const config = {
     notebookId,
     headsHash: headsHash ?? null,
-    pinnedRenderBasePath: `${notebookApiBasePath}/renders/`,
+    catalogEndpoint: notebookApiBasePath,
+    snapshotBasePath: `${notebookApiBasePath}/snapshots/`,
+    runtimeSnapshotBasePath: `${notebookApiBasePath}/runtime-snapshots/`,
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -181,10 +181,6 @@ export function blobKey(notebookId: string, hash: string): string {
   return `n/${encodePathComponent(notebookId)}/blobs/${encodePathComponent(hash)}`;
 }
 
-export function renderKey(notebookId: string, headsHash: string): string {
-  return `n/${encodePathComponent(notebookId)}/renders/${encodePathComponent(headsHash)}.json`;
-}
-
 export async function ensureCatalogSchema(env: Env): Promise<void> {
   if (!env.DB) {
     return;

--- a/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
@@ -32,7 +32,7 @@ describe("hosted live smoke environment", () => {
     assert.equal(
       Object.hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE"),
       false,
-      "live smoke should use the latest viewer path without requiring /render by default",
+      "live smoke should use catalog plus Automerge snapshots without requiring a render API",
     );
   });
 

--- a/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-preflight.test.mjs
@@ -4,8 +4,7 @@ import { describe, it } from "node:test";
 import { hasPreflightFailures } from "../scripts/hosted-render-smoke-preflight.mjs";
 
 describe("hosted render smoke preflight", () => {
-  it("fails fast for route-level render, catalog API, and viewer CSS failures", () => {
-    assert.equal(hasPreflightFailures([{ kind: "render-api" }]), true);
+  it("fails fast for route-level catalog API and viewer CSS failures", () => {
     assert.equal(hasPreflightFailures([{ kind: "catalog-api" }]), true);
     assert.equal(hasPreflightFailures([{ kind: "viewer-css" }]), true);
   });

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -3,40 +3,11 @@ import { describe, it } from "node:test";
 
 import {
   catalogApiUrlForViewer,
-  expectedRenderSourceForViewer,
   notebookViewerUrl,
   pinnedNotebookViewerUrl,
-  renderApiUrlForViewer,
 } from "../scripts/hosted-render-smoke-routes.mjs";
 
 describe("hosted render smoke routes", () => {
-  it("derives the pinned render API URL from a hosted notebook viewer URL", () => {
-    assert.equal(
-      renderApiUrlForViewer(
-        "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
-        "heads-latest",
-      ),
-      "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet/renders/heads-latest",
-    );
-  });
-
-  it("derives the pinned render API URL from a hosted vanity notebook viewer URL", () => {
-    assert.equal(
-      renderApiUrlForViewer(
-        "https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit",
-        "heads-edit",
-      ),
-      "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80/renders/heads-edit",
-    );
-  });
-
-  it("derives the render API URL directly from a pinned snapshot viewer URL", () => {
-    assert.equal(
-      renderApiUrlForViewer("https://preview.runt.run/n/topic-viz/r/heads-pinned", null),
-      "https://preview.runt.run/api/n/topic-viz/renders/heads-pinned",
-    );
-  });
-
   it("derives the catalog API URL from a hosted notebook viewer URL", () => {
     assert.equal(
       catalogApiUrlForViewer(
@@ -80,24 +51,7 @@ describe("hosted render smoke routes", () => {
     });
   });
 
-  it("treats render API checks as opt-in for latest URLs and default-on for pinned URLs", () => {
-    assert.equal(expectedRenderSourceForViewer("https://example.com/n/foo", undefined), null);
-    assert.equal(
-      expectedRenderSourceForViewer("https://example.com/n/foo/r/heads", undefined),
-      "snapshot-pair",
-    );
-    assert.equal(
-      expectedRenderSourceForViewer("https://example.com/n/foo", "snapshot-pair"),
-      "snapshot-pair",
-    );
-    assert.equal(expectedRenderSourceForViewer("https://example.com/n/foo/r/heads", ""), null);
-  });
-
   it("returns null for non-viewer URLs", () => {
-    assert.equal(renderApiUrlForViewer("https://example.com/"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo", null), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/sync", "heads"), null);
-    assert.equal(renderApiUrlForViewer("https://example.com/n/foo/debug", "heads"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -69,7 +69,9 @@ describe("HTML script serialization", () => {
       "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
     );
     assert.doesNotMatch(html, /"renderEndpoint"/);
-    assert.match(html, /"pinnedRenderBasePath":"\/api\/n\/demo\/renders\/"/);
+    assert.match(html, /"catalogEndpoint":"\/api\/n\/demo"/);
+    assert.match(html, /"snapshotBasePath":"\/api\/n\/demo\/snapshots\/"/);
+    assert.match(html, /"runtimeSnapshotBasePath":"\/api\/n\/demo\/runtime-snapshots\/"/);
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
@@ -92,7 +94,9 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config"/);
     assert.match(html, /"headsHash":null/);
     assert.doesNotMatch(html, /"renderEndpoint"/);
-    assert.match(html, /"pinnedRenderBasePath":"\/api\/n\/demo\/renders\/"/);
+    assert.doesNotMatch(html, /"pinnedRenderBasePath"/);
+    assert.match(html, /"catalogEndpoint":"\/api\/n\/demo"/);
+    assert.match(html, /"snapshotBasePath":"\/api\/n\/demo\/snapshots\/"/);
     assert.match(html, /"syncEndpoint":"\/n\/demo\/sync"/);
   });
 

--- a/apps/notebook-cloud/test/observability.test.ts
+++ b/apps/notebook-cloud/test/observability.test.ts
@@ -22,14 +22,14 @@ describe("notebook-cloud observability", () => {
   });
 
   it("omits undefined fields so log-derived counters stay sparse", () => {
-    const record = structuredCloudLog("render.materialization.completed", {
+    const record = structuredCloudLog("snapshot_pair.validation.completed", {
       notebook_id: "demo",
       runtime_heads_hash: undefined,
-      counter: "render_materializations",
+      counter: "snapshot_pair_validations",
       counter_delta: 1,
     });
 
     assert.equal("runtime_heads_hash" in record, false);
-    assert.equal(record.counter, "render_materializations");
+    assert.equal(record.counter, "snapshot_pair_validations");
   });
 });

--- a/apps/notebook-cloud/test/output-document-worker.test.ts
+++ b/apps/notebook-cloud/test/output-document-worker.test.ts
@@ -66,7 +66,7 @@ describe("output document Worker", () => {
 
   it("does not expose app APIs, room sockets, viewer bundles, renderer assets, or blobs", async () => {
     const blockedRoutes = [
-      "/api/n/demo/renders/heads-demo",
+      "/api/n/demo/snapshots/heads-demo",
       "/api/n/demo/blobs/sha256-demo",
       "/n/demo/sync",
       "/assets/notebook-cloud-viewer.js",

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -30,7 +30,6 @@ import {
   createNotebookWithOwnerAcl,
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
-  renderKey,
   runtimeStateSnapshotKey,
   snapshotKey,
 } from "../src/storage.ts";
@@ -502,7 +501,7 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.revisions.length, 0);
   });
 
-  it("keeps render caches derived from snapshot pairs instead of accepting uploads", async () => {
+  it("does not expose materialized render-cache routes", async () => {
     const env = fakeEnv();
     const response = await ownerPut(
       env,
@@ -513,8 +512,7 @@ describe("Worker artifact routes", () => {
       },
     );
 
-    assert.equal(response.status, 405);
-    assert.deepEqual(await response.json(), { error: "method not allowed" });
+    assert.equal(response.status, 404);
     assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
     assert.equal(env.DB.notebooks.size, 0);
   });
@@ -2771,7 +2769,7 @@ describe("Worker artifact routes", () => {
     }
   });
 
-  it("publishes a snapshot pair and materializes render JSON through the route layer", async () => {
+  it("publishes a snapshot pair and records revision metadata for snapshot loading", async () => {
     const env = fakeEnv();
     const [notebookBytes, runtimeStateBytes] = await Promise.all([
       readFile(
@@ -2826,38 +2824,26 @@ describe("Worker artifact routes", () => {
         ["route-demo", "public", "anonymous", "viewer"],
       ],
     );
-    assert.equal(
-      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("route-demo", "heads-fixture")),
-      true,
-      "snapshot publish should pre-materialize a render cache for complete snapshot pairs",
-    );
-
     const response = await worker.fetch(
-      new Request("http://localhost/api/n/route-demo/renders/heads-fixture"),
+      new Request("http://localhost/api/n/route-demo/snapshots/heads-fixture"),
       env,
       fakeContext(),
     );
     assert.equal(response.status, 200);
-    const render = (await response.json()) as {
-      source: string;
-      cells: Array<{ id: string; outputs: Array<{ output_id: string }> }>;
-    };
-
-    assert.equal(render.source, "snapshot-pair");
-    assert.equal(render.cells[0].id, "cell-1");
-    assert.deepEqual(
-      render.cells[0].outputs.map((output) => output.output_id),
-      [
-        "c8b09c2d-a456-5186-b875-441a5fadf374",
-        "58af4526-9a90-5bca-98de-d8d0e36718b2",
-        "cad63e3f-42e3-542b-b28b-5d3acde7906d",
-      ],
-    );
     assert.equal(
-      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("route-demo", "heads-fixture")),
-      true,
-      "materialized render should be cached back into R2",
+      (await response.arrayBuffer()).byteLength,
+      notebookBytes.byteLength,
+      "snapshot route should return raw Automerge bytes",
     );
+
+    const runtimeResponse = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/runtime-snapshots/runtime-fixture", {
+        headers: { "X-Runtime-State-Doc-Id": "runtime:route-demo" },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(runtimeResponse.status, 200);
 
     const latestRenderRoute = await worker.fetch(
       new Request("http://localhost/api/n/route-demo/render"),
@@ -2865,6 +2851,12 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
     assert.equal(latestRenderRoute.status, 404);
+    const renderCacheRoute = await worker.fetch(
+      new Request("http://localhost/api/n/route-demo/renders/heads-fixture"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(renderCacheRoute.status, 404);
   });
 
   it("rejects snapshot publish when the referenced runtime snapshot is missing", async () => {
@@ -2930,7 +2922,7 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 422);
     assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
     const body = (await response.json()) as { error: string; details: string };
-    assert.equal(body.error, "render materialization failed");
+    assert.equal(body.error, "snapshot pair validation failed");
     assert.match(body.details, /load|document|decode|automerge/i);
     assert.equal(env.DB.revisions.length, 0);
     assert.equal(
@@ -2938,14 +2930,9 @@ describe("Worker artifact routes", () => {
       false,
       "rejected snapshot publish should not leave a corrupt notebook snapshot",
     );
-    assert.equal(
-      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("corrupt-demo", "heads-corrupt")),
-      false,
-      "failed publish materialization should not cache a render object",
-    );
     assert.equal(warnings.length, 1);
     assert.equal(warnings[0][0], "[notebook-cloud]");
-    assert.equal((warnings[0][1] as { event: string }).event, "render.materialization.failed");
+    assert.equal((warnings[0][1] as { event: string }).event, "snapshot_pair.validation.failed");
   });
 
   it("rejects snapshot publish when materialized blob refs are missing from R2", async () => {
@@ -3011,7 +2998,7 @@ describe("Worker artifact routes", () => {
       error: string;
       missing_blobs: Array<{ hash: string }>;
     };
-    assert.equal(body.error, "render materialization missing blobs");
+    assert.equal(body.error, "snapshot pair validation missing blobs");
     assert.ok(
       body.missing_blobs.some((blob) => blob.hash === missingHash),
       "response should include the missing fixture blob hash",
@@ -3022,16 +3009,11 @@ describe("Worker artifact routes", () => {
       false,
       "rejected snapshot publish should not leave an orphan notebook snapshot",
     );
-    assert.equal(
-      env.NOTEBOOK_SNAPSHOTS.objects.has(renderKey("missing-blob-demo", "heads-fixture")),
-      false,
-      "failed blob validation should not cache a render object",
-    );
     assert.equal(warnings.length, 1);
     assert.equal(warnings[0][0], "[notebook-cloud]");
     assert.equal(
       (warnings[0][1] as { event: string }).event,
-      "render.materialization.missing_blobs",
+      "snapshot_pair.validation.missing_blobs",
     );
   });
 });

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -42,10 +42,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { isTextAttributionEvent } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
-import {
-  normalizeSnapshotWidgetComms,
-  snapshotWidgetCommsFromRuntimeState,
-} from "../src/widget-comms";
+import { snapshotWidgetCommsFromRuntimeState } from "../src/widget-comms";
 import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable-markdown-cell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import {
@@ -65,6 +62,7 @@ import {
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
+import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import {
   beginOidcLogin,
   completeOidcRedirect,
@@ -126,7 +124,9 @@ loadSupplementalViewerCss();
 interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
-  pinnedRenderBasePath: string;
+  catalogEndpoint: string;
+  snapshotBasePath: string;
+  runtimeSnapshotBasePath: string;
   aclEndpoint: string;
   invitesEndpoint: string;
   syncEndpoint: string;
@@ -141,18 +141,20 @@ interface CloudViewerAuthConfig {
   oidc: CloudOidcAuthConfig | null;
 }
 
+interface CloudNotebookCatalogRevision {
+  notebook_heads_hash: string;
+  runtime_heads_hash: string | null;
+  runtime_state_doc_id: string | null;
+}
+
+interface CloudNotebookCatalog {
+  revisions?: CloudNotebookCatalogRevision[];
+}
+
 type CloudAuthRenewalState =
   | { kind: "idle"; message: null }
   | { kind: "refreshing"; message: string }
   | { kind: "failed"; message: string };
-
-interface SnapshotRender {
-  heads_hash?: string;
-  metadata?: unknown;
-  source?: string;
-  cells?: unknown;
-  widget_comms?: unknown;
-}
 
 type ViewerStatus =
   | { kind: "loading"; message: string }
@@ -183,7 +185,9 @@ function loadConfig(): CloudViewerConfig {
   const parsed = JSON.parse(element.textContent ?? "{}") as Partial<CloudViewerConfig>;
   if (
     !parsed.notebookId ||
-    !parsed.pinnedRenderBasePath ||
+    !parsed.catalogEndpoint ||
+    !parsed.snapshotBasePath ||
+    !parsed.runtimeSnapshotBasePath ||
     !parsed.aclEndpoint ||
     !parsed.invitesEndpoint ||
     !parsed.syncEndpoint ||
@@ -197,7 +201,9 @@ function loadConfig(): CloudViewerConfig {
   return {
     notebookId: parsed.notebookId,
     headsHash: parsed.headsHash ?? null,
-    pinnedRenderBasePath: parsed.pinnedRenderBasePath,
+    catalogEndpoint: parsed.catalogEndpoint,
+    snapshotBasePath: parsed.snapshotBasePath,
+    runtimeSnapshotBasePath: parsed.runtimeSnapshotBasePath,
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
     syncEndpoint: parsed.syncEndpoint,
@@ -659,39 +665,94 @@ function NotebookViewer({
       snapshotResolvedRef.current = true;
       return;
     }
-    const renderEndpoint = pinnedRenderEndpoint(config);
-    if (!renderEndpoint) {
+    if (!config.headsHash) {
       snapshotResolvedRef.current = true;
       setStatus({ kind: "error", message: "Pinned notebook heads are not configured." });
       return;
     }
+    const pinnedHeadsHash = config.headsHash;
 
     let cancelled = false;
 
     void (async () => {
+      let handle: Awaited<ReturnType<typeof loadSnapshotPairHandle>> | null = null;
       try {
-        const response = await fetch(
-          renderEndpoint,
+        const catalogResponse = await fetch(
+          config.catalogEndpoint,
           withCloudPrototypeAuthHeaders({ headers: { Accept: "application/json" } }, authState),
         );
-        if (!response.ok) {
+        if (!catalogResponse.ok) {
           if (!cancelled) {
             snapshotResolvedRef.current = true;
             setStatus({
-              kind: response.status === 404 ? "empty" : "error",
+              kind: catalogResponse.status === 404 ? "empty" : "error",
               message:
-                response.status === 404
+                catalogResponse.status === 404
                   ? "No published snapshot is available for this notebook yet."
-                  : `Unable to load notebook render: ${response.status}`,
+                  : `Unable to load notebook catalog: ${catalogResponse.status}`,
             });
           }
           return;
         }
 
-        const render = (await response.json()) as SnapshotRender;
-        const rawCells = Array.isArray(render.cells) ? (render.cells as RenderCell[]) : [];
-        const widgetComms = normalizeSnapshotWidgetComms(render.widget_comms);
-        const notebookLanguage = languageFromNotebookMetadata(render.metadata) ?? "python";
+        const catalog = (await catalogResponse.json()) as CloudNotebookCatalog;
+        const revision = catalog.revisions?.find(
+          (candidate) => candidate.notebook_heads_hash === pinnedHeadsHash,
+        );
+        if (!revision || !revision.runtime_heads_hash || !revision.runtime_state_doc_id) {
+          if (!cancelled) {
+            snapshotResolvedRef.current = true;
+            setStatus({
+              kind: "empty",
+              message: "No complete snapshot pair is available for these pinned heads.",
+            });
+          }
+          return;
+        }
+
+        const [notebookSnapshotResponse, runtimeSnapshotResponse] = await Promise.all([
+          fetch(
+            pinnedSnapshotEndpoint(config.snapshotBasePath, pinnedHeadsHash),
+            withCloudPrototypeAuthHeaders(
+              { headers: { Accept: "application/octet-stream" } },
+              authState,
+            ),
+          ),
+          fetch(
+            pinnedSnapshotEndpoint(config.runtimeSnapshotBasePath, revision.runtime_heads_hash),
+            withCloudPrototypeAuthHeaders(
+              {
+                headers: {
+                  Accept: "application/octet-stream",
+                  "X-Runtime-State-Doc-Id": revision.runtime_state_doc_id,
+                },
+              },
+              authState,
+            ),
+          ),
+        ]);
+        if (!notebookSnapshotResponse.ok || !runtimeSnapshotResponse.ok) {
+          if (!cancelled) {
+            snapshotResolvedRef.current = true;
+            setStatus({
+              kind: "error",
+              message: `Unable to load pinned snapshot pair: notebook ${notebookSnapshotResponse.status}, runtime ${runtimeSnapshotResponse.status}`,
+            });
+          }
+          return;
+        }
+
+        handle = await loadSnapshotPairHandle(
+          new Uint8Array(await notebookSnapshotResponse.arrayBuffer()),
+          new Uint8Array(await runtimeSnapshotResponse.arrayBuffer()),
+          config.runtimedWasmModulePath,
+          config.runtimedWasmPath,
+        );
+        const rawCells = JSON.parse(handle.get_cells_json()) as RenderCell[];
+        const runtimeState = handle.get_runtime_state();
+        const widgetComms = snapshotWidgetCommsFromRuntimeState(runtimeState, blobResolver);
+        const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json?.());
+        const notebookLanguage = languageFromNotebookMetadata(metadata) ?? "python";
         notebookLanguageRef.current = notebookLanguage;
         const outputResolutionCache = outputResolutionCacheRef.current;
         const syncCells = rawCells.map((cell, index) =>
@@ -724,16 +785,17 @@ function NotebookViewer({
           return;
         }
 
-        const source = render.source === "snapshot-pair" ? "snapshot pair" : "render cache";
         setStatus({
           kind: "ready",
-          message: `Rendering ${resolvedCells.length} cells from a persisted ${source}.`,
+          message: `Rendering ${resolvedCells.length} cells from pinned Automerge snapshots.`,
         });
       } catch (error) {
         if (!cancelled) {
           snapshotResolvedRef.current = true;
           setStatus({ kind: "error", message: `Unable to load notebook: ${String(error)}` });
         }
+      } finally {
+        handle?.free();
       }
     })();
 
@@ -744,9 +806,13 @@ function NotebookViewer({
     authRenewal.kind,
     authState,
     blobResolver,
+    config.catalogEndpoint,
     config.blobBasePath,
     config.headsHash,
-    config.pinnedRenderBasePath,
+    config.runtimeSnapshotBasePath,
+    config.runtimedWasmModulePath,
+    config.runtimedWasmPath,
+    config.snapshotBasePath,
     loadingPolicy.shouldFetchSnapshotRender,
     preloadSiftWasm,
     widgetStore,
@@ -2018,14 +2084,9 @@ function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {
   }
 }
 
-function pinnedRenderEndpoint(config: CloudViewerConfig): string | null {
-  if (!config.headsHash) {
-    return null;
-  }
-  const basePath = config.pinnedRenderBasePath.endsWith("/")
-    ? config.pinnedRenderBasePath
-    : `${config.pinnedRenderBasePath}/`;
-  return `${basePath}${encodeURIComponent(config.headsHash)}`;
+function pinnedSnapshotEndpoint(basePath: string, headsHash: string): string {
+  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`;
+  return `${normalizedBasePath}${encodeURIComponent(headsHash)}`;
 }
 
 createRoot(requireElement("#root")).render(

--- a/apps/notebook-cloud/viewer/render-resolution.ts
+++ b/apps/notebook-cloud/viewer/render-resolution.ts
@@ -404,7 +404,7 @@ function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
 }
 
-function isContentRefLike(value: unknown, mimeType?: string): boolean {
+function isContentRefLike(value: unknown, mimeType?: string): value is ContentRef {
   if (typeof value !== "object" || value === null) return false;
   const ref = value as Record<string, unknown>;
   if ("inline" in ref) return typeof ref.inline === "string";

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -47,6 +47,16 @@ export async function createBootstrapNotebookHandle(
   return module.NotebookHandle.create_bootstrap(actorLabel);
 }
 
+export async function loadSnapshotPairHandle(
+  notebookBytes: Uint8Array,
+  runtimeStateBytes: Uint8Array,
+  modulePath: string | URL,
+  moduleOrPath: WasmModuleOrPath,
+): Promise<NotebookHandle> {
+  const module = await initializeRuntimedWasmClient(modulePath, moduleOrPath);
+  return module.NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
+}
+
 export function encodeHeartbeatPresenceAfterInit(peerId: string): Uint8Array {
   return runtimedWasmModuleAfterInit().encode_heartbeat_presence(peerId);
 }

--- a/crates/runt-publish/src/main.rs
+++ b/crates/runt-publish/src/main.rs
@@ -208,9 +208,19 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    let render = publisher.get_render(&notebook_heads_hash).await?;
-    if render.get("source").and_then(Value::as_str) != Some("snapshot-pair") {
-        bail!("latest render was not materialized from the uploaded snapshot pair");
+    let catalog = publisher.get_catalog().await?;
+    let revisions = catalog
+        .get("revisions")
+        .and_then(Value::as_array)
+        .context("published catalog did not include revisions")?;
+    let published_revision = revisions.iter().any(|revision| {
+        revision.get("notebook_heads_hash").and_then(Value::as_str)
+            == Some(notebook_heads_hash.as_str())
+            && revision.get("runtime_heads_hash").and_then(Value::as_str)
+                == Some(runtime_heads_hash.as_str())
+    });
+    if !published_revision {
+        bail!("published catalog did not include the uploaded snapshot pair");
     }
 
     println!(
@@ -227,7 +237,6 @@ async fn main() -> Result<()> {
             "initial_blob_refs": initial_ref_count,
             "total_blob_refs": refs.len(),
             "uploaded_blobs": uploaded_blobs,
-            "render_source": render.get("source").and_then(Value::as_str),
         }))?
     );
 
@@ -408,15 +417,8 @@ impl Publisher {
         serde_json::from_str(&text).with_context(|| format!("decode JSON response from {url}"))
     }
 
-    async fn get_render(&self, notebook_heads_hash: &str) -> Result<Value> {
-        self.get_json(&[
-            "api",
-            "n",
-            &self.notebook_id,
-            "renders",
-            notebook_heads_hash,
-        ])
-        .await
+    async fn get_catalog(&self) -> Result<Value> {
+        self.get_json(&["api", "n", &self.notebook_id]).await
     }
 
     fn add_identity_headers(
@@ -996,7 +998,7 @@ mod tests {
     }
 
     #[test]
-    fn publisher_verifies_materialized_render_by_heads_hash() {
+    fn publisher_reads_catalog_by_notebook_id() {
         let publisher = Publisher {
             client: reqwest::Client::new(),
             base_url: Url::parse("https://cloud.test/").unwrap(),
@@ -1013,16 +1015,10 @@ mod tests {
 
         assert_eq!(
             publisher
-                .endpoint(&[
-                    "api",
-                    "n",
-                    &publisher.notebook_id,
-                    "renders",
-                    "heads-fixture"
-                ])
+                .endpoint(&["api", "n", &publisher.notebook_id])
                 .unwrap()
                 .as_str(),
-            "https://cloud.test/api/n/topic-viz/renders/heads-fixture"
+            "https://cloud.test/api/n/topic-viz"
         );
     }
 }

--- a/docs/architecture/hosted-notebook-artifacts.md
+++ b/docs/architecture/hosted-notebook-artifacts.md
@@ -53,12 +53,9 @@ The revision row records:
 - `runtime_snapshot_key`
 - `actor_label`
 
-Render caches may exist, but they are derived caches. They are not the source of
-truth and can be regenerated from the snapshot pair.
-
-The publish API may materialize that cache before recording the catalog row.
-This is a validation step, not a change in durability: if the `NotebookDoc` /
-`RuntimeStateDoc` pair cannot load, or if any rendered cell, widget comm, or
+Derived render JSON is not a durable artifact. The publish API validates the
+snapshot pair before recording the catalog row: if the `NotebookDoc` /
+`RuntimeStateDoc` pair cannot load, or if any projected cell, widget comm, or
 manifest child points at a missing blob object, the host rejects the publish and
 leaves no revision row.
 
@@ -70,7 +67,6 @@ The current compatibility layout for a notebook `n/:id` is:
 n/{id}/snapshots/{notebookHeadsHash}.am
 n/{id}/snapshots/runtime-state/{runtimeHeadsHash}.am
 n/{id}/blobs/{sha256}
-n/{id}/renders/{notebookHeadsHash}.json
 ```
 
 New storage work should move toward the first-class document namespace in
@@ -82,17 +78,15 @@ docs/{docId}/incremental/{chunkHash}
 blobs/{sha256}
 ```
 
-The render path is derived. Snapshot paths and blob paths are the durable
-publish artifact set; incremental paths are an optional future optimization that
-should follow Automerge Repo's logical storage shape rather than introduce a
-new file-extension convention. Hosts can precompute the render path at publish
-time to prove the snapshot pair and blob set are complete.
+Snapshot paths and blob paths are the durable publish artifact set; incremental
+paths are an optional future optimization that should follow Automerge Repo's
+logical storage shape rather than introduce a new file-extension convention. The
+host can load the snapshot pair at publish time to prove the snapshot pair and
+blob set are complete.
 
-For connected notebook pages, the live room supersedes the render path. `/render`
-is a warm-start cache and static/export read model, not a separate state lane.
-After the WebSocket materializes, viewers and editors render the same live
-`NotebookDoc` + `RuntimeStateDoc`; permission differences only change which
-frames the client may author.
+For connected notebook pages, the live room is the primary read model. Viewers
+and editors render the same live `NotebookDoc` + `RuntimeStateDoc`; permission
+differences only change which frames the client may author.
 
 ## Decision 3: Materialization uses runtimed-wasm
 
@@ -107,8 +101,8 @@ uses. This keeps execution-id lookup and output manifest projection in the Rust
 runtime document code rather than duplicating projection in a Worker-local JSON
 format.
 
-In the current prototype the Worker materializes a JSON render response on
-request. The browser viewer normalizes that host response into shared
+The browser viewer loads raw snapshot bytes for pinned revisions, opens them
+through `runtimed-wasm`, normalizes the resulting cell/runtime state into shared
 `ReadOnlyNotebookCellData`, then renders through the same React notebook output
 stack as desktop: `ReadOnlyNotebook` → `ReadOnlyNotebookCell` → `OutputArea` →
 `MediaRouter` / isolated iframe. The framework-agnostic
@@ -116,13 +110,13 @@ stack as desktop: `ReadOnlyNotebook` → `ReadOnlyNotebookCell` → `OutputArea`
 but the cloud notebook viewer itself should not fork a separate DOM renderer.
 
 Widget comm state has one additional host-specific projection step. The Worker
-serializes `widget_comms` alongside rendered cells, resolving comm
-`ContentRef`s through the hosted `BlobResolver`. The viewer then seeds a
-read-only `WidgetStore`: `_esm` / `_css` stay URL strings for browser loading,
-text refs listed in `text_paths` are fetched and inlined by the viewer, and
-binary refs listed in `buffer_paths` are installed as `DataView`s. This keeps
-the rendered widget components shared while making the blob authority boundary
-explicit in the host.
+validates comm `ContentRef`s through the hosted `BlobResolver` during publish.
+The viewer projects comm topology from `RuntimeStateDoc` and seeds a read-only
+`WidgetStore`: `_esm` / `_css` stay URL strings for browser loading, text refs
+listed in `text_paths` are fetched and inlined by the viewer, and binary refs
+listed in `buffer_paths` are installed as `DataView`s. This keeps the rendered
+widget components shared while making the blob authority boundary explicit in
+the host.
 
 ## Decision 4: Blob refs stay host-neutral
 
@@ -175,8 +169,7 @@ The bundle imports the shared isolated output embed API and the existing
 renderer plugin virtual modules. It receives notebook-specific configuration
 from the Worker HTML shell as JSON:
 
-- render endpoint (`/api/n/:id/render` or pinned `/renders/:headsHash`) for
-  warm start;
+- catalog endpoint plus snapshot endpoints for pinned revision discovery;
 - sync endpoint for the live notebook room;
 - blob base path (`/api/n/:id/blobs/`);
 - renderer asset base URL;
@@ -196,11 +189,11 @@ API or blob origin.
 
 The cloud renderer boundary is intentionally narrow:
 
-- Worker: authenticate reads, load snapshot pairs, materialize render-cache JSON,
-  and map content-addressed blobs to host URLs.
+- Worker: authenticate reads, validate snapshot pairs, serve snapshot/blob
+  artifacts, and map content-addressed blobs to host URLs.
 - Cloud viewer: own the browser shell, live-room bridge, theme selection,
-  presence chrome, and normalization from render JSON to shared cell/output
-  props.
+  presence chrome, and normalization from live or pinned Automerge documents to
+  shared cell/output props.
 - Shared renderer components: own MIME priority, output manifest resolution,
   plugin installation, iframe sandboxing, scroll handoff, and output DOM.
 


### PR DESCRIPTION
## Summary

- removes the public pinned `/api/n/:id/renders/:headsHash` render-cache route and the R2 `renderKey` lane
- changes pinned notebook boot to resolve catalog metadata, fetch raw `NotebookDoc` + `RuntimeStateDoc` Automerge snapshots, and materialize them in the browser through `runtimed-wasm`
- keeps publish-time safety by validating snapshot pairs and referenced blobs before recording catalog revisions, without storing derived render JSON
- updates publish/smoke scripts, route tests, and docs around catalog + raw snapshot readback

## Notes

This replaces the prior render warm-start direction. Latest notebooks continue to use live `/sync`; pinned revisions now load persisted Automerge snapshots directly.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/hosted-smoke-routes.test.mjs test/hosted-live-smoke-env.test.mjs test/observability.test.ts test/output-document-worker.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `cargo test -p runt-publish`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
