### PR TITLE
test(notebook-cloud): budget hosted payload sizes

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-performance.mjs
@@ -96,6 +96,9 @@ export function summarizePerformanceResources(resources, milestones = {}) {
       first_end_ms: null,
       max_end_ms: null,
       max_duration_ms: null,
+      total_bytes: 0,
+      max_bytes: null,
+      unknown_byte_count: 0,
       statuses: [],
       urls: [],
       slowest: [],
@@ -106,6 +109,12 @@ export function summarizePerformanceResources(resources, milestones = {}) {
     summary.max_end_ms = maxDefined(summary.max_end_ms, resource.end_ms);
     const duration = resourceDuration(resource);
     summary.max_duration_ms = maxDefined(summary.max_duration_ms, duration);
+    if (typeof resource.contentLength === "number") {
+      summary.total_bytes += resource.contentLength;
+      summary.max_bytes = maxDefined(summary.max_bytes, resource.contentLength);
+    } else {
+      summary.unknown_byte_count += 1;
+    }
     if (resource.status !== null && resource.status !== undefined) {
       summary.statuses.push(resource.status);
     }
@@ -170,22 +179,26 @@ export function performanceBudgetFailures(diagnostics, budgets = {}) {
     }
     const value = diagnostics?.[spec.group]?.[metric] ?? null;
     if (value === null) {
+      const unit = budgetUnit(spec);
       failures.push({
         kind: "performance-budget",
         metric,
-        text: `${spec.label} timing was missing; expected <= ${budget} ms`,
-        expected_ms: budget,
-        actual_ms: null,
+        text: `${spec.label} ${missingBudgetNoun(spec)} was missing; expected <= ${budget} ${budgetUnit(spec)}`,
+        expected_value: budget,
+        actual_value: null,
+        unit,
       });
       continue;
     }
     if (value > budget) {
+      const unit = budgetUnit(spec);
       failures.push({
         kind: "performance-budget",
         metric,
-        text: `${spec.label} took ${value} ms, expected <= ${budget} ms`,
-        expected_ms: budget,
-        actual_ms: value,
+        text: `${spec.label} ${budgetVerb(spec)} ${value} ${budgetUnit(spec)}, expected <= ${budget} ${budgetUnit(spec)}`,
+        expected_value: budget,
+        actual_value: value,
+        unit,
       });
     }
   }
@@ -204,6 +217,35 @@ export function withTiming(result, started, ended) {
       duration: ended - started,
     },
   };
+}
+
+export function applyResourceTimingSizes(resources, resourceTimings) {
+  const timingsByUrl = new Map();
+  for (const timing of resourceTimings) {
+    const encodedBodySize =
+      typeof timing.encodedBodySize === "number" && timing.encodedBodySize > 0
+        ? timing.encodedBodySize
+        : null;
+    if (encodedBodySize === null) {
+      continue;
+    }
+    const timings = timingsByUrl.get(timing.name) ?? [];
+    timings.push(encodedBodySize);
+    timingsByUrl.set(timing.name, timings);
+  }
+  for (const resource of resources) {
+    if (typeof resource.contentLength === "number") {
+      continue;
+    }
+    // Playwright response events and browser Resource Timing entries arrive in
+    // fetch order for this smoke page, so duplicate URLs consume timing entries
+    // FIFO. Keep the original response header size when it exists.
+    const timings = timingsByUrl.get(resource.url);
+    const encodedBodySize = timings?.shift();
+    if (encodedBodySize !== undefined) {
+      resource.contentLength = encodedBodySize;
+    }
+  }
 }
 
 function minDefined(current, candidate) {
@@ -249,6 +291,7 @@ function summarizeLivePath(byKind, milestones) {
     notebook_snapshot_ms: notebookSnapshotEndMs,
     runtime_snapshot_ms: runtimeSnapshotEndMs,
     snapshot_pair_complete_ms: snapshotPairCompleteMs,
+    snapshot_pair_bytes: sumBytesOfKinds(byKind, ["notebook_snapshot", "runtime_snapshot"]),
     live_sync_websocket_ms: timing(milestones, "live_sync_websocket"),
     source_text_ms: timing(milestones, "source_text"),
     rendered_cell_marker_ms: renderedCellMarkerMs,
@@ -267,16 +310,27 @@ function summarizeLivePath(byKind, milestones) {
 function summarizeSidecarAssets(byKind) {
   return {
     viewer_shell_complete_ms: maxOfKinds(byKind, ["viewer_document", "viewer_js", "viewer_css"]),
+    viewer_shell_bytes: sumBytesOfKinds(byKind, ["viewer_js", "viewer_css"]),
     runtimed_wasm_complete_ms: maxOfKinds(byKind, ["runtimed_wasm_js", "runtimed_wasm_binary"]),
+    runtimed_wasm_bytes: sumBytesOfKinds(byKind, ["runtimed_wasm_js", "runtimed_wasm_binary"]),
     isolated_renderer_complete_ms: maxOfKinds(byKind, ["renderer_asset_js", "renderer_asset_css"]),
+    isolated_renderer_bytes: sumBytesOfKinds(byKind, ["renderer_asset_js", "renderer_asset_css"]),
     output_document_complete_ms: maxOfKinds(byKind, [
       "output_document_frame",
       "output_document_js",
       "output_document_css",
       "output_document_asset",
     ]),
+    output_document_bytes: sumBytesOfKinds(byKind, [
+      "output_document_frame",
+      "output_document_js",
+      "output_document_css",
+      "output_document_asset",
+    ]),
     sift_wasm_complete_ms: kindMaxEnd(byKind, "sift_wasm_binary"),
+    sift_wasm_bytes: sumBytesOfKinds(byKind, ["sift_wasm_binary"]),
     arrow_data_complete_ms: maxOfKinds(byKind, ["arrow_manifest_blob", "arrow_stream_blob"]),
+    arrow_data_bytes: sumBytesOfKinds(byKind, ["arrow_manifest_blob", "arrow_stream_blob"]),
   };
 }
 
@@ -297,6 +351,23 @@ function maxOfKinds(byKind, kinds) {
   return kinds.reduce((current, kind) => maxDefined(current, kindMaxEnd(byKind, kind)), null);
 }
 
+function sumBytesOfKinds(byKind, kinds) {
+  let total = 0;
+  let sawResource = false;
+  for (const kind of kinds) {
+    const summary = byKind[kind];
+    if (!summary) {
+      continue;
+    }
+    sawResource = true;
+    if (summary.unknown_byte_count > 0) {
+      return null;
+    }
+    total += summary.total_bytes;
+  }
+  return sawResource ? total : null;
+}
+
 function delta(start, end) {
   if (start === null || start === undefined || end === null || end === undefined) {
     return null;
@@ -306,6 +377,18 @@ function delta(start, end) {
 
 function firstDefined(...values) {
   return values.find((value) => value !== null && value !== undefined) ?? null;
+}
+
+function budgetUnit(spec) {
+  return spec.unit ?? "ms";
+}
+
+function budgetVerb(spec) {
+  return budgetUnit(spec) === "bytes" ? "was" : "took";
+}
+
+function missingBudgetNoun(spec) {
+  return budgetUnit(spec) === "bytes" ? "size" : "timing";
 }
 
 const PERFORMANCE_BUDGET_METRICS = {
@@ -376,5 +459,40 @@ const PERFORMANCE_BUDGET_METRICS = {
   arrow_data_complete_ms: {
     group: "sidecar_assets",
     label: "Arrow data",
+  },
+  snapshot_pair_bytes: {
+    group: "live_path",
+    label: "snapshot pair payload",
+    unit: "bytes",
+  },
+  viewer_shell_bytes: {
+    group: "sidecar_assets",
+    label: "viewer shell payload",
+    unit: "bytes",
+  },
+  runtimed_wasm_bytes: {
+    group: "sidecar_assets",
+    label: "runtimed WASM payload",
+    unit: "bytes",
+  },
+  isolated_renderer_bytes: {
+    group: "sidecar_assets",
+    label: "isolated renderer payload",
+    unit: "bytes",
+  },
+  output_document_bytes: {
+    group: "sidecar_assets",
+    label: "output document payload",
+    unit: "bytes",
+  },
+  sift_wasm_bytes: {
+    group: "sidecar_assets",
+    label: "Sift WASM payload",
+    unit: "bytes",
+  },
+  arrow_data_bytes: {
+    group: "sidecar_assets",
+    label: "Arrow data payload",
+    unit: "bytes",
   },
 };

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -19,6 +19,7 @@ import {
 } from "./hosted-render-smoke-assets.mjs";
 import { hasPreflightFailures } from "./hosted-render-smoke-preflight.mjs";
 import {
+  applyResourceTimingSizes,
   classifyPerformanceResource,
   performanceBudgetFailures,
   refinePerformanceResourceKind,
@@ -101,6 +102,13 @@ const performanceBudgets = {
   ),
   sift_wasm_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_SIFT_WASM_COMPLETE_MS"),
   arrow_data_complete_ms: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_ARROW_DATA_COMPLETE_MS"),
+  snapshot_pair_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_SNAPSHOT_PAIR_BYTES"),
+  viewer_shell_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_VIEWER_SHELL_BYTES"),
+  runtimed_wasm_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_RUNTIMED_WASM_BYTES"),
+  isolated_renderer_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_ISOLATED_RENDERER_BYTES"),
+  output_document_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_OUTPUT_DOCUMENT_BYTES"),
+  sift_wasm_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_SIFT_WASM_BYTES"),
+  arrow_data_bytes: parseOptionalBudget("NOTEBOOK_CLOUD_MAX_ARROW_DATA_BYTES"),
 };
 const expectedThemeModes = parseExpectedTexts("NOTEBOOK_CLOUD_SMOKE_THEME_MODES", [
   "light",
@@ -215,6 +223,7 @@ async function main() {
       end_ms: null,
       status: null,
       contentType: null,
+      contentLength: null,
       failure: null,
     });
   });
@@ -224,6 +233,7 @@ async function main() {
     finishPerformanceRequest(response.request(), {
       status: response.status(),
       contentType: response.headers()["content-type"] ?? null,
+      contentLength: parseContentLength(response.headers()["content-length"]),
     });
     if (url.includes("sift_wasm.wasm")) {
       siftWasmRequests.push({
@@ -384,6 +394,8 @@ async function main() {
     await flushDiagnosticTasks();
     await Promise.race([networkIdleTask, Promise.resolve()]);
     markTiming("diagnostics_flushed");
+    const browserResourceTimings = await collectBrowserResourceTimings(page);
+    applyResourceTimingSizes(performanceResources, browserResourceTimings);
 
     const executionCounts = await page
       .locator("[data-slot='execution-count']")
@@ -544,6 +556,7 @@ async function main() {
           viewer_milestones_ms: viewerMilestones,
           performanceDiagnostics,
           performanceBudgets,
+          browserResourceTimingCount: browserResourceTimings.length,
           catalogApiCheck,
           viewerCssCheck,
           runtimeWasmHintCheck,
@@ -610,6 +623,14 @@ function parseOptionalBudget(envName) {
   return parsePositiveInteger(process.env[envName], null, envName);
 }
 
+function parseContentLength(value) {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
 function markTiming(name) {
   markTimingAt(name, elapsedMs());
 }
@@ -634,6 +655,17 @@ function finishPerformanceRequest(request, updates) {
       ...updates,
       end_ms: elapsedMs(),
     }),
+  );
+}
+
+async function collectBrowserResourceTimings(page) {
+  return page.evaluate(() =>
+    performance.getEntriesByType("resource").map((entry) => ({
+      name: entry.name,
+      transferSize: entry.transferSize,
+      encodedBodySize: entry.encodedBodySize,
+      decodedBodySize: entry.decodedBodySize,
+    })),
   );
 }
 

--- a/apps/notebook-cloud/src/output-document-worker.ts
+++ b/apps/notebook-cloud/src/output-document-worker.ts
@@ -75,6 +75,7 @@ function withOutputDocumentHeaders(response: Response): Response {
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("Referrer-Policy", "no-referrer");
   response.headers.set("Cross-Origin-Resource-Policy", "cross-origin");
+  response.headers.set("Timing-Allow-Origin", "*");
   response.headers.set("Content-Security-Policy", OUTPUT_DOCUMENT_CSP);
   response.headers.set(
     "Permissions-Policy",

--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -75,6 +75,7 @@ function withRendererAssetCors(
   response.headers.set("Access-Control-Allow-Origin", "*");
   response.headers.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
   response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  response.headers.set("Timing-Allow-Origin", "*");
   if (options.immutable && response.ok) {
     response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
   }

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  applyResourceTimingSizes,
   classifyPerformanceResource,
   performanceBudgetFailures,
   refinePerformanceResourceKind,
@@ -132,245 +133,204 @@ describe("hosted smoke performance diagnostics", () => {
   });
 
   it("summarizes first and latest timings by resource kind", () => {
-    assert.deepEqual(
-      summarizePerformanceResources(
-        [
-          {
-            kind: "catalog_api",
-            url: "https://preview.runt.run/api/n/topic-viz",
-            start_ms: 1,
-            end_ms: 6,
-            status: 200,
-          },
-          {
-            kind: "notebook_snapshot",
-            url: "https://preview.runt.run/api/n/topic-viz/snapshots/heads-a",
-            start_ms: 5,
-            end_ms: 15,
-            status: 200,
-          },
-          {
-            kind: "runtime_snapshot",
-            url: "https://preview.runt.run/api/n/topic-viz/runtime-snapshots/heads-b",
-            start_ms: 6,
-            end_ms: 18,
-            status: 200,
-          },
-          {
-            kind: "viewer_js",
-            url: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
-            start_ms: 2,
-            end_ms: 12,
-            status: 200,
-          },
-          {
-            kind: "runtimed_wasm_binary",
-            url: "https://preview.runt.run/renderer-assets/runtimed_wasm_bg.wasm",
-            start_ms: 8,
-            end_ms: 44,
-            status: 200,
-          },
-          {
-            kind: "arrow_stream_blob",
-            url: "https://preview.runt.run/api/n/topic-viz/blobs/arrow",
-            start_ms: 24,
-            end_ms: 70,
-            status: 200,
-          },
-          {
-            kind: "output_document_frame",
-            url: "https://preview.runtusercontent.com/frame/",
-            start_ms: 10,
-            end_ms: 30,
-            status: 200,
-          },
-          {
-            kind: "output_document_frame",
-            url: "https://preview.runtusercontent.com/frame/?two",
-            start_ms: 20,
-            end_ms: 50,
-            status: 200,
-          },
-        ],
-        { live_sync_websocket: 11, source_text: 42, rendered_cell_marker: 55, frame_texts: 80 },
-      ),
-      {
-        milestones: {
-          live_sync_websocket: 11,
-          source_text: 42,
-          rendered_cell_marker: 55,
-          frame_texts: 80,
+    const summary = summarizePerformanceResources(
+      [
+        {
+          kind: "catalog_api",
+          url: "https://preview.runt.run/api/n/topic-viz",
+          start_ms: 1,
+          end_ms: 6,
+          status: 200,
+          contentLength: 128,
         },
-        live_path: {
-          catalog_api_ms: 6,
-          notebook_snapshot_ms: 15,
-          runtime_snapshot_ms: 18,
-          snapshot_pair_complete_ms: 18,
-          live_sync_websocket_ms: 11,
-          source_text_ms: 42,
-          rendered_cell_marker_ms: 55,
-          first_output_iframe_ms: null,
-          frame_texts_ms: 80,
-          first_useful_render_ms: 80,
-          snapshot_pair_to_rendered_cell_ms: 37,
-          snapshot_pair_to_frame_texts_ms: 62,
+        {
+          kind: "notebook_snapshot",
+          url: "https://preview.runt.run/api/n/topic-viz/snapshots/heads-a",
+          start_ms: 5,
+          end_ms: 15,
+          status: 200,
+          contentLength: 2_048,
         },
-        sidecar_assets: {
-          viewer_shell_complete_ms: 12,
-          runtimed_wasm_complete_ms: 44,
-          isolated_renderer_complete_ms: null,
-          output_document_complete_ms: 50,
-          sift_wasm_complete_ms: null,
-          arrow_data_complete_ms: 70,
+        {
+          kind: "runtime_snapshot",
+          url: "https://preview.runt.run/api/n/topic-viz/runtime-snapshots/heads-b",
+          start_ms: 6,
+          end_ms: 18,
+          status: 200,
+          contentLength: 1_024,
         },
-        resources_by_kind: {
-          catalog_api: {
-            count: 1,
-            first_start_ms: 1,
-            first_end_ms: 6,
-            max_end_ms: 6,
-            max_duration_ms: 5,
-            statuses: [200],
-            urls: ["https://preview.runt.run/api/n/topic-viz"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/api/n/topic-viz",
-                start_ms: 1,
-                end_ms: 6,
-                duration_ms: 5,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          notebook_snapshot: {
-            count: 1,
-            first_start_ms: 5,
-            first_end_ms: 15,
-            max_end_ms: 15,
-            max_duration_ms: 10,
-            statuses: [200],
-            urls: ["https://preview.runt.run/api/n/topic-viz/snapshots/heads-a"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/api/n/topic-viz/snapshots/heads-a",
-                start_ms: 5,
-                end_ms: 15,
-                duration_ms: 10,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          runtime_snapshot: {
-            count: 1,
-            first_start_ms: 6,
-            first_end_ms: 18,
-            max_end_ms: 18,
-            max_duration_ms: 12,
-            statuses: [200],
-            urls: ["https://preview.runt.run/api/n/topic-viz/runtime-snapshots/heads-b"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/api/n/topic-viz/runtime-snapshots/heads-b",
-                start_ms: 6,
-                end_ms: 18,
-                duration_ms: 12,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          viewer_js: {
-            count: 1,
-            first_start_ms: 2,
-            first_end_ms: 12,
-            max_end_ms: 12,
-            max_duration_ms: 10,
-            statuses: [200],
-            urls: ["https://preview.runt.run/assets/notebook-cloud-viewer.js"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
-                start_ms: 2,
-                end_ms: 12,
-                duration_ms: 10,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          runtimed_wasm_binary: {
-            count: 1,
-            first_start_ms: 8,
-            first_end_ms: 44,
-            max_end_ms: 44,
-            max_duration_ms: 36,
-            statuses: [200],
-            urls: ["https://preview.runt.run/renderer-assets/runtimed_wasm_bg.wasm"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/renderer-assets/runtimed_wasm_bg.wasm",
-                start_ms: 8,
-                end_ms: 44,
-                duration_ms: 36,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          arrow_stream_blob: {
-            count: 1,
-            first_start_ms: 24,
-            first_end_ms: 70,
-            max_end_ms: 70,
-            max_duration_ms: 46,
-            statuses: [200],
-            urls: ["https://preview.runt.run/api/n/topic-viz/blobs/arrow"],
-            slowest: [
-              {
-                url: "https://preview.runt.run/api/n/topic-viz/blobs/arrow",
-                start_ms: 24,
-                end_ms: 70,
-                duration_ms: 46,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
-          output_document_frame: {
-            count: 2,
-            first_start_ms: 10,
-            first_end_ms: 30,
-            max_end_ms: 50,
-            max_duration_ms: 30,
-            statuses: [200, 200],
-            urls: [
-              "https://preview.runtusercontent.com/frame/",
-              "https://preview.runtusercontent.com/frame/?two",
-            ],
-            slowest: [
-              {
-                url: "https://preview.runtusercontent.com/frame/?two",
-                start_ms: 20,
-                end_ms: 50,
-                duration_ms: 30,
-                status: 200,
-                failure: null,
-              },
-              {
-                url: "https://preview.runtusercontent.com/frame/",
-                start_ms: 10,
-                end_ms: 30,
-                duration_ms: 20,
-                status: 200,
-                failure: null,
-              },
-            ],
-          },
+        {
+          kind: "viewer_js",
+          url: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
+          start_ms: 2,
+          end_ms: 12,
+          status: 200,
+          contentLength: 4_096,
         },
-      },
+        {
+          kind: "runtimed_wasm_binary",
+          url: "https://preview.runt.run/renderer-assets/runtimed_wasm_bg.wasm",
+          start_ms: 8,
+          end_ms: 44,
+          status: 200,
+          contentLength: 512,
+        },
+        {
+          kind: "arrow_stream_blob",
+          url: "https://preview.runt.run/api/n/topic-viz/blobs/arrow",
+          start_ms: 24,
+          end_ms: 70,
+          status: 200,
+          contentLength: 8_192,
+        },
+        {
+          kind: "output_document_frame",
+          url: "https://preview.runtusercontent.com/frame/",
+          start_ms: 10,
+          end_ms: 30,
+          status: 200,
+          contentLength: 768,
+        },
+        {
+          kind: "output_document_frame",
+          url: "https://preview.runtusercontent.com/frame/?two",
+          start_ms: 20,
+          end_ms: 50,
+          status: 200,
+          contentLength: 1_024,
+        },
+      ],
+      { live_sync_websocket: 11, source_text: 42, rendered_cell_marker: 55, frame_texts: 80 },
     );
+
+    assert.deepEqual(summary.live_path, {
+      catalog_api_ms: 6,
+      notebook_snapshot_ms: 15,
+      runtime_snapshot_ms: 18,
+      snapshot_pair_complete_ms: 18,
+      snapshot_pair_bytes: 3_072,
+      live_sync_websocket_ms: 11,
+      source_text_ms: 42,
+      rendered_cell_marker_ms: 55,
+      first_output_iframe_ms: null,
+      frame_texts_ms: 80,
+      first_useful_render_ms: 80,
+      snapshot_pair_to_rendered_cell_ms: 37,
+      snapshot_pair_to_frame_texts_ms: 62,
+    });
+    assert.deepEqual(summary.sidecar_assets, {
+      viewer_shell_complete_ms: 12,
+      viewer_shell_bytes: 4_096,
+      runtimed_wasm_complete_ms: 44,
+      runtimed_wasm_bytes: 512,
+      isolated_renderer_complete_ms: null,
+      isolated_renderer_bytes: null,
+      output_document_complete_ms: 50,
+      output_document_bytes: 1_792,
+      sift_wasm_complete_ms: null,
+      sift_wasm_bytes: null,
+      arrow_data_complete_ms: 70,
+      arrow_data_bytes: 8_192,
+    });
+    assert.deepEqual(summary.resources_by_kind.output_document_frame.slowest, [
+      {
+        url: "https://preview.runtusercontent.com/frame/?two",
+        start_ms: 20,
+        end_ms: 50,
+        duration_ms: 30,
+        status: 200,
+        failure: null,
+      },
+      {
+        url: "https://preview.runtusercontent.com/frame/",
+        start_ms: 10,
+        end_ms: 30,
+        duration_ms: 20,
+        status: 200,
+        failure: null,
+      },
+    ]);
+    assert.equal(summary.resources_by_kind.output_document_frame.total_bytes, 1_792);
+    assert.equal(summary.resources_by_kind.output_document_frame.max_bytes, 1_024);
+    assert.equal(summary.resources_by_kind.output_document_frame.unknown_byte_count, 0);
+  });
+
+  it("does not summarize byte budgets when any grouped response size is unknown", () => {
+    const summary = summarizePerformanceResources([
+      {
+        kind: "viewer_js",
+        url: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
+        start_ms: 1,
+        end_ms: 2,
+        status: 200,
+        contentLength: 4_096,
+      },
+      {
+        kind: "viewer_css",
+        url: "https://preview.runt.run/assets/notebook-cloud-viewer.css",
+        start_ms: 1,
+        end_ms: 3,
+        status: 200,
+      },
+    ]);
+
+    assert.equal(summary.resources_by_kind.viewer_css.unknown_byte_count, 1);
+    assert.equal(summary.sidecar_assets.viewer_shell_bytes, null);
+  });
+
+  it("fills missing response sizes from browser Resource Timing entries", () => {
+    const resources = [
+      {
+        kind: "viewer_js",
+        url: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
+        contentLength: 123,
+      },
+      {
+        kind: "output_document_frame",
+        url: "https://preview.runtusercontent.com/frame/",
+        contentLength: null,
+      },
+      {
+        kind: "output_document_frame",
+        url: "https://preview.runtusercontent.com/frame/",
+        contentLength: null,
+      },
+      {
+        kind: "sift_wasm_binary",
+        url: "https://assets.example/sift_wasm.wasm",
+        contentLength: null,
+      },
+      {
+        kind: "renderer_asset_js",
+        url: "https://assets.example/isolated-renderer.js",
+        contentLength: null,
+      },
+    ];
+
+    applyResourceTimingSizes(resources, [
+      {
+        name: "https://preview.runt.run/assets/notebook-cloud-viewer.js",
+        encodedBodySize: 999,
+      },
+      {
+        name: "https://preview.runtusercontent.com/frame/",
+        encodedBodySize: 512,
+      },
+      {
+        name: "https://preview.runtusercontent.com/frame/",
+        encodedBodySize: 768,
+      },
+      {
+        name: "https://assets.example/sift_wasm.wasm",
+        encodedBodySize: 0,
+      },
+    ]);
+
+    assert.equal(resources[0].contentLength, 123);
+    assert.equal(resources[1].contentLength, 512);
+    assert.equal(resources[2].contentLength, 768);
+    assert.equal(resources[3].contentLength, null);
+    assert.equal(resources[4].contentLength, null);
   });
 
   it("attaches stable preflight timing without crashing on null checks", () => {
@@ -405,10 +365,12 @@ describe("hosted smoke performance diagnostics", () => {
       live_path: {
         first_useful_render_ms: 5_025,
         live_sync_websocket_ms: 1_323,
+        snapshot_pair_bytes: 4_500,
       },
       sidecar_assets: {
         sift_wasm_complete_ms: 3_025,
         arrow_data_complete_ms: null,
+        viewer_shell_bytes: null,
       },
     };
 
@@ -419,28 +381,49 @@ describe("hosted smoke performance diagnostics", () => {
         live_sync_websocket_ms: null,
         sift_wasm_complete_ms: 3_000,
         arrow_data_complete_ms: 8_000,
+        snapshot_pair_bytes: 4_000,
+        viewer_shell_bytes: 1_000,
       }),
       [
         {
           kind: "performance-budget",
           metric: "collab_anonymous_update_max_ms",
           text: "editor-to-anonymous viewer update propagation took 1250 ms, expected <= 1000 ms",
-          expected_ms: 1000,
-          actual_ms: 1250,
+          expected_value: 1000,
+          actual_value: 1250,
+          unit: "ms",
         },
         {
           kind: "performance-budget",
           metric: "sift_wasm_complete_ms",
           text: "Sift WASM took 3025 ms, expected <= 3000 ms",
-          expected_ms: 3000,
-          actual_ms: 3025,
+          expected_value: 3000,
+          actual_value: 3025,
+          unit: "ms",
         },
         {
           kind: "performance-budget",
           metric: "arrow_data_complete_ms",
           text: "Arrow data timing was missing; expected <= 8000 ms",
-          expected_ms: 8000,
-          actual_ms: null,
+          expected_value: 8000,
+          actual_value: null,
+          unit: "ms",
+        },
+        {
+          kind: "performance-budget",
+          metric: "snapshot_pair_bytes",
+          text: "snapshot pair payload was 4500 bytes, expected <= 4000 bytes",
+          expected_value: 4000,
+          actual_value: 4500,
+          unit: "bytes",
+        },
+        {
+          kind: "performance-budget",
+          metric: "viewer_shell_bytes",
+          text: "viewer shell payload size was missing; expected <= 1000 bytes",
+          expected_value: 1000,
+          actual_value: null,
+          unit: "bytes",
         },
       ],
     );

--- a/apps/notebook-cloud/test/output-document-worker.test.ts
+++ b/apps/notebook-cloud/test/output-document-worker.test.ts
@@ -29,6 +29,7 @@ describe("output document Worker", () => {
     assert.equal(response.headers.get("X-Content-Type-Options"), "nosniff");
     assert.equal(response.headers.get("Referrer-Policy"), "no-referrer");
     assert.equal(response.headers.get("Cross-Origin-Resource-Policy"), "cross-origin");
+    assert.equal(response.headers.get("Timing-Allow-Origin"), "*");
     assert.match(response.headers.get("Content-Security-Policy") ?? "", /script-src/);
     assert.match(response.headers.get("Content-Security-Policy") ?? "", /frame-src 'none'/);
     assert.match(response.headers.get("Permissions-Policy") ?? "", /camera=\(\)/);

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -25,6 +25,7 @@ describe("renderer assets Worker", () => {
     assert.deepEqual(seenPaths, ["/sift_wasm.wasm"]);
     assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
     assert.equal(response.headers.get("Access-Control-Allow-Methods"), "GET, HEAD, OPTIONS");
+    assert.equal(response.headers.get("Timing-Allow-Origin"), "*");
     assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
     assert.equal(response.headers.get("Content-Type"), "application/wasm");
     assert.equal(await response.text(), "wasm");
@@ -50,6 +51,7 @@ describe("renderer assets Worker", () => {
     assert.equal(response.status, 200);
     assert.deepEqual(seenPaths, ["/runtimed_wasm_bg.wasm"]);
     assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Timing-Allow-Origin"), "*");
     assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
   });
 


### PR DESCRIPTION
## Summary

- add payload byte diagnostics to the hosted render smoke alongside the existing timing milestones
- add optional hosted byte budgets for snapshot pairs, viewer shell assets, runtimed WASM, renderer sidecars, output frames, Sift WASM, and Arrow data
- expose cross-origin Resource Timing for renderer assets and output documents with `Timing-Allow-Origin: *`

Stack order:
- Depends on #3172 (`test(notebook-cloud): budget hosted collab smoke`)
- Merge #3172 first, then this PR after GitHub retargets the branch.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-smoke-performance.test.mjs test/hosted-smoke-routes.test.mjs test/hosted-smoke-assets.test.mjs test/hosted-smoke-runtime-wasm.test.mjs test/renderer-assets-worker.test.ts test/output-document-worker.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud smoke:hosted`

## Notes

- Current deployed `preview.runt.run` exposes same-origin viewer JS/CSS payload bytes through Resource Timing, and output/Arrow payload bytes through response headers.
- Renderer sidecar bytes remain unknown until this branch is deployed because the current renderer-assets Worker does not yet emit `Timing-Allow-Origin`.
