### PR TITLE
docs(elements): catalog full cell surfaces

### DIFF
--- a/apps/elements/app/docs/layout.tsx
+++ b/apps/elements/app/docs/layout.tsx
@@ -1,11 +1,17 @@
 import type { ReactNode } from "react";
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { NotebookPaletteToggle } from "@/components/notebook-palette-toggle";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <DocsLayout {...baseOptions()} tree={source.getPageTree()} searchToggle={{ enabled: false }}>
+    <DocsLayout
+      {...baseOptions()}
+      tree={source.getPageTree()}
+      searchToggle={{ enabled: false }}
+      sidebar={{ footer: <NotebookPaletteToggle key="notebook-flavor" className="mt-2" /> }}
+    >
       {children}
     </DocsLayout>
   );

--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -8,6 +8,7 @@
 @source "../**/*.{ts,tsx,mdx}";
 @source "../../../src/components/cell/**/*.{ts,tsx}";
 @source "../../../src/components/editor/**/*.{ts,tsx}";
+@source "../../../src/components/isolated/**/*.{ts,tsx}";
 @source "../../../src/components/outputs/**/*.{ts,tsx}";
 @source "../../../src/components/ui/**/*.{ts,tsx}";
 @source "../../../src/components/widgets/**/*.{ts,tsx}";

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -17,9 +17,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "28",
+    value: "31",
     detail:
-      "used shell toolbar, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -69,8 +69,9 @@ const families = [
     family: "Cells",
     source: "apps/notebook/src/components/{CodeCell,MarkdownCell,RawCell}.tsx",
     target: "nteract cells",
-    status: "next",
-    intent: "Document code, markdown, and raw cells after their runtime hooks can be fixture-fed.",
+    status: "active",
+    intent:
+      "CodeCell, MarkdownCell, and RawCell now render with seeded store state and a null CRDT handle; markdown preview still documents its isolated-renderer adapter boundary.",
   },
   {
     family: "Cell internals",
@@ -102,7 +103,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, TracebackOutput, and MIME priority now render from fixtures.",
+      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, TracebackOutput, and MIME priority now render from fixtures; Sift can join via a URL-backed Hugging Face parquet fixture like the demo page.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -29,6 +29,7 @@ import {
   addTextAttributions,
   textAttributionExtension,
 } from "@/components/editor/text-attribution";
+import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 
 type SampleKey = "python" | "sql" | "markdown" | "json";
 
@@ -185,9 +186,11 @@ function SectionHeader({
 
 export function EditorSurfacesExample() {
   const [sampleKey, setSampleKey] = useState<SampleKey>("python");
-  const [mode, setMode] = useState<"light" | "dark">("light");
-  const [colorTheme, setColorTheme] = useState<ColorTheme>("classic");
   const [draftSource, setDraftSource] = useState(codeSamples.python.source);
+  const isDark = useDarkMode();
+  const documentColorTheme = useColorTheme();
+  const mode = isDark ? "dark" : "light";
+  const colorTheme: ColorTheme = documentColorTheme === "cream" ? "cream" : "classic";
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const sample = codeSamples[sampleKey];
   const activeOffset = useMemo(
@@ -263,7 +266,7 @@ export function EditorSurfacesExample() {
 
     frame = window.requestAnimationFrame(applyFixtureState);
     return () => window.cancelAnimationFrame(frame);
-  }, [colorTheme, mode, sample.search, sample.source]);
+  }, [sample.search, sample.source]);
 
   const detectedMagic = detectCellMagic(magicSource);
   const magicLanguage = detectedMagic ? getCellMagicLanguage(detectedMagic) : "plain";
@@ -309,38 +312,9 @@ export function EditorSurfacesExample() {
               </button>
             ))}
             <span className="mx-1 h-5 w-px bg-fd-border" aria-hidden="true" />
-            {(["light", "dark"] as const).map((nextMode) => (
-              <button
-                key={nextMode}
-                type="button"
-                aria-pressed={mode === nextMode}
-                onClick={() => setMode(nextMode)}
-                className={[
-                  "rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors",
-                  mode === nextMode
-                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
-                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
-                ].join(" ")}
-              >
-                {nextMode}
-              </button>
-            ))}
-            {(["classic", "cream"] as const).map((nextTheme) => (
-              <button
-                key={nextTheme}
-                type="button"
-                aria-pressed={colorTheme === nextTheme}
-                onClick={() => setColorTheme(nextTheme)}
-                className={[
-                  "rounded-md border px-3 py-1.5 text-xs font-medium capitalize transition-colors",
-                  colorTheme === nextTheme
-                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
-                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
-                ].join(" ")}
-              >
-                {nextTheme}
-              </button>
-            ))}
+            <span className="text-xs font-medium capitalize text-fd-muted-foreground">
+              {mode} / {colorTheme}
+            </span>
           </div>
 
           <div className="overflow-hidden rounded-lg border border-border bg-background">
@@ -360,8 +334,6 @@ export function EditorSurfacesExample() {
               ref={editorRef}
               initialValue={sample.source}
               language={sample.language}
-              theme={mode}
-              colorTheme={colorTheme}
               lineWrapping
               extensions={editorExtensions}
               onValueChange={setDraftSource}

--- a/apps/elements/components/full-cell-surfaces-client.tsx
+++ b/apps/elements/components/full-cell-surfaces-client.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const FullCellSurfacesExample = dynamic(
+  () => import("./full-cell-surfaces-example").then((mod) => mod.FullCellSurfacesExample),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="not-prose rounded-lg border border-fd-border bg-fd-card p-4 text-sm text-fd-muted-foreground">
+        Loading full cell fixtures...
+      </div>
+    ),
+  },
+);
+
+export function FullCellSurfacesClient() {
+  return <FullCellSurfacesExample />;
+}

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { FileCode2, FileText, Rows3, ShieldCheck } from "lucide-react";
+import { useLayoutEffect, useMemo, useState } from "react";
+import { CodeCell } from "@/notebook-components/CodeCell";
+import { MarkdownCell } from "@/notebook-components/MarkdownCell";
+import { RawCell } from "@/notebook-components/RawCell";
+import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
+import {
+  flushCellUIState,
+  setExecutingCellIds,
+  setFocusedCellId,
+  setQueuedCellIds,
+  setSearchCurrentMatch,
+  setSearchQuery,
+} from "../../notebook/src/lib/cell-ui-state";
+import { replaceNotebookCells } from "../../notebook/src/lib/notebook-cells";
+import {
+  resetNotebookExecutions,
+  setCellExecutionPointer,
+  setExecution,
+} from "../../notebook/src/lib/notebook-executions";
+import { resetNotebookOutputs, setOutput } from "../../notebook/src/lib/notebook-outputs";
+import type {
+  CodeCell as CodeCellType,
+  MarkdownCell as MarkdownCellType,
+  RawCell as RawCellType,
+} from "../../notebook/src/types";
+
+const codeCell: CodeCellType = {
+  cell_type: "code",
+  id: "elements-full-code-cell",
+  source: [
+    "features = orders.assign(month=orders.date.dt.month)",
+    "model.fit(features[columns], target)",
+    "predictions = model.predict(features_holdout)",
+  ].join("\n"),
+  execution_count: 12,
+  outputs: [],
+  metadata: {},
+};
+
+const markdownCell: MarkdownCellType = {
+  cell_type: "markdown",
+  id: "elements-full-markdown-cell",
+  source: "",
+  metadata: {},
+};
+
+const rawCell: RawCellType = {
+  cell_type: "raw",
+  id: "elements-full-raw-cell",
+  source: ["---", "title: Forecast Review", "format: dashboard", "kernel: python3", "---"].join(
+    "\n",
+  ),
+  metadata: {
+    format: "yaml",
+  },
+};
+
+const markdownFixtureSource = [
+  "## Forecast review",
+  "",
+  "The production `MarkdownCell` owns edit/preview switching and the isolated markdown iframe.",
+  "This catalog keeps it in edit mode until the isolated renderer bundle is wired as a docs adapter.",
+].join("\n");
+
+const fullCellRows = [
+  {
+    label: "CodeCell",
+    source: "apps/notebook/src/components/CodeCell.tsx",
+    detail:
+      "Rendered with seeded execution and output stores, real CodeMirror source, CompactExecutionButton, and OutputArea.",
+  },
+  {
+    label: "MarkdownCell",
+    source: "apps/notebook/src/components/MarkdownCell.tsx",
+    detail:
+      "Rendered in its source-editing state. Preview mode remains an explicit isolated-renderer adapter boundary.",
+  },
+  {
+    label: "RawCell",
+    source: "apps/notebook/src/components/RawCell.tsx",
+    detail:
+      "Rendered with current raw-format detection, CodeMirror source editor, and shared cell chrome.",
+  },
+];
+
+const noop = () => {};
+
+function seedFullCellFixtures() {
+  replaceNotebookCells([codeCell, markdownCell, rawCell]);
+  resetNotebookOutputs();
+  resetNotebookExecutions();
+
+  setOutput("elements-output-stream", {
+    output_id: "elements-output-stream",
+    output_type: "stream",
+    name: "stdout",
+    text: "loaded 22,767 rows\nvalidated 16 week backtest window\n",
+  });
+  setOutput("elements-output-result", {
+    output_id: "elements-output-result",
+    output_type: "execute_result",
+    execution_count: 12,
+    data: {
+      "text/plain": "MAE 8.42\nMAPE 6.8%\nBacktest 16 weeks",
+    },
+    metadata: {},
+  });
+  setExecution("elements-execution", {
+    execution_count: 12,
+    status: "done",
+    success: true,
+    output_ids: ["elements-output-stream", "elements-output-result"],
+    submitted_by_actor_label: "local:kyle",
+  });
+  setCellExecutionPointer(codeCell.id, "elements-execution");
+
+  setFocusedCellId(codeCell.id);
+  setExecutingCellIds(new Set());
+  setQueuedCellIds(new Set());
+  setSearchQuery(undefined);
+  setSearchCurrentMatch(null);
+  flushCellUIState();
+}
+
+function focusFixtureCell(cellId: string) {
+  setFocusedCellId(cellId);
+  flushCellUIState();
+}
+
+export function FullCellSurfacesExample() {
+  const [fixturesSeeded, setFixturesSeeded] = useState(false);
+
+  useLayoutEffect(() => {
+    seedFullCellFixtures();
+    setFixturesSeeded(true);
+  }, []);
+
+  const adapterValue = useMemo(
+    () => ({
+      getHandle: () => null,
+      onSyncNeeded: noop,
+      localActor: "elements-fixture",
+    }),
+    [],
+  );
+
+  if (!fixturesSeeded) {
+    return (
+      <div className="not-prose rounded-lg border border-fd-border bg-fd-card p-4 text-sm text-fd-muted-foreground">
+        Loading full cell fixtures...
+      </div>
+    );
+  }
+
+  return (
+    <div className="not-prose space-y-6">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Full cell fixtures</h2>
+            <p className="mt-1 text-xs leading-5">
+              These examples import the notebook app cell components directly. Store-backed state is
+              seeded from fixture data, while the CRDT bridge exposes a null handle so edits never
+              leave the docs app.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <CrdtBridgeProvider {...adapterValue}>
+        <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <FileCode2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">CodeCell</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              The output count, execution button, and rendered text outputs come from the same
+              stores the notebook app consumes.
+            </p>
+          </div>
+          <div className="bg-background py-4 pl-12 pr-2">
+            <CodeCell
+              cell={codeCell}
+              language="python"
+              onFocus={() => focusFixtureCell(codeCell.id)}
+              onExecute={noop}
+              onInterrupt={noop}
+              onDelete={noop}
+              onFocusPrevious={noop}
+              onFocusNext={() => focusFixtureCell(markdownCell.id)}
+              onInsertCellAfter={noop}
+              rightGutterContent={
+                <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+                  seeded runtime
+                </span>
+              }
+            />
+          </div>
+        </section>
+
+        <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <FileText className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">MarkdownCell</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              The production component is rendered in edit mode. Its preview path stays documented
+              as an isolated-renderer adapter boundary for the docs app.
+            </p>
+          </div>
+          <div className="grid gap-4 bg-background p-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="min-w-0 pl-8 pr-2">
+              <MarkdownCell
+                cell={markdownCell}
+                onFocus={() => focusFixtureCell(markdownCell.id)}
+                onDelete={noop}
+                onFocusPrevious={() => focusFixtureCell(codeCell.id)}
+                onFocusNext={() => focusFixtureCell(rawCell.id)}
+                onInsertCellAfter={noop}
+                rightGutterContent={
+                  <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-[11px] font-medium text-sky-700 dark:text-sky-300">
+                    edit state
+                  </span>
+                }
+              />
+            </div>
+            <div className="rounded-lg border border-fd-border bg-fd-background p-3">
+              <div className="mb-2 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
+                <Rows3 className="size-3.5" aria-hidden="true" />
+                Preview adapter input
+              </div>
+              <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-fd-muted-foreground">
+                {markdownFixtureSource}
+              </pre>
+            </div>
+          </div>
+        </section>
+
+        <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">RawCell</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              Raw format detection and the shared editor chrome run from the current notebook app
+              component.
+            </p>
+          </div>
+          <div className="bg-background py-4 pl-12 pr-2">
+            <RawCell
+              cell={rawCell}
+              onFocus={() => focusFixtureCell(rawCell.id)}
+              onDelete={noop}
+              onFocusPrevious={() => focusFixtureCell(markdownCell.id)}
+              onFocusNext={noop}
+              onInsertCellAfter={noop}
+              rightGutterContent={
+                <span className="rounded-full border border-fd-border bg-fd-background px-2 py-1 font-mono text-[11px] text-fd-muted-foreground">
+                  yaml
+                </span>
+              }
+            />
+          </div>
+        </section>
+      </CrdtBridgeProvider>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {fullCellRows.map((row) => (
+          <div key={row.label} className="rounded-lg border border-fd-border bg-fd-card p-4">
+            <h3 className="text-sm font-semibold">{row.label}</h3>
+            <p className="mt-2 font-mono text-[11px] leading-5 text-fd-muted-foreground">
+              {row.source}
+            </p>
+            <p className="mt-3 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/components/isolated/iframe-libraries.ts
+++ b/apps/elements/components/isolated/iframe-libraries.ts
@@ -1,0 +1,23 @@
+export interface RendererPluginTarget {
+  installRenderer(code: string, css?: string): void;
+}
+
+export function needsPlugin(_mime: string): boolean {
+  return false;
+}
+
+export function loadPluginForMime(_mime: string): Promise<undefined> {
+  return Promise.resolve(undefined);
+}
+
+export function preWarmForMimes(_mimes: Iterable<string>): void {}
+
+export async function injectPluginsForMimes(
+  _frame: RendererPluginTarget,
+  mimes: Iterable<string>,
+  injectedSet: Set<string>,
+): Promise<void> {
+  for (const mime of mimes) {
+    injectedSet.add(mime);
+  }
+}

--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import {
+  anyOutputNeedsIsolation,
+  hasWidgetOutputs,
+  isScrollPassthroughMimeType,
+  isSiftMimeType,
+  outputAllowsScrollPassthrough,
+  outputNeedsIsolation,
+  outputSegmentLane,
+  outputUsesSift,
+  outputUsesWidget,
+  segmentedOutputLanes,
+  selectedOutputMimeType,
+  splitOutputSegments,
+  type OutputLane,
+  type OutputSegment,
+  type OutputSegmentationOptions,
+} from "../../../../src/components/isolated/output-lane-policy";
+import type {
+  IframeToParentMessage,
+  ParentToIframeMessage,
+  RenderPayload,
+} from "../../../../src/components/isolated/frame-bridge";
+import type { IsolatedDiagnosticHandler } from "../../../../src/components/isolated/diagnostics";
+import type { NteractEmbedHostContextPatch } from "../../../../src/components/isolated/host-context";
+
+export {
+  anyOutputNeedsIsolation,
+  hasWidgetOutputs,
+  isScrollPassthroughMimeType,
+  isSiftMimeType,
+  outputAllowsScrollPassthrough,
+  outputNeedsIsolation,
+  outputSegmentLane,
+  outputUsesSift,
+  outputUsesWidget,
+  segmentedOutputLanes,
+  selectedOutputMimeType,
+  splitOutputSegments,
+};
+export type {
+  IframeToParentMessage,
+  IsolatedDiagnosticHandler,
+  OutputLane,
+  OutputSegment,
+  OutputSegmentationOptions,
+  RenderPayload,
+};
+
+export interface IsolatedFrameProps {
+  id?: string;
+  name?: string;
+  initialContent?: RenderPayload;
+  darkMode?: boolean;
+  colorTheme?: string;
+  hostContext?: NteractEmbedHostContextPatch;
+  outputDocumentUrl?: string | null;
+  minHeight?: number;
+  maxHeight?: number;
+  autoHeight?: boolean;
+  className?: string;
+  allowWheelBoundaryScroll?: boolean;
+  scrollPassthrough?: boolean;
+  revealOnRender?: boolean;
+  onReady?: () => void;
+  onResize?: (height: number) => void;
+  onLinkClick?: (url: string, newTab: boolean) => void;
+  onMouseDown?: () => void;
+  onDoubleClick?: () => void;
+  onWidgetUpdate?: (commId: string, state: Record<string, unknown>) => void;
+  onError?: (error: { message: string; stack?: string }) => void;
+  onMessage?: (message: IframeToParentMessage) => void;
+  onDiagnostic?: IsolatedDiagnosticHandler;
+}
+
+export interface IsolatedFrameHandle {
+  send: (message: ParentToIframeMessage) => void;
+  render: (payload: RenderPayload) => void;
+  renderBatch: (outputs: RenderPayload[]) => void;
+  eval: (code: string) => void;
+  installRenderer: (code: string, css?: string) => void;
+  setTheme: (isDark: boolean, colorTheme?: string | null) => void;
+  setHostContext: (hostContext: NteractEmbedHostContextPatch) => void;
+  clear: () => void;
+  search: (query: string, caseSensitive?: boolean) => void;
+  searchNavigate: (matchIndex: number) => void;
+  isReady: boolean;
+  isIframeReady: boolean;
+}
+
+export class CommBridgeManager {
+  constructor(_options: unknown) {}
+
+  handleIframeMessage(_message: IframeToParentMessage): void {}
+
+  dispose(): void {}
+}
+
+export function createCommBridgeManager(options: unknown): CommBridgeManager {
+  return new CommBridgeManager(options);
+}
+
+function stringifyPayloadData(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (Array.isArray(data)) return data.map(stringifyPayloadData).join("");
+  if (data == null) return "";
+  return JSON.stringify(data, null, 2);
+}
+
+function outputLabel(payload: RenderPayload): string {
+  if (payload.mimeType === "text/markdown") return "markdown preview adapter";
+  if (payload.mimeType === "text/plain") return "text output adapter";
+  return payload.mimeType;
+}
+
+export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>(
+  function IsolatedFrame(
+    {
+      id,
+      name,
+      initialContent,
+      darkMode = false,
+      minHeight = 24,
+      maxHeight,
+      autoHeight = false,
+      className,
+      onReady,
+      onResize,
+      onMouseDown,
+      onDoubleClick,
+    },
+    ref,
+  ) {
+    const [outputs, setOutputs] = useState<RenderPayload[]>(() =>
+      initialContent ? [initialContent] : [],
+    );
+    const [theme, setThemeState] = useState(darkMode ? "dark" : "light");
+    const [hostContext, setHostContextState] = useState<NteractEmbedHostContextPatch>({});
+    const onReadyRef = useRef(onReady);
+    const onResizeRef = useRef(onResize);
+
+    useEffect(() => {
+      onReadyRef.current = onReady;
+      onResizeRef.current = onResize;
+    }, [onReady, onResize]);
+
+    useEffect(() => {
+      onReadyRef.current?.();
+    }, []);
+
+    useEffect(() => {
+      onResizeRef.current?.(Math.max(minHeight, outputs.length * 72));
+    }, [minHeight, outputs.length]);
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        send: () => {},
+        render: (payload) =>
+          setOutputs(payload.replace ? [payload] : (current) => [...current, payload]),
+        renderBatch: (nextOutputs) => setOutputs(nextOutputs),
+        eval: () => {},
+        installRenderer: () => {},
+        setTheme: (isDark) => setThemeState(isDark ? "dark" : "light"),
+        setHostContext: (nextHostContext) =>
+          setHostContextState((current) => ({ ...current, ...nextHostContext })),
+        clear: () => setOutputs([]),
+        search: () => {},
+        searchNavigate: () => {},
+        isReady: true,
+        isIframeReady: true,
+      }),
+      [],
+    );
+
+    const frameStyle = useMemo<CSSProperties>(
+      () => ({
+        minHeight,
+        maxHeight: autoHeight ? undefined : maxHeight,
+      }),
+      [autoHeight, maxHeight, minHeight],
+    );
+
+    return (
+      <div
+        id={id}
+        data-elements-isolated-adapter="true"
+        data-elements-frame-name={name}
+        data-elements-frame-theme={theme}
+        data-elements-host-context={hostContext.nteract?.colorTheme ?? undefined}
+        className={className}
+        style={frameStyle}
+        onMouseDown={onMouseDown}
+        onDoubleClick={onDoubleClick}
+      >
+        {outputs.map((payload) => (
+          <div
+            key={payload.outputId}
+            className="rounded-md border border-fd-border bg-fd-muted/30 p-3 text-sm"
+          >
+            <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-fd-muted-foreground">
+              {outputLabel(payload)}
+            </div>
+            <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-fd-foreground">
+              {stringifyPayloadData(payload.data)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    );
+  },
+);

--- a/apps/elements/components/notebook-palette-toggle.tsx
+++ b/apps/elements/components/notebook-palette-toggle.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { ChevronDown, Palette } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Palette } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type NotebookPalette = "classic" | "cream";
 
@@ -10,17 +11,14 @@ const storageKey = "notebook-color-theme";
 const options: Array<{
   value: NotebookPalette;
   label: string;
-  swatch: string;
 }> = [
   {
     value: "classic",
     label: "Classic",
-    swatch: "bg-white",
   },
   {
     value: "cream",
     label: "Cream",
-    swatch: "bg-[#f5f2ec]",
   },
 ];
 
@@ -41,7 +39,7 @@ function applyPalette(value: NotebookPalette) {
   document.documentElement.setAttribute("data-color-theme", value);
 }
 
-export function NotebookPaletteToggle() {
+export function NotebookPaletteToggle({ className }: { className?: string }) {
   const [palette, setPalette] = useState<NotebookPalette>("classic");
 
   useEffect(() => {
@@ -62,38 +60,34 @@ export function NotebookPaletteToggle() {
 
   return (
     <div
-      className="flex items-center gap-1 rounded-lg border border-fd-border bg-fd-secondary/50 p-0.5 text-fd-muted-foreground"
-      aria-label="Notebook palette"
+      className={cn(
+        "flex items-center gap-2 rounded-lg border border-fd-border bg-fd-secondary/50 px-2 py-1 text-fd-muted-foreground",
+        className,
+      )}
+      aria-label="Notebook flavor"
     >
-      <Palette className="ml-1 size-3.5" aria-hidden="true" />
-      {options.map((option) => {
-        const isActive = palette === option.value;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            aria-pressed={isActive}
-            title={`${option.label} notebook palette`}
-            onClick={() => selectPalette(option.value)}
-            className={[
-              "inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-medium transition-colors",
-              isActive
-                ? "bg-fd-background text-fd-foreground shadow-sm"
-                : "hover:bg-fd-accent hover:text-fd-accent-foreground",
-            ].join(" ")}
-          >
-            <span
-              className={[
-                "size-2.5 rounded-full border",
-                option.swatch,
-                option.value === "cream" ? "border-[#d8cec3]" : "border-fd-border",
-              ].join(" ")}
-              aria-hidden="true"
-            />
-            {option.label}
-          </button>
-        );
-      })}
+      <Palette className="size-4 flex-none" aria-hidden="true" />
+      <label className="sr-only" htmlFor="notebook-flavor-select">
+        Notebook flavor
+      </label>
+      <div className="relative min-w-0 flex-1">
+        <select
+          id="notebook-flavor-select"
+          value={palette}
+          onChange={(event) => selectPalette(event.target.value as NotebookPalette)}
+          className="h-8 w-full appearance-none rounded-md bg-fd-background py-0 pe-8 ps-3 text-sm font-medium text-fd-foreground shadow-sm outline-none transition-colors hover:bg-fd-accent focus-visible:ring-2 focus-visible:ring-fd-ring"
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-2 top-1/2 size-3.5 -translate-y-1/2"
+          aria-hidden="true"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -4,6 +4,7 @@ description: A fixture-backed inventory map for existing nteract cell components
 ---
 
 import { CellAnatomyExample } from "@/components/cell-anatomy-example";
+import { FullCellSurfacesClient } from "@/components/full-cell-surfaces-client";
 
 The first component family to document is the existing cell frame. This page
 now renders the production-used cell shell pieces with fixture content, so the
@@ -12,6 +13,13 @@ helpers.
 
 <CellAnatomyExample />
 
+## Full cell surfaces
+
+The next cell slice imports the notebook app cell components directly and feeds
+them fixture state through the same stores they use in the desktop app.
+
+<FullCellSurfacesClient />
+
 ## Why this comes first
 
 The sidebar outline should scroll to cells and reflect heading state, but it
@@ -19,10 +27,11 @@ should not own cell rendering. A clear cell anatomy gives the sidebar a stable
 contract while preserving the existing `NotebookView` DOM-order invariant.
 
 This docs site should keep moving component by component toward runtime-free
-fixtures. The cell frame, compact execution button, execution count, and
-cell-type gutter accents now render from current source. Editor, output, and
-full cell examples still need adapters before they can safely render without
-generated WASM, iframe/plugin context, notebook sync state, or runtime hooks.
+fixtures. The cell frame, compact execution button, execution count,
+cell-type gutter accents, and the full code/markdown/raw cell components now
+render from current source. Markdown preview mode remains an isolated-renderer
+adapter boundary before the docs app should render it as production notebook
+preview output.
 
 Unused legacy cell helper components should be removed rather than cataloged.
 Catalog entries need to trace to notebook app usage, an active migration target,

--- a/apps/elements/lib/layout.shared.tsx
+++ b/apps/elements/lib/layout.shared.tsx
@@ -1,5 +1,4 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
-import { NotebookPaletteToggle } from "@/components/notebook-palette-toggle";
 
 export function baseOptions(): BaseLayoutProps {
   return {
@@ -12,11 +11,6 @@ export function baseOptions(): BaseLayoutProps {
         text: "Catalog",
         url: "/docs",
         active: "nested-url",
-      },
-      {
-        type: "custom",
-        secondary: true,
-        children: <NotebookPaletteToggle />,
       },
     ],
   };

--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "fumadocs-core": "16.9.3",
     "fumadocs-mdx": "15.0.10",
     "fumadocs-ui": "16.9.3",

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -8,12 +8,20 @@
     "paths": {
       "@/components/cell/*": ["../../src/components/cell/*"],
       "@/components/editor/*": ["../../src/components/editor/*"],
+      "@/components/isolated": ["./components/isolated/index.tsx"],
+      "@/components/isolated/iframe-libraries": [
+        "./components/isolated/iframe-libraries.ts"
+      ],
+      "@/components/isolated/*": ["../../src/components/isolated/*"],
       "@/components/outputs/*": ["../../src/components/outputs/*"],
       "@/components/ui/*": ["../../src/components/ui/*"],
       "@/components/widgets/*": ["../../src/components/widgets/*"],
       "@/lib/dark-mode": ["../../src/lib/dark-mode"],
       "@/lib/error-boundary": ["../../src/lib/error-boundary"],
+      "@/lib/highlight-text": ["../../src/lib/highlight-text"],
+      "@/lib/katex-options": ["../../src/lib/katex-options"],
       "@/lib/output-error-fallback": ["../../src/lib/output-error-fallback"],
+      "@/lib/renderer-registry": ["../../src/lib/renderer-registry"],
       "@/lib/utils": ["../../src/lib/utils"],
       "@/lib/widget-error-fallback": ["../../src/lib/widget-error-fallback"],
       "@/notebook-components/*": ["../../apps/notebook/src/components/*"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-core:
         specifier: 16.9.3
         version: 16.9.3(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.15)(lucide-react@0.513.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@4.4.3)


### PR DESCRIPTION
## Summary

- add a client-only full cell surfaces section to the elements cell anatomy page
- render the current `CodeCell`, `MarkdownCell`, and `RawCell` components from fixture-backed notebook stores
- add an elements-local isolated renderer adapter so Next can build the catalog without bundling the notebook iframe runtime or Vite virtual renderer plugins
- sync editor surface dark/light and classic/cream rendering from the outer docs shell instead of separate page-local theme controls
- move the notebook flavor picker out of the nav link stack and into a compact sidebar-footer dropdown
- update the component burn-down, including the Sift/parquet direction for URL-backed Hugging Face fixtures

## Notes

The full cell examples keep production components as the source of truth. Runtime/sync edges remain adapter boundaries:

- CRDT bridge uses a null handle
- markdown preview stays documented as the isolated-renderer boundary
- isolated frame/plugin imports are mapped to docs-only no-op adapters

## Test Plan

- `pnpm --dir apps/elements build`
- headless browser smoke against `http://127.0.0.1:5176/docs/editor-surfaces`
- headless browser smoke against `http://127.0.0.1:5176/docs/cell-anatomy`
- headless browser smoke against `http://127.0.0.1:5176/docs/notebook-outline`
- `cargo xtask lint --fix`

Notebook app build not rerun: this PR only changes `apps/elements`, its package metadata, and docs-local path mappings.
