### PR TITLE
fix(pi): scope extension list to avoid loading test files

### DIFF
--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -27,7 +27,7 @@
   ],
   "pi": {
     "extensions": [
-      "./extensions"
+      "./extensions/repl.ts"
     ]
   },
   "files": [


### PR DESCRIPTION
## Summary

- Pi's `package.json` sets `"extensions": ["./extensions"]`, causing pi's extension loader to load every file in the directory — including `repl.test.ts`
- The test file references test-harness globals (`config`) that don't exist at runtime, crashing pi on startup
- Scope the list to the specific extension file (`./extensions/repl.ts`) so test files are never loaded as extensions

## Test plan

- [ ] `pi` starts without the "Cannot read properties of undefined (reading 'config')" error
- [ ] The REPL extension still loads and functions normally