### PR TITLE
fix(notebook-cloud): shorten presence fallback labels

### DIFF
--- a/apps/notebook-cloud/src/display-label.ts
+++ b/apps/notebook-cloud/src/display-label.ts
@@ -1,0 +1,66 @@
+export interface IdentityDisplayLabelInput {
+  displayName?: string | null;
+  email?: string | null;
+  principal: string;
+}
+
+export function identityDisplayLabel(input: IdentityDisplayLabelInput): string {
+  const displayName = input.displayName?.trim();
+  if (displayName) return displayName;
+
+  const email = input.email?.trim();
+  if (email) return email;
+
+  return compactPrincipalLabel(input.principal);
+}
+
+export function compactPrincipalLabel(value: string): string {
+  const principal = value.split("/")[0]?.trim() || value.trim();
+  if (!principal) return "User";
+  if (principal.startsWith("anonymous:")) return "Anonymous";
+
+  const userMatch = principal.match(/^user:([^:]+):(.+)$/);
+  if (!userMatch) return principal;
+
+  const namespace = safeDecode(userMatch[1] ?? "");
+  const subject = safeDecode(userMatch[2] ?? "").trim();
+  if (!subject) return providerUserLabel(namespace);
+  if (looksLikeEmail(subject)) return subject;
+  if (namespace === "dev") return subject;
+
+  return `${providerUserLabel(namespace)} ${shortSubject(subject)}`;
+}
+
+function providerUserLabel(namespace: string): string {
+  switch (namespace) {
+    case "anaconda":
+      return "Anaconda user";
+    case "oidc":
+      return "OIDC user";
+    default:
+      return `${titleCase(namespace)} user`;
+  }
+}
+
+function shortSubject(subject: string): string {
+  const normalized = subject.replace(/[^A-Za-z0-9._-]+/g, "").trim();
+  return (normalized || subject).slice(0, 8);
+}
+
+function looksLikeEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function titleCase(value: string): string {
+  const normalized = value.replace(/[-_]+/g, " ").trim();
+  if (!normalized) return "User";
+  return normalized.replace(/\b\w/g, (match) => match.toUpperCase());
+}

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1,4 +1,5 @@
 import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
+import { identityDisplayLabel } from "./display-label.ts";
 import {
   allowsBlobUpload,
   isAnonymousViewer,
@@ -711,9 +712,11 @@ export function rewritePresenceFrame(
 }
 
 export function presencePeerLabel(identity: AuthenticatedConnection): string {
-  return (
-    identity.metadata.displayName?.trim() || identity.metadata.email?.trim() || identity.principal
-  );
+  return identityDisplayLabel({
+    displayName: identity.metadata.displayName,
+    email: identity.metadata.email,
+    principal: identity.principal,
+  });
 }
 
 function notebookIdFromPath(pathname: string): string | undefined {

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -124,10 +124,7 @@ describe("cloud live sync", () => {
       "alice@example.com",
     );
     const { display_name: _displayName, email: _email, ...actorOnlyReady } = ready;
-    assert.equal(
-      cloudRoomReadyPeerLabel(actorOnlyReady),
-      "user:anaconda:uuid-123/browser:session-1",
-    );
+    assert.equal(cloudRoomReadyPeerLabel(actorOnlyReady), "Anaconda user uuid-123");
   });
 
   it("does not expose PoolDoc sync from the cloud viewer adapter", () => {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -86,7 +86,23 @@ describe("NotebookRoom presence rewrite", () => {
 
     assert.equal(presencePeerLabel(baseIdentity), "alice");
     assert.equal(presencePeerLabel(withoutDisplayName), "alice@example.com");
-    assert.equal(presencePeerLabel(withoutFriendlyMetadata), "user:dev:alice");
+    assert.equal(presencePeerLabel(withoutFriendlyMetadata), "alice");
+  });
+
+  it("keeps rewritten Anaconda presence labels human-scale when metadata is missing", () => {
+    const identity = {
+      ...authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=editor"),
+      ),
+      principal: "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      metadata: {
+        provider: "oidc" as const,
+        transport: "oidc-bearer" as const,
+        principalNamespace: "user:anaconda",
+      },
+    };
+
+    assert.equal(presencePeerLabel(identity), "Anaconda user fe0f6c3a");
   });
 
   it("falls back to the authenticated operator for invalid presented actor labels", async () => {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -7,6 +7,7 @@ import {
   type SyncableHandle,
 } from "runtimed";
 import { isConnectionScope, type ConnectionScope } from "../src/auth-shared";
+import { identityDisplayLabel } from "../src/display-label";
 import { FrameType, type SessionControlMessage } from "../src/protocol";
 import {
   cloudPrototypeAuthFromWindow,
@@ -409,7 +410,11 @@ export function cloudRoomReadyPeerLabel(
     "actor_label" | "display_name" | "email"
   >,
 ): string {
-  return ready.display_name?.trim() || ready.email?.trim() || ready.actor_label;
+  return identityDisplayLabel({
+    displayName: ready.display_name,
+    email: ready.email,
+    principal: ready.actor_label,
+  });
 }
 
 const consoleSyncLogger = {


### PR DESCRIPTION
## Summary

- adds a shared identity display label formatter for cloud presence
- keeps display name and email precedence, then compacts principal/actor fallbacks
- shortens Anaconda UUID-style fallback labels from full principals to human-scale labels such as `Anaconda user fe0f6c3a`

## Stack

Merge order:

1. #3151
2. #3155
3. #3157
4. #3159
5. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- This is intentionally schema-neutral while the NotebookDoc / RuntimeStateDoc data-loss bug is being handled separately.
- It remains draft until preview.runt.run deployment verification is possible; local Wrangler auth currently fails with `Invalid access token [code: 9109]`.
