### PR TITLE
docs(elements): catalog cell presence indicators

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -13,11 +13,34 @@ import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { ExecutionCount } from "@/components/cell/ExecutionCount";
+import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
+import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 
 const primaryCellId = "fixture-code-cell";
+const sourceFixture = `features = orders.assign(month=orders.date.dt.month)
+model.fit(features[columns], target)
+predictions = model.predict(features_holdout)`;
+
+const outputFixtures: JupyterOutput[] = [
+  {
+    output_id: "cell-anatomy-stream",
+    output_type: "stream",
+    name: "stdout",
+    text: "training fold=01 mae=8.91\nvalidating fold=02 mae=8.42",
+  },
+  {
+    output_id: "cell-anatomy-result",
+    output_type: "execute_result",
+    execution_count: 12,
+    data: {
+      "text/plain": "MAE=8.42  MAPE=6.8%  Backtest=16 weeks",
+    },
+    metadata: {},
+  },
+];
 
 const layers = [
   {
@@ -48,13 +71,13 @@ const layers = [
     name: "CodeMirrorEditor",
     source: "src/components/editor/codemirror-editor.tsx",
     role: "Source editing, search highlighting, remote cursors, completion, and attribution.",
-    status: "adapter needed",
+    status: "rendered",
   },
   {
     name: "OutputArea",
     source: "src/components/cell/OutputArea.tsx",
     role: "Output focus, display mode controls, and frame-level output interaction.",
-    status: "adapter needed",
+    status: "rendered",
   },
 ];
 
@@ -164,7 +187,7 @@ function SourceFixture() {
           <div className="min-w-0">
             <h3 className="truncate text-sm font-semibold">Code cell frame</h3>
             <p className="text-xs text-fd-muted-foreground">
-              Current CellContainer with fixture source content
+              Current CellContainer, CodeMirrorEditor, and OutputArea
             </p>
           </div>
         </div>
@@ -175,39 +198,36 @@ function SourceFixture() {
 
       <div className="mb-2 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
         <Braces className="size-4" aria-hidden="true" />
-        Source editor fixture
+        CodeMirrorEditor
       </div>
-      <pre className="overflow-x-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs leading-6 text-foreground">
-        <code>{`features = orders.assign(month=orders.date.dt.month)
-model.fit(features[columns], target)
-predictions = model.predict(features_holdout)`}</code>
-      </pre>
+      <div className="overflow-hidden rounded-md border border-border bg-background">
+        <CodeMirrorEditor
+          initialValue={sourceFixture}
+          language="python"
+          lineWrapping
+          maxHeight="190px"
+          readOnly
+        />
+      </div>
     </div>
   );
 }
 
 function OutputFixture() {
   return (
-    <div className="px-3 py-2">
+    <div className="px-3 py-3">
       <div className="mb-3 flex items-center gap-2 text-xs font-medium text-fd-muted-foreground">
         <FileText className="size-4" aria-hidden="true" />
-        OutputArea fixture
+        OutputArea
       </div>
-      <div className="rounded-md border border-border bg-background p-3">
-        <div className="grid gap-2 text-xs sm:grid-cols-3">
-          <div>
-            <div className="text-muted-foreground">MAE</div>
-            <div className="mt-1 text-sm font-semibold">8.42</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground">MAPE</div>
-            <div className="mt-1 text-sm font-semibold">6.8%</div>
-          </div>
-          <div>
-            <div className="text-muted-foreground">Backtest</div>
-            <div className="mt-1 text-sm font-semibold">16 weeks</div>
-          </div>
-        </div>
+      <div className="rounded-md border border-border bg-background py-2">
+        <OutputArea
+          outputs={outputFixtures}
+          cellId={primaryCellId}
+          executionCount={12}
+          isolated={false}
+          useOutputWell={false}
+        />
       </div>
     </div>
   );
@@ -222,8 +242,8 @@ export function CellAnatomyExample() {
           <div>
             <h2 className="text-sm font-semibold">Catalog fidelity rule</h2>
             <p className="mt-1 text-xs leading-5">
-              This page renders only the cell shell pieces the notebook app imports today. Editor
-              and output regions remain fixture-backed until their runtime-free adapters exist.
+              This page renders the cell shell, editor, output, and presence pieces the notebook app
+              imports today. Runtime state is supplied as fixture props instead of hooks.
             </p>
           </div>
         </div>

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -9,9 +9,15 @@ import {
   Search,
   ShieldCheck,
 } from "lucide-react";
+import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { ExecutionCount } from "@/components/cell/ExecutionCount";
+import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
+import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
+import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
+
+const primaryCellId = "fixture-code-cell";
 
 const layers = [
   {
@@ -30,6 +36,12 @@ const layers = [
     name: "ExecutionCount",
     source: "src/components/cell/ExecutionCount.tsx",
     role: "Read-only gutter count used when notebook cells are rendered without execution controls.",
+    status: "rendered",
+  },
+  {
+    name: "CellPresenceIndicators",
+    source: "apps/notebook/src/components/cell/CellPresenceIndicators.tsx",
+    role: "Remote peer markers in the cell gutter, backed by the cursor registry and presence bus.",
     status: "rendered",
   },
   {
@@ -76,6 +88,72 @@ const contracts = [
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
 ];
+
+const presenceSnapshot = {
+  type: "snapshot",
+  peer_id: "local-docs-peer",
+  peers: [
+    {
+      peer_id: "peer-forecast",
+      peer_label: "forecast reviewer",
+      actor_label: "Forecast Reviewer",
+      channels: [
+        {
+          channel: "cursor",
+          data: { cell_id: primaryCellId, line: 2, column: 18 },
+        },
+      ],
+    },
+    {
+      peer_id: "peer-runtime",
+      peer_label: "runtime analyst",
+      actor_label: "Runtime Analyst",
+      channels: [
+        {
+          channel: "focus",
+          data: { cell_id: primaryCellId },
+        },
+      ],
+    },
+    {
+      peer_id: "peer-output",
+      peer_label: "output reviewer",
+      actor_label: "Output Reviewer",
+      channels: [
+        {
+          channel: "selection",
+          data: {
+            cell_id: primaryCellId,
+            anchor_line: 1,
+            anchor_col: 0,
+            head_line: 1,
+            head_col: 16,
+          },
+        },
+        {
+          channel: "cursor",
+          data: { cell_id: primaryCellId, line: 1, column: 16 },
+        },
+      ],
+    },
+  ],
+};
+
+function PresenceFixtureProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    const stopCursorDispatch = startCursorDispatch("local-docs-peer");
+
+    emitPresence(presenceSnapshot);
+    const retry = window.setTimeout(() => emitPresence(presenceSnapshot), 0);
+
+    return () => {
+      window.clearTimeout(retry);
+      stopCursorDispatch();
+    };
+  }, []);
+
+  return children;
+}
 
 function SourceFixture() {
   return (
@@ -158,33 +236,29 @@ export function CellAnatomyExample() {
           <div className="hidden text-right sm:block">real shell, fixture content</div>
         </div>
         <div className="bg-background py-4 pl-12 pr-2">
-          <CellContainer
-            id="fixture-code-cell"
-            cellType="code"
-            isFocused
-            className="mx-0 px-0"
-            gutterContent={<CompactExecutionButton count={12} />}
-            codeContent={<SourceFixture />}
-            outputContent={<OutputFixture />}
-            rightGutterContent={
-              <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-900">
-                real
-              </span>
-            }
-            outputRightGutterContent={
-              <span className="rounded-full bg-fd-muted px-1.5 py-0.5 text-[10px] font-medium text-fd-muted-foreground">
-                fixture
-              </span>
-            }
-            presenceIndicators={
-              <div className="mt-1 flex flex-col gap-1" aria-label="Fixture presence markers">
-                <span className="size-1.5 rounded-full bg-rose-500" />
-                <span className="size-1.5 rounded-full bg-amber-500" />
-                <span className="size-1.5 rounded-full bg-sky-500" />
-              </div>
-            }
-            dragHandleProps={{ "aria-label": "Fixture drag handle" }}
-          />
+          <PresenceFixtureProvider>
+            <CellContainer
+              id={primaryCellId}
+              cellType="code"
+              isFocused
+              className="mx-0 px-0"
+              gutterContent={<CompactExecutionButton count={12} />}
+              codeContent={<SourceFixture />}
+              outputContent={<OutputFixture />}
+              rightGutterContent={
+                <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-900">
+                  real
+                </span>
+              }
+              outputRightGutterContent={
+                <span className="rounded-full bg-fd-muted px-1.5 py-0.5 text-[10px] font-medium text-fd-muted-foreground">
+                  fixture
+                </span>
+              }
+              presenceIndicators={<CellPresenceIndicators cellId={primaryCellId} />}
+              dragHandleProps={{ "aria-label": "Fixture drag handle" }}
+            />
+          </PresenceFixtureProvider>
         </div>
       </section>
 

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "63",
+    value: "64",
     detail:
-      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, runtime dialogs and banners, theme, output area, plugin renderer, editor, and expanded widget surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, plugin renderer, editor, and expanded widget surfaces",
   },
 ];
 
@@ -113,7 +113,7 @@ const families = [
     target: "nteract cells",
     status: "active",
     intent:
-      "CellContainer, CompactExecutionButton, and ExecutionCount now render from current source; unused legacy helpers have been removed instead of cataloged.",
+      "CellContainer, CompactExecutionButton, ExecutionCount, and CellPresenceIndicators now render from current source; unused legacy helpers have been removed instead of cataloged.",
   },
   {
     family: "Editors",

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -28,10 +28,12 @@ contract while preserving the existing `NotebookView` DOM-order invariant.
 
 This docs site should keep moving component by component toward runtime-free
 fixtures. The cell frame, compact execution button, execution count,
-cell-type gutter accents, and the full code/markdown/raw cell components now
-render from current source. Markdown preview mode remains an isolated-renderer
-adapter boundary before the docs app should render it as production notebook
-preview output.
+cell-type gutter accents, cell-level presence indicators, and the full
+code/markdown/raw cell components now render from current source. The presence
+example seeds the notebook cursor registry through a fixture presence snapshot,
+without connecting runtimed or generated WASM. Markdown preview mode remains an
+isolated-renderer adapter boundary before the docs app should render it as
+production notebook preview output.
 
 Unused legacy cell helper components should be removed rather than cataloged.
 Catalog entries need to trace to notebook app usage, an active migration target,

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -28,12 +28,12 @@ contract while preserving the existing `NotebookView` DOM-order invariant.
 
 This docs site should keep moving component by component toward runtime-free
 fixtures. The cell frame, compact execution button, execution count,
-cell-type gutter accents, cell-level presence indicators, and the full
-code/markdown/raw cell components now render from current source. The presence
-example seeds the notebook cursor registry through a fixture presence snapshot,
-without connecting runtimed or generated WASM. Markdown preview mode remains an
-isolated-renderer adapter boundary before the docs app should render it as
-production notebook preview output.
+cell-type gutter accents, `CodeMirrorEditor`, `OutputArea`, cell-level presence
+indicators, and the full code/markdown/raw cell components now render from
+current source. The presence example seeds the notebook cursor registry through
+a fixture presence snapshot, without connecting runtimed or generated WASM.
+Markdown preview mode remains an isolated-renderer adapter boundary before the
+docs app should render it as production notebook preview output.
 
 Unused legacy cell helper components should be removed rather than cataloged.
 Catalog entries need to trace to notebook app usage, an active migration target,


### PR DESCRIPTION
## Summary

- replace the schematic cell presence dots on the cell anatomy page with the real `CellPresenceIndicators`
- seed the notebook cursor registry through a static fixture presence snapshot, without runtimed or generated WASM
- replace the top cell anatomy source/output placeholders with real `CodeMirrorEditor` and `OutputArea` fixtures
- update the burn-down count and cell docs to include the presence surface as a current nteract-owned component

## Verification

- `pnpm --dir apps/elements build`
- Playwright smoke on `http://127.0.0.1:5176/docs/cell-anatomy`
- `cargo xtask lint --fix`

## Stack

Base: #3139 (`quod/elements-plugin-renderer-surfaces`)
