### PR TITLE
docs(elements): load sift parquet urls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,8 @@ apps/notebook/src/renderer-plugins/isolated-renderer.css filter=lfs diff=lfs mer
 # they're opaque Automerge binaries — regular git storage would bloat history
 # each time we regenerate them for a schema change.
 packages/runtimed/tests/fixtures/**/*.bin filter=lfs diff=lfs merge=lfs -text
+
+# Docs catalog static copy of the Sift WASM runtime. This lets apps/elements
+# exercise @nteract/sift URL loading without depending on ignored local
+# wasm-pack outputs at build time.
+apps/elements/public/wasm/sift_wasm_bg.wasm filter=lfs diff=lfs merge=lfs -text

--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -138,7 +138,7 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable, and a fixture-backed Sift parquet URL handoff now render from fixtures; live JavaScript execution, third-party renderer loading, live kernel widget comm transport, and generated Sift WASM decoding remain explicit adapter boundaries.",
+      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable with static TableData, and a HuggingFace Parquet URL decoded by docs-served Sift WASM now render from fixtures; live JavaScript execution, third-party renderer loading, live kernel widget comm transport, Arrow stream manifests, and production isolated-frame asset loading remain explicit adapter boundaries.",
   },
   {
     family: "Output isolation",

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { SiftTable, type TableData, type TableEngineState } from "@nteract/sift";
+import {
+  setWasmUrl,
+  SiftTable,
+  type SiftTableProps,
+  type TableData,
+  type TableEngineState,
+} from "@nteract/sift";
 import {
   AlertTriangle,
   Braces,
@@ -35,6 +41,10 @@ import "@/components/widgets/controls";
 import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 import { WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
+
+setWasmUrl("/wasm/sift_wasm_bg.wasm");
+
+type SiftLoadMilestone = Parameters<NonNullable<SiftTableProps["onLoadMilestone"]>>[0];
 
 const svgFigure = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 180">
   <rect width="420" height="180" rx="16" fill="#f8fafc"/>
@@ -321,9 +331,9 @@ const siftData: TableData = {
 const siftParquetUrl =
   "https://huggingface.co/datasets/mstz/heart_failure/resolve/refs%2Fconvert%2Fparquet/death/train/0000.parquet";
 
-const siftUrlMilestones = [
+const expectedSiftUrlMilestones = [
   {
-    phase: "Resolve",
+    phase: "URL",
     value: "mstz/heart_failure - death/train/0000.parquet",
   },
   {
@@ -331,12 +341,12 @@ const siftUrlMilestones = [
     value: "12 KB parquet source from HuggingFace",
   },
   {
-    phase: "Decode boundary",
-    value: "generated sift-wasm load_parquet_row_group",
+    phase: "Decode",
+    value: "docs-served sift-wasm load_parquet_row_group",
   },
   {
     phase: "Render",
-    value: "SiftTable mounted with fixture TableData",
+    value: "SiftTable source.kind = url",
   },
 ];
 
@@ -823,7 +833,7 @@ const renderedPieces = [
   {
     name: "SiftTable",
     source: "packages/sift/src/react.tsx",
-    note: "nteract-owned Arrow/parquet table UI rendered here with static TableData and a fixture-backed URL handoff.",
+    note: "nteract-owned Arrow/parquet table UI rendered here with static TableData and a live HuggingFace parquet URL decoded by the docs-served Sift WASM asset.",
   },
 ];
 
@@ -839,9 +849,9 @@ const adapterBoundaries = [
       "Top-level widget-view MIME renders through OutputArea with fixture comm state. The widget catalog also covers OutputModel nested widget-view routing through MediaProvider; live comm replay remains outside this runtime-free page.",
   },
   {
-    name: "Generated Sift WASM decode",
+    name: "Sift renderer frame wiring",
     reason:
-      "Parquet and Arrow URL bytes still need generated sift-wasm glue and a served WASM asset; this catalog shows the URL handoff with decoded TableData until the docs app owns that asset path.",
+      "The HuggingFace parquet URL path now runs through SiftTable and docs-served sift-wasm. Production isolated-frame asset loading and Arrow stream manifests remain separate adapter slices.",
   },
 ];
 
@@ -926,8 +936,28 @@ function OutputWidgetFixtureProvider({ children }: { children: ReactNode }) {
 export function OutputRenderersExample() {
   const [siftState, setSiftState] = useState<TableEngineState | null>(null);
   const [siftUrlState, setSiftUrlState] = useState<TableEngineState | null>(null);
+  const [siftUrlLoadMilestones, setSiftUrlLoadMilestones] = useState<SiftLoadMilestone[]>([]);
   const [outputAreaCollapsed, setOutputAreaCollapsed] = useState(false);
   const [outputAreaMatchCount, setOutputAreaMatchCount] = useState(0);
+  const handleSiftUrlLoadMilestone = useCallback((milestone: SiftLoadMilestone) => {
+    setSiftUrlLoadMilestones((current) => [...current.slice(-7), milestone]);
+  }, []);
+  const visibleSiftUrlMilestones =
+    siftUrlLoadMilestones.length > 0
+      ? siftUrlLoadMilestones.slice(-4).map((milestone) => ({
+          phase: milestone.phase,
+          value: [
+            milestone.format,
+            typeof milestone.rowCount === "number" ? `${milestone.rowCount} rows` : null,
+            typeof milestone.byteLength === "number"
+              ? `${Math.round(milestone.byteLength / 1024)} KB`
+              : null,
+            `${milestone.elapsedMs} ms`,
+          ]
+            .filter(Boolean)
+            .join(" · "),
+        }))
+      : expectedSiftUrlMilestones;
 
   return (
     <div className="not-prose space-y-6" data-testid="output-renderers-example">
@@ -939,7 +969,7 @@ export function OutputRenderersExample() {
             <p className="mt-1 text-xs leading-5">
               These examples render current output components with static nbformat-like fixtures.
               OutputArea uses the docs isolated-frame adapter for iframe lanes, while widget comms,
-              plugin injection, and generated WASM stay explicit adapter boundaries.
+              plugin injection, and production frame bootstrapping stay explicit adapter boundaries.
             </p>
           </div>
         </div>
@@ -1162,7 +1192,7 @@ export function OutputRenderersExample() {
           <div className="grid gap-2 text-xs text-fd-muted-foreground md:grid-cols-[minmax(0,1fr)_auto]">
             <div>
               Static TableData mirrors the renderer handoff after parquet/Arrow bytes have been
-              decoded. The generated WASM decode path is still tracked as an adapter boundary.
+              decoded.
             </div>
             <div className="font-mono">
               {siftState
@@ -1173,11 +1203,7 @@ export function OutputRenderersExample() {
         </div>
       </RendererCard>
 
-      <RendererCard
-        title="Sift parquet URL handoff"
-        source="packages/sift/src/react.tsx"
-        icon={Database}
-      >
+      <RendererCard title="Sift parquet URL" source="packages/sift/src/react.tsx" icon={Database}>
         <div className="space-y-4" data-testid="sift-parquet-url-surface">
           <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_280px]">
             <div className="rounded-md border border-fd-border bg-fd-background p-3">
@@ -1195,20 +1221,18 @@ export function OutputRenderersExample() {
             </div>
             <div className="rounded-md border border-fd-border bg-fd-background p-3">
               <div className="text-xs font-medium text-fd-muted-foreground">Catalog source</div>
-              <div className="mt-2 font-mono text-xs text-fd-foreground">
-                source.kind = table-data
-              </div>
+              <div className="mt-2 font-mono text-xs text-fd-foreground">source.kind = url</div>
               <div className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-                The URL is real; the docs surface stays runtime-free by rendering the decoded table
-                fixture.
+                The docs app serves Sift WASM as a static catalog asset, then lets the current
+                SiftTable URL loader fetch and decode the Parquet file.
               </div>
             </div>
           </div>
 
           <div className="grid gap-2 md:grid-cols-4">
-            {siftUrlMilestones.map((milestone) => (
+            {visibleSiftUrlMilestones.map((milestone) => (
               <div
-                key={milestone.phase}
+                key={`${milestone.phase}-${milestone.value}`}
                 className="rounded-md border border-fd-border bg-fd-background p-3"
               >
                 <div className="text-xs font-semibold">{milestone.phase}</div>
@@ -1220,12 +1244,16 @@ export function OutputRenderersExample() {
           </div>
 
           <div className="h-[320px] min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
-            <SiftTable source={{ kind: "table-data", data: siftData }} onChange={setSiftUrlState} />
+            <SiftTable
+              source={{ kind: "url", url: siftParquetUrl }}
+              onChange={setSiftUrlState}
+              onLoadMilestone={handleSiftUrlLoadMilestone}
+            />
           </div>
           <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-fd-muted-foreground">
             <span>
-              This keeps the visible renderer faithful to the Sift UI while keeping network, blob,
-              and generated WASM concerns outside the docs runtime.
+              This keeps the visible renderer on the Sift URL path while keeping daemon blob
+              resolution and isolated-frame production bootstrapping outside the docs runtime.
             </span>
             <span className="font-mono">
               {siftUrlState

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -24,7 +24,9 @@ repo-level `docs/` tree.
 
 Start with the outline rail and the first production-backed component surfaces.
 The catalog should keep fixture-backed examples close to real notebook imports
-without importing the desktop runtime, sync engine, or generated WASM bindings.
+without importing the desktop runtime, sync engine, or generated runtimed WASM
+bindings. Renderer-specific assets like Sift WASM should stay explicit,
+docs-served adapters.
 
 ## Next slice
 

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -8,8 +8,10 @@ import { OutputRenderersExample } from "@/components/output-renderers-example";
 Notebook outputs are nteract-owned UI, not generic cards or prose examples.
 This page starts the renderer catalog with current components from
 `src/components/outputs/**` plus the current `@nteract/sift` table component,
-using fixture data that does not require runtimed, WASM materialization, sync
-state, iframe bootstrapping, or plugin injection.
+using fixture data that does not require runtimed, sync state, iframe
+bootstrapping, or plugin injection. The Sift URL surface is the exception: it
+uses a docs-served static `sift-wasm` asset so the catalog can exercise the real
+Parquet loader without a daemon.
 
 <OutputRenderersExample />
 
@@ -19,16 +21,17 @@ The rendered surfaces import current output components directly: `OutputArea`
 lane composition, ANSI streams and errors, JSON trees, image output, math
 output, SVG output, audio output, the JavaScript isolation fallback, Plotly,
 Vega/Vega-Lite, GeoJSON, PDF, video, the structured traceback renderer, and
-`SiftTable` with static `TableData`. The page also renders top-level
+`SiftTable` with static `TableData` plus a live HuggingFace Parquet URL. The
+page also renders top-level
 `application/vnd.jupyter.widget-view+json` output through `OutputArea` with a
 fixture-backed `WidgetStore`, matching the notebook app's widget MIME handoff
 without booting a live comm bridge. The plugin renderer examples use docs-local
 fixture globals for Plotly, `vegaEmbed`, and Leaflet, so they exercise the
 current nteract components without bundling third-party renderer libraries into
-the catalog. The Sift section also shows the HuggingFace parquet URL handoff the
-demo uses, then renders the decoded table fixture so the docs app stays
-runtime-free. The MIME selection table uses the same priority helper the
-notebook uses before rendering.
+the catalog. The Sift section fetches the same kind of public HuggingFace
+Parquet URL used by the Sift demo, then lets `SiftTable` detect and decode it
+through the docs static WASM asset. The MIME selection table uses the same
+priority helper the notebook uses before rendering.
 
 ## What still needs an adapter
 
@@ -36,8 +39,9 @@ The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
 frame policy, host-context conversion, sizing, lane routing, and MCP structured
 output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
 third-party renderer library loading, live output-widget comm transport, and
-generated Sift parquet/Arrow WASM decoding still need fixture-backed iframe,
+production isolated-frame asset loading still need fixture-backed iframe,
 widget-store, or generated asset adapters before this docs app should own those
-runtime paths. The widget catalog covers local `OutputModel` replay through
-`WidgetStore`; the remaining output-widget boundary is the live kernel capture
-and comm transport.
+runtime paths. The Sift Parquet URL path now has a docs-owned static WASM asset;
+Arrow stream manifests remain a separate renderer adapter slice. The widget
+catalog covers local `OutputModel` replay through `WidgetStore`; the remaining
+output-widget boundary is the live kernel capture and comm transport.

--- a/apps/elements/lib/sift-wasm-module.ts
+++ b/apps/elements/lib/sift-wasm-module.ts
@@ -1,0 +1,79 @@
+type SiftWasmModule = Record<string, (...args: unknown[]) => unknown> & {
+  default: (options?: unknown) => Promise<void> | void;
+};
+
+let modulePromise: Promise<SiftWasmModule> | null = null;
+let loadedModule: SiftWasmModule | null = null;
+const siftWasmPublicModule: string = "/wasm/sift_wasm.js";
+
+async function loadModule(): Promise<SiftWasmModule> {
+  modulePromise ??= import(/* webpackIgnore: true */ siftWasmPublicModule) as Promise<SiftWasmModule>;
+  return modulePromise;
+}
+
+function getLoadedModule(): SiftWasmModule {
+  if (!loadedModule) {
+    throw new Error("sift-wasm is not initialized. Call default() before using exports.");
+  }
+  return loadedModule;
+}
+
+function delegate(name: string) {
+  return (...args: unknown[]) => {
+    const target = getLoadedModule()[name];
+    if (typeof target !== "function") {
+      throw new Error(`sift-wasm export ${name} is unavailable.`);
+    }
+    return target(...args);
+  };
+}
+
+export default async function initialize(options?: unknown) {
+  const mod = await loadModule();
+  await mod.default(options);
+  loadedModule = mod;
+}
+
+export const append_arrow_stream_chunk = delegate("append_arrow_stream_chunk");
+export const arrow_ipc_column_hints = delegate("arrow_ipc_column_hints");
+export const arrow_ipc_column_hints_with_row_count = delegate(
+  "arrow_ipc_column_hints_with_row_count",
+);
+export const cast_column = delegate("cast_column");
+export const col_names = delegate("col_names");
+export const col_timezone = delegate("col_timezone");
+export const col_type = delegate("col_type");
+export const create_arrow_stream_store = delegate("create_arrow_stream_store");
+export const filter_rows = delegate("filter_rows");
+export const finish_arrow_stream_store = delegate("finish_arrow_stream_store");
+export const free = delegate("free");
+export const get_cell_bytes = delegate("get_cell_bytes");
+export const get_cell_f64 = delegate("get_cell_f64");
+export const get_cell_image_bytes_at = delegate("get_cell_image_bytes_at");
+export const get_cell_image_count = delegate("get_cell_image_count");
+export const get_cell_string = delegate("get_cell_string");
+export const get_viewport = delegate("get_viewport");
+export const get_viewport_by_indices = delegate("get_viewport_by_indices");
+export const has_original_column = delegate("has_original_column");
+export const histogram = delegate("histogram");
+export const is_null = delegate("is_null");
+export const load_ipc = delegate("load_ipc");
+export const load_parquet = delegate("load_parquet");
+export const load_parquet_row_group = delegate("load_parquet_row_group");
+export const num_cols = delegate("num_cols");
+export const num_rows = delegate("num_rows");
+export const parquet_column_hints = delegate("parquet_column_hints");
+export const parquet_metadata = delegate("parquet_metadata");
+export const store_bool_counts = delegate("store_bool_counts");
+export const store_filter_rows = delegate("store_filter_rows");
+export const store_filtered_bool_counts = delegate("store_filtered_bool_counts");
+export const store_filtered_histogram = delegate("store_filtered_histogram");
+export const store_filtered_value_counts = delegate("store_filtered_value_counts");
+export const store_histogram = delegate("store_histogram");
+export const store_sort_indices = delegate("store_sort_indices");
+export const store_temporal_histogram = delegate("store_temporal_histogram");
+export const store_value_counts = delegate("store_value_counts");
+export const store_viewport_cells = delegate("store_viewport_cells");
+export const string_contains = delegate("string_contains");
+export const undo_cast_column = delegate("undo_cast_column");
+export const value_counts = delegate("value_counts");

--- a/apps/elements/next.config.mjs
+++ b/apps/elements/next.config.mjs
@@ -3,11 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
-const siftWasmMockPath = path.join(
-  dirname,
-  "../../packages/sift/src/__mocks__/sift-wasm/sift_wasm.js",
-);
-const siftWasmMockImport = "../../packages/sift/src/__mocks__/sift-wasm/sift_wasm.js";
+const siftWasmAdapterPath = path.join(dirname, "lib/sift-wasm-module.ts");
+const siftWasmAdapterImport = "./lib/sift-wasm-module.ts";
 
 /** @type {import("next").NextConfig} */
 const config = {
@@ -20,13 +17,13 @@ const config = {
   transpilePackages: ["@nteract/sift"],
   turbopack: {
     resolveAlias: {
-      "sift-wasm/sift_wasm.js": siftWasmMockImport,
+      "sift-wasm/sift_wasm.js": siftWasmAdapterImport,
     },
   },
   webpack(nextConfig) {
     nextConfig.resolve.alias = {
       ...nextConfig.resolve.alias,
-      "sift-wasm/sift_wasm.js": siftWasmMockPath,
+      "sift-wasm/sift_wasm.js": siftWasmAdapterPath,
     };
     return nextConfig;
   },

--- a/apps/elements/public/wasm/sift_wasm.js
+++ b/apps/elements/public/wasm/sift_wasm.js
@@ -1,0 +1,1361 @@
+/* @ts-self-types="./sift_wasm.d.ts" */
+
+/**
+ * Append one self-contained Arrow IPC stream chunk into an existing store.
+ * The first chunk initializes the store schema; later chunks must match it.
+ * @param {number} handle
+ * @param {Uint8Array} ipc_bytes
+ */
+export function append_arrow_stream_chunk(handle, ipc_bytes) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.append_arrow_stream_chunk(handle, ptr0, len0);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+/**
+ * Extract canonical column hints from Arrow IPC schema metadata.
+ * @param {Uint8Array} ipc_bytes
+ * @returns {any}
+ */
+export function arrow_ipc_column_hints(ipc_bytes) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.arrow_ipc_column_hints(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Extract canonical column hints from Arrow IPC schema metadata using a row
+ * count the caller already has from the loaded table.
+ * @param {Uint8Array} ipc_bytes
+ * @param {number} total_rows
+ * @returns {any}
+ */
+export function arrow_ipc_column_hints_with_row_count(ipc_bytes, total_rows) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.arrow_ipc_column_hints_with_row_count(ptr0, len0, total_rows);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Cast a column to a different type in-place.
+ * Supported casts: string→timestamp (parse ISO dates), string→numeric, etc.
+ * Uses arrow-cast for type conversion. Updates the store's column type metadata.
+ * Saves the original column data so it can be restored when casting back.
+ * @param {number} handle
+ * @param {number} col
+ * @param {string} target_type
+ */
+export function cast_column(handle, col, target_type) {
+    const ptr0 = passStringToWasm0(target_type, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.cast_column(handle, col, ptr0, len0);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+/**
+ * Get column names as a JSON array.
+ * @param {number} handle
+ * @returns {any}
+ */
+export function col_names(handle) {
+    const ret = wasm.col_names(handle);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Get the IANA timezone of a timestamp column, or null if not set.
+ * @param {number} handle
+ * @param {number} col
+ * @returns {string | undefined}
+ */
+export function col_timezone(handle, col) {
+    const ret = wasm.col_timezone(handle, col);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    let v1;
+    if (ret[0] !== 0) {
+        v1 = getStringFromWasm0(ret[0], ret[1]).slice();
+        wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    }
+    return v1;
+}
+
+/**
+ * Get the detected type of a column ("numeric", "categorical", "boolean", "timestamp").
+ * @param {number} handle
+ * @param {number} col
+ * @returns {string}
+ */
+export function col_type(handle, col) {
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ret = wasm.col_type(handle, col);
+        var ptr1 = ret[0];
+        var len1 = ret[1];
+        if (ret[3]) {
+            ptr1 = 0; len1 = 0;
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        deferred2_0 = ptr1;
+        deferred2_1 = len1;
+        return getStringFromWasm0(ptr1, len1);
+    } finally {
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1);
+    }
+}
+
+/**
+ * Create an empty Arrow stream store. Append self-contained Arrow IPC stream
+ * chunks with `append_arrow_stream_chunk`, then call `finish_arrow_stream_store`
+ * when the manifest is complete.
+ * @returns {number}
+ */
+export function create_arrow_stream_store() {
+    const ret = wasm.create_arrow_stream_store();
+    return ret >>> 0;
+}
+
+/**
+ * Filter rows by a boolean mask and return filtered Arrow IPC bytes.
+ *
+ * Takes: Arrow IPC bytes, boolean mask as Uint8Array (0/1 per row)
+ * Returns: Filtered Arrow IPC bytes
+ * @param {Uint8Array} ipc_bytes
+ * @param {Uint8Array} mask
+ * @returns {Uint8Array}
+ */
+export function filter_rows(ipc_bytes, mask) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ptr1 = passArray8ToWasm0(mask, wasm.__wbindgen_malloc);
+    const len1 = WASM_VECTOR_LEN;
+    const ret = wasm.filter_rows(ptr0, len0, ptr1, len1);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v3 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v3;
+}
+
+/**
+ * Mark an Arrow stream store as complete. Further chunk appends are rejected.
+ * @param {number} handle
+ */
+export function finish_arrow_stream_store(handle) {
+    const ret = wasm.finish_arrow_stream_store(handle);
+    if (ret[1]) {
+        throw takeFromExternrefTable0(ret[0]);
+    }
+}
+
+/**
+ * Free a loaded dataset from WASM memory.
+ * @param {number} handle
+ */
+export function free(handle) {
+    wasm.free(handle);
+}
+
+/**
+ * Get the raw bytes of a `Struct{bytes, path}` cell — HuggingFace's
+ * Image/Audio/Video/Pdf/Nifti shape. See `cell_bytes_for` for semantics.
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @returns {Uint8Array}
+ */
+export function get_cell_bytes(handle, row, col) {
+    const ret = wasm.get_cell_bytes(handle, row, col);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
+}
+
+/**
+ * Get a cell value as f64. Returns NaN for null or unsupported types.
+ * Handles numeric types and timestamps (as epoch milliseconds).
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @returns {number}
+ */
+export function get_cell_f64(handle, row, col) {
+    const ret = wasm.get_cell_f64(handle, row, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0];
+}
+
+/**
+ * Bytes for the `idx`-th image in a cell. Works for both `Struct{bytes,path}`
+ * (only `idx == 0`) and `List<Struct{bytes,path}>`. See `cell_bytes_at_for`.
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @param {number} idx
+ * @returns {Uint8Array}
+ */
+export function get_cell_image_bytes_at(handle, row, col, idx) {
+    const ret = wasm.get_cell_image_bytes_at(handle, row, col, idx);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
+}
+
+/**
+ * Number of images in a cell. `1` for a single struct, `len` for a list,
+ * `0` otherwise. The renderer pairs this with `get_cell_image_bytes_at`
+ * to lay out a thumbnail strip without one round-trip per probe.
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @returns {number}
+ */
+export function get_cell_image_count(handle, row, col) {
+    const ret = wasm.get_cell_image_count(handle, row, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Get a cell value as a formatted string (for display).
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @returns {string}
+ */
+export function get_cell_string(handle, row, col) {
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ret = wasm.get_cell_string(handle, row, col);
+        var ptr1 = ret[0];
+        var len1 = ret[1];
+        if (ret[3]) {
+            ptr1 = 0; len1 = 0;
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        deferred2_0 = ptr1;
+        deferred2_1 = len1;
+        return getStringFromWasm0(ptr1, len1);
+    } finally {
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1);
+    }
+}
+
+/**
+ * Get a viewport slice as Arrow IPC bytes.
+ * Returns the rows [start_row, end_row) serialized as Arrow IPC stream.
+ * This is the hot-path function — one call per scroll frame.
+ * @param {number} handle
+ * @param {number} start_row
+ * @param {number} end_row
+ * @returns {Uint8Array}
+ */
+export function get_viewport(handle, start_row, end_row) {
+    const ret = wasm.get_viewport(handle, start_row, end_row);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
+}
+
+/**
+ * Get a viewport slice for specific rows by index (for sorted/filtered views).
+ * `indices` is a Uint32Array of row indices to fetch.
+ * Returns Arrow IPC bytes containing those specific rows in order.
+ * @param {number} handle
+ * @param {Uint32Array} indices
+ * @returns {Uint8Array}
+ */
+export function get_viewport_by_indices(handle, indices) {
+    const ptr0 = passArray32ToWasm0(indices, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.get_viewport_by_indices(handle, ptr0, len0);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v2 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v2;
+}
+
+/**
+ * Check if a column has been cast (i.e. original data is saved and can be restored).
+ * @param {number} handle
+ * @param {number} col
+ * @returns {boolean}
+ */
+export function has_original_column(handle, col) {
+    const ret = wasm.has_original_column(handle, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] !== 0;
+}
+
+/**
+ * Compute a histogram (binned counts) for a numeric column.
+ *
+ * Takes: Arrow IPC bytes, column index, number of bins
+ * Returns: JSON array of { x0, x1, count }
+ * @param {Uint8Array} ipc_bytes
+ * @param {number} column_index
+ * @param {number} num_bins
+ * @returns {any}
+ */
+export function histogram(ipc_bytes, column_index, num_bins) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.histogram(ptr0, len0, column_index, num_bins);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Initialize the WASM module. Call once before using other functions.
+ * Sets up panic hook so Rust panics show readable messages in the browser console.
+ */
+export function init() {
+    wasm.init();
+}
+
+/**
+ * Check if a cell is null.
+ * @param {number} handle
+ * @param {number} row
+ * @param {number} col
+ * @returns {boolean}
+ */
+export function is_null(handle, row, col) {
+    const ret = wasm.is_null(handle, row, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] !== 0;
+}
+
+/**
+ * Load Arrow IPC bytes into WASM memory. Returns a handle for subsequent operations.
+ * @param {Uint8Array} ipc_bytes
+ * @returns {number}
+ */
+export function load_ipc(ipc_bytes) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.load_ipc(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Load Parquet bytes into WASM memory. Returns a handle for subsequent operations.
+ * This replaces the need for parquet-wasm — one WASM binary for everything.
+ * @param {Uint8Array} parquet_bytes
+ * @returns {number}
+ */
+export function load_parquet(parquet_bytes) {
+    const ptr0 = passArray8ToWasm0(parquet_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.load_parquet(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Load a single Parquet row group into a new or existing store.
+ * If handle is 0, creates a new store and returns the handle.
+ * If handle is non-zero, appends the row group to the existing store.
+ * @param {Uint8Array} parquet_bytes
+ * @param {number} row_group
+ * @param {number} handle
+ * @returns {number}
+ */
+export function load_parquet_row_group(parquet_bytes, row_group, handle) {
+    const ptr0 = passArray8ToWasm0(parquet_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.load_parquet_row_group(ptr0, len0, row_group, handle);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Get the number of columns in a loaded dataset.
+ * @param {number} handle
+ * @returns {number}
+ */
+export function num_cols(handle) {
+    const ret = wasm.num_cols(handle);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Get the number of rows in a loaded dataset.
+ * @param {number} handle
+ * @returns {number}
+ */
+export function num_rows(handle) {
+    const ret = wasm.num_rows(handle);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0] >>> 0;
+}
+
+/**
+ * Extract canonical column hints from Parquet file-level metadata.
+ * @param {Uint8Array} parquet_bytes
+ * @returns {any}
+ */
+export function parquet_column_hints(parquet_bytes) {
+    const ptr0 = passArray8ToWasm0(parquet_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.parquet_column_hints(ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Get Parquet metadata: number of row groups and total rows.
+ * Returns [num_row_groups, total_rows] as Vec<u32>.
+ * @param {Uint8Array} parquet_bytes
+ * @returns {Uint32Array}
+ */
+export function parquet_metadata(parquet_bytes) {
+    const ptr0 = passArray8ToWasm0(parquet_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.parquet_metadata(ptr0, len0);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v2 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v2;
+}
+
+/**
+ * Count boolean values in a column: returns [true_count, false_count, null_count].
+ * @param {number} handle
+ * @param {number} col
+ * @returns {Uint32Array}
+ */
+export function store_bool_counts(handle, col) {
+    const ret = wasm.store_bool_counts(handle, col);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v1;
+}
+
+/**
+ * Apply filter predicates to the store and return matching row indices.
+ * `filters_js` is a JSON array of filter specs:
+ *   [{kind: "range", col: 0, min: 10, max: 50},
+ *    {kind: "set", col: 1, values: ["a", "b"]},
+ *    {kind: "boolean", col: 3, value: true}]
+ * Returns a Vec<u32> of row indices that pass ALL filters (AND logic).
+ * @param {number} handle
+ * @param {any} filters_js
+ * @returns {Uint32Array}
+ */
+export function store_filter_rows(handle, filters_js) {
+    const ret = wasm.store_filter_rows(handle, filters_js);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v1;
+}
+
+/**
+ * Filtered bool counts: returns [true_count, false_count, null_count] for masked rows.
+ * @param {number} handle
+ * @param {number} col
+ * @param {Uint8Array} mask
+ * @returns {Uint32Array}
+ */
+export function store_filtered_bool_counts(handle, col, mask) {
+    const ptr0 = passArray8ToWasm0(mask, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.store_filtered_bool_counts(handle, col, ptr0, len0);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v2 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v2;
+}
+
+/**
+ * Filtered histogram: computes bins only for rows where mask[row] != 0.
+ * @param {number} handle
+ * @param {number} col
+ * @param {Uint8Array} mask
+ * @param {number} num_bins
+ * @returns {any}
+ */
+export function store_filtered_histogram(handle, col, mask, num_bins) {
+    const ptr0 = passArray8ToWasm0(mask, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.store_filtered_histogram(handle, col, ptr0, len0, num_bins);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Filtered value_counts: counts string values only for rows where mask[row] != 0.
+ * @param {number} handle
+ * @param {number} col
+ * @param {Uint8Array} mask
+ * @returns {any}
+ */
+export function store_filtered_value_counts(handle, col, mask) {
+    const ptr0 = passArray8ToWasm0(mask, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.store_filtered_value_counts(handle, col, ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Compute histogram for a numeric column in a loaded store.
+ * @param {number} handle
+ * @param {number} col
+ * @param {number} num_bins
+ * @returns {any}
+ */
+export function store_histogram(handle, col, num_bins) {
+    const ret = wasm.store_histogram(handle, col, num_bins);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Sort a column and return sorted row indices.
+ * `ascending`: true for asc, false for desc.
+ * Nulls are always sorted to the end.
+ * @param {number} handle
+ * @param {number} col
+ * @param {boolean} ascending
+ * @returns {Uint32Array}
+ */
+export function store_sort_indices(handle, col, ascending) {
+    const ret = wasm.store_sort_indices(handle, col, ascending);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v1;
+}
+
+/**
+ * Compute temporal histogram: bins timestamps by calendar unit (auto-detected).
+ * Granularity: <48h → hourly, <90d → daily, <3y → monthly, else yearly.
+ * Returns bins with x0/x1 as epoch milliseconds.
+ * @param {number} handle
+ * @param {number} col
+ * @returns {any}
+ */
+export function store_temporal_histogram(handle, col) {
+    const ret = wasm.store_temporal_histogram(handle, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Compute value_counts for a column in a loaded store. Much faster than
+ * the JS accumulator path since it iterates batches in Rust.
+ * @param {number} handle
+ * @param {number} col
+ * @returns {any}
+ */
+export function store_value_counts(handle, col) {
+    const ret = wasm.store_value_counts(handle, col);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Batch-fetch display strings and raw numeric values for viewport rows.
+ *
+ * The frontend calls this once per render window instead of calling
+ * is_null/get_cell_string/get_cell_f64 for every visible cell.
+ * @param {number} handle
+ * @param {Uint32Array} rows
+ * @returns {any}
+ */
+export function store_viewport_cells(handle, rows) {
+    const ptr0 = passArray32ToWasm0(rows, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.store_viewport_cells(handle, ptr0, len0);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Search a string column for values containing a substring.
+ * Returns indices of matching rows as a Uint32Array.
+ *
+ * Takes: Arrow IPC bytes, column index, search query
+ * Returns: Array of matching row indices
+ * @param {Uint8Array} ipc_bytes
+ * @param {number} column_index
+ * @param {string} query
+ * @returns {Uint32Array}
+ */
+export function string_contains(ipc_bytes, column_index, query) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ptr1 = passStringToWasm0(query, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len1 = WASM_VECTOR_LEN;
+    const ret = wasm.string_contains(ptr0, len0, column_index, ptr1, len1);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v3 = getArrayU32FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 4, 4);
+    return v3;
+}
+
+/**
+ * Undo a column cast, restoring the original column data and type.
+ * Returns the original column type string (e.g. "categorical", "numeric").
+ * @param {number} handle
+ * @param {number} col
+ * @returns {string}
+ */
+export function undo_cast_column(handle, col) {
+    let deferred2_0;
+    let deferred2_1;
+    try {
+        const ret = wasm.undo_cast_column(handle, col);
+        var ptr1 = ret[0];
+        var len1 = ret[1];
+        if (ret[3]) {
+            ptr1 = 0; len1 = 0;
+            throw takeFromExternrefTable0(ret[2]);
+        }
+        deferred2_0 = ptr1;
+        deferred2_1 = len1;
+        return getStringFromWasm0(ptr1, len1);
+    } finally {
+        wasm.__wbindgen_free(deferred2_0, deferred2_1, 1);
+    }
+}
+
+/**
+ * Compute a frequency table (value_counts) for a string column
+ * passed as Arrow IPC bytes.
+ *
+ * Takes: Arrow IPC bytes containing a single string/dictionary column
+ * Returns: JSON array of { label, count } sorted by count descending
+ * @param {Uint8Array} ipc_bytes
+ * @param {number} column_index
+ * @returns {any}
+ */
+export function value_counts(ipc_bytes, column_index) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.value_counts(ptr0, len0, column_index);
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return takeFromExternrefTable0(ret[0]);
+}
+
+/**
+ * Build a Parquet file directly from SQLite query results. The caller
+ * supplies:
+ *
+ * - `pragma_rows`: rows returned by `PRAGMA table_info(tablename)`, i.e. an
+ *   array of `{ name, type, notnull, pk, dflt_value, cid }` objects. Schema
+ *   is taken from here; only `name` and `type` are used.
+ * - `data_rows`: rows returned by `SELECT * FROM tablename`, i.e. an array
+ *   of `{ col_name: value, ... }` objects.
+ *
+ * One row group per call, ZSTD compression.
+ * @param {any} pragma_rows
+ * @param {any} data_rows
+ * @returns {Uint8Array}
+ */
+export function write_parquet_from_sqlite(pragma_rows, data_rows) {
+    const ret = wasm.write_parquet_from_sqlite(pragma_rows, data_rows);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
+}
+
+/**
+ * Write an Arrow IPC stream to a Parquet file. ZSTD compressed,
+ * one row group per input RecordBatch.
+ * @param {Uint8Array} ipc_bytes
+ * @returns {Uint8Array}
+ */
+export function write_parquet_ipc(ipc_bytes) {
+    const ptr0 = passArray8ToWasm0(ipc_bytes, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.write_parquet_ipc(ptr0, len0);
+    if (ret[3]) {
+        throw takeFromExternrefTable0(ret[2]);
+    }
+    var v2 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v2;
+}
+function __wbg_get_imports() {
+    const import0 = {
+        __proto__: null,
+        __wbg_Error_960c155d3d49e4c2: function(arg0, arg1) {
+            const ret = Error(getStringFromWasm0(arg0, arg1));
+            return ret;
+        },
+        __wbg_String_8564e559799eccda: function(arg0, arg1) {
+            const ret = String(arg1);
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_bigint_get_as_i64_3d3aba5d616c6a51: function(arg0, arg1) {
+            const v = arg1;
+            const ret = typeof(v) === 'bigint' ? v : undefined;
+            getDataViewMemory0().setBigInt64(arg0 + 8 * 1, isLikeNone(ret) ? BigInt(0) : ret, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+        },
+        __wbg___wbindgen_boolean_get_6ea149f0a8dcc5ff: function(arg0) {
+            const v = arg0;
+            const ret = typeof(v) === 'boolean' ? v : undefined;
+            return isLikeNone(ret) ? 0xFFFFFF : ret ? 1 : 0;
+        },
+        __wbg___wbindgen_debug_string_ab4b34d23d6778bd: function(arg0, arg1) {
+            const ret = debugString(arg1);
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_in_a5d8b22e52b24dd1: function(arg0, arg1) {
+            const ret = arg0 in arg1;
+            return ret;
+        },
+        __wbg___wbindgen_is_bigint_ec25c7f91b4d9e93: function(arg0) {
+            const ret = typeof(arg0) === 'bigint';
+            return ret;
+        },
+        __wbg___wbindgen_is_function_3baa9db1a987f47d: function(arg0) {
+            const ret = typeof(arg0) === 'function';
+            return ret;
+        },
+        __wbg___wbindgen_is_null_52ff4ec04186736f: function(arg0) {
+            const ret = arg0 === null;
+            return ret;
+        },
+        __wbg___wbindgen_is_object_63322ec0cd6ea4ef: function(arg0) {
+            const val = arg0;
+            const ret = typeof(val) === 'object' && val !== null;
+            return ret;
+        },
+        __wbg___wbindgen_is_undefined_29a43b4d42920abd: function(arg0) {
+            const ret = arg0 === undefined;
+            return ret;
+        },
+        __wbg___wbindgen_jsval_eq_d3465d8a07697228: function(arg0, arg1) {
+            const ret = arg0 === arg1;
+            return ret;
+        },
+        __wbg___wbindgen_jsval_loose_eq_cac3565e89b4134c: function(arg0, arg1) {
+            const ret = arg0 == arg1;
+            return ret;
+        },
+        __wbg___wbindgen_number_get_c7f42aed0525c451: function(arg0, arg1) {
+            const obj = arg1;
+            const ret = typeof(obj) === 'number' ? obj : undefined;
+            getDataViewMemory0().setFloat64(arg0 + 8 * 1, isLikeNone(ret) ? 0 : ret, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
+        },
+        __wbg___wbindgen_string_get_7ed5322991caaec5: function(arg0, arg1) {
+            const obj = arg1;
+            const ret = typeof(obj) === 'string' ? obj : undefined;
+            var ptr1 = isLikeNone(ret) ? 0 : passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            var len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_throw_6b64449b9b9ed33c: function(arg0, arg1) {
+            throw new Error(getStringFromWasm0(arg0, arg1));
+        },
+        __wbg___wbindgen_typeof_f84d8f695b18b75f: function(arg0) {
+            const ret = typeof arg0;
+            return ret;
+        },
+        __wbg_call_14b169f759b26747: function() { return handleError(function (arg0, arg1) {
+            const ret = arg0.call(arg1);
+            return ret;
+        }, arguments); },
+        __wbg_call_a24592a6f349a97e: function() { return handleError(function (arg0, arg1, arg2) {
+            const ret = arg0.call(arg1, arg2);
+            return ret;
+        }, arguments); },
+        __wbg_done_9158f7cc8751ba32: function(arg0) {
+            const ret = arg0.done;
+            return ret;
+        },
+        __wbg_entries_e0b73aa8571ddb56: function(arg0) {
+            const ret = Object.entries(arg0);
+            return ret;
+        },
+        __wbg_error_a6fa202b58aa1cd3: function(arg0, arg1) {
+            let deferred0_0;
+            let deferred0_1;
+            try {
+                deferred0_0 = arg0;
+                deferred0_1 = arg1;
+                console.error(getStringFromWasm0(arg0, arg1));
+            } finally {
+                wasm.__wbindgen_free(deferred0_0, deferred0_1, 1);
+            }
+        },
+        __wbg_from_0dbf29f09e7fb200: function(arg0) {
+            const ret = Array.from(arg0);
+            return ret;
+        },
+        __wbg_get_1affdbdd5573b16a: function() { return handleError(function (arg0, arg1) {
+            const ret = Reflect.get(arg0, arg1);
+            return ret;
+        }, arguments); },
+        __wbg_get_6011fa3a58f61074: function() { return handleError(function (arg0, arg1) {
+            const ret = Reflect.get(arg0, arg1);
+            return ret;
+        }, arguments); },
+        __wbg_get_8360291721e2339f: function(arg0, arg1) {
+            const ret = arg0[arg1 >>> 0];
+            return ret;
+        },
+        __wbg_get_unchecked_17f53dad852b9588: function(arg0, arg1) {
+            const ret = arg0[arg1 >>> 0];
+            return ret;
+        },
+        __wbg_get_with_ref_key_6412cf3094599694: function(arg0, arg1) {
+            const ret = arg0[arg1];
+            return ret;
+        },
+        __wbg_instanceof_ArrayBuffer_7c8433c6ed14ffe3: function(arg0) {
+            let result;
+            try {
+                result = arg0 instanceof ArrayBuffer;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_instanceof_Map_1b76fd4635be43eb: function(arg0) {
+            let result;
+            try {
+                result = arg0 instanceof Map;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_instanceof_Object_7c99480a1cdfb911: function(arg0) {
+            let result;
+            try {
+                result = arg0 instanceof Object;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_instanceof_Uint8Array_152ba1f289edcf3f: function(arg0) {
+            let result;
+            try {
+                result = arg0 instanceof Uint8Array;
+            } catch (_) {
+                result = false;
+            }
+            const ret = result;
+            return ret;
+        },
+        __wbg_isArray_c3109d14ffc06469: function(arg0) {
+            const ret = Array.isArray(arg0);
+            return ret;
+        },
+        __wbg_isSafeInteger_4fc213d1989d6d2a: function(arg0) {
+            const ret = Number.isSafeInteger(arg0);
+            return ret;
+        },
+        __wbg_iterator_013bc09ec998c2a7: function() {
+            const ret = Symbol.iterator;
+            return ret;
+        },
+        __wbg_length_3d4ecd04bd8d22f1: function(arg0) {
+            const ret = arg0.length;
+            return ret;
+        },
+        __wbg_length_9f1775224cf1d815: function(arg0) {
+            const ret = arg0.length;
+            return ret;
+        },
+        __wbg_new_0c7403db6e782f19: function(arg0) {
+            const ret = new Uint8Array(arg0);
+            return ret;
+        },
+        __wbg_new_227d7c05414eb861: function() {
+            const ret = new Error();
+            return ret;
+        },
+        __wbg_new_682678e2f47e32bc: function() {
+            const ret = new Array();
+            return ret;
+        },
+        __wbg_new_aa8d0fa9762c29bd: function() {
+            const ret = new Object();
+            return ret;
+        },
+        __wbg_next_0340c4ae324393c3: function() { return handleError(function (arg0) {
+            const ret = arg0.next();
+            return ret;
+        }, arguments); },
+        __wbg_next_7646edaa39458ef7: function(arg0) {
+            const ret = arg0.next;
+            return ret;
+        },
+        __wbg_prototypesetcall_a6b02eb00b0f4ce2: function(arg0, arg1, arg2) {
+            Uint8Array.prototype.set.call(getArrayU8FromWasm0(arg0, arg1), arg2);
+        },
+        __wbg_set_3bf1de9fab0cd644: function(arg0, arg1, arg2) {
+            arg0[arg1 >>> 0] = arg2;
+        },
+        __wbg_set_6be42768c690e380: function(arg0, arg1, arg2) {
+            arg0[arg1] = arg2;
+        },
+        __wbg_stack_3b0d974bbf31e44f: function(arg0, arg1) {
+            const ret = arg1.stack;
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg_static_accessor_GLOBAL_8cfadc87a297ca02: function() {
+            const ret = typeof global === 'undefined' ? null : global;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_GLOBAL_THIS_602256ae5c8f42cf: function() {
+            const ret = typeof globalThis === 'undefined' ? null : globalThis;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_SELF_e445c1c7484aecc3: function() {
+            const ret = typeof self === 'undefined' ? null : self;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_static_accessor_WINDOW_f20e8576ef1e0f17: function() {
+            const ret = typeof window === 'undefined' ? null : window;
+            return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+        },
+        __wbg_value_ee3a06f4579184fa: function(arg0) {
+            const ret = arg0.value;
+            return ret;
+        },
+        __wbindgen_cast_0000000000000001: function(arg0) {
+            // Cast intrinsic for `F64 -> Externref`.
+            const ret = arg0;
+            return ret;
+        },
+        __wbindgen_cast_0000000000000002: function(arg0) {
+            // Cast intrinsic for `I64 -> Externref`.
+            const ret = arg0;
+            return ret;
+        },
+        __wbindgen_cast_0000000000000003: function(arg0, arg1) {
+            // Cast intrinsic for `Ref(String) -> Externref`.
+            const ret = getStringFromWasm0(arg0, arg1);
+            return ret;
+        },
+        __wbindgen_cast_0000000000000004: function(arg0) {
+            // Cast intrinsic for `U64 -> Externref`.
+            const ret = BigInt.asUintN(64, arg0);
+            return ret;
+        },
+        __wbindgen_init_externref_table: function() {
+            const table = wasm.__wbindgen_externrefs;
+            const offset = table.grow(4);
+            table.set(0, undefined);
+            table.set(offset + 0, undefined);
+            table.set(offset + 1, null);
+            table.set(offset + 2, true);
+            table.set(offset + 3, false);
+        },
+    };
+    return {
+        __proto__: null,
+        "./sift_wasm_bg.js": import0,
+    };
+}
+
+function addToExternrefTable0(obj) {
+    const idx = wasm.__externref_table_alloc();
+    wasm.__wbindgen_externrefs.set(idx, obj);
+    return idx;
+}
+
+function debugString(val) {
+    // primitive types
+    const type = typeof val;
+    if (type == 'number' || type == 'boolean' || val == null) {
+        return  `${val}`;
+    }
+    if (type == 'string') {
+        return `"${val}"`;
+    }
+    if (type == 'symbol') {
+        const description = val.description;
+        if (description == null) {
+            return 'Symbol';
+        } else {
+            return `Symbol(${description})`;
+        }
+    }
+    if (type == 'function') {
+        const name = val.name;
+        if (typeof name == 'string' && name.length > 0) {
+            return `Function(${name})`;
+        } else {
+            return 'Function';
+        }
+    }
+    // objects
+    if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = '[';
+        if (length > 0) {
+            debug += debugString(val[0]);
+        }
+        for(let i = 1; i < length; i++) {
+            debug += ', ' + debugString(val[i]);
+        }
+        debug += ']';
+        return debug;
+    }
+    // Test for built-in
+    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+    let className;
+    if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+    } else {
+        // Failed to match the standard '[object ClassName]'
+        return toString.call(val);
+    }
+    if (className == 'Object') {
+        // we're a user defined class or Object
+        // JSON.stringify avoids problems with cycles, and is generally much
+        // easier than looping through ownProperties of `val`.
+        try {
+            return 'Object(' + JSON.stringify(val) + ')';
+        } catch (_) {
+            return 'Object';
+        }
+    }
+    // errors
+    if (val instanceof Error) {
+        return `${val.name}: ${val.message}\n${val.stack}`;
+    }
+    // TODO we could test for more things here, like `Set`s and `Map`s.
+    return className;
+}
+
+function getArrayU32FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint32ArrayMemory0().subarray(ptr / 4, ptr / 4 + len);
+}
+
+function getArrayU8FromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+}
+
+let cachedDataViewMemory0 = null;
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return decodeText(ptr, len);
+}
+
+let cachedUint32ArrayMemory0 = null;
+function getUint32ArrayMemory0() {
+    if (cachedUint32ArrayMemory0 === null || cachedUint32ArrayMemory0.byteLength === 0) {
+        cachedUint32ArrayMemory0 = new Uint32Array(wasm.memory.buffer);
+    }
+    return cachedUint32ArrayMemory0;
+}
+
+let cachedUint8ArrayMemory0 = null;
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store(idx);
+    }
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+
+function passArray32ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 4, 4) >>> 0;
+    getUint32ArrayMemory0().set(arg, ptr / 4);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+
+function passArray8ToWasm0(arg, malloc) {
+    const ptr = malloc(arg.length * 1, 1) >>> 0;
+    getUint8ArrayMemory0().set(arg, ptr / 1);
+    WASM_VECTOR_LEN = arg.length;
+    return ptr;
+}
+
+function passStringToWasm0(arg, malloc, realloc) {
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+function takeFromExternrefTable0(idx) {
+    const value = wasm.__wbindgen_externrefs.get(idx);
+    wasm.__externref_table_dealloc(idx);
+    return value;
+}
+
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+cachedTextDecoder.decode();
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const cachedTextEncoder = new TextEncoder();
+
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    };
+}
+
+let WASM_VECTOR_LEN = 0;
+
+let wasmModule, wasm;
+function __wbg_finalize_init(instance, module) {
+    wasm = instance.exports;
+    wasmModule = module;
+    cachedDataViewMemory0 = null;
+    cachedUint32ArrayMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+            } catch (e) {
+                const validResponse = module.ok && expectedResponseType(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else { throw e; }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+        } else {
+            return instance;
+        }
+    }
+
+    function expectedResponseType(type) {
+        switch (type) {
+            case 'basic': case 'cors': case 'default': return true;
+        }
+        return false;
+    }
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module !== undefined) {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+    const instance = new WebAssembly.Instance(module, imports);
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module_or_path !== undefined) {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (module_or_path === undefined) {
+        module_or_path = new URL('sift_wasm_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync, __wbg_init as default };

--- a/apps/elements/public/wasm/sift_wasm_bg.wasm
+++ b/apps/elements/public/wasm/sift_wasm_bg.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94e9b817e9fd9874db2ffe0d2120fe510e63085131598eb3da0079a4c73ab99f
+size 6870253


### PR DESCRIPTION
## Summary

- replace the elements Sift parquet URL handoff with the real `SiftTable` URL source
- serve Sift WASM as a static docs catalog asset and route the `sift-wasm` import through a small docs adapter
- update the output renderer docs and burn-down to mark HuggingFace parquet URL decoding as covered

## Verification

- `pnpm --dir apps/elements build`
- Playwright desktop: `/docs/output-renderers` loads the HuggingFace parquet URL, `/wasm/sift_wasm.js`, `/wasm/sift_wasm_bg.wasm`, and reaches `engine-mounted` with 299 rows
- Playwright mobile: `/docs/output-renderers` reaches `engine-mounted` with no horizontal overflow and no console errors
- `cargo xtask lint --fix`
- `git diff --check`
