### PR TITLE
test(notebook-cloud): capture viewer load milestones

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -120,6 +120,39 @@ export function summarizePerformanceResources(resources, milestones = {}) {
   return { milestones, resources_by_kind: byKind };
 }
 
+export const VIEWER_MILESTONE_PREFIX = "nteract:notebook-cloud:";
+
+export function summarizeViewerMilestones(entries) {
+  const milestones = {};
+
+  for (const entry of entries ?? []) {
+    if (!entry || typeof entry.name !== "string") {
+      continue;
+    }
+    if (!entry.name.startsWith(VIEWER_MILESTONE_PREFIX)) {
+      continue;
+    }
+
+    const name = entry.name
+      .slice(VIEWER_MILESTONE_PREFIX.length)
+      .replace(/[^a-zA-Z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .toLowerCase();
+    if (!name) {
+      continue;
+    }
+
+    const startTime = Number(entry.startTime);
+    if (!Number.isFinite(startTime)) {
+      continue;
+    }
+
+    milestones[name] ??= Math.round(startTime);
+  }
+
+  return milestones;
+}
+
 export function withTiming(result, started, ended) {
   if (!result) {
     return result;

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -22,6 +22,7 @@ import {
   classifyPerformanceResource,
   refinePerformanceResourceKind,
   summarizePerformanceResources,
+  summarizeViewerMilestones,
   withTiming,
 } from "./hosted-render-smoke-performance.mjs";
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
@@ -107,6 +108,7 @@ let viewerCssCheck = null;
 let runtimeWasmHintCheck = null;
 let screenshotSaved = false;
 let pageTextMatches = {};
+let viewerMilestones = {};
 let themeModeChecks = [];
 const siftLoadMilestoneMatches = {};
 const smokeStartedAt = performance.now();
@@ -369,6 +371,7 @@ async function main() {
       .locator(".cloud-presence")
       .textContent({ timeout: 1_000 })
       .catch(() => null);
+    viewerMilestones = summarizeViewerMilestones(await collectViewerLoadMarks(page));
 
     if (requireSiftWasm && siftWasmRequests.length === 0) {
       failures.push({ kind: "sift-wasm", text: "Sift WASM was not requested" });
@@ -492,6 +495,7 @@ async function main() {
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
           timings_ms: timingsMs,
+          viewer_milestones_ms: viewerMilestones,
           performanceDiagnostics: summarizePerformanceResources(performanceResources, timingsMs),
           catalogApiCheck,
           viewerCssCheck,
@@ -789,6 +793,15 @@ async function collectRuntimeWasmHints(page) {
       type: link.getAttribute("type") ?? "",
       crossorigin: link.getAttribute("crossorigin"),
       crossOrigin: link.crossOrigin,
+    })),
+  );
+}
+
+async function collectViewerLoadMarks(page) {
+  return page.evaluate(() =>
+    performance.getEntriesByType("mark").map((entry) => ({
+      name: entry.name,
+      startTime: entry.startTime,
     })),
   );
 }

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -5,6 +5,7 @@ import {
   classifyPerformanceResource,
   refinePerformanceResourceKind,
   summarizePerformanceResources,
+  summarizeViewerMilestones,
   withTiming,
 } from "../scripts/hosted-render-smoke-performance.mjs";
 
@@ -193,5 +194,21 @@ describe("hosted smoke performance diagnostics", () => {
       status: 200,
       timing_ms: { start: 10, end: 20, duration: 10 },
     });
+  });
+
+  it("summarizes viewer load marks by milestone name", () => {
+    assert.deepEqual(
+      summarizeViewerMilestones([
+        { name: "nteract:notebook-cloud:viewer-start", startTime: 3.4 },
+        { name: "nteract:notebook-cloud:live-room-ready", startTime: 24.6 },
+        { name: "nteract:notebook-cloud:live-room-ready", startTime: 99 },
+        { name: "other:mark", startTime: 12 },
+        { name: "nteract:notebook-cloud:snapshot-ready", startTime: Number.NaN },
+      ]),
+      {
+        viewer_start: 3,
+        live_room_ready: 25,
+      },
+    );
   });
 });

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -78,6 +78,7 @@ import {
   type CloudLivePresenceSnapshot,
 } from "./live-presence";
 import { cloudViewerLoadingPolicy } from "./loading-policy";
+import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
   cloudViewerPresenceDisplay,
@@ -649,6 +650,10 @@ function NotebookViewer({
   );
 
   useEffect(() => {
+    markCloudViewerLoadMilestone("viewer-start");
+  }, []);
+
+  useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
 
@@ -763,6 +768,7 @@ function NotebookViewer({
             shouldContinue: () => !cancelled && !liveMaterializedRef.current,
             onInitialCells(syncCells) {
               if (syncCells.length === 0) return;
+              markCloudViewerLoadMilestone("snapshot-initial-cells");
               setCells(syncCells);
               setStatus({
                 kind: "loading",
@@ -795,6 +801,7 @@ function NotebookViewer({
           kind: "ready",
           message: `Rendering ${resolvedCells.length} cells from pinned Automerge snapshots.`,
         });
+        markCloudViewerLoadMilestone("snapshot-ready");
       } catch (error) {
         if (!cancelled) {
           snapshotResolvedRef.current = true;
@@ -888,6 +895,7 @@ function NotebookViewer({
           onInitialCells(syncCells) {
             if (syncCells.length === 0) return;
             liveMaterializedRef.current = true;
+            markCloudViewerLoadMilestone("live-initial-cells");
             preloadSiftWasm(syncCells);
             setCells(syncCells);
             setStatus({
@@ -921,6 +929,9 @@ function NotebookViewer({
               message: `Rendering ${resolvedCells.length} cells from the live notebook room.`,
             },
       );
+      if (resolvedCells.length > 0) {
+        markCloudViewerLoadMilestone("live-ready");
+      }
     };
 
     const materializeLiveCellsSafely = (liveRuntime: CloudSyncRuntime) => {
@@ -952,6 +963,7 @@ function NotebookViewer({
           setPresence((state) => reduceCloudViewerPresenceMessage(state, message));
         }
         if (message.type === "cloud_room_ready") {
+          markCloudViewerLoadMilestone("live-room-ready");
           setConnectionError(null);
           setConnectionScope(message.connection_scope);
           setConnectionActorLabel(message.actor_label);

--- a/apps/notebook-cloud/viewer/load-milestones.ts
+++ b/apps/notebook-cloud/viewer/load-milestones.ts
@@ -1,0 +1,26 @@
+const CLOUD_VIEWER_MILESTONE_PREFIX = "nteract:notebook-cloud:";
+
+export type CloudViewerLoadMilestone =
+  | "viewer-start"
+  | "snapshot-initial-cells"
+  | "snapshot-ready"
+  | "live-room-ready"
+  | "live-initial-cells"
+  | "live-ready";
+
+export function markCloudViewerLoadMilestone(name: CloudViewerLoadMilestone): void {
+  if (typeof performance === "undefined" || typeof performance.mark !== "function") {
+    return;
+  }
+
+  try {
+    performance.mark(cloudViewerLoadMilestoneName(name));
+  } catch {
+    // Performance marks are diagnostic only; never let browser support or quota
+    // issues affect notebook rendering.
+  }
+}
+
+export function cloudViewerLoadMilestoneName(name: CloudViewerLoadMilestone): string {
+  return `${CLOUD_VIEWER_MILESTONE_PREFIX}${name}`;
+}


### PR DESCRIPTION
## Summary

- Adds diagnostic-only viewer performance marks for snapshot and live-room load milestones.
- Teaches the hosted render smoke to collect those browser marks as `viewer_milestones_ms`.
- Covers milestone summarization in the hosted smoke performance tests.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-performance.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

- This avoids schema, snapshot, and runtime-doc storage changes while the data-loss bug is being handled separately.
- PR should stay draft until reviewer and CI are clear.
