### PR TITLE
docs(elements): fix math output fixture escaping

### DIFF
--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -1070,7 +1070,9 @@ export function OutputRenderersExample() {
           icon={Braces}
         >
           <div className="rounded-md border border-fd-border bg-fd-background p-3">
-            <MathOutput content="$$\\operatorname{MAE}=\\frac{1}{n}\\sum_{i=1}^{n}|y_i-\\hat{y}_i|=8.42$$" />
+            <MathOutput
+              content={String.raw`$$\operatorname{MAE}=\frac{1}{n}\sum_{i=1}^{n}|y_i-\hat{y}_i|=8.42$$`}
+            />
           </div>
         </RendererCard>
 


### PR DESCRIPTION
## Summary

- Fix the elements output renderer fixture so `MathOutput` receives raw LaTeX instead of a JSX string with double-escaped commands.
- Keep KaTeX CSS scoped to the existing output components rather than adding another docs-global stylesheet import.

## Verification

- `pnpm elements:build`
- `cargo xtask lint --fix`
- `git diff --check`
- Playwright smoke against `http://127.0.0.1:5176/docs/output-renderers` confirmed the math card renders the fraction/sum form and KaTeX font rules.
