### PR TITLE
refactor(notebook-cloud): remove legacy runtime snapshot key

### DIFF
--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -173,10 +173,6 @@ export function runtimeStateSnapshotKey(runtimeStateDocId: string, headsHash: st
   return documentSnapshotKey(runtimeStateDocId, headsHash);
 }
 
-export function runtimeSnapshotKey(notebookId: string, headsHash: string): string {
-  return `n/${encodePathComponent(notebookId)}/snapshots/runtime-state/${encodePathComponent(headsHash)}.am`;
-}
-
 export function blobKey(notebookId: string, hash: string): string {
   return `n/${encodePathComponent(notebookId)}/blobs/${encodePathComponent(hash)}`;
 }


### PR DESCRIPTION
## Summary

- remove the unused `runtimeSnapshotKey(notebookId, headsHash)` helper
- leave `runtimeStateSnapshotKey(runtimeStateDocId, headsHash)` as the only runtime-state snapshot key builder
- eliminate the last notebook-nested runtime snapshot path helper from notebook-cloud storage code

## Stack

Targets `quod/notebook-cloud-remove-access-identity` / #3155.

Merge order:

1. #3151
2. #3155
3. this PR

## Notes

- No NotebookDoc / RuntimeStateDoc schema or storage materialization changes.
- No output iframe sandbox changes.
- This only removes dead code for the old `n/{notebookId}/snapshots/runtime-state/{heads}.am` layout.
- Kept draft because it depends on #3155, which remains draft until preview deployment verification is possible.

## Validation

- `rg -n "runtimeSnapshotKey\\(|n/.*/snapshots/runtime-state|runtime-state/" apps/notebook-cloud/src apps/notebook-cloud/test apps/notebook-cloud/scripts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/sharing-storage.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3157 --max-turns 120 --out .context/reviews/pr-3157.json`
- GitHub CI: green
