### PR TITLE
docs(elements): catalog widget output handoff

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -18,9 +18,9 @@ const stats = [
   { label: "component forks", value: "0", detail: "current sources stay canonical" },
   {
     label: "current imports",
-    value: "95+",
+    value: "100+",
     detail:
-      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, isolated output policy, plugin renderer, editor, widget controls, widget media, hydrated widget buffers, widget output, ipycanvas, and anywidget surfaces",
+      "used shell toolbar, notebook rail, package headers, search, full cells, read-only cells, cell gutter, cell presence, runtime dialogs and banners, theme, output area, isolated output policy, widget-view MIME handoff, plugin renderer, editor, widget controls, widget media, hydrated widget buffers, widget output, ipycanvas, and anywidget surfaces",
   },
 ];
 
@@ -138,7 +138,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, top-level widget-view MIME handoff, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, nested OutputModel widgets, third-party renderer loading, live widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
   },
   {
     family: "Output isolation",

--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -9,6 +9,9 @@ import {
   useState,
   type CSSProperties,
 } from "react";
+import { WidgetView } from "@/components/widgets/widget-view";
+import { useWidgetStore } from "@/components/widgets/widget-store-context";
+import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import {
   anyOutputNeedsIsolation,
   hasWidgetOutputs,
@@ -118,9 +121,45 @@ function stringifyPayloadData(data: unknown): string {
 }
 
 function outputLabel(payload: RenderPayload): string {
+  if (payload.mimeType === WIDGET_VIEW_MIME) return "widget view adapter";
   if (payload.mimeType === "text/markdown") return "markdown preview adapter";
   if (payload.mimeType === "text/plain") return "text output adapter";
   return payload.mimeType;
+}
+
+function WidgetPayloadPreview({ payload }: { payload: RenderPayload }) {
+  const widgetContext = useWidgetStore();
+  const modelId = parseWidgetViewModelId(payload.data);
+
+  if (!modelId || widgetContext === null) {
+    return (
+      <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-fd-foreground">
+        {stringifyPayloadData(payload.data)}
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-md border border-fd-border bg-fd-background p-3"
+      data-elements-widget-frame-adapter="true"
+      data-widget-model-id={modelId}
+    >
+      <WidgetView modelId={modelId} />
+    </div>
+  );
+}
+
+function PayloadPreview({ payload }: { payload: RenderPayload }) {
+  if (payload.mimeType === WIDGET_VIEW_MIME) {
+    return <WidgetPayloadPreview payload={payload} />;
+  }
+
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-fd-foreground">
+      {stringifyPayloadData(payload.data)}
+    </pre>
+  );
 }
 
 export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>(
@@ -211,9 +250,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
             <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-fd-muted-foreground">
               {outputLabel(payload)}
             </div>
-            <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5 text-fd-foreground">
-              {stringifyPayloadData(payload.data)}
-            </pre>
+            <PayloadPreview payload={payload} />
           </div>
         ))}
       </div>

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -10,10 +10,11 @@ import {
   FileText,
   FileWarning,
   ListFilter,
+  SlidersHorizontal,
   Table2,
   Terminal,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { AudioOutput } from "@/components/outputs/audio-output";
 import { ImageOutput } from "@/components/outputs/image-output";
@@ -30,6 +31,10 @@ import { TracebackOutput } from "@/components/outputs/traceback-output";
 import { VegaOutput } from "@/components/outputs/vega-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
+import "@/components/widgets/controls";
+import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
+import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
+import { WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 
 const svgFigure = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
   <rect width="420" height="180" rx="16" fill="#f8fafc"/>
@@ -628,6 +633,79 @@ const outputAreaFixtures: JupyterOutput[] = [
   },
 ];
 
+const widgetOutputModels = [
+  {
+    id: "output-widget-summary",
+    state: {
+      _model_name: "HTMLModel",
+      _model_module: "@jupyter-widgets/controls",
+      value: "<strong>Widget output</strong> <span>rendered through OutputArea</span>",
+    },
+  },
+  {
+    id: "output-widget-threshold",
+    state: {
+      _model_name: "IntSliderModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "threshold",
+      value: 42,
+      min: 0,
+      max: 100,
+      step: 1,
+      readout: true,
+      orientation: "horizontal",
+      disabled: false,
+    },
+  },
+  {
+    id: "output-widget-progress-style",
+    state: {
+      _model_name: "ProgressStyleModel",
+      _model_module: "@jupyter-widgets/controls",
+      bar_color: "#10b981",
+    },
+  },
+  {
+    id: "output-widget-progress",
+    state: {
+      _model_name: "IntProgressModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "complete",
+      value: 68,
+      min: 0,
+      max: 100,
+      bar_style: "success",
+      orientation: "horizontal",
+      style: "IPY_MODEL_output-widget-progress-style",
+    },
+  },
+  {
+    id: "output-widget-panel",
+    state: {
+      _model_name: "VBoxModel",
+      _model_module: "@jupyter-widgets/controls",
+      children: [
+        "IPY_MODEL_output-widget-summary",
+        "IPY_MODEL_output-widget-threshold",
+        "IPY_MODEL_output-widget-progress",
+      ],
+      box_style: "success",
+    },
+  },
+];
+
+const widgetOutputFixtures: JupyterOutput[] = [
+  {
+    output_id: "output-area-widget-view",
+    output_type: "display_data",
+    data: {
+      [WIDGET_VIEW_MIME]: { model_id: "output-widget-panel" },
+      "text/plain": "VBox(children=(HTML(), IntSlider(), IntProgress()))",
+    },
+    metadata: {},
+  },
+];
+
 const mimeFixtures = [
   {
     label: "Rich traceback beats text",
@@ -651,6 +729,13 @@ const mimeFixtures = [
     },
   },
   {
+    label: "Widget view selects widget MIME",
+    data: {
+      [WIDGET_VIEW_MIME]: { model_id: "output-widget-panel" },
+      "text/plain": "VBox(children=...)",
+    },
+  },
+  {
     label: "Structured JSON stays inspectable",
     data: {
       "application/json": jsonFixture,
@@ -663,7 +748,7 @@ const renderedPieces = [
   {
     name: "OutputArea",
     source: "src/components/cell/OutputArea.tsx",
-    note: "Notebook output lane composition, collapse control, DOM-vs-isolated segmentation, and search count plumbing rendered with static outputs.",
+    note: "Notebook output lane composition, collapse control, DOM-vs-isolated segmentation, widget-view MIME handoff, and search count plumbing rendered with static outputs.",
   },
   {
     name: "AnsiStreamOutput",
@@ -746,12 +831,12 @@ const adapterBoundaries = [
   {
     name: "IsolatedFrame",
     reason:
-      "Required in production for HTML, markdown with raw HTML, executable JavaScript, and renderer library bootstrap. This page uses deterministic fixture globals for visible Plotly, Vega, and GeoJSON component paths.",
+      "Required in production for HTML, markdown with raw HTML, executable JavaScript, widget bridge bootstrap, and renderer library bootstrap. This page uses deterministic fixture globals and a docs widget adapter for visible component paths.",
   },
   {
-    name: "Widget output",
+    name: "Nested widget output",
     reason:
-      "Needs fixture-backed WidgetStore and saved widget state before controls can be shown without kernel comm state.",
+      "Top-level widget-view MIME now renders through OutputArea with fixture comm state. Widget views nested inside OutputModel outputs still use the current unsupported nested-widget guard until that production path exists.",
   },
   {
     name: "Generated Sift WASM decode",
@@ -790,6 +875,52 @@ function RendererCard({
       <div className="p-4">{children}</div>
     </section>
   );
+}
+
+function seedOutputWidgetStore(store: WidgetStore) {
+  for (const model of widgetOutputModels) {
+    store.createModel(model.id, model.state);
+  }
+}
+
+function OutputWidgetFixtureProvider({ children }: { children: ReactNode }) {
+  const storeRef = useRef<WidgetStore | null>(null);
+  if (!storeRef.current) {
+    storeRef.current = createWidgetStore();
+  }
+  const store = storeRef.current;
+
+  useEffect(() => {
+    seedOutputWidgetStore(store);
+  }, [store]);
+
+  const sendUpdate = useCallback(
+    async (commId: string, state: Record<string, unknown>) => {
+      store.updateModel(commId, state);
+    },
+    [store],
+  );
+
+  const sendCustom = useCallback(() => {}, []);
+
+  const closeComm = useCallback(
+    (commId: string) => {
+      store.deleteModel(commId);
+    },
+    [store],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      store,
+      sendUpdate,
+      sendCustom,
+      closeComm,
+    }),
+    [closeComm, sendCustom, sendUpdate, store],
+  );
+
+  return <WidgetStoreContext.Provider value={contextValue}>{children}</WidgetStoreContext.Provider>;
 }
 
 export function OutputRenderersExample() {
@@ -988,6 +1119,39 @@ export function OutputRenderersExample() {
         icon={FileWarning}
       >
         <TracebackOutput data={tracebackFixture} />
+      </RendererCard>
+
+      <RendererCard
+        title="Widget display output"
+        source="apps/notebook/src/App.tsx + src/components/cell/OutputArea.tsx"
+        icon={SlidersHorizontal}
+      >
+        <OutputWidgetFixtureProvider>
+          <div className="space-y-3" data-testid="output-widget-view-surface">
+            <div className="rounded-md border border-fd-border bg-fd-background p-3">
+              <div className="text-xs font-medium text-fd-muted-foreground">
+                application/vnd.jupyter.widget-view+json
+              </div>
+              <div className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+                The docs isolated-frame adapter receives the same payload shape that OutputArea
+                sends to the production renderer frame, then resolves the model from a local
+                WidgetStore fixture.
+              </div>
+            </div>
+            <div className="rounded-md border border-fd-border bg-background py-3">
+              <OutputArea
+                outputs={widgetOutputFixtures}
+                cellId="elements-widget-output"
+                executionCount={18}
+                hostContext={{
+                  nteract: {
+                    colorTheme: "classic",
+                  },
+                }}
+              />
+            </div>
+          </div>
+        </OutputWidgetFixtureProvider>
       </RendererCard>
 
       <RendererCard title="Sift table renderer" source="packages/sift/src/react.tsx" icon={Table2}>

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -19,12 +19,15 @@ The rendered surfaces import current output components directly: `OutputArea`
 lane composition, ANSI streams and errors, JSON trees, image output, math
 output, SVG output, audio output, the JavaScript isolation fallback, Plotly,
 Vega/Vega-Lite, GeoJSON, PDF, video, the structured traceback renderer, and
-`SiftTable` with static `TableData`. The plugin renderer examples use
-docs-local fixture globals for Plotly, `vegaEmbed`, and Leaflet, so they exercise
-the current nteract components without bundling third-party renderer libraries
-into the catalog. The Sift section also shows the HuggingFace parquet URL
-handoff the demo uses, then renders the decoded table fixture so the docs app
-stays runtime-free. The MIME selection table uses the same priority helper the
+`SiftTable` with static `TableData`. The page also renders top-level
+`application/vnd.jupyter.widget-view+json` output through `OutputArea` with a
+fixture-backed `WidgetStore`, matching the notebook app's widget MIME handoff
+without booting a live comm bridge. The plugin renderer examples use docs-local
+fixture globals for Plotly, `vegaEmbed`, and Leaflet, so they exercise the
+current nteract components without bundling third-party renderer libraries into
+the catalog. The Sift section also shows the HuggingFace parquet URL handoff the
+demo uses, then renders the decoded table fixture so the docs app stays
+runtime-free. The MIME selection table uses the same priority helper the
 notebook uses before rendering.
 
 ## What still needs an adapter
@@ -32,6 +35,7 @@ notebook uses before rendering.
 The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
 frame policy, host-context conversion, sizing, lane routing, and MCP structured
 output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
-live widget views, third-party renderer library loading, and generated Sift
-parquet/Arrow WASM decoding still need fixture-backed iframe, widget-store, or
-generated asset adapters before this docs app should own those runtime paths.
+widget views nested inside `OutputModel`, third-party renderer library loading,
+and generated Sift parquet/Arrow WASM decoding still need fixture-backed iframe,
+widget-store, or generated asset adapters before this docs app should own those
+runtime paths.


### PR DESCRIPTION
## Summary

- render top-level `application/vnd.jupyter.widget-view+json` output on the output renderer catalog page
- teach the docs-local isolated-frame adapter to resolve widget-view payloads through `WidgetView` when a fixture `WidgetStoreContext` is present
- update the output renderer docs and burn-down so top-level widget output is cataloged, while nested `OutputModel` widget views remain an explicit adapter boundary

## Verification

- `pnpm --dir apps/elements build`
- Playwright render check for `/docs/output-renderers` at 1440px and 390px
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
