### PR TITLE
test(notebook-cloud): split hosted output resource diagnostics

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -33,10 +33,12 @@ export function classifyPerformanceResource(
     }
   }
 
-  const isRendererAsset =
-    rendererAssetOrigin && parsed.origin === rendererAssetOrigin && parsed.pathname.includes("/");
-  const isTargetAsset = targetOrigin && parsed.origin === targetOrigin;
-  if (isRendererAsset || isTargetAsset) {
+  const isRendererAsset = rendererAssetOrigin && parsed.origin === rendererAssetOrigin;
+  const isTargetRendererAsset =
+    targetOrigin &&
+    parsed.origin === targetOrigin &&
+    parsed.pathname.startsWith("/renderer-assets/");
+  if (isRendererAsset || isTargetRendererAsset) {
     if (parsed.pathname.endsWith("/runtimed_wasm.js")) {
       return "runtimed_wasm_js";
     }
@@ -46,17 +48,42 @@ export function classifyPerformanceResource(
     if (parsed.pathname.endsWith("/sift_wasm.wasm")) {
       return "sift_wasm_binary";
     }
+    if (parsed.pathname.endsWith(".js")) {
+      return "renderer_asset_js";
+    }
+    if (parsed.pathname.endsWith(".css")) {
+      return "renderer_asset_css";
+    }
   }
 
-  if (
-    outputDocumentOrigin &&
-    parsed.origin === outputDocumentOrigin &&
-    parsed.pathname.startsWith("/frame/")
-  ) {
-    return "output_document_frame";
+  if (outputDocumentOrigin && parsed.origin === outputDocumentOrigin) {
+    if (parsed.pathname.startsWith("/frame/")) {
+      return "output_document_frame";
+    }
+    if (parsed.pathname.endsWith(".js")) {
+      return "output_document_js";
+    }
+    if (parsed.pathname.endsWith(".css")) {
+      return "output_document_css";
+    }
+    return "output_document_asset";
   }
 
   return null;
+}
+
+export function refinePerformanceResourceKind(resource) {
+  if (resource.kind !== "notebook_blob") {
+    return resource;
+  }
+  const contentType = resource.contentType ?? "";
+  if (contentType.includes("application/vnd.apache.arrow.stream")) {
+    return { ...resource, kind: "arrow_stream_blob" };
+  }
+  if (contentType.includes("application/vnd.nteract.arrow-stream-manifest+json")) {
+    return { ...resource, kind: "arrow_manifest_blob" };
+  }
+  return resource;
 }
 
 export function summarizePerformanceResources(resources, milestones = {}) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -18,6 +18,7 @@ import {
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import {
   classifyPerformanceResource,
+  refinePerformanceResourceKind,
   summarizePerformanceResources,
   withTiming,
 } from "./hosted-render-smoke-performance.mjs";
@@ -533,11 +534,13 @@ function finishPerformanceRequest(request, updates) {
     return;
   }
   performanceRequests.delete(request);
-  performanceResources.push({
-    ...record,
-    ...updates,
-    end_ms: elapsedMs(),
-  });
+  performanceResources.push(
+    refinePerformanceResourceKind({
+      ...record,
+      ...updates,
+      end_ms: elapsedMs(),
+    }),
+  );
 }
 
 function themeModeSpec(value) {

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   classifyPerformanceResource,
+  refinePerformanceResourceKind,
   summarizePerformanceResources,
   withTiming,
 } from "../scripts/hosted-render-smoke-performance.mjs";
@@ -60,10 +61,70 @@ describe("hosted smoke performance diagnostics", () => {
     );
     assert.equal(
       classifyPerformanceResource(
+        "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/isolated-renderer.js",
+        origins,
+      ),
+      "renderer_asset_js",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/isolated-renderer.css",
+        origins,
+      ),
+      "renderer_asset_css",
+    );
+    assert.equal(
+      classifyPerformanceResource(
+        "https://preview.runt.run/renderer-assets/isolated-renderer.js",
+        origins,
+      ),
+      "renderer_asset_js",
+    );
+    assert.equal(
+      classifyPerformanceResource(
         "https://preview.runtusercontent.com/frame/?nteract_theme=light",
         origins,
       ),
       "output_document_frame",
+    );
+    assert.equal(
+      classifyPerformanceResource("https://preview.runtusercontent.com/assets/frame.js", origins),
+      "output_document_js",
+    );
+    assert.equal(
+      classifyPerformanceResource("https://preview.runtusercontent.com/assets/frame.css", origins),
+      "output_document_css",
+    );
+  });
+
+  it("refines notebook blobs by response content type", () => {
+    assert.deepEqual(
+      refinePerformanceResourceKind({
+        kind: "notebook_blob",
+        url: "https://preview.runt.run/api/n/topic-viz/blobs/arrow",
+        contentType: "application/vnd.apache.arrow.stream",
+      }),
+      {
+        kind: "arrow_stream_blob",
+        url: "https://preview.runt.run/api/n/topic-viz/blobs/arrow",
+        contentType: "application/vnd.apache.arrow.stream",
+      },
+    );
+    assert.deepEqual(
+      refinePerformanceResourceKind({
+        kind: "notebook_blob",
+        url: "https://preview.runt.run/api/n/topic-viz/blobs/manifest",
+        contentType: "application/vnd.nteract.arrow-stream-manifest+json",
+      }),
+      {
+        kind: "arrow_manifest_blob",
+        url: "https://preview.runt.run/api/n/topic-viz/blobs/manifest",
+        contentType: "application/vnd.nteract.arrow-stream-manifest+json",
+      },
+    );
+    assert.equal(
+      refinePerformanceResourceKind({ kind: "notebook_blob", contentType: "text/plain" }).kind,
+      "notebook_blob",
     );
   });
 


### PR DESCRIPTION
## Summary

- split hosted smoke resource diagnostics for output-related fetches
- classify renderer sidecar JS/CSS and output-document assets instead of leaving them invisible
- refine hosted notebook blob timings by response content type so Arrow manifests and Arrow stream chunks are measured separately

## Why

The current topic-viz hosted smoke shows first useful content much earlier than the Sift table text. This keeps the smoke evidence aligned with the next optimization target: output frames, Sift, and Arrow chunk streaming rather than `/render` or the main viewer bundle.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-performance.test.mjs test/hosted-smoke-runtime-wasm.test.mjs`
- `cargo xtask lint --fix`
- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `pnpm --dir apps/notebook-cloud typecheck`
- `NOTEBOOK_CLOUD_URL=https://preview.runt.run pnpm --dir apps/notebook-cloud smoke:hosted`
