### PR TITLE
perf(sift): prefetch arrow stream chunks

### DIFF
--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -266,6 +266,64 @@ describe("SiftTable", () => {
     vi.useFakeTimers();
   });
 
+  it("starts Arrow stream chunk fetches without waiting for first chunk append", async () => {
+    vi.useRealTimers();
+    const fetchResolvers: ((response: {
+      ok: true;
+      arrayBuffer: () => Promise<ArrayBuffer>;
+    }) => void)[] = [];
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<{ ok: true; arrayBuffer: () => Promise<ArrayBuffer> }>((resolve) => {
+          fetchResolvers.push(resolve);
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { unmount } = render(
+      <SiftTable
+        source={{
+          kind: "arrow-stream-manifest",
+          manifest: {
+            chunks: [
+              { url: "http://127.0.0.1:9000/blob/chunk-0" },
+              { url: "http://127.0.0.1:9000/blob/chunk-1" },
+              { url: "http://127.0.0.1:9000/blob/chunk-2" },
+            ],
+            complete: true,
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+    expect(predicateModule.append_arrow_stream_chunk).not.toHaveBeenCalled();
+
+    const responseFor = (bytes: number[]) => ({
+      ok: true as const,
+      arrayBuffer: async () => new Uint8Array(bytes).buffer,
+    });
+    fetchResolvers[0](responseFor([1, 2, 3]));
+
+    await waitFor(() => {
+      expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
+    });
+
+    fetchResolvers[1](responseFor([4, 5, 6]));
+    fetchResolvers[2](responseFor([7, 8, 9]));
+
+    await waitFor(() => {
+      expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(3);
+      expect(predicateModule.finish_arrow_stream_store).toHaveBeenCalledWith(9);
+    });
+
+    unmount();
+    vi.unstubAllGlobals();
+    vi.useFakeTimers();
+  });
+
   it("does not reload a manifest source when only object identity changes", async () => {
     vi.useRealTimers();
     const chunkBytes = new Uint8Array([1, 2, 3, 4]);

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -433,6 +433,8 @@ export function SiftTable({
       return new Uint8Array(await response.arrayBuffer());
     }
 
+    type ChunkFetchResult = { ok: true; bytes: Uint8Array } | { ok: false; error: unknown };
+
     async function loadFromManifest() {
       setStatus("loading");
       setError(null);
@@ -459,7 +461,19 @@ export function SiftTable({
       const handle = mod.create_arrow_stream_store();
       disposePendingStore = () => mod.free(handle);
 
-      const firstBytes = await fetchChunkBytes(chunks[0], 0);
+      const chunkFetches: Promise<ChunkFetchResult>[] = chunks.map((chunk, index) =>
+        fetchChunkBytes(chunk, index).then(
+          (bytes) => ({ ok: true, bytes }),
+          (error: unknown) => ({ ok: false, error }),
+        ),
+      );
+      const readChunkBytes = async (index: number) => {
+        const result = await chunkFetches[index];
+        if (!result.ok) throw result.error;
+        return result.bytes;
+      };
+
+      const firstBytes = await readChunkBytes(0);
       if (cancelled) return;
       emitLoadMilestone(startedAt, {
         source: "arrow-stream-manifest",
@@ -519,7 +533,7 @@ export function SiftTable({
         if (cancelled) return;
         await new Promise((r) => setTimeout(r, 0));
         if (cancelled) return;
-        const bytes = await fetchChunkBytes(chunks[i], i);
+        const bytes = await readChunkBytes(i);
         if (cancelled) return;
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",


### PR DESCRIPTION
## Summary

- Start all Arrow stream manifest chunk fetches after Sift WASM is ready instead of fetching trailing chunks serially after the first table mount
- Preserve append order by awaiting each chunk promise in manifest order
- Add a focused Sift test that proves later chunk requests begin before the first chunk is appended

## Context

This follows the deployed `preview.runt.run` smoke after #3117. The shell/first iframe is visible around 3.4s, but `topic-viz` Sift outputs were still completing table hydration around 6.0-6.5s relative to Sift load because later Arrow stream chunks were fetched serially. This PR removes that strict network serialization while keeping the progressive first-chunk mount behavior.

## Validation

- `pnpm --dir packages/sift test -- react.test.tsx`
- `pnpm --dir packages/sift build:lib`
- `pnpm --workspace-root exec vp test run src/isolated-renderer/__tests__/sift-renderer.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
