### PR TITLE
docs(elements): add package rail fixture

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -19,7 +19,7 @@ const stats = [
     label: "current imports",
     value: "31",
     detail:
-      "used shell toolbar, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, package header, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -59,11 +59,11 @@ const phases = [
 const families = [
   {
     family: "Notebook workspace",
-    source: "apps/notebook/src/components/{NotebookView,NotebookToolbar}.tsx",
+    source: "apps/notebook/src/components/{NotebookView,NotebookToolbar,DependencyHeader}.tsx",
     target: "nteract shell",
     status: "active",
     intent:
-      "NotebookToolbar now renders from current source; the sidebar rail remains a fixture-backed adapter until the app owns that component.",
+      "NotebookToolbar renders from current source; the sidebar rail remains a fixture-backed adapter, and its package panel now hosts the current DependencyHeader instead of a catalog-only package list.",
   },
   {
     family: "Cells",

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -1,10 +1,17 @@
 "use client";
 
 import { Boxes, ListTree, Package, PanelLeft, ShieldCheck, Variable } from "lucide-react";
+import { useState } from "react";
 import { KERNEL_STATUS, RUNTIME_STATUS, type RuntimeLifecycle } from "runtimed";
+import { cn } from "@/lib/utils";
+import { DependencyHeader } from "@/notebook-components/DependencyHeader";
 import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
 
 const noop = () => {};
+const asyncNoop = async () => {};
+const asyncTrue = async () => true;
+
+type RailPanelKey = "outline" | "packages" | "variables" | "renderers";
 
 const runningIdleLifecycle: RuntimeLifecycle = {
   lifecycle: "Running",
@@ -12,11 +19,11 @@ const runningIdleLifecycle: RuntimeLifecycle = {
 };
 
 const outlineItems = [
-  { title: "Load data", depth: 0, active: true },
-  { title: "Clean columns", depth: 1, active: false },
-  { title: "Explore shape", depth: 0, active: false },
-  { title: "Model run", depth: 0, active: false },
-  { title: "Findings", depth: 1, active: false },
+  { title: "Load data", depth: 0 },
+  { title: "Clean columns", depth: 1 },
+  { title: "Explore shape", depth: 0 },
+  { title: "Model run", depth: 0 },
+  { title: "Findings", depth: 1 },
 ];
 
 const cells = [
@@ -37,9 +44,43 @@ const cells = [
   },
 ];
 
+const variableItems = [
+  { name: "orders", type: "DataFrame", value: "2,148 rows x 18 columns" },
+  { name: "features", type: "DataFrame", value: "2,148 rows x 32 columns" },
+  { name: "model", type: "Pipeline", value: "StandardScaler -> Ridge" },
+  { name: "mae", type: "float", value: "8.42" },
+];
+
+const rendererItems = [
+  { name: "text/html", state: "isolated" },
+  { name: "application/vnd.apache.arrow.file", state: "sift" },
+  { name: "image/png", state: "inline" },
+];
+
+const railItems = [
+  { key: "outline", icon: ListTree, label: "Outline" },
+  { key: "packages", icon: Package, label: "Packages" },
+  { key: "variables", icon: Variable, label: "Variables" },
+  { key: "renderers", icon: Boxes, label: "Renderers" },
+] satisfies Array<{ key: RailPanelKey; icon: typeof ListTree; label: string }>;
+
 export function RailOutlineExample() {
+  const [activePanel, setActivePanel] = useState<RailPanelKey>("outline");
+  const panelTitle = railItems.find((item) => item.key === activePanel)?.label ?? "Outline";
+  const panelDetail =
+    activePanel === "outline"
+      ? `${outlineItems.length} headings`
+      : activePanel === "packages"
+        ? "uv:inline · 4 packages"
+        : activePanel === "variables"
+          ? `${variableItems.length} live names`
+          : `${rendererItems.length} renderers`;
+
   return (
-    <div className="not-prose overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm">
+    <div
+      className="not-prose overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm"
+      data-elements-slot="rail-outline-example"
+    >
       <NotebookToolbar
         kernelStatus={KERNEL_STATUS.IDLE}
         statusKey={RUNTIME_STATUS.RUNNING_IDLE}
@@ -62,59 +103,49 @@ export function RailOutlineExample() {
         isDepsOpen={false}
         depsOutOfSync={false}
       />
-      <div className="grid min-h-[420px] grid-cols-[48px_260px_minmax(420px,1fr)] overflow-x-auto">
+      <div className="grid min-h-[500px] grid-cols-[48px_minmax(260px,300px)_minmax(320px,1fr)] overflow-x-auto">
         <aside className="flex flex-col items-center gap-2 border-r border-fd-border bg-fd-muted/40 px-2 py-3">
           <div className="mb-3 flex size-8 items-center justify-center rounded-md bg-fd-primary text-fd-primary-foreground">
             <PanelLeft className="size-4" aria-hidden="true" />
           </div>
-          {[
-            { icon: ListTree, label: "Outline", active: true },
-            { icon: Package, label: "Packages", active: false },
-            { icon: Variable, label: "Variables", active: false },
-            { icon: Boxes, label: "Renderers", active: false },
-          ].map((item) => (
-            <div
+          {railItems.map((item) => (
+            <button
               key={item.label}
-              className={[
+              type="button"
+              aria-pressed={activePanel === item.key}
+              onClick={() => setActivePanel(item.key)}
+              className={cn(
                 "flex size-8 items-center justify-center rounded-md border text-xs",
-                item.active
+                "transition-colors hover:border-fd-border hover:bg-fd-background hover:text-fd-foreground",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-primary/40",
+                activePanel === item.key
                   ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
                   : "border-transparent text-fd-muted-foreground",
-              ].join(" ")}
+              )}
               title={item.label}
             >
               <item.icon className="size-4" aria-hidden="true" />
-            </div>
+            </button>
           ))}
         </aside>
 
-        <aside className="border-r border-fd-border bg-fd-background p-4">
-          <div className="mb-4">
-            <p className="text-xs font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-              Notebook
-            </p>
-            <h3 className="mt-1 text-sm font-semibold">Outline</h3>
+        <aside className="min-h-0 overflow-y-auto border-r border-fd-border bg-fd-background p-4">
+          <div className="mb-4 flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                Notebook
+              </p>
+              <h3 className="mt-1 text-sm font-semibold">{panelTitle}</h3>
+            </div>
+            <span className="rounded-full border border-fd-border bg-fd-muted px-2 py-1 text-[11px] text-fd-muted-foreground">
+              {panelDetail}
+            </span>
           </div>
-          <nav className="space-y-1" aria-label="Notebook outline preview">
-            {outlineItems.map((item) => (
-              <div
-                key={item.title}
-                className={[
-                  "flex items-center rounded-md px-2 py-1.5 text-sm",
-                  item.depth === 1 ? "ml-4" : "",
-                  item.active
-                    ? "bg-fd-primary text-fd-primary-foreground"
-                    : "text-fd-muted-foreground",
-                ].join(" ")}
-              >
-                {item.title}
-              </div>
-            ))}
-          </nav>
-          <div className="mt-6 rounded-md border border-dashed border-fd-border p-3 text-xs leading-5 text-fd-muted-foreground">
-            Packages and variables become sibling panels on the same rail, not sections inside the
-            outline.
-          </div>
+
+          {activePanel === "outline" && <OutlinePanel />}
+          {activePanel === "packages" && <PackagePanel />}
+          {activePanel === "variables" && <VariablesPanel />}
+          {activePanel === "renderers" && <RenderersPanel />}
         </aside>
 
         <main className="bg-fd-muted/20 p-6">
@@ -122,11 +153,11 @@ export function RailOutlineExample() {
             <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
               <div className="mb-1 flex items-center gap-2 font-semibold">
                 <ShieldCheck className="size-3.5" aria-hidden="true" />
-                NotebookToolbar is rendered from the notebook app.
+                NotebookToolbar and DependencyHeader are rendered from the notebook app.
               </div>
               <p>
-                The rail and outline data remain fixture-backed until the app has a production rail
-                component and heading adapter.
+                The rail shell stays fixture-backed while package management starts using current
+                dependency UI inside the left-side panel.
               </p>
             </div>
             {cells.map((cell) => (
@@ -146,6 +177,97 @@ export function RailOutlineExample() {
           </div>
         </main>
       </div>
+    </div>
+  );
+}
+
+function OutlinePanel() {
+  return (
+    <>
+      <nav className="space-y-1" aria-label="Notebook outline preview">
+        {outlineItems.map((item, index) => (
+          <div
+            key={item.title}
+            className={cn(
+              "flex items-center rounded-md px-2 py-1.5 text-sm",
+              item.depth === 1 && "ml-4",
+              index === 0 ? "bg-fd-primary text-fd-primary-foreground" : "text-fd-muted-foreground",
+            )}
+          >
+            {item.title}
+          </div>
+        ))}
+      </nav>
+      <div className="mt-6 rounded-md border border-dashed border-fd-border p-3 text-xs leading-5 text-fd-muted-foreground">
+        Packages and variables are sibling rail panels, not sections inside the outline.
+      </div>
+    </>
+  );
+}
+
+function PackagePanel() {
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-fd-border bg-fd-muted/40 p-3 text-xs leading-5 text-fd-muted-foreground">
+        This uses the current notebook dependency panel in a rail-sized frame. The catalog owns only
+        the fixture state and inert callbacks.
+      </div>
+      <div className="overflow-hidden rounded-md border border-fd-border bg-fd-card">
+        <DependencyHeader
+          dependencies={["pandas>=2", "polars", "plotly", "scikit-learn"]}
+          requiresPython=">=3.13"
+          loading={false}
+          onAdd={asyncNoop}
+          onRemove={asyncNoop}
+          onSetRequiresPython={asyncNoop}
+          syncState={{ status: "dirty", added: ["altair"], removed: [] }}
+          onSyncNow={asyncTrue}
+          pyprojectInfo={null}
+          pyprojectDeps={null}
+          isUsingProjectEnv={false}
+          justSynced={false}
+        />
+      </div>
+    </div>
+  );
+}
+
+function VariablesPanel() {
+  return (
+    <div className="space-y-2">
+      {variableItems.map((variable) => (
+        <div key={variable.name} className="rounded-md border border-fd-border px-2 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="min-w-0 truncate font-mono text-xs text-fd-foreground">
+              {variable.name}
+            </span>
+            <span className="rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
+              {variable.type}
+            </span>
+          </div>
+          <div className="mt-1 truncate text-[11px] text-fd-muted-foreground">{variable.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RenderersPanel() {
+  return (
+    <div className="space-y-2">
+      {rendererItems.map((renderer) => (
+        <div
+          key={renderer.name}
+          className="flex items-center justify-between gap-3 rounded-md border border-fd-border px-2 py-2"
+        >
+          <span className="min-w-0 truncate font-mono text-xs text-fd-foreground">
+            {renderer.name}
+          </span>
+          <span className="rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
+            {renderer.state}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -11,7 +11,8 @@ slots for packages, variables, renderers, and future notebook tools.
 
 This fixture now renders the current notebook app toolbar directly. The rail
 itself stays catalog-owned until the notebook app has a production left-rail
-component to import.
+component to import, but the package panel already renders the current
+`DependencyHeader` inside that rail frame.
 
 <RailOutlineExample />
 
@@ -21,6 +22,8 @@ component to import.
   moving cells into the sidebar.
 - `NotebookToolbar` is imported from `apps/notebook/src/components` with inert
   fixture callbacks and runtime status props.
+- The package panel imports `DependencyHeader` from the notebook app with
+  fixture dependency and sync state.
 - The outline should start from materialized markdown headings.
 - Keep the rail icon-led: outline, packages, variables, renderers, and future
   side panels should scan as compact tools before a panel opens.


### PR DESCRIPTION
## Summary

- Make the notebook outline rail example interactive across outline, packages, variables, and renderers.
- Render the current notebook `DependencyHeader` inside the rail package panel with fixture state and inert callbacks.
- Update the outline docs and burn-down so the package rail is described as the next shell direction, not a forked package UI.

## Verification

- `pnpm --dir apps/elements build`
- Headless Playwright smoke for `/docs/notebook-outline`: click Packages, verify `DependencyHeader`, no console errors, no page-level horizontal overflow.
- `cargo xtask lint --fix`
