### PR TITLE
fix(notebook-cloud): validate runtime doc pointer

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -584,6 +584,7 @@ async function routeSnapshot(
       notebookId,
       notebookHeadsHash: headsHash,
       runtimeHeadsHash,
+      expectedRuntimeStateDocId: runtimeStateDocId,
       notebookBytes: new Uint8Array(body),
       runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
     });
@@ -1097,6 +1098,7 @@ async function validateSnapshotPair(options: {
   notebookId: string;
   notebookHeadsHash: string;
   runtimeHeadsHash: string | null;
+  expectedRuntimeStateDocId: string;
   notebookBytes: Uint8Array;
   runtimeStateBytes: Uint8Array;
 }): Promise<SnapshotPairValidationResult> {
@@ -1139,6 +1141,28 @@ async function validateSnapshotPair(options: {
       body: {
         error: "snapshot pair validation failed",
         details: errorMessage(error),
+      },
+    };
+  }
+
+  if (render.runtime_state_doc_id !== options.expectedRuntimeStateDocId) {
+    cloudLog("warn", "snapshot_pair.validation.runtime_state_doc_id_mismatch", {
+      notebook_id: options.notebookId,
+      notebook_heads_hash: options.notebookHeadsHash,
+      runtime_heads_hash: options.runtimeHeadsHash,
+      expected_runtime_state_doc_id: options.expectedRuntimeStateDocId,
+      actual_runtime_state_doc_id: render.runtime_state_doc_id,
+      duration_ms: durationMs(startedAt),
+      counter: "snapshot_pair_validation_runtime_doc_mismatches",
+      counter_delta: 1,
+    });
+    return {
+      ok: false,
+      status: 409,
+      body: {
+        error: "snapshot pair runtime_state_doc_id mismatch",
+        expected_runtime_state_doc_id: options.expectedRuntimeStateDocId,
+        actual_runtime_state_doc_id: render.runtime_state_doc_id,
       },
     };
   }

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -47,6 +47,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_dependency_fingerprint(): string | undefined;
     get_heads_hex(): string[];
     get_metadata_snapshot_json(): string | undefined;
+    get_runtime_state_doc_id(): string | undefined;
     get_runtime_state(): unknown;
     get_runtime_state_heads_hex(): string[];
     receive_frame(frameBytes: Uint8Array): unknown;

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -13,6 +13,7 @@ export interface SnapshotRender {
   generated_at: string;
   notebook_id: string;
   heads_hash: string;
+  runtime_state_doc_id: string | null;
   runtime_heads_hash: string | null;
   metadata: unknown;
   source: "snapshot-pair";
@@ -45,6 +46,7 @@ export async function materializeSnapshotPairRender(input: {
       generated_at: input.generatedAt ?? new Date().toISOString(),
       notebook_id: input.notebookId,
       heads_hash: input.notebookHeadsHash,
+      runtime_state_doc_id: handle.get_runtime_state_doc_id() ?? null,
       runtime_heads_hash: input.runtimeHeadsHash,
       metadata,
       source: "snapshot-pair",

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2791,7 +2791,7 @@ describe("Worker artifact routes", () => {
       "/api/n/route-demo/runtime-snapshots/runtime-fixture",
       runtimeStateBytes,
       {
-        "X-Runtime-State-Doc-Id": "runtime:route-demo",
+        "X-Runtime-State-Doc-Id": "runtime:output-streaming",
       },
     );
     assert.equal(runtimePut.status, 201);
@@ -2806,16 +2806,16 @@ describe("Worker artifact routes", () => {
       notebookBytes,
       {
         "X-Runtime-Heads-Hash": "runtime-fixture",
-        "X-Runtime-State-Doc-Id": "runtime:route-demo",
+        "X-Runtime-State-Doc-Id": "runtime:output-streaming",
       },
     );
     assert.equal(notebookPut.status, 201);
     const notebookPutBody = (await notebookPut.json()) as { runtime_state_doc_id: string };
-    assert.equal(notebookPutBody.runtime_state_doc_id, "runtime:route-demo");
-    assert.equal(env.DB.revisions[0]?.runtime_state_doc_id, "runtime:route-demo");
+    assert.equal(notebookPutBody.runtime_state_doc_id, "runtime:output-streaming");
+    assert.equal(env.DB.revisions[0]?.runtime_state_doc_id, "runtime:output-streaming");
     assert.equal(
       env.DB.revisions[0]?.runtime_snapshot_key,
-      runtimeStateSnapshotKey("runtime:route-demo", "runtime-fixture"),
+      runtimeStateSnapshotKey("runtime:output-streaming", "runtime-fixture"),
     );
     assert.deepEqual(
       env.DB.acl.map((row) => [row.notebook_id, row.subject_kind, row.subject, row.scope]),
@@ -2838,7 +2838,7 @@ describe("Worker artifact routes", () => {
 
     const runtimeResponse = await worker.fetch(
       new Request("http://localhost/api/n/route-demo/runtime-snapshots/runtime-fixture", {
-        headers: { "X-Runtime-State-Doc-Id": "runtime:route-demo" },
+        headers: { "X-Runtime-State-Doc-Id": "runtime:output-streaming" },
       }),
       env,
       fakeContext(),
@@ -2857,6 +2857,57 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
     assert.equal(renderCacheRoute.status, 404);
+  });
+
+  it("rejects snapshot publish when the header runtime id disagrees with the NotebookDoc pointer", async () => {
+    const env = fakeEnv();
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/route-demo/runtime-snapshots/runtime-fixture",
+      runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:wrong-route-demo",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const response = await ownerPut(
+      env,
+      "/api/n/route-demo/snapshots/heads-fixture",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-fixture",
+        "X-Runtime-State-Doc-Id": "runtime:wrong-route-demo",
+      },
+    );
+
+    assert.equal(response.status, 409);
+    assert.deepEqual(await response.json(), {
+      error: "snapshot pair runtime_state_doc_id mismatch",
+      expected_runtime_state_doc_id: "runtime:wrong-route-demo",
+      actual_runtime_state_doc_id: "runtime:output-streaming",
+    });
+    assert.equal(env.DB.revisions.length, 0);
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.has(snapshotKey("route-demo", "heads-fixture")),
+      false,
+      "rejected snapshot publish should not leave an orphan notebook snapshot",
+    );
   });
 
   it("rejects snapshot publish when the referenced runtime snapshot is missing", async () => {
@@ -2967,7 +3018,7 @@ describe("Worker artifact routes", () => {
       "/api/n/missing-blob-demo/runtime-snapshots/runtime-fixture",
       runtimeStateBytes,
       {
-        "X-Runtime-State-Doc-Id": "runtime:missing-blob-demo",
+        "X-Runtime-State-Doc-Id": "runtime:sift-arrow",
       },
     );
     assert.equal(runtimePut.status, 201);
@@ -2985,7 +3036,7 @@ describe("Worker artifact routes", () => {
         notebookBytes,
         {
           "X-Runtime-Heads-Hash": "runtime-fixture",
-          "X-Runtime-State-Doc-Id": "runtime:missing-blob-demo",
+          "X-Runtime-State-Doc-Id": "runtime:sift-arrow",
         },
       );
     } finally {

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1257,6 +1257,11 @@ impl NotebookHandle {
         Ok(())
     }
 
+    /// RuntimeStateDoc identity recorded by the NotebookDoc pointer.
+    pub fn get_runtime_state_doc_id(&self) -> Option<String> {
+        self.doc.runtime_state_doc_id()
+    }
+
     /// Get the actor identity label for this document.
     pub fn get_actor_id(&self) -> String {
         self.doc.get_actor_id()


### PR DESCRIPTION
## Summary

- validate uploaded snapshot pairs against the `NotebookDoc.runtime_state_doc_id` pointer
- expose the NotebookDoc runtime-state pointer through `runtimed-wasm` for notebook-cloud validation
- update worker route tests to use the RuntimeStateDoc ids carried by the fixtures instead of route-derived ids

This keeps notebook-cloud on the NotebookDoc -> RuntimeStateDoc model and does not reintroduce `/render` as a load path.

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo test -p runtimed-wasm --target wasm32-unknown-unknown --no-run`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud test`

## Draft Gate

Keeping this draft until reviewer, CI, and preview deployment validation pass.
