### PR TITLE
docs(elements): catalog read-only notebook surfaces

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import {
   ArrowRight,
   Boxes,
+  Cloud,
   FileCode2,
   ListChecks,
   Palette,
@@ -42,6 +43,12 @@ const entries = [
     description: "Runtime-free fixtures for current nteract output components.",
     href: "/docs/output-renderers",
     icon: Boxes,
+  },
+  {
+    title: "Read-only notebooks",
+    description: "Hosted and cloud notebook cells rendered through shared components.",
+    href: "/docs/read-only-notebook-surfaces",
+    icon: Cloud,
   },
   {
     title: "Runtime surfaces",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -1,6 +1,7 @@
 import {
   CheckCircle2,
   CircleDotDashed,
+  Cloud,
   Code2,
   FileCode2,
   ListChecks,
@@ -13,13 +14,13 @@ import {
 
 const stats = [
   { label: "shadcn primitives", value: "24", detail: "current generic UI floor" },
-  { label: "notebook domains", value: "10", detail: "first catalog targets" },
+  { label: "notebook domains", value: "11", detail: "first catalog targets" },
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "36",
+    value: "39",
     detail:
-      "used shell toolbar, package headers, search, full cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
   },
 ];
 
@@ -53,6 +54,12 @@ const phases = [
     state: "active",
     icon: ShieldCheck,
     summary: "Trust, dependency headers, environment decisions, daemon state, and launch banners.",
+  },
+  {
+    title: "Capture hosted notebooks",
+    state: "active",
+    icon: Cloud,
+    summary: "Read-only notebook cells, cloud/report paths, loading states, and output adapters.",
   },
 ];
 
@@ -89,6 +96,15 @@ const families = [
     status: "active",
     intent:
       "CodeCell, MarkdownCell, and RawCell now render with seeded store state and a null CRDT handle; markdown preview still documents its isolated-renderer adapter boundary.",
+  },
+  {
+    family: "Read-only notebooks",
+    source:
+      "src/components/cell/{ReadOnlyNotebook,ReadOnlyNotebookCell}.tsx + apps/notebook/src/components/CellSkeleton.tsx",
+    target: "nteract hosted",
+    status: "active",
+    intent:
+      "ReadOnlyNotebook, ReadOnlyNotebookCell, and CellSkeleton now render from fixture nbformat output data, covering the shared cloud and hosted artifact path without live runtime state.",
   },
   {
     family: "Cell internals",
@@ -199,7 +215,7 @@ export function ComponentBurndown() {
           <CircleDotDashed className="size-4 text-fd-muted-foreground" aria-hidden="true" />
           <h2 className="text-sm font-semibold">Next Phases</h2>
         </div>
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-5">
+        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
           {phases.map((phase, index) => (
             <div
               key={phase.title}

--- a/apps/elements/components/read-only-notebook-surfaces-example.tsx
+++ b/apps/elements/components/read-only-notebook-surfaces-example.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { Cloud, Eye, FileCode2, Loader2, Rows3 } from "lucide-react";
+import { CellSkeleton } from "@/notebook-components/CellSkeleton";
+import {
+  ReadOnlyNotebook,
+  type ReadOnlyNotebookCellData,
+} from "@/components/cell/ReadOnlyNotebook";
+import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
+
+const notebookCells: ReadOnlyNotebookCellData[] = [
+  {
+    id: "hosted-intro",
+    cellType: "markdown",
+    source: [
+      "## Hosted forecast report",
+      "",
+      "Read-only notebook surfaces keep notebook structure and output rendering without a live kernel.",
+    ].join("\n"),
+  },
+  {
+    id: "hosted-model",
+    cellType: "code",
+    language: "python",
+    source: [
+      "features = orders.assign(month=orders.date.dt.month)",
+      "predictions = model.predict(features[columns])",
+      "display(metrics)",
+    ].join("\n"),
+    executionCount: 12,
+    outputs: [
+      {
+        output_id: "hosted-model-stream",
+        output_type: "stream",
+        name: "stdout",
+        text: "validated 16 week backtest window\n",
+      },
+      {
+        output_id: "hosted-model-json",
+        output_type: "execute_result",
+        execution_count: 12,
+        data: {
+          "application/json": {
+            mae: 8.42,
+            mape: "6.8%",
+            holdout_weeks: 16,
+          },
+          "text/plain": "MAE 8.42, MAPE 6.8%, holdout 16 weeks",
+        },
+        metadata: {},
+      },
+    ],
+  },
+  {
+    id: "hosted-summary",
+    cellType: "code",
+    language: "python",
+    source: "display(summary_markdown)",
+    executionCount: 13,
+    outputs: [
+      {
+        output_id: "hosted-summary-markdown",
+        output_type: "display_data",
+        data: {
+          "text/markdown": [
+            "### Summary",
+            "",
+            "- Forecast error stayed within the review threshold.",
+            "- The hosted renderer uses the docs isolated-frame adapter.",
+          ].join("\n"),
+        },
+        metadata: {},
+      },
+    ],
+  },
+];
+
+const singleCellOutputs = [
+  {
+    output_id: "single-cell-json",
+    output_type: "display_data" as const,
+    data: {
+      "application/json": {
+        renderer: "cell",
+        displayMode: "report",
+        outputs: 1,
+      },
+      "text/plain": "ReadOnlyNotebookCell report mode",
+    },
+    metadata: {},
+  },
+];
+
+export function ReadOnlyNotebookSurfacesExample() {
+  return (
+    <div className="not-prose space-y-6" data-testid="read-only-notebook-surfaces-example">
+      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+        <div className="flex items-start gap-3">
+          <Cloud className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Hosted notebook fixture</h2>
+            <p className="mt-1 text-xs leading-5">
+              These examples render the shared read-only notebook components used by cloud and
+              published artifact paths. Outputs are static nbformat fixtures, and markdown uses the
+              docs app isolated-frame adapter instead of a runtime iframe bundle.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <Rows3 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+            <div className="min-w-0">
+              <h2 className="text-sm font-semibold">ReadOnlyNotebook</h2>
+              <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                src/components/cell/ReadOnlyNotebook.tsx
+              </div>
+            </div>
+          </div>
+          <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+            rendered
+          </span>
+        </div>
+        <div className="bg-background p-4">
+          <ReadOnlyNotebook
+            cells={notebookCells}
+            displayMode="notebook"
+            className="gap-3"
+            cellClassName="rounded-lg border border-fd-border bg-fd-background pl-1"
+            label="Hosted notebook fixture"
+          />
+        </div>
+      </section>
+
+      <section className="grid items-start gap-3 lg:grid-cols-[minmax(0,1fr)_340px]">
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
+            <div className="flex min-w-0 items-center gap-2">
+              <FileCode2 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold">ReadOnlyNotebookCell</h2>
+                <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                  src/components/cell/ReadOnlyNotebookCell.tsx
+                </div>
+              </div>
+            </div>
+            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+              rendered
+            </span>
+          </div>
+          <div className="bg-background p-4">
+            <ReadOnlyNotebookCell
+              id="single-read-only-cell"
+              cellType="code"
+              source="summary = {'renderer': 'cell'}"
+              language="python"
+              executionCount={7}
+              outputs={singleCellOutputs}
+              displayMode="report"
+              className="rounded-lg border border-fd-border bg-fd-background p-3"
+            />
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
+            <div className="flex min-w-0 items-center gap-2">
+              <Loader2 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold">CellSkeleton</h2>
+                <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                  apps/notebook/src/components/CellSkeleton.tsx
+                </div>
+              </div>
+            </div>
+            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+              rendered
+            </span>
+          </div>
+          <div className="bg-background p-4">
+            <div className="rounded-lg border border-fd-border bg-fd-background">
+              <CellSkeleton />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <div className="flex items-start gap-3">
+          <Eye className="mt-0.5 size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Adapter boundary</h2>
+            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+              The production components still route through `OutputArea`. The catalog uses the local
+              isolated-frame adapter for markdown output, so this page stays runtime-free while
+              exercising the same read-only cell composition path.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -37,6 +37,7 @@ generic shadcn primitives under the hood.
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Output renderers](/docs/output-renderers)
+- [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)
 - [Theme surfaces](/docs/theme-surfaces)
 - [Widget surfaces](/docs/widget-surfaces)

--- a/apps/elements/content/docs/read-only-notebook-surfaces.mdx
+++ b/apps/elements/content/docs/read-only-notebook-surfaces.mdx
@@ -1,0 +1,21 @@
+---
+title: Read-only notebook surfaces
+description: Shared hosted notebook components rendered from runtime-free fixtures.
+---
+
+import { ReadOnlyNotebookSurfacesExample } from "@/components/read-only-notebook-surfaces-example";
+
+Hosted notebooks and cloud previews should not fork the notebook cell stack.
+This page renders the shared read-only path from current nteract components
+with static nbformat-style fixtures.
+
+<ReadOnlyNotebookSurfacesExample />
+
+## Implementation intent
+
+- `ReadOnlyNotebook` and `ReadOnlyNotebookCell` come from `src/components/cell`.
+- `CellSkeleton` comes from the notebook app loading state.
+- The examples exercise `OutputArea` through static outputs, not a kernel,
+  daemon, CRDT handle, live room, or generated WASM binding.
+- Markdown output uses the docs app isolated-frame adapter so the production
+  component path can render without server or runtime dependencies.


### PR DESCRIPTION
## Summary

- add a runtime-free `ReadOnlyNotebook` catalog page backed by static nbformat-style fixtures
- render current `ReadOnlyNotebook`, `ReadOnlyNotebookCell`, and notebook app `CellSkeleton` components
- add the page to the elements home/index navigation and update the component burn-down counts/family list

Stacked on #3125 because it builds on the same elements docs navigation and burn-down state.

## Verification

- `pnpm --dir apps/elements build`
- Playwright smoke for `/docs/read-only-notebook-surfaces`
- `curl http://127.0.0.1:5176/docs/read-only-notebook-surfaces`
- `cargo xtask lint --fix`
