### PR TITLE
perf(notebook-cloud): stage async output resolution

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-diagnostics.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-diagnostics.mjs
@@ -43,3 +43,18 @@ export function isolatedDiagnosticFailure(diagnostic) {
     details: diagnostic.details ?? null,
   };
 }
+
+export function siftLoadMilestoneTimingName(milestone) {
+  return `sift_${milestone.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "")}`;
+}
+
+export function matchesSiftLoadMilestone(
+  diagnostic,
+  { source = "arrow-stream-manifest", phase } = {},
+) {
+  return (
+    diagnostic?.phase === "sift-load-milestone" &&
+    diagnostic.details?.source === source &&
+    diagnostic.details?.phase === phase
+  );
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -8,7 +8,9 @@ import {
   consoleMessageLevel,
   isolatedDiagnosticFailure,
   isFatalIsolatedDiagnostic,
+  matchesSiftLoadMilestone,
   parseIsolatedDiagnosticText,
+  siftLoadMilestoneTimingName,
 } from "./hosted-render-smoke-diagnostics.mjs";
 import {
   DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES,
@@ -59,6 +61,10 @@ const expectedLatestRevisionNotebookHeadsHash =
 const expectedLatestRevisionRuntimeHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH ?? "";
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
+const expectedSiftLoadMilestones = parseExpectedTexts(
+  "NOTEBOOK_CLOUD_EXPECTED_SIFT_LOAD_MILESTONES",
+  requireSiftWasm ? ["first-chunk-fetched", "engine-mounted", "streaming-complete"] : [],
+);
 const requireRuntimedWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_RUNTIMED_WASM !== "0";
 const requireViewerCssSplit = process.env.NOTEBOOK_CLOUD_REQUIRE_VIEWER_CSS_SPLIT !== "0";
 const maxPrimaryViewerCssBytes = parsePositiveInteger(
@@ -102,6 +108,7 @@ let runtimeWasmHintCheck = null;
 let screenshotSaved = false;
 let pageTextMatches = {};
 let themeModeChecks = [];
+const siftLoadMilestoneMatches = {};
 const smokeStartedAt = performance.now();
 const timingsMs = {};
 
@@ -304,10 +311,35 @@ async function main() {
       );
       markTiming("first_output_iframe");
     }
+    const siftLoadMilestoneTask = Promise.all(
+      expectedSiftLoadMilestones.map((milestone) =>
+        waitForSiftLoadMilestone(page, milestone).then((diagnostic) => {
+          siftLoadMilestoneMatches[milestone] = {
+            observed_ms: diagnostic.observedAtMs,
+            renderer_elapsed_ms:
+              typeof diagnostic.details?.elapsedMs === "number"
+                ? diagnostic.details.elapsedMs
+                : null,
+            row_count:
+              typeof diagnostic.details?.rowCount === "number" ? diagnostic.details.rowCount : null,
+            chunk_count:
+              typeof diagnostic.details?.chunkCount === "number"
+                ? diagnostic.details.chunkCount
+                : null,
+          };
+          markTimingAt(siftLoadMilestoneTimingName(milestone), diagnostic.observedAtMs);
+          return diagnostic;
+        }),
+      ),
+    ).catch((error) => ({ error }));
     const frameTextMatches =
       expectedFrameTexts.length > 0 ? await waitForFrameText(page, expectedFrameTexts) : {};
     if (expectedFrameTexts.length > 0) {
       markTiming("frame_texts");
+    }
+    const siftLoadMilestoneResult = await siftLoadMilestoneTask;
+    if ("error" in siftLoadMilestoneResult) {
+      throw siftLoadMilestoneResult.error;
     }
 
     // Give async iframe plugin fetches a beat to surface late CORS or WASM failures.
@@ -467,6 +499,7 @@ async function main() {
           executionCounts,
           reportCellCount,
           presenceText,
+          siftLoadMilestoneMatches,
           frameTextMatches,
           pageTextMatches,
           themeModeChecks,
@@ -521,7 +554,11 @@ function parseExpectedTexts(envName, fallback) {
 }
 
 function markTiming(name) {
-  timingsMs[name] ??= Math.round(performance.now() - smokeStartedAt);
+  markTimingAt(name, elapsedMs());
+}
+
+function markTimingAt(name, value) {
+  timingsMs[name] ??= Math.round(value);
 }
 
 function elapsedMs() {
@@ -862,6 +899,7 @@ async function checkHostedCatalogApi(
 function captureIsolatedDiagnostic(message, parsedDiagnostic) {
   const diagnostic = {
     ...parsedDiagnostic,
+    observedAtMs: elapsedMs(),
     level: consoleMessageLevel(message.type()),
     text: message.text(),
     details: null,
@@ -935,6 +973,27 @@ async function waitForFrameText(page, expectedTexts) {
     .filter(([, found]) => !found)
     .map(([text]) => text);
   throw new Error(`Timed out waiting for hosted renderer iframe text: ${missing.join(", ")}`);
+}
+
+async function waitForSiftLoadMilestone(page, milestone) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (fatalIsolatedDiagnostics.length > 0) {
+      await flushDiagnosticTasks();
+      throw new SmokeFailure(fatalIsolatedDiagnostics.map(isolatedDiagnosticFailure));
+    }
+    await flushDiagnosticTasks();
+    const diagnostic = siftDiagnostics.find((entry) =>
+      matchesSiftLoadMilestone(entry, { phase: milestone }),
+    );
+    if (diagnostic) {
+      return diagnostic;
+    }
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(`Timed out waiting for Sift load milestone: ${milestone}`);
 }
 
 async function saveScreenshot(page) {

--- a/apps/notebook-cloud/test/hosted-smoke-diagnostics.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-diagnostics.test.mjs
@@ -5,7 +5,9 @@ import {
   consoleMessageLevel,
   isolatedDiagnosticFailure,
   isFatalIsolatedDiagnostic,
+  matchesSiftLoadMilestone,
   parseIsolatedDiagnosticText,
+  siftLoadMilestoneTimingName,
 } from "../scripts/hosted-render-smoke-diagnostics.mjs";
 
 describe("hosted render smoke diagnostics", () => {
@@ -45,5 +47,27 @@ describe("hosted render smoke diagnostics", () => {
     assert.equal(consoleMessageLevel("warning"), "warn");
     assert.equal(consoleMessageLevel("info"), "info");
     assert.equal(consoleMessageLevel("log"), "debug");
+  });
+
+  it("matches Sift load milestones from parsed console details", () => {
+    const diagnostic = {
+      source: "isolated-renderer",
+      phase: "sift-load-milestone",
+      level: "debug",
+      text: "[isolated-renderer] sift-load-milestone Object",
+      details: {
+        source: "arrow-stream-manifest",
+        phase: "engine-mounted",
+      },
+    };
+
+    assert.equal(matchesSiftLoadMilestone(diagnostic, { phase: "engine-mounted" }), true);
+    assert.equal(matchesSiftLoadMilestone(diagnostic, { phase: "streaming-complete" }), false);
+    assert.equal(
+      matchesSiftLoadMilestone(diagnostic, { source: "url", phase: "engine-mounted" }),
+      false,
+    );
+    assert.equal(siftLoadMilestoneTimingName("engine-mounted"), "sift_engine_mounted");
+    assert.equal(siftLoadMilestoneTimingName("first chunk fetched"), "sift_first_chunk_fetched");
   });
 });

--- a/apps/notebook-cloud/test/progressive-cell-resolution.test.ts
+++ b/apps/notebook-cloud/test/progressive-cell-resolution.test.ts
@@ -124,6 +124,74 @@ describe("cloud viewer progressive cell resolution", () => {
 
     assert.deepEqual(events, ["initial"]);
   });
+
+  it("limits async output resolution to top-down batches", async () => {
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+    const events: string[] = [];
+
+    const resolution = resolveCellsProgressively(
+      [
+        blobBackedCodeCell("first", "sha256:first"),
+        blobBackedCodeCell("second", "sha256:second"),
+        blobBackedCodeCell("third", "sha256:third"),
+      ],
+      textBlobResolver({
+        "sha256:first": async () => {
+          events.push("fetch:first:start");
+          await gates[0].promise;
+          events.push("fetch:first:finish");
+          return "first output";
+        },
+        "sha256:second": async () => {
+          events.push("fetch:second:start");
+          await gates[1].promise;
+          events.push("fetch:second:finish");
+          return "second output";
+        },
+        "sha256:third": async () => {
+          events.push("fetch:third:start");
+          await gates[2].promise;
+          events.push("fetch:third:finish");
+          return "third output";
+        },
+      }),
+      "python",
+      createOutputResolutionCache(),
+      {
+        maxConcurrentAsyncCells: 2,
+        onInitialCells() {
+          events.push("initial");
+        },
+        onCellResolved(cell) {
+          events.push(`resolved:${cell.id}`);
+        },
+      },
+    );
+
+    await Promise.resolve();
+    assert.deepEqual(events, ["initial", "fetch:first:start", "fetch:second:start"]);
+
+    gates[1].resolve();
+    await waitForEvent(events, "fetch:third:start");
+    assert.deepEqual(events, [
+      "initial",
+      "fetch:first:start",
+      "fetch:second:start",
+      "fetch:second:finish",
+      "resolved:second",
+      "fetch:third:start",
+    ]);
+
+    gates[0].resolve();
+    gates[2].resolve();
+    const cells = await resolution;
+
+    assert.deepEqual(
+      cells.map((cell) => cell.outputs.length),
+      [1, 1, 1],
+    );
+    assert.ok(events.indexOf("fetch:third:start") > events.indexOf("resolved:second"));
+  });
 });
 
 function textBlobResolver(values: Record<string, string | (() => Promise<string>)>): BlobResolver {
@@ -139,6 +207,24 @@ function textBlobResolver(values: Record<string, string | (() => Promise<string>
   };
 }
 
+function blobBackedCodeCell(id: string, blob: string) {
+  return {
+    id,
+    cell_type: "code",
+    source: id,
+    outputs: [
+      {
+        output_id: `${id}-output`,
+        output_type: "display_data",
+        data: {
+          "text/plain": { blob },
+        },
+        metadata: {},
+      },
+    ],
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -147,4 +233,12 @@ function deferred<T>() {
     reject = promiseReject;
   });
   return { promise, resolve, reject };
+}
+
+async function waitForEvent(events: readonly string[], expected: string): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    if (events.includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail(`Timed out waiting for event ${expected}. Saw: ${events.join(", ")}`);
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1238,6 +1238,8 @@ function NotebookViewer({
           cellClassName="cloud-cell"
           sourceClassName="cloud-source-block"
           outputClassName="cloud-output-block"
+          deferIsolatedFrameUntilVisible
+          deferredIsolatedFrameRootMargin="600px 0px"
           resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
           onNavigateToTracebackCell={handleTracebackCellNavigate}
           renderCellError={(error, _cell, index) => (
@@ -1984,6 +1986,8 @@ function CloudLiveNotebook({
               className="cloud-cell"
               sourceClassName="cloud-source-block"
               outputClassName="cloud-output-block"
+              deferIsolatedFrameUntilVisible
+              deferredIsolatedFrameRootMargin="600px 0px"
               resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
               onNavigateToTracebackCell={onNavigateToTracebackCell}
             />

--- a/apps/notebook-cloud/viewer/progressive-cell-resolution.ts
+++ b/apps/notebook-cloud/viewer/progressive-cell-resolution.ts
@@ -11,7 +11,10 @@ export interface ProgressiveCellResolutionCallbacks {
   shouldContinue?: () => boolean;
   onInitialCells?: (cells: ResolvedCell[]) => void;
   onCellResolved?: (cell: ResolvedCell, index: number, cells: ResolvedCell[]) => void;
+  maxConcurrentAsyncCells?: number;
 }
+
+export const DEFAULT_ASYNC_CELL_RESOLUTION_CONCURRENCY = 2;
 
 export async function resolveCellsProgressively(
   rawCells: readonly RenderCell[],
@@ -28,15 +31,50 @@ export async function resolveCellsProgressively(
   if (!shouldContinue()) return resolvedCells;
   callbacks.onInitialCells?.(resolvedCells.slice());
 
-  await Promise.all(
-    rawCells.map(async (cell, index) => {
+  await resolveCellsInTopDownBatches(
+    rawCells,
+    async (cell, index) => {
       const resolvedCell = await resolveCell(cell, blobResolver, index, defaultLanguage, cache);
       if (!shouldContinue()) return;
 
       resolvedCells[index] = resolvedCell;
       callbacks.onCellResolved?.(resolvedCell, index, resolvedCells.slice());
-    }),
+    },
+    {
+      maxConcurrency: callbacks.maxConcurrentAsyncCells,
+      shouldContinue,
+    },
   );
 
   return resolvedCells;
+}
+
+async function resolveCellsInTopDownBatches(
+  rawCells: readonly RenderCell[],
+  resolveCellAtIndex: (cell: RenderCell, index: number) => Promise<void>,
+  options: {
+    maxConcurrency?: number;
+    shouldContinue: () => boolean;
+  },
+): Promise<void> {
+  const maxConcurrency = normalizeAsyncResolutionConcurrency(options.maxConcurrency);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (options.shouldContinue()) {
+      const index = nextIndex++;
+      if (index >= rawCells.length) return;
+      await resolveCellAtIndex(rawCells[index], index);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(maxConcurrency, rawCells.length) }, () => worker());
+  await Promise.all(workers);
+}
+
+function normalizeAsyncResolutionConcurrency(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_ASYNC_CELL_RESOLUTION_CONCURRENCY;
+  }
+  return Math.max(1, Math.floor(value));
 }

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -84,8 +84,10 @@ function withSavedWidgetStateHint(
 
 const FOCUSED_OUTPUT_WELL_VIEWPORT_RATIO = 0.8;
 const MIN_OUTPUT_WELL_HEIGHT = 360;
+const DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT = 96;
 const SIFT_VIEWPORT_TOP_INSET_PX = 96;
 const SIFT_VIEWPORT_BOTTOM_INSET_PX = 32;
+const DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN = "1200px 0px";
 
 function siftFocusAccent(isDark: boolean, colorTheme?: string): string {
   if (colorTheme === "cream") {
@@ -112,6 +114,53 @@ function useOutputWellMaxHeight(viewportRatio: number): number {
   }, [viewportRatio]);
 
   return height;
+}
+
+function useDeferredIsolatedFrame({
+  enabled,
+  rootMargin,
+}: {
+  enabled: boolean;
+  rootMargin: string;
+}) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const [activated, setActivated] = useState(!enabled);
+
+  useEffect(() => {
+    if (!enabled) {
+      setActivated(true);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || activated) return;
+
+    if (typeof window === "undefined" || typeof window.IntersectionObserver === "undefined") {
+      setActivated(true);
+      return;
+    }
+
+    const target = targetRef.current;
+    if (!target) {
+      setActivated(true);
+      return;
+    }
+
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting || entry.intersectionRatio > 0)) {
+          setActivated(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin },
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [activated, enabled, rootMargin]);
+
+  return { activated, targetRef };
 }
 
 import type { JupyterOutput } from "./jupyter-output";
@@ -198,6 +247,18 @@ interface OutputAreaProps {
    * @default false
    */
   preloadIframe?: boolean;
+  /**
+   * Defer mounting isolated output frames until the output is near the
+   * viewport. Once mounted, the frame stays mounted so interactive outputs
+   * keep their internal state.
+   * @default false
+   */
+  deferIsolatedFrameUntilVisible?: boolean;
+  /**
+   * IntersectionObserver root margin used when
+   * `deferIsolatedFrameUntilVisible` is enabled.
+   */
+  deferredIsolatedFrameRootMargin?: string;
   /**
    * Callback when a link is clicked in isolated outputs.
    */
@@ -531,6 +592,8 @@ function OutputAreaSingle({
   priority = DEFAULT_PRIORITY,
   isolated = "auto",
   preloadIframe = false,
+  deferIsolatedFrameUntilVisible = false,
+  deferredIsolatedFrameRootMargin = DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN,
   onLinkClick,
   onWidgetUpdate,
   searchQuery,
@@ -588,6 +651,13 @@ function OutputAreaSingle({
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
   const showPreloadedIframe = preloadIframe && !collapsed;
+  const shouldDeferIsolatedFrame =
+    deferIsolatedFrameUntilVisible && shouldIsolate && !showPreloadedIframe && !collapsed;
+  const deferredIsolatedFrame = useDeferredIsolatedFrame({
+    enabled: shouldDeferIsolatedFrame,
+    rootMargin: deferredIsolatedFrameRootMargin,
+  });
+  const shouldMountIsolatedFrame = !shouldDeferIsolatedFrame || deferredIsolatedFrame.activated;
 
   // Frame name for dev-tools picker. `code-Out[N]-{cellId}` mirrors the
   // Jupyter `Out[N]` convention with the cell ID appended so the picker can
@@ -612,7 +682,10 @@ function OutputAreaSingle({
   const allowWheelBoundaryScroll =
     !focused && !shouldScrollPassthroughFrame && !shouldLockSiftWheelBoundary;
   const showSiftInteractionCue =
-    hasSiftOutputs && shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+    shouldMountIsolatedFrame &&
+    hasSiftOutputs &&
+    shouldUseScrollPassthroughFrame &&
+    !staticFrameInteractionActive;
   const siftFrameAccent = siftFocusAccent(darkMode, colorTheme);
   const siftFrameStyle = hasSiftOutputs
     ? ({
@@ -622,6 +695,11 @@ function OutputAreaSingle({
           ? `0 0 0 2px ${siftFrameAccent}cc, 0 12px 30px ${siftFrameAccent}24`
           : undefined,
       } as React.CSSProperties)
+    : undefined;
+  const deferredIsolatedFramePlaceholderStyle = shouldDeferIsolatedFrame
+    ? {
+        minHeight: `${hasSiftOutputs ? MIN_OUTPUT_WELL_HEIGHT : DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT}px`,
+      }
     : undefined;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
@@ -678,6 +756,14 @@ function OutputAreaSingle({
       setStaticFrameInteractionActive(false);
     }
   }, []);
+
+  const setStaticFrameInteractionNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      staticFrameInteractionRef.current = node;
+      deferredIsolatedFrame.targetRef.current = node;
+    },
+    [deferredIsolatedFrame.targetRef],
+  );
 
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
@@ -938,7 +1024,7 @@ function OutputAreaSingle({
           {/* Preloaded or active isolated frame */}
           {(shouldIsolate || showPreloadedIframe) && (
             <div
-              ref={staticFrameInteractionRef}
+              ref={setStaticFrameInteractionNode}
               className={cn(
                 shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
                 hasSiftOutputs && "group/sift rounded-md overflow-hidden",
@@ -957,26 +1043,35 @@ function OutputAreaSingle({
               }
               onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
             >
-              <IsolatedFrame
-                ref={frameRef}
-                name={frameName}
-                darkMode={darkMode}
-                colorTheme={colorTheme}
-                minHeight={24}
-                maxHeight={isolatedOutputWellMaxHeight}
-                autoHeight={shouldIsolate && !focused}
-                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
-                scrollPassthrough={shouldScrollPassthroughFrame}
-                onReady={handleIsolatedFrameReady}
-                onLinkClick={onLinkClick}
-                onMouseDown={activateStaticFrameInteraction}
-                onWidgetUpdate={onWidgetUpdate}
-                onMessage={handleIframeMessage}
-                onError={handleIframeError}
-                onDiagnostic={onDiagnostic}
-                hostContext={hostContext}
-                outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
-              />
+              {shouldMountIsolatedFrame ? (
+                <IsolatedFrame
+                  ref={frameRef}
+                  name={frameName}
+                  darkMode={darkMode}
+                  colorTheme={colorTheme}
+                  minHeight={24}
+                  maxHeight={isolatedOutputWellMaxHeight}
+                  autoHeight={shouldIsolate && !focused}
+                  allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+                  scrollPassthrough={shouldScrollPassthroughFrame}
+                  onReady={handleIsolatedFrameReady}
+                  onLinkClick={onLinkClick}
+                  onMouseDown={activateStaticFrameInteraction}
+                  onWidgetUpdate={onWidgetUpdate}
+                  onMessage={handleIframeMessage}
+                  onError={handleIframeError}
+                  onDiagnostic={onDiagnostic}
+                  hostContext={hostContext}
+                  outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
+                />
+              ) : (
+                <div
+                  aria-hidden="true"
+                  className="rounded-md"
+                  data-slot="isolated-frame-deferred"
+                  style={deferredIsolatedFramePlaceholderStyle}
+                />
+              )}
               {showSiftInteractionCue && (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
                   <SiftScrollHandoffCue

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -27,6 +27,8 @@ export interface ReadOnlyNotebookProps {
   displayMode?: "notebook" | "report";
   showCode?: boolean;
   focusOutputs?: boolean;
+  deferIsolatedFrameUntilVisible?: boolean;
+  deferredIsolatedFrameRootMargin?: string;
   className?: string;
   cellClassName?: string;
   sourceClassName?: string;
@@ -46,6 +48,8 @@ export function ReadOnlyNotebook({
   displayMode = "notebook",
   showCode = true,
   focusOutputs = false,
+  deferIsolatedFrameUntilVisible,
+  deferredIsolatedFrameRootMargin,
   className,
   cellClassName,
   sourceClassName,
@@ -95,6 +99,8 @@ export function ReadOnlyNotebook({
                 displayMode={displayMode}
                 showSource={displayMode === "report" ? cell.cellType !== "code" || showCode : true}
                 focusOutputs={focusOutputs}
+                deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
+                deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
                 className={cellClassName}
                 sourceClassName={sourceClassName}
                 outputClassName={outputClassName}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -28,6 +28,8 @@ export interface ReadOnlyNotebookCellProps {
   sourceClassName?: string;
   outputClassName?: string;
   lineWrapping?: boolean;
+  deferIsolatedFrameUntilVisible?: boolean;
+  deferredIsolatedFrameRootMargin?: string;
   resolveTracebackExecutionTarget?: TracebackExecutionResolver;
   onNavigateToTracebackCell?: TracebackCellNavigator;
 }
@@ -48,6 +50,8 @@ export function ReadOnlyNotebookCell({
   sourceClassName,
   outputClassName,
   lineWrapping = true,
+  deferIsolatedFrameUntilVisible,
+  deferredIsolatedFrameRootMargin,
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
 }: ReadOnlyNotebookCellProps) {
@@ -78,6 +82,8 @@ export function ReadOnlyNotebookCell({
         priority={priority}
         hostContext={hostContext}
         className={outputClassName}
+        deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
+        deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
         resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
         onNavigateToTracebackCell={onNavigateToTracebackCell}
       />

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,4 +1,4 @@
-import { createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
@@ -215,6 +215,7 @@ describe("OutputArea iframe theme sync", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("re-sends the current cream color theme when the iframe becomes ready", async () => {
@@ -302,6 +303,50 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-host-context")).toContain(
       "https://cdn.example.test/plugins/",
     );
+  });
+
+  it("defers opt-in isolated output frames until the output nears the viewport", async () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+    const observer = {
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+      takeRecords: vi.fn(() => []),
+    };
+    vi.stubGlobal(
+      "IntersectionObserver",
+      vi.fn(function MockIntersectionObserver(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+        return observer;
+      }),
+    );
+
+    const { container } = render(
+      <OutputArea outputs={makeMarkdownOutput()} isolated deferIsolatedFrameUntilVisible />,
+    );
+
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+    expect(container.querySelector('[data-slot="isolated-frame-deferred"]')).not.toBeNull();
+    expect(mockFrameHandle.renderBatch).not.toHaveBeenCalled();
+    expect(observer.observe).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      intersectionCallback?.(
+        [{ isIntersecting: true, intersectionRatio: 1 } as IntersectionObserverEntry],
+        observer as unknown as IntersectionObserver,
+      );
+    });
+
+    expect(screen.getByTestId("isolated-frame")).toBeInTheDocument();
+    expect(observer.disconnect).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/markdown",
+          outputId: "markdown-output",
+        }),
+      ]);
+    });
   });
 
   it("activates static iframe outputs on pointer down and keeps them active when the pointer leaves", () => {


### PR DESCRIPTION
## Summary

- resolve cloud async output payloads in top-down batches instead of fanning out across every cell at once
- keep the synchronous cell shell render path so live NotebookDoc/RuntimeStateDoc materialization still paints source/markdown immediately
- add a regression test that below-the-fold async output resolution waits for an available resolver slot

## Stack

This PR targets `quod/notebook-cloud-lazy-output-frames` and should merge after #3140.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/progressive-cell-resolution.test.ts test/render-resolution.test.ts test/viewer-loading-policy.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud test`

## Notes

- No schema, storage, auth, or iframe sandbox changes.
- This keeps `/render` out of the latest viewer path; it only changes how live/snapshot materialized cells resolve blob-backed outputs after the cell shell exists.
