### PR TITLE
docs(elements): catalog widget binary media surface

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "90+",
+    value: "95+",
     detail:
-      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, isolated output policy, plugin renderer, editor, widget controls, widget media, widget output, ipycanvas, and anywidget surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, isolated output policy, plugin renderer, editor, widget controls, widget media, hydrated widget buffers, widget output, ipycanvas, and anywidget surfaces",
   },
 ];
 
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, the current built-in controls registry, form, selection, numeric, status, media, file upload, OutputModel, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -29,6 +29,21 @@ type FixtureModel = {
   bufferPaths?: string[][];
 };
 
+const binaryImageSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 96">
+  <rect width="220" height="96" rx="12" fill="#f0fdf4"/>
+  <rect x="18" y="18" width="58" height="60" rx="8" fill="#10b981"/>
+  <circle cx="126" cy="48" r="28" fill="#0ea5e9"/>
+  <path d="M158 70 L194 28" stroke="#111827" stroke-width="8" stroke-linecap="round"/>
+  <text x="18" y="88" font-family="ui-sans-serif, system-ui" font-size="12" font-weight="700" fill="#111827">DataView ImageModel</text>
+</svg>`;
+
+function textDataView(value: string): DataView {
+  const bytes = new TextEncoder().encode(value);
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return new DataView(copy.buffer);
+}
+
 const anyWidgetEsm = `
 export default {
   render({ model, el }) {
@@ -180,6 +195,19 @@ const fixtureModels: FixtureModel[] = [
     },
   },
   {
+    id: "widget-binary-image",
+    state: {
+      _model_name: "ImageModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "binary image",
+      value: textDataView(binaryImageSvg),
+      format: "svg+xml",
+      width: "220",
+      height: "96",
+    },
+    bufferPaths: [["value"]],
+  },
+  {
     id: "widget-audio",
     state: {
       _model_name: "AudioModel",
@@ -287,6 +315,7 @@ const fixtureModels: FixtureModel[] = [
       _model_module: "@jupyter-widgets/controls",
       children: [
         "IPY_MODEL_widget-image",
+        "IPY_MODEL_widget-binary-image",
         "IPY_MODEL_widget-audio",
         "IPY_MODEL_widget-video",
         "IPY_MODEL_widget-file-upload",
@@ -706,7 +735,7 @@ const renderedWidgets = [
   {
     name: "Media widgets",
     source: "src/components/widgets/controls/{image-widget,audio-widget,video-widget}.tsx",
-    role: "Image, audio, and video widgets render through buildMediaSrc with static data URLs instead of kernel-provided buffers.",
+    role: "Image, audio, and video widgets render through buildMediaSrc with static data URLs and a hydrated DataView ImageModel fixture.",
   },
   {
     name: "FileUploadWidget",
@@ -755,7 +784,7 @@ const adapterBoundaries = [
   {
     title: "Binary buffers",
     icon: FileJson,
-    body: "Media widgets render from static data URLs here; ipycanvas replays a local DataView command buffer, while live kernel bufferPaths and blob hydration remain adapter concerns.",
+    body: "Media widgets now cover a hydrated DataView value and ipycanvas replays a local DataView command buffer; live kernel bufferPaths, blob URL fetching, and sync hydration remain adapter concerns.",
   },
   {
     title: "Anywidget ESM",
@@ -1063,7 +1092,8 @@ export function WidgetSurfacesExample() {
                 <h3 className="text-sm font-semibold">Media and captured output widgets</h3>
                 <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                   Image, audio, video, file upload, and OutputModel fixtures render through
-                  WidgetView with saved comm state and static payloads.
+                  WidgetView with saved comm state, static payloads, and a hydrated DataView image
+                  value.
                 </p>
               </div>
               <div className="space-y-4">
@@ -1157,7 +1187,7 @@ export function WidgetSurfacesExample() {
           <div>
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-              The remaining widget catalog work is narrower now: binary buffer hydration, live
+              The remaining widget catalog work is narrower now: live blob URL hydration,
               ControllerModel Gamepad polling, output-widget nesting, richer ipycanvas image
               buffers, and remote anywidget ESM/CSS URLs need explicit iframe/runtime adapters
               before they can render here.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -14,7 +14,10 @@ The catalog now includes saved-state fixtures for control widgets, media
 widgets, `FileUploadModel`, `OutputModel`, layout containers, play controls, and
 controller sub-controls. It also renders `CanvasModel` through the ipycanvas
 path with a local binary command buffer routed by the CanvasManager adapter, and
-an `AnyModel` fixture through `AnyWidgetView` with inline `_esm` and `_css`.
+an `AnyModel` fixture through `AnyWidgetView` with inline `_esm` and `_css`. The
+media section includes an `ImageModel` whose `value` is a hydrated `DataView`, so
+the same `buildMediaSrc` binary path used by ipywidgets media traitlets is visible
+in the catalog.
 
 <WidgetSurfacesExample />
 
@@ -23,7 +26,7 @@ an `AnyModel` fixture through `AnyWidgetView` with inline `_esm` and `_css`.
 The live notebook receives widget state from `RuntimeStateDoc` through
 `SyncEngine.commChanges$`, then forwards it to isolated output frames over the
 comm bridge. The catalog keeps those host responsibilities outside the rendered
-component examples. Browser APIs, blob/DataView conversion, nested
-output-widget routing, live controller/gamepad input, richer ipycanvas image
-buffers, remote anywidget ESM/CSS URLs, and generated WASM handoffs remain
-explicit adapter boundaries for later catalog slices.
+component examples. Browser APIs, live blob URL fetching, nested output-widget
+routing, live controller/gamepad input, richer ipycanvas image buffers, remote
+anywidget ESM/CSS URLs, and generated WASM handoffs remain explicit adapter
+boundaries for later catalog slices.


### PR DESCRIPTION
## Summary

- Adds a hydrated `DataView` `ImageModel` fixture to the elements widget surfaces catalog.
- Exercises the production `ImageWidget` and `buildMediaSrc` binary media path without runtime sync, blob fetching, or a live kernel.
- Updates the widget docs and burn-down to mark hydrated widget buffers as covered while keeping live blob URL hydration as an adapter boundary.

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Playwright route check for `/docs/widget-surfaces`:
  - found `data-widget-id="widget-binary-image"`
  - verified the rendered image source starts with `data:image/svg+xml;base64,`
  - verified non-zero natural and rendered dimensions
  - verified no mobile horizontal overflow at 390px
