### PR TITLE
perf(notebook-cloud): preload runtime wasm for viewer

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1811,6 +1811,11 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
   );
 }
 
+interface ViewerShellConfig extends Record<string, unknown> {
+  runtimedWasmModulePath: string;
+  runtimedWasmPath: string;
+}
+
 function homeViewer(request: Request, env: Env): Response {
   return viewerShell("nteract cloud notebooks", env, authConfigForRequest(request, env), null);
 }
@@ -1828,7 +1833,7 @@ function viewerShell(
   title: string,
   env: Env,
   authConfig: unknown,
-  config: Record<string, unknown> | null,
+  config: ViewerShellConfig | null,
 ): Response {
   const html = `<!doctype html>
 <html lang="en">
@@ -1838,6 +1843,7 @@ function viewerShell(
   <title>${title}</title>
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
+  ${viewerResourceHints(config)}
   <link rel="stylesheet" href="/assets/notebook-cloud-viewer.css" />
 </head>
 <body>
@@ -1865,6 +1871,19 @@ function viewerShell(
       viewerContentSecurityPolicy(env),
     ),
   );
+}
+
+function viewerResourceHints(config: ViewerShellConfig | null): string {
+  if (!config) {
+    return "";
+  }
+
+  return [
+    `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
+    `<link rel="preload" href="${escapeHtml(
+      config.runtimedWasmPath,
+    )}" as="fetch" type="application/wasm" crossorigin />`,
+  ].join("\n  ");
 }
 
 function authConfigForRequest(request: Request, env: Env): { oidc: Record<string, string> | null } {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -59,14 +59,24 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/runtimed_wasm\.js" crossorigin/);
+    assert.match(
+      html,
+      /rel="preload" href="\/assets\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
+    );
     assert.ok(
       html.indexOf(viewerThemeFirstPaintStyle()) < html.indexOf(viewerThemeBootstrapScript()),
       "theme first-paint style must apply before the bootstrap script resolves the final theme",
     );
     assert.ok(
       html.indexOf(viewerThemeBootstrapScript()) <
+        html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"'),
+      "theme bootstrap must run before runtime WASM hints so first paint stays theme-safe",
+    );
+    assert.ok(
+      html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"') <
         html.indexOf("/assets/notebook-cloud-viewer.css"),
-      "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
+      "runtime WASM modulepreload should be discoverable before the render-blocking stylesheet",
     );
     assert.doesNotMatch(html, /"renderEndpoint"/);
     assert.match(html, /"catalogEndpoint":"\/api\/n\/demo"/);
@@ -117,6 +127,8 @@ describe("HTML script serialization", () => {
     assert.match(html, /nteract cloud notebooks/);
     assert.match(html, /id="nteract-cloud-auth-config"/);
     assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
+    assert.doesNotMatch(html, /rel="modulepreload" href="[^"]*runtimed_wasm\.js/);
+    assert.doesNotMatch(html, /rel="preload" href="[^"]*runtimed_wasm_bg\.wasm/);
     assert.doesNotMatch(html, /In the Loop - Collaborative Notebooks/);
   });
 
@@ -210,6 +222,14 @@ describe("HTML script serialization", () => {
     assert.match(
       html,
       /"runtimedWasmPath":"https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm"/,
+    );
+    assert.match(
+      html,
+      /rel="modulepreload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm\.js" crossorigin/,
+    );
+    assert.match(
+      html,
+      /rel="preload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
     );
     assert.match(
       response.headers.get("Content-Security-Policy") ?? "",


### PR DESCRIPTION
## Summary

- Add server-rendered resource hints for the cloud viewer's `runtimed_wasm` JS module and WASM binary.
- Keep the hints aligned with `RUNTIMED_WASM_BASE_URL`, including separate CDN/asset-worker origins.
- Leave home and OIDC callback shells light by only emitting the hints for notebook viewer pages.

## Stack

- Based on `main` after #3126 merged.

## Validation

- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/viewer-loading-policy.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build`
- Deployed preview branch to `preview.runt.run`
- `NOTEBOOK_CLOUD_URL=https://preview.runt.run pnpm --dir apps/notebook-cloud smoke:hosted`
- Direct HTML check confirmed `runtimed_wasm.js` and `runtimed_wasm_bg.wasm` resource hints are present and no `renderEndpoint` is emitted.

## Notes

This is a narrow first performance slice for the Automerge-first load path. It does not add or revive `/render`; latest notebook pages still connect to `/n/:id/sync`, and pinned pages still load the persisted NotebookDoc + RuntimeStateDoc snapshot pair.
