### PR TITLE
perf(notebook-cloud): preload viewer entry module

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1828,11 +1828,13 @@ function viewerShell(
 }
 
 function viewerResourceHints(config: ViewerShellConfig | null): string {
+  const viewerEntryHint = `<link rel="modulepreload" href="/assets/notebook-cloud-viewer.js" />`;
   if (!config) {
-    return "";
+    return viewerEntryHint;
   }
 
   return [
+    viewerEntryHint,
     `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
     `<link rel="preload" href="${escapeHtml(
       config.runtimedWasmPath,

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -59,6 +59,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/runtimed_wasm\.js" crossorigin/);
     assert.match(
       html,
@@ -70,13 +71,23 @@ describe("HTML script serialization", () => {
     );
     assert.ok(
       html.indexOf(viewerThemeBootstrapScript()) <
+        html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"'),
+      "theme bootstrap must run before viewer bundle hints so first paint stays theme-safe",
+    );
+    assert.ok(
+      html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"') <
         html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"'),
-      "theme bootstrap must run before runtime WASM hints so first paint stays theme-safe",
+      "viewer bundle modulepreload should be discoverable before runtime WASM hints",
     );
     assert.ok(
       html.indexOf('rel="modulepreload" href="/assets/runtimed_wasm.js"') <
         html.indexOf("/assets/notebook-cloud-viewer.css"),
       "runtime WASM modulepreload should be discoverable before the render-blocking stylesheet",
+    );
+    assert.ok(
+      html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"') <
+        html.indexOf("/assets/notebook-cloud-viewer.css"),
+      "viewer bundle modulepreload should be discoverable before the render-blocking stylesheet",
     );
     assert.doesNotMatch(html, /"renderEndpoint"/);
     assert.match(html, /"catalogEndpoint":"\/api\/n\/demo"/);
@@ -127,6 +138,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /nteract cloud notebooks/);
     assert.match(html, /id="nteract-cloud-auth-config"/);
     assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
     assert.doesNotMatch(html, /rel="modulepreload" href="[^"]*runtimed_wasm\.js/);
     assert.doesNotMatch(html, /rel="preload" href="[^"]*runtimed_wasm_bg\.wasm/);
     assert.doesNotMatch(html, /In the Loop - Collaborative Notebooks/);


### PR DESCRIPTION
## Summary

- preloads the notebook-cloud viewer entry module from the HTML head
- keeps the theme bootstrap first, then exposes viewer/WASM hints before the render-blocking stylesheet
- adds HTML coverage for notebook pages and the sign-in shell

## Stack

Merge order:

1. #3151
2. #3155
3. #3157
4. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- This slice is intentionally schema-neutral while the NotebookDoc / RuntimeStateDoc data-loss bug is being handled separately.
- It remains draft until preview.runt.run deployment verification is possible; local Wrangler auth currently fails with `Invalid access token [code: 9109]`.
