### PR TITLE
test(notebook-cloud): add hosted performance budgets

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -158,6 +158,40 @@ export function summarizeViewerMilestones(entries) {
   return milestones;
 }
 
+export function performanceBudgetFailures(diagnostics, budgets = {}) {
+  const failures = [];
+  for (const [metric, budget] of Object.entries(budgets)) {
+    if (budget === null || budget === undefined) {
+      continue;
+    }
+    const spec = PERFORMANCE_BUDGET_METRICS[metric];
+    if (!spec) {
+      throw new Error(`Unknown performance budget metric: ${metric}`);
+    }
+    const value = diagnostics?.[spec.group]?.[metric] ?? null;
+    if (value === null) {
+      failures.push({
+        kind: "performance-budget",
+        metric,
+        text: `${spec.label} timing was missing; expected <= ${budget} ms`,
+        expected_ms: budget,
+        actual_ms: null,
+      });
+      continue;
+    }
+    if (value > budget) {
+      failures.push({
+        kind: "performance-budget",
+        metric,
+        text: `${spec.label} took ${value} ms, expected <= ${budget} ms`,
+        expected_ms: budget,
+        actual_ms: value,
+      });
+    }
+  }
+  return failures;
+}
+
 export function withTiming(result, started, ended) {
   if (!result) {
     return result;
@@ -273,3 +307,54 @@ function delta(start, end) {
 function firstDefined(...values) {
   return values.find((value) => value !== null && value !== undefined) ?? null;
 }
+
+const PERFORMANCE_BUDGET_METRICS = {
+  first_useful_render_ms: {
+    group: "live_path",
+    label: "first useful render",
+  },
+  live_sync_websocket_ms: {
+    group: "live_path",
+    label: "live sync WebSocket",
+  },
+  source_text_ms: {
+    group: "live_path",
+    label: "source text",
+  },
+  rendered_cell_marker_ms: {
+    group: "live_path",
+    label: "rendered cell marker",
+  },
+  first_output_iframe_ms: {
+    group: "live_path",
+    label: "first output iframe",
+  },
+  frame_texts_ms: {
+    group: "live_path",
+    label: "expected output frame text",
+  },
+  viewer_shell_complete_ms: {
+    group: "sidecar_assets",
+    label: "viewer shell assets",
+  },
+  runtimed_wasm_complete_ms: {
+    group: "sidecar_assets",
+    label: "runtimed WASM assets",
+  },
+  isolated_renderer_complete_ms: {
+    group: "sidecar_assets",
+    label: "isolated renderer assets",
+  },
+  output_document_complete_ms: {
+    group: "sidecar_assets",
+    label: "output document assets",
+  },
+  sift_wasm_complete_ms: {
+    group: "sidecar_assets",
+    label: "Sift WASM",
+  },
+  arrow_data_complete_ms: {
+    group: "sidecar_assets",
+    label: "Arrow data",
+  },
+};

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -20,6 +20,7 @@ import {
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import {
   classifyPerformanceResource,
+  performanceBudgetFailures,
   refinePerformanceResourceKind,
   summarizePerformanceResources,
   summarizeViewerMilestones,
@@ -83,6 +84,24 @@ const minSupplementalViewerCssCount = parsePositiveInteger(
   1,
   "NOTEBOOK_CLOUD_MIN_SUPPLEMENTAL_VIEWER_CSS_COUNT",
 );
+const performanceBudgets = {
+  first_useful_render_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_FIRST_USEFUL_RENDER_MS"),
+  live_sync_websocket_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_LIVE_SYNC_WEBSOCKET_MS"),
+  source_text_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_SOURCE_TEXT_MS"),
+  rendered_cell_marker_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_RENDERED_CELL_MARKER_MS"),
+  first_output_iframe_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_FIRST_OUTPUT_IFRAME_MS"),
+  frame_texts_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_FRAME_TEXTS_MS"),
+  viewer_shell_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_VIEWER_SHELL_COMPLETE_MS"),
+  runtimed_wasm_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_RUNTIMED_WASM_COMPLETE_MS"),
+  isolated_renderer_complete_ms: parseOptionalBudget(
+    "NOTEBOOK_CLOUD_MAX_ISOLATED_RENDERER_COMPLETE_MS",
+  ),
+  output_document_complete_ms: parseOptionalBudget(
+    "NOTEBOOK_CLOUD_MAX_OUTPUT_DOCUMENT_COMPLETE_MS",
+  ),
+  sift_wasm_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_SIFT_WASM_COMPLETE_MS"),
+  arrow_data_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_ARROW_DATA_COMPLETE_MS"),
+};
 const expectedThemeModes = parseExpectedTexts("NOTEBOOK_CLOUD_SMOKE_THEME_MODES", [
   "light",
   "dark",
@@ -488,6 +507,8 @@ async function main() {
         requests: renderCacheRequests,
       });
     }
+    const performanceDiagnostics = summarizePerformanceResources(performanceResources, timingsMs);
+    failures.push(...performanceBudgetFailures(performanceDiagnostics, performanceBudgets));
     if (screenshotPath) {
       await saveScreenshot(page);
     }
@@ -521,7 +542,8 @@ async function main() {
           requireLatestRevisionRuntimeStateDocId,
           timings_ms: timingsMs,
           viewer_milestones_ms: viewerMilestones,
-          performanceDiagnostics: summarizePerformanceResources(performanceResources, timingsMs),
+          performanceDiagnostics,
+          performanceBudgets,
           catalogApiCheck,
           viewerCssCheck,
           runtimeWasmHintCheck,
@@ -582,6 +604,10 @@ function parseExpectedTexts(envName, fallback) {
     .split("|")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function parseOptionalBudget(envName) {
+  return parsePositiveInteger(process.env[envName], null, envName);
 }
 
 function markTiming(name) {

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   classifyPerformanceResource,
+  performanceBudgetFailures,
   refinePerformanceResourceKind,
   summarizePerformanceResources,
   summarizeViewerMilestones,
@@ -392,6 +393,52 @@ describe("hosted smoke performance diagnostics", () => {
         viewer_start: 3,
         live_room_ready: 25,
       },
+    );
+  });
+
+  it("reports explicit hosted performance budget failures", () => {
+    const diagnostics = {
+      live_path: {
+        first_useful_render_ms: 5_025,
+        live_sync_websocket_ms: 1_323,
+      },
+      sidecar_assets: {
+        sift_wasm_complete_ms: 3_025,
+        arrow_data_complete_ms: null,
+      },
+    };
+
+    assert.deepEqual(
+      performanceBudgetFailures(diagnostics, {
+        first_useful_render_ms: 5_500,
+        live_sync_websocket_ms: null,
+        sift_wasm_complete_ms: 3_000,
+        arrow_data_complete_ms: 8_000,
+      }),
+      [
+        {
+          kind: "performance-budget",
+          metric: "sift_wasm_complete_ms",
+          text: "Sift WASM took 3025 ms, expected <= 3000 ms",
+          expected_ms: 3000,
+          actual_ms: 3025,
+        },
+        {
+          kind: "performance-budget",
+          metric: "arrow_data_complete_ms",
+          text: "Arrow data timing was missing; expected <= 8000 ms",
+          expected_ms: 8000,
+          actual_ms: null,
+        },
+      ],
+    );
+  });
+
+  it("rejects unknown hosted performance budget metrics", () => {
+    assert.throws(
+      () =>
+        performanceBudgetFailures({ live_path: {}, sidecar_assets: {} }, { made_up_metric_ms: 1 }),
+      /Unknown performance budget metric: made_up_metric_ms/,
     );
   });
 });


### PR DESCRIPTION
## Summary

- adds opt-in hosted smoke performance budgets for live path and sidecar asset timing diagnostics
- reports budget failures for Automerge/sync, first useful render, output iframe, Sift, Arrow, and sidecar asset milestones
- keeps the smoke usable without budgets by default, so CI and ad hoc diagnostics continue to collect timings without hard-coded thresholds

## Stack

Merge order:

1. #3151
2. #3155
3. #3157
4. #3159
5. #3160
6. #3162
7. #3164
8. #3165
9. #3166
10. #3168
11. this PR

This PR targets `quod/notebook-cloud-smoke-live-path-summary`.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-performance.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `NOTEBOOK_CLOUD_MAX_FIRST_USEFUL_RENDER_MS=15000 NOTEBOOK_CLOUD_MAX_LIVE_SYNC_WEBSOCKET_MS=6000 NOTEBOOK_CLOUD_MAX_SOURCE_TEXT_MS=8000 NOTEBOOK_CLOUD_MAX_RENDERED_CELL_MARKER_MS=8000 NOTEBOOK_CLOUD_MAX_FIRST_OUTPUT_IFRAME_MS=8000 NOTEBOOK_CLOUD_MAX_FRAME_TEXTS_MS=15000 NOTEBOOK_CLOUD_MAX_VIEWER_SHELL_COMPLETE_MS=5000 NOTEBOOK_CLOUD_MAX_RUNTIMED_WASM_COMPLETE_MS=5000 NOTEBOOK_CLOUD_MAX_ISOLATED_RENDERER_COMPLETE_MS=6000 NOTEBOOK_CLOUD_MAX_OUTPUT_DOCUMENT_COMPLETE_MS=8000 NOTEBOOK_CLOUD_MAX_SIFT_WASM_COMPLETE_MS=9000 NOTEBOOK_CLOUD_MAX_ARROW_DATA_COMPLETE_MS=12000 pnpm --dir apps/notebook-cloud smoke:hosted`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3170 --max-turns 120 --out .context/reviews/pr-3170.json`
- GitHub CI passed

Latest budgeted hosted smoke against `https://preview.runt.run/n/topic-viz` reported:

- live sync WebSocket: 1257 ms
- source text: 2330 ms
- rendered cell marker: 2348 ms
- first output iframe: 2355 ms
- frame texts / first useful render: 5232 ms
- viewer shell complete: 1010 ms
- runtimed WASM complete: 1110 ms
- isolated renderer complete: 1324 ms
- output document complete: 2815 ms
- Sift WASM complete: 3009 ms
- Arrow data complete: 5396 ms
- render-cache requests: none

## Notes

- Schema-neutral: no NotebookDoc / RuntimeStateDoc schema, genesis, storage materialization, runtime-state pointer, sync, or permission changes.
- Output iframe sandboxing is unchanged.
- Budgets are explicit env vars only; missing budgets do not fail the smoke.
- pr-reviewer is clear with no findings.
- GitHub CI passed.
- Leaving draft because preview deployment is still gated on valid Wrangler auth.
