### PR TITLE
docs(elements): catalog anywidget asset urls

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -335,6 +335,18 @@ const fixtureModels: FixtureModel[] = [
     },
   },
   {
+    id: "widget-anywidget-url",
+    state: {
+      _model_name: "AnyModel",
+      _model_module: "anywidget",
+      _esm: "",
+      _css: "",
+      title: "AnyWidget URL fixture",
+      status: "static ESM and CSS URL loaded by AnyWidgetView",
+      value: 7,
+    },
+  },
+  {
     id: "widget-media-box",
     state: {
       _model_name: "GridBoxModel",
@@ -781,7 +793,7 @@ const renderedWidgets = [
   {
     name: "AnyWidgetView",
     source: "src/components/widgets/anywidget-view.tsx",
-    role: "Inline _esm and _css fixtures exercise the AFM model proxy, CSS injection, state save, and custom message bridge.",
+    role: "Inline and URL-backed _esm/_css fixtures exercise the AFM model proxy, CSS injection, state save, and custom message bridge.",
   },
   {
     name: "Layout containers",
@@ -815,7 +827,7 @@ const adapterBoundaries = [
   {
     title: "Anywidget ESM",
     icon: PackageOpen,
-    body: "Inline _esm and _css now mount through AnyWidgetView; remote URL loading, sandbox policy, and kernel-originated assets remain iframe/runtime adapter concerns.",
+    body: "Inline and URL-backed _esm/_css now mount through AnyWidgetView. Kernel-originated blob resolver URLs and sandbox policy remain iframe/runtime adapter concerns.",
   },
 ];
 
@@ -831,7 +843,15 @@ const savedPasswordModel = {
 
 function seedStore(store: WidgetStore) {
   for (const model of fixtureModels) {
-    store.createModel(model.id, model.state, model.bufferPaths);
+    const state =
+      model.id === "widget-anywidget-url"
+        ? {
+            ...model.state,
+            _esm: new URL("/fixtures/anywidget-url-fixture.js", window.location.origin).href,
+            _css: new URL("/fixtures/anywidget-url-fixture.css", window.location.origin).href,
+          }
+        : model.state;
+    store.createModel(model.id, state, model.bufferPaths);
   }
 }
 
@@ -934,6 +954,7 @@ function AnyWidgetFixture() {
   const sendCustomPayload = useCallback(() => {
     const buffer = new Uint8Array([4, 8, 15, 16]).buffer;
     store.emitCustomMessage("widget-anywidget", { kind: "docs-custom-payload" }, [buffer]);
+    store.emitCustomMessage("widget-anywidget-url", { kind: "docs-url-payload" }, [buffer]);
   }, [store]);
 
   useEffect(() => {
@@ -949,15 +970,23 @@ function AnyWidgetFixture() {
         <div>
           <h3 className="text-sm font-semibold">AnyWidget AFM fixture</h3>
           <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-            AnyModel renders through WidgetView and AnyWidgetView. The fixture uses inline ESM and
-            CSS to exercise model.get, model.set, save_changes, and msg:custom without a live comm.
+            AnyModel renders through WidgetView and AnyWidgetView. The fixtures exercise inline and
+            URL-backed ESM/CSS, model.get, model.set, save_changes, and msg:custom without a live
+            comm.
           </p>
         </div>
         <Button size="sm" variant="outline" onClick={sendCustomPayload}>
           Send custom payload
         </Button>
       </div>
-      <WidgetView modelId="widget-anywidget" />
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div data-testid="widget-anywidget-inline-surface">
+          <WidgetView modelId="widget-anywidget" />
+        </div>
+        <div data-testid="widget-anywidget-url-surface">
+          <WidgetView modelId="widget-anywidget-url" />
+        </div>
+      </div>
     </div>
   );
 }
@@ -1227,8 +1256,8 @@ export function WidgetSurfacesExample() {
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               The remaining widget catalog work is narrower now: live blob URL hydration,
               ControllerModel Gamepad polling, live output-widget comm replay, richer ipycanvas
-              image buffers, and remote anywidget ESM/CSS URLs need explicit iframe/runtime adapters
-              before they can render here.
+              image buffers, and kernel-originated anywidget asset URLs need explicit iframe/runtime
+              adapters before they can render here.
             </p>
           </div>
         </div>

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -14,10 +14,10 @@ The catalog now includes saved-state fixtures for control widgets, media
 widgets, `FileUploadModel`, `OutputModel`, layout containers, play controls, and
 controller sub-controls. It also renders `CanvasModel` through the ipycanvas
 path with a local binary command buffer routed by the CanvasManager adapter, and
-an `AnyModel` fixture through `AnyWidgetView` with inline `_esm` and `_css`. The
-media section includes an `ImageModel` whose `value` is a hydrated `DataView`, so
-the same `buildMediaSrc` binary path used by ipywidgets media traitlets is visible
-in the catalog. The `OutputModel` fixture also includes a nested
+`AnyModel` fixtures through `AnyWidgetView` with inline plus URL-backed `_esm`
+and `_css` assets. The media section includes an `ImageModel` whose `value` is a
+hydrated `DataView`, so the same `buildMediaSrc` binary path used by ipywidgets
+media traitlets is visible in the catalog. The `OutputModel` fixture also includes a nested
 `application/vnd.jupyter.widget-view+json` output, resolved by the same
 `MediaProvider` custom renderer shape used by the notebook app.
 
@@ -30,5 +30,5 @@ The live notebook receives widget state from `RuntimeStateDoc` through
 comm bridge. The catalog keeps those host responsibilities outside the rendered
 component examples. Browser APIs, live blob URL fetching, live output-widget
 comm replay, live controller/gamepad input, richer ipycanvas image buffers,
-remote anywidget ESM/CSS URLs, and generated WASM handoffs remain explicit
-adapter boundaries for later catalog slices.
+kernel-originated anywidget asset URLs, and generated WASM handoffs remain
+explicit adapter boundaries for later catalog slices.

--- a/apps/elements/public/fixtures/anywidget-url-fixture.css
+++ b/apps/elements/public/fixtures/anywidget-url-fixture.css
@@ -1,0 +1,58 @@
+.elements-anywidget-url-fixture {
+  display: grid;
+  gap: 12px;
+  border: 1px solid color-mix(in srgb, currentColor 14%, transparent);
+  border-radius: 8px;
+  padding: 14px;
+  background: color-mix(in srgb, canvas 92%, #10b981 8%);
+  color: canvastext;
+}
+
+.elements-anywidget-url-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.elements-anywidget-url-title {
+  font:
+    700 14px/1.3 ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+.elements-anywidget-url-badge {
+  border-radius: 999px;
+  padding: 3px 8px;
+  background: #047857;
+  color: white;
+  font:
+    700 11px/1 ui-sans-serif,
+    system-ui,
+    sans-serif;
+}
+
+.elements-anywidget-url-status,
+.elements-anywidget-url-custom {
+  color: color-mix(in srgb, currentColor 62%, transparent);
+  font:
+    500 12px/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.elements-anywidget-url-meter {
+  overflow: hidden;
+  height: 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.elements-anywidget-url-meter-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: #0ea5e9;
+  transition: width 160ms ease;
+}

--- a/apps/elements/public/fixtures/anywidget-url-fixture.js
+++ b/apps/elements/public/fixtures/anywidget-url-fixture.js
@@ -1,0 +1,54 @@
+export default {
+  render({ model, el }) {
+    el.classList.add("elements-anywidget-url-fixture");
+
+    const header = document.createElement("div");
+    header.className = "elements-anywidget-url-header";
+
+    const title = document.createElement("div");
+    title.className = "elements-anywidget-url-title";
+    title.textContent = String(model.get("title") || "URL-backed AnyWidget");
+
+    const badge = document.createElement("div");
+    badge.className = "elements-anywidget-url-badge";
+    badge.textContent = "url asset";
+
+    header.append(title, badge);
+
+    const status = document.createElement("div");
+    status.className = "elements-anywidget-url-status";
+    status.textContent = String(model.get("status") || "loaded");
+
+    const meter = document.createElement("div");
+    meter.className = "elements-anywidget-url-meter";
+    const meterFill = document.createElement("div");
+    meterFill.className = "elements-anywidget-url-meter-fill";
+    meter.append(meterFill);
+
+    const custom = document.createElement("div");
+    custom.className = "elements-anywidget-url-custom";
+    custom.textContent = "waiting for URL-backed custom message";
+
+    el.append(header, status, meter, custom);
+
+    const update = () => {
+      const value = Number(model.get("value") || 0);
+      meterFill.style.width = Math.min(100, value * 10) + "%";
+    };
+
+    const onCustom = (content, buffers) => {
+      const kind = content && typeof content.kind === "string" ? content.kind : "message";
+      custom.textContent = kind + " with " + (buffers ? buffers.length : 0) + " buffer(s)";
+    };
+
+    model.on("change:value", update);
+    model.on("msg:custom", onCustom);
+    update();
+
+    return () => {
+      model.off("change:value", update);
+      model.off("msg:custom", onCustom);
+      el.replaceChildren();
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- add static docs ESM/CSS fixtures for URL-backed anywidget assets
- seed a second `AnyModel` fixture whose `_esm` and `_css` values resolve to those docs asset URLs
- update the widget surfaces copy and burn-down so `AnyWidgetView` now covers inline and URL-backed asset loading

## Verification

- `pnpm --dir apps/elements build`
- Playwright check for `/docs/widget-surfaces` at 1440px and 390px:
  - URL-backed anywidget renders
  - URL-backed CSS is injected through a `<link rel="stylesheet">`
  - inline anywidget still renders
  - horizontal overflow is `0`
- Playwright custom-message check for the URL-backed anywidget
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
