### PR TITLE
test(notebook-cloud): include blob timings in hosted smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -106,9 +106,9 @@ materialized render API. Override the target with
 `NOTEBOOK_CLOUD_SMOKE_SCREENSHOT=/tmp/notebook-cloud.png` to save a visual
 artifact. The JSON report includes coarse `timings_ms` milestones plus
 `performanceDiagnostics.resources_by_kind` for viewer document, viewer JS/CSS,
-`runtimed-wasm`, output document frames, Sift WASM, and pinned snapshot fetches
-when a pinned URL is tested. Use these diagnostics to choose performance work
-before adding timing budgets.
+`runtimed-wasm`, output document frames, Sift WASM, notebook output blob fetches,
+and pinned snapshot fetches when a pinned URL is tested. Use these diagnostics
+to choose performance work before adding timing budgets.
 
 For non-MathNet published notebooks, customize the hosted smoke expectations
 with `NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT`,

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -19,6 +19,9 @@ export function classifyPerformanceResource(
     if (/^\/api\/n\/[^/]+\/runtime-snapshots\/[^/]+\/?$/.test(parsed.pathname)) {
       return "runtime_snapshot";
     }
+    if (/^\/api\/n\/[^/]+\/blobs\/[^/]+\/?$/.test(parsed.pathname)) {
+      return "notebook_blob";
+    }
     if (/^\/n\/[^/]+(?:\/[^/]+|\/r\/[^/]+)?\/?$/.test(parsed.pathname)) {
       return "viewer_document";
     }
@@ -65,18 +68,25 @@ export function summarizePerformanceResources(resources, milestones = {}) {
       first_start_ms: null,
       first_end_ms: null,
       max_end_ms: null,
+      max_duration_ms: null,
       statuses: [],
       urls: [],
+      slowest: [],
     });
     summary.count += 1;
     summary.first_start_ms = minDefined(summary.first_start_ms, resource.start_ms);
     summary.first_end_ms = minDefined(summary.first_end_ms, resource.end_ms);
     summary.max_end_ms = maxDefined(summary.max_end_ms, resource.end_ms);
+    const duration = resourceDuration(resource);
+    summary.max_duration_ms = maxDefined(summary.max_duration_ms, duration);
     if (resource.status !== null && resource.status !== undefined) {
       summary.statuses.push(resource.status);
     }
     if (summary.urls.length < 5 && !summary.urls.includes(resource.url)) {
       summary.urls.push(resource.url);
+    }
+    if (duration !== null) {
+      trackSlowResource(summary.slowest, resource, duration);
     }
   }
 
@@ -107,4 +117,23 @@ function maxDefined(current, candidate) {
   if (candidate === null || candidate === undefined) return current;
   if (current === null || current === undefined) return candidate;
   return Math.max(current, candidate);
+}
+
+function resourceDuration(resource) {
+  if (resource.start_ms === null || resource.start_ms === undefined) return null;
+  if (resource.end_ms === null || resource.end_ms === undefined) return null;
+  return resource.end_ms - resource.start_ms;
+}
+
+function trackSlowResource(slowest, resource, duration) {
+  slowest.push({
+    url: resource.url,
+    start_ms: resource.start_ms,
+    end_ms: resource.end_ms,
+    duration_ms: duration,
+    status: resource.status ?? null,
+    failure: resource.failure ?? null,
+  });
+  slowest.sort((a, b) => b.duration_ms - a.duration_ms || a.start_ms - b.start_ms);
+  slowest.splice(5);
 }

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -34,6 +34,13 @@ describe("hosted smoke performance diagnostics", () => {
       "runtime_snapshot",
     );
     assert.equal(
+      classifyPerformanceResource(
+        "https://preview.runt.run/api/n/topic-viz/blobs/sha256-abc",
+        origins,
+      ),
+      "notebook_blob",
+    );
+    assert.equal(
       classifyPerformanceResource("https://preview.runt.run/n/topic-viz", origins),
       "viewer_document",
     );
@@ -89,10 +96,29 @@ describe("hosted smoke performance diagnostics", () => {
             first_start_ms: 10,
             first_end_ms: 30,
             max_end_ms: 50,
+            max_duration_ms: 30,
             statuses: [200, 200],
             urls: [
               "https://preview.runtusercontent.com/frame/",
               "https://preview.runtusercontent.com/frame/?two",
+            ],
+            slowest: [
+              {
+                url: "https://preview.runtusercontent.com/frame/?two",
+                start_ms: 20,
+                end_ms: 50,
+                duration_ms: 30,
+                status: 200,
+                failure: null,
+              },
+              {
+                url: "https://preview.runtusercontent.com/frame/",
+                start_ms: 10,
+                end_ms: 30,
+                duration_ms: 20,
+                status: 200,
+                failure: null,
+              },
             ],
           },
         },


### PR DESCRIPTION
## Summary

- include `/api/n/:id/blobs/:hash` requests in hosted smoke performance diagnostics
- report `max_duration_ms` and the five slowest resources for each load-path bucket
- document that hosted smoke now reports notebook output blob fetch timing

## Why

After the Automerge snapshot path landed, the hosted smoke could time the viewer
shell, output frames, and WASM sidecars, but not the blob fetches used by Sift
Arrow stream outputs. This fills that gap so the next rendering-performance PR
can distinguish transfer time from table decode/hydration work.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-performance.test.mjs test/hosted-smoke-routes.test.mjs`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
