### PR TITLE
docs(elements): catalog mcp output frame surface

### DIFF
--- a/apps/elements/components/component-burndown.tsx
+++ b/apps/elements/components/component-burndown.tsx
@@ -138,16 +138,16 @@ const families = [
     target: "nteract renderers",
     status: "active",
     intent:
-      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable with static TableData, and a HuggingFace Parquet URL decoded by docs-served Sift WASM now render from fixtures; live JavaScript execution, third-party renderer loading, live kernel widget comm transport, Arrow stream manifests, and production isolated-frame asset loading remain explicit adapter boundaries.",
+      "OutputArea lane composition, top-level widget-view MIME handoff, nested OutputModel widget-view routing, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, ImageOutput, MathOutput, SvgOutput, AudioOutput, JavaScriptOutput, PlotlyOutput, VegaOutput, GeoJsonOutput, PdfOutput, VideoOutput, TracebackOutput, MIME priority, SiftTable with static TableData, and a HuggingFace Parquet URL decoded by docs-served Sift WASM now render from fixtures; live JavaScript execution, third-party renderer loading, live kernel widget comm transport, Arrow stream manifests, and production renderer asset bundles remain explicit adapter boundaries.",
   },
   {
     family: "Output isolation",
     source:
-      "src/components/isolated/{host-context,mcp-app-structured-content,output-frame-sizing,output-lane-policy}.ts + apps/elements/components/isolated/{index.tsx,frame-config-adapter.ts}",
+      "src/components/isolated/{mcp-app-output-frame,output-embed,host-context,mcp-app-structured-content,output-frame-sizing,output-lane-policy}.ts + apps/elements/components/isolated/{index.tsx,frame-config-adapter.ts}",
     target: "nteract renderers",
     status: "active",
     intent:
-      "Host-context theme merging, output lane routing, sizing, MCP structured output mapping, and the docs IsolatedFrame and frame-config adapters now render without booting production iframe scripts.",
+      "Host-context theme merging, output lane routing, sizing, MCP structured output mapping, the production McpAppOutputFrame/createNteractOutputEmbed wrapper, and the docs IsolatedFrame/frame-config adapters now render with fixture-owned iframe readiness instead of desktop renderer artifacts.",
   },
   {
     family: "Widgets",

--- a/apps/elements/components/isolated-output-surfaces-example.tsx
+++ b/apps/elements/components/isolated-output-surfaces-example.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   ArrowDownToLine,
   Boxes,
@@ -7,6 +8,7 @@ import {
   Gauge,
   Layers3,
   LockKeyhole,
+  MonitorPlay,
   Palette,
   ShieldCheck,
 } from "lucide-react";
@@ -30,6 +32,7 @@ import {
   mcpAppStructuredContentToSharedOutputInputs,
   type McpAppStructuredContent,
 } from "@/components/isolated/mcp-app-structured-content";
+import { McpAppOutputFrame, type McpAppCellData } from "@/components/isolated/mcp-app-output-frame";
 import { outputFrameDisplayHeight } from "@/components/isolated/output-frame-sizing";
 
 const laneOutputs: JupyterOutput[] = [
@@ -125,6 +128,100 @@ const structuredContent: McpAppStructuredContent = {
   ],
 };
 
+const mcpFrameCell: McpAppCellData = {
+  cell_id: "cell-mcp-frame",
+  cell_type: "code",
+  source: "display(report_card)",
+  execution_count: 4,
+  status: "idle",
+  outputs: [
+    {
+      output_id: "mcp-frame-html",
+      output_type: "display_data",
+      data: {
+        "text/html": [
+          '<section style="font: 14px system-ui; padding: 14px; border: 1px solid #d4d4d8; border-radius: 8px;">',
+          '<div style="font-size: 12px; color: #71717a; text-transform: uppercase; letter-spacing: .04em;">MCP App Output</div>',
+          '<strong style="display: block; margin-top: 6px; font-size: 18px;">Hosted frame handoff</strong>',
+          '<p style="margin: 8px 0 0; color: #52525b;">Structured cell output resolves into the shared iframe embed API.</p>',
+          "</section>",
+        ].join(""),
+        "text/plain": "Hosted frame handoff",
+      },
+      llm_preview: { head: "Hosted frame handoff" },
+    },
+  ],
+};
+
+const docsOutputFrameRendererBundle = {
+  rendererCode: `
+    (function () {
+      if (window.__NTERACT_ELEMENTS_RENDERER__) return;
+      window.__NTERACT_ELEMENTS_RENDERER__ = true;
+      var root = document.getElementById("root");
+
+      function send(method, params) {
+        window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params || {} }, "*");
+      }
+
+      function renderOne(payload) {
+        var output = document.createElement("div");
+        var mimeType = payload && payload.mimeType;
+        var data = payload && payload.data;
+
+        if (mimeType === "text/html") {
+          output.innerHTML = String(data || "");
+        } else {
+          var pre = document.createElement("pre");
+          pre.textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+          output.appendChild(pre);
+        }
+
+        return output;
+      }
+
+      function complete() {
+        var height = Math.max(
+          1,
+          Math.ceil(document.documentElement.scrollHeight || document.body.scrollHeight || 1),
+        );
+        send("nteract/renderComplete", { height: height });
+        send("ui/notifications/size-changed", { height: height });
+      }
+
+      function scheduleComplete() {
+        complete();
+        requestAnimationFrame(complete);
+        window.setTimeout(complete, 0);
+      }
+
+      window.addEventListener("message", function (event) {
+        if (event.source && event.source !== window.parent) return;
+
+        var message = event.data || {};
+        if (message.jsonrpc !== "2.0") return;
+
+        if (message.method === "nteract/renderOutput") {
+          root.replaceChildren(renderOne(message.params || {}));
+          scheduleComplete();
+        }
+
+        if (message.method === "nteract/renderBatch") {
+          root.replaceChildren();
+          ((message.params && message.params.outputs) || []).forEach(function (payload) {
+            root.appendChild(renderOne(payload));
+          });
+          scheduleComplete();
+        }
+      });
+
+      send("nteract/rendererReady");
+      window.parent.postMessage({ type: "renderer_ready", payload: null }, "*");
+    })();
+  `,
+  rendererCss: "",
+};
+
 const framePayloads: RenderPayload[] = [
   {
     outputId: "html-frame",
@@ -169,6 +266,7 @@ function documentPreview(document: ReturnType<typeof createIsolatedFrameDocument
 }
 
 export function IsolatedOutputSurfacesExample() {
+  const [mcpFrameEvents, setMcpFrameEvents] = useState<string[]>([]);
   const baseContext = createNteractEmbedHostContext({
     isDark: false,
     colorTheme: "cream",
@@ -410,6 +508,72 @@ export function IsolatedOutputSurfacesExample() {
             <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-fd-muted-foreground">
               {formatJson(sharedOutputs)}
             </pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <MonitorPlay className="size-4 text-fd-muted-foreground" />
+            <h2 className="text-sm font-semibold">MCP App output frame</h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            This surface mounts the production McpAppOutputFrame and createNteractOutputEmbed path
+            with a fixture renderer bundle that handles resolved HTML/text payloads. The sandboxed
+            frame renders one resolved HTML output without daemon state or Vite virtual renderer
+            artifacts.
+          </p>
+        </div>
+        <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+          <div className="min-h-[180px] rounded-md border border-fd-border bg-fd-background p-3">
+            <McpAppOutputFrame
+              cell={mcpFrameCell}
+              hostContext={{
+                theme: mergedContext.theme,
+                displayMode: "inline",
+                containerDimensions: { width: 720, maxHeight: 320 },
+                styles: {
+                  variables: {
+                    "--mcp-accent": "#0ea5e9",
+                  },
+                },
+              }}
+              rendererBundle={docsOutputFrameRendererBundle}
+              rendererAssetsBaseUrl="/renderer-assets"
+              autoHeight={false}
+              maxHeight={320}
+              className="overflow-hidden rounded-md"
+              onDiagnostic={(phase) => {
+                setMcpFrameEvents((events) => [...events.slice(-5), phase]);
+              }}
+              onError={(error) =>
+                setMcpFrameEvents((events) => [...events.slice(-5), `error: ${error.message}`])
+              }
+            />
+          </div>
+          <div className="rounded-md border border-fd-border bg-fd-background p-3">
+            <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+              frame cell fixture
+            </div>
+            <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-5 text-fd-muted-foreground">
+              {formatJson(mcpFrameCell)}
+            </pre>
+            <div className="mt-3 border-t border-fd-border pt-3">
+              <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                embed events
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {(mcpFrameEvents.length > 0 ? mcpFrameEvents : ["waiting"]).map((event, index) => (
+                  <span
+                    key={`${index}-${event}`}
+                    className="rounded-full border border-fd-border bg-fd-card px-2 py-1 font-mono text-[11px] text-fd-muted-foreground"
+                  >
+                    {event}
+                  </span>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       </section>

--- a/apps/elements/components/isolated/frame-config-adapter.ts
+++ b/apps/elements/components/isolated/frame-config-adapter.ts
@@ -15,7 +15,168 @@ interface IsolatedFrameThemeSeed {
 }
 
 const NTERACT_FRAME_URL = "nteract-frame://localhost/";
-const FRAME_HTML_STUB = '<!doctype html><html><body><div id="root"></div></body></html>';
+const FRAME_HTML_STUB = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      :root {
+        color-scheme: light;
+        --frame-bg: transparent;
+        --frame-text: #18181b;
+        --frame-muted: #71717a;
+        --frame-border: #d4d4d8;
+      }
+      :root.dark {
+        color-scheme: dark;
+        --frame-text: #f4f4f5;
+        --frame-muted: #a1a1aa;
+        --frame-border: #3f3f46;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        background: var(--frame-bg);
+        color: var(--frame-text);
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      pre {
+        margin: 0;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        color: var(--frame-muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script>
+      (function () {
+        var root = document.getElementById("root");
+
+        function sendLegacy(type, payload) {
+          window.parent.postMessage({ type: type, payload: payload || null }, "*");
+        }
+
+        function sendRpc(method, params) {
+          window.parent.postMessage({ jsonrpc: "2.0", method: method, params: params || {} }, "*");
+        }
+
+        function height() {
+          return Math.max(
+            1,
+            Math.ceil(document.documentElement.scrollHeight || document.body.scrollHeight || 1),
+          );
+        }
+
+        function complete() {
+          var nextHeight = height();
+          sendLegacy("render_complete", { height: nextHeight });
+          sendRpc("nteract/renderComplete", { height: nextHeight });
+          sendRpc("ui/notifications/size-changed", { height: nextHeight });
+        }
+
+        function scheduleComplete() {
+          complete();
+          requestAnimationFrame(complete);
+          window.setTimeout(complete, 0);
+        }
+
+        function render(payload) {
+          var output = document.createElement("div");
+          var mimeType = payload && payload.mimeType;
+          var data = payload && payload.data;
+
+          if (mimeType === "text/html") {
+            output.innerHTML = String(data || "");
+          } else if (mimeType === "application/json") {
+            var pre = document.createElement("pre");
+            pre.textContent = JSON.stringify(data, null, 2);
+            output.appendChild(pre);
+          } else {
+            var fallback = document.createElement("pre");
+            fallback.textContent = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+            output.appendChild(fallback);
+          }
+
+          root.replaceChildren(output);
+          scheduleComplete();
+        }
+
+        function renderBatch(payload) {
+          var outputs = (payload && payload.outputs) || [];
+          root.replaceChildren();
+          outputs.forEach(function (entry) {
+            var output = document.createElement("div");
+            var mimeType = entry && entry.mimeType;
+            var data = entry && entry.data;
+
+            if (mimeType === "text/html") {
+              output.innerHTML = String(data || "");
+            } else {
+              var fallback = document.createElement("pre");
+              fallback.textContent =
+                typeof data === "string" ? data : JSON.stringify(data, null, 2);
+              output.appendChild(fallback);
+            }
+            root.appendChild(output);
+          });
+          scheduleComplete();
+        }
+
+        function setTheme(payload) {
+          var isDark = Boolean(payload && (payload.isDark || payload.theme === "dark"));
+          document.documentElement.classList.toggle("dark", isDark);
+        }
+
+        window.addEventListener("message", function (event) {
+          if (event.source && event.source !== window.parent) return;
+
+          var data = event.data || {};
+          var payload = data.payload || data.params || {};
+
+          try {
+            if (data.type === "eval" || data.method === "nteract/eval") {
+              var code = payload.code;
+              if (typeof code === "string") {
+                eval.call(null, code);
+                sendRpc("nteract/evalResult", { success: true });
+              }
+              return;
+            }
+
+            if (data.type === "render" || data.method === "nteract/renderOutput") {
+              render(payload);
+              return;
+            }
+
+            if (data.type === "render_batch" || data.method === "nteract/renderBatch") {
+              renderBatch(payload);
+              return;
+            }
+
+            if (data.type === "theme" || data.method === "nteract/theme") {
+              setTheme(payload);
+              return;
+            }
+
+            if (data.type === "clear" || data.method === "nteract/clearOutputs") {
+              root.replaceChildren();
+              complete();
+            }
+          } catch (error) {
+            sendLegacy("error", { message: error && error.message ? error.message : String(error) });
+          }
+        });
+
+        sendLegacy("ready");
+      })();
+    </script>
+  </body>
+</html>`;
 
 export function createIsolatedFrameDocument(options?: {
   isTauriRuntime?: boolean;

--- a/apps/elements/content/docs/isolated-output-surfaces.mdx
+++ b/apps/elements/content/docs/isolated-output-surfaces.mdx
@@ -16,16 +16,17 @@ content becomes shared output manifests.
 
 The page imports current helpers from `src/components/isolated/**`: output lane
 policy, frame sizing, host-context theme variables, MCP host-context conversion,
-and MCP structured content conversion. Frame document selection and sandbox
-policy use a docs-local adapter that mirrors the production helper while
-avoiding the raw `frame.html?raw` bundle. It also renders the docs-local
-`IsolatedFrame` adapter so payload shape and host context stay visible without
-booting production iframe scripts.
+MCP structured content conversion, and the production `McpAppOutputFrame`
+wrapper. Frame document selection and sandbox policy use a docs-local alias for
+the production helper so Next does not import the raw Tauri `frame.html?raw`
+bundle. The MCP frame surface uses a fixture renderer bundle for resolved
+HTML/text payloads, while the docs-local `IsolatedFrame` adapter keeps payload
+shape and host context visible without Vite virtual renderer artifacts.
 
 ## What stays behind adapters
 
 The production frame runtime still owns JavaScript evaluation, renderer plugin
-installation, widget comm replay, raw HTML execution, and generated Sift WASM
-asset loading. The catalog should keep those as explicit adapters until they can
-be exercised without importing desktop runtime state or executing untrusted
-output code in the docs app.
+installation, widget comm replay, untrusted raw HTML execution, and generated
+renderer asset loading. The catalog should keep those as explicit adapters until
+they can be exercised without importing desktop runtime state or executing
+untrusted output code in the docs app.

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -36,12 +36,14 @@ priority helper the notebook uses before rendering.
 ## What still needs an adapter
 
 The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
-frame policy, host-context conversion, sizing, lane routing, and MCP structured
-output mapping. Executable JavaScript, raw HTML and markdown runtime execution,
-third-party renderer library loading, live output-widget comm transport, and
-production isolated-frame asset loading still need fixture-backed iframe,
-widget-store, or generated asset adapters before this docs app should own those
-runtime paths. The Sift Parquet URL path now has a docs-owned static WASM asset;
-Arrow stream manifests remain a separate renderer adapter slice. The widget
-catalog covers local `OutputModel` replay through `WidgetStore`; the remaining
-output-widget boundary is the live kernel capture and comm transport.
+frame policy, host-context conversion, sizing, lane routing, MCP structured
+output mapping, and the production MCP output-frame wrapper with a fixture
+renderer bundle for resolved HTML/text payloads. Executable JavaScript, raw HTML
+and markdown runtime execution, third-party renderer library loading, live
+output-widget comm transport, and production renderer bundle/plugin artifacts
+still need fixture-backed iframe, widget-store, or generated asset adapters
+before this docs app should own those runtime paths. The Sift Parquet URL path
+now has a docs-owned static WASM asset; Arrow stream manifests remain a separate
+renderer adapter slice. The widget catalog covers local `OutputModel` replay
+through `WidgetStore`; the remaining output-widget boundary is the live kernel
+capture and comm transport.

--- a/apps/elements/next.config.mjs
+++ b/apps/elements/next.config.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from "node:url";
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const siftWasmAdapterPath = path.join(dirname, "lib/sift-wasm-module.ts");
 const siftWasmAdapterImport = "./lib/sift-wasm-module.ts";
+const frameConfigSourcePath = path.join(dirname, "../../src/components/isolated/frame-config.ts");
+const frameConfigAdapterPath = path.join(dirname, "components/isolated/frame-config-adapter.ts");
+const frameConfigAdapterImport = "./components/isolated/frame-config-adapter.ts";
 
 /** @type {import("next").NextConfig} */
 const config = {
@@ -17,12 +20,16 @@ const config = {
   transpilePackages: ["@nteract/sift"],
   turbopack: {
     resolveAlias: {
+      "./frame-config": frameConfigAdapterImport,
+      [frameConfigSourcePath]: frameConfigAdapterImport,
       "sift-wasm/sift_wasm.js": siftWasmAdapterImport,
     },
   },
   webpack(nextConfig) {
     nextConfig.resolve.alias = {
       ...nextConfig.resolve.alias,
+      "./frame-config": frameConfigAdapterPath,
+      [frameConfigSourcePath]: frameConfigAdapterPath,
       "sift-wasm/sift_wasm.js": siftWasmAdapterPath,
     };
     return nextConfig;

--- a/apps/elements/types/raw-html.d.ts
+++ b/apps/elements/types/raw-html.d.ts
@@ -1,0 +1,4 @@
+declare module "*.html?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary

- adds the production `McpAppOutputFrame` / `createNteractOutputEmbed` path to the `apps/elements` output-isolation catalog
- expands the docs-local frame config adapter so Next can render the fixture-backed sandbox without importing the raw desktop `frame.html?raw` bundle
- updates the burn-down and output docs to show the MCP output-frame wrapper is covered while production renderer/plugin artifacts remain explicit adapter boundaries

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- CDP desktop/mobile check for `/docs/isolated-output-surfaces`: MCP frame renders, iframe resizes, sandbox/allow attrs match production policy, no horizontal overflow, no network failures

## Stack

Base: `quod/elements-sift-parquet-url-surface` (#3171)
