### PR TITLE
docs(elements): catalog media output surfaces

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "39",
+    value: "43",
     detail:
-      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, renderer, editor, and widget surfaces",
+      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, expanded renderer, editor, and widget surfaces",
   },
 ];
 
@@ -136,7 +136,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, TracebackOutput, MIME priority, and SiftTable now render from fixtures; Sift parquet/Arrow URL loading remains an explicit WASM asset adapter boundary.",
+      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, TracebackOutput, MIME priority, and SiftTable now render from fixtures; plugin-backed HTML/Plotly/Vega/GeoJSON and Sift URL loading remain explicit adapter boundaries.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "43",
+    value: "44",
     detail:
-      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, expanded renderer, editor, and widget surfaces",
+      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, expanded renderer, editor, and widget surfaces",
   },
 ];
 
@@ -132,11 +132,12 @@ const families = [
   },
   {
     family: "Outputs",
-    source: "src/components/outputs/** + packages/sift/src/react.tsx",
+    source:
+      "src/components/cell/OutputArea.tsx + src/components/outputs/** + packages/sift/src/react.tsx",
     target: "nteract renderers",
     status: "active",
     intent:
-      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; plugin-backed HTML/Plotly/Vega/GeoJSON and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; production iframe bootstrapping, plugin-backed HTML/Plotly/Vega/GeoJSON, widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -136,7 +136,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, TracebackOutput, MIME priority, and SiftTable now render from fixtures; plugin-backed HTML/Plotly/Vega/GeoJSON and Sift URL loading remain explicit adapter boundaries.",
+      "AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; plugin-backed HTML/Plotly/Vega/GeoJSON and generated Sift WASM decoding remain explicit adapter boundaries.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -4,7 +4,9 @@ import { SiftTable, type TableData, type TableEngineState } from "@nteract/sift"
 import {
   AlertTriangle,
   Braces,
+  FileAudio,
   FileImage,
+  FileText,
   FileWarning,
   ListFilter,
   Table2,
@@ -12,10 +14,14 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
+import { AudioOutput } from "@/components/outputs/audio-output";
 import { ImageOutput } from "@/components/outputs/image-output";
+import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
+import { MathOutput } from "@/components/outputs/math-output";
 import { selectMimeType } from "@/components/outputs/mime-priority";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
+import { SvgOutput } from "@/components/outputs/svg-output";
 import { TracebackOutput } from "@/components/outputs/traceback-output";
 
 const svgFigure = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
@@ -30,6 +36,18 @@ const svgFigure = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180"
 </svg>`;
 
 const imageDataUrl = `data:image/svg+xml;utf8,${encodeURIComponent(svgFigure)}`;
+
+const svgOutputFixture = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
+  <rect width="420" height="180" rx="16" fill="#eef2ff"/>
+  <circle cx="92" cy="92" r="36" fill="#3b82f6" opacity="0.85"/>
+  <circle cx="174" cy="72" r="44" fill="#10b981" opacity="0.82"/>
+  <circle cx="280" cy="98" r="52" fill="#f59e0b" opacity="0.78"/>
+  <path d="M56 142 H360" stroke="#475569" stroke-width="3" stroke-linecap="round"/>
+  <text x="56" y="38" fill="#1e293b" font-family="ui-sans-serif, system-ui" font-size="16" font-weight="700">svg-output fixture</text>
+</svg>`;
+
+const silentAudioDataUrl =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=";
 
 const jsonFixture = {
   run: {
@@ -329,6 +347,26 @@ const renderedPieces = [
     note: "Notebook media frame with data URL and preload handling.",
   },
   {
+    name: "MathOutput",
+    source: "src/components/outputs/math-output.tsx",
+    note: "KaTeX-backed text/latex rendering that is safe in the main output lane.",
+  },
+  {
+    name: "SvgOutput",
+    source: "src/components/outputs/svg-output.tsx",
+    note: "SVG insertion and responsive sizing for vector notebook figures.",
+  },
+  {
+    name: "AudioOutput",
+    source: "src/components/outputs/audio-output.tsx",
+    note: "Notebook audio player for data URLs, blob URLs, and base64 payloads.",
+  },
+  {
+    name: "JavaScriptOutput",
+    source: "src/components/outputs/javascript-output.tsx",
+    note: "Main-DOM safety fallback for JavaScript output; execution remains isolated only.",
+  },
+  {
     name: "TracebackOutput",
     source: "src/components/outputs/traceback-output.tsx",
     note: "nteract-owned structured traceback renderer with source context and copy affordance.",
@@ -349,7 +387,7 @@ const adapterBoundaries = [
   {
     name: "IsolatedFrame",
     reason:
-      "Required for HTML, markdown with raw HTML, SVG insertion, JavaScript, Plotly, Vega, and GeoJSON plugin surfaces.",
+      "Required for HTML, markdown with raw HTML, executable JavaScript, Plotly, Vega, and GeoJSON plugin surfaces.",
   },
   {
     name: "Widget output",
@@ -444,6 +482,44 @@ export function OutputRenderersExample() {
           icon={FileImage}
         >
           <ImageOutput data={imageDataUrl} mediaType="image/svg+xml" alt="Fixture line chart" />
+        </RendererCard>
+
+        <RendererCard
+          title="Math output"
+          source="src/components/outputs/math-output.tsx"
+          icon={Braces}
+        >
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <MathOutput content="$$\\operatorname{MAE}=\\frac{1}{n}\\sum_{i=1}^{n}|y_i-\\hat{y}_i|=8.42$$" />
+          </div>
+        </RendererCard>
+
+        <RendererCard
+          title="SVG output"
+          source="src/components/outputs/svg-output.tsx"
+          icon={FileImage}
+        >
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <SvgOutput data={svgOutputFixture} />
+          </div>
+        </RendererCard>
+
+        <RendererCard
+          title="Audio output"
+          source="src/components/outputs/audio-output.tsx"
+          icon={FileAudio}
+        >
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <AudioOutput data={silentAudioDataUrl} mediaType="audio/wav" />
+          </div>
+        </RendererCard>
+
+        <RendererCard
+          title="JavaScript output boundary"
+          source="src/components/outputs/javascript-output.tsx"
+          icon={FileText}
+        >
+          <JavaScriptOutput code="element.textContent = 'executed in isolated iframe only';" />
         </RendererCard>
 
         <RendererCard

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -4,6 +4,7 @@ import { SiftTable, type TableData, type TableEngineState } from "@nteract/sift"
 import {
   AlertTriangle,
   Braces,
+  Database,
   FileAudio,
   FileImage,
   FileText,
@@ -251,6 +252,28 @@ const siftData: TableData = {
   ],
 };
 
+const siftParquetUrl =
+  "https://huggingface.co/datasets/mstz/heart_failure/resolve/refs%2Fconvert%2Fparquet/death/train/0000.parquet";
+
+const siftUrlMilestones = [
+  {
+    phase: "Resolve",
+    value: "mstz/heart_failure - death/train/0000.parquet",
+  },
+  {
+    phase: "Fetch",
+    value: "12 KB parquet source from HuggingFace",
+  },
+  {
+    phase: "Decode boundary",
+    value: "generated sift-wasm load_parquet_row_group",
+  },
+  {
+    phase: "Render",
+    value: "SiftTable mounted with fixture TableData",
+  },
+];
+
 const tracebackFixture = {
   ename: "ValueError",
   evalue: "feature matrix contains null values",
@@ -374,7 +397,7 @@ const renderedPieces = [
   {
     name: "SiftTable",
     source: "packages/sift/src/react.tsx",
-    note: "nteract-owned Arrow/parquet table UI rendered here with static TableData.",
+    note: "nteract-owned Arrow/parquet table UI rendered here with static TableData and a fixture-backed URL handoff.",
   },
 ];
 
@@ -395,9 +418,9 @@ const adapterBoundaries = [
       "Needs fixture-backed WidgetStore and saved widget state before controls can be shown without kernel comm state.",
   },
   {
-    name: "Sift URL loader",
+    name: "Generated Sift WASM decode",
     reason:
-      "Parquet and Arrow URL sources need generated sift-wasm glue and a served WASM asset; this catalog uses TableData until the docs app owns that asset path.",
+      "Parquet and Arrow URL bytes still need generated sift-wasm glue and a served WASM asset; this catalog shows the URL handoff with decoded TableData until the docs app owns that asset path.",
   },
 ];
 
@@ -435,6 +458,7 @@ function RendererCard({
 
 export function OutputRenderersExample() {
   const [siftState, setSiftState] = useState<TableEngineState | null>(null);
+  const [siftUrlState, setSiftUrlState] = useState<TableEngineState | null>(null);
 
   return (
     <div className="not-prose space-y-6" data-testid="output-renderers-example">
@@ -555,13 +579,76 @@ export function OutputRenderersExample() {
           <div className="grid gap-2 text-xs text-fd-muted-foreground md:grid-cols-[minmax(0,1fr)_auto]">
             <div>
               Static TableData mirrors the renderer handoff after parquet/Arrow bytes have been
-              decoded. The production URL path is still tracked as an adapter boundary.
+              decoded. The generated WASM decode path is still tracked as an adapter boundary.
             </div>
             <div className="font-mono">
               {siftState
                 ? `${siftState.filteredCount}/${siftState.totalCount} rows`
                 : `${siftData.rowCount}/${siftData.rowCount} rows`}
             </div>
+          </div>
+        </div>
+      </RendererCard>
+
+      <RendererCard
+        title="Sift parquet URL handoff"
+        source="packages/sift/src/react.tsx"
+        icon={Database}
+      >
+        <div className="space-y-4" data-testid="sift-parquet-url-surface">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_280px]">
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-xs font-medium text-fd-muted-foreground">
+                HuggingFace parquet source
+              </div>
+              <a
+                href={siftParquetUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-2 block break-words font-mono text-xs leading-5 text-fd-foreground [overflow-wrap:anywhere]"
+              >
+                {siftParquetUrl}
+              </a>
+            </div>
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-xs font-medium text-fd-muted-foreground">Catalog source</div>
+              <div className="mt-2 font-mono text-xs text-fd-foreground">
+                source.kind = table-data
+              </div>
+              <div className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+                The URL is real; the docs surface stays runtime-free by rendering the decoded table
+                fixture.
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-2 md:grid-cols-4">
+            {siftUrlMilestones.map((milestone) => (
+              <div
+                key={milestone.phase}
+                className="rounded-md border border-fd-border bg-fd-background p-3"
+              >
+                <div className="text-xs font-semibold">{milestone.phase}</div>
+                <div className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+                  {milestone.value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="h-[320px] min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+            <SiftTable source={{ kind: "table-data", data: siftData }} onChange={setSiftUrlState} />
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-fd-muted-foreground">
+            <span>
+              This keeps the visible renderer faithful to the Sift UI while keeping network, blob,
+              and generated WASM concerns outside the docs runtime.
+            </span>
+            <span className="font-mono">
+              {siftUrlState
+                ? `${siftUrlState.filteredCount}/${siftUrlState.totalCount} rows`
+                : `${siftData.rowCount}/${siftData.rowCount} rows`}
+            </span>
           </div>
         </div>
       </RendererCard>

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -24,6 +24,7 @@ import { selectMimeType } from "@/components/outputs/mime-priority";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { TracebackOutput } from "@/components/outputs/traceback-output";
+import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
 
 const svgFigure = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
   <rect width="420" height="180" rx="16" fill="#f8fafc"/>
@@ -317,6 +318,36 @@ const tracebackFixture = {
   ],
 };
 
+const outputAreaFixtures: JupyterOutput[] = [
+  {
+    output_id: "output-area-stream",
+    output_type: "stream",
+    name: "stdout",
+    text: "loaded 22,767 rows\nvalidated fold 02 with mae=8.42\n",
+  },
+  {
+    output_id: "output-area-html",
+    output_type: "display_data",
+    data: {
+      "text/html": "<strong>unsafe HTML fixture</strong>",
+      "text/plain": "unsafe HTML fixture",
+    },
+    metadata: {},
+  },
+  {
+    output_id: "output-area-parquet",
+    output_type: "display_data",
+    data: {
+      "application/vnd.apache.parquet": {
+        url: siftParquetUrl,
+        rows: siftData.rowCount,
+      },
+      "text/plain": "heart_failure parquet fixture",
+    },
+    metadata: {},
+  },
+];
+
 const mimeFixtures = [
   {
     label: "Rich traceback beats text",
@@ -349,6 +380,11 @@ const mimeFixtures = [
 ];
 
 const renderedPieces = [
+  {
+    name: "OutputArea",
+    source: "src/components/cell/OutputArea.tsx",
+    note: "Notebook output lane composition, collapse control, DOM-vs-isolated segmentation, and search count plumbing rendered with static outputs.",
+  },
   {
     name: "AnsiStreamOutput",
     source: "src/components/outputs/ansi-output.tsx",
@@ -403,11 +439,6 @@ const renderedPieces = [
 
 const adapterBoundaries = [
   {
-    name: "OutputArea",
-    reason:
-      "Owns output focus, scroll handoff, iframe sizing, search highlighting, and widget bridge wiring.",
-  },
-  {
     name: "IsolatedFrame",
     reason:
       "Required for HTML, markdown with raw HTML, executable JavaScript, Plotly, Vega, and GeoJSON plugin surfaces.",
@@ -459,6 +490,8 @@ function RendererCard({
 export function OutputRenderersExample() {
   const [siftState, setSiftState] = useState<TableEngineState | null>(null);
   const [siftUrlState, setSiftUrlState] = useState<TableEngineState | null>(null);
+  const [outputAreaCollapsed, setOutputAreaCollapsed] = useState(false);
+  const [outputAreaMatchCount, setOutputAreaMatchCount] = useState(0);
 
   return (
     <div className="not-prose space-y-6" data-testid="output-renderers-example">
@@ -468,9 +501,9 @@ export function OutputRenderersExample() {
           <div>
             <h2 className="text-sm font-semibold">Output fixture adapter</h2>
             <p className="mt-1 text-xs leading-5">
-              These examples render current output components directly with static nbformat-like
-              fixtures. The iframe and widget paths stay documented as adapter boundaries until the
-              docs app has a runtime-free isolation fixture.
+              These examples render current output components with static nbformat-like fixtures.
+              OutputArea uses the docs isolated-frame adapter for iframe lanes, while widget comms,
+              plugin injection, and generated WASM stay explicit adapter boundaries.
             </p>
           </div>
         </div>
@@ -562,6 +595,56 @@ export function OutputRenderersExample() {
           />
         </RendererCard>
       </section>
+
+      <RendererCard
+        title="Output area lanes"
+        source="src/components/cell/OutputArea.tsx"
+        icon={ListFilter}
+      >
+        <div className="space-y-3" data-testid="output-area-lanes-surface">
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-xs font-medium text-fd-muted-foreground">
+                Static output sequence
+              </div>
+              <div className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+                Stream output stays in the document lane. HTML and parquet split into the docs
+                isolated-frame adapter, matching the production lane policy without loading a
+                runtime iframe bundle.
+              </div>
+            </div>
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-xs font-medium text-fd-muted-foreground">Search fixture</div>
+              <div className="mt-2 font-mono text-xs text-fd-foreground">
+                query=fold · matches={outputAreaMatchCount}
+              </div>
+              <button
+                type="button"
+                className="mt-3 rounded-md border border-fd-border px-2 py-1 text-xs font-medium text-fd-foreground transition-colors hover:bg-fd-muted"
+                onClick={() => setOutputAreaCollapsed((value) => !value)}
+              >
+                {outputAreaCollapsed ? "Show outputs" : "Collapse outputs"}
+              </button>
+            </div>
+          </div>
+          <div className="rounded-md border border-fd-border bg-background py-3">
+            <OutputArea
+              outputs={outputAreaFixtures}
+              cellId="elements-output-area"
+              executionCount={12}
+              collapsed={outputAreaCollapsed}
+              onToggleCollapse={() => setOutputAreaCollapsed((value) => !value)}
+              searchQuery="fold"
+              onSearchMatchCount={setOutputAreaMatchCount}
+              hostContext={{
+                nteract: {
+                  colorTheme: "classic",
+                },
+              }}
+            />
+          </div>
+        </div>
+      </RendererCard>
 
       <RendererCard
         title="Rich traceback"

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -18,12 +18,14 @@ state, iframe bootstrapping, or plugin injection.
 The rendered surfaces import current output components directly: ANSI streams
 and errors, JSON trees, image output, math output, SVG output, audio output,
 the JavaScript isolation fallback, the structured traceback renderer, and
-`SiftTable` with static `TableData`. The MIME selection table uses the same
-priority helper the notebook uses before rendering.
+`SiftTable` with static `TableData`. The Sift section also shows the
+HuggingFace parquet URL handoff the demo uses, then renders the decoded table
+fixture so the docs app stays runtime-free. The MIME selection table uses the
+same priority helper the notebook uses before rendering.
 
 ## What still needs an adapter
 
 `OutputArea`, isolated HTML/markdown, executable JavaScript,
-Plotly/Vega/GeoJSON plugin renderers, widget views, and Sift parquet/Arrow URL
-loading still need fixture-backed isolation, widget-store, or generated WASM
-asset adapters before this docs app should render those paths.
+Plotly/Vega/GeoJSON plugin renderers, widget views, and generated Sift
+parquet/Arrow WASM decoding still need fixture-backed isolation, widget-store,
+or generated asset adapters before this docs app should render those paths.

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -16,13 +16,14 @@ state, iframe bootstrapping, or plugin injection.
 ## What is real here
 
 The rendered surfaces import current output components directly: ANSI streams
-and errors, JSON trees, image output, the structured traceback renderer, and
+and errors, JSON trees, image output, math output, SVG output, audio output,
+the JavaScript isolation fallback, the structured traceback renderer, and
 `SiftTable` with static `TableData`. The MIME selection table uses the same
 priority helper the notebook uses before rendering.
 
 ## What still needs an adapter
 
-`OutputArea`, isolated HTML/markdown/SVG/JavaScript, Plotly/Vega/GeoJSON plugin
-renderers, widget views, and Sift parquet/Arrow URL loading still need
-fixture-backed isolation, widget-store, or generated WASM asset adapters before
-this docs app should render those paths.
+`OutputArea`, isolated HTML/markdown, executable JavaScript,
+Plotly/Vega/GeoJSON plugin renderers, widget views, and Sift parquet/Arrow URL
+loading still need fixture-backed isolation, widget-store, or generated WASM
+asset adapters before this docs app should render those paths.

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -15,17 +15,18 @@ state, iframe bootstrapping, or plugin injection.
 
 ## What is real here
 
-The rendered surfaces import current output components directly: ANSI streams
-and errors, JSON trees, image output, math output, SVG output, audio output,
-the JavaScript isolation fallback, the structured traceback renderer, and
-`SiftTable` with static `TableData`. The Sift section also shows the
-HuggingFace parquet URL handoff the demo uses, then renders the decoded table
-fixture so the docs app stays runtime-free. The MIME selection table uses the
-same priority helper the notebook uses before rendering.
+The rendered surfaces import current output components directly: `OutputArea`
+lane composition, ANSI streams and errors, JSON trees, image output, math
+output, SVG output, audio output, the JavaScript isolation fallback, the
+structured traceback renderer, and `SiftTable` with static `TableData`. The Sift
+section also shows the HuggingFace parquet URL handoff the demo uses, then
+renders the decoded table fixture so the docs app stays runtime-free. The MIME
+selection table uses the same priority helper the notebook uses before
+rendering.
 
 ## What still needs an adapter
 
-`OutputArea`, isolated HTML/markdown, executable JavaScript,
+Production `IsolatedFrame` bootstrapping, executable JavaScript,
 Plotly/Vega/GeoJSON plugin renderers, widget views, and generated Sift
 parquet/Arrow WASM decoding still need fixture-backed isolation, widget-store,
 or generated asset adapters before this docs app should render those paths.


### PR DESCRIPTION
## Summary

- expand the elements output-renderers catalog with real nteract media/math output components
- add a real `OutputArea` lane-composition fixture that uses the docs isolated-frame adapter for HTML/parquet lanes
- add fixture-backed `MathOutput`, `SvgOutput`, `AudioOutput`, and `JavaScriptOutput` boundary examples
- add a fixture-backed Sift parquet URL handoff using the current `SiftTable` UI and a real HuggingFace parquet source URL
- update the component burn-down and output-renderer docs to reflect what is now real versus still adapter-backed

## Stack

- Targets `main` after #3128 merged
- Keeps executable/plugin-backed surfaces documented as adapter boundaries: production `IsolatedFrame` bootstrapping, executable JavaScript, Plotly/Vega/GeoJSON, widget comms, and generated Sift WASM decoding/assets

## Test Plan

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Browser smoke: `/docs/output-renderers` renders the output page, `OutputArea` lane fixture, math, SVG, audio, JavaScript boundary, traceback, Sift table, and Sift parquet URL handoff sections without console errors
