### PR TITLE
docs(elements): catalog nested output widgets

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -138,7 +138,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, top-level widget-view MIME handoff, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, nested OutputModel widgets, third-party renderer loading, live widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, live widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
   },
   {
     family: "Output isolation",
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -834,9 +834,9 @@ const adapterBoundaries = [
       "Required in production for HTML, markdown with raw HTML, executable JavaScript, widget bridge bootstrap, and renderer library bootstrap. This page uses deterministic fixture globals and a docs widget adapter for visible component paths.",
   },
   {
-    name: "Nested widget output",
+    name: "Output widget comm replay",
     reason:
-      "Top-level widget-view MIME now renders through OutputArea with fixture comm state. Widget views nested inside OutputModel outputs still use the current unsupported nested-widget guard until that production path exists.",
+      "Top-level widget-view MIME renders through OutputArea with fixture comm state. The widget catalog also covers OutputModel nested widget-view routing through MediaProvider; live comm replay remains outside this runtime-free page.",
   },
   {
     name: "Generated Sift WASM decode",

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -10,6 +10,8 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { MediaProvider } from "@/components/outputs/media-provider";
+import type { CustomRenderer } from "@/components/outputs/media-router";
 import { Button } from "@/components/ui/button";
 import "@/components/widgets/controls";
 import "@/components/widgets/ipycanvas";
@@ -22,6 +24,7 @@ import {
 } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 import { WidgetView } from "@/components/widgets/widget-view";
+import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 
 type FixtureModel = {
   id: string;
@@ -282,7 +285,30 @@ const fixtureModels: FixtureModel[] = [
             "application/json": { collapsed: 1 },
           },
         },
+        {
+          output_type: "display_data",
+          data: {
+            [WIDGET_VIEW_MIME]: { model_id: "widget-output-nested-threshold" },
+            "text/plain": "IntSlider(value=41)",
+          },
+          metadata: {},
+        },
       ],
+    },
+  },
+  {
+    id: "widget-output-nested-threshold",
+    state: {
+      _model_name: "IntSliderModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "nested threshold",
+      value: 41,
+      min: 0,
+      max: 100,
+      step: 1,
+      readout: true,
+      orientation: "horizontal",
+      disabled: false,
     },
   },
   {
@@ -745,7 +771,7 @@ const renderedWidgets = [
   {
     name: "OutputWidget",
     source: "src/components/widgets/controls/output-widget.tsx",
-    role: "Captured outputs flow through the widget OutputModel path and MediaRouter without a live comm channel.",
+    role: "Captured outputs flow through the widget OutputModel path and nested widget-view MIME resolves through MediaProvider without a live comm channel.",
   },
   {
     name: "ipycanvas widget",
@@ -991,28 +1017,40 @@ function WidgetFixtureProvider({ children }: { children: ReactNode }) {
     [closeComm, sendCustom, sendUpdate, store],
   );
 
+  const widgetRenderers = useMemo<Record<string, CustomRenderer>>(
+    () => ({
+      [WIDGET_VIEW_MIME]: ({ data }) => {
+        const modelId = parseWidgetViewModelId(data);
+        return modelId ? <WidgetView modelId={modelId} /> : null;
+      },
+    }),
+    [],
+  );
+
   return (
     <WidgetStoreContext.Provider value={contextValue}>
-      <div className="space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <WidgetInventory />
-          <Button size="sm" variant="outline" onClick={resetFixtures}>
-            Reset fixtures
-          </Button>
-        </div>
-        {children}
-        <div
-          className="rounded-lg border border-fd-border bg-fd-background p-3"
-          data-testid="widget-event-log"
-        >
-          <div className="text-xs font-medium uppercase text-fd-muted-foreground">Comm log</div>
-          <div className="mt-2 space-y-1 font-mono text-xs text-fd-muted-foreground">
-            {events.length > 0
-              ? events.map((event, index) => <div key={`${index}-${event}`}>{event}</div>)
-              : "idle"}
+      <MediaProvider renderers={widgetRenderers}>
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <WidgetInventory />
+            <Button size="sm" variant="outline" onClick={resetFixtures}>
+              Reset fixtures
+            </Button>
+          </div>
+          {children}
+          <div
+            className="rounded-lg border border-fd-border bg-fd-background p-3"
+            data-testid="widget-event-log"
+          >
+            <div className="text-xs font-medium uppercase text-fd-muted-foreground">Comm log</div>
+            <div className="mt-2 space-y-1 font-mono text-xs text-fd-muted-foreground">
+              {events.length > 0
+                ? events.map((event, index) => <div key={`${index}-${event}`}>{event}</div>)
+                : "idle"}
+            </div>
           </div>
         </div>
-      </div>
+      </MediaProvider>
     </WidgetStoreContext.Provider>
   );
 }
@@ -1092,8 +1130,8 @@ export function WidgetSurfacesExample() {
                 <h3 className="text-sm font-semibold">Media and captured output widgets</h3>
                 <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                   Image, audio, video, file upload, and OutputModel fixtures render through
-                  WidgetView with saved comm state, static payloads, and a hydrated DataView image
-                  value.
+                  WidgetView with saved comm state, static payloads, a hydrated DataView image
+                  value, and a nested widget-view MIME output.
                 </p>
               </div>
               <div className="space-y-4">
@@ -1188,8 +1226,8 @@ export function WidgetSurfacesExample() {
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               The remaining widget catalog work is narrower now: live blob URL hydration,
-              ControllerModel Gamepad polling, output-widget nesting, richer ipycanvas image
-              buffers, and remote anywidget ESM/CSS URLs need explicit iframe/runtime adapters
+              ControllerModel Gamepad polling, live output-widget comm replay, richer ipycanvas
+              image buffers, and remote anywidget ESM/CSS URLs need explicit iframe/runtime adapters
               before they can render here.
             </p>
           </div>

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -35,7 +35,7 @@ notebook uses before rendering.
 The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
 frame policy, host-context conversion, sizing, lane routing, and MCP structured
 output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
-widget views nested inside `OutputModel`, third-party renderer library loading,
-and generated Sift parquet/Arrow WASM decoding still need fixture-backed iframe,
+third-party renderer library loading, live output-widget comm replay, and
+generated Sift parquet/Arrow WASM decoding still need fixture-backed iframe,
 widget-store, or generated asset adapters before this docs app should own those
 runtime paths.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -17,7 +17,9 @@ path with a local binary command buffer routed by the CanvasManager adapter, and
 an `AnyModel` fixture through `AnyWidgetView` with inline `_esm` and `_css`. The
 media section includes an `ImageModel` whose `value` is a hydrated `DataView`, so
 the same `buildMediaSrc` binary path used by ipywidgets media traitlets is visible
-in the catalog.
+in the catalog. The `OutputModel` fixture also includes a nested
+`application/vnd.jupyter.widget-view+json` output, resolved by the same
+`MediaProvider` custom renderer shape used by the notebook app.
 
 <WidgetSurfacesExample />
 
@@ -26,7 +28,7 @@ in the catalog.
 The live notebook receives widget state from `RuntimeStateDoc` through
 `SyncEngine.commChanges$`, then forwards it to isolated output frames over the
 comm bridge. The catalog keeps those host responsibilities outside the rendered
-component examples. Browser APIs, live blob URL fetching, nested output-widget
-routing, live controller/gamepad input, richer ipycanvas image buffers, remote
-anywidget ESM/CSS URLs, and generated WASM handoffs remain explicit adapter
-boundaries for later catalog slices.
+component examples. Browser APIs, live blob URL fetching, live output-widget
+comm replay, live controller/gamepad input, richer ipycanvas image buffers,
+remote anywidget ESM/CSS URLs, and generated WASM handoffs remain explicit
+adapter boundaries for later catalog slices.


### PR DESCRIPTION
## Summary

- add a nested `application/vnd.jupyter.widget-view+json` fixture inside the widget `OutputModel`
- wrap the widget catalog fixture store in `MediaProvider` so nested widget MIME uses the same renderer shape as the notebook app
- update the widget/output docs and burn-down copy so nested `OutputModel` widget-view routing is no longer tracked as an unsupported catalog boundary

## Verification

- `pnpm --dir apps/elements build`
- Playwright check for `/docs/widget-surfaces` at 1440px and 390px:
  - nested `widget-output-nested-threshold` renders
  - unsupported nested-widget message is absent
  - horizontal overflow is `0`
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
