### PR TITLE
perf(sift): stage arrow stream prefetch

### DIFF
--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -266,15 +266,20 @@ describe("SiftTable", () => {
     vi.useFakeTimers();
   });
 
-  it("starts Arrow stream chunk fetches without waiting for first chunk append", async () => {
+  it("starts trailing Arrow stream chunk fetches before first chunk append", async () => {
     vi.useRealTimers();
     const fetchResolvers: ((response: {
       ok: true;
       arrayBuffer: () => Promise<ArrayBuffer>;
     }) => void)[] = [];
+    const fetchEvents: { url: string; appendCallCount: number }[] = [];
     const fetchMock = vi.fn(
-      () =>
+      (url: string) =>
         new Promise<{ ok: true; arrayBuffer: () => Promise<ArrayBuffer> }>((resolve) => {
+          fetchEvents.push({
+            url,
+            appendCallCount: predicateModule.append_arrow_stream_chunk.mock.calls.length,
+          });
           fetchResolvers.push(resolve);
         }),
     );
@@ -297,7 +302,7 @@ describe("SiftTable", () => {
     );
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
     expect(predicateModule.append_arrow_stream_chunk).not.toHaveBeenCalled();
 
@@ -310,6 +315,14 @@ describe("SiftTable", () => {
     await waitFor(() => {
       expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
     });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchEvents.map((event) => event.url)).toEqual([
+      "http://127.0.0.1:9000/blob/chunk-0",
+      "http://127.0.0.1:9000/blob/chunk-1",
+      "http://127.0.0.1:9000/blob/chunk-2",
+    ]);
+    expect(fetchEvents[1].appendCallCount).toBe(0);
+    expect(fetchEvents[2].appendCallCount).toBe(0);
 
     fetchResolvers[1](responseFor([4, 5, 6]));
     fetchResolvers[2](responseFor([7, 8, 9]));

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -461,19 +461,21 @@ export function SiftTable({
       const handle = mod.create_arrow_stream_store();
       disposePendingStore = () => mod.free(handle);
 
-      const chunkFetches: Promise<ChunkFetchResult>[] = chunks.map((chunk, index) =>
+      const fetchChunkResult = (chunk: ArrowStreamManifestChunk, index: number) =>
         fetchChunkBytes(chunk, index).then(
-          (bytes) => ({ ok: true, bytes }),
-          (error: unknown) => ({ ok: false, error }),
-        ),
-      );
-      const readChunkBytes = async (index: number) => {
-        const result = await chunkFetches[index];
+          (bytes) => ({ ok: true as const, bytes }),
+          (error: unknown) => ({ ok: false as const, error }),
+        );
+      const readChunkBytes = async (fetchResult: Promise<ChunkFetchResult>) => {
+        const result = await fetchResult;
         if (!result.ok) throw result.error;
         return result.bytes;
       };
 
-      const firstBytes = await readChunkBytes(0);
+      const firstBytes = await readChunkBytes(fetchChunkResult(chunks[0], 0));
+      const trailingChunkFetches = chunks
+        .slice(1)
+        .map((chunk, index) => fetchChunkResult(chunk, index + 1));
       if (cancelled) return;
       emitLoadMilestone(startedAt, {
         source: "arrow-stream-manifest",
@@ -533,7 +535,7 @@ export function SiftTable({
         if (cancelled) return;
         await new Promise((r) => setTimeout(r, 0));
         if (cancelled) return;
-        const bytes = await readChunkBytes(i);
+        const bytes = await readChunkBytes(trailingChunkFetches[i - 1]);
         if (cancelled) return;
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",


### PR DESCRIPTION
## Summary

- Adjust #3119's Arrow stream prefetch so chunk 0 remains the priority request
- Start trailing chunk fetches only after chunk 0 resolves, but before chunk 0 is appended
- Update the Sift regression test to prove trailing fetches start before the first append without competing with the first chunk request

## Context

#3119 was merged after it was ready, but preview validation showed the all-at-once prefetch could delay first-chunk paint even though it made full streaming complete sooner. This follow-up keeps the intended ordered trailing-chunk overlap while preserving Sift's progressive first-chunk render path.

## Validation

- `pnpm --dir packages/sift test -- react.test.tsx`
- `pnpm --dir packages/sift build:lib`
- `pnpm --workspace-root exec vp test run src/isolated-renderer/__tests__/sift-renderer.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Preview validation

- Deployed this branch to `preview.runt.run`
- Main worker version: `0a4268e2-5bd6-45c0-94d7-9b3b4d938ee6`
- `pnpm --dir apps/notebook-cloud smoke:hosted`

Result:

- Hosted smoke passed
- first output iframe: 2489 ms
- expected frame texts: 6991 ms
- first Sift chunk fetched: 3344 ms and 3474 ms after Sift load start
- trailing chunks overlapped: chunk 1 and chunk 2 completed together at about 6.7s after Sift load start

This fixes the all-at-once #3119 preview regression where first chunk readiness moved to about 5.2s after Sift load start.
