### PR TITLE
fix(notebook-cloud): show friendly presence labels

### DIFF
--- a/apps/notebook-cloud/test/live-presence.test.ts
+++ b/apps/notebook-cloud/test/live-presence.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CloudLivePresenceStore, normalizeCloudPresencePayload } from "../viewer/live-presence.ts";
+
+describe("cloud live presence", () => {
+  it("normalizes raw actor labels before they reach shared cursor rendering", () => {
+    const store = new CloudLivePresenceStore("local-peer");
+    const snapshot = store.handlePresence({
+      type: "update",
+      peer_id: "remote-peer",
+      peer_label: "user:anaconda:550e8400-e29b-41d4-a716-446655440000",
+      actor_label: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+      channel: "cursor",
+      data: { cell_id: "cell-1", line: 2, column: 4 },
+    });
+
+    assert.ok(snapshot);
+    assert.equal(snapshot.cells.get("cell-1")?.cursors[0]?.peerLabel, "Anaconda user");
+  });
+
+  it("preserves friendly peer labels from presence snapshots", () => {
+    const normalized = normalizeCloudPresencePayload({
+      type: "snapshot",
+      peer_id: "local-peer",
+      peers: [
+        {
+          peer_id: "remote-a",
+          peer_label: "Alice Demo",
+          actor_label: "user:anaconda:alice/browser:tab",
+          channels: [],
+        },
+        {
+          peer_id: "remote-b",
+          peer_label: "user:anaconda:550e8400-e29b-41d4-a716-446655440000",
+          actor_label: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+          channels: [],
+        },
+      ],
+    }) as {
+      peers: Array<{ peer_label: string }>;
+    };
+
+    assert.deepEqual(
+      normalized.peers.map((peer) => peer.peer_label),
+      ["Alice Demo", "Anaconda user"],
+    );
+  });
+});

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  cloudFriendlyPeerLabel,
+  cloudVisiblePeerLabel,
   cloudViewerPresenceDisplay,
   initialCloudViewerPresence,
   reduceCloudViewerConnection,
@@ -26,12 +28,14 @@ describe("cloud viewer presence", () => {
         connection: state.connection,
         ownPeerId: state.ownPeerId,
         actorLabel: state.actorLabel,
+        ownPeerLabel: state.ownPeerLabel,
         roomPeerCount: state.roomPeerCount,
       },
       {
         connection: "connected",
         ownPeerId: "peer-a",
         actorLabel: "anonymous:viewer:session-a/desktop:browser",
+        ownPeerLabel: "Anonymous",
         roomPeerCount: 1,
       },
     );
@@ -80,5 +84,54 @@ describe("cloud viewer presence", () => {
       title: "Disconnected from the notebook room",
       connected: false,
     });
+  });
+
+  it("uses friendly display metadata in the connected status title", () => {
+    const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-a",
+      actor_label: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+      connection_scope: "editor",
+      display_name: "Alice Demo",
+      email: "alice@example.com",
+      room_peer_count: 2,
+      timestamp: "2026-05-23T00:00:00.000Z",
+    });
+
+    assert.equal(state.ownPeerLabel, "Alice Demo");
+    assert.deepEqual(cloudViewerPresenceDisplay(state), {
+      label: "2 viewing",
+      title: "2 readers connected to this notebook room; You are Alice Demo",
+      connected: true,
+    });
+  });
+
+  it("falls back to readable cloud peer labels instead of raw actor labels", () => {
+    assert.equal(
+      cloudFriendlyPeerLabel({
+        actorLabel: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+      }),
+      "Anaconda user",
+    );
+    assert.equal(
+      cloudVisiblePeerLabel(
+        "user:anaconda:550e8400-e29b-41d4-a716-446655440000",
+        "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+      ),
+      "Anaconda user",
+    );
+    assert.equal(
+      cloudVisiblePeerLabel("Alice Demo", "user:anaconda:alice/browser:tab"),
+      "Alice Demo",
+    );
+    assert.equal(
+      cloudFriendlyPeerLabel({
+        email: "alice@example.com",
+        actorLabel: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
+      }),
+      "alice@example.com",
+    );
   });
 });

--- a/apps/notebook-cloud/viewer/live-presence.ts
+++ b/apps/notebook-cloud/viewer/live-presence.ts
@@ -1,5 +1,6 @@
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import { RemotePresenceState } from "@/components/editor/presence-state";
+import { cloudVisiblePeerLabel } from "./presence";
 
 export interface CloudLivePresenceSnapshot {
   version: number;
@@ -16,7 +17,7 @@ export class CloudLivePresenceStore {
   }
 
   handlePresence(payload: unknown): CloudLivePresenceSnapshot | null {
-    const affectedCells = this.state.handlePresence(payload);
+    const affectedCells = this.state.handlePresence(normalizeCloudPresencePayload(payload));
     if (affectedCells.size === 0) return null;
 
     for (const cellId of affectedCells) {
@@ -40,4 +41,42 @@ export function emptyCloudLivePresenceSnapshot(): CloudLivePresenceSnapshot {
     version: 0,
     cells: new Map(),
   };
+}
+
+export function normalizeCloudPresencePayload(payload: unknown): unknown {
+  if (!isRecord(payload)) return payload;
+
+  if (payload.type === "update") {
+    const peerLabel = stringValue(payload.peer_label);
+    const actorLabel = stringValue(payload.actor_label);
+    return {
+      ...payload,
+      peer_label: cloudVisiblePeerLabel(peerLabel, actorLabel),
+    };
+  }
+
+  if (payload.type === "snapshot" && Array.isArray(payload.peers)) {
+    return {
+      ...payload,
+      peers: payload.peers.map((peer) => {
+        if (!isRecord(peer)) return peer;
+        const peerLabel = stringValue(peer.peer_label);
+        const actorLabel = stringValue(peer.actor_label);
+        return {
+          ...peer,
+          peer_label: cloudVisiblePeerLabel(peerLabel, actorLabel),
+        };
+      }),
+    };
+  }
+
+  return payload;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
 }

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -6,6 +6,7 @@ export interface CloudViewerPresenceState {
   connection: CloudViewerPresenceConnection;
   ownPeerId: string | null;
   actorLabel: string | null;
+  ownPeerLabel: string | null;
   roomPeerCount: number | null;
 }
 
@@ -20,6 +21,7 @@ export function initialCloudViewerPresence(): CloudViewerPresenceState {
     connection: "connecting",
     ownPeerId: null,
     actorLabel: null,
+    ownPeerLabel: null,
     roomPeerCount: null,
   };
 }
@@ -44,6 +46,11 @@ export function reduceCloudViewerPresenceMessage(
         connection: "connected",
         ownPeerId: message.peer_id,
         actorLabel: message.actor_label,
+        ownPeerLabel: cloudFriendlyPeerLabel({
+          displayName: message.display_name,
+          email: message.email,
+          actorLabel: message.actor_label,
+        }),
         roomPeerCount: safeRoomPeerCount(message.room_peer_count),
       };
     case "cloud_peer_joined":
@@ -78,16 +85,101 @@ export function cloudViewerPresenceDisplay(
   }
 
   const count = Math.max(1, state.roomPeerCount);
+  const readerTitle =
+    count === 1
+      ? "1 reader connected to this notebook room"
+      : `${count} readers connected to this notebook room`;
+  const selfTitle = state.ownPeerLabel ? `You are ${state.ownPeerLabel}` : null;
   return {
     label: `${count} viewing`,
-    title:
-      count === 1
-        ? "1 reader connected to this notebook room"
-        : `${count} readers connected to this notebook room`,
+    title: selfTitle ? `${readerTitle}; ${selfTitle}` : readerTitle,
     connected: true,
   };
 }
 
+export interface CloudFriendlyPeerLabelInput {
+  displayName?: string | null;
+  email?: string | null;
+  actorLabel?: string | null;
+}
+
+export function cloudVisiblePeerLabel(
+  peerLabel?: string | null,
+  actorLabel?: string | null,
+): string {
+  const trimmedPeerLabel = peerLabel?.trim();
+  if (trimmedPeerLabel && !looksLikeRawIdentityLabel(trimmedPeerLabel)) {
+    return trimmedPeerLabel;
+  }
+
+  return cloudFriendlyPeerLabel({ actorLabel: actorLabel ?? trimmedPeerLabel });
+}
+
+export function cloudFriendlyPeerLabel({
+  displayName,
+  email,
+  actorLabel,
+}: CloudFriendlyPeerLabelInput): string {
+  const trimmedDisplayName = displayName?.trim();
+  if (trimmedDisplayName && !looksLikeRawIdentityLabel(trimmedDisplayName)) {
+    return trimmedDisplayName;
+  }
+
+  const trimmedEmail = email?.trim();
+  if (trimmedEmail) {
+    return trimmedEmail;
+  }
+
+  return friendlyActorLabel(actorLabel) ?? "Peer";
+}
+
 function safeRoomPeerCount(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
+}
+
+function friendlyActorLabel(actorLabel: string | null | undefined): string | null {
+  const trimmedActorLabel = actorLabel?.trim();
+  if (!trimmedActorLabel) return null;
+
+  const principal = trimmedActorLabel.split("/", 1)[0];
+  if (principal.startsWith("anonymous:")) {
+    return "Anonymous";
+  }
+
+  if (!principal.startsWith("user:")) {
+    return null;
+  }
+
+  const parts = principal.split(":");
+  const namespace = parts.slice(0, 2).join(":");
+  const encodedSubject = parts.slice(2).join(":");
+  const subject = decodeActorLabelSubject(encodedSubject);
+  if (!subject) {
+    return namespace === "user:anaconda" ? "Anaconda user" : "User";
+  }
+  if (subject.includes("@")) {
+    return subject;
+  }
+  if (namespace === "user:anaconda" && looksOpaqueSubject(subject)) {
+    return "Anaconda user";
+  }
+
+  return subject;
+}
+
+function decodeActorLabelSubject(value: string): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function looksLikeRawIdentityLabel(value: string): boolean {
+  return /^(anonymous|user):/.test(value);
+}
+
+function looksOpaqueSubject(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }


### PR DESCRIPTION
## Summary

- normalize notebook-cloud live presence labels before they reach the shared editor cursor rendering state
- prefer display name/email and use readable fallbacks for opaque Anaconda actor labels
- keep the toolbar presence state aware of the current user's friendly label without changing the shared presence components

## Stack

- Base: `main`
- Independent of the pending NotebookDoc/RuntimeStateDoc schema data-loss fix.
- Independent of the notebook-cloud performance stack (#3140/#3145); it can merge separately.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-presence.test.ts test/live-presence.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

- This keeps cloud-specific identity cleanup in the notebook-cloud adapter and does not fork the shared editor presence renderer.
- No preview deploy has been attempted for this slice yet.
