### PR TITLE
docs(elements): catalog widget replay adapters

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, docs-local bufferPaths URL hydration, file upload, OutputModel with nested widget-view output and local replay, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, docs-local bufferPaths URL hydration, file upload, OutputModel with nested widget-view output and local replay, layout containers, ControllerModel polling against a fixture Gamepad API, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -138,7 +138,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, live widget comms, and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, live kernel widget comm transport, and generated Sift WASM decoding remain explicit adapter boundaries.",
   },
   {
     family: "Output isolation",
@@ -156,7 +156,7 @@ const families = [
     target: "nteract widgets",
     status: "active",
     intent:
-      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, docs-local bufferPaths URL hydration, file upload, OutputModel with nested widget-view output, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
+      "WidgetView, WidgetStore, AnyWidgetView, the AFM model proxy, inline and URL-backed anywidget assets, the current built-in controls registry, form, selection, numeric, status, media, hydrated DataView image buffers, docs-local bufferPaths URL hydration, file upload, OutputModel with nested widget-view output and local replay, layout containers, controller sub-controls, ipycanvas CanvasModel command replay, unsupported fallback, and static snapshots now render from comm-state fixtures.",
   },
   {
     family: "Runtime decisions",

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -494,6 +494,20 @@ const fixtureModels: FixtureModel[] = [
     },
   },
   {
+    id: "widget-controller",
+    state: {
+      _model_name: "ControllerModel",
+      _model_module: "@jupyter-widgets/controls",
+      index: 0,
+      connected: false,
+      name: "",
+      mapping: "",
+      timestamp: 0,
+      buttons: ["IPY_MODEL_widget-controller-a", "IPY_MODEL_widget-controller-b"],
+      axes: ["IPY_MODEL_widget-axis-x", "IPY_MODEL_widget-axis-y"],
+    },
+  },
+  {
     id: "widget-controller-a",
     state: {
       _model_name: "ControllerButtonModel",
@@ -919,8 +933,8 @@ const renderedWidgets = [
   {
     name: "Play and controller controls",
     source:
-      "src/components/widgets/controls/{play-widget,controller-button-widget,controller-axis-widget}.tsx",
-    role: "Browser-bound controls render from frozen state while live Gamepad polling remains an explicit adapter boundary.",
+      "src/components/widgets/controls/{play-widget,controller-widget,controller-button-widget,controller-axis-widget}.tsx",
+    role: "ControllerModel polls a docs-owned Gamepad API fixture and updates child button/axis models through the production widget context.",
   },
 ];
 
@@ -946,6 +960,35 @@ const adapterBoundaries = [
     body: "Inline and URL-backed _esm/_css now mount through AnyWidgetView. Kernel-originated blob resolver URLs and sandbox policy remain iframe/runtime adapter concerns.",
   },
 ];
+
+function fixtureGamepad(frame: number): Gamepad {
+  const primaryPressed = frame % 2 === 1;
+  const secondaryPressed = frame % 3 === 0;
+
+  return {
+    id: "nteract fixture gamepad",
+    index: 0,
+    connected: true,
+    mapping: "standard",
+    timestamp: 1000 + frame,
+    buttons: [
+      {
+        pressed: primaryPressed,
+        touched: primaryPressed,
+        value: primaryPressed ? 1 : 0.18,
+      },
+      {
+        pressed: secondaryPressed,
+        touched: secondaryPressed,
+        value: secondaryPressed ? 0.82 : 0.08,
+      },
+    ],
+    axes: [
+      Number((Math.sin(frame / 2) * 0.85).toFixed(2)),
+      Number((Math.cos(frame / 3) * 0.65).toFixed(2)),
+    ],
+  } as unknown as Gamepad;
+}
 
 const savedPasswordModel = {
   id: "widget-password-snapshot",
@@ -1177,6 +1220,80 @@ function OutputWidgetReplayFixture() {
   );
 }
 
+function ControllerPollingFixture() {
+  const [frame, setFrame] = useState(1);
+  const frameRef = useRef(frame);
+  const [mockReady, setMockReady] = useState(false);
+  const [mockError, setMockError] = useState<string | null>(null);
+
+  useEffect(() => {
+    frameRef.current = frame;
+  }, [frame]);
+
+  useEffect(() => {
+    const target = navigator as Navigator & { getGamepads?: Navigator["getGamepads"] };
+    const ownDescriptor = Object.getOwnPropertyDescriptor(target, "getGamepads");
+
+    try {
+      Object.defineProperty(target, "getGamepads", {
+        configurable: true,
+        value: () => [fixtureGamepad(frameRef.current), null, null, null],
+      });
+      setMockReady(true);
+      setMockError(null);
+    } catch (error) {
+      setMockReady(false);
+      setMockError(error instanceof Error ? error.message : "Gamepad API fixture unavailable");
+    }
+
+    return () => {
+      if (ownDescriptor) {
+        Object.defineProperty(target, "getGamepads", ownDescriptor);
+      } else {
+        Reflect.deleteProperty(target, "getGamepads");
+      }
+    };
+  }, []);
+
+  const pulseGamepad = useCallback(() => {
+    setFrame((current) => current + 1);
+  }, []);
+
+  return (
+    <div className="space-y-3" data-testid="widget-controller-polling-suite">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold">ControllerModel polling</h4>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            The fixture installs a local Gamepad API response so the real ControllerWidget polls
+            browser state, marks the controller connected, and updates child button and axis models.
+          </p>
+        </div>
+        <Button size="sm" variant="outline" onClick={pulseGamepad}>
+          Pulse gamepad
+        </Button>
+      </div>
+      <div className="rounded-md border border-fd-border bg-fd-background p-3">
+        {mockReady ? (
+          <WidgetView modelId="widget-controller" />
+        ) : (
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-fd-muted-foreground">
+            Gamepad fixture unavailable{mockError ? `: ${mockError}` : "."}
+          </div>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2 text-xs text-fd-muted-foreground">
+        <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
+          fixture frame <span className="font-mono">{frame}</span>
+        </span>
+        <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
+          navigator.getGamepads
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function WidgetFixtureProvider({ children }: { children: ReactNode }) {
   const storeRef = useRef<WidgetStore | null>(null);
   if (!storeRef.current) {
@@ -1368,8 +1485,9 @@ export function WidgetSurfacesExample() {
               <div className="mb-3">
                 <h3 className="text-sm font-semibold">Layout and browser-bound controls</h3>
                 <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-                  Tabs, accordion, stack, play, and controller sub-controls render from fixture
-                  state. The live ControllerModel Gamepad loop remains a browser adapter boundary.
+                  Tabs, accordion, stack, play, and controller controls render from fixture state.
+                  The controller fixture drives the production Gamepad polling path with a local
+                  browser adapter.
                 </p>
               </div>
               <div className="grid gap-4 lg:grid-cols-[1.3fr_0.7fr]">
@@ -1380,12 +1498,7 @@ export function WidgetSurfacesExample() {
                 </div>
                 <div className="space-y-3 rounded-lg border border-fd-border bg-fd-card p-3">
                   <WidgetView modelId="widget-play" />
-                  <div className="flex items-center gap-2">
-                    <WidgetView modelId="widget-controller-a" />
-                    <WidgetView modelId="widget-controller-b" />
-                  </div>
-                  <WidgetView modelId="widget-axis-x" />
-                  <WidgetView modelId="widget-axis-y" />
+                  <ControllerPollingFixture />
                 </div>
               </div>
             </div>
@@ -1445,9 +1558,9 @@ export function WidgetSurfacesExample() {
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               The remaining widget catalog work is narrower now: live kernel blob resolver state,
-              ControllerModel Gamepad polling, live captured-output comm transport, richer ipycanvas
-              image buffers, and kernel-originated anywidget asset URLs need explicit iframe/runtime
-              adapters before they can render here.
+              live captured-output comm transport, richer ipycanvas image buffers, and
+              kernel-originated anywidget asset URLs need explicit iframe/runtime adapters before
+              they can render here.
             </p>
           </div>
         </div>

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -10,6 +10,7 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import type { CustomRenderer } from "@/components/outputs/media-router";
 import { Button } from "@/components/ui/button";
@@ -226,6 +227,69 @@ const anyWidgetCss = `
 }
 `;
 
+const initialOutputWidgetOutputs: JupyterOutput[] = [
+  {
+    output_type: "stream",
+    name: "stdout",
+    text: "captured widget output\n",
+  },
+  {
+    output_type: "display_data",
+    data: {
+      "application/json": {
+        status: "complete",
+        rows: 128,
+        source: "OutputWidget fixture",
+      },
+      "text/plain": "{status: complete, rows: 128}",
+    },
+    metadata: {
+      "application/json": { collapsed: 1 },
+    },
+  },
+  {
+    output_type: "display_data",
+    data: {
+      [WIDGET_VIEW_MIME]: { model_id: "widget-output-nested-threshold" },
+      "text/plain": "IntSlider(value=41)",
+    },
+    metadata: {},
+  },
+];
+
+function replayedOutputWidgetOutputs(run: number): JupyterOutput[] {
+  return [
+    {
+      output_type: "stream",
+      name: "stdout",
+      text: `replayed widget output ${run}\n`,
+    },
+    {
+      output_type: "display_data",
+      data: {
+        "application/json": {
+          replayed: true,
+          run,
+          rows: 128 + run * 8,
+          source: "OutputWidget replay fixture",
+        },
+        "text/plain": `OutputWidget replay ${run}`,
+      },
+      metadata: {
+        "application/json": { collapsed: 0 },
+      },
+    },
+    {
+      output_type: "display_data",
+      data: {
+        [WIDGET_VIEW_MIME]: { model_id: "widget-output-replay-threshold" },
+        "text/plain": `IntSlider(value=${Math.min(95, 48 + run * 7)})`,
+      },
+      metadata: {},
+    },
+  ];
+}
+
 const fixtureModels: FixtureModel[] = [
   {
     id: "widget-media-title",
@@ -329,35 +393,7 @@ const fixtureModels: FixtureModel[] = [
     state: {
       _model_name: "OutputModel",
       _model_module: "@jupyter-widgets/output",
-      outputs: [
-        {
-          output_type: "stream",
-          name: "stdout",
-          text: "captured widget output\n",
-        },
-        {
-          output_type: "display_data",
-          data: {
-            "application/json": {
-              status: "complete",
-              rows: 128,
-              source: "OutputWidget fixture",
-            },
-            "text/plain": "{status: complete, rows: 128}",
-          },
-          metadata: {
-            "application/json": { collapsed: 1 },
-          },
-        },
-        {
-          output_type: "display_data",
-          data: {
-            [WIDGET_VIEW_MIME]: { model_id: "widget-output-nested-threshold" },
-            "text/plain": "IntSlider(value=41)",
-          },
-          metadata: {},
-        },
-      ],
+      outputs: initialOutputWidgetOutputs,
     },
   },
   {
@@ -367,6 +403,21 @@ const fixtureModels: FixtureModel[] = [
       _model_module: "@jupyter-widgets/controls",
       description: "nested threshold",
       value: 41,
+      min: 0,
+      max: 100,
+      step: 1,
+      readout: true,
+      orientation: "horizontal",
+      disabled: false,
+    },
+  },
+  {
+    id: "widget-output-replay-threshold",
+    state: {
+      _model_name: "IntSliderModel",
+      _model_module: "@jupyter-widgets/controls",
+      description: "replay threshold",
+      value: 55,
       min: 0,
       max: 100,
       step: 1,
@@ -848,7 +899,7 @@ const renderedWidgets = [
   {
     name: "OutputWidget",
     source: "src/components/widgets/controls/output-widget.tsx",
-    role: "Captured outputs flow through the widget OutputModel path and nested widget-view MIME resolves through MediaProvider without a live comm channel.",
+    role: "Captured outputs flow through the widget OutputModel path; local replay updates the same store key and nested widget-view MIME resolves through MediaProvider.",
   },
   {
     name: "ipycanvas widget",
@@ -882,7 +933,7 @@ const adapterBoundaries = [
   {
     title: "Comm bridge outbound",
     icon: Cable,
-    body: "State updates stay local to the fixture. Custom messages are logged instead of crossing JSON-RPC or shell channels.",
+    body: "State updates stay local to the fixture. Custom messages and output replay updates are logged instead of crossing JSON-RPC or shell channels.",
   },
   {
     title: "Binary buffers",
@@ -1065,6 +1116,67 @@ function AnyWidgetFixture() {
   );
 }
 
+function OutputWidgetReplayFixture() {
+  const { sendUpdate } = useWidgetStoreRequired();
+  const [replayCount, setReplayCount] = useState(0);
+
+  const replayOutputs = useCallback(() => {
+    const next = replayCount + 1;
+    void sendUpdate("widget-output-replay-threshold", {
+      value: Math.min(95, 48 + next * 7),
+    });
+    void sendUpdate("widget-output", { outputs: replayedOutputWidgetOutputs(next) });
+    setReplayCount(next);
+  }, [replayCount, sendUpdate]);
+
+  const restoreOutputs = useCallback(() => {
+    setReplayCount(0);
+    void sendUpdate("widget-output-nested-threshold", { value: 41 });
+    void sendUpdate("widget-output-replay-threshold", { value: 55 });
+    void sendUpdate("widget-output", { outputs: initialOutputWidgetOutputs });
+  }, [sendUpdate]);
+
+  const clearOutputs = useCallback(() => {
+    setReplayCount(0);
+    void sendUpdate("widget-output", { outputs: [] });
+  }, [sendUpdate]);
+
+  return (
+    <div
+      className="rounded-md border border-fd-border bg-fd-card p-3"
+      data-testid="widget-output-replay-suite"
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h4 className="text-sm font-semibold">OutputModel replay</h4>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            The fixture updates the OutputModel&apos;s `outputs` trait through the widget context,
+            matching the store update shape used after captured output state is resolved.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" variant="outline" onClick={replayOutputs}>
+            Replay outputs
+          </Button>
+          <Button size="sm" variant="outline" onClick={restoreOutputs}>
+            Restore
+          </Button>
+          <Button size="sm" variant="ghost" onClick={clearOutputs}>
+            Clear
+          </Button>
+        </div>
+      </div>
+      <div
+        className="mb-3 text-xs text-fd-muted-foreground"
+        data-testid="widget-output-replay-count"
+      >
+        replay count: <span className="font-mono">{replayCount}</span>
+      </div>
+      <WidgetView modelId="widget-output" />
+    </div>
+  );
+}
+
 function WidgetFixtureProvider({ children }: { children: ReactNode }) {
   const storeRef = useRef<WidgetStore | null>(null);
   if (!storeRef.current) {
@@ -1237,13 +1349,14 @@ export function WidgetSurfacesExample() {
                 <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
                   Image, audio, video, file upload, and OutputModel fixtures render through
                   WidgetView with saved comm state, static payloads, hydrated DataView image values,
-                  a docs-local buffer URL fixture, and a nested widget-view MIME output.
+                  a docs-local buffer URL fixture, nested widget-view MIME output, and local output
+                  replay updates.
                 </p>
               </div>
               <div className="space-y-4">
                 <WidgetView modelId="widget-media-title" />
                 <WidgetView modelId="widget-media-box" />
-                <WidgetView modelId="widget-output" />
+                <OutputWidgetReplayFixture />
               </div>
             </div>
             <CanvasCommandFixture />
@@ -1332,7 +1445,7 @@ export function WidgetSurfacesExample() {
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               The remaining widget catalog work is narrower now: live kernel blob resolver state,
-              ControllerModel Gamepad polling, live output-widget comm replay, richer ipycanvas
+              ControllerModel Gamepad polling, live captured-output comm transport, richer ipycanvas
               image buffers, and kernel-originated anywidget asset URLs need explicit iframe/runtime
               adapters before they can render here.
             </p>

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -35,7 +35,9 @@ notebook uses before rendering.
 The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
 frame policy, host-context conversion, sizing, lane routing, and MCP structured
 output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
-third-party renderer library loading, live output-widget comm replay, and
+third-party renderer library loading, live output-widget comm transport, and
 generated Sift parquet/Arrow WASM decoding still need fixture-backed iframe,
 widget-store, or generated asset adapters before this docs app should own those
-runtime paths.
+runtime paths. The widget catalog covers local `OutputModel` replay through
+`WidgetStore`; the remaining output-widget boundary is the live kernel capture
+and comm transport.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -22,7 +22,10 @@ fixture URL listed in `bufferPaths`, hydrated into a `DataView` before seeding
 `WidgetStore`, mirroring the iframe bridge shape without importing that runtime.
 The `OutputModel` fixture also includes a nested
 `application/vnd.jupyter.widget-view+json` output, resolved by the same
-`MediaProvider` custom renderer shape used by the notebook app.
+`MediaProvider` custom renderer shape used by the notebook app. A local replay
+control updates the same `outputs` trait through the widget context, so the
+catalog covers the `OutputWidget` state-update path without opening a live comm
+channel.
 
 <WidgetSurfacesExample />
 
@@ -32,7 +35,7 @@ The live notebook receives widget state from `RuntimeStateDoc` through
 `SyncEngine.commChanges$`, then forwards it to isolated output frames over the
 comm bridge. The catalog keeps those host responsibilities outside the rendered
 component examples. Browser APIs, live blob URL fetching, live output-widget
-comm replay, live controller/gamepad input, richer ipycanvas image buffers,
+comm transport, live controller/gamepad input, richer ipycanvas image buffers,
 kernel-originated anywidget asset URLs, and generated WASM handoffs remain
 explicit adapter boundaries for later catalog slices. The docs-local media URL
 hydrator only fetches static assets from this app; production daemon blob

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -12,8 +12,10 @@ the production controls registry and render through `WidgetView`, so the page is
 tracking nteract-owned widget surfaces instead of page-local form stand-ins.
 The catalog now includes saved-state fixtures for control widgets, media
 widgets, `FileUploadModel`, `OutputModel`, layout containers, play controls, and
-controller sub-controls. It also renders `CanvasModel` through the ipycanvas
-path with a local binary command buffer routed by the CanvasManager adapter, and
+controller controls. The controller fixture installs a local Gamepad API response
+so `ControllerModel` can poll browser state and update child button/axis models
+without a real gamepad. It also renders `CanvasModel` through the ipycanvas path
+with a local binary command buffer routed by the CanvasManager adapter, and
 `AnyModel` fixtures through `AnyWidgetView` with inline plus URL-backed `_esm`
 and `_css` assets. The media section includes an `ImageModel` whose `value` is a
 hydrated `DataView`, so the same `buildMediaSrc` binary path used by ipywidgets
@@ -34,8 +36,8 @@ channel.
 The live notebook receives widget state from `RuntimeStateDoc` through
 `SyncEngine.commChanges$`, then forwards it to isolated output frames over the
 comm bridge. The catalog keeps those host responsibilities outside the rendered
-component examples. Browser APIs, live blob URL fetching, live output-widget
-comm transport, live controller/gamepad input, richer ipycanvas image buffers,
+component examples. Browser APIs beyond the docs-owned Gamepad fixture, live blob
+URL fetching, live output-widget comm transport, richer ipycanvas image buffers,
 kernel-originated anywidget asset URLs, and generated WASM handoffs remain
 explicit adapter boundaries for later catalog slices. The docs-local media URL
 hydrator only fetches static assets from this app; production daemon blob


### PR DESCRIPTION
## Summary

- extract the `OutputModel` widget outputs into named fixtures and add a replay fixture panel
- update the same `WidgetStore` `outputs` trait through the widget context, covering replay, clear, and restore states without a live comm channel
- render the real `ControllerModel` against a docs-owned Gamepad API fixture so polling updates child button/axis models through `WidgetView`
- update widget/output docs and the burn-down to distinguish local replay and browser fixtures from live kernel capture/blob transport

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- headless Chromium `/docs/widget-surfaces` at desktop and mobile widths verifies output replay, clear, restore, ControllerModel polling, axis updates, buffer image hydration, and no horizontal overflow
