### PR TITLE
test(notebook-cloud): budget hosted collab smoke

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-collab-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke-performance.mjs
@@ -1,0 +1,55 @@
+export function summarizeCollabPerformanceTimings(timings = {}) {
+  return {
+    collab_path: {
+      collab_connected_ms: maxNamedTiming(timings, [
+        "alice_connected",
+        "bob_connected",
+        "anonymous_connected",
+      ]),
+      collab_editor_update_max_ms: maxNamedTiming(timings, [
+        "alice_to_bob",
+        "alice_to_bob_editor",
+        "bob_to_alice",
+        "bob_to_alice_editor",
+        ...numberedRoundTimingNames(timings, "_alice_exact"),
+        ...numberedRoundTimingNames(timings, "_bob_exact"),
+      ]),
+      collab_anonymous_update_max_ms: maxNamedTiming(timings, [
+        "alice_to_anonymous",
+        "bob_to_anonymous",
+        "overlap_anonymous",
+        ...numberedRoundTimingNames(timings, "_anonymous"),
+      ]),
+      collab_editor_convergence_max_ms: maxNamedTiming(timings, [
+        "bob_to_alice_exact",
+        "bob_to_bob_exact",
+        "overlap_editors_converged",
+        ...numberedRoundTimingNames(timings, "_alice_exact"),
+        ...numberedRoundTimingNames(timings, "_bob_exact"),
+      ]),
+      collab_total_ms: numericTiming(timings.total),
+    },
+  };
+}
+
+function maxNamedTiming(timings, names) {
+  let max = null;
+  for (const name of names) {
+    const value = numericTiming(timings[name]);
+    if (value === null) {
+      continue;
+    }
+    max = max === null ? value : Math.max(max, value);
+  }
+  return max;
+}
+
+function numberedRoundTimingNames(timings, suffix) {
+  return Object.keys(timings).filter(
+    (name) => /^(alice|bob)_ping_\d+_/.test(name) && name.endsWith(suffix),
+  );
+}
+
+function numericTiming(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -10,6 +10,8 @@ import {
   storageStateForDevIdentity,
   viewerUrlForRoom,
 } from "./hosted-collab-smoke-env.mjs";
+import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-performance.mjs";
+import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -20,6 +22,19 @@ const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const convergenceRounds = Number(process.env.NOTEBOOK_CLOUD_COLLAB_ROUNDS ?? 4);
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timingsMs = {};
+const performanceBudgets = {
+  collab_connected_ms: parseOptionalBudget(process.env.NOTEBOOK_CLOUD_MAX_COLLAB_CONNECTED_MS),
+  collab_editor_update_max_ms: parseOptionalBudget(
+    process.env.NOTEBOOK_CLOUD_MAX_COLLAB_EDITOR_UPDATE_MS,
+  ),
+  collab_anonymous_update_max_ms: parseOptionalBudget(
+    process.env.NOTEBOOK_CLOUD_MAX_COLLAB_ANONYMOUS_UPDATE_MS,
+  ),
+  collab_editor_convergence_max_ms: parseOptionalBudget(
+    process.env.NOTEBOOK_CLOUD_MAX_COLLAB_EDITOR_CONVERGENCE_MS,
+  ),
+  collab_total_ms: parseOptionalBudget(process.env.NOTEBOOK_CLOUD_MAX_COLLAB_TOTAL_MS),
+};
 
 const startedAt = performance.now();
 
@@ -206,6 +221,13 @@ ${bobMarker}
     assertTokenAbsentFromUrls(visitedUrls, token);
     checks.push("token_absent_from_urls");
 
+    const timingSummary = {
+      ...timingsMs,
+      total: elapsedMs(startedAt),
+    };
+    const performanceDiagnostics = summarizeCollabPerformanceTimings(timingSummary);
+    failures.push(...performanceBudgetFailures(performanceDiagnostics, performanceBudgets));
+
     if (screenshotPath) {
       await alice.page.screenshot({ path: screenshotPath, fullPage: true });
       checks.push("screenshot_saved");
@@ -224,10 +246,9 @@ ${bobMarker}
           viewerUrl,
           roomId: room.roomId,
           checks,
-          timings_ms: {
-            ...timingsMs,
-            total: elapsedMs(startedAt),
-          },
+          timings_ms: timingSummary,
+          performance: performanceDiagnostics,
+          performanceBudgets,
           screenshot: screenshotPath ?? null,
         },
         null,
@@ -498,6 +519,17 @@ async function timed(name, fn) {
 
 function elapsedMs(started) {
   return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
+}
+
+function parseOptionalBudget(value) {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  const budget = Number(value);
+  if (!Number.isFinite(budget) || budget < 0) {
+    throw new Error(`Invalid performance budget ${JSON.stringify(value)}`);
+  }
+  return budget;
 }
 
 function capitalize(value) {

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -12,6 +12,7 @@ import {
 } from "./hosted-collab-smoke-env.mjs";
 import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-performance.mjs";
 import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
+import { isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 
 const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -21,6 +22,7 @@ const providedViewerUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_COLLAB_V
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const convergenceRounds = Number(process.env.NOTEBOOK_CLOUD_COLLAB_ROUNDS ?? 4);
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
+const forbidRenderCacheRequests = process.env.NOTEBOOK_CLOUD_FORBID_RENDER_CACHE_REQUESTS !== "0";
 const timingsMs = {};
 const editableMarkdownCellSelector = ".cloud-editable-markdown-cell";
 const editableMarkdownEditorSelector = `${editableMarkdownCellSelector} .cm-content[contenteditable='true']`;
@@ -61,6 +63,7 @@ async function main() {
   });
   const failures = [];
   const visitedUrls = new Set();
+  const renderCacheRequests = [];
   const contexts = [];
 
   try {
@@ -77,6 +80,7 @@ async function main() {
         }),
         failures,
         visitedUrls,
+        renderCacheRequests,
       }),
     );
     const bob = await timed("bob_open", () =>
@@ -92,6 +96,7 @@ async function main() {
         }),
         failures,
         visitedUrls,
+        renderCacheRequests,
       }),
     );
     const anonymous = await timed("anonymous_open", () =>
@@ -102,6 +107,7 @@ async function main() {
         storageState: undefined,
         failures,
         visitedUrls,
+        renderCacheRequests,
       }),
     );
     contexts.push(alice.context, bob.context, anonymous.context);
@@ -221,6 +227,9 @@ ${bobMarker}
 
     assertTokenAbsentFromUrls(visitedUrls, token);
     checks.push("token_absent_from_urls");
+    if (renderCacheRequests.length === 0) {
+      checks.push("render_cache_not_requested");
+    }
 
     const timingSummary = {
       ...timingsMs,
@@ -250,6 +259,8 @@ ${bobMarker}
           timings_ms: timingSummary,
           performance: performanceDiagnostics,
           performanceBudgets,
+          forbidRenderCacheRequests,
+          renderCacheRequests,
           screenshot: screenshotPath ?? null,
         },
         null,
@@ -286,6 +297,7 @@ async function openNotebookContext({
   storageState,
   failures,
   visitedUrls,
+  renderCacheRequests,
   allowSyncFailure = false,
 }) {
   const context = await browser.newContext({
@@ -294,15 +306,36 @@ async function openNotebookContext({
     deviceScaleFactor: 1,
   });
   const page = await context.newPage();
-  instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure });
+  instrumentPage({ page, name, failures, visitedUrls, renderCacheRequests, allowSyncFailure });
   await page.goto(viewerUrl, { waitUntil: "domcontentloaded", timeout: timeoutMs });
   await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
   return { context, page };
 }
 
-function instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure }) {
+function instrumentPage({
+  page,
+  name,
+  failures,
+  visitedUrls,
+  renderCacheRequests,
+  allowSyncFailure,
+}) {
   page.on("request", (request) => {
-    visitedUrls.add(request.url());
+    const url = request.url();
+    visitedUrls.add(url);
+    if (forbidRenderCacheRequests && isRenderCacheApiUrl(url)) {
+      const requestSummary = {
+        page: name,
+        method: request.method(),
+        url,
+      };
+      renderCacheRequests.push(requestSummary);
+      failures.push({
+        kind: "render-cache-request",
+        text: "Hosted collaboration smoke requested stale render-cache endpoints instead of live sync materialization",
+        ...requestSummary,
+      });
+    }
   });
   page.on("response", (response) => {
     visitedUrls.add(response.url());

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -22,6 +22,8 @@ const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const convergenceRounds = Number(process.env.NOTEBOOK_CLOUD_COLLAB_ROUNDS ?? 4);
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
 const timingsMs = {};
+const editableMarkdownCellSelector = ".cloud-editable-markdown-cell";
+const editableMarkdownEditorSelector = `${editableMarkdownCellSelector} .cm-content[contenteditable='true']`;
 const performanceBudgets = {
   collab_connected_ms: parseOptionalBudget(process.env.NOTEBOOK_CLOUD_MAX_COLLAB_CONNECTED_MS),
   collab_editor_update_max_ms: parseOptionalBudget(
@@ -210,13 +212,12 @@ ${bobMarker}
         }),
         failures,
         visitedUrls,
-        allowSyncFailure: true,
       }),
     );
     contexts.push(charlie.context);
-    await timed("charlie_denied", () => waitForPresence(charlie.page, "Offline"));
+    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "viewing"));
     await assertNoEditableMarkdown(charlie.page);
-    checks.push("ungranted_editor_denied");
+    checks.push("ungranted_editor_downgraded_to_viewer");
 
     assertTokenAbsentFromUrls(visitedUrls, token);
     checks.push("token_absent_from_urls");
@@ -334,10 +335,7 @@ function instrumentPage({ page, name, failures, visitedUrls, allowSyncFailure })
 }
 
 async function replaceMarkdown(page, source, localEvidenceText) {
-  const editor = page
-    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
-    .first();
-  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  const editor = await ensureEditableMarkdown(page);
   await editor.click();
   await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
   await page.keyboard.insertText(source);
@@ -345,38 +343,26 @@ async function replaceMarkdown(page, source, localEvidenceText) {
 }
 
 async function waitForEditableMarkdown(page) {
-  await page
-    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
-    .first()
-    .waitFor({ state: "visible", timeout: timeoutMs });
+  await ensureEditableMarkdown(page);
 }
 
 async function focusEditableMarkdown(page) {
-  const editor = page
-    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
-    .first();
-  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  const editor = await ensureEditableMarkdown(page);
   await editor.click();
 }
 
 async function waitForEditableMarkdownText(page, expectedText) {
-  const editor = page
-    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
-    .first();
+  const editor = page.locator(editableMarkdownEditorSelector).first();
   await editor.waitFor({ state: "visible", timeout: timeoutMs });
   await page.waitForFunction(
     ([selector, expected]) => document.querySelector(selector)?.textContent?.includes(expected),
-    [
-      "[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']",
-      expectedText,
-    ],
+    [editableMarkdownEditorSelector, expectedText],
     { timeout: timeoutMs },
   );
 }
 
 async function waitForEditableMarkdownExactText(page, expectedText) {
-  const selector = "[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']";
-  const editor = page.locator(selector).first();
+  const editor = page.locator(editableMarkdownEditorSelector).first();
   await editor.waitFor({ state: "visible", timeout: timeoutMs });
   await page.waitForFunction(
     ([contentSelector, expected]) => {
@@ -387,7 +373,7 @@ async function waitForEditableMarkdownExactText(page, expectedText) {
         .join("\n");
       return text.trimEnd() === expected.trimEnd();
     },
-    [selector, expectedText],
+    [editableMarkdownEditorSelector, expectedText],
     { timeout: timeoutMs },
   );
 }
@@ -413,24 +399,38 @@ async function waitForEditorsEqualContaining(pages, expectedMarkers) {
 }
 
 async function editableMarkdownText(page) {
-  const selector = "[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']";
-  await page.locator(selector).first().waitFor({ state: "visible", timeout: timeoutMs });
+  await page.locator(editableMarkdownEditorSelector).first().waitFor({
+    state: "visible",
+    timeout: timeoutMs,
+  });
   return page.evaluate((contentSelector) => {
     const content = document.querySelector(contentSelector);
     if (!content) return "";
     return Array.from(content.querySelectorAll(".cm-line"))
       .map((line) => line.textContent ?? "")
       .join("\n");
-  }, selector);
+  }, editableMarkdownEditorSelector);
 }
 
 async function assertNoEditableMarkdown(page) {
-  const count = await page
-    .locator("[data-slot='cloud-editable-markdown-cell'] .cm-content[contenteditable='true']")
-    .count();
+  const count = await page.locator(editableMarkdownEditorSelector).count();
   if (count !== 0) {
     throw new Error("ungranted editor unexpectedly received an editable markdown surface");
   }
+}
+
+async function ensureEditableMarkdown(page) {
+  const cell = page.locator(editableMarkdownCellSelector).first();
+  await cell.waitFor({ state: "visible", timeout: timeoutMs });
+
+  const editor = page.locator(editableMarkdownEditorSelector).first();
+  if ((await editor.count()) > 0 && (await editor.isVisible().catch(() => false))) {
+    return editor;
+  }
+
+  await cell.locator(".cloud-markdown-cell-action").first().click({ timeout: timeoutMs });
+  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  return editor;
 }
 
 async function waitForPresence(page, expectedText) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -309,6 +309,26 @@ function firstDefined(...values) {
 }
 
 const PERFORMANCE_BUDGET_METRICS = {
+  collab_connected_ms: {
+    group: "collab_path",
+    label: "browser collaboration connections",
+  },
+  collab_editor_update_max_ms: {
+    group: "collab_path",
+    label: "editor-to-editor update propagation",
+  },
+  collab_anonymous_update_max_ms: {
+    group: "collab_path",
+    label: "editor-to-anonymous viewer update propagation",
+  },
+  collab_editor_convergence_max_ms: {
+    group: "collab_path",
+    label: "editor convergence",
+  },
+  collab_total_ms: {
+    group: "collab_path",
+    label: "browser collaboration smoke",
+  },
   first_useful_render_ms: {
     group: "live_path",
     label: "first useful render",

--- a/apps/notebook-cloud/scripts/raw-websocket-client.mjs
+++ b/apps/notebook-cloud/scripts/raw-websocket-client.mjs
@@ -36,6 +36,7 @@ export async function clientForSocket(socket, safeUrl) {
   socket.addEventListener("error", (event) => {
     failWaiters(event.error ?? new Error(`WebSocket error from ${safeUrl}`));
   });
+  socket.drainBufferedData?.();
 
   if (socket.readyState !== RawWebSocketClient.OPEN) {
     await new Promise((resolve, reject) => {
@@ -185,6 +186,9 @@ export class RawWebSocketClient {
       this.dispatch("close", {});
     });
     this.socket.on("error", (error) => this.dispatch("error", { error }));
+  }
+
+  drainBufferedData() {
     if (this.buffer.length > 0) {
       this.receive(Buffer.alloc(0));
     }

--- a/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
+++ b/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
@@ -1,4 +1,5 @@
 import { access, readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { FrameType } from "runtimed";
 import {
@@ -13,6 +14,7 @@ import { assertWasmRoundtripAuthEnv, credentialedSmokeOrigin } from "./wasm-roun
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const roomId = `wasm-${Date.now()}`;
+const runtimeStateDocId = `runtime-state:${randomUUID()}`;
 const timingsMs = {};
 const wasmJsUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
@@ -48,7 +50,7 @@ await timed("acl_grants", async () => {
     scope: "viewer",
   });
 });
-await timed("ungranted_editor_denial", () => assertEditorDenied(roomId, "charlie"));
+await timed("ungranted_editor_downgrade", () => assertEditorDowngraded(roomId, "charlie"));
 
 const { alice, bob, anonymous } = await timed("connect_peers", async () => ({
   alice: await connect(roomId, "alice", "desktop:wasm", "owner"),
@@ -106,12 +108,13 @@ console.log(
       ok: true,
       baseUrl,
       roomId,
+      runtimeStateDocId,
       checks: [
         "runtimed_wasm_init",
         "owner_seeded_acl_room",
         "editor_acl_grant",
         "anonymous_viewer_acl_grant",
-        "ungranted_editor_denied",
+        "ungranted_editor_downgraded_to_viewer",
         "real_automerge_sync_payload",
         "durable_object_materialized_room_sync",
         "editor_editor_convergence",
@@ -192,14 +195,16 @@ async function grantAcl(notebookId, body) {
   assert(response.status === 201, `ACL grant failed: ${response.status} ${await response.text()}`);
 }
 
-async function assertEditorDenied(notebookId, user) {
+async function assertEditorDowngraded(notebookId, user) {
+  const client = await connect(notebookId, user, "desktop:wasm", "editor");
   try {
-    const client = await connect(notebookId, user, "desktop:wasm", "editor");
+    assert(
+      client.ready.connection_scope === "viewer",
+      `ungranted editor ${user} connected with scope ${client.ready.connection_scope}`,
+    );
+  } finally {
     await closeClient(client);
-  } catch {
-    return;
   }
-  throw new Error(`ungranted editor ${user} unexpectedly connected`);
 }
 
 function sendHandleChanges(client, handle) {
@@ -299,6 +304,7 @@ function requestHeaders(user, operator, scope, contentType) {
     "X-User": user,
     "X-Operator": operator,
     "X-Scope": scope,
+    "X-Runtime-State-Doc-Id": runtimeStateDocId,
   };
   if (devAuthToken) {
     headers["X-Notebook-Cloud-Dev-Token"] = devAuthToken;

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -9,6 +9,7 @@ import {
   summarizeViewerMilestones,
   withTiming,
 } from "../scripts/hosted-render-smoke-performance.mjs";
+import { summarizeCollabPerformanceTimings } from "../scripts/hosted-collab-smoke-performance.mjs";
 
 describe("hosted smoke performance diagnostics", () => {
   const origins = {
@@ -398,6 +399,9 @@ describe("hosted smoke performance diagnostics", () => {
 
   it("reports explicit hosted performance budget failures", () => {
     const diagnostics = {
+      collab_path: {
+        collab_anonymous_update_max_ms: 1_250,
+      },
       live_path: {
         first_useful_render_ms: 5_025,
         live_sync_websocket_ms: 1_323,
@@ -411,11 +415,19 @@ describe("hosted smoke performance diagnostics", () => {
     assert.deepEqual(
       performanceBudgetFailures(diagnostics, {
         first_useful_render_ms: 5_500,
+        collab_anonymous_update_max_ms: 1_000,
         live_sync_websocket_ms: null,
         sift_wasm_complete_ms: 3_000,
         arrow_data_complete_ms: 8_000,
       }),
       [
+        {
+          kind: "performance-budget",
+          metric: "collab_anonymous_update_max_ms",
+          text: "editor-to-anonymous viewer update propagation took 1250 ms, expected <= 1000 ms",
+          expected_ms: 1000,
+          actual_ms: 1250,
+        },
         {
           kind: "performance-budget",
           metric: "sift_wasm_complete_ms",
@@ -439,6 +451,39 @@ describe("hosted smoke performance diagnostics", () => {
       () =>
         performanceBudgetFailures({ live_path: {}, sidecar_assets: {} }, { made_up_metric_ms: 1 }),
       /Unknown performance budget metric: made_up_metric_ms/,
+    );
+  });
+
+  it("summarizes browser collaboration timings for live viewer budgets", () => {
+    assert.deepEqual(
+      summarizeCollabPerformanceTimings({
+        alice_connected: 110,
+        bob_connected: 125,
+        anonymous_connected: 180,
+        alice_to_bob: 55,
+        alice_to_bob_editor: 65,
+        alice_to_anonymous: 70,
+        bob_to_alice: 45,
+        bob_to_alice_editor: 75,
+        bob_to_anonymous: 80,
+        bob_to_alice_exact: 90,
+        bob_to_bob_exact: 60,
+        alice_ping_1_alice_exact: 100,
+        alice_ping_1_bob_exact: 115,
+        alice_ping_1_anonymous: 130,
+        overlap_editors_converged: 140,
+        overlap_anonymous: 150,
+        total: 2_500,
+      }),
+      {
+        collab_path: {
+          collab_connected_ms: 180,
+          collab_editor_update_max_ms: 115,
+          collab_anonymous_update_max_ms: 150,
+          collab_editor_convergence_max_ms: 140,
+          collab_total_ms: 2500,
+        },
+      },
     );
   });
 });

--- a/apps/notebook-cloud/test/raw-websocket-client.test.mjs
+++ b/apps/notebook-cloud/test/raw-websocket-client.test.mjs
@@ -62,6 +62,26 @@ describe("raw WebSocket client helpers", () => {
     assert.deepEqual(Array.from(received[0]), [FrameType.AUTOMERGE_SYNC, 1, 2, 3]);
   });
 
+  it("keeps upgrade response leftover frames until client listeners are attached", async () => {
+    const payload = new TextEncoder().encode(JSON.stringify({ type: "cloud_room_ready" }));
+    const bytes = new Uint8Array(payload.byteLength + 1);
+    bytes[0] = FrameType.SESSION_CONTROL;
+    bytes.set(payload, 1);
+    const raw = new RawWebSocketClient(
+      new FakeNetSocket(),
+      serverFrame({ fin: true, opcode: 0x2, payload: Buffer.from(bytes) }),
+    );
+
+    const client = await clientForSocket(raw, "wss://cloud.test/n/demo/sync");
+    const frame = await client.nextFrame(
+      (candidate) =>
+        candidate.type === FrameType.SESSION_CONTROL && candidate.json?.type === "cloud_room_ready",
+      250,
+    );
+
+    assert.equal(frame.json.type, "cloud_room_ready");
+  });
+
   it("decodes session control JSON and fingerprints principals without leaking raw ids", async () => {
     const payload = new TextEncoder().encode(JSON.stringify({ type: "cloud_room_ready" }));
     const bytes = new Uint8Array(payload.byteLength + 1);


### PR DESCRIPTION
## Summary

- adds budgetable hosted collaboration smoke timings for browser connections, editor-to-editor propagation, editor-to-anonymous viewer propagation, editor convergence, and total smoke duration
- reuses the hosted smoke performance budget failure format so render and live-collaboration checks report comparable diagnostics
- fails the hosted collaboration smoke if any participant requests stale `/api/n/:id/render` or `/api/n/:id/renders/:heads` cache endpoints instead of the live sync path
- includes focused unit coverage for the collaboration timing summary and budget failure path

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-performance.test.mjs test/hosted-collab-smoke-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/raw-websocket-client.test.mjs test/hosted-smoke-performance.test.mjs test/hosted-collab-smoke-env.test.mjs test/wasm-roundtrip-env.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-routes.test.mjs test/hosted-smoke-performance.test.mjs test/hosted-collab-smoke-env.test.mjs test/wasm-roundtrip-env.test.mjs test/raw-websocket-client.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `NOTEBOOK_CLOUD_URL=http://localhost:8787 NOTEBOOK_CLOUD_DEV_TOKEN=local-dev-token NOTEBOOK_CLOUD_COLLAB_ROUNDS=2 NOTEBOOK_CLOUD_MAX_COLLAB_CONNECTED_MS=15000 NOTEBOOK_CLOUD_MAX_COLLAB_EDITOR_UPDATE_MS=10000 NOTEBOOK_CLOUD_MAX_COLLAB_ANONYMOUS_UPDATE_MS=12000 NOTEBOOK_CLOUD_MAX_COLLAB_EDITOR_CONVERGENCE_MS=12000 NOTEBOOK_CLOUD_MAX_COLLAB_TOTAL_MS=60000 pnpm --dir apps/notebook-cloud smoke:hosted:collab`
- `cargo xtask lint --fix`

## Notes

- The local collaboration smoke now seeds an explicit opaque runtime-state doc id in its setup request, opens markdown cells through the current rendered-first UI, and verifies ungranted editor requests are downgraded to viewer scope.
- The collaboration smoke now reports `renderCacheRequests` and defaults to failing if live collaboration ever uses the stale render-cache API lane. Set `NOTEBOOK_CLOUD_FORBID_RENDER_CACHE_REQUESTS=0` only for diagnostics.
- The raw WebSocket smoke client now drains upgrade-response leftover frames after listeners are attached, preventing early session-control frames from being dropped in local protocol smoke setup.
- This remains schema-neutral: it does not change NotebookDoc / RuntimeStateDoc shape, genesis, materialization, pointer writes, or migration behavior.
- Keep this PR draft until the stacked preview deploy can verify the hosted collab smoke against `preview.runt.run`.

## Review / CI

- `pr-reviewer`: clear, no findings (`.context/reviews/pr-3172.json`)
- GitHub CI: passing
