### PR TITLE
perf(notebook-cloud): resolve viewer outputs progressively

### DIFF
--- a/apps/notebook-cloud/test/progressive-cell-resolution.test.ts
+++ b/apps/notebook-cloud/test/progressive-cell-resolution.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { BlobResolver } from "runtimed";
+import { resolveCellsProgressively } from "../viewer/progressive-cell-resolution.ts";
+import { createOutputResolutionCache } from "../viewer/render-resolution.ts";
+
+describe("cloud viewer progressive cell resolution", () => {
+  it("emits sync cells before waiting for blob-backed outputs", async () => {
+    const slowBlob = deferred<void>();
+    const events: string[] = [];
+    const resolver = textBlobResolver({
+      "sha256:slow": async () => {
+        events.push("fetch:slow:start");
+        await slowBlob.promise;
+        events.push("fetch:slow:finish");
+        return "shape: (200, 12)";
+      },
+    });
+
+    const resolution = resolveCellsProgressively(
+      [
+        {
+          id: "intro",
+          cell_type: "markdown",
+          source: "# Topic viz",
+        },
+        {
+          id: "slow-table",
+          cell_type: "code",
+          source: "df",
+          execution_count: 2,
+          outputs: [
+            {
+              output_id: "slow-table-output",
+              output_type: "execute_result",
+              execution_count: 2,
+              data: {
+                "text/plain": { blob: "sha256:slow" },
+              },
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      resolver,
+      "python",
+      createOutputResolutionCache(),
+      {
+        onInitialCells(cells) {
+          events.push(`initial:${cells.map((cell) => cell.outputs.length).join(",")}`);
+        },
+        onCellResolved(cell) {
+          events.push(`resolved:${cell.id}:${cell.outputs.length}`);
+        },
+      },
+    );
+
+    await Promise.resolve();
+    assert.equal(events[0], "initial:0,0");
+    assert.ok(events.includes("fetch:slow:start"));
+    assert.ok(events.includes("resolved:intro:0"));
+    assert.ok(!events.includes("fetch:slow:finish"));
+    assert.ok(!events.includes("resolved:slow-table:1"));
+
+    slowBlob.resolve();
+    const cells = await resolution;
+
+    assert.equal(cells.length, 2);
+    assert.equal(cells[1].outputs.length, 1);
+    assert.equal(cells[1].outputs[0].output_type, "execute_result");
+    if (cells[1].outputs[0].output_type === "execute_result") {
+      assert.equal(cells[1].outputs[0].data["text/plain"], "shape: (200, 12)");
+    }
+    assert.ok(events.indexOf("fetch:slow:finish") < events.indexOf("resolved:slow-table:1"));
+    assert.equal(events.at(-1), "resolved:slow-table:1");
+  });
+
+  it("stops emitting progressive updates when shouldContinue turns false", async () => {
+    let continueResolving = true;
+    const slowBlob = deferred<void>();
+    const events: string[] = [];
+
+    const resolution = resolveCellsProgressively(
+      [
+        {
+          id: "slow-table",
+          cell_type: "code",
+          source: "df",
+          outputs: [
+            {
+              output_id: "slow-table-output",
+              output_type: "display_data",
+              data: {
+                "text/plain": { blob: "sha256:slow" },
+              },
+              metadata: {},
+            },
+          ],
+        },
+      ],
+      textBlobResolver({
+        "sha256:slow": async () => {
+          await slowBlob.promise;
+          return "late output";
+        },
+      }),
+      "python",
+      createOutputResolutionCache(),
+      {
+        shouldContinue: () => continueResolving,
+        onInitialCells() {
+          events.push("initial");
+        },
+        onCellResolved() {
+          events.push("resolved");
+        },
+      },
+    );
+
+    await Promise.resolve();
+    continueResolving = false;
+    slowBlob.resolve();
+    await resolution;
+
+    assert.deepEqual(events, ["initial"]);
+  });
+});
+
+function textBlobResolver(values: Record<string, string | (() => Promise<string>)>): BlobResolver {
+  return {
+    url(ref) {
+      return `https://cloud.test/blobs/${encodeURIComponent(ref.blob)}`;
+    },
+    async fetch(ref) {
+      const value = values[ref.blob];
+      if (value === undefined) return new Response("missing", { status: 404 });
+      return new Response(typeof value === "function" ? await value() : value);
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -89,11 +89,10 @@ import {
 import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import {
   createOutputResolutionCache,
-  resolveCell,
-  resolveCellSync,
   type RenderCell,
   type ResolvedCell,
 } from "./render-resolution";
+import { resolveCellsProgressively } from "./progressive-cell-resolution";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
 import {
   buildCloudShareAccessRows,
@@ -755,20 +754,27 @@ function NotebookViewer({
         const notebookLanguage = languageFromNotebookMetadata(metadata) ?? "python";
         notebookLanguageRef.current = notebookLanguage;
         const outputResolutionCache = outputResolutionCacheRef.current;
-        const syncCells = rawCells.map((cell, index) =>
-          resolveCellSync(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
-        );
-        if (!cancelled && !liveMaterializedRef.current && syncCells.length > 0) {
-          setCells(syncCells);
-          setStatus({
-            kind: "loading",
-            message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
-          });
-        }
-        const resolvedCells = await Promise.all(
-          rawCells.map((cell, index) =>
-            resolveCell(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
-          ),
+        const resolvedCells = await resolveCellsProgressively(
+          rawCells,
+          blobResolver,
+          notebookLanguage,
+          outputResolutionCache,
+          {
+            shouldContinue: () => !cancelled && !liveMaterializedRef.current,
+            onInitialCells(syncCells) {
+              if (syncCells.length === 0) return;
+              setCells(syncCells);
+              setStatus({
+                kind: "loading",
+                message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
+              });
+            },
+            onCellResolved(resolvedCell, _index, progressiveCells) {
+              if (progressiveCells.length === 0) return;
+              preloadSiftWasm([resolvedCell]);
+              setCells(progressiveCells);
+            },
+          },
         );
         if (cancelled || liveMaterializedRef.current) return;
 
@@ -872,23 +878,30 @@ function NotebookViewer({
         languageFromNotebookMetadata(metadata) ?? notebookLanguageRef.current ?? "python";
       notebookLanguageRef.current = notebookLanguage;
       const outputResolutionCache = outputResolutionCacheRef.current;
-      const syncCells = rawCells.map((cell, index) =>
-        resolveCellSync(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
-      );
-      if (disposed || sequence !== materializeSequence) return;
-      if (syncCells.length > 0) {
-        liveMaterializedRef.current = true;
-        preloadSiftWasm(syncCells);
-        setCells(syncCells);
-        setStatus({
-          kind: "loading",
-          message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
-        });
-      }
-      const resolvedCells = await Promise.all(
-        rawCells.map((cell, index) =>
-          resolveCell(cell, blobResolver, index, notebookLanguage, outputResolutionCache),
-        ),
+      const resolvedCells = await resolveCellsProgressively(
+        rawCells,
+        blobResolver,
+        notebookLanguage,
+        outputResolutionCache,
+        {
+          shouldContinue: () => !disposed && sequence === materializeSequence,
+          onInitialCells(syncCells) {
+            if (syncCells.length === 0) return;
+            liveMaterializedRef.current = true;
+            preloadSiftWasm(syncCells);
+            setCells(syncCells);
+            setStatus({
+              kind: "loading",
+              message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
+            });
+          },
+          onCellResolved(resolvedCell, _index, progressiveCells) {
+            if (progressiveCells.length === 0) return;
+            liveMaterializedRef.current = true;
+            preloadSiftWasm([resolvedCell]);
+            setCells(progressiveCells);
+          },
+        },
       );
       if (disposed || sequence !== materializeSequence) return;
 

--- a/apps/notebook-cloud/viewer/progressive-cell-resolution.ts
+++ b/apps/notebook-cloud/viewer/progressive-cell-resolution.ts
@@ -1,0 +1,42 @@
+import type { BlobResolver } from "runtimed";
+import {
+  resolveCell,
+  resolveCellSync,
+  type OutputResolutionCache,
+  type RenderCell,
+  type ResolvedCell,
+} from "./render-resolution";
+
+export interface ProgressiveCellResolutionCallbacks {
+  shouldContinue?: () => boolean;
+  onInitialCells?: (cells: ResolvedCell[]) => void;
+  onCellResolved?: (cell: ResolvedCell, index: number, cells: ResolvedCell[]) => void;
+}
+
+export async function resolveCellsProgressively(
+  rawCells: readonly RenderCell[],
+  blobResolver: BlobResolver,
+  defaultLanguage: string | null,
+  cache: OutputResolutionCache | undefined,
+  callbacks: ProgressiveCellResolutionCallbacks = {},
+): Promise<ResolvedCell[]> {
+  const shouldContinue = callbacks.shouldContinue ?? (() => true);
+  const resolvedCells = rawCells.map((cell, index) =>
+    resolveCellSync(cell, blobResolver, index, defaultLanguage, cache),
+  );
+
+  if (!shouldContinue()) return resolvedCells;
+  callbacks.onInitialCells?.(resolvedCells.slice());
+
+  await Promise.all(
+    rawCells.map(async (cell, index) => {
+      const resolvedCell = await resolveCell(cell, blobResolver, index, defaultLanguage, cache);
+      if (!shouldContinue()) return;
+
+      resolvedCells[index] = resolvedCell;
+      callbacks.onCellResolved?.(resolvedCell, index, resolvedCells.slice());
+    }),
+  );
+
+  return resolvedCells;
+}


### PR DESCRIPTION
## Summary

- add a progressive cloud viewer cell-resolution helper
- render sync-resolved cells immediately, then update each cell as its async/blob-backed outputs resolve
- use the same progressive path for pinned snapshot loading and live room materialization

## Why

Hosted topic-viz currently couples fast cells to slower Arrow/Sift payloads because async output resolution waits for every cell before updating the notebook with blob-backed outputs. This moves the viewer closer to live Automerge materialization: the document structure can paint first, and each cell's resolved outputs can appear independently as their RuntimeStateDoc payloads are ready.

This is independent of #3133. #3133 improves smoke diagnostics for measuring the hosted result after this behavior change lands.

## Validation

```bash
cargo xtask wasm runtimed --skip-renderer-plugins
pnpm --dir apps/notebook-cloud exec node --import tsx --test test/progressive-cell-resolution.test.ts test/render-resolution.test.ts
pnpm --dir apps/notebook-cloud typecheck
cargo xtask lint --fix
```

## Preview verification

Deployed this branch to preview.runt.run and ran:

```bash
pnpm --dir apps/notebook-cloud build
pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.renderer-assets.toml
pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.output-document.toml
pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml
NOTEBOOK_CLOUD_URL=https://preview.runt.run pnpm --dir apps/notebook-cloud smoke:hosted
```

Hosted smoke passed for `https://preview.runt.run/n/topic-viz`.
