### PR TITLE
fix(notebook-cloud): clarify expired sign-in action

### DIFF
--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -8,6 +8,7 @@ import {
   NOTEBOOK_CLOUD_SCOPE_STORAGE_KEY,
   NOTEBOOK_CLOUD_USER_STORAGE_KEY,
   cloudHttpHeadersFromPrototypeAuthState,
+  cloudNotebookSignInCopy,
   clearCloudPrototypeDevAuth,
   cloudSyncAuthFromPrototypeAuthState,
   isCloudPrototypeAuthStorageKey,
@@ -202,6 +203,38 @@ describe("cloud collaborator auth", () => {
     assert.match(diagnostics.copyText, /Sign-in: Stored OIDC session is expired/);
     assert.match(diagnostics.copyText, /Effective auth: No expired bearer token is sent/);
     assert.doesNotMatch(diagnostics.copyText, new RegExp(accessToken.replaceAll(".", "\\.")));
+  });
+
+  it("uses state-specific notebook page sign-in copy", () => {
+    const anonymous = readCloudPrototypeAuth(new MemoryStorage());
+    assert.deepEqual(cloudNotebookSignInCopy(anonymous, "idle"), {
+      label: "Sign in",
+      title: "Sign in with Anaconda",
+    });
+    assert.deepEqual(cloudNotebookSignInCopy(anonymous, "starting"), {
+      label: "Signing in",
+      title: "Starting Anaconda sign-in",
+    });
+    assert.deepEqual(cloudNotebookSignInCopy(anonymous, "idle", "network failed"), {
+      label: "Sign-in failed",
+      title: "network failed",
+    });
+
+    const storage = new MemoryStorage();
+    storage.setItem(
+      NOTEBOOK_CLOUD_OIDC_TOKEN_STORAGE_KEY,
+      JSON.stringify({
+        accessToken: jwt({ sub: "expired-user", name: "Expired User" }),
+        refreshToken: null,
+        expiresAt: Math.floor(Date.now() / 1000) - 3600,
+        claims: { sub: "expired-user", name: "Expired User" },
+      }),
+    );
+
+    assert.deepEqual(cloudNotebookSignInCopy(readCloudPrototypeAuth(storage), "idle"), {
+      label: "Sign in again",
+      title: "Renew your Anaconda sign-in for this notebook",
+    });
   });
 
   it("switches requested scope without replacing stored OIDC token material", () => {

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -75,6 +75,13 @@ export interface CloudPrototypeAuthDiagnostics {
   copyText: string;
 }
 
+export type CloudNotebookSignInAction = "idle" | "starting";
+
+export interface CloudNotebookSignInCopy {
+  label: string;
+  title: string;
+}
+
 export function cloudPrototypeAuthFromWindow(): CloudPrototypeAuthState {
   if (typeof window === "undefined") {
     return anonymousAuthState();
@@ -286,6 +293,41 @@ export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
     return state.problem ?? "Stored collaborator token is invalid.";
   }
   return "Anonymous read-only viewer";
+}
+
+export function cloudNotebookSignInCopy(
+  state: CloudPrototypeAuthState,
+  action: CloudNotebookSignInAction,
+  error: string | null = null,
+): CloudNotebookSignInCopy {
+  if (error) {
+    return {
+      label: "Sign-in failed",
+      title: error,
+    };
+  }
+  if (action === "starting") {
+    return {
+      label: "Signing in",
+      title: "Starting Anaconda sign-in",
+    };
+  }
+  if (state.mode === "oidc_expired") {
+    return {
+      label: "Sign in again",
+      title: "Renew your Anaconda sign-in for this notebook",
+    };
+  }
+  if (state.mode === "invalid") {
+    return {
+      label: "Sign in",
+      title: "Replace the invalid stored auth state with Anaconda sign-in",
+    };
+  }
+  return {
+    label: "Sign in",
+    title: "Sign in with Anaconda",
+  };
 }
 
 export function prototypeAuthDiagnostics(

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -47,6 +47,7 @@ import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import {
   clearCloudPrototypeDevAuth,
+  cloudNotebookSignInCopy,
   cloudPrototypeAuthFromWindow,
   cloudSyncAuthFromPrototypeAuthState,
   fetchWithCloudPrototypeAuth,
@@ -1640,6 +1641,7 @@ function CloudNotebookSignInButton({
   if (!authConfig.oidc || authState.mode === "oidc") {
     return null;
   }
+  const copy = cloudNotebookSignInCopy(authState, authAction, error);
 
   const beginOidcAuth = async () => {
     if (!authConfig.oidc) return;
@@ -1664,11 +1666,11 @@ function CloudNotebookSignInButton({
       className="cloud-sign-in-button"
       data-state={error ? "error" : authAction}
       disabled={authAction === "starting"}
-      title={error ?? "Sign in with Anaconda"}
+      title={copy.title}
       onClick={beginOidcAuth}
     >
       <LogIn aria-hidden="true" />
-      <span>{error ? "Sign-in failed" : authAction === "starting" ? "Signing in" : "Sign in"}</span>
+      <span>{copy.label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

- adds a tested helper for notebook-page sign-in CTA copy
- shows `Sign in again` when a stored OIDC session is expired
- keeps failed and in-progress sign-in button copy explicit without changing auth storage or server behavior

## Stack

Merge order:

1. #3151
2. #3155
3. #3157
4. #3159
5. #3160
6. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- This is intentionally schema-neutral while the NotebookDoc / RuntimeStateDoc data-loss bug is being handled separately.
- It remains draft until preview.runt.run deployment verification is possible; local Wrangler auth currently fails with `Invalid access token [code: 9109]`.
