### PR TITLE
perf(notebook-cloud): defer supplemental viewer css

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -59,3 +59,27 @@ test("cloud viewer exposes the shared theme toggle and shared theme hook", () =>
   assert.match(sourceText, /<ThemeToggle/);
   assert.match(sourceText, /className="cloud-theme-toggle"/);
 });
+
+test("cloud viewer defers supplemental CSS loading until the notebook surface mounts", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    sourcePath.pathname,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const topLevelSupplementalLoads = sourceFile.statements.filter(
+    (statement) =>
+      ts.isExpressionStatement(statement) &&
+      statement.expression.getText(sourceFile) === "loadSupplementalViewerCss()",
+  );
+
+  assert.equal(topLevelSupplementalLoads.length, 0);
+  assert.match(
+    sourceText,
+    /function CloudNotebookProviders[\s\S]*useEffect\(\(\) => \{\s*loadSupplementalViewerCss\(\);\s*\}, \[\]\);/,
+  );
+});

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -118,8 +118,6 @@ import {
 } from "./widget-runtime";
 import "./index.css";
 
-loadSupplementalViewerCss();
-
 interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
@@ -384,6 +382,10 @@ function CloudNotebookProviders({
   children: ReactNode;
   config: CloudViewerConfig;
 }) {
+  useEffect(() => {
+    loadSupplementalViewerCss();
+  }, []);
+
   return (
     <IsolatedRendererProvider
       basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}


### PR DESCRIPTION
## Summary

- defer notebook-cloud supplemental CSS discovery until the notebook provider mounts
- avoid scheduling the large split CSS manifest from viewer module evaluation and non-notebook surfaces
- add a regression check that the load stays out of the top-level viewer module

## Notes

This is a small rendering-performance slice and does not touch the NotebookDoc/RuntimeStateDoc schema or storage migration path.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-supplemental-css.test.ts test/viewer-css-assets.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
