### PR TITLE
test(notebook-cloud): forbid stale render cache smoke

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -6,6 +6,17 @@ export function catalogApiUrlForViewer(viewerUrl) {
   return new URL(`/api/n/${parsed.notebookId}`, parsed.origin).href;
 }
 
+export function isRenderCacheApiUrl(requestUrl) {
+  let parsed;
+  try {
+    parsed = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+
+  return /^\/api\/n\/[^/]+\/(?:render|renders\/[^/]+)\/?$/.test(parsed.pathname);
+}
+
 export function notebookViewerUrl(viewerUrl) {
   const parsed = new URL(viewerUrl);
   const match = parsed.pathname.match(/^\/n\/([^/]+)(?:\/([^/]+))?\/?$/);

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -25,7 +25,7 @@ import {
   withTiming,
 } from "./hosted-render-smoke-performance.mjs";
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
-import { catalogApiUrlForViewer } from "./hosted-render-smoke-routes.mjs";
+import { catalogApiUrlForViewer, isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -67,6 +67,7 @@ const expectedSiftLoadMilestones = parseExpectedTexts(
 );
 const requireRuntimedWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_RUNTIMED_WASM !== "0";
 const requireViewerCssSplit = process.env.NOTEBOOK_CLOUD_REQUIRE_VIEWER_CSS_SPLIT !== "0";
+const forbidRenderCacheRequests = process.env.NOTEBOOK_CLOUD_FORBID_RENDER_CACHE_REQUESTS !== "0";
 const maxPrimaryViewerCssBytes = parsePositiveInteger(
   process.env.NOTEBOOK_CLOUD_MAX_PRIMARY_VIEWER_CSS_BYTES,
   DEFAULT_PRIMARY_VIEWER_CSS_MAX_BYTES,
@@ -102,6 +103,7 @@ const siftDiagnostics = [];
 const diagnosticTasks = [];
 const performanceResources = [];
 const performanceRequests = new Map();
+const renderCacheRequests = [];
 let catalogApiCheck = null;
 let viewerCssCheck = null;
 let runtimeWasmHintCheck = null;
@@ -167,6 +169,12 @@ async function main() {
   });
 
   page.on("request", (request) => {
+    if (forbidRenderCacheRequests && isRenderCacheApiUrl(request.url())) {
+      renderCacheRequests.push({
+        method: request.method(),
+        url: request.url(),
+      });
+    }
     const kind = classifyPerformanceResource(request.url(), {
       targetOrigin,
       rendererAssetOrigin,
@@ -462,6 +470,13 @@ async function main() {
         });
       }
     }
+    if (forbidRenderCacheRequests && renderCacheRequests.length > 0) {
+      failures.push({
+        kind: "render-cache-request",
+        text: "Hosted viewer requested stale render-cache endpoints instead of live sync materialization",
+        requests: renderCacheRequests,
+      });
+    }
     if (screenshotPath) {
       await saveScreenshot(page);
     }
@@ -496,6 +511,8 @@ async function main() {
           catalogApiCheck,
           viewerCssCheck,
           runtimeWasmHintCheck,
+          forbidRenderCacheRequests,
+          renderCacheRequests,
           executionCounts,
           reportCellCount,
           presenceText,

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   catalogApiUrlForViewer,
+  isRenderCacheApiUrl,
   notebookViewerUrl,
   pinnedNotebookViewerUrl,
 } from "../scripts/hosted-render-smoke-routes.mjs";
@@ -54,5 +55,20 @@ describe("hosted render smoke routes", () => {
   it("returns null for non-viewer URLs", () => {
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
+  });
+
+  it("identifies stale render-cache API URLs", () => {
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/render"), true);
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/render?cache=1"), true);
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/renders/heads"), true);
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/renders/heads/"), true);
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/snapshots/heads"), false);
+    assert.equal(
+      isRenderCacheApiUrl("https://example.com/api/n/foo/runtime-snapshots/heads"),
+      false,
+    );
+    assert.equal(isRenderCacheApiUrl("https://example.com/api/n/foo/blobs/sha256"), false);
+    assert.equal(isRenderCacheApiUrl("https://example.com/n/foo/r/heads"), false);
+    assert.equal(isRenderCacheApiUrl("not a url"), false);
   });
 });


### PR DESCRIPTION
## Summary

- fail the hosted topic-viz smoke if the viewer requests stale `/api/n/:id/render` or `/api/n/:id/renders/:heads` endpoints
- expose the observed render-cache request list in smoke output for diagnostics
- keep the guard enabled by default, with `NOTEBOOK_CLOUD_FORBID_RENDER_CACHE_REQUESTS=0` available for targeted debugging

## Stack order

1. #3151
2. #3155
3. #3157
4. #3159
5. #3160
6. #3162
7. #3164
8. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3165 --max-turns 120 --out .context/reviews/pr-3165.json`
- GitHub CI passed

## Notes

- Schema-neutral: no NotebookDoc / RuntimeStateDoc schema, storage materialization, sync protocol, permissions, or iframe sandbox changes.
- Latest hosted smoke against `https://preview.runt.run/n/topic-viz` passed with `renderCacheRequests: []`.
- Left draft while the preview-deploy/auth gate for this cloud stack remains blocked locally by Wrangler auth: `Invalid access token [code: 9109]`.
