### PR TITLE
docs(elements): catalog notebook search surfaces

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -13,13 +13,13 @@ import {
 
 const stats = [
   { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
-  { label: "notebook domains", value: "7", detail: "first catalog targets" },
+  { label: "notebook domains", value: "8", detail: "first catalog targets" },
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "31",
+    value: "33",
     detail:
-      "used shell toolbar, package header, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, package header, search, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -64,6 +64,14 @@ const families = [
     status: "active",
     intent:
       "NotebookToolbar renders from current source; the sidebar rail remains a fixture-backed adapter, and its package panel now hosts the current DependencyHeader instead of a catalog-only package list.",
+  },
+  {
+    family: "Notebook search",
+    source: "apps/notebook/src/components/{GlobalFindBar,HistorySearchDialog}.tsx",
+    target: "nteract shell",
+    status: "active",
+    intent:
+      "GlobalFindBar and HistorySearchDialog now render from fixture search state; the history dialog uses a docs-local NotebookHost transport that only serves get_history.",
   },
   {
     family: "Cells",

--- a/apps/elements/components/fixture-notebook-host.ts
+++ b/apps/elements/components/fixture-notebook-host.ts
@@ -1,0 +1,108 @@
+import type { NotebookHost } from "@nteract/notebook-host";
+
+export const noop = () => {};
+export const asyncNoop = async () => {};
+export const asyncTrue = async () => true;
+
+const unlisten = () => {};
+
+interface FixtureNotebookHostOptions {
+  name?: string;
+  transport?: Partial<NotebookHost["transport"]>;
+}
+
+export function createFixtureNotebookHost({
+  name = "elements-fixture",
+  transport: transportOverrides = {},
+}: FixtureNotebookHostOptions = {}): NotebookHost {
+  const transport: NotebookHost["transport"] = {
+    sendFrame: asyncNoop,
+    sendTypedRequest: async () => {
+      throw new Error("Fixture host does not send typed requests.");
+    },
+    onFrame: () => unlisten,
+    sendRequest: async () => {
+      throw new Error("Fixture host does not send requests.");
+    },
+    connected: true,
+    disconnect: noop,
+    ...transportOverrides,
+  };
+
+  return {
+    name,
+    transport,
+    daemon: {
+      isConnected: async () => true,
+      reconnect: asyncNoop,
+      getInfo: async () => null,
+      getReadyInfo: async () => null,
+    },
+    daemonEvents: {
+      onReadyLive: () => unlisten,
+      onReady: () => unlisten,
+      onProgress: () => unlisten,
+      onDisconnected: () => unlisten,
+      onUnavailable: () => unlisten,
+    },
+    relay: {
+      requiresReadyGeneration: false,
+      notifySyncReady: asyncNoop,
+    },
+    blobs: {
+      port: async () => 0,
+      resolver: async () => {
+        throw new Error("Fixture host does not resolve blobs.");
+      },
+    },
+    trust: {
+      approve: asyncNoop,
+    },
+    deps: {
+      checkTyposquats: async () => [],
+    },
+    notebook: {
+      applyPathChanged: asyncNoop,
+      getDefaultSaveDirectory: async () => "/Users/kyle/notebooks",
+      saveAs: asyncNoop,
+      openInNewWindow: asyncNoop,
+      cloneToEphemeral: async () => "fixture-room",
+    },
+    window: {
+      getTitle: async () => "fixture.ipynb",
+      setTitle: asyncNoop,
+      onFocusChange: () => unlisten,
+    },
+    system: {
+      getGitInfo: async () => null,
+      getUsername: async () => "kyle",
+    },
+    dialog: {
+      openFile: async () => null,
+      saveFile: async () => null,
+    },
+    externalLinks: {
+      open: asyncNoop,
+    },
+    updater: {
+      getSnapshot: () => ({ status: "idle", version: null, error: null }),
+      subscribe: () => unlisten,
+      check: async () => ({ status: "idle", version: null, error: null }),
+      beginUpgrade: asyncNoop,
+    },
+    settings: {
+      openWindow: asyncNoop,
+    },
+    commands: {
+      register: () => unlisten,
+      run: asyncNoop,
+      list: () => [],
+    },
+    log: {
+      debug: noop,
+      info: noop,
+      warn: noop,
+      error: noop,
+    },
+  };
+}

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { NotebookHostProvider, type NotebookHost } from "@nteract/notebook-host";
+import { NotebookHostProvider } from "@nteract/notebook-host";
 import {
   AlertTriangle,
   CircleDot,
@@ -12,6 +12,12 @@ import {
 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  asyncNoop,
+  asyncTrue,
+  createFixtureNotebookHost,
+  noop,
+} from "@/components/fixture-notebook-host";
 import { DaemonStatusBanner } from "@/notebook-components/DaemonStatusBanner";
 import { DebugBanner } from "@/notebook-components/DebugBanner";
 import { DependencyHeader } from "@/notebook-components/DependencyHeader";
@@ -21,23 +27,6 @@ import { PoolErrorBanner } from "@/notebook-components/PoolErrorBanner";
 import { RuntimeDecisionDialog } from "@/notebook-components/RuntimeDecisionDialog";
 import { TrustDialog } from "@/notebook-components/TrustDialog";
 import { UntrustedBanner } from "@/notebook-components/UntrustedBanner";
-
-const noop = () => {};
-const asyncNoop = async () => {};
-const asyncTrue = async () => true;
-const unlisten = () => {};
-const fixtureTransport: NotebookHost["transport"] = {
-  sendFrame: asyncNoop,
-  sendTypedRequest: async () => {
-    throw new Error("Fixture host does not send typed requests.");
-  },
-  onFrame: () => unlisten,
-  sendRequest: async () => {
-    throw new Error("Fixture host does not send requests.");
-  },
-  connected: true,
-  disconnect: noop,
-};
 
 const runtimePieces = [
   {
@@ -96,82 +85,7 @@ const runtimePieces = [
   },
 ];
 
-const fixtureHost: NotebookHost = {
-  name: "elements-fixture",
-  transport: fixtureTransport,
-  daemon: {
-    isConnected: async () => true,
-    reconnect: asyncNoop,
-    getInfo: async () => null,
-    getReadyInfo: async () => null,
-  },
-  daemonEvents: {
-    onReadyLive: () => unlisten,
-    onReady: () => unlisten,
-    onProgress: () => unlisten,
-    onDisconnected: () => unlisten,
-    onUnavailable: () => unlisten,
-  },
-  relay: {
-    requiresReadyGeneration: false,
-    notifySyncReady: asyncNoop,
-  },
-  blobs: {
-    port: async () => 0,
-    resolver: async () => {
-      throw new Error("Fixture host does not resolve blobs.");
-    },
-  },
-  trust: {
-    approve: asyncNoop,
-  },
-  deps: {
-    checkTyposquats: async () => [],
-  },
-  notebook: {
-    applyPathChanged: asyncNoop,
-    getDefaultSaveDirectory: async () => "/Users/kyle/notebooks",
-    saveAs: asyncNoop,
-    openInNewWindow: asyncNoop,
-    cloneToEphemeral: async () => "fixture-room",
-  },
-  window: {
-    getTitle: async () => "fixture.ipynb",
-    setTitle: asyncNoop,
-    onFocusChange: () => unlisten,
-  },
-  system: {
-    getGitInfo: async () => null,
-    getUsername: async () => "kyle",
-  },
-  dialog: {
-    openFile: async () => null,
-    saveFile: async () => null,
-  },
-  externalLinks: {
-    open: asyncNoop,
-  },
-  updater: {
-    getSnapshot: () => ({ status: "idle", version: null, error: null }),
-    subscribe: () => unlisten,
-    check: async () => ({ status: "idle", version: null, error: null }),
-    beginUpgrade: asyncNoop,
-  },
-  settings: {
-    openWindow: asyncNoop,
-  },
-  commands: {
-    register: () => unlisten,
-    run: asyncNoop,
-    list: () => [],
-  },
-  log: {
-    debug: noop,
-    info: noop,
-    warn: noop,
-    error: noop,
-  },
-};
+const fixtureHost = createFixtureNotebookHost();
 
 const trustInfo = {
   status: "untrusted" as const,

--- a/apps/elements/components/search-surfaces-example.tsx
+++ b/apps/elements/components/search-surfaces-example.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { NotebookHostProvider } from "@nteract/notebook-host";
+import { History, Search, TextCursorInput } from "lucide-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import type { HistoryEntry, NotebookRequest, NotebookResponse } from "runtimed";
+import { Button } from "@/components/ui/button";
+import { createFixtureNotebookHost } from "@/components/fixture-notebook-host";
+import { GlobalFindBar } from "@/notebook-components/GlobalFindBar";
+import { HistorySearchDialog } from "@/notebook-components/HistorySearchDialog";
+
+const notebookCells = [
+  {
+    id: "cell-imports",
+    label: "cell 1",
+    source: [
+      "from datasets import load_dataset",
+      "import pandas as pd",
+      "from sklearn.ensemble import RandomForestRegressor",
+    ].join("\n"),
+  },
+  {
+    id: "cell-features",
+    label: "cell 2",
+    source: [
+      "features = orders.assign(month=orders.date.dt.month)",
+      "model.fit(features[columns], target)",
+      "predictions = model.predict(features_holdout)",
+      "display(predictions.head())",
+    ].join("\n"),
+  },
+  {
+    id: "cell-review",
+    label: "cell 3",
+    source: [
+      "summary = predictions.groupby(features.region).mean()",
+      "summary.sort_values('forecast_error').tail()",
+    ].join("\n"),
+  },
+];
+
+const fixtureHistoryEntries: HistoryEntry[] = [
+  {
+    session: 24,
+    line: 83,
+    source: [
+      "features = orders.assign(month=orders.date.dt.month)",
+      "model.fit(features[columns], target)",
+      "predictions = model.predict(features_holdout)",
+    ].join("\n"),
+  },
+  {
+    session: 24,
+    line: 71,
+    source: [
+      "columns = ['country', 'competition', 'problem_length']",
+      "features = ds_slice.to_pandas()[columns]",
+    ].join("\n"),
+  },
+  {
+    session: 23,
+    line: 18,
+    source: [
+      "history = client.get_history(pattern='features', n=100, unique=True)",
+      "len(history)",
+    ].join("\n"),
+  },
+  {
+    session: 21,
+    line: 4,
+    source: [
+      "from datasets import load_dataset",
+      "ds_slice = load_dataset('ShadenA/MathNet', 'all', split='train')",
+    ].join("\n"),
+  },
+];
+
+function isGetHistoryRequest(
+  request: unknown,
+): request is Extract<NotebookRequest, { type: "get_history" }> {
+  return (
+    typeof request === "object" &&
+    request !== null &&
+    "type" in request &&
+    request.type === "get_history"
+  );
+}
+
+function filterHistoryEntries({
+  pattern,
+  n,
+  unique,
+}: Extract<NotebookRequest, { type: "get_history" }>) {
+  const needle = pattern?.split("*").join("").trim().toLowerCase() ?? "";
+  const filtered = needle
+    ? fixtureHistoryEntries.filter((entry) => entry.source.toLowerCase().includes(needle))
+    : fixtureHistoryEntries;
+
+  const entries = unique
+    ? filtered.filter(
+        (entry, index, list) =>
+          list.findIndex((candidate) => candidate.source === entry.source) === index,
+      )
+    : filtered;
+
+  return entries.slice(0, n);
+}
+
+const historyFixtureHost = createFixtureNotebookHost({
+  name: "elements-history-fixture",
+  transport: {
+    sendRequest: async (request): Promise<NotebookResponse> => {
+      if (isGetHistoryRequest(request)) {
+        return { result: "history_result", entries: filterHistoryEntries(request) };
+      }
+
+      throw new Error("Search fixture host only handles get_history requests.");
+    },
+  },
+});
+
+function countMatches(source: string, query: string) {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return 0;
+
+  let count = 0;
+  let cursor = 0;
+  const haystack = source.toLowerCase();
+  while (cursor < haystack.length) {
+    const next = haystack.indexOf(needle, cursor);
+    if (next === -1) break;
+    count += 1;
+    cursor = next + needle.length;
+  }
+  return count;
+}
+
+function HighlightedLine({ line, query }: { line: string; query: string }) {
+  const needle = query.trim();
+  if (!needle) return line;
+
+  const lowerLine = line.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  const segments: ReactNode[] = [];
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    const next = lowerLine.indexOf(lowerNeedle, cursor);
+    if (next === -1) {
+      segments.push(line.slice(cursor));
+      break;
+    }
+
+    if (next > cursor) {
+      segments.push(line.slice(cursor, next));
+    }
+
+    segments.push(
+      <mark key={`${line}-${next}`} className="rounded-sm bg-amber-300/70 px-0.5 text-foreground">
+        {line.slice(next, next + needle.length)}
+      </mark>,
+    );
+    cursor = next + needle.length;
+  }
+
+  return <>{segments}</>;
+}
+
+export function SearchSurfacesExample() {
+  const [findOpen, setFindOpen] = useState(true);
+  const [query, setQuery] = useState("features");
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [selectedHistorySource, setSelectedHistorySource] = useState(
+    fixtureHistoryEntries[0].source,
+  );
+
+  const matchCount = useMemo(
+    () => notebookCells.reduce((total, cell) => total + countMatches(cell.source, query), 0),
+    [query],
+  );
+
+  useEffect(() => {
+    if (currentMatchIndex >= matchCount) {
+      setCurrentMatchIndex(0);
+    }
+  }, [currentMatchIndex, matchCount]);
+
+  return (
+    <div className="not-prose space-y-5" data-elements-slot="search-surfaces">
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="grid gap-3 border-b border-fd-border p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+          <div>
+            <div className="flex items-center gap-2 text-fd-muted-foreground">
+              <Search className="size-4" aria-hidden="true" />
+              <h2 className="text-sm font-semibold text-fd-foreground">GlobalFindBar</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              Rendered from the notebook app with fixture notebook text and inert navigation
+              callbacks.
+            </p>
+          </div>
+          <Button size="sm" variant="outline" onClick={() => setFindOpen(true)}>
+            Show find bar
+          </Button>
+        </div>
+        <div className="bg-background">
+          {findOpen ? (
+            <GlobalFindBar
+              query={query}
+              matchCount={matchCount}
+              currentMatchIndex={currentMatchIndex}
+              onQueryChange={(nextQuery) => {
+                setQuery(nextQuery);
+                setCurrentMatchIndex(0);
+              }}
+              onNextMatch={() =>
+                setCurrentMatchIndex((index) => (matchCount ? (index + 1) % matchCount : 0))
+              }
+              onPrevMatch={() =>
+                setCurrentMatchIndex((index) =>
+                  matchCount ? (index - 1 + matchCount) % matchCount : 0,
+                )
+              }
+              onClose={() => setFindOpen(false)}
+            />
+          ) : (
+            <div className="flex items-center justify-between border-b px-3 py-2 text-xs text-muted-foreground">
+              <span>Notebook find is closed.</span>
+              <button
+                type="button"
+                className="font-medium text-foreground"
+                onClick={() => setFindOpen(true)}
+              >
+                Reopen
+              </button>
+            </div>
+          )}
+
+          <div className="divide-y divide-border">
+            {notebookCells.map((cell) => (
+              <article key={cell.id} className="grid gap-3 p-4 md:grid-cols-[84px_minmax(0,1fr)]">
+                <div className="font-mono text-xs text-muted-foreground">{cell.label}</div>
+                <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap rounded-md border bg-muted/30 p-3 font-mono text-xs leading-6 text-foreground">
+                  {cell.source.split("\n").map((line, index) => (
+                    <span key={`${cell.id}-${index}`}>
+                      <HighlightedLine line={line} query={query} />
+                      {index < cell.source.split("\n").length - 1 ? "\n" : null}
+                    </span>
+                  ))}
+                </pre>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="grid gap-3 border-b border-fd-border p-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+          <div>
+            <div className="flex items-center gap-2 text-fd-muted-foreground">
+              <History className="size-4" aria-hidden="true" />
+              <h2 className="text-sm font-semibold text-fd-foreground">HistorySearchDialog</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              Rendered from the notebook app under a fixture host whose transport only answers typed
+              `get_history` requests.
+            </p>
+          </div>
+          <NotebookHostProvider host={historyFixtureHost}>
+            <Button size="sm" onClick={() => setHistoryOpen(true)}>
+              Open history search
+            </Button>
+            <HistorySearchDialog
+              open={historyOpen}
+              onOpenChange={setHistoryOpen}
+              onSelect={setSelectedHistorySource}
+              initialQuery={query}
+            />
+          </NotebookHostProvider>
+        </div>
+        <div className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+          <div className="flex items-start gap-2 text-fd-muted-foreground">
+            <TextCursorInput className="mt-0.5 size-4" aria-hidden="true" />
+            <div>
+              <h3 className="text-sm font-semibold text-fd-foreground">Selected history source</h3>
+              <p className="mt-2 text-xs leading-5">
+                Choosing a command in the dialog feeds the same source string the notebook inserts
+                into an editor.
+              </p>
+            </div>
+          </div>
+          <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap rounded-md border border-fd-border bg-fd-background p-3 font-mono text-xs leading-6 text-fd-foreground">
+            {selectedHistorySource}
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/search-surfaces.mdx
+++ b/apps/elements/content/docs/search-surfaces.mdx
@@ -1,0 +1,20 @@
+---
+title: Search surfaces
+description: Fixture-backed notebook search components from the desktop app.
+---
+
+import { SearchSurfacesExample } from "@/components/search-surfaces-example";
+
+Notebook search is a notebook-level surface, not a generic command palette.
+This page catalogs the current global notebook find bar and IPython history
+dialog with static notebook text and a docs-local host adapter.
+
+<SearchSurfacesExample />
+
+## Adapter notes
+
+`GlobalFindBar` renders directly from fixture search state. `HistorySearchDialog`
+still uses the real `useHistorySearch` hook, but the docs app supplies a
+`NotebookHost` transport that only answers `get_history` requests with static
+entries. The catalog does not start a daemon, sync a notebook, or import
+generated WASM to render these search surfaces.


### PR DESCRIPTION
## Summary

- Adds a Search surfaces docs page that renders the notebook app's `GlobalFindBar` and `HistorySearchDialog`.
- Adds a shared fixture `NotebookHost` helper so runtime-backed catalog pages can keep host calls inert and explicit.
- Updates the component burn-down to track notebook search as an active nteract-owned surface.

## Stack

Stacked on #3120 (`quod/elements-sift-renderer`) so this PR reviews as one search-surfaces commit.

## Verification

- `pnpm --dir apps/elements build`
- Playwright smoke against `http://127.0.0.1:5176/docs/search-surfaces`:
  - fill `GlobalFindBar` and verify match count updates
  - open `HistorySearchDialog`
  - fill history search and verify fixture `get_history` results render
- `cargo xtask lint --fix`
