### PR TITLE
test(notebook-cloud): require runtime doc pointer in hosted smoke

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-catalog.mjs
@@ -19,6 +19,10 @@ export function summarizeCatalog(json) {
     typeof latestRevision?.runtime_heads_hash === "string"
       ? latestRevision.runtime_heads_hash
       : null;
+  const latestRevisionRuntimeStateDocId =
+    typeof latestRevision?.runtime_state_doc_id === "string"
+      ? latestRevision.runtime_state_doc_id
+      : null;
 
   return {
     ownerPrincipal,
@@ -26,6 +30,7 @@ export function summarizeCatalog(json) {
     latestRevisionActorLabel,
     latestRevisionNotebookHeadsHash,
     latestRevisionRuntimeHeadsHash,
+    latestRevisionRuntimeStateDocId,
     revisionCount: revisions.length,
   };
 }
@@ -37,6 +42,8 @@ export function catalogExpectationFailures(
     expectedLatestRevisionActorLabel,
     expectedLatestRevisionNotebookHeadsHash,
     expectedLatestRevisionRuntimeHeadsHash,
+    expectedLatestRevisionRuntimeStateDocId,
+    requireLatestRevisionRuntimeStateDocId,
   },
 ) {
   const failures = [];
@@ -74,6 +81,21 @@ export function catalogExpectationFailures(
     failures.push({
       text: `expected latest runtime heads ${expectedLatestRevisionRuntimeHeadsHash}, got ${
         summary.latestRevisionRuntimeHeadsHash ?? "missing"
+      }`,
+    });
+  }
+  if (requireLatestRevisionRuntimeStateDocId && !summary.latestRevisionRuntimeStateDocId) {
+    failures.push({
+      text: "expected latest revision runtime_state_doc_id, got missing",
+    });
+  }
+  if (
+    expectedLatestRevisionRuntimeStateDocId &&
+    summary.latestRevisionRuntimeStateDocId !== expectedLatestRevisionRuntimeStateDocId
+  ) {
+    failures.push({
+      text: `expected latest runtime_state_doc_id ${expectedLatestRevisionRuntimeStateDocId}, got ${
+        summary.latestRevisionRuntimeStateDocId ?? "missing"
       }`,
     });
   }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -60,6 +60,10 @@ const expectedLatestRevisionNotebookHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH ?? "";
 const expectedLatestRevisionRuntimeHeadsHash =
   process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH ?? "";
+const expectedLatestRevisionRuntimeStateDocId =
+  process.env.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID ?? "";
+const requireLatestRevisionRuntimeStateDocId =
+  process.env.NOTEBOOK_CLOUD_REQUIRE_LATEST_REVISION_RUNTIME_STATE_DOC_ID !== "0";
 const requireSiftWasm = process.env.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM !== "0";
 const expectedSiftLoadMilestones = parseExpectedTexts(
   "NOTEBOOK_CLOUD_EXPECTED_SIFT_LOAD_MILESTONES",
@@ -229,7 +233,9 @@ async function main() {
       expectedCatalogOwnerPrincipal ||
       expectedLatestRevisionActorLabel ||
       expectedLatestRevisionNotebookHeadsHash ||
-      expectedLatestRevisionRuntimeHeadsHash
+      expectedLatestRevisionRuntimeHeadsHash ||
+      expectedLatestRevisionRuntimeStateDocId ||
+      requireLatestRevisionRuntimeStateDocId
     ) {
       const started = elapsedMs();
       catalogApiCheck = await checkHostedCatalogApi(targetUrl, {
@@ -237,6 +243,8 @@ async function main() {
         expectedLatestRevisionActorLabel,
         expectedLatestRevisionNotebookHeadsHash,
         expectedLatestRevisionRuntimeHeadsHash,
+        expectedLatestRevisionRuntimeStateDocId,
+        requireLatestRevisionRuntimeStateDocId,
       });
       catalogApiCheck = withTiming(catalogApiCheck, started, elapsedMs());
     }
@@ -506,6 +514,8 @@ async function main() {
           expectedLatestRevisionActorLabel,
           expectedLatestRevisionNotebookHeadsHash,
           expectedLatestRevisionRuntimeHeadsHash,
+          expectedLatestRevisionRuntimeStateDocId,
+          requireLatestRevisionRuntimeStateDocId,
           timings_ms: timingsMs,
           performanceDiagnostics: summarizePerformanceResources(performanceResources, timingsMs),
           catalogApiCheck,
@@ -871,6 +881,8 @@ async function checkHostedCatalogApi(
     expectedLatestRevisionActorLabel,
     expectedLatestRevisionNotebookHeadsHash,
     expectedLatestRevisionRuntimeHeadsHash,
+    expectedLatestRevisionRuntimeStateDocId,
+    requireLatestRevisionRuntimeStateDocId,
   },
 ) {
   const catalogUrl = catalogApiUrlForViewer(viewerUrl);
@@ -898,6 +910,8 @@ async function checkHostedCatalogApi(
     expectedLatestRevisionActorLabel,
     expectedLatestRevisionNotebookHeadsHash,
     expectedLatestRevisionRuntimeHeadsHash,
+    expectedLatestRevisionRuntimeStateDocId,
+    requireLatestRevisionRuntimeStateDocId,
   })) {
     failures.push({
       ...failure,

--- a/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs
@@ -20,6 +20,7 @@ describe("hosted render smoke catalog checks", () => {
           actor_label: "user:dev:live-publish/agent:publish-live",
           notebook_heads_hash: "heads-notebook",
           runtime_heads_hash: "heads-runtime",
+          runtime_state_doc_id: "runtime-state-doc-id",
         },
       ],
     });
@@ -30,6 +31,7 @@ describe("hosted render smoke catalog checks", () => {
       latestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
       latestRevisionNotebookHeadsHash: "heads-notebook",
       latestRevisionRuntimeHeadsHash: "heads-runtime",
+      latestRevisionRuntimeStateDocId: "runtime-state-doc-id",
       revisionCount: 2,
     });
   });
@@ -44,6 +46,7 @@ describe("hosted render smoke catalog checks", () => {
     assert.equal(summary.latestRevisionActorLabel, null);
     assert.equal(summary.latestRevisionNotebookHeadsHash, null);
     assert.equal(summary.latestRevisionRuntimeHeadsHash, null);
+    assert.equal(summary.latestRevisionRuntimeStateDocId, null);
   });
 
   it("reports catalog expectation mismatches", () => {
@@ -60,6 +63,8 @@ describe("hosted render smoke catalog checks", () => {
           expectedLatestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
           expectedLatestRevisionNotebookHeadsHash: "heads-notebook",
           expectedLatestRevisionRuntimeHeadsHash: "heads-runtime",
+          expectedLatestRevisionRuntimeStateDocId: "runtime-state-doc-id",
+          requireLatestRevisionRuntimeStateDocId: true,
         },
       ),
       [
@@ -75,7 +80,27 @@ describe("hosted render smoke catalog checks", () => {
         {
           text: "expected latest runtime heads heads-runtime, got missing",
         },
+        {
+          text: "expected latest revision runtime_state_doc_id, got missing",
+        },
+        {
+          text: "expected latest runtime_state_doc_id runtime-state-doc-id, got missing",
+        },
       ],
+    );
+  });
+
+  it("accepts any present latest runtime_state_doc_id when only presence is required", () => {
+    assert.deepEqual(
+      catalogExpectationFailures(
+        {
+          latestRevisionRuntimeStateDocId: "runtime-state-doc-id",
+        },
+        {
+          requireLatestRevisionRuntimeStateDocId: true,
+        },
+      ),
+      [],
     );
   });
 });


### PR DESCRIPTION
## Summary

- include the latest revision `runtime_state_doc_id` in hosted catalog smoke summaries
- fail hosted smoke by default when the latest revision is missing that runtime-state document pointer
- keep exact pointer matching optional via `NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID`

## Stack order

1. #3151
2. #3155
3. #3157
4. #3159
5. #3160
6. #3162
7. #3164
8. #3165
9. this PR

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-catalog.test.mjs test/hosted-smoke-routes.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3166 --max-turns 120 --out .context/reviews/pr-3166.json`
- GitHub CI passed

## Notes

- Schema-neutral: no NotebookDoc / RuntimeStateDoc schema, storage materialization, sync protocol, permissions, or iframe sandbox changes.
- Latest hosted smoke against `https://preview.runt.run/n/topic-viz` passed with `latestRevisionRuntimeStateDocId: runtime:abec8544-ddf0-4abd-a6b7-8e217e1ae00c`.
- Left draft while the preview deployment gate remains blocked locally by Wrangler auth: `Invalid access token [code: 9109]`.
