### PR TITLE
perf(notebook-cloud): preconnect hosted sidecar origins

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1766,6 +1766,8 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
 }
 
 interface ViewerShellConfig extends Record<string, unknown> {
+  outputDocumentBaseUrl?: string | null;
+  rendererAssetsBasePath?: string;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
 }
@@ -1834,12 +1836,40 @@ function viewerResourceHints(config: ViewerShellConfig | null): string {
   }
 
   return [
+    ...preconnectResourceHints([
+      config.rendererAssetsBasePath,
+      config.outputDocumentBaseUrl,
+      config.runtimedWasmModulePath,
+    ]),
     viewerEntryHint,
     `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
     `<link rel="preload" href="${escapeHtml(
       config.runtimedWasmPath,
     )}" as="fetch" type="application/wasm" crossorigin />`,
   ].join("\n  ");
+}
+
+function preconnectResourceHints(urls: Array<string | null | undefined>): string[] {
+  const origins = new Set<string>();
+  const hints: string[] = [];
+  for (const value of urls) {
+    if (!value) continue;
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      continue;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      continue;
+    }
+    if (origins.has(url.origin)) {
+      continue;
+    }
+    origins.add(url.origin);
+    hints.push(`<link rel="preconnect" href="${escapeHtml(url.origin)}" crossorigin />`);
+  }
+  return hints;
 }
 
 function authConfigForRequest(request: Request, env: Env): { oidc: Record<string, string> | null } {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -210,6 +210,7 @@ describe("HTML script serialization", () => {
 
     assert.equal(response.status, 200);
     assert.match(html, /"rendererAssetsBasePath":"https:\/\/outputs\.example\/plugins\/"/);
+    assert.match(html, /rel="preconnect" href="https:\/\/outputs\.example" crossorigin/);
     assert.match(
       response.headers.get("Content-Security-Policy") ?? "",
       /connect-src 'self' ws: wss: https:\/\/outputs\.example/,
@@ -235,6 +236,7 @@ describe("HTML script serialization", () => {
       html,
       /"runtimedWasmPath":"https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm"/,
     );
+    assert.match(html, /rel="preconnect" href="https:\/\/wasm\.example" crossorigin/);
     assert.match(
       html,
       /rel="modulepreload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm\.js" crossorigin/,
@@ -261,9 +263,38 @@ describe("HTML script serialization", () => {
 
     assert.equal(response.status, 200);
     assert.match(html, /"outputDocumentBaseUrl":"https:\/\/outputs\.example\/frame\/"/);
+    assert.match(html, /rel="preconnect" href="https:\/\/outputs\.example" crossorigin/);
     assert.match(
       response.headers.get("Content-Security-Policy") ?? "",
       /frame-src 'self' blob: data: https:\/\/outputs\.example/,
+    );
+  });
+
+  it("deduplicates hosted sidecar preconnect hints by origin", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo"),
+      fakeEnv({
+        OUTPUT_DOCUMENT_BASE_URL: "https://outputs.example/frame",
+        RENDERER_ASSETS_BASE_URL: "https://outputs.example/renderer-assets",
+        RUNTIMED_WASM_BASE_URL: "https://wasm.example/runtime",
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      (html.match(/rel="preconnect" href="https:\/\/outputs\.example" crossorigin/g) ?? []).length,
+      1,
+    );
+    assert.equal(
+      (html.match(/rel="preconnect" href="https:\/\/wasm\.example" crossorigin/g) ?? []).length,
+      1,
+    );
+    assert.ok(
+      html.indexOf('rel="preconnect" href="https://outputs.example" crossorigin') <
+        html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"'),
+      "hosted sidecar preconnect hints should be emitted before module fetches",
     );
   });
 


### PR DESCRIPTION
## Summary

- emits `preconnect` hints for hosted renderer-assets, output-document, and runtime-WASM sidecar origins
- deduplicates hints by origin and ignores local relative asset paths
- keeps the viewer bundle and renderer/output assets as separate deployable sidecars

## Stack

Merge order:

1. #3151
2. #3155
3. #3157
4. #3159
5. #3160
6. #3162
7. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- This is intentionally schema-neutral while the NotebookDoc / RuntimeStateDoc data-loss bug is being handled separately.
- It remains draft until preview.runt.run deployment verification is possible; local Wrangler auth currently fails with `Invalid access token [code: 9109]`.
