### PR TITLE
test(notebook-cloud): assert hosted runtime wasm hints

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-runtime-wasm.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-runtime-wasm.mjs
@@ -1,0 +1,97 @@
+const RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
+const RUNTIMED_WASM_BINARY_NAME = "runtimed_wasm_bg.wasm";
+
+export function checkRuntimeWasmHints(hints, options = {}) {
+  const expectedRendererAssetOrigin = options.expectedRendererAssetOrigin ?? "";
+  const requireHints = options.requireHints ?? true;
+  const failures = [];
+  const modulepreload = hints.find(
+    (hint) =>
+      relIncludes(hint.rel, "modulepreload") && hint.href.includes(RUNTIMED_WASM_MODULE_NAME),
+  );
+  const wasmPreload = hints.find(
+    (hint) => relIncludes(hint.rel, "preload") && hint.href.includes(RUNTIMED_WASM_BINARY_NAME),
+  );
+
+  if (requireHints && !modulepreload) {
+    failures.push({
+      kind: "runtimed-wasm-hint",
+      text: `Missing ${RUNTIMED_WASM_MODULE_NAME} modulepreload hint`,
+    });
+  }
+  if (requireHints && !wasmPreload) {
+    failures.push({
+      kind: "runtimed-wasm-hint",
+      text: `Missing ${RUNTIMED_WASM_BINARY_NAME} preload hint`,
+    });
+  }
+
+  if (modulepreload) {
+    assertCrossOrigin(modulepreload, failures, `${RUNTIMED_WASM_MODULE_NAME} modulepreload`);
+    assertExpectedOrigin(
+      modulepreload,
+      expectedRendererAssetOrigin,
+      failures,
+      `${RUNTIMED_WASM_MODULE_NAME} modulepreload`,
+    );
+  }
+  if (wasmPreload) {
+    if (wasmPreload.as !== "fetch") {
+      failures.push({
+        kind: "runtimed-wasm-hint",
+        text: `${RUNTIMED_WASM_BINARY_NAME} preload used as=${JSON.stringify(wasmPreload.as)}`,
+      });
+    }
+    if (wasmPreload.type !== "application/wasm") {
+      failures.push({
+        kind: "runtimed-wasm-hint",
+        text: `${RUNTIMED_WASM_BINARY_NAME} preload used type=${JSON.stringify(wasmPreload.type)}`,
+      });
+    }
+    assertCrossOrigin(wasmPreload, failures, `${RUNTIMED_WASM_BINARY_NAME} preload`);
+    assertExpectedOrigin(
+      wasmPreload,
+      expectedRendererAssetOrigin,
+      failures,
+      `${RUNTIMED_WASM_BINARY_NAME} preload`,
+    );
+  }
+
+  return {
+    ok: failures.length === 0,
+    modulepreload: modulepreload ?? null,
+    wasmPreload: wasmPreload ?? null,
+    runtimedWasmHints: hints.filter((hint) => hint.href.includes("runtimed_wasm")),
+    failures,
+  };
+}
+
+function relIncludes(rel, expected) {
+  return rel
+    .split(/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .includes(expected);
+}
+
+function assertCrossOrigin(hint, failures, label) {
+  if (!hint.crossorigin && hint.crossOrigin !== "" && hint.crossOrigin !== "anonymous") {
+    failures.push({
+      kind: "runtimed-wasm-hint",
+      text: `${label} did not declare crossorigin`,
+    });
+  }
+}
+
+function assertExpectedOrigin(hint, expectedRendererAssetOrigin, failures, label) {
+  if (!expectedRendererAssetOrigin) {
+    return;
+  }
+  if (!hint.href.startsWith(expectedRendererAssetOrigin)) {
+    failures.push({
+      kind: "runtimed-wasm-hint-origin",
+      text: `${label} did not point at ${expectedRendererAssetOrigin}`,
+      href: hint.href,
+    });
+  }
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -21,6 +21,7 @@ import {
   summarizePerformanceResources,
   withTiming,
 } from "./hosted-render-smoke-performance.mjs";
+import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
 import { catalogApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
@@ -96,6 +97,7 @@ const performanceResources = [];
 const performanceRequests = new Map();
 let catalogApiCheck = null;
 let viewerCssCheck = null;
+let runtimeWasmHintCheck = null;
 let screenshotSaved = false;
 let pageTextMatches = {};
 let themeModeChecks = [];
@@ -238,6 +240,12 @@ async function main() {
 
     await page.goto(targetUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
     markTiming("domcontentloaded");
+    runtimeWasmHintCheck = checkRuntimeWasmHints(await collectRuntimeWasmHints(page), {
+      expectedRendererAssetOrigin,
+      requireHints: requireRuntimedWasm,
+    });
+    failures.push(...runtimeWasmHintCheck.failures);
+    markTiming("runtime_wasm_hints");
     const networkIdleTask = page
       .waitForLoadState("networkidle", { timeout: timeoutMs })
       .then(() => markTiming("networkidle"))
@@ -454,6 +462,7 @@ async function main() {
           performanceDiagnostics: summarizePerformanceResources(performanceResources, timingsMs),
           catalogApiCheck,
           viewerCssCheck,
+          runtimeWasmHintCheck,
           executionCounts,
           reportCellCount,
           presenceText,
@@ -729,6 +738,19 @@ async function checkHostedThemeModes(browser, modes) {
   }
 
   return checks;
+}
+
+async function collectRuntimeWasmHints(page) {
+  return page.evaluate(() =>
+    Array.from(document.head.querySelectorAll("link[href*='runtimed_wasm']")).map((link) => ({
+      rel: link.getAttribute("rel") ?? "",
+      href: link.href,
+      as: link.getAttribute("as") ?? "",
+      type: link.getAttribute("type") ?? "",
+      crossorigin: link.getAttribute("crossorigin"),
+      crossOrigin: link.crossOrigin,
+    })),
+  );
 }
 
 async function waitForPageText(page, expectedTexts) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1811,6 +1811,11 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
   );
 }
 
+interface ViewerShellConfig extends Record<string, unknown> {
+  runtimedWasmModulePath: string;
+  runtimedWasmPath: string;
+}
+
 function homeViewer(request: Request, env: Env): Response {
   return viewerShell("nteract cloud notebooks", env, authConfigForRequest(request, env), null);
 }
@@ -1828,7 +1833,7 @@ function viewerShell(
   title: string,
   env: Env,
   authConfig: unknown,
-  config: Record<string, unknown> | null,
+  config: ViewerShellConfig | null,
 ): Response {
   const html = `<!doctype html>
 <html lang="en">
@@ -1838,6 +1843,7 @@ function viewerShell(
   <title>${title}</title>
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
+  ${viewerResourceHints(config)}
   <link rel="stylesheet" href="/assets/notebook-cloud-viewer.css" />
 </head>
 <body>
@@ -1865,6 +1871,19 @@ function viewerShell(
       viewerContentSecurityPolicy(env),
     ),
   );
+}
+
+function viewerResourceHints(config: ViewerShellConfig | null): string {
+  if (!config) {
+    return "";
+  }
+
+  return [
+    `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
+    `<link rel="preload" href="${escapeHtml(
+      config.runtimedWasmPath,
+    )}" as="fetch" type="application/wasm" crossorigin />`,
+  ].join("\n  ");
 }
 
 function authConfigForRequest(request: Request, env: Env): { oidc: Record<string, string> | null } {

--- a/apps/notebook-cloud/test/hosted-smoke-runtime-wasm.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-runtime-wasm.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { checkRuntimeWasmHints } from "../scripts/hosted-render-smoke-runtime-wasm.mjs";
+
+describe("hosted smoke runtime WASM hints", () => {
+  it("accepts the viewer shell modulepreload and fetch preload pair", () => {
+    const check = checkRuntimeWasmHints(
+      [
+        {
+          rel: "modulepreload",
+          href: "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/runtimed_wasm.js",
+          as: "",
+          type: "",
+          crossorigin: "",
+          crossOrigin: "",
+        },
+        {
+          rel: "preload",
+          href: "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/runtimed_wasm_bg.wasm",
+          as: "fetch",
+          type: "application/wasm",
+          crossorigin: "",
+          crossOrigin: "",
+        },
+      ],
+      {
+        expectedRendererAssetOrigin: "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev",
+      },
+    );
+
+    assert.equal(check.ok, true);
+    assert.deepEqual(check.failures, []);
+    assert.match(check.modulepreload.href, /runtimed_wasm\.js$/);
+    assert.match(check.wasmPreload.href, /runtimed_wasm_bg\.wasm$/);
+  });
+
+  it("reports missing or malformed runtime WASM preload hints", () => {
+    const check = checkRuntimeWasmHints(
+      [
+        {
+          rel: "preload",
+          href: "https://preview.runt.run/assets/runtimed_wasm_bg.wasm",
+          as: "script",
+          type: "application/octet-stream",
+          crossorigin: null,
+          crossOrigin: null,
+        },
+      ],
+      {
+        expectedRendererAssetOrigin: "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev",
+      },
+    );
+
+    assert.equal(check.ok, false);
+    assert.equal(check.failures.length, 5);
+    assert.match(check.failures[0].text, /Missing runtimed_wasm\.js modulepreload hint/);
+    assert.match(check.failures[1].text, /used as="script"/);
+    assert.match(check.failures[2].text, /used type="application\/octet-stream"/);
+    assert.match(check.failures[3].text, /did not declare crossorigin/);
+    assert.match(
+      check.failures[4].text,
+      /runtimed_wasm_bg\.wasm preload did not point at https:\/\/nteract-notebook-cloud-assets\.rgbkrk\.workers\.dev/,
+    );
+  });
+
+  it("can collect diagnostics without failing when runtime WASM is optional", () => {
+    const check = checkRuntimeWasmHints([], { requireHints: false });
+
+    assert.equal(check.ok, true);
+    assert.deepEqual(check.runtimedWasmHints, []);
+  });
+});

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -59,14 +59,24 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/runtimed_wasm\.js" crossorigin/);
+    assert.match(
+      html,
+      /rel="preload" href="\/assets\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
+    );
     assert.ok(
       html.indexOf(viewerThemeFirstPaintStyle()) < html.indexOf(viewerThemeBootstrapScript()),
       "theme first-paint style must apply before the bootstrap script resolves the final theme",
     );
     assert.ok(
       html.indexOf(viewerThemeBootstrapScript()) <
+        html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"'),
+      "theme bootstrap must run before runtime WASM hints so first paint stays theme-safe",
+    );
+    assert.ok(
+      html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"') <
         html.indexOf("/assets/notebook-cloud-viewer.css"),
-      "theme bootstrap must run before the stylesheet to avoid dark-to-light first paint",
+      "runtime WASM modulepreload should be discoverable before the render-blocking stylesheet",
     );
     assert.doesNotMatch(html, /"renderEndpoint"/);
     assert.match(html, /"catalogEndpoint":"\/api\/n\/demo"/);
@@ -117,6 +127,8 @@ describe("HTML script serialization", () => {
     assert.match(html, /nteract cloud notebooks/);
     assert.match(html, /id="nteract-cloud-auth-config"/);
     assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
+    assert.doesNotMatch(html, /rel="modulepreload" href="[^"]*runtimed_wasm\.js/);
+    assert.doesNotMatch(html, /rel="preload" href="[^"]*runtimed_wasm_bg\.wasm/);
     assert.doesNotMatch(html, /In the Loop - Collaborative Notebooks/);
   });
 
@@ -210,6 +222,14 @@ describe("HTML script serialization", () => {
     assert.match(
       html,
       /"runtimedWasmPath":"https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm"/,
+    );
+    assert.match(
+      html,
+      /rel="modulepreload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm\.js" crossorigin/,
+    );
+    assert.match(
+      html,
+      /rel="preload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
     );
     assert.match(
       response.headers.get("Content-Security-Policy") ?? "",


### PR DESCRIPTION
## Summary

- add hosted smoke diagnostics for the runtime WASM shell hints introduced by #3129
- fail the hosted smoke when the viewer shell loses the `runtimed_wasm.js` modulepreload or `runtimed_wasm_bg.wasm` fetch preload
- assert the hints keep `crossorigin` and the configured renderer asset origin, then include the check in smoke JSON output

## Stack order

This PR is stacked on #3129 (`quod/notebook-cloud-live-viewer-sync`). Merge #3129 first, then retarget this PR to `main`.

## Validation

- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-runtime-wasm.test.mjs test/hosted-smoke-performance.test.mjs test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
