### PR TITLE
fix(runtimed): don't zero a notebook on disk when streaming load fails [parked behind genesis fix]

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -215,6 +215,11 @@ where
                     );
                 }
             }
+            // The rollback above emptied the room doc. Mark the load failed so
+            // the persistence layer refuses to autosave this empty doc over the
+            // notebook's on-disk content — a failed open must not delete the
+            // file. Cleared when a later connection re-attempts the load.
+            room.mark_load_failed();
             room.finish_loading();
             let _ = room.broadcasts.changed_tx.send(());
             warn!(

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -101,6 +101,53 @@ pub(crate) async fn save_notebook_to_disk(
         (cells, metadata_snapshot, eids)
     };
 
+    // A failed streaming load empties the room doc as an in-memory rollback
+    // (see the failure branch in peer_session.rs). Never persist that empty doc
+    // over an existing notebook file: a failed *open* must not become a file
+    // deletion. This holds even when the file on disk is malformed JSON or has a
+    // non-array `cells` field — those are the *most* important to preserve, not
+    // the least, since the user can still recover them by hand. We only key off
+    // "the file has bytes," not whether it parses. The on-disk content stays
+    // intact and the next open re-streams from it. A genuine "user deleted all
+    // cells" save is unaffected — that path loaded successfully, so
+    // `load_failed` is false.
+    if cells.is_empty() && room.load_failed() {
+        let disk_has_content = existing_raw
+            .as_deref()
+            .is_some_and(|bytes| !bytes.is_empty());
+        if disk_has_content {
+            match target_path {
+                // Autosave / kernel-teardown save (no explicit target). These
+                // fire automatically and silently; skipping is a clean no-op
+                // that leaves the file intact and the next open re-streams it.
+                None => {
+                    warn!(
+                        "[notebook-sync] Skipping autosave of {:?}: streaming load failed and \
+                         the room is empty; preserving existing on-disk file",
+                        notebook_path
+                    );
+                    return Ok(notebook_path.to_string_lossy().to_string());
+                }
+                // Explicit Save / Save As. Refuse rather than report a phantom
+                // success: returning Ok would tell the UI the notebook saved and
+                // could rebind the room to this path, none of which happened.
+                Some(_) => {
+                    return Err(SaveError::Unrecoverable(format!(
+                        "Refusing to save {:?}: the notebook failed to load and the in-memory \
+                         copy is empty; the file on disk was left intact. Reopen the notebook \
+                         and try again.",
+                        notebook_path
+                    )));
+                }
+            }
+        }
+    } else if !cells.is_empty() {
+        // A non-empty save proves the room recovered real content; drop any
+        // stale failed-load marker so a later legitimate empty save is not
+        // blocked by the guard above.
+        room.clear_load_failed();
+    }
+
     let previous_visible_execution_ids: HashMap<String, String> = cells
         .iter()
         .filter_map(|cell| {
@@ -1361,6 +1408,18 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 has_kernel,
                             )
                             .await;
+
+                            // If the reload actually populated the room, any
+                            // earlier failed-load marker is resolved — clear it
+                            // (this path does not go through `try_start_loading`)
+                            // so a later legitimate empty save is not suppressed.
+                            // Gate on the doc being non-empty rather than on
+                            // `cells_changed`: that bool is false both for "no
+                            // diff" and for an apply failure, and a failed reapply
+                            // must not drop the guard.
+                            if room.doc.read().await.cell_count() > 0 {
+                                room.clear_load_failed();
+                            }
 
                             // Apply metadata changes to Automerge doc.
                             // Only update when the external file has a metadata

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -111,6 +111,18 @@ pub(crate) async fn save_notebook_to_disk(
     // intact and the next open re-streams from it. A genuine "user deleted all
     // cells" save is unaffected — that path loaded successfully, so
     // `load_failed` is false.
+    //
+    // Scope note (deferred to the root-cause fix, which removes the failed-load
+    // trigger by matching the frontend genesis seed to the daemon):
+    //  - An explicit in-place Save (`NotebookRequest::SaveNotebook`) passes
+    //    `target_path = None`, the same as autosave, so it is skipped silently
+    //    here and reported as a (phantom) success rather than surfaced. Only an
+    //    explicit Save As (`Some`) returns an error. Distinguishing them needs a
+    //    save-origin signal threaded from the request handler.
+    //  - A successful *empty* external reload (`cells: []`) leaves `load_failed`
+    //    set (the watcher only clears on a non-empty reload), so a legitimately
+    //    empty notebook stays guarded until a cell is added or it is reopened.
+    // Neither is data loss — both keep the file intact.
     if cells.is_empty() && room.load_failed() {
         let disk_has_content = existing_raw
             .as_deref()

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -361,6 +361,12 @@ pub struct RoomPersistence {
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
+    /// Set when the most recent streaming load failed before completing.
+    /// A failed load empties the room doc as an in-memory rollback; this flag
+    /// stops that empty doc from being autosaved over a non-empty `.ipynb`,
+    /// turning a failed *open* into a file *deletion*. Cleared when a new load
+    /// attempt is claimed via `try_start_loading`.
+    load_failed: AtomicBool,
 }
 
 /// The debounced `.automerge` persist channels. See `spawn_persist_debouncer`.
@@ -385,6 +391,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
+            load_failed: AtomicBool::new(false),
         }
     }
 
@@ -402,6 +409,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
+            load_failed: AtomicBool::new(false),
         }
     }
 
@@ -475,11 +483,17 @@ impl RoomPersistence {
     }
 
     /// Atomically claim the loading role. Returns `true` if this caller won
-    /// the race and should perform the streaming load.
+    /// the race and should perform the streaming load. A fresh attempt clears
+    /// any prior `load_failed` flag — this attempt gets to decide the outcome.
     pub fn try_start_loading(&self) -> bool {
-        self.is_loading
+        let won = self
+            .is_loading
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+            .is_ok();
+        if won {
+            self.load_failed.store(false, Ordering::Release);
+        }
+        won
     }
 
     /// Mark loading complete (success or failure).
@@ -490,6 +504,29 @@ impl RoomPersistence {
     /// True if a streaming load is currently in progress.
     pub fn is_loading(&self) -> bool {
         self.is_loading.load(Ordering::Acquire)
+    }
+
+    /// Record that the most recent streaming load failed before completing.
+    /// The failure handler empties the room doc as an in-memory rollback; this
+    /// flag tells the persistence layer not to write that empty doc over
+    /// existing on-disk content.
+    pub fn mark_load_failed(&self) {
+        self.load_failed.store(true, Ordering::Release);
+    }
+
+    /// Clear the failed-load marker. Called once the room has been repopulated
+    /// from disk by some path other than `try_start_loading` (an external-change
+    /// reload) or once a non-empty save proves the room recovered real content.
+    /// Without this the stale flag would suppress a later legitimate
+    /// delete-all-cells save.
+    pub fn clear_load_failed(&self) {
+        self.load_failed.store(false, Ordering::Release);
+    }
+
+    /// True if the most recent streaming load failed and no newer attempt has
+    /// started. Used to suppress a destructive autosave of the emptied room.
+    pub fn load_failed(&self) -> bool {
+        self.load_failed.load(Ordering::Acquire)
     }
 }
 
@@ -1028,6 +1065,23 @@ impl NotebookRoom {
     /// Mark the streaming load complete.
     pub fn finish_loading(&self) {
         self.persistence.finish_loading();
+    }
+
+    /// Record that the most recent streaming load failed before completing.
+    pub fn mark_load_failed(&self) {
+        self.persistence.mark_load_failed();
+    }
+
+    /// Clear the failed-load marker after the room recovers content by a path
+    /// other than a fresh streaming load.
+    pub fn clear_load_failed(&self) {
+        self.persistence.clear_load_failed();
+    }
+
+    /// True if the most recent streaming load failed and no newer attempt has
+    /// started.
+    pub fn load_failed(&self) -> bool {
+        self.persistence.load_failed()
     }
 
     /// Get kernel info if a kernel is running (runtime-agent-backed).

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -239,6 +239,160 @@ async fn file_backed_room_has_path_some() {
     );
 }
 
+/// A valid one-cell notebook used to seed an on-disk `.ipynb`.
+const ONE_CELL_IPYNB: &str = r#"{"cells":[{"cell_type":"code","source":["print(1)"],"metadata":{},"outputs":[],"execution_count":null}],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+
+fn disk_cell_count(path: &std::path::Path) -> usize {
+    let bytes = std::fs::read(path).unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    v.get("cells")
+        .and_then(|c| c.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0)
+}
+
+/// A failed streaming load empties the room doc as a rollback. The teardown
+/// autosave must not write that empty doc over a notebook that still has cells
+/// on disk — a failed open must not delete the file.
+#[tokio::test]
+async fn failed_load_does_not_zero_existing_notebook() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let path = tmp.path().join("note.ipynb");
+    tokio::fs::write(&path, ONE_CELL_IPYNB).await.unwrap();
+
+    let room = NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+    // The room doc starts empty, matching the post-`clear_all_cells` state.
+    room.mark_load_failed();
+
+    let result = save_notebook_to_disk(&room, None).await;
+    assert!(result.is_ok(), "save should no-op cleanly: {result:?}");
+    assert_eq!(
+        disk_cell_count(&path),
+        1,
+        "a failed load must not zero the on-disk notebook"
+    );
+}
+
+/// The guard is scoped to failed loads only. An empty room whose load did not
+/// fail is a legitimate "user deleted every cell" save and must still write.
+#[tokio::test]
+async fn empty_room_without_failed_load_still_writes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let path = tmp.path().join("note.ipynb");
+    tokio::fs::write(&path, ONE_CELL_IPYNB).await.unwrap();
+
+    let room = NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+    // No load failure recorded.
+    save_notebook_to_disk(&room, None).await.unwrap();
+    assert_eq!(
+        disk_cell_count(&path),
+        0,
+        "an empty room without a failed load must still persist (legit clear)"
+    );
+}
+
+/// A malformed notebook on disk is the most important to preserve after a
+/// failed load, not the least — the guard keys off "the file has bytes," not
+/// whether it parses.
+#[tokio::test]
+async fn failed_load_does_not_overwrite_malformed_notebook() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let path = tmp.path().join("note.ipynb");
+    let garbage = b"{ this is not valid json \x00 cells".to_vec();
+    tokio::fs::write(&path, &garbage).await.unwrap();
+
+    let room = NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+    room.mark_load_failed();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        garbage,
+        "a failed load must not overwrite a malformed file"
+    );
+}
+
+/// Once the room recovers (e.g. the file-watcher reload clears the marker), a
+/// later legitimate delete-all-cells save must persist. Guards against a stale
+/// `load_failed` flag wedging empty saves after recovery.
+#[tokio::test]
+async fn cleared_failed_load_lets_empty_save_through() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let path = tmp.path().join("note.ipynb");
+    tokio::fs::write(&path, ONE_CELL_IPYNB).await.unwrap();
+
+    let room = NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+    room.mark_load_failed();
+    // Recovery clears the marker (stands in for a file-watcher reload).
+    room.clear_load_failed();
+
+    save_notebook_to_disk(&room, None).await.unwrap();
+    assert_eq!(
+        disk_cell_count(&path),
+        0,
+        "a cleared failed-load marker must not block a legit empty save"
+    );
+}
+
+/// An explicit Save (target path provided) from a failed-load-empty room over a
+/// non-empty file must fail loudly rather than silently report success — a
+/// phantom Ok would tell the UI it saved and could rebind the room path.
+#[tokio::test]
+async fn explicit_save_after_failed_load_errors_and_preserves_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+    let path = tmp.path().join("note.ipynb");
+    tokio::fs::write(&path, ONE_CELL_IPYNB).await.unwrap();
+
+    let room = NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    );
+    room.mark_load_failed();
+
+    let result = save_notebook_to_disk(&room, Some(path.to_str().unwrap())).await;
+    assert!(
+        matches!(result, Err(SaveError::Unrecoverable(_))),
+        "explicit save from a failed-load-empty room must error, got {result:?}"
+    );
+    assert_eq!(
+        disk_cell_count(&path),
+        1,
+        "explicit save must not zero the file either"
+    );
+}
+
 #[tokio::test]
 async fn reservation_guard_increments_and_decrements_counter() {
     use std::sync::atomic::Ordering;


### PR DESCRIPTION
**Status: parked draft.** The real fix is the genesis-seed divergence (separate
PR) — once the frontend wasm and daemon share a genesis seed, streaming loads
stop failing and this whole failed-load class becomes near-unreachable. This PR
is the safety net for that class and is intentionally scoped to "a failed open
must never cost the file."

## What it does

A failed streaming load empties the room doc as an in-memory rollback
(`clear_all_cells` in `peer_session.rs`). Kernel-teardown / autosave then wrote
that empty doc back over the source `.ipynb`, so a failed *open* deleted the
notebook on disk. Reproduced: a 15-cell notebook opened to 0 cells (223 bytes).

The room records when its most recent streaming load failed. The persistence
path refuses to write an empty room over a file that still has bytes on disk
(parseable or not), and the marker is cleared on a fresh load, on a non-empty
save, or on a non-empty external reload.

## Solid and covered

| Path | Behavior |
|---|---|
| autosave / teardown over a non-empty file (failed load) | skipped, file preserved |
| explicit Save As over a non-empty file (failed load) | error, file preserved |
| empty room, load did **not** fail (user cleared cells) | normal write |
| populated room | normal write |

Tests: `failed_load_does_not_zero_existing_notebook`,
`failed_load_does_not_overwrite_malformed_notebook`,
`cleared_failed_load_lets_empty_save_through`,
`explicit_save_after_failed_load_errors_and_preserves_file`. CI green on the core.

## Known limitations (deferred — documented in code)

Both keep the file intact; neither is data loss. Deferred because the root-cause
PR removes the failed-load trigger, making these near-unreachable:

- **Explicit in-place Save reports phantom success.** `NotebookRequest::SaveNotebook`
  passes `path: None`, the same as autosave, so an in-place save of a
  failed-load-empty room is silently skipped and reported as saved. Surfacing it
  needs a save-origin signal threaded from the request handler (the `SaveOrigin`
  refactor was started and set aside as out of proportion to the payoff).
- **Valid empty external reload leaves the marker set.** A `cells: []` file fixed
  externally keeps `load_failed` set until a cell is added or it is reopened.

## Why parked

The flag lifecycle keeps generating edge cases (codex found four in sequence,
each narrower). The correct sequencing is to land the root-cause fix first
(genesis seed parity) so loads stop failing, then decide whether the residual
explicit-save/empty-reload edges here are even worth the added machinery.
