### PR TITLE
docs(elements): catalog widget control surfaces

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "46",
+    value: "58",
     detail:
-      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, expanded renderer, editor, and widget surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, expanded renderer, editor, and expanded widget surfaces",
   },
 ];
 
@@ -142,11 +142,12 @@ const families = [
   },
   {
     family: "Widgets",
-    source: "src/components/widgets/**",
+    source:
+      "src/components/widgets/{widget-view,widget-store-context,widget-store}.tsx + src/components/widgets/controls/index.ts",
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, selected built-in controls, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, the current built-in controls registry, form, selection, numeric, status, and layout controls, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "44",
+    value: "46",
     detail:
-      "used shell toolbar, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, expanded renderer, editor, and widget surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, expanded renderer, editor, and widget surfaces",
   },
 ];
 
@@ -66,11 +66,12 @@ const phases = [
 const families = [
   {
     family: "Notebook workspace",
-    source: "apps/notebook/src/components/{NotebookView,NotebookToolbar,DependencyHeader}.tsx",
+    source:
+      "apps/notebook/src/components/{NotebookView,NotebookToolbar,DependencyHeader}.tsx + src/components/notebook-rail/NotebookRail.tsx",
     target: "nteract shell",
     status: "active",
     intent:
-      "NotebookToolbar renders from current source; the sidebar rail remains a fixture-backed adapter, and its package panel now hosts the current DependencyHeader instead of a catalog-only package list.",
+      "NotebookToolbar, NotebookRail, NotebookPackagesPanel, and the package panel DependencyHeader now render from current source with fixture-owned panel state and inert host callbacks.",
   },
   {
     family: "Notebook search",

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { Boxes, ListTree, Package, PanelLeft, ShieldCheck, Variable } from "lucide-react";
+import { Boxes, ListTree, ShieldCheck, Variable } from "lucide-react";
 import { useState } from "react";
-import { KERNEL_STATUS, RUNTIME_STATUS, type RuntimeLifecycle } from "runtimed";
+import {
+  KERNEL_STATUS,
+  RUNTIME_STATUS,
+  type NotebookOutlineItem,
+  type RuntimeLifecycle,
+} from "runtimed";
+import {
+  NotebookPackagesPanel,
+  NotebookRail,
+  type NotebookRailPanelId,
+} from "@/components/notebook-rail";
 import { cn } from "@/lib/utils";
 import { DependencyHeader } from "@/notebook-components/DependencyHeader";
 import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
@@ -11,19 +21,69 @@ const noop = () => {};
 const asyncNoop = async () => {};
 const asyncTrue = async () => true;
 
-type RailPanelKey = "outline" | "packages" | "variables" | "renderers";
-
 const runningIdleLifecycle: RuntimeLifecycle = {
   lifecycle: "Running",
   activity: "Idle",
 };
 
-const outlineItems = [
-  { title: "Load data", depth: 0 },
-  { title: "Clean columns", depth: 1 },
-  { title: "Explore shape", depth: 0 },
-  { title: "Model run", depth: 0 },
-  { title: "Findings", depth: 1 },
+const outlineItems: NotebookOutlineItem[] = [
+  {
+    id: "cell-load-data:heading:0",
+    cellId: "cell-load-data",
+    title: "Load data",
+    level: 1,
+    kind: "heading",
+    cellAnchorId: "notebook-cell-cell-load-data",
+    headingAnchorId: "notebook-cell-cell-load-data-heading-load-data",
+    href: "#notebook-cell-cell-load-data",
+    anchor: "load-data",
+    statusLabel: "markdown",
+  },
+  {
+    id: "cell-clean-columns:heading:0",
+    cellId: "cell-clean-columns",
+    title: "Clean columns",
+    level: 2,
+    kind: "heading",
+    cellAnchorId: "notebook-cell-cell-clean-columns",
+    headingAnchorId: "notebook-cell-cell-clean-columns-heading-clean-columns",
+    href: "#notebook-cell-cell-clean-columns",
+    anchor: "clean-columns",
+    detail: "code",
+  },
+  {
+    id: "cell-explore-shape:heading:0",
+    cellId: "cell-explore-shape",
+    title: "Explore shape",
+    level: 1,
+    kind: "heading",
+    cellAnchorId: "notebook-cell-cell-explore-shape",
+    headingAnchorId: "notebook-cell-cell-explore-shape-heading-explore-shape",
+    href: "#notebook-cell-cell-explore-shape",
+    anchor: "explore-shape",
+  },
+  {
+    id: "cell-model-run:heading:0",
+    cellId: "cell-model-run",
+    title: "Model run",
+    level: 1,
+    kind: "heading",
+    cellAnchorId: "notebook-cell-cell-model-run",
+    headingAnchorId: "notebook-cell-cell-model-run-heading-model-run",
+    href: "#notebook-cell-cell-model-run",
+    anchor: "model-run",
+  },
+  {
+    id: "cell-findings:heading:0",
+    cellId: "cell-findings",
+    title: "Findings",
+    level: 2,
+    kind: "heading",
+    cellAnchorId: "notebook-cell-cell-findings",
+    headingAnchorId: "notebook-cell-cell-findings-heading-findings",
+    href: "#notebook-cell-cell-findings",
+    anchor: "findings",
+  },
 ];
 
 const cells = [
@@ -34,12 +94,12 @@ const cells = [
   },
   {
     label: "Code",
-    title: "read_csv",
+    title: "Clean columns",
     body: "df = pandas.read_csv('runs.csv')",
   },
   {
     label: "Output",
-    title: "Preview",
+    title: "Explore shape",
     body: "2,148 rows x 18 columns",
   },
 ];
@@ -57,24 +117,27 @@ const rendererItems = [
   { name: "image/png", state: "inline" },
 ];
 
-const railItems = [
-  { key: "outline", icon: ListTree, label: "Outline" },
-  { key: "packages", icon: Package, label: "Packages" },
-  { key: "variables", icon: Variable, label: "Variables" },
-  { key: "renderers", icon: Boxes, label: "Renderers" },
-] satisfies Array<{ key: RailPanelKey; icon: typeof ListTree; label: string }>;
+const plannedRailPanels = [
+  {
+    icon: Variable,
+    title: "Variables",
+    detail: `${variableItems.length} fixture names`,
+    body: "A future rail sibling for live namespace inspection once the app has a current variable surface.",
+  },
+  {
+    icon: Boxes,
+    title: "Renderers",
+    detail: `${rendererItems.length} fixture MIME lanes`,
+    body: "A future diagnostics panel for output MIME routing, plugin loading, and renderer health.",
+  },
+];
 
 export function RailOutlineExample() {
-  const [activePanel, setActivePanel] = useState<RailPanelKey>("outline");
-  const panelTitle = railItems.find((item) => item.key === activePanel)?.label ?? "Outline";
-  const panelDetail =
-    activePanel === "outline"
-      ? `${outlineItems.length} headings`
-      : activePanel === "packages"
-        ? "uv:inline · 4 packages"
-        : activePanel === "variables"
-          ? `${variableItems.length} live names`
-          : `${rendererItems.length} renderers`;
+  const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
+  const [railCollapsed, setRailCollapsed] = useState(false);
+  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState(outlineItems[1]?.id ?? null);
+  const selectedOutlineItem =
+    outlineItems.find((item) => item.id === selectedOutlineItemId) ?? outlineItems[0];
 
   return (
     <div
@@ -103,67 +166,44 @@ export function RailOutlineExample() {
         isDepsOpen={false}
         depsOutOfSync={false}
       />
-      <div className="grid min-h-[500px] grid-cols-[48px_minmax(260px,300px)_minmax(320px,1fr)] overflow-x-auto">
-        <aside className="flex flex-col items-center gap-2 border-r border-fd-border bg-fd-muted/40 px-2 py-3">
-          <div className="mb-3 flex size-8 items-center justify-center rounded-md bg-fd-primary text-fd-primary-foreground">
-            <PanelLeft className="size-4" aria-hidden="true" />
-          </div>
-          {railItems.map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              aria-pressed={activePanel === item.key}
-              onClick={() => setActivePanel(item.key)}
-              className={cn(
-                "flex size-8 items-center justify-center rounded-md border text-xs",
-                "transition-colors hover:border-fd-border hover:bg-fd-background hover:text-fd-foreground",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-primary/40",
-                activePanel === item.key
-                  ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
-                  : "border-transparent text-fd-muted-foreground",
-              )}
-              title={item.label}
-            >
-              <item.icon className="size-4" aria-hidden="true" />
-            </button>
-          ))}
-        </aside>
+      <div className="grid min-h-[500px] grid-cols-[auto_minmax(320px,1fr)] overflow-x-auto">
+        <NotebookRail
+          activePanelId={activePanel}
+          collapsed={railCollapsed}
+          outlineItems={outlineItems}
+          selectedOutlineItemId={selectedOutlineItemId}
+          selectedOutlineCellId={selectedOutlineItem?.cellId ?? null}
+          packagesSummary="uv:inline · 4 packages"
+          packagesPanel={
+            <NotebookPackagesPanel>
+              <PackagePanelContent />
+            </NotebookPackagesPanel>
+          }
+          onActivePanelChange={setActivePanel}
+          onCollapsedChange={setRailCollapsed}
+          onSelectOutlineItem={(item) => setSelectedOutlineItemId(item.id)}
+          onNavigateOutlineItem={() => true}
+        />
 
-        <aside className="min-h-0 overflow-y-auto border-r border-fd-border bg-fd-background p-4">
-          <div className="mb-4 flex items-start justify-between gap-3">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                Notebook
-              </p>
-              <h3 className="mt-1 text-sm font-semibold">{panelTitle}</h3>
-            </div>
-            <span className="rounded-full border border-fd-border bg-fd-muted px-2 py-1 text-[11px] text-fd-muted-foreground">
-              {panelDetail}
-            </span>
-          </div>
-
-          {activePanel === "outline" && <OutlinePanel />}
-          {activePanel === "packages" && <PackagePanel />}
-          {activePanel === "variables" && <VariablesPanel />}
-          {activePanel === "renderers" && <RenderersPanel />}
-        </aside>
-
-        <main className="bg-fd-muted/20 p-6">
+        <main className="min-w-[320px] bg-fd-muted/20 p-6">
           <div className="mx-auto max-w-2xl space-y-3">
             <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
               <div className="mb-1 flex items-center gap-2 font-semibold">
                 <ShieldCheck className="size-3.5" aria-hidden="true" />
-                NotebookToolbar and DependencyHeader are rendered from the notebook app.
+                NotebookToolbar, NotebookRail, and DependencyHeader render from current sources.
               </div>
               <p>
-                The rail shell stays fixture-backed while package management starts using current
-                dependency UI inside the left-side panel.
+                The docs app owns fixture state only: selected outline item, collapsed state,
+                package callbacks, and inert anchor navigation.
               </p>
             </div>
             {cells.map((cell) => (
               <section
                 key={cell.title}
-                className="rounded-lg border border-fd-border bg-fd-background p-4 shadow-sm"
+                className={cn(
+                  "rounded-lg border border-fd-border bg-fd-background p-4 shadow-sm",
+                  selectedOutlineItem?.title === cell.title && "border-fd-primary/50",
+                )}
               >
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h4 className="text-sm font-semibold">{cell.title}</h4>
@@ -174,6 +214,31 @@ export function RailOutlineExample() {
                 <p className="font-mono text-xs leading-6 text-fd-muted-foreground">{cell.body}</p>
               </section>
             ))}
+            <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+                <h4 className="text-sm font-semibold">Planned sibling panels</h4>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {plannedRailPanels.map((panel) => (
+                  <div key={panel.title} className="rounded-md border border-fd-border p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2">
+                        <panel.icon
+                          className="size-4 text-fd-muted-foreground"
+                          aria-hidden="true"
+                        />
+                        <h5 className="text-sm font-medium">{panel.title}</h5>
+                      </div>
+                      <span className="shrink-0 rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
+                        {panel.detail}
+                      </span>
+                    </div>
+                    <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{panel.body}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
           </div>
         </main>
       </div>
@@ -181,31 +246,7 @@ export function RailOutlineExample() {
   );
 }
 
-function OutlinePanel() {
-  return (
-    <>
-      <nav className="space-y-1" aria-label="Notebook outline preview">
-        {outlineItems.map((item, index) => (
-          <div
-            key={item.title}
-            className={cn(
-              "flex items-center rounded-md px-2 py-1.5 text-sm",
-              item.depth === 1 && "ml-4",
-              index === 0 ? "bg-fd-primary text-fd-primary-foreground" : "text-fd-muted-foreground",
-            )}
-          >
-            {item.title}
-          </div>
-        ))}
-      </nav>
-      <div className="mt-6 rounded-md border border-dashed border-fd-border p-3 text-xs leading-5 text-fd-muted-foreground">
-        Packages and variables are sibling rail panels, not sections inside the outline.
-      </div>
-    </>
-  );
-}
-
-function PackagePanel() {
+function PackagePanelContent() {
   return (
     <div className="space-y-3">
       <div className="rounded-md border border-fd-border bg-fd-muted/40 p-3 text-xs leading-5 text-fd-muted-foreground">
@@ -228,46 +269,6 @@ function PackagePanel() {
           justSynced={false}
         />
       </div>
-    </div>
-  );
-}
-
-function VariablesPanel() {
-  return (
-    <div className="space-y-2">
-      {variableItems.map((variable) => (
-        <div key={variable.name} className="rounded-md border border-fd-border px-2 py-2">
-          <div className="flex items-center justify-between gap-2">
-            <span className="min-w-0 truncate font-mono text-xs text-fd-foreground">
-              {variable.name}
-            </span>
-            <span className="rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
-              {variable.type}
-            </span>
-          </div>
-          <div className="mt-1 truncate text-[11px] text-fd-muted-foreground">{variable.value}</div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function RenderersPanel() {
-  return (
-    <div className="space-y-2">
-      {rendererItems.map((renderer) => (
-        <div
-          key={renderer.name}
-          className="flex items-center justify-between gap-3 rounded-md border border-fd-border px-2 py-2"
-        >
-          <span className="min-w-0 truncate font-mono text-xs text-fd-foreground">
-            {renderer.name}
-          </span>
-          <span className="rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
-            {renderer.state}
-          </span>
-        </div>
-      ))}
     </div>
   );
 }

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -11,25 +11,10 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { ButtonWidget } from "@/components/widgets/controls/button-widget";
-import { CheckboxWidget } from "@/components/widgets/controls/checkbox-widget";
-import { DropdownWidget } from "@/components/widgets/controls/dropdown-widget";
-import { HTMLWidget } from "@/components/widgets/controls/html-widget";
-import { IntProgress } from "@/components/widgets/controls/int-progress";
-import { IntSlider } from "@/components/widgets/controls/int-slider";
-import { VBoxWidget } from "@/components/widgets/controls/vbox-widget";
-import { registerWidget } from "@/components/widgets/widget-registry";
+import "@/components/widgets/controls";
 import { WidgetStoreContext, useWidgetModels } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 import { WidgetView } from "@/components/widgets/widget-view";
-
-registerWidget("ButtonModel", ButtonWidget);
-registerWidget("CheckboxModel", CheckboxWidget);
-registerWidget("DropdownModel", DropdownWidget);
-registerWidget("HTMLModel", HTMLWidget);
-registerWidget("IntProgressModel", IntProgress);
-registerWidget("IntSliderModel", IntSlider);
-registerWidget("VBoxModel", VBoxWidget);
 
 type FixtureModel = {
   id: string;
@@ -135,6 +120,177 @@ const fixtureModels: FixtureModel[] = [
     },
   },
   {
+    id: "widget-region",
+    state: {
+      _model_name: "RadioButtonsModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "region",
+      index: 2,
+      _options_labels: ["North", "South", "West"],
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-metric",
+    state: {
+      _model_name: "ToggleButtonsModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "metric",
+      index: 0,
+      _options_labels: ["MAE", "MAPE", "RMSE"],
+      tooltips: [
+        "Mean absolute error",
+        "Mean absolute percentage error",
+        "Root mean squared error",
+      ],
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-horizon",
+    state: {
+      _model_name: "FloatSliderModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "horizon",
+      value: 6.5,
+      min: 1,
+      max: 12,
+      step: 0.5,
+      readout: true,
+      readout_format: ".1f",
+      orientation: "horizontal",
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-confidence",
+    state: {
+      _model_name: "FloatRangeSliderModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "confidence",
+      value: [0.12, 0.84],
+      min: 0,
+      max: 1,
+      step: 0.01,
+      readout: true,
+      readout_format: ".2f",
+      orientation: "horizontal",
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-feature-picker",
+    state: {
+      _model_name: "SelectMultipleModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "features",
+      index: [0, 2, 3],
+      _options_labels: ["month", "region", "segment", "discount"],
+      rows: 4,
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-sku",
+    state: {
+      _model_name: "ComboboxModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "sku",
+      value: "SKU-2048",
+      options: ["SKU-1024", "SKU-2048", "SKU-4096"],
+      placeholder: "Select SKU",
+      ensure_option: false,
+      continuous_update: true,
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-notes",
+    state: {
+      _model_name: "TextareaModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "notes",
+      value: "Holiday lift is excluded from the baseline forecast.",
+      rows: 3,
+      placeholder: "Fixture notebook note",
+      continuous_update: false,
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-report-date",
+    state: {
+      _model_name: "DatePickerModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "report date",
+      value: { year: 2026, month: 4, date: 29 },
+      min: { year: 2026, month: 0, date: 1 },
+      max: { year: 2026, month: 11, date: 31 },
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-accent",
+    state: {
+      _model_name: "ColorPickerModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "accent",
+      value: "#0ea5e9",
+      concise: false,
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-valid",
+    state: {
+      _model_name: "ValidModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "validated",
+      value: true,
+      readout: "missing columns",
+    },
+  },
+  {
+    id: "widget-control-note",
+    state: {
+      _model_name: "LabelModel",
+      _model_module: "@jupyter-widgets/controls",
+      value: "Control widgets render through the same registry path as live comms.",
+    },
+  },
+  {
+    id: "widget-control-strip",
+    state: {
+      _model_name: "HBoxModel",
+      _model_module: "@jupyter-widgets/controls",
+      children: [
+        "IPY_MODEL_widget-report-date",
+        "IPY_MODEL_widget-accent",
+        "IPY_MODEL_widget-valid",
+      ],
+      box_style: "success",
+    },
+  },
+  {
+    id: "widget-controls-suite",
+    state: {
+      _model_name: "VBoxModel",
+      _model_module: "@jupyter-widgets/controls",
+      children: [
+        "IPY_MODEL_widget-control-note",
+        "IPY_MODEL_widget-region",
+        "IPY_MODEL_widget-metric",
+        "IPY_MODEL_widget-horizon",
+        "IPY_MODEL_widget-confidence",
+        "IPY_MODEL_widget-feature-picker",
+        "IPY_MODEL_widget-sku",
+        "IPY_MODEL_widget-notes",
+        "IPY_MODEL_widget-control-strip",
+      ],
+      box_style: "success",
+    },
+  },
+  {
     id: "widget-unknown",
     state: {
       _model_name: "CustomResearchWidgetModel",
@@ -164,6 +320,28 @@ const renderedWidgets = [
     name: "IntProgress",
     source: "src/components/widgets/controls/int-progress.tsx",
     role: "ProgressStyleModel reference resolution through IPY_MODEL state.",
+  },
+  {
+    name: "Form controls",
+    source:
+      "src/components/widgets/controls/{textarea,radio-buttons,toggle-buttons,combobox,select-multiple}-widget.tsx",
+    role: "Text entry and selection traitlets update local fixture state through the production store contract.",
+  },
+  {
+    name: "Numeric controls",
+    source: "src/components/widgets/controls/{float-slider,float-range-slider}.tsx",
+    role: "Float widgets exercise the same readout formatting and range update paths as live comms.",
+  },
+  {
+    name: "Status controls",
+    source:
+      "src/components/widgets/controls/{date-picker-widget,color-picker,valid-widget,label-widget}.tsx",
+    role: "Date, color, validation, and label models render from ordinary saved widget state.",
+  },
+  {
+    name: "HBoxWidget",
+    source: "src/components/widgets/controls/hbox-widget.tsx",
+    role: "Horizontal container resolves child model references and shares the WidgetView nesting path.",
   },
   {
     name: "VBoxWidget",
@@ -350,6 +528,19 @@ export function WidgetSurfacesExample() {
             >
               <WidgetView modelId="widget-dashboard" />
             </div>
+            <div
+              className="rounded-lg border border-fd-border bg-fd-background p-4"
+              data-testid="widget-control-suite"
+            >
+              <div className="mb-3">
+                <h3 className="text-sm font-semibold">Built-in controls suite</h3>
+                <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+                  These models come from the current controls registry and render through
+                  WidgetView, not page-local form components.
+                </p>
+              </div>
+              <WidgetView modelId="widget-controls-suite" />
+            </div>
             <div className="grid gap-3 md:grid-cols-2">
               <div className="rounded-lg border border-fd-border bg-fd-background p-4">
                 <h3 className="text-sm font-semibold">Unsupported model fallback</h3>
@@ -405,9 +596,9 @@ export function WidgetSurfacesExample() {
           <div>
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-              Image, audio, video, FileUpload, OutputModel, ipycanvas, and anywidget examples should
-              be added once the catalog has isolated adapters for blob URLs, DataViews, rich output
-              routing, and ESM module loading.
+              Image, audio, video, FileUpload, OutputModel, controller, ipycanvas, and anywidget
+              examples should be added once the catalog has isolated adapters for blob URLs,
+              DataViews, rich output routing, browser APIs, and ESM module loading.
             </p>
           </div>
         </div>

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -9,10 +9,10 @@ The rail outline is the first production direction for a notebook table of
 contents. It keeps reading navigation available while leaving clear sibling
 slots for packages, variables, renderers, and future notebook tools.
 
-This fixture now renders the current notebook app toolbar directly. The rail
-itself stays catalog-owned until the notebook app has a production left-rail
-component to import, but the package panel already renders the current
-`DependencyHeader` inside that rail frame.
+This fixture now renders the current notebook app toolbar and shared
+`NotebookRail` directly. The package panel is supplied through
+`NotebookPackagesPanel` and hosts the current `DependencyHeader` with static
+dependency state.
 
 <RailOutlineExample />
 
@@ -22,13 +22,15 @@ component to import, but the package panel already renders the current
   moving cells into the sidebar.
 - `NotebookToolbar` is imported from `apps/notebook/src/components` with inert
   fixture callbacks and runtime status props.
+- `NotebookRail` and `NotebookPackagesPanel` come from
+  `src/components/notebook-rail`, with docs-owned active panel, collapsed state,
+  outline selection, and inert navigation callbacks.
 - The package panel imports `DependencyHeader` from the notebook app with
   fixture dependency and sync state.
 - The outline should start from materialized markdown headings.
-- Keep the rail icon-led: outline, packages, variables, renderers, and future
-  side panels should scan as compact tools before a panel opens.
-- Package and variable panels should become sibling rail panels, not sections
-  embedded inside the outline.
+- Keep the rail icon-led. The current shared rail exposes outline and packages;
+  variables, renderers, and future side panels are tracked as planned sibling
+  panels until the app has current components for them.
 - This example is fixture-backed and intentionally avoids `App.tsx`,
   `useAutomergeNotebook`, `usePresence`, `CrdtBridgeProvider`, and generated
   `runtimed-wasm` imports.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -5,9 +5,11 @@ description: Fixture-backed notebook widget components from nteract/nteract.
 
 import { WidgetSurfacesExample } from "@/components/widget-surfaces-example";
 
-Widgets are notebook output components. This page starts cataloging the current
+Widgets are notebook output components. This page catalogs the current
 `src/components/widgets` path with local comm-state fixtures, not a live kernel,
-iframe, sync engine, or generated WASM resolver.
+iframe, sync engine, or generated WASM resolver. The interactive examples import
+the production controls registry and render through `WidgetView`, so the page is
+tracking nteract-owned widget surfaces instead of page-local form stand-ins.
 
 <WidgetSurfacesExample />
 
@@ -16,4 +18,6 @@ iframe, sync engine, or generated WASM resolver.
 The live notebook receives widget state from `RuntimeStateDoc` through
 `SyncEngine.commChanges$`, then forwards it to isolated output frames over the
 comm bridge. The catalog keeps those host responsibilities outside the rendered
-component examples.
+component examples. Browser APIs, blob/DataView conversion, output-widget routing,
+controller/gamepad input, anywidget ESM loading, and generated WASM handoffs
+remain explicit adapter boundaries for later catalog slices.

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -13,6 +13,8 @@
         "./components/isolated/iframe-libraries.ts"
       ],
       "@/components/isolated/*": ["../../src/components/isolated/*"],
+      "@/components/notebook-rail": ["../../src/components/notebook-rail/index.ts"],
+      "@/components/notebook-rail/*": ["../../src/components/notebook-rail/*"],
       "@/components/outputs/*": ["../../src/components/outputs/*"],
       "@/components/ui/*": ["../../src/components/ui/*"],
       "@/components/widgets/*": ["../../src/components/widgets/*"],


### PR DESCRIPTION
## Summary

- expands the elements widget catalog to import the current production controls registry instead of page-local widget registration
- adds fixture-backed form, selection, numeric, status, and layout control examples rendered through `WidgetView`
- updates the widget docs and component burn-down bookkeeping for the expanded control coverage

## Stack

Stacked on #3136 (`quod/elements-notebook-rail-surfaces`), which is stacked on #3131.

## Verification

- `pnpm --dir apps/elements build`
- Playwright smoke against `http://127.0.0.1:5176/docs/widget-surfaces`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

The page remains runtime-free. Live comm transport, isolated iframe forwarding, blob/DataView conversion, controller/gamepad input, anywidget ESM loading, and generated WASM handoffs stay documented as adapter boundaries.
