### PR TITLE
test(notebook-cloud): report hosted smoke performance timings

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -104,7 +104,11 @@ through the live viewer path and catalog metadata; pinned
 materialized render API. Override the target with
 `NOTEBOOK_CLOUD_HOSTED_URL` or a positional URL argument. Set
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
-artifact.
+artifact. The JSON report includes coarse `timings_ms` milestones plus
+`performanceDiagnostics.resources_by_kind` for viewer document, viewer JS/CSS,
+`runtimed-wasm`, output document frames, Sift WASM, and pinned snapshot fetches
+when a pinned URL is tested. Use these diagnostics to choose performance work
+before adding timing budgets.
 
 For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -1,0 +1,110 @@
+export function classifyPerformanceResource(
+  url,
+  { targetOrigin, rendererAssetOrigin = null, outputDocumentOrigin = null } = {},
+) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (targetOrigin && parsed.origin === targetOrigin) {
+    if (/^\/api\/n\/[^/]+\/?$/.test(parsed.pathname)) {
+      return "catalog_api";
+    }
+    if (/^\/api\/n\/[^/]+\/snapshots\/[^/]+\/?$/.test(parsed.pathname)) {
+      return "notebook_snapshot";
+    }
+    if (/^\/api\/n\/[^/]+\/runtime-snapshots\/[^/]+\/?$/.test(parsed.pathname)) {
+      return "runtime_snapshot";
+    }
+    if (/^\/n\/[^/]+(?:\/[^/]+|\/r\/[^/]+)?\/?$/.test(parsed.pathname)) {
+      return "viewer_document";
+    }
+    if (parsed.pathname === "/assets/notebook-cloud-viewer.js") {
+      return "viewer_js";
+    }
+    if (parsed.pathname === "/assets/notebook-cloud-viewer.css") {
+      return "viewer_css";
+    }
+  }
+
+  const isRendererAsset =
+    rendererAssetOrigin && parsed.origin === rendererAssetOrigin && parsed.pathname.includes("/");
+  const isTargetAsset = targetOrigin && parsed.origin === targetOrigin;
+  if (isRendererAsset || isTargetAsset) {
+    if (parsed.pathname.endsWith("/runtimed_wasm.js")) {
+      return "runtimed_wasm_js";
+    }
+    if (parsed.pathname.endsWith("/runtimed_wasm_bg.wasm")) {
+      return "runtimed_wasm_binary";
+    }
+    if (parsed.pathname.endsWith("/sift_wasm.wasm")) {
+      return "sift_wasm_binary";
+    }
+  }
+
+  if (
+    outputDocumentOrigin &&
+    parsed.origin === outputDocumentOrigin &&
+    parsed.pathname.startsWith("/frame/")
+  ) {
+    return "output_document_frame";
+  }
+
+  return null;
+}
+
+export function summarizePerformanceResources(resources, milestones = {}) {
+  const byKind = {};
+
+  for (const resource of resources) {
+    const summary = (byKind[resource.kind] ??= {
+      count: 0,
+      first_start_ms: null,
+      first_end_ms: null,
+      max_end_ms: null,
+      statuses: [],
+      urls: [],
+    });
+    summary.count += 1;
+    summary.first_start_ms = minDefined(summary.first_start_ms, resource.start_ms);
+    summary.first_end_ms = minDefined(summary.first_end_ms, resource.end_ms);
+    summary.max_end_ms = maxDefined(summary.max_end_ms, resource.end_ms);
+    if (resource.status !== null && resource.status !== undefined) {
+      summary.statuses.push(resource.status);
+    }
+    if (summary.urls.length < 5 && !summary.urls.includes(resource.url)) {
+      summary.urls.push(resource.url);
+    }
+  }
+
+  return { milestones, resources_by_kind: byKind };
+}
+
+export function withTiming(result, started, ended) {
+  if (!result) {
+    return result;
+  }
+  return {
+    ...result,
+    timing_ms: {
+      start: started,
+      end: ended,
+      duration: ended - started,
+    },
+  };
+}
+
+function minDefined(current, candidate) {
+  if (candidate === null || candidate === undefined) return current;
+  if (current === null || current === undefined) return candidate;
+  return Math.min(current, candidate);
+}
+
+function maxDefined(current, candidate) {
+  if (candidate === null || candidate === undefined) return current;
+  if (current === null || current === undefined) return candidate;
+  return Math.max(current, candidate);
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -16,6 +16,11 @@ import {
   parsePositiveInteger,
 } from "./hosted-render-smoke-assets.mjs";
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
+import {
+  classifyPerformanceResource,
+  summarizePerformanceResources,
+  withTiming,
+} from "./hosted-render-smoke-performance.mjs";
 import { catalogApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
@@ -86,6 +91,8 @@ const runtimedWasmRequests = [];
 const rendererCompletions = [];
 const fatalIsolatedDiagnostics = [];
 const diagnosticTasks = [];
+const performanceResources = [];
+const performanceRequests = new Map();
 let catalogApiCheck = null;
 let viewerCssCheck = null;
 let screenshotSaved = false;
@@ -135,6 +142,9 @@ async function main() {
   });
 
   page.on("requestfailed", (request) => {
+    finishPerformanceRequest(request, {
+      failure: request.failure()?.errorText ?? "unknown",
+    });
     if (!isRelevantRequestUrl(request.url())) {
       return;
     }
@@ -145,8 +155,32 @@ async function main() {
     });
   });
 
+  page.on("request", (request) => {
+    const kind = classifyPerformanceResource(request.url(), {
+      targetOrigin,
+      rendererAssetOrigin,
+      outputDocumentOrigin,
+    });
+    if (!kind) {
+      return;
+    }
+    performanceRequests.set(request, {
+      kind,
+      url: request.url(),
+      start_ms: elapsedMs(),
+      end_ms: null,
+      status: null,
+      contentType: null,
+      failure: null,
+    });
+  });
+
   page.on("response", (response) => {
     const url = response.url();
+    finishPerformanceRequest(response.request(), {
+      status: response.status(),
+      contentType: response.headers()["content-type"] ?? null,
+    });
     if (url.includes("sift_wasm.wasm")) {
       siftWasmRequests.push({
         url,
@@ -165,6 +199,12 @@ async function main() {
     }
   });
 
+  page.on("websocket", (socket) => {
+    if (socket.url().includes("/sync?")) {
+      markTiming("live_sync_websocket");
+    }
+  });
+
   try {
     if (
       expectedCatalogOwnerPrincipal ||
@@ -172,18 +212,22 @@ async function main() {
       expectedLatestRevisionNotebookHeadsHash ||
       expectedLatestRevisionRuntimeHeadsHash
     ) {
+      const started = elapsedMs();
       catalogApiCheck = await checkHostedCatalogApi(targetUrl, {
         expectedCatalogOwnerPrincipal,
         expectedLatestRevisionActorLabel,
         expectedLatestRevisionNotebookHeadsHash,
         expectedLatestRevisionRuntimeHeadsHash,
       });
+      catalogApiCheck = withTiming(catalogApiCheck, started, elapsedMs());
     }
     if (requireViewerCssSplit) {
+      const started = elapsedMs();
       viewerCssCheck = await checkViewerCssSplit(targetUrl, {
         maxPrimaryBytes: maxPrimaryViewerCssBytes,
         minSupplementalCount: minSupplementalViewerCssCount,
       });
+      viewerCssCheck = withTiming(viewerCssCheck, started, elapsedMs());
       failures.push(...viewerCssCheck.failures);
     }
     markTiming("preflight");
@@ -406,6 +450,7 @@ async function main() {
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
           timings_ms: timingsMs,
+          performanceDiagnostics: summarizePerformanceResources(performanceResources, timingsMs),
           catalogApiCheck,
           viewerCssCheck,
           executionCounts,
@@ -465,6 +510,23 @@ function parseExpectedTexts(envName, fallback) {
 
 function markTiming(name) {
   timingsMs[name] ??= Math.round(performance.now() - smokeStartedAt);
+}
+
+function elapsedMs() {
+  return Math.round(performance.now() - smokeStartedAt);
+}
+
+function finishPerformanceRequest(request, updates) {
+  const record = performanceRequests.get(request);
+  if (!record) {
+    return;
+  }
+  performanceRequests.delete(request);
+  performanceResources.push({
+    ...record,
+    ...updates,
+    end_ms: elapsedMs(),
+  });
 }
 
 function themeModeSpec(value) {

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  classifyPerformanceResource,
+  summarizePerformanceResources,
+  withTiming,
+} from "../scripts/hosted-render-smoke-performance.mjs";
+
+describe("hosted smoke performance diagnostics", () => {
+  const origins = {
+    targetOrigin: "https://preview.runt.run",
+    rendererAssetOrigin: "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev",
+    outputDocumentOrigin: "https://preview.runtusercontent.com",
+  };
+
+  it("classifies hosted notebook resources by load-path role", () => {
+    assert.equal(
+      classifyPerformanceResource("https://preview.runt.run/api/n/topic-viz", origins),
+      "catalog_api",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://preview.runt.run/api/n/topic-viz/snapshots/heads-a",
+        origins,
+      ),
+      "notebook_snapshot",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://preview.runt.run/api/n/topic-viz/runtime-snapshots/heads-b",
+        origins,
+      ),
+      "runtime_snapshot",
+    );
+    assert.equal(
+      classifyPerformanceResource("https://preview.runt.run/n/topic-viz", origins),
+      "viewer_document",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/runtimed_wasm_bg.wasm",
+        origins,
+      ),
+      "runtimed_wasm_binary",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/sift_wasm.wasm?v=abc",
+        origins,
+      ),
+      "sift_wasm_binary",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://preview.runtusercontent.com/frame/?nteract_theme=light",
+        origins,
+      ),
+      "output_document_frame",
+    );
+  });
+
+  it("summarizes first and latest timings by resource kind", () => {
+    assert.deepEqual(
+      summarizePerformanceResources(
+        [
+          {
+            kind: "output_document_frame",
+            url: "https://preview.runtusercontent.com/frame/",
+            start_ms: 10,
+            end_ms: 30,
+            status: 200,
+          },
+          {
+            kind: "output_document_frame",
+            url: "https://preview.runtusercontent.com/frame/?two",
+            start_ms: 20,
+            end_ms: 50,
+            status: 200,
+          },
+        ],
+        { source_text: 42 },
+      ),
+      {
+        milestones: { source_text: 42 },
+        resources_by_kind: {
+          output_document_frame: {
+            count: 2,
+            first_start_ms: 10,
+            first_end_ms: 30,
+            max_end_ms: 50,
+            statuses: [200, 200],
+            urls: [
+              "https://preview.runtusercontent.com/frame/",
+              "https://preview.runtusercontent.com/frame/?two",
+            ],
+          },
+        },
+      },
+    );
+  });
+
+  it("attaches stable preflight timing without crashing on null checks", () => {
+    assert.equal(withTiming(null, 10, 20), null);
+    assert.deepEqual(withTiming({ status: 200 }, 10, 20), {
+      status: 200,
+      timing_ms: { start: 10, end: 20, duration: 10 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- adds hosted smoke performance diagnostics that classify viewer document, viewer JS/CSS, runtimed WASM, output document frames, Sift WASM, and pinned snapshot fetches by resource kind
- records preflight timings for catalog and viewer CSS checks
- documents the new diagnostics in the notebook-cloud README

## Why

The current `topic-viz` hosted smoke proves the page renders, but the timing output was too coarse to choose the next optimization target. This makes the smoke report show whether the delay is in catalog/preflight, the live viewer bootstrap, WASM loading, output iframe fanout, or Sift/table hydration.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-performance.test.mjs test/hosted-smoke-routes.test.mjs`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
