### PR TITLE
docs(elements): catalog output isolation surfaces

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -4,6 +4,7 @@ import {
   Boxes,
   Cloud,
   FileCode2,
+  Frame,
   ListChecks,
   Palette,
   PanelLeft,
@@ -50,6 +51,12 @@ const entries = [
     description: "Runtime-free fixtures for current nteract output components.",
     href: "/docs/output-renderers",
     icon: Boxes,
+  },
+  {
+    title: "Output isolation",
+    description: "Frame policy, host context, and MCP output mapping surfaces.",
+    href: "/docs/isolated-output-surfaces",
+    icon: Frame,
   },
   {
     title: "Read-only notebooks",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "70+",
+    value: "80+",
     detail:
-      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, plugin renderer, editor, widget controls, widget media, and widget output surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, isolated output policy, plugin renderer, editor, widget controls, widget media, and widget output surfaces",
   },
 ];
 
@@ -41,7 +41,7 @@ const phases = [
     title: "Separate renderers",
     state: "active",
     icon: FileCode2,
-    summary: "ANSI, JSON, image, traceback, MIME priority, and isolated-renderer blockers.",
+    summary: "ANSI, JSON, image, traceback, MIME priority, frame policy, and isolated adapters.",
   },
   {
     title: "Expose notebook themes",
@@ -138,7 +138,16 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; production iframe bootstrapping, HTML/markdown isolation, third-party renderer loading, widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
+  },
+  {
+    family: "Output isolation",
+    source:
+      "src/components/isolated/{host-context,mcp-app-structured-content,output-frame-sizing,output-lane-policy}.ts + apps/elements/components/isolated/{index.tsx,frame-config-adapter.ts}",
+    target: "nteract renderers",
+    status: "active",
+    intent:
+      "Host-context theme merging, output lane routing, sizing, MCP structured output mapping, and the docs IsolatedFrame and frame-config adapters now render without booting production iframe scripts.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/isolated-output-surfaces-example.tsx
+++ b/apps/elements/components/isolated-output-surfaces-example.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import {
+  ArrowDownToLine,
+  Boxes,
+  Frame,
+  Gauge,
+  Layers3,
+  LockKeyhole,
+  Palette,
+  ShieldCheck,
+} from "lucide-react";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import { IsolatedFrame, outputSegmentLane, selectedOutputMimeType } from "@/components/isolated";
+import type { RenderPayload } from "@/components/isolated";
+import {
+  createIsolatedFrameDocument,
+  ISOLATED_FRAME_ALLOW_ATTR,
+  ISOLATED_FRAME_SANDBOX_ATTRS,
+} from "./isolated/frame-config-adapter";
+import {
+  createNteractEmbedHostContext,
+  createNteractThemeVariables,
+  mcpAppHostContextToNteractEmbedPatch,
+  mergeNteractEmbedHostContext,
+} from "@/components/isolated/host-context";
+import {
+  mcpAppCellHasRichOutput,
+  mcpAppCellPreviewText,
+  mcpAppStructuredContentToSharedOutputInputs,
+  type McpAppStructuredContent,
+} from "@/components/isolated/mcp-app-structured-content";
+import { outputFrameDisplayHeight } from "@/components/isolated/output-frame-sizing";
+
+const laneOutputs: JupyterOutput[] = [
+  {
+    output_id: "stdout-1",
+    output_type: "stream",
+    name: "stdout",
+    text: "downloaded 56 parquet fragments",
+  },
+  {
+    output_id: "png-1",
+    output_type: "display_data",
+    data: {
+      "image/png":
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEklEQVR4nGNgaGBgYAAAAAQAARV7J8EAAAAASUVORK5CYII=",
+      "text/plain": "<chart thumbnail>",
+    },
+  },
+  {
+    output_id: "html-1",
+    output_type: "display_data",
+    data: {
+      "text/html": "<section><strong>trusted by iframe policy only</strong></section>",
+      "text/plain": "HTML preview",
+    },
+  },
+  {
+    output_id: "widget-1",
+    output_type: "display_data",
+    data: {
+      "application/vnd.jupyter.widget-view+json": { model_id: "widget-slider" },
+      "text/llm+plain": "IntSlider(value=7, min=0, max=10)",
+      "text/plain": "IntSlider(value=7)",
+    },
+  },
+  {
+    output_id: "sift-1",
+    output_type: "display_data",
+    data: {
+      "application/vnd.nteract.arrow-stream-manifest+json": {
+        schema: "sample_schema",
+        chunks: [{ blob: "arrow-chunk-0", byteLength: 8192 }],
+      },
+      "text/plain": "Arrow stream manifest",
+    },
+  },
+];
+
+const structuredContent: McpAppStructuredContent = {
+  blob_base_url: "https://outputs.example.test/artifacts",
+  cells: [
+    {
+      cell_id: "cell-forecast",
+      cell_type: "code",
+      source: "display(forecast_chart)\ncontrols = widgets.IntSlider(value=7)",
+      execution_count: 12,
+      status: "idle",
+      outputs: [
+        {
+          output_id: "forecast-stream",
+          output_type: "stream",
+          name: "stdout",
+          text: "loaded 56/56 fragments",
+        },
+        {
+          output_id: "forecast-html",
+          output_type: "display_data",
+          data: {
+            "text/html": '<div class="metric">MAPE 6.8%</div>',
+            "text/plain": "MAPE 6.8%",
+          },
+          llm_preview: { head: "MAPE 6.8%" },
+        },
+        {
+          output_id: "forecast-image",
+          output_type: "display_data",
+          data: {
+            "image/png": "https://outputs.example.test/artifacts/blob/forecast-chart-png",
+            "text/plain": "<forecast chart>",
+          },
+        },
+        {
+          output_id: "forecast-widget",
+          output_type: "display_data",
+          data: {
+            "application/vnd.jupyter.widget-view+json": { model_id: "widget-slider" },
+            "text/llm+plain": "IntSlider(value=7, min=0, max=10)",
+            "text/plain": "IntSlider(value=7)",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const framePayloads: RenderPayload[] = [
+  {
+    outputId: "html-frame",
+    mimeType: "text/html",
+    data: "<article><h3>Hosted HTML</h3><p>Rendered by the isolated document shell.</p></article>",
+  },
+  {
+    outputId: "sift-frame",
+    mimeType: "application/vnd.nteract.arrow-stream-manifest+json",
+    data: {
+      chunks: [{ url: "https://outputs.example.test/artifacts/blob/arrow-chunk-0" }],
+      rowCount: 22767,
+    },
+  },
+];
+
+const sizingSamples = [
+  { contentHeight: 18, autoHeight: true, maxHeight: 400, minHeight: 24 },
+  { contentHeight: 720, autoHeight: false, maxHeight: 420, minHeight: 24 },
+  { contentHeight: 1680, autoHeight: false, maxHeight: 900, minHeight: 24 },
+];
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+function outputKind(output: JupyterOutput) {
+  return selectedOutputMimeType(output) ?? output.output_type;
+}
+
+function outputIsolationLabel(output: JupyterOutput) {
+  const lane = outputSegmentLane(output);
+  if (lane === "dom") return "main DOM";
+  if (lane === "sift-frame") return "sift frame";
+  if (lane === "static-frame") return "static frame";
+  return "interactive frame";
+}
+
+function documentPreview(document: ReturnType<typeof createIsolatedFrameDocument>) {
+  if (document.kind === "src") return document.url;
+  return `srcdoc frame shell (${document.html.length.toLocaleString()} chars)`;
+}
+
+export function IsolatedOutputSurfacesExample() {
+  const baseContext = createNteractEmbedHostContext({
+    isDark: false,
+    colorTheme: "cream",
+    containerDimensions: { width: 960, maxHeight: 640 },
+    locale: "en-US",
+    timeZone: "America/Los_Angeles",
+    userAgent: "nteract-elements-fixture",
+    platform: "desktop",
+    deviceCapabilities: { hover: true, touch: false },
+  });
+  const mcpPatch = mcpAppHostContextToNteractEmbedPatch(
+    {
+      theme: "dark",
+      styles: {
+        variables: {
+          "--mcp-accent": "#38bdf8",
+          "--ignored-number": 12,
+        },
+        css: {
+          fonts: "@font-face { font-family: nteract-fixture; src: local(system-ui); }",
+        },
+      },
+      displayMode: "fullscreen",
+      availableDisplayModes: ["inline", "fullscreen", "unsupported"],
+      containerDimensions: { width: 1280, height: "invalid", maxHeight: 780 },
+      locale: "en-US",
+      timeZone: "America/Los_Angeles",
+      userAgent: "mcp-host-fixture",
+      platform: "desktop",
+      deviceCapabilities: { hover: true },
+      safeAreaInsets: { bottom: 12 },
+    },
+    {
+      includeContainerDimensions: true,
+      rendererAssetsBaseUrl: "/renderer-assets",
+      outputDocumentUrl: "/output-document.html",
+    },
+  );
+  const mergedContext = mergeNteractEmbedHostContext(baseContext, mcpPatch);
+  const themeVariables = createNteractThemeVariables(false, "cream");
+  const sharedOutputInputs = mcpAppStructuredContentToSharedOutputInputs(structuredContent);
+  const sharedOutputs = sharedOutputInputs.outputs;
+  const blobPreviewUrl = sharedOutputInputs.resolveOptions.blobResolver?.url({
+    blob: "forecast-chart-png",
+  });
+  const documents = [
+    {
+      label: "Desktop runtime",
+      document: createIsolatedFrameDocument({ isTauriRuntime: true }),
+    },
+    {
+      label: "Browser docs",
+      document: createIsolatedFrameDocument({ isTauriRuntime: false }),
+    },
+    {
+      label: "Hosted output origin",
+      document: createIsolatedFrameDocument({
+        isTauriRuntime: false,
+        outputDocumentUrl: "/output-document.html",
+        themeSeed: { theme: "dark", colorTheme: "cream" },
+      }),
+    },
+  ];
+
+  return (
+    <div className="not-prose space-y-8" data-testid="isolated-output-surfaces">
+      <section className="grid gap-3 lg:grid-cols-3">
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <ShieldCheck className="mb-3 size-5 text-emerald-600 dark:text-emerald-300" />
+          <h2 className="text-sm font-semibold">Sandbox contract</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The docs adapter mirrors the production frame policy without importing the raw frame
+            HTML bundle, relaxing the sandbox, or booting renderer scripts.
+          </p>
+          <div className="mt-4 space-y-2">
+            {ISOLATED_FRAME_SANDBOX_ATTRS.split(" ").map((token) => (
+              <div
+                key={token}
+                className="rounded-md border border-fd-border bg-fd-background px-3 py-2"
+              >
+                <code className="text-xs">{token}</code>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 rounded-md border border-fd-border bg-fd-background px-3 py-2">
+            <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">allow</div>
+            <code className="text-xs">{ISOLATED_FRAME_ALLOW_ATTR}</code>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <Frame className="mb-3 size-5 text-fd-muted-foreground" />
+          <h2 className="text-sm font-semibold">Frame document selection</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            Desktop, browser, and hosted deployments choose different frame documents through the
+            same adapter shape.
+          </p>
+          <div className="mt-4 space-y-3">
+            {documents.map((item) => (
+              <div
+                key={item.label}
+                className="rounded-md border border-fd-border bg-fd-background p-3"
+              >
+                <div className="text-xs font-semibold">{item.label}</div>
+                <div className="mt-1 break-words font-mono text-[11px] leading-5 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                  {item.document.kind}: {documentPreview(item.document)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <Palette className="mb-3 size-5 text-fd-muted-foreground" />
+          <h2 className="text-sm font-semibold">Host context merge</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            MCP host context becomes a nteract embed patch, then merges with notebook theme tokens
+            and renderer asset URLs.
+          </p>
+          <dl className="mt-4 grid gap-2 text-xs">
+            <div className="flex justify-between gap-4">
+              <dt className="text-fd-muted-foreground">theme</dt>
+              <dd className="font-mono">{mergedContext.theme}</dd>
+            </div>
+            <div className="flex justify-between gap-4">
+              <dt className="text-fd-muted-foreground">flavor</dt>
+              <dd className="font-mono">{mergedContext.nteract?.colorTheme}</dd>
+            </div>
+            <div className="flex justify-between gap-4">
+              <dt className="text-fd-muted-foreground">output document</dt>
+              <dd className="font-mono">{mergedContext.nteract?.outputDocumentUrl}</dd>
+            </div>
+            <div className="flex justify-between gap-4">
+              <dt className="text-fd-muted-foreground">assets base</dt>
+              <dd className="font-mono">{mergedContext.nteract?.rendererAssetsBaseUrl}</dd>
+            </div>
+            <div className="flex justify-between gap-4">
+              <dt className="text-fd-muted-foreground">safe bottom</dt>
+              <dd className="font-mono">{mergedContext.safeAreaInsets?.bottom}px</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Layers3 className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">Output lane policy</h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The catalog uses the same policy helpers that decide whether notebook outputs stay in
+            the main DOM, move to a static iframe, require an interactive iframe, or route through
+            Sift.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border">
+          {laneOutputs.map((output) => (
+            <div
+              key={output.output_id}
+              className="grid gap-3 p-4 md:grid-cols-[minmax(0,1fr)_160px_160px]"
+              data-output-lane={outputSegmentLane(output)}
+            >
+              <div className="min-w-0">
+                <div className="font-mono text-xs text-fd-muted-foreground">{output.output_id}</div>
+                <div className="mt-1 break-words text-sm font-semibold [overflow-wrap:anywhere]">
+                  {outputKind(output)}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                  lane
+                </div>
+                <div className="mt-1 text-sm">{outputIsolationLabel(output)}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                  selected MIME
+                </div>
+                <div className="mt-1 break-words font-mono text-xs [overflow-wrap:anywhere]">
+                  {selectedOutputMimeType(output) ?? "none"}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-[0.95fr_1.05fr]">
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <div className="mb-4 flex items-center gap-2">
+            <ArrowDownToLine className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">MCP output mapping</h2>
+          </div>
+          <p className="text-xs leading-5 text-fd-muted-foreground">
+            Structured MCP cell output is converted to shared nteract manifests before the iframe
+            runtime resolves inline, blob, or URL-backed content.
+          </p>
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                manifests
+              </div>
+              <div className="mt-1 text-2xl font-semibold">{sharedOutputs.length}</div>
+            </div>
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                rich output
+              </div>
+              <div className="mt-1 text-2xl font-semibold">
+                {mcpAppCellHasRichOutput(structuredContent.cells![0]) ? "yes" : "no"}
+              </div>
+            </div>
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                preview
+              </div>
+              <div className="mt-1 truncate text-sm font-semibold">
+                {mcpAppCellPreviewText(structuredContent.cells![0])}
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+              blob URL handoff
+            </div>
+            <div className="mt-1 break-words font-mono text-xs [overflow-wrap:anywhere]">
+              {blobPreviewUrl}
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <div className="mb-4 flex items-center gap-2">
+            <Boxes className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">Shared manifest preview</h2>
+          </div>
+          <div className="max-h-80 overflow-auto rounded-md border border-fd-border bg-fd-background p-3">
+            <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-fd-muted-foreground">
+              {formatJson(sharedOutputs)}
+            </pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-[1fr_1fr]">
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <div className="mb-4 flex items-center gap-2">
+            <Gauge className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">Frame sizing policy</h2>
+          </div>
+          <div className="divide-y divide-fd-border rounded-md border border-fd-border bg-fd-background">
+            {sizingSamples.map((sample) => (
+              <div
+                key={`${sample.contentHeight}-${sample.maxHeight}`}
+                className="grid grid-cols-3 gap-3 p-3 text-xs"
+              >
+                <div>
+                  <div className="text-fd-muted-foreground">content</div>
+                  <div className="mt-1 font-mono">{sample.contentHeight}px</div>
+                </div>
+                <div>
+                  <div className="text-fd-muted-foreground">policy</div>
+                  <div className="mt-1 font-mono">
+                    {sample.autoHeight ? "auto" : `max ${sample.maxHeight}px`}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-fd-muted-foreground">display</div>
+                  <div className="mt-1 font-mono">
+                    {outputFrameDisplayHeight(sample.contentHeight, sample)}px
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+              sample theme variables
+            </div>
+            <div className="mt-1 grid gap-1 font-mono text-[11px] text-fd-muted-foreground">
+              <span>--sift-bg: {themeVariables["--sift-bg"]}</span>
+              <span>--output-document-font: {themeVariables["--output-document-font"]}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-fd-border bg-fd-card p-4">
+          <div className="mb-4 flex items-center gap-2">
+            <LockKeyhole className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">Docs isolated-frame adapter</h2>
+          </div>
+          <p className="mb-4 text-xs leading-5 text-fd-muted-foreground">
+            This renders through the docs adapter for `IsolatedFrame`, so the surface can show host
+            context and payload shape without loading production iframe scripts.
+          </p>
+          <div className="grid gap-3">
+            {framePayloads.map((payload) => (
+              <IsolatedFrame
+                key={payload.outputId}
+                name={payload.outputId}
+                initialContent={payload}
+                darkMode={mergedContext.theme === "dark"}
+                colorTheme={mergedContext.nteract?.colorTheme ?? undefined}
+                hostContext={mergedContext}
+                minHeight={96}
+                maxHeight={220}
+                className="rounded-md border border-fd-border bg-fd-background p-3"
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/components/isolated/frame-config-adapter.ts
+++ b/apps/elements/components/isolated/frame-config-adapter.ts
@@ -1,0 +1,58 @@
+export const ISOLATED_FRAME_SANDBOX_ATTRS = [
+  "allow-scripts",
+  "allow-downloads",
+  "allow-forms",
+  "allow-pointer-lock",
+].join(" ");
+
+export const ISOLATED_FRAME_ALLOW_ATTR = "fullscreen *";
+
+export type IsolatedFrameDocument = { kind: "src"; url: string } | { kind: "srcdoc"; html: string };
+
+interface IsolatedFrameThemeSeed {
+  theme?: "light" | "dark" | null;
+  colorTheme?: string | null;
+}
+
+const NTERACT_FRAME_URL = "nteract-frame://localhost/";
+const FRAME_HTML_STUB = '<!doctype html><html><body><div id="root"></div></body></html>';
+
+export function createIsolatedFrameDocument(options?: {
+  isTauriRuntime?: boolean;
+  outputDocumentUrl?: string | null;
+  themeSeed?: IsolatedFrameThemeSeed;
+}): IsolatedFrameDocument {
+  const outputDocumentUrl = options?.outputDocumentUrl?.trim();
+  if (outputDocumentUrl) {
+    return { kind: "src", url: withIsolatedFrameThemeSeed(outputDocumentUrl, options?.themeSeed) };
+  }
+
+  if (options?.isTauriRuntime) {
+    return { kind: "src", url: NTERACT_FRAME_URL };
+  }
+  return { kind: "srcdoc", html: FRAME_HTML_STUB };
+}
+
+function withIsolatedFrameThemeSeed(
+  outputDocumentUrl: string,
+  themeSeed: IsolatedFrameThemeSeed | undefined,
+): string {
+  if (!themeSeed?.theme && !themeSeed?.colorTheme) return outputDocumentUrl;
+
+  try {
+    const isAbsoluteOrProtocolRelative =
+      /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(outputDocumentUrl) || outputDocumentUrl.startsWith("//");
+    const parsed = new URL(outputDocumentUrl, "https://nteract.invalid");
+    if (themeSeed.theme === "light" || themeSeed.theme === "dark") {
+      parsed.searchParams.set("nteract_theme", themeSeed.theme);
+    }
+    if (themeSeed.colorTheme && themeSeed.colorTheme !== "classic") {
+      parsed.searchParams.set("nteract_color_theme", themeSeed.colorTheme);
+    }
+
+    if (isAbsoluteOrProtocolRelative) return parsed.href;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return outputDocumentUrl;
+  }
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -37,6 +37,7 @@ generic shadcn primitives under the hood.
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Output renderers](/docs/output-renderers)
+- [Output isolation surfaces](/docs/isolated-output-surfaces)
 - [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)

--- a/apps/elements/content/docs/isolated-output-surfaces.mdx
+++ b/apps/elements/content/docs/isolated-output-surfaces.mdx
@@ -1,0 +1,31 @@
+---
+title: Output isolation surfaces
+description: Runtime-free frame, host-context, and MCP output mapping surfaces.
+---
+
+import { IsolatedOutputSurfacesExample } from "@/components/isolated-output-surfaces-example";
+
+Notebook output isolation is nteract-owned UI infrastructure. It decides which
+outputs stay in the notebook DOM, which move into sandboxed frames, how hosted
+output documents receive theme and asset context, and how MCP app structured
+content becomes shared output manifests.
+
+<IsolatedOutputSurfacesExample />
+
+## What is real here
+
+The page imports current helpers from `src/components/isolated/**`: output lane
+policy, frame sizing, host-context theme variables, MCP host-context conversion,
+and MCP structured content conversion. Frame document selection and sandbox
+policy use a docs-local adapter that mirrors the production helper while
+avoiding the raw `frame.html?raw` bundle. It also renders the docs-local
+`IsolatedFrame` adapter so payload shape and host context stay visible without
+booting production iframe scripts.
+
+## What stays behind adapters
+
+The production frame runtime still owns JavaScript evaluation, renderer plugin
+installation, widget comm replay, raw HTML execution, and generated Sift WASM
+asset loading. The catalog should keep those as explicit adapters until they can
+be exercised without importing desktop runtime state or executing untrusted
+output code in the docs app.

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -29,8 +29,9 @@ notebook uses before rendering.
 
 ## What still needs an adapter
 
-Production `IsolatedFrame` bootstrapping, executable JavaScript, raw HTML and
-markdown iframe rendering, live widget views, third-party renderer library
-loading, and generated Sift parquet/Arrow WASM decoding still need
-fixture-backed isolation, widget-store, or generated asset adapters before this
-docs app should own those runtime paths.
+The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
+frame policy, host-context conversion, sizing, lane routing, and MCP structured
+output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
+live widget views, third-party renderer library loading, and generated Sift
+parquet/Arrow WASM decoding still need fixture-backed iframe, widget-store, or
+generated asset adapters before this docs app should own those runtime paths.


### PR DESCRIPTION
## Summary

- add an `apps/elements` output isolation catalog page for sandbox policy, frame document selection, host-context merging, output lane routing, frame sizing, and MCP structured output mapping
- render the docs-local `IsolatedFrame` adapter with fixture payloads while keeping production iframe scripts, raw HTML execution, widget comm replay, and generated Sift WASM behind explicit adapters
- update the elements landing page, index, output renderer notes, and burn-down bookkeeping

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Playwright route checks for `/docs/isolated-output-surfaces` on desktop and mobile viewports
