### PR TITLE
fix(notebook-cloud): publish runtime doc pointer

### DIFF
--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -21,7 +21,8 @@ const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
 const wasmBytes = await readFile(wasmBytesUrl);
 initSync({ module: wasmBytes });
 
-const handle = NotebookHandle.create_bootstrap(actorLabel);
+const handle = new NotebookHandle(notebookId);
+handle.set_actor(actorLabel);
 handle.add_cell_after("intro", "markdown", null);
 handle.update_source(
   "intro",
@@ -48,12 +49,16 @@ const heads = handle.get_heads_hex();
 const runtimeHeads = handle.get_runtime_state_heads_hex();
 const headsHash = headsDigest(heads);
 const runtimeHeadsHash = headsDigest(runtimeHeads);
+const runtimeStateDocId = requiredRuntimeStateDocId(handle);
 const cells = JSON.parse(handle.get_cells_json());
 
 await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
   runtimeSnapshotBytes,
   "application/octet-stream",
+  {
+    "X-Runtime-State-Doc-Id": runtimeStateDocId,
+  },
 );
 await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
@@ -61,6 +66,7 @@ await putBytes(
   "application/octet-stream",
   {
     "X-Runtime-Heads-Hash": runtimeHeadsHash,
+    "X-Runtime-State-Doc-Id": runtimeStateDocId,
   },
 );
 
@@ -81,6 +87,7 @@ console.log(
       baseUrl,
       notebookId,
       viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      runtimeStateDocId,
       headsHash,
       runtimeHeadsHash,
       cells: cells.length,
@@ -99,6 +106,15 @@ console.log(
 function headsDigest(heads) {
   const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
   return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+function requiredRuntimeStateDocId(handle) {
+  const runtimeStateDocId = handle.get_runtime_state_doc_id();
+  assert(
+    typeof runtimeStateDocId === "string" && runtimeStateDocId.length > 0,
+    "NotebookDoc snapshot is missing runtime_state_doc_id",
+  );
+  return runtimeStateDocId;
 }
 
 async function assertWasmBuildExists() {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -38,6 +38,7 @@ const fixtureBlobs = Array.isArray(fixtureManifest.blobs) ? fixtureManifest.blob
 const handle = NotebookHandle.load_snapshot(snapshotBytes, runtimeSnapshotBytes);
 const headsHash = headsDigest(handle.get_heads_hex());
 const runtimeHeadsHash = headsDigest(handle.get_runtime_state_heads_hex());
+const runtimeStateDocId = requiredRuntimeStateDocId(handle);
 const cells = JSON.parse(handle.get_cells_json());
 handle.free();
 
@@ -49,6 +50,9 @@ await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
   runtimeSnapshotBytes,
   "application/octet-stream",
+  {
+    "X-Runtime-State-Doc-Id": runtimeStateDocId,
+  },
 );
 await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
@@ -56,6 +60,7 @@ await putBytes(
   "application/octet-stream",
   {
     "X-Runtime-Heads-Hash": runtimeHeadsHash,
+    "X-Runtime-State-Doc-Id": runtimeStateDocId,
   },
 );
 
@@ -77,6 +82,7 @@ console.log(
       fixtureName,
       notebookId,
       viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      runtimeStateDocId,
       headsHash,
       runtimeHeadsHash,
       cells: cells.length,
@@ -126,6 +132,15 @@ async function uploadFixtureBlob(blob) {
 function headsDigest(heads) {
   const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
   return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+function requiredRuntimeStateDocId(handle) {
+  const runtimeStateDocId = handle.get_runtime_state_doc_id();
+  assert(
+    typeof runtimeStateDocId === "string" && runtimeStateDocId.length > 0,
+    "NotebookDoc fixture is missing runtime_state_doc_id",
+  );
+  return runtimeStateDocId;
 }
 
 async function putBytes(pathname, body, contentType, extraHeaders = {}) {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -36,10 +36,13 @@ const [snapshotBytes, runtimeSnapshotBytes] = await Promise.all([
 const fixtureManifest = JSON.parse(await readFile(new URL("manifest.json", fixtureRoot), "utf8"));
 const fixtureBlobs = Array.isArray(fixtureManifest.blobs) ? fixtureManifest.blobs : [];
 const handle = NotebookHandle.load_snapshot(snapshotBytes, runtimeSnapshotBytes);
+handle.set_runtime_state_doc_id(`runtime:${notebookId}`);
 const headsHash = headsDigest(handle.get_heads_hex());
 const runtimeHeadsHash = headsDigest(handle.get_runtime_state_heads_hex());
 const runtimeStateDocId = requiredRuntimeStateDocId(handle);
 const cells = JSON.parse(handle.get_cells_json());
+const publishedSnapshotBytes = handle.save();
+const publishedRuntimeSnapshotBytes = handle.save_state_doc();
 handle.free();
 
 for (const blob of fixtureBlobs) {
@@ -48,7 +51,7 @@ for (const blob of fixtureBlobs) {
 
 await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
-  runtimeSnapshotBytes,
+  publishedRuntimeSnapshotBytes,
   "application/octet-stream",
   {
     "X-Runtime-State-Doc-Id": runtimeStateDocId,
@@ -56,7 +59,7 @@ await putBytes(
 );
 await putBytes(
   `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
-  snapshotBytes,
+  publishedSnapshotBytes,
   "application/octet-stream",
   {
     "X-Runtime-Heads-Hash": runtimeHeadsHash,

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -35,7 +35,10 @@ const session = sourceNotebookId
 
 try {
   const snapshot = await session.exportSnapshotPair();
-  const cells = await cellsFromSnapshotPair(snapshot.notebookBytes, snapshot.runtimeStateBytes);
+  const { cells, runtimeStateDocId } = await snapshotPairMetadata(
+    snapshot.notebookBytes,
+    snapshot.runtimeStateBytes,
+  );
   const blobRefs = collectBlobRefs(cells);
   const headsHash = headsDigest(snapshot.notebookHeads);
   const runtimeHeadsHash = headsDigest(snapshot.runtimeStateHeads);
@@ -48,6 +51,9 @@ try {
     `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeadsHash)}`,
     snapshot.runtimeStateBytes,
     "application/octet-stream",
+    {
+      "X-Runtime-State-Doc-Id": runtimeStateDocId,
+    },
   );
   await putBytes(
     `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(headsHash)}`,
@@ -55,6 +61,7 @@ try {
     "application/octet-stream",
     {
       "X-Runtime-Heads-Hash": runtimeHeadsHash,
+      "X-Runtime-State-Doc-Id": runtimeStateDocId,
     },
   );
 
@@ -78,6 +85,7 @@ try {
         sourceNotebookId: sourceNotebookId ?? session.notebookId,
         notebookId,
         viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+        runtimeStateDocId,
         headsHash,
         runtimeHeadsHash,
         cells: Array.isArray(cells) ? cells.length : null,
@@ -100,16 +108,28 @@ try {
   await session.close().catch(() => {});
 }
 
-async function cellsFromSnapshotPair(notebookBytes, runtimeStateBytes) {
+async function snapshotPairMetadata(notebookBytes, runtimeStateBytes) {
   const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
   const wasmBytes = await readFile(wasmBytesUrl);
   initSync({ module: wasmBytes });
   const handle = NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
   try {
-    return JSON.parse(handle.get_cells_json());
+    return {
+      cells: JSON.parse(handle.get_cells_json()),
+      runtimeStateDocId: requiredRuntimeStateDocId(handle),
+    };
   } finally {
     handle.free();
   }
+}
+
+function requiredRuntimeStateDocId(handle) {
+  const runtimeStateDocId = handle.get_runtime_state_doc_id();
+  assert(
+    typeof runtimeStateDocId === "string" && runtimeStateDocId.length > 0,
+    "NotebookDoc live snapshot is missing runtime_state_doc_id",
+  );
+  return runtimeStateDocId;
 }
 
 async function uploadLiveBlob(ref, snapshot) {

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { FrameType } from "runtimed";
+import { openWebSocket } from "./hosted-access-smoke-ws.mjs";
+import { credentialedSmokeOrigin } from "./wasm-roundtrip-env.mjs";
 
 const wasmJsPath = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
@@ -28,11 +30,6 @@ const [fixtureNotebookBytes, fixtureRuntimeBytes] = await Promise.all([
     ),
   ),
 ]);
-const fixtureRuntimeStateDocId = runtimeStateDocIdFromSnapshotPair(
-  fixtureNotebookBytes,
-  fixtureRuntimeBytes,
-);
-
 if (typeof WebSocket === "undefined") {
   throw new Error("This smoke script requires Node.js with a global WebSocket implementation");
 }
@@ -214,8 +211,11 @@ const snapshotHeads = `heads-${roomId}`;
 const runtimeHeads = `runtime-${roomId}`;
 const runtimePath = `/api/n/${encodeURIComponent(roomId)}/runtime-snapshots/${encodeURIComponent(runtimeHeads)}`;
 const snapshotPath = `/api/n/${encodeURIComponent(roomId)}/snapshots/${encodeURIComponent(snapshotHeads)}`;
-const snapshotBytes = fixtureNotebookBytes;
-const runtimeBytes = fixtureRuntimeBytes;
+const {
+  notebookBytes: snapshotBytes,
+  runtimeBytes,
+  runtimeStateDocId,
+} = snapshotPairForNotebook(roomId);
 const invalidAuthResponse = await fetch(new URL(snapshotPath, baseUrl), {
   method: "PUT",
   headers: {
@@ -231,17 +231,17 @@ assert(
   `invalid auth should return 400, got ${invalidAuthResponse.status}`,
 );
 const runtimePut = await putBytes(runtimePath, runtimeBytes, "application/octet-stream", {
-  "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
+  "X-Runtime-State-Doc-Id": runtimeStateDocId,
 });
 assert(runtimePut.ok === true, `runtime snapshot PUT failed: ${JSON.stringify(runtimePut)}`);
 assertBytesEqual(
-  await fetchBytes(runtimePath, { "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId }),
+  await fetchBytes(runtimePath, { "X-Runtime-State-Doc-Id": runtimeStateDocId }),
   runtimeBytes,
   "runtime snapshot GET did not round-trip",
 );
 const snapshotPut = await putBytes(snapshotPath, snapshotBytes, "application/octet-stream", {
   "X-Runtime-Heads-Hash": runtimeHeads,
-  "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
+  "X-Runtime-State-Doc-Id": runtimeStateDocId,
 });
 assert(snapshotPut.ok === true, `snapshot PUT failed: ${JSON.stringify(snapshotPut)}`);
 assertBytesEqual(await fetchBytes(snapshotPath), snapshotBytes, "snapshot GET did not round-trip");
@@ -318,20 +318,21 @@ process.exit(0);
 async function seedNotebook(notebookId, ownerUser, grants = []) {
   const runtimeHeads = `bootstrap-runtime-${notebookId}`;
   const snapshotHeads = `bootstrap-heads-${notebookId}`;
+  const { notebookBytes, runtimeBytes, runtimeStateDocId } = snapshotPairForNotebook(notebookId);
   await putBytes(
     `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeads)}`,
-    fixtureRuntimeBytes,
+    runtimeBytes,
     "application/octet-stream",
-    { "X-User": ownerUser, "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId },
+    { "X-User": ownerUser, "X-Runtime-State-Doc-Id": runtimeStateDocId },
   );
   await putBytes(
     `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(snapshotHeads)}`,
-    fixtureNotebookBytes,
+    notebookBytes,
     "application/octet-stream",
     {
       "X-User": ownerUser,
       "X-Runtime-Heads-Hash": runtimeHeads,
-      "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
+      "X-Runtime-State-Doc-Id": runtimeStateDocId,
     },
   );
   for (const grant of grants) {
@@ -441,8 +442,15 @@ async function connect(notebookId, user, operator, scope) {
   const safeUrl = url.href;
   const protocols = devAuthProtocols();
 
-  const socket = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
-  socket.binaryType = "arraybuffer";
+  const socket = protocols
+    ? await openWebSocket(url, {
+        origin: credentialedSmokeOrigin({ baseUrl, protocols }),
+        protocols,
+      })
+    : new WebSocket(url);
+  if ("binaryType" in socket) {
+    socket.binaryType = "arraybuffer";
+  }
   const queue = [];
   const waiters = [];
   socket.addEventListener("message", async (event) => {
@@ -458,12 +466,14 @@ async function connect(notebookId, user, operator, scope) {
     waiter.resolve(frame);
   });
 
-  await new Promise((resolve, reject) => {
-    socket.addEventListener("open", resolve, { once: true });
-    socket.addEventListener("error", () => reject(new Error(`failed to connect ${safeUrl}`)), {
-      once: true,
+  if (!protocols) {
+    await new Promise((resolve, reject) => {
+      socket.addEventListener("open", resolve, { once: true });
+      socket.addEventListener("error", () => reject(new Error(`failed to connect ${safeUrl}`)), {
+        once: true,
+      });
     });
-  });
+  }
 
   const client = {
     socket,
@@ -592,15 +602,22 @@ async function putBytes(pathname, body, contentType, extraHeaders = {}) {
   return response.json();
 }
 
-function runtimeStateDocIdFromSnapshotPair(notebookBytes, runtimeBytes) {
-  const handle = wasm.NotebookHandle.load_snapshot(notebookBytes, runtimeBytes);
+function snapshotPairForNotebook(notebookId) {
+  const handle = wasm.NotebookHandle.load_snapshot(fixtureNotebookBytes, fixtureRuntimeBytes);
   try {
+    handle.set_runtime_state_doc_id(`runtime:${notebookId}`);
+    const savedNotebookBytes = handle.save();
+    const savedRuntimeBytes = handle.save_state_doc();
     const runtimeStateDocId = handle.get_runtime_state_doc_id();
     assert(
       typeof runtimeStateDocId === "string" && runtimeStateDocId.length > 0,
       "NotebookDoc smoke fixture is missing runtime_state_doc_id",
     );
-    return runtimeStateDocId;
+    return {
+      notebookBytes: savedNotebookBytes,
+      runtimeBytes: savedRuntimeBytes,
+      runtimeStateDocId,
+    };
   } finally {
     handle.free();
   }

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -28,6 +28,10 @@ const [fixtureNotebookBytes, fixtureRuntimeBytes] = await Promise.all([
     ),
   ),
 ]);
+const fixtureRuntimeStateDocId = runtimeStateDocIdFromSnapshotPair(
+  fixtureNotebookBytes,
+  fixtureRuntimeBytes,
+);
 
 if (typeof WebSocket === "undefined") {
   throw new Error("This smoke script requires Node.js with a global WebSocket implementation");
@@ -226,15 +230,18 @@ assert(
   invalidAuthResponse.status === 400,
   `invalid auth should return 400, got ${invalidAuthResponse.status}`,
 );
-const runtimePut = await putBytes(runtimePath, runtimeBytes, "application/octet-stream");
+const runtimePut = await putBytes(runtimePath, runtimeBytes, "application/octet-stream", {
+  "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
+});
 assert(runtimePut.ok === true, `runtime snapshot PUT failed: ${JSON.stringify(runtimePut)}`);
 assertBytesEqual(
-  await fetchBytes(runtimePath),
+  await fetchBytes(runtimePath, { "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId }),
   runtimeBytes,
   "runtime snapshot GET did not round-trip",
 );
 const snapshotPut = await putBytes(snapshotPath, snapshotBytes, "application/octet-stream", {
   "X-Runtime-Heads-Hash": runtimeHeads,
+  "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
 });
 assert(snapshotPut.ok === true, `snapshot PUT failed: ${JSON.stringify(snapshotPut)}`);
 assertBytesEqual(await fetchBytes(snapshotPath), snapshotBytes, "snapshot GET did not round-trip");
@@ -315,7 +322,7 @@ async function seedNotebook(notebookId, ownerUser, grants = []) {
     `/api/n/${encodeURIComponent(notebookId)}/runtime-snapshots/${encodeURIComponent(runtimeHeads)}`,
     fixtureRuntimeBytes,
     "application/octet-stream",
-    { "X-User": ownerUser },
+    { "X-User": ownerUser, "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId },
   );
   await putBytes(
     `/api/n/${encodeURIComponent(notebookId)}/snapshots/${encodeURIComponent(snapshotHeads)}`,
@@ -324,6 +331,7 @@ async function seedNotebook(notebookId, ownerUser, grants = []) {
     {
       "X-User": ownerUser,
       "X-Runtime-Heads-Hash": runtimeHeads,
+      "X-Runtime-State-Doc-Id": fixtureRuntimeStateDocId,
     },
   );
   for (const grant of grants) {
@@ -584,9 +592,23 @@ async function putBytes(pathname, body, contentType, extraHeaders = {}) {
   return response.json();
 }
 
-async function fetchBytes(pathname) {
+function runtimeStateDocIdFromSnapshotPair(notebookBytes, runtimeBytes) {
+  const handle = wasm.NotebookHandle.load_snapshot(notebookBytes, runtimeBytes);
+  try {
+    const runtimeStateDocId = handle.get_runtime_state_doc_id();
+    assert(
+      typeof runtimeStateDocId === "string" && runtimeStateDocId.length > 0,
+      "NotebookDoc smoke fixture is missing runtime_state_doc_id",
+    );
+    return runtimeStateDocId;
+  } finally {
+    handle.free();
+  }
+}
+
+async function fetchBytes(pathname, extraHeaders = {}) {
   const url = new URL(pathname, baseUrl);
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: extraHeaders });
   assert(response.ok, `${url.href} returned ${response.status}`);
   return new Uint8Array(await response.arrayBuffer());
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -550,9 +550,10 @@ async function routeSnapshot(
   if (!runtimeStateDocId) {
     return json({ error: "X-Runtime-State-Doc-Id header is required" }, 400);
   }
-  const runtimeKey = runtimeHeadsHash
-    ? runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash)
-    : null;
+  if (!runtimeHeadsHash) {
+    return json({ error: "X-Runtime-Heads-Hash header is required" }, 400);
+  }
+  const runtimeKey = runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash);
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -565,33 +566,31 @@ async function routeSnapshot(
     },
   });
 
-  if (runtimeHeadsHash && runtimeKey) {
-    const runtimeObject = await env.NOTEBOOK_SNAPSHOTS.get(runtimeKey);
-    if (!runtimeObject) {
-      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
-      return json(
-        {
-          error: "snapshot publish missing runtime-state snapshot",
-          runtime_heads_hash: runtimeHeadsHash,
-        },
-        424,
-      );
-    }
+  const runtimeObject = await env.NOTEBOOK_SNAPSHOTS.get(runtimeKey);
+  if (!runtimeObject) {
+    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    return json(
+      {
+        error: "snapshot publish missing runtime-state snapshot",
+        runtime_heads_hash: runtimeHeadsHash,
+      },
+      424,
+    );
+  }
 
-    const validated = await validateSnapshotPair({
-      request,
-      env,
-      notebookId,
-      notebookHeadsHash: headsHash,
-      runtimeHeadsHash,
-      expectedRuntimeStateDocId: runtimeStateDocId,
-      notebookBytes: new Uint8Array(body),
-      runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
-    });
-    if (!validated.ok) {
-      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
-      return json(validated.body, validated.status);
-    }
+  const validated = await validateSnapshotPair({
+    request,
+    env,
+    notebookId,
+    notebookHeadsHash: headsHash,
+    runtimeHeadsHash,
+    expectedRuntimeStateDocId: runtimeStateDocId,
+    notebookBytes: new Uint8Array(body),
+    runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
+  });
+  if (!validated.ok) {
+    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    return json(validated.body, validated.status);
   }
 
   let revisionId: string;

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -32,6 +32,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
   ): Uint8Array;
 
   export class NotebookHandle {
+    constructor(notebookId: string);
     static create_bootstrap(actorLabel: string): NotebookHandle;
     static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): NotebookHandle;
     cell_count(): number;
@@ -52,6 +53,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_runtime_state_heads_hex(): string[];
     receive_frame(frameBytes: Uint8Array): unknown;
     reset_sync_state(): void;
+    set_actor(actorLabel: string): void;
     set_comm_state_batch(commId: string, patchJson: string): boolean;
     set_comm_state_property(commId: string, key: string, valueJson: string): boolean;
     update_source(cellId: string, source: string): boolean;

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -54,6 +54,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     receive_frame(frameBytes: Uint8Array): unknown;
     reset_sync_state(): void;
     set_actor(actorLabel: string): void;
+    set_runtime_state_doc_id(runtimeStateDocId: string): void;
     set_comm_state_batch(commId: string, patchJson: string): boolean;
     set_comm_state_property(commId: string, key: string, valueJson: string): boolean;
     update_source(cellId: string, source: string): boolean;

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -753,6 +753,19 @@ describe("Worker artifact routes", () => {
       error: "X-Runtime-State-Doc-Id header is required",
     });
 
+    const notebookPutWithoutRuntimeHeads = await ownerPut(
+      env,
+      "/api/n/runtime-id-required/snapshots/heads",
+      body,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:runtime-id-required",
+      },
+    );
+    assert.equal(notebookPutWithoutRuntimeHeads.status, 400);
+    assert.deepEqual(await notebookPutWithoutRuntimeHeads.json(), {
+      error: "X-Runtime-Heads-Hash header is required",
+    });
+
     assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.size, 0);
     assert.equal(env.DB.revisions.length, 0);
   });

--- a/crates/runt-publish/src/main.rs
+++ b/crates/runt-publish/src/main.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use automerge::AutoCommit;
 use clap::Parser;
-use notebook_doc::{default_runtime_state_doc_id, NotebookDoc};
+use notebook_doc::NotebookDoc;
 use notebook_sync::connect;
 use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
 use runtime_doc::RuntimeStateDoc;
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
         collect_snapshot_blob_refs(&snapshot.notebook_bytes, &snapshot.runtime_state_bytes)?;
     let initial_ref_count = refs.len();
     let runtime_state_doc_id =
-        runtime_state_doc_id_from_notebook_snapshot(&snapshot.notebook_bytes, &notebook_id)?;
+        runtime_state_doc_id_from_notebook_snapshot(&snapshot.notebook_bytes)?;
 
     let publisher = Publisher::new(args, notebook_id, blob_base_url, blob_store_path)?;
     let uploaded_blobs = publisher.upload_blob_closure(&mut refs).await?;
@@ -520,15 +520,12 @@ async fn wait_for_imported_cells(
     }
 }
 
-fn runtime_state_doc_id_from_notebook_snapshot(
-    notebook_bytes: &[u8],
-    fallback_notebook_id: &str,
-) -> Result<String> {
+fn runtime_state_doc_id_from_notebook_snapshot(notebook_bytes: &[u8]) -> Result<String> {
     let notebook_doc = NotebookDoc::load(notebook_bytes)
         .context("load NotebookDoc from exported snapshot bytes")?;
-    Ok(notebook_doc
+    notebook_doc
         .runtime_state_doc_id()
-        .unwrap_or_else(|| default_runtime_state_doc_id(fallback_notebook_id)))
+        .context("NotebookDoc snapshot is missing runtime_state_doc_id")
 }
 
 fn collect_runtime_snapshot_blob_refs(
@@ -803,6 +800,7 @@ fn with_trailing_slash(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use automerge::transaction::Transactable;
     use notebook_doc::{AttachmentEncoding, AttachmentRef};
     use std::collections::HashMap;
 
@@ -985,6 +983,35 @@ mod tests {
         assert_eq!(
             default_notebook_id(Path::new("/tmp/Topic Viz!.ipynb")),
             "topic-viz"
+        );
+    }
+
+    #[test]
+    fn runtime_state_doc_id_comes_from_notebook_pointer() {
+        let mut notebook_doc = NotebookDoc::new("publish-runtime-pointer");
+        let runtime_state_doc_id =
+            runtime_state_doc_id_from_notebook_snapshot(&notebook_doc.save()).unwrap();
+
+        assert_eq!(
+            runtime_state_doc_id,
+            notebook_doc.runtime_state_doc_id().unwrap()
+        );
+    }
+
+    #[test]
+    fn runtime_state_doc_id_is_required() {
+        let mut notebook_doc = NotebookDoc::new("publish-runtime-pointer");
+        notebook_doc
+            .doc_mut()
+            .delete(automerge::ROOT, "runtime_state_doc_id")
+            .unwrap();
+
+        let error = runtime_state_doc_id_from_notebook_snapshot(&notebook_doc.save()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("NotebookDoc snapshot is missing runtime_state_doc_id"),
+            "{error:#}"
         );
     }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1262,6 +1262,22 @@ impl NotebookHandle {
         self.doc.runtime_state_doc_id()
     }
 
+    /// Set the RuntimeStateDoc identity on both documents in this snapshot pair.
+    ///
+    /// This is intentionally narrower than changing notebook identity: fixture
+    /// publishers can clone a canned NotebookDoc + RuntimeStateDoc pair into a
+    /// route-specific runtime document namespace without creating a legacy
+    /// route-derived fallback.
+    pub fn set_runtime_state_doc_id(&mut self, runtime_state_doc_id: &str) -> Result<(), JsError> {
+        self.doc
+            .set_runtime_state_doc_id(runtime_state_doc_id)
+            .map_err(|e| JsError::new(&format!("set notebook runtime_state_doc_id failed: {e}")))?;
+        self.state_doc
+            .set_runtime_state_doc_id(Some(runtime_state_doc_id))
+            .map_err(|e| JsError::new(&format!("set runtime state doc id failed: {e}")))?;
+        Ok(())
+    }
+
     /// Get the actor identity label for this document.
     pub fn get_actor_id(&self) -> String {
         self.doc.get_actor_id()


### PR DESCRIPTION
## Summary

- make notebook-cloud JS publish scripts upload runtime snapshots and notebook snapshots with `X-Runtime-State-Doc-Id` from `NotebookDoc.runtime_state_doc_id`
- make fixture publishing clone the canned snapshot pair into a route-specific RuntimeStateDoc namespace before upload
- make `runt-publish` require the NotebookDoc pointer instead of falling back to `runtime:{notebookId}`
- require notebook snapshot publishes to include paired runtime heads so the Worker always validates NotebookDoc -> RuntimeStateDoc consistency before recording a revision
- update the notebook-cloud smoke publisher path to seed route-specific runtime docs and use token-bearing WebSocket subprotocol credentials with same-origin `Origin`

## Compatibility

This intentionally does not support legacy NotebookDoc snapshots that lack `runtime_state_doc_id`. `runt-publish` and the hosted publish routes are still internal preview/demo surfaces, and preview content can be republished with current snapshot pairs.

## Verification

- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `node --check apps/notebook-cloud/scripts/publish-demo.mjs`
- `node --check apps/notebook-cloud/scripts/publish-fixture.mjs`
- `node --check apps/notebook-cloud/scripts/publish-live.mjs`
- `node --check apps/notebook-cloud/scripts/smoke.mjs`
- `cargo test -p runt-publish runtime_state_doc_id`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.renderer-assets.toml`
- `pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.output-document.toml`
- `pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml`
- deployed preview publish validation: `NOTEBOOK_CLOUD_URL=https://preview.runt.run NOTEBOOK_CLOUD_NOTEBOOK_ID=deploy-publish-pointer-1780115862 pnpm --dir apps/notebook-cloud publish:fixture`
- deployed preview smoke validation: `NOTEBOOK_CLOUD_URL=https://preview.runt.run pnpm --dir apps/notebook-cloud smoke`
- deployed negative validation: notebook snapshot PUT without `X-Runtime-Heads-Hash` returns `400 {"error":"X-Runtime-Heads-Hash header is required"}`

## Ready Gate

Satisfied before marking ready:

- pr-reviewer rerun is clear: `.context/reviews/pr-3126-final.json`
- GitHub CI is green on the rebased branch
- preview.runt.run was redeployed from this branch and validated with publish, smoke, and negative header checks
