### PR TITLE
docs(elements): catalog widget buffer urls

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, docs-local bufferPaths URL hydration, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -47,6 +47,57 @@ function textDataView(value: string): DataView {
   return new DataView(copy.buffer);
 }
 
+function fixtureAssetUrl(pathname: string): string {
+  return new URL(pathname, window.location.origin).href;
+}
+
+function isHydratableFixtureUrl(value: string): boolean {
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.origin === window.location.origin && url.pathname.startsWith("/fixtures/");
+  } catch {
+    return false;
+  }
+}
+
+async function resolveFixtureBufferUrlsInPlace(
+  state: Record<string, unknown>,
+  bufferPaths: string[][] | undefined,
+): Promise<string[]> {
+  if (!bufferPaths || bufferPaths.length === 0) return [];
+
+  const hydratedPaths: string[] = [];
+  await Promise.all(
+    bufferPaths.map(async (path) => {
+      if (path.length === 0) return;
+
+      let current: unknown = state;
+      for (const segment of path) {
+        if (typeof current !== "object" || current === null) return;
+        current = (current as Record<string, unknown>)[segment];
+      }
+
+      if (typeof current !== "string" || !isHydratableFixtureUrl(current)) return;
+
+      const response = await fetch(current);
+      if (!response.ok) return;
+
+      let parent: Record<string, unknown> = state;
+      for (let i = 0; i < path.length - 1; i++) {
+        const segment = path[i];
+        const next = parent[segment];
+        if (typeof next !== "object" || next === null) return;
+        parent = next as Record<string, unknown>;
+      }
+
+      parent[path[path.length - 1]] = new DataView(await response.arrayBuffer());
+      hydratedPaths.push(path.join("."));
+    }),
+  );
+
+  return hydratedPaths;
+}
+
 const anyWidgetEsm = `
 export default {
   render({ model, el }) {
@@ -211,6 +262,19 @@ const fixtureModels: FixtureModel[] = [
     bufferPaths: [["value"]],
   },
   {
+    id: "widget-buffer-url-image",
+    state: {
+      _model_name: "ImageModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "buffer URL",
+      value: "",
+      format: "svg+xml",
+      width: "260",
+      height: "112",
+    },
+    bufferPaths: [["value"]],
+  },
+  {
     id: "widget-audio",
     state: {
       _model_name: "AudioModel",
@@ -354,6 +418,7 @@ const fixtureModels: FixtureModel[] = [
       children: [
         "IPY_MODEL_widget-image",
         "IPY_MODEL_widget-binary-image",
+        "IPY_MODEL_widget-buffer-url-image",
         "IPY_MODEL_widget-audio",
         "IPY_MODEL_widget-video",
         "IPY_MODEL_widget-file-upload",
@@ -773,7 +838,7 @@ const renderedWidgets = [
   {
     name: "Media widgets",
     source: "src/components/widgets/controls/{image-widget,audio-widget,video-widget}.tsx",
-    role: "Image, audio, and video widgets render through buildMediaSrc with static data URLs and a hydrated DataView ImageModel fixture.",
+    role: "Image, audio, and video widgets render through buildMediaSrc with static data URLs, hydrated DataViews, and a bufferPaths URL fixture.",
   },
   {
     name: "FileUploadWidget",
@@ -822,7 +887,7 @@ const adapterBoundaries = [
   {
     title: "Binary buffers",
     icon: FileJson,
-    body: "Media widgets now cover a hydrated DataView value and ipycanvas replays a local DataView command buffer; live kernel bufferPaths, blob URL fetching, and sync hydration remain adapter concerns.",
+    body: "Media widgets now cover inline DataViews and a docs-local bufferPaths URL hydrator; ipycanvas replays a local DataView command buffer. Live kernel blob resolver state and sync hydration remain adapter concerns.",
   },
   {
     title: "Anywidget ESM",
@@ -841,18 +906,27 @@ const savedPasswordModel = {
   },
 };
 
-function seedStore(store: WidgetStore) {
+async function seedStore(store: WidgetStore): Promise<string[]> {
+  const hydratedModels: string[] = [];
+
   for (const model of fixtureModels) {
-    const state =
-      model.id === "widget-anywidget-url"
-        ? {
-            ...model.state,
-            _esm: new URL("/fixtures/anywidget-url-fixture.js", window.location.origin).href,
-            _css: new URL("/fixtures/anywidget-url-fixture.css", window.location.origin).href,
-          }
-        : model.state;
+    const state = structuredClone(model.state) as Record<string, unknown>;
+    if (model.id === "widget-anywidget-url") {
+      state._esm = fixtureAssetUrl("/fixtures/anywidget-url-fixture.js");
+      state._css = fixtureAssetUrl("/fixtures/anywidget-url-fixture.css");
+    } else if (model.id === "widget-buffer-url-image") {
+      state.value = fixtureAssetUrl("/fixtures/widget-buffer-url-image.svg");
+    }
+
+    const hydratedPaths = await resolveFixtureBufferUrlsInPlace(state, model.bufferPaths);
+    if (hydratedPaths.length > 0) {
+      hydratedModels.push(`${model.id}: ${hydratedPaths.join(", ")}`);
+    }
+
     store.createModel(model.id, state, model.bufferPaths);
   }
+
+  return hydratedModels;
 }
 
 function canvasCommand(name: (typeof COMMANDS)[number], args: unknown[] = []) {
@@ -1003,13 +1077,16 @@ function WidgetFixtureProvider({ children }: { children: ReactNode }) {
     setEvents((current) => [event, ...current].slice(0, 5));
   }, []);
 
-  const resetFixtures = useCallback(() => {
-    seedStore(store);
+  const resetFixtures = useCallback(async () => {
+    const hydratedModels = await seedStore(store);
     logEvent("seeded fixture comm state");
+    for (const model of hydratedModels) {
+      logEvent(`hydrated ${model}`);
+    }
   }, [logEvent, store]);
 
   useEffect(() => {
-    resetFixtures();
+    void resetFixtures();
   }, [resetFixtures]);
   useEffect(() => createCanvasManagerRouter(store), [store]);
 
@@ -1062,7 +1139,7 @@ function WidgetFixtureProvider({ children }: { children: ReactNode }) {
         <div className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <WidgetInventory />
-            <Button size="sm" variant="outline" onClick={resetFixtures}>
+            <Button size="sm" variant="outline" onClick={() => void resetFixtures()}>
               Reset fixtures
             </Button>
           </div>
@@ -1159,8 +1236,8 @@ export function WidgetSurfacesExample() {
                 <h3 className="text-sm font-semibold">Media and captured output widgets</h3>
                 <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                   Image, audio, video, file upload, and OutputModel fixtures render through
-                  WidgetView with saved comm state, static payloads, a hydrated DataView image
-                  value, and a nested widget-view MIME output.
+                  WidgetView with saved comm state, static payloads, hydrated DataView image values,
+                  a docs-local buffer URL fixture, and a nested widget-view MIME output.
                 </p>
               </div>
               <div className="space-y-4">
@@ -1254,7 +1331,7 @@ export function WidgetSurfacesExample() {
           <div>
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-              The remaining widget catalog work is narrower now: live blob URL hydration,
+              The remaining widget catalog work is narrower now: live kernel blob resolver state,
               ControllerModel Gamepad polling, live output-widget comm replay, richer ipycanvas
               image buffers, and kernel-originated anywidget asset URLs need explicit iframe/runtime
               adapters before they can render here.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -17,7 +17,10 @@ path with a local binary command buffer routed by the CanvasManager adapter, and
 `AnyModel` fixtures through `AnyWidgetView` with inline plus URL-backed `_esm`
 and `_css` assets. The media section includes an `ImageModel` whose `value` is a
 hydrated `DataView`, so the same `buildMediaSrc` binary path used by ipywidgets
-media traitlets is visible in the catalog. The `OutputModel` fixture also includes a nested
+media traitlets is visible in the catalog. It also includes a same-origin static
+fixture URL listed in `bufferPaths`, hydrated into a `DataView` before seeding
+`WidgetStore`, mirroring the iframe bridge shape without importing that runtime.
+The `OutputModel` fixture also includes a nested
 `application/vnd.jupyter.widget-view+json` output, resolved by the same
 `MediaProvider` custom renderer shape used by the notebook app.
 
@@ -31,4 +34,7 @@ comm bridge. The catalog keeps those host responsibilities outside the rendered
 component examples. Browser APIs, live blob URL fetching, live output-widget
 comm replay, live controller/gamepad input, richer ipycanvas image buffers,
 kernel-originated anywidget asset URLs, and generated WASM handoffs remain
-explicit adapter boundaries for later catalog slices.
+explicit adapter boundaries for later catalog slices. The docs-local media URL
+hydrator only fetches static assets from this app; production daemon blob
+resolver lifecycle and sync-originated `bufferPaths` still stay outside the
+catalog runtime.

--- a/apps/elements/public/fixtures/widget-buffer-url-image.svg
+++ b/apps/elements/public/fixtures/widget-buffer-url-image.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 112">
+  <rect width="260" height="112" rx="14" fill="#f8fafc"/>
+  <path d="M20 78 C54 42 86 52 116 30 C150 5 178 50 232 24" fill="none" stroke="#2563eb" stroke-width="8" stroke-linecap="round"/>
+  <rect x="26" y="22" width="54" height="54" rx="8" fill="#10b981"/>
+  <circle cx="151" cy="61" r="25" fill="#0ea5e9"/>
+  <path d="M178 82 L225 40" stroke="#111827" stroke-width="7" stroke-linecap="round"/>
+  <text x="22" y="98" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#111827">bufferPaths URL -> DataView</text>
+</svg>


### PR DESCRIPTION
## Summary

- add a widget media fixture whose binary `value` starts as a same-origin static URL listed in `bufferPaths`
- hydrate that URL into a `DataView` before seeding the fixture `WidgetStore`, mirroring the production iframe bridge shape without importing runtime code
- update the widget docs and component burn-down so static buffer URL hydration is cataloged separately from live daemon blob resolver state

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- headless Chromium `/docs/widget-surfaces` at desktop and mobile widths verifies `widget-buffer-url-image` renders as `data:image/svg+xml;base64,...`, logs hydration, and has no horizontal overflow
