### PR TITLE
fix(runtimed): don't autosave an empty room over a non-empty notebook file

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -256,14 +256,14 @@ pub(crate) fn parse_notebook_jiter(bytes: &[u8]) -> Result<ParsedStreamingNotebo
     let cells_arr = match jobj_get(obj, "cells") {
         Some(jiter::JsonValue::Array(arr)) => arr,
         Some(_) => return Err("'cells' is not an array".to_string()),
-        None => {
-            return Ok(ParsedStreamingNotebook {
-                cells: vec![],
-                metadata,
-                metadata_value,
-                attachments: HashMap::new(),
-            })
-        }
+        // A notebook with no `cells` key is malformed (nbformat requires it),
+        // exactly like a non-array `cells`. Erroring here (rather than returning
+        // an empty notebook) means the streaming load FAILS, so the room stays
+        // empty-and-never-ready and the autosave zeroing guard preserves the
+        // file on disk instead of overwriting recoverable-but-clobbered content
+        // with an empty notebook. A genuine empty notebook still has `cells: []`
+        // and loads normally.
+        None => return Err("notebook has no 'cells' key".to_string()),
     };
 
     use loro_fractional_index::FractionalIndex;

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -169,6 +169,10 @@ where
     {
         Ok(count) => {
             room.finish_loading();
+            // Load completed: the room now reflects disk. Latch it ready so a
+            // later legitimate emptying autosaves instead of being skipped by
+            // the zeroing guard.
+            room.mark_ready();
             info!(
                 "[notebook-sync] Streaming load complete: {} cells from {}",
                 count,

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -169,6 +169,11 @@ where
     {
         Ok(count) => {
             room.finish_loading();
+            // The load succeeded and the room now reflects the file on disk, so
+            // any prior failed-load hazard is resolved. Clear it here (on
+            // completion, not at retry start) to avoid racing an in-flight
+            // autosave during the retry window.
+            room.clear_load_failed();
             info!(
                 "[notebook-sync] Streaming load complete: {} cells from {}",
                 count,

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -169,10 +169,6 @@ where
     {
         Ok(count) => {
             room.finish_loading();
-            // Load completed: the room now reflects disk. Latch it ready so a
-            // later legitimate emptying autosaves instead of being skipped by
-            // the zeroing guard.
-            room.mark_ready();
             info!(
                 "[notebook-sync] Streaming load complete: {} cells from {}",
                 count,
@@ -219,6 +215,10 @@ where
                     );
                 }
             }
+            // The room was just emptied by a failed load; mark it so the
+            // persistence guard refuses to autosave this empty doc over a
+            // non-empty file.
+            room.mark_load_failed();
             room.finish_loading();
             let _ = room.broadcasts.changed_tx.send(());
             warn!(

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -243,41 +243,34 @@ pub(crate) async fn save_notebook_to_disk(
     .map_err(|e| SaveError::Unrecoverable(format!("Failed to build v4 notebook: {e}")))?;
     let cell_count = v4_notebook.cells.len();
 
-    // Any doc we observe with at least one cell is, by definition, a room in a
-    // known-good state. Latch it ready (monotonic) so a later emptying of this
-    // same room autosaves instead of being mistaken for a failed load. This
-    // also rescues a room repopulated by the file watcher after an earlier
-    // failed initial load.
-    if cell_count >= 1 {
-        room.mark_ready();
-    }
-
     // Zeroing guard (automatic saves only). A failed/incomplete streaming load
     // empties the room doc (peer_session clears all cells on load failure).
     // Autosave and kernel-teardown both call this with `target_path = None`, so
     // without this guard an empty room would overwrite a populated `.ipynb` and
     // destroy the user's notebook. Skip the write when the in-memory doc has 0
-    // cells, the room has never been ready, and a non-empty file already exists
-    // on disk; return Ok so the autosave debouncer keeps running (Unrecoverable
-    // would disable it). This keys on `target_path = None`, which is the
-    // automatic autosave/teardown path — but note an explicit in-place Save
-    // (Cmd+S / SDK `save()`) ALSO passes `None`; only Save As passes `Some`. So
-    // an explicit in-place Save of a never-ready empty room is skipped here too:
-    // the file is preserved (no data loss), but the save reports success without
-    // writing. Distinguishing autosave from explicit in-place Save, and
+    // cells, the room was emptied by a failed load (`load_failed`), and a
+    // non-empty file already exists on disk; return Ok so the autosave debouncer
+    // keeps running (Unrecoverable would disable it). This keys on
+    // `target_path = None`, which is the automatic autosave/teardown path — but
+    // note an explicit in-place Save (Cmd+S / SDK `save()`) ALSO passes `None`;
+    // only Save As passes `Some`. So an explicit in-place Save of a failed-load
+    // empty room is skipped here too: the file is preserved (no data loss), but
+    // the save reports success without writing. Distinguishing autosave from
+    // explicit in-place Save, and
     // surfacing the failed load to the client instead of a silent success, is
     // deferred to the honest-failure-messaging work (Step 1). A genuinely empty
     // doc over an empty/absent file still round-trips, and a brand-new untitled
     // notebook has no existing file to protect.
     //
-    // `!room.ever_ready()` is what separates a failed load from a legitimate
-    // emptying. `ever_ready` is a set-once latch (never cleared) flipped true
-    // when a load completes, the room is created fresh, or any doc with >=1
-    // cell is observed. So once a notebook has loaded or held content, deleting
-    // its last cell or editing metadata on a loaded-empty notebook WRITES the
-    // empty state; only a room that has never been ready (initial load failed
-    // or never ran) is protected. Because the bit is monotonic there is no
-    // clear-on-reload / clear-on-save lifecycle to get wrong.
+    // `room.load_failed()` is what separates a failed load from a legitimate
+    // emptying. The flag is set at exactly one production point — the
+    // streaming-load Err branch in peer_session, co-located with the
+    // `clear_all_cells()` that empties the room — and cleared on a fresh load
+    // attempt (`try_start_loading` winning the claim). So a legitimately-empty
+    // notebook reached via ANY init path (no failed load) is never flagged and
+    // always saves: deleting the last cell or editing metadata on a loaded room
+    // WRITES the empty state. Only a room emptied by a failed load over a
+    // non-empty/corrupt file on disk is protected.
     //
     // The disk trigger is "disk has bytes," not "disk parses to >=1 cell." The
     // most common reason a streaming load fails is that the file is corrupt
@@ -288,15 +281,15 @@ pub(crate) async fn save_notebook_to_disk(
     // clobbered by a crashed prior write, and well-formed populated notebooks
     // alike. The only cost is that an unparseable file is never auto-overwritten
     // by an empty doc, which is the safe direction for a data-loss guard.
-    if target_path.is_none() && cell_count == 0 && !room.ever_ready() {
+    if target_path.is_none() && cell_count == 0 && room.load_failed() {
         let disk_has_content = existing_raw
             .as_ref()
             .is_some_and(|bytes| bytes.iter().any(|b| !b.is_ascii_whitespace()));
         if disk_has_content {
             warn!(
                 "[notebook-sync] Skipping save of empty doc over existing on-disk content for \
-                 {:?} (room never ready, likely a failed initial load); preserving file. Save As \
-                 to a new path still writes.",
+                 {:?} (room emptied by a failed load); preserving file. Save As to a new path \
+                 still writes.",
                 notebook_path
             );
             return Ok(notebook_path.to_string_lossy().to_string());
@@ -340,10 +333,6 @@ pub(crate) async fn save_notebook_to_disk(
                 }
                 *room.persistence.last_save_sources.write().await = saved;
             }
-            // A no-op save still means the room's content matches disk — a good
-            // persisted state — so latch ready here too (the post-write
-            // mark_ready below is not reached on this early return).
-            room.mark_ready();
             return Ok(notebook_path.to_string_lossy().to_string());
         }
     }
@@ -370,16 +359,6 @@ pub(crate) async fn save_notebook_to_disk(
                 _ => SaveError::Retryable(msg),
             }
         })?;
-
-    // A completed write means this room now has a persisted good state on disk,
-    // so latch it ready (monotonic). This covers the case where an empty
-    // notebook is explicitly saved/Save-As'd to a path before it ever held a
-    // cell: without this, a later autosave of a legitimately-empty edit
-    // (e.g. metadata/dependency change) would have cell_count == 0 and
-    // ever_ready == false and be mistaken for a failed-load empty by the
-    // zeroing guard above. A failed-load room never reaches this point — the
-    // guard returns early before any write.
-    room.mark_ready();
 
     // Update last_self_write timestamp so the file watcher skips our own write.
     // Applies to all rooms (including ephemeral that were just promoted to

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -284,9 +284,24 @@ pub(crate) async fn save_notebook_to_disk(
     let is_in_place_save = match target_path {
         None => true,
         Some(_) => {
-            room.file_binding
-                .path_matches(notebook_path.as_path())
-                .await
+            // Recognize an in-place save even when the caller spells the bound
+            // path differently (symlink, `..`, etc.): compare canonical forms,
+            // falling back to raw equality when canonicalization fails (e.g. a
+            // genuine Save As to a not-yet-existing path — correctly NOT in-place,
+            // since it does not target the bound file).
+            match room.file_binding.path().await {
+                Some(bound) => {
+                    let same_file = match (
+                        tokio::fs::canonicalize(notebook_path.as_path()).await,
+                        tokio::fs::canonicalize(&bound).await,
+                    ) {
+                        (Ok(a), Ok(b)) => a == b,
+                        _ => bound == notebook_path,
+                    };
+                    same_file
+                }
+                None => false,
+            }
         }
     };
     if is_in_place_save && cell_count == 0 && room.load_failed() {

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -1435,13 +1435,14 @@ pub(crate) fn spawn_notebook_file_watcher(
 
                             // The file watcher is a recovery path that does not go
                             // through `try_start_loading`. Clear the failed-load
-                            // hazard ONLY once the watcher has actually reconciled
-                            // file content into the doc — parsing valid JSON is not
-                            // enough (apply can still fail, e.g. on bad
-                            // attachments, leaving the room empty). Gate on the doc
-                            // now holding cells, so a failed apply keeps the file
-                            // protected.
-                            if room.doc.read().await.cell_count() > 0 {
+                            // hazard once the watcher has actually reconciled the
+                            // file into the doc — i.e. the doc now matches the
+                            // parsed file's cell count. This clears on a valid
+                            // reload whether the file is empty (`cells: []`) or
+                            // populated, but NOT when apply failed (e.g. on bad
+                            // attachments) and left the doc out of sync, which
+                            // keeps the on-disk file protected.
+                            if room.doc.read().await.cell_count() == external_cells.len() {
                                 room.clear_load_failed();
                             }
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -243,21 +243,21 @@ pub(crate) async fn save_notebook_to_disk(
     .map_err(|e| SaveError::Unrecoverable(format!("Failed to build v4 notebook: {e}")))?;
     let cell_count = v4_notebook.cells.len();
 
-    // Zeroing guard (automatic saves only). A failed/incomplete streaming load
-    // empties the room doc (peer_session clears all cells on load failure).
-    // Autosave and kernel-teardown both call this with `target_path = None`, so
-    // without this guard an empty room would overwrite a populated `.ipynb` and
-    // destroy the user's notebook. Skip the write when the in-memory doc has 0
-    // cells, the room was emptied by a failed load (`load_failed`), and a
-    // non-empty file already exists on disk; return Ok so the autosave debouncer
-    // keeps running (Unrecoverable would disable it). This keys on
-    // `target_path = None`, which is the automatic autosave/teardown path — but
-    // note an explicit in-place Save (Cmd+S / SDK `save()`) ALSO passes `None`;
-    // only Save As passes `Some`. So an explicit in-place Save of a failed-load
-    // empty room is skipped here too: the file is preserved (no data loss), but
-    // the save reports success without writing. Distinguishing autosave from
-    // explicit in-place Save, and
-    // surfacing the failed load to the client instead of a silent success, is
+    // Zeroing guard (in-place saves). A failed/incomplete streaming load empties
+    // the room doc (peer_session clears all cells on load failure). Writing that
+    // empty room back to its own file overwrites a populated `.ipynb` and
+    // destroys the notebook. Skip the write when the save is IN-PLACE, the
+    // in-memory doc has 0 cells, the room was emptied by a failed load
+    // (`load_failed`), and a non-empty file already exists on disk; return Ok so
+    // the autosave debouncer keeps running (Unrecoverable would disable it).
+    //
+    // "In-place" = the save targets the room's current bound path. Desktop
+    // autosave/teardown/Save pass `target_path = None`; MCP/Node/Python
+    // `save(path)` pass `Some(current_path)`. BOTH are in-place and must be
+    // protected — keying on `None` alone would let a same-path `Some` save zero
+    // the file. Only a genuine Save As to a DIFFERENT path bypasses the guard
+    // (the user is deliberately writing elsewhere). A failed-load room's in-place
+    // save still reports success without writing; surfacing that to the client is
     // deferred to the honest-failure-messaging work (Step 1). A genuinely empty
     // doc over an empty/absent file still round-trips, and a brand-new untitled
     // notebook has no existing file to protect.
@@ -281,7 +281,15 @@ pub(crate) async fn save_notebook_to_disk(
     // clobbered by a crashed prior write, and well-formed populated notebooks
     // alike. The only cost is that an unparseable file is never auto-overwritten
     // by an empty doc, which is the safe direction for a data-loss guard.
-    if target_path.is_none() && cell_count == 0 && room.load_failed() {
+    let is_in_place_save = match target_path {
+        None => true,
+        Some(_) => {
+            room.file_binding
+                .path_matches(notebook_path.as_path())
+                .await
+        }
+    };
+    if is_in_place_save && cell_count == 0 && room.load_failed() {
         let disk_has_content = existing_raw
             .as_ref()
             .is_some_and(|bytes| bytes.iter().any(|b| !b.is_ascii_whitespace()));
@@ -1412,15 +1420,6 @@ pub(crate) fn spawn_notebook_file_watcher(
                             };
                             let external_metadata = parse_metadata_from_ipynb(&json);
 
-                            // Reaching here means a valid notebook was just read
-                            // from disk and is being reconciled into this resident
-                            // room — a recovery path that does NOT go through
-                            // `try_start_loading`. Clear any failed-load hazard
-                            // flag so a later legitimate empty save is not blocked
-                            // by the zeroing guard (the file watcher is the other
-                            // recovery path besides a load retry).
-                            room.clear_load_failed();
-
                             // Check if kernel is running (to preserve outputs)
                             let has_kernel = room.has_kernel().await;
 
@@ -1433,6 +1432,18 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 has_kernel,
                             )
                             .await;
+
+                            // The file watcher is a recovery path that does not go
+                            // through `try_start_loading`. Clear the failed-load
+                            // hazard ONLY once the watcher has actually reconciled
+                            // file content into the doc — parsing valid JSON is not
+                            // enough (apply can still fail, e.g. on bad
+                            // attachments, leaving the room empty). Gate on the doc
+                            // now holding cells, so a failed apply keeps the file
+                            // protected.
+                            if room.doc.read().await.cell_count() > 0 {
+                                room.clear_load_failed();
+                            }
 
                             // Apply metadata changes to Automerge doc.
                             // Only update when the external file has a metadata

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -333,6 +333,9 @@ pub(crate) async fn save_notebook_to_disk(
                 }
                 *room.persistence.last_save_sources.write().await = saved;
             }
+            // Disk already matches the room, so any failed-load hazard is
+            // resolved — clear the flag so a later legitimate empty save writes.
+            room.clear_load_failed();
             return Ok(notebook_path.to_string_lossy().to_string());
         }
     }
@@ -359,6 +362,13 @@ pub(crate) async fn save_notebook_to_disk(
                 _ => SaveError::Retryable(msg),
             }
         })?;
+
+    // A successful write makes disk match the room, so any failed-load hazard is
+    // resolved — clear the flag so later legitimate empty saves are not blocked.
+    // (A still-failed empty room over existing content is skipped by the guard
+    // above and never reaches here, so this only clears genuine recoveries:
+    // Save As, or adding a cell to a failed-load room and saving.)
+    room.clear_load_failed();
 
     // Update last_self_write timestamp so the file watcher skips our own write.
     // Applies to all rooms (including ephemeral that were just promoted to

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -243,20 +243,38 @@ pub(crate) async fn save_notebook_to_disk(
     .map_err(|e| SaveError::Unrecoverable(format!("Failed to build v4 notebook: {e}")))?;
     let cell_count = v4_notebook.cells.len();
 
+    // Any doc we observe with at least one cell is, by definition, a room in a
+    // known-good state. Latch it ready (monotonic) so a later emptying of this
+    // same room autosaves instead of being mistaken for a failed load. This
+    // also rescues a room repopulated by the file watcher after an earlier
+    // failed initial load.
+    if cell_count >= 1 {
+        room.mark_ready();
+    }
+
     // Zeroing guard (automatic saves only). A failed/incomplete streaming load
     // empties the room doc (peer_session clears all cells on load failure).
     // Autosave and kernel-teardown both call this with `target_path = None`, so
     // without this guard an empty room would overwrite a populated `.ipynb` and
     // destroy the user's notebook. Skip the write when the in-memory doc has 0
-    // cells but a non-empty file already exists on disk, and return Ok so the
-    // autosave debouncer keeps running (Unrecoverable would disable it). An
-    // explicit user save (`target_path = Some`) is a deliberate action and
-    // bypasses this: emptying then saving on purpose still works. A genuinely
-    // empty doc over an empty/absent file still round-trips, and a brand-new
-    // untitled notebook has no existing file to protect.
+    // cells, the room has never been ready, and a non-empty file already exists
+    // on disk; return Ok so the autosave debouncer keeps running (Unrecoverable
+    // would disable it). An explicit user save (`target_path = Some`) is a
+    // deliberate action and bypasses this. A genuinely empty doc over an
+    // empty/absent file still round-trips, and a brand-new untitled notebook
+    // has no existing file to protect.
     //
-    // The trigger condition is "disk has bytes," not "disk parses to >=1 cell."
-    // The most common reason a streaming load fails is that the file is corrupt
+    // `!room.ever_ready()` is what separates a failed load from a legitimate
+    // emptying. `ever_ready` is a set-once latch (never cleared) flipped true
+    // when a load completes, the room is created fresh, or any doc with >=1
+    // cell is observed. So once a notebook has loaded or held content, deleting
+    // its last cell or editing metadata on a loaded-empty notebook WRITES the
+    // empty state; only a room that has never been ready (initial load failed
+    // or never ran) is protected. Because the bit is monotonic there is no
+    // clear-on-reload / clear-on-save lifecycle to get wrong.
+    //
+    // The disk trigger is "disk has bytes," not "disk parses to >=1 cell." The
+    // most common reason a streaming load fails is that the file is corrupt
     // (load.rs: jiter parse error, "not a JSON object", "'cells' is not an
     // array") — exactly the cases where a parse-and-count of the on-disk bytes
     // returns 0 and would let the empty doc through. Protecting on raw
@@ -264,15 +282,15 @@ pub(crate) async fn save_notebook_to_disk(
     // clobbered by a crashed prior write, and well-formed populated notebooks
     // alike. The only cost is that an unparseable file is never auto-overwritten
     // by an empty doc, which is the safe direction for a data-loss guard.
-    if target_path.is_none() && cell_count == 0 {
+    if target_path.is_none() && cell_count == 0 && !room.ever_ready() {
         let disk_has_content = existing_raw
             .as_ref()
             .is_some_and(|bytes| bytes.iter().any(|b| !b.is_ascii_whitespace()));
         if disk_has_content {
             warn!(
                 "[notebook-sync] Skipping autosave of empty doc over existing on-disk content for \
-                 {:?} (likely a failed initial load); preserving file. Explicit save still \
-                 permitted.",
+                 {:?} (room never ready, likely a failed initial load); preserving file. Explicit \
+                 save still permitted.",
                 notebook_path
             );
             return Ok(notebook_path.to_string_lossy().to_string());

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -290,16 +290,13 @@ pub(crate) async fn save_notebook_to_disk(
             // genuine Save As to a not-yet-existing path — correctly NOT in-place,
             // since it does not target the bound file).
             match room.file_binding.path().await {
-                Some(bound) => {
-                    let same_file = match (
-                        tokio::fs::canonicalize(notebook_path.as_path()).await,
-                        tokio::fs::canonicalize(&bound).await,
-                    ) {
-                        (Ok(a), Ok(b)) => a == b,
-                        _ => bound == notebook_path,
-                    };
-                    same_file
-                }
+                Some(bound) => match (
+                    tokio::fs::canonicalize(notebook_path.as_path()).await,
+                    tokio::fs::canonicalize(&bound).await,
+                ) {
+                    (Ok(a), Ok(b)) => a == b,
+                    _ => bound == notebook_path,
+                },
                 None => false,
             }
         }

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -1402,6 +1402,15 @@ pub(crate) fn spawn_notebook_file_watcher(
                             };
                             let external_metadata = parse_metadata_from_ipynb(&json);
 
+                            // Reaching here means a valid notebook was just read
+                            // from disk and is being reconciled into this resident
+                            // room — a recovery path that does NOT go through
+                            // `try_start_loading`. Clear any failed-load hazard
+                            // flag so a later legitimate empty save is not blocked
+                            // by the zeroing guard (the file watcher is the other
+                            // recovery path besides a load retry).
+                            room.clear_load_failed();
+
                             // Check if kernel is running (to preserve outputs)
                             let has_kernel = room.has_kernel().await;
 

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -259,10 +259,16 @@ pub(crate) async fn save_notebook_to_disk(
     // destroy the user's notebook. Skip the write when the in-memory doc has 0
     // cells, the room has never been ready, and a non-empty file already exists
     // on disk; return Ok so the autosave debouncer keeps running (Unrecoverable
-    // would disable it). An explicit user save (`target_path = Some`) is a
-    // deliberate action and bypasses this. A genuinely empty doc over an
-    // empty/absent file still round-trips, and a brand-new untitled notebook
-    // has no existing file to protect.
+    // would disable it). This keys on `target_path = None`, which is the
+    // automatic autosave/teardown path — but note an explicit in-place Save
+    // (Cmd+S / SDK `save()`) ALSO passes `None`; only Save As passes `Some`. So
+    // an explicit in-place Save of a never-ready empty room is skipped here too:
+    // the file is preserved (no data loss), but the save reports success without
+    // writing. Distinguishing autosave from explicit in-place Save, and
+    // surfacing the failed load to the client instead of a silent success, is
+    // deferred to the honest-failure-messaging work (Step 1). A genuinely empty
+    // doc over an empty/absent file still round-trips, and a brand-new untitled
+    // notebook has no existing file to protect.
     //
     // `!room.ever_ready()` is what separates a failed load from a legitimate
     // emptying. `ever_ready` is a set-once latch (never cleared) flipped true
@@ -288,9 +294,9 @@ pub(crate) async fn save_notebook_to_disk(
             .is_some_and(|bytes| bytes.iter().any(|b| !b.is_ascii_whitespace()));
         if disk_has_content {
             warn!(
-                "[notebook-sync] Skipping autosave of empty doc over existing on-disk content for \
-                 {:?} (room never ready, likely a failed initial load); preserving file. Explicit \
-                 save still permitted.",
+                "[notebook-sync] Skipping save of empty doc over existing on-disk content for \
+                 {:?} (room never ready, likely a failed initial load); preserving file. Save As \
+                 to a new path still writes.",
                 notebook_path
             );
             return Ok(notebook_path.to_string_lossy().to_string());
@@ -334,6 +340,10 @@ pub(crate) async fn save_notebook_to_disk(
                 }
                 *room.persistence.last_save_sources.write().await = saved;
             }
+            // A no-op save still means the room's content matches disk — a good
+            // persisted state — so latch ready here too (the post-write
+            // mark_ready below is not reached on this early return).
+            room.mark_ready();
             return Ok(notebook_path.to_string_lossy().to_string());
         }
     }

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -361,6 +361,16 @@ pub(crate) async fn save_notebook_to_disk(
             }
         })?;
 
+    // A completed write means this room now has a persisted good state on disk,
+    // so latch it ready (monotonic). This covers the case where an empty
+    // notebook is explicitly saved/Save-As'd to a path before it ever held a
+    // cell: without this, a later autosave of a legitimately-empty edit
+    // (e.g. metadata/dependency change) would have cell_count == 0 and
+    // ever_ready == false and be mistaken for a failed-load empty by the
+    // zeroing guard above. A failed-load room never reaches this point — the
+    // guard returns early before any write.
+    room.mark_ready();
+
     // Update last_self_write timestamp so the file watcher skips our own write.
     // Applies to all rooms (including ephemeral that were just promoted to
     // file-backed via this save) - a watcher may start up right after

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -243,6 +243,42 @@ pub(crate) async fn save_notebook_to_disk(
     .map_err(|e| SaveError::Unrecoverable(format!("Failed to build v4 notebook: {e}")))?;
     let cell_count = v4_notebook.cells.len();
 
+    // Zeroing guard (automatic saves only). A failed/incomplete streaming load
+    // empties the room doc (peer_session clears all cells on load failure).
+    // Autosave and kernel-teardown both call this with `target_path = None`, so
+    // without this guard an empty room would overwrite a populated `.ipynb` and
+    // destroy the user's notebook. Skip the write when the in-memory doc has 0
+    // cells but a non-empty file already exists on disk, and return Ok so the
+    // autosave debouncer keeps running (Unrecoverable would disable it). An
+    // explicit user save (`target_path = Some`) is a deliberate action and
+    // bypasses this: emptying then saving on purpose still works. A genuinely
+    // empty doc over an empty/absent file still round-trips, and a brand-new
+    // untitled notebook has no existing file to protect.
+    //
+    // The trigger condition is "disk has bytes," not "disk parses to >=1 cell."
+    // The most common reason a streaming load fails is that the file is corrupt
+    // (load.rs: jiter parse error, "not a JSON object", "'cells' is not an
+    // array") — exactly the cases where a parse-and-count of the on-disk bytes
+    // returns 0 and would let the empty doc through. Protecting on raw
+    // non-whitespace content covers corrupt files, files whose `cells` key was
+    // clobbered by a crashed prior write, and well-formed populated notebooks
+    // alike. The only cost is that an unparseable file is never auto-overwritten
+    // by an empty doc, which is the safe direction for a data-loss guard.
+    if target_path.is_none() && cell_count == 0 {
+        let disk_has_content = existing_raw
+            .as_ref()
+            .is_some_and(|bytes| bytes.iter().any(|b| !b.is_ascii_whitespace()));
+        if disk_has_content {
+            warn!(
+                "[notebook-sync] Skipping autosave of empty doc over existing on-disk content for \
+                 {:?} (likely a failed initial load); preserving file. Explicit save still \
+                 permitted.",
+                notebook_path
+            );
+            return Ok(notebook_path.to_string_lossy().to_string());
+        }
+    }
+
     // Collect raw-cell attachments (markdown attachments are already on the
     // typed v4::Cell::Markdown variant; raw cells lose theirs in typed
     // conversion and get re-injected during serialize).

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -361,6 +361,21 @@ pub struct RoomPersistence {
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
+    /// Monotonic "this room has been in a known-good state" latch. Set true
+    /// (and never cleared) the first time the room is known ready: a streaming
+    /// load completes (peer_session) or the doc is observed with >=1 cell
+    /// (save_notebook_to_disk). The zeroing guard in `save_notebook_to_disk`
+    /// reads this to tell a legitimately-emptied loaded notebook (write the
+    /// empty state) apart from a room emptied by a failed/never-completed load
+    /// (skip, preserve disk). Set-once means no clear-point lifecycle.
+    ///
+    /// Production room creation (`new_fresh_with_trusted_packages`) does NOT
+    /// latch this: a real untitled notebook never reaches the guard because
+    /// `save_notebook_to_disk` returns early when no path is bound, and a real
+    /// file-backed room latches via the load-success or >=1-cell set-point. The
+    /// test-only `new_fresh` marks ready for convenience; tests needing a
+    /// not-ready file-backed room use `test_room_with_path` (leaves it false).
+    ever_ready: AtomicBool,
 }
 
 /// The debounced `.automerge` persist channels. See `spawn_persist_debouncer`.
@@ -385,6 +400,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
+            ever_ready: AtomicBool::new(false),
         }
     }
 
@@ -402,6 +418,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
+            ever_ready: AtomicBool::new(false),
         }
     }
 
@@ -490,6 +507,19 @@ impl RoomPersistence {
     /// True if a streaming load is currently in progress.
     pub fn is_loading(&self) -> bool {
         self.is_loading.load(Ordering::Acquire)
+    }
+
+    /// Latch the room as known-ready. Monotonic: once set it is never cleared,
+    /// so callers can fire it freely (load success, fresh-room creation, any
+    /// observed non-empty doc) without coordinating a clear point.
+    pub fn mark_ready(&self) {
+        self.ever_ready.store(true, Ordering::Release);
+    }
+
+    /// True once the room has been observed in a known-good state. See
+    /// `mark_ready` and the zeroing guard in `save_notebook_to_disk`.
+    pub fn ever_ready(&self) -> bool {
+        self.ever_ready.load(Ordering::Acquire)
     }
 }
 
@@ -730,7 +760,7 @@ impl NotebookRoom {
         blob_store: Arc<BlobStore>,
         ephemeral: bool,
     ) -> Self {
-        Self::new_fresh_with_trusted_packages(
+        let room = Self::new_fresh_with_trusted_packages(
             uuid,
             path,
             docs_dir,
@@ -738,7 +768,19 @@ impl NotebookRoom {
             ephemeral,
             crate::trusted_packages::TrustedPackageStore::unavailable("not configured"),
         )
-        .expect("create test notebook room runtime state")
+        .expect("create test notebook room runtime state");
+        // Test-only convenience: a room built straight from `new_fresh` has no
+        // streaming load to latch it, so mark it ready here to model the
+        // common "already in a good state" case tests want. Production room
+        // creation goes through `new_fresh_with_trusted_packages`, which does
+        // NOT mark ready; a real file-backed room latches ready via the
+        // load-success set-point (peer_session) or the >=1-cell set-point
+        // (save_notebook_to_disk), and a real untitled notebook never reaches
+        // the zeroing guard (save_notebook_to_disk returns early without a
+        // bound path). Tests that need a not-ready file-backed room build it
+        // via `test_room_with_path` instead, which leaves ever_ready false.
+        room.mark_ready();
+        room
     }
 
     #[allow(private_interfaces)]
@@ -1028,6 +1070,18 @@ impl NotebookRoom {
     /// Mark the streaming load complete.
     pub fn finish_loading(&self) {
         self.persistence.finish_loading();
+    }
+
+    /// Latch the room as known-ready (monotonic, never cleared). See
+    /// `RoomPersistence::mark_ready`.
+    pub fn mark_ready(&self) {
+        self.persistence.mark_ready();
+    }
+
+    /// True once the room has been observed in a known-good state. See
+    /// `RoomPersistence::ever_ready`.
+    pub fn ever_ready(&self) -> bool {
+        self.persistence.ever_ready()
     }
 
     /// Get kernel info if a kernel is running (runtime-agent-backed).

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -489,17 +489,15 @@ impl RoomPersistence {
     /// Atomically claim the loading role. Returns `true` if this caller won
     /// the race and should perform the streaming load.
     pub fn try_start_loading(&self) -> bool {
-        let won = self
-            .is_loading
+        // Note: load_failed is deliberately NOT cleared here. Clearing at the
+        // START of a retry opens a race — an in-flight autosave that already
+        // passed its is_loading() check could then see load_failed == false with
+        // the room still empty mid-retry and zero the file. The flag is cleared
+        // only on recovery COMPLETION (a successful load in peer_session, a
+        // watcher reconcile, or a successful save).
+        self.is_loading
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok();
-        if won {
-            // A fresh load attempt supersedes any prior failure; clear the
-            // hazard flag so a stale failed-load state cannot keep blocking
-            // autosaves after this retry.
-            self.clear_load_failed();
-        }
-        won
+            .is_ok()
     }
 
     /// Mark loading complete (success or failure).

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -768,7 +768,11 @@ impl NotebookRoom {
         blob_store: Arc<BlobStore>,
         ephemeral: bool,
     ) -> Self {
-        let room = Self::new_fresh_with_trusted_packages(
+        // A fresh room has `load_failed = false` by default, so the zeroing
+        // guard does not fire for it: a legitimately-empty room from any init
+        // path always saves. Tests that need the guard to fire drive a doc
+        // empty and then call `mark_load_failed()` to model a failed load.
+        Self::new_fresh_with_trusted_packages(
             uuid,
             path,
             docs_dir,
@@ -776,12 +780,7 @@ impl NotebookRoom {
             ephemeral,
             crate::trusted_packages::TrustedPackageStore::unavailable("not configured"),
         )
-        .expect("create test notebook room runtime state");
-        // A fresh room has `load_failed = false` by default, so the zeroing
-        // guard does not fire for it: a legitimately-empty room from any init
-        // path always saves. Tests that need the guard to fire drive a doc
-        // empty and then call `mark_load_failed()` to model a failed load.
-        room
+        .expect("create test notebook room runtime state")
     }
 
     #[allow(private_interfaces)]

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -361,21 +361,16 @@ pub struct RoomPersistence {
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
-    /// Monotonic "this room has been in a known-good state" latch. Set true
-    /// (and never cleared) the first time the room is known ready: a streaming
-    /// load completes (peer_session) or the doc is observed with >=1 cell
-    /// (save_notebook_to_disk). The zeroing guard in `save_notebook_to_disk`
-    /// reads this to tell a legitimately-emptied loaded notebook (write the
-    /// empty state) apart from a room emptied by a failed/never-completed load
-    /// (skip, preserve disk). Set-once means no clear-point lifecycle.
-    ///
-    /// Production room creation (`new_fresh_with_trusted_packages`) does NOT
-    /// latch this: a real untitled notebook never reaches the guard because
-    /// `save_notebook_to_disk` returns early when no path is bound, and a real
-    /// file-backed room latches via the load-success or >=1-cell set-point. The
-    /// test-only `new_fresh` marks ready for convenience; tests needing a
-    /// not-ready file-backed room use `test_room_with_path` (leaves it false).
-    ever_ready: AtomicBool,
+    /// Hazard flag set only when a FAILED streaming load empties this room.
+    /// Set true at the one production point that zeroes a room out from under a
+    /// possibly-non-empty file: the streaming-load Err branch in peer_session,
+    /// co-located with `doc.clear_all_cells()`. Cleared on a fresh load attempt
+    /// (`try_start_loading` winning the claim) since a retry supersedes any
+    /// prior failure. The zeroing guard in `save_notebook_to_disk` reads this:
+    /// a room emptied by a failed load (flag true) must not autosave its empty
+    /// state over a non-empty/corrupt file, while a legitimately-empty room from
+    /// ANY init path (flag false) always saves.
+    load_failed: AtomicBool,
 }
 
 /// The debounced `.automerge` persist channels. See `spawn_persist_debouncer`.
@@ -400,7 +395,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
-            ever_ready: AtomicBool::new(false),
+            load_failed: AtomicBool::new(false),
         }
     }
 
@@ -418,7 +413,7 @@ impl RoomPersistence {
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
             is_loading: AtomicBool::new(false),
-            ever_ready: AtomicBool::new(false),
+            load_failed: AtomicBool::new(false),
         }
     }
 
@@ -494,9 +489,17 @@ impl RoomPersistence {
     /// Atomically claim the loading role. Returns `true` if this caller won
     /// the race and should perform the streaming load.
     pub fn try_start_loading(&self) -> bool {
-        self.is_loading
+        let won = self
+            .is_loading
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
+            .is_ok();
+        if won {
+            // A fresh load attempt supersedes any prior failure; clear the
+            // hazard flag so a stale failed-load state cannot keep blocking
+            // autosaves after this retry.
+            self.clear_load_failed();
+        }
+        won
     }
 
     /// Mark loading complete (success or failure).
@@ -509,17 +512,24 @@ impl RoomPersistence {
         self.is_loading.load(Ordering::Acquire)
     }
 
-    /// Latch the room as known-ready. Monotonic: once set it is never cleared,
-    /// so callers can fire it freely (load success, fresh-room creation, any
-    /// observed non-empty doc) without coordinating a clear point.
-    pub fn mark_ready(&self) {
-        self.ever_ready.store(true, Ordering::Release);
+    /// Flag the room as emptied by a failed streaming load. Set at the one
+    /// production point that zeroes the room (peer_session Err branch); the
+    /// zeroing guard then refuses to autosave this empty doc over a file.
+    pub fn mark_load_failed(&self) {
+        self.load_failed.store(true, Ordering::Release);
     }
 
-    /// True once the room has been observed in a known-good state. See
-    /// `mark_ready` and the zeroing guard in `save_notebook_to_disk`.
-    pub fn ever_ready(&self) -> bool {
-        self.ever_ready.load(Ordering::Acquire)
+    /// True if the room was emptied by a failed streaming load and not yet
+    /// retried. See `mark_load_failed` and the zeroing guard in
+    /// `save_notebook_to_disk`.
+    pub fn load_failed(&self) -> bool {
+        self.load_failed.load(Ordering::Acquire)
+    }
+
+    /// Clear the failed-load hazard flag. Called when a fresh load attempt
+    /// wins the loading claim, since the retry supersedes the prior failure.
+    pub fn clear_load_failed(&self) {
+        self.load_failed.store(false, Ordering::Release);
     }
 }
 
@@ -769,17 +779,10 @@ impl NotebookRoom {
             crate::trusted_packages::TrustedPackageStore::unavailable("not configured"),
         )
         .expect("create test notebook room runtime state");
-        // Test-only convenience: a room built straight from `new_fresh` has no
-        // streaming load to latch it, so mark it ready here to model the
-        // common "already in a good state" case tests want. Production room
-        // creation goes through `new_fresh_with_trusted_packages`, which does
-        // NOT mark ready; a real file-backed room latches ready via the
-        // load-success set-point (peer_session) or the >=1-cell set-point
-        // (save_notebook_to_disk), and a real untitled notebook never reaches
-        // the zeroing guard (save_notebook_to_disk returns early without a
-        // bound path). Tests that need a not-ready file-backed room build it
-        // via `test_room_with_path` instead, which leaves ever_ready false.
-        room.mark_ready();
+        // A fresh room has `load_failed = false` by default, so the zeroing
+        // guard does not fire for it: a legitimately-empty room from any init
+        // path always saves. Tests that need the guard to fire drive a doc
+        // empty and then call `mark_load_failed()` to model a failed load.
         room
     }
 
@@ -1072,16 +1075,22 @@ impl NotebookRoom {
         self.persistence.finish_loading();
     }
 
-    /// Latch the room as known-ready (monotonic, never cleared). See
-    /// `RoomPersistence::mark_ready`.
-    pub fn mark_ready(&self) {
-        self.persistence.mark_ready();
+    /// Flag the room as emptied by a failed streaming load. See
+    /// `RoomPersistence::mark_load_failed`.
+    pub fn mark_load_failed(&self) {
+        self.persistence.mark_load_failed();
     }
 
-    /// True once the room has been observed in a known-good state. See
-    /// `RoomPersistence::ever_ready`.
-    pub fn ever_ready(&self) -> bool {
-        self.persistence.ever_ready()
+    /// True if the room was emptied by a failed streaming load and not yet
+    /// retried. See `RoomPersistence::load_failed`.
+    pub fn load_failed(&self) -> bool {
+        self.persistence.load_failed()
+    }
+
+    /// Clear the failed-load hazard flag. See
+    /// `RoomPersistence::clear_load_failed`.
+    pub fn clear_load_failed(&self) {
+        self.persistence.clear_load_failed();
     }
 
     /// Get kernel info if a kernel is running (runtime-agent-backed).

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -8950,12 +8950,14 @@ async fn autosave_skips_zeroing_write_after_failed_load() {
     let (room, notebook_path) = test_room_with_path(&tmp, "failed_load.ipynb");
     write_two_cell_notebook(&notebook_path).await;
 
-    // Reproduce the post-failed-load room state: doc emptied, loading done.
+    // Reproduce the post-failed-load room state: doc emptied, loading done,
+    // failed-load hazard flagged (peer_session does this in the Err branch).
     {
         let mut doc = room.doc.write().await;
         doc.clear_all_cells().unwrap();
         assert_eq!(doc.cell_count(), 0);
     }
+    room.mark_load_failed();
     room.finish_loading();
 
     // Autosave / kernel-teardown path.
@@ -9054,12 +9056,13 @@ async fn autosave_skips_zeroing_write_over_corrupt_file() {
     let corrupt = b"{ \"nbformat\": 4, \"cells\": [ {\"id\": \"a\", trunc";
     tokio::fs::write(&notebook_path, corrupt).await.unwrap();
 
-    // Post-failed-load room state: doc emptied, loading done.
+    // Post-failed-load room state: doc emptied, loading done, hazard flagged.
     {
         let mut doc = room.doc.write().await;
         doc.clear_all_cells().unwrap();
         assert_eq!(doc.cell_count(), 0);
     }
+    room.mark_load_failed();
     room.finish_loading();
 
     save_notebook_to_disk(&room, None)
@@ -9091,6 +9094,7 @@ async fn autosave_skips_zeroing_write_when_disk_cells_not_array() {
         doc.clear_all_cells().unwrap();
         assert_eq!(doc.cell_count(), 0);
     }
+    room.mark_load_failed();
     room.finish_loading();
 
     save_notebook_to_disk(&room, None)
@@ -9105,11 +9109,11 @@ async fn autosave_skips_zeroing_write_when_disk_cells_not_array() {
     );
 }
 
-/// Codex P1: the user deletes the last cell of a notebook that loaded
-/// successfully (e.g. via MCP/Python). The room legitimately has 0 cells and
-/// the on-disk file still has bytes, so the old guard skipped the write and
-/// reported success — disk kept stale content. With the `ever_ready` latch set
-/// by load success, this autosave WRITES the empty notebook.
+/// Codex P1, the key "legit empty saves" case: the user deletes the last cell
+/// of a notebook that loaded successfully (e.g. via MCP/Python). The room
+/// legitimately has 0 cells and the on-disk file still has bytes, but the load
+/// did NOT fail, so `load_failed` stays false and the guard does not fire: this
+/// autosave WRITES the empty notebook over the populated file.
 #[tokio::test]
 async fn autosave_writes_empty_doc_after_successful_load_then_emptied() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -9117,14 +9121,16 @@ async fn autosave_writes_empty_doc_after_successful_load_then_emptied() {
     write_two_cell_notebook(&notebook_path).await;
 
     // Reproduce a successful streaming load: the load populates the doc and
-    // latches the room ready (peer_session calls mark_ready on the Ok branch).
+    // does NOT flag load_failed (peer_session sets the flag only in the Err
+    // branch). The room is built via test_room_with_path, so load_failed is
+    // false by default.
     {
         let mut doc = room.doc.write().await;
         doc.add_cell(0, "cell-a", "code").unwrap();
         doc.add_cell(1, "cell-b", "markdown").unwrap();
     }
     room.finish_loading();
-    room.mark_ready();
+    assert!(!room.load_failed());
 
     // User now deletes every cell.
     {
@@ -9145,9 +9151,8 @@ async fn autosave_writes_empty_doc_after_successful_load_then_emptied() {
 }
 
 /// Codex P1, second case: a metadata/dependency edit on an already-saved EMPTY
-/// notebook. The room has 0 cells and the file has bytes, so the old guard
-/// skipped. Because the room loaded successfully (ever_ready true), the write
-/// goes through and the metadata edit lands on disk.
+/// notebook. The room has 0 cells and the file has bytes, but no load failed,
+/// so `load_failed` is false and the write goes through, landing the edit.
 #[tokio::test]
 async fn autosave_writes_metadata_edit_on_loaded_empty_notebook() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -9161,9 +9166,9 @@ async fn autosave_writes_metadata_edit_on_loaded_empty_notebook() {
     .await
     .unwrap();
 
-    // The room loaded that empty notebook successfully.
+    // The room loaded that empty notebook successfully (no failed load).
     room.finish_loading();
-    room.mark_ready();
+    assert!(!room.load_failed());
     assert_eq!(room.doc.read().await.cell_count(), 0);
 
     // A metadata edit lands; the doc stays at 0 cells.
@@ -9182,42 +9187,41 @@ async fn autosave_writes_metadata_edit_on_loaded_empty_notebook() {
     );
 }
 
-/// Observing a doc with >=1 cell latches the room ready. This covers a room
-/// repopulated by the file watcher after an earlier failed load: once content
-/// has gone through save_notebook_to_disk, a later emptying autosaves rather
-/// than being treated as a failed-load zeroing.
+/// A retry supersedes a prior failure: after a failed load flags the room and
+/// the guard would fire, winning a fresh loading claim via `try_start_loading`
+/// clears `load_failed`, so a subsequent empty save writes through again.
 #[tokio::test]
-async fn autosave_latches_ready_on_first_populated_save_then_writes_empty() {
+async fn retry_load_clears_failed_flag_so_empty_save_writes() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let (room, notebook_path) = test_room_with_path(&tmp, "repopulated.ipynb");
+    let (room, notebook_path) = test_room_with_path(&tmp, "retry.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
 
-    // Room starts not-ready (built via with_debouncer, not new_fresh).
-    assert!(!room.ever_ready());
-
-    // First save observes one cell -> latches ready and writes.
-    {
-        let mut doc = room.doc.write().await;
-        doc.add_cell(0, "only-cell", "code").unwrap();
-        doc.update_source("only-cell", "x = 1").unwrap();
-    }
-    save_notebook_to_disk(&room, None)
-        .await
-        .expect("populated save writes");
-    assert!(room.ever_ready(), ">=1-cell save must latch the room ready");
-    assert_eq!(disk_cell_count(&notebook_path), 1);
-
-    // Now empty it; the autosave must write the empty state, not skip.
+    // First load failed: doc emptied, hazard flagged. The guard would skip.
     {
         let mut doc = room.doc.write().await;
         doc.clear_all_cells().unwrap();
     }
+    room.mark_load_failed();
+    room.finish_loading();
+    assert!(room.load_failed());
+
+    // A retry wins the loading claim, which clears the failed-load flag.
+    assert!(room.try_start_loading(), "retry must win the loading claim");
+    assert!(
+        !room.load_failed(),
+        "winning a fresh loading claim must clear the failed-load flag"
+    );
+    room.finish_loading();
+
+    // The room is still empty, but the flag is cleared, so the empty state
+    // writes through (guard does not fire).
     save_notebook_to_disk(&room, None)
         .await
-        .expect("emptying a once-populated room must write the empty state");
+        .expect("empty save after a cleared retry flag must write");
     assert_eq!(
         disk_cell_count(&notebook_path),
         0,
-        "ready room writes its empty state instead of preserving stale disk"
+        "a retried room with the flag cleared writes its empty state"
     );
 }
 
@@ -9244,44 +9248,9 @@ async fn autosave_writes_empty_doc_over_whitespace_only_file() {
     );
 }
 
-/// Codex P2a: an empty notebook explicitly saved to a path latches the room
-/// ready, so a later autosave of the still-empty room writes (is not mistaken
-/// for a failed-load empty by the zeroing guard).
-#[tokio::test]
-async fn explicit_save_of_empty_notebook_latches_ready_for_later_autosave() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let (room, notebook_path) = test_room_with_path(&tmp, "empty.ipynb");
-
-    // Starts not-ready, 0 cells, no file on disk.
-    assert!(!room.ever_ready());
-    assert_eq!(room.doc.read().await.cell_count(), 0);
-
-    // Explicit save of the empty notebook writes the file and latches ready.
-    save_notebook_to_disk(&room, Some(notebook_path.to_str().unwrap()))
-        .await
-        .expect("explicit save of empty notebook must write");
-    assert!(
-        room.ever_ready(),
-        "a completed write must latch the room ready"
-    );
-
-    // Now place real content on disk and autosave the still-empty (but ready)
-    // room: it must overwrite, proving the zeroing guard did NOT skip it.
-    write_two_cell_notebook(&notebook_path).await;
-    assert_eq!(disk_cell_count(&notebook_path), 2);
-    save_notebook_to_disk(&room, None)
-        .await
-        .expect("ready empty room must autosave through");
-    assert_eq!(
-        disk_cell_count(&notebook_path),
-        0,
-        "a ready room writes its empty state on autosave (not skipped)"
-    );
-}
-
 /// Codex P1: a valid-JSON file with no `cells` key is malformed and must fail
-/// the load (not silently load as empty), so the room stays never-ready and the
-/// zeroing guard preserves the clobbered file instead of overwriting it.
+/// the load (not silently load as empty), so the failed load sets load_failed and
+/// the zeroing guard preserves the clobbered file instead of overwriting it.
 #[test]
 fn parse_notebook_jiter_errors_on_missing_or_invalid_cells() {
     // Missing `cells` key -> Err (was previously Ok with empty cells).

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -8893,3 +8893,237 @@ fn finalize_trust_status_unavailable_store_is_untrusted() {
     let status = super::metadata::finalize_trust_status(&info, &store);
     assert_eq!(status, runt_trust::TrustStatus::Untrusted);
 }
+
+// ── Autosave zeroing guard ─────────────────────────────────────────────
+//
+// A failed/incomplete streaming load empties the room doc (peer_session
+// clears all cells on load failure). Autosave and kernel-teardown then call
+// save_notebook_to_disk(.., None), which would overwrite a populated .ipynb
+// with zero cells. The guard skips that write.
+
+/// Write a populated two-cell .ipynb to disk.
+async fn write_two_cell_notebook(path: &Path) {
+    tokio::fs::write(
+        path,
+        r##"{
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {},
+            "cells": [
+                {
+                    "id": "cell-a",
+                    "cell_type": "code",
+                    "metadata": {},
+                    "source": "a = 1",
+                    "execution_count": null,
+                    "outputs": []
+                },
+                {
+                    "id": "cell-b",
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": "# heading"
+                }
+            ]
+        }"##,
+    )
+    .await
+    .unwrap();
+}
+
+fn disk_cell_count(path: &Path) -> usize {
+    let content = std::fs::read_to_string(path).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&content).unwrap();
+    value
+        .get("cells")
+        .and_then(|cells| cells.as_array())
+        .map(|cells| cells.len())
+        .unwrap_or(0)
+}
+
+/// The production zeroing case: a streaming load fails, the room doc is
+/// emptied (clear_all_cells + finish_loading), and an autosave fires with
+/// target_path = None. The on-disk notebook must be left intact.
+#[tokio::test]
+async fn autosave_skips_zeroing_write_after_failed_load() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "failed_load.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    // Reproduce the post-failed-load room state: doc emptied, loading done.
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+        assert_eq!(doc.cell_count(), 0);
+    }
+    room.finish_loading();
+
+    // Autosave / kernel-teardown path.
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("guard skips the write and returns Ok so autosave stays armed");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        2,
+        "empty doc must not overwrite the populated .ipynb"
+    );
+}
+
+/// An explicit user save (target_path = Some) is a deliberate action and
+/// bypasses the guard: emptying then saving on purpose still writes.
+#[tokio::test]
+async fn explicit_save_of_empty_doc_still_writes() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "explicit.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+    }
+
+    let target = notebook_path.to_string_lossy().to_string();
+    save_notebook_to_disk(&room, Some(&target))
+        .await
+        .expect("explicit save must succeed");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "explicit save of an emptied doc must write through the guard"
+    );
+}
+
+/// A genuinely empty doc over an empty/absent file still round-trips on the
+/// autosave path: the guard only fires when there are on-disk cells to lose.
+#[tokio::test]
+async fn autosave_writes_empty_doc_when_disk_has_no_cells() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "empty.ipynb");
+
+    // No file on disk yet; doc starts empty.
+    assert_eq!(room.doc.read().await.cell_count(), 0);
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("empty doc over absent file must write");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "empty notebook should round-trip to an empty .ipynb"
+    );
+}
+
+/// A normal populated autosave is unaffected by the guard.
+#[tokio::test]
+async fn autosave_writes_populated_doc_normally() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "populated.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "only-cell", "code").unwrap();
+        doc.update_source("only-cell", "print('hi')").unwrap();
+    }
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("populated autosave must write");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        1,
+        "populated doc must overwrite the on-disk notebook as usual"
+    );
+}
+
+/// Corrupt/unparseable on-disk .ipynb is the single most common reason a
+/// streaming load fails (jiter parse error, "not a JSON object"). The empty
+/// post-failure doc must NOT overwrite those bytes on autosave, even though
+/// the file cannot be parsed into a cells array. A guard that counts on-disk
+/// cells by parsing would fall open here (count == 0) and destroy the
+/// corrupt-but-recoverable file.
+#[tokio::test]
+async fn autosave_skips_zeroing_write_over_corrupt_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "corrupt.ipynb");
+
+    let corrupt = b"{ \"nbformat\": 4, \"cells\": [ {\"id\": \"a\", trunc";
+    tokio::fs::write(&notebook_path, corrupt).await.unwrap();
+
+    // Post-failed-load room state: doc emptied, loading done.
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+        assert_eq!(doc.cell_count(), 0);
+    }
+    room.finish_loading();
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("guard skips the write and returns Ok");
+
+    let on_disk = std::fs::read(&notebook_path).unwrap();
+    assert_eq!(
+        on_disk, corrupt,
+        "empty doc must not overwrite the corrupt-but-recoverable file"
+    );
+}
+
+/// A file that parses as JSON but whose `cells` key is missing or not an
+/// array (e.g. clobbered by a crashed prior write) also fails the streaming
+/// load. The empty post-failure doc must not overwrite it. The old
+/// parse-and-count guard fell open here because `cells.as_array()` returned
+/// None -> count 0.
+#[tokio::test]
+async fn autosave_skips_zeroing_write_when_disk_cells_not_array() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "no_cells_array.ipynb");
+
+    let no_array = br#"{ "nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": {} }"#;
+    tokio::fs::write(&notebook_path, no_array).await.unwrap();
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+        assert_eq!(doc.cell_count(), 0);
+    }
+    room.finish_loading();
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("guard skips the write and returns Ok");
+
+    let on_disk = std::fs::read(&notebook_path).unwrap();
+    assert_eq!(
+        on_disk.as_slice(),
+        no_array.as_slice(),
+        "empty doc must not overwrite a file whose cells key is non-array"
+    );
+}
+
+/// A file that is only whitespace carries no cells to lose, so the guard must
+/// not fire: an empty doc over a whitespace-only file still writes through.
+#[tokio::test]
+async fn autosave_writes_empty_doc_over_whitespace_only_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "whitespace.ipynb");
+
+    tokio::fs::write(&notebook_path, b"   \n\t  \n")
+        .await
+        .unwrap();
+    assert_eq!(room.doc.read().await.cell_count(), 0);
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("empty doc over whitespace-only file must write");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "whitespace-only file has no cells to protect; empty doc writes through"
+    );
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9105,6 +9105,122 @@ async fn autosave_skips_zeroing_write_when_disk_cells_not_array() {
     );
 }
 
+/// Codex P1: the user deletes the last cell of a notebook that loaded
+/// successfully (e.g. via MCP/Python). The room legitimately has 0 cells and
+/// the on-disk file still has bytes, so the old guard skipped the write and
+/// reported success — disk kept stale content. With the `ever_ready` latch set
+/// by load success, this autosave WRITES the empty notebook.
+#[tokio::test]
+async fn autosave_writes_empty_doc_after_successful_load_then_emptied() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "loaded_then_emptied.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+
+    // Reproduce a successful streaming load: the load populates the doc and
+    // latches the room ready (peer_session calls mark_ready on the Ok branch).
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell-a", "code").unwrap();
+        doc.add_cell(1, "cell-b", "markdown").unwrap();
+    }
+    room.finish_loading();
+    room.mark_ready();
+
+    // User now deletes every cell.
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+        assert_eq!(doc.cell_count(), 0);
+    }
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("autosave of a legitimately-emptied loaded notebook must write");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "deleting the last cell of a loaded notebook must persist the empty state"
+    );
+}
+
+/// Codex P1, second case: a metadata/dependency edit on an already-saved EMPTY
+/// notebook. The room has 0 cells and the file has bytes, so the old guard
+/// skipped. Because the room loaded successfully (ever_ready true), the write
+/// goes through and the metadata edit lands on disk.
+#[tokio::test]
+async fn autosave_writes_metadata_edit_on_loaded_empty_notebook() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "loaded_empty_meta.ipynb");
+
+    // An already-saved empty notebook on disk (valid nbformat, zero cells).
+    tokio::fs::write(
+        &notebook_path,
+        r#"{ "nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": [] }"#,
+    )
+    .await
+    .unwrap();
+
+    // The room loaded that empty notebook successfully.
+    room.finish_loading();
+    room.mark_ready();
+    assert_eq!(room.doc.read().await.cell_count(), 0);
+
+    // A metadata edit lands; the doc stays at 0 cells.
+    room.state
+        .with_doc(|sd| sd.set_path(Some(&notebook_path.to_string_lossy())))
+        .unwrap();
+
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("metadata edit on a loaded empty notebook must write");
+
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "loaded empty notebook stays empty but the write must not be skipped"
+    );
+}
+
+/// Observing a doc with >=1 cell latches the room ready. This covers a room
+/// repopulated by the file watcher after an earlier failed load: once content
+/// has gone through save_notebook_to_disk, a later emptying autosaves rather
+/// than being treated as a failed-load zeroing.
+#[tokio::test]
+async fn autosave_latches_ready_on_first_populated_save_then_writes_empty() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "repopulated.ipynb");
+
+    // Room starts not-ready (built via with_debouncer, not new_fresh).
+    assert!(!room.ever_ready());
+
+    // First save observes one cell -> latches ready and writes.
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "only-cell", "code").unwrap();
+        doc.update_source("only-cell", "x = 1").unwrap();
+    }
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("populated save writes");
+    assert!(room.ever_ready(), ">=1-cell save must latch the room ready");
+    assert_eq!(disk_cell_count(&notebook_path), 1);
+
+    // Now empty it; the autosave must write the empty state, not skip.
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+    }
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("emptying a once-populated room must write the empty state");
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "ready room writes its empty state instead of preserving stale disk"
+    );
+}
+
 /// A file that is only whitespace carries no cells to lose, so the guard must
 /// not fire: an empty doc over a whitespace-only file still writes through.
 #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9225,6 +9225,38 @@ async fn retry_load_clears_failed_flag_so_empty_save_writes() {
     );
 }
 
+/// A failed-load room recovered by SAVING (a successful write makes disk match
+/// the room) clears the hazard, so later legitimate empty saves write. Covers
+/// the save-based recovery path (e.g. Save As, or add-a-cell-then-save).
+#[tokio::test]
+async fn save_based_recovery_clears_failed_flag() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "saverecover.ipynb");
+    room.mark_load_failed();
+    assert!(room.load_failed());
+
+    // An explicit save (target Some) writes to disk and recovers the room.
+    save_notebook_to_disk(&room, Some(notebook_path.to_str().unwrap()))
+        .await
+        .expect("explicit save must write and recover");
+    assert!(
+        !room.load_failed(),
+        "a successful write clears the failed-load flag"
+    );
+
+    // Put content on disk and autosave the still-empty (but recovered) room: it
+    // must write through, proving the flag was cleared by the save.
+    write_two_cell_notebook(&notebook_path).await;
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("recovered room must autosave through");
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "a save-recovered room writes its empty state on autosave"
+    );
+}
+
 /// A file that is only whitespace carries no cells to lose, so the guard must
 /// not fire: an empty doc over a whitespace-only file still writes through.
 #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9243,3 +9243,38 @@ async fn autosave_writes_empty_doc_over_whitespace_only_file() {
         "whitespace-only file has no cells to protect; empty doc writes through"
     );
 }
+
+/// Codex P2a: an empty notebook explicitly saved to a path latches the room
+/// ready, so a later autosave of the still-empty room writes (is not mistaken
+/// for a failed-load empty by the zeroing guard).
+#[tokio::test]
+async fn explicit_save_of_empty_notebook_latches_ready_for_later_autosave() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "empty.ipynb");
+
+    // Starts not-ready, 0 cells, no file on disk.
+    assert!(!room.ever_ready());
+    assert_eq!(room.doc.read().await.cell_count(), 0);
+
+    // Explicit save of the empty notebook writes the file and latches ready.
+    save_notebook_to_disk(&room, Some(notebook_path.to_str().unwrap()))
+        .await
+        .expect("explicit save of empty notebook must write");
+    assert!(
+        room.ever_ready(),
+        "a completed write must latch the room ready"
+    );
+
+    // Now place real content on disk and autosave the still-empty (but ready)
+    // room: it must overwrite, proving the zeroing guard did NOT skip it.
+    write_two_cell_notebook(&notebook_path).await;
+    assert_eq!(disk_cell_count(&notebook_path), 2);
+    save_notebook_to_disk(&room, None)
+        .await
+        .expect("ready empty room must autosave through");
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        0,
+        "a ready room writes its empty state on autosave (not skipped)"
+    );
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9278,3 +9278,23 @@ async fn explicit_save_of_empty_notebook_latches_ready_for_later_autosave() {
         "a ready room writes its empty state on autosave (not skipped)"
     );
 }
+
+/// Codex P1: a valid-JSON file with no `cells` key is malformed and must fail
+/// the load (not silently load as empty), so the room stays never-ready and the
+/// zeroing guard preserves the clobbered file instead of overwriting it.
+#[test]
+fn parse_notebook_jiter_errors_on_missing_or_invalid_cells() {
+    // Missing `cells` key -> Err (was previously Ok with empty cells).
+    let missing = br#"{"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+    assert!(
+        parse_notebook_jiter(missing).is_err(),
+        "a notebook with no cells key must fail to load"
+    );
+    // `cells` present but not an array -> Err (unchanged).
+    let not_array = br#"{"cells":{},"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+    assert!(parse_notebook_jiter(not_array).is_err());
+    // A genuine empty notebook (cells: []) still parses successfully.
+    let empty = br#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+    let ok = parse_notebook_jiter(empty).expect("cells: [] is a valid empty notebook");
+    assert_eq!(ok.cells.len(), 0);
+}

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9187,11 +9187,13 @@ async fn autosave_writes_metadata_edit_on_loaded_empty_notebook() {
     );
 }
 
-/// A retry supersedes a prior failure: after a failed load flags the room and
-/// the guard would fire, winning a fresh loading claim via `try_start_loading`
-/// clears `load_failed`, so a subsequent empty save writes through again.
+/// The hazard flag clears on recovery COMPLETION, not at retry start. Winning a
+/// fresh loading claim via `try_start_loading` must NOT clear it (that would race
+/// an in-flight autosave during the retry window); only a completed recovery
+/// (here, `clear_load_failed`, as a successful load / watcher reconcile / save
+/// would call) re-enables empty saves.
 #[tokio::test]
-async fn retry_load_clears_failed_flag_so_empty_save_writes() {
+async fn failed_flag_clears_on_recovery_completion_not_retry_start() {
     let tmp = tempfile::TempDir::new().unwrap();
     let (room, notebook_path) = test_room_with_path(&tmp, "retry.ipynb");
     write_two_cell_notebook(&notebook_path).await;
@@ -9205,23 +9207,25 @@ async fn retry_load_clears_failed_flag_so_empty_save_writes() {
     room.finish_loading();
     assert!(room.load_failed());
 
-    // A retry wins the loading claim, which clears the failed-load flag.
+    // A retry wins the loading claim, but the flag stays set while the retry is
+    // in flight — the in-flight-autosave race fix.
     assert!(room.try_start_loading(), "retry must win the loading claim");
     assert!(
-        !room.load_failed(),
-        "winning a fresh loading claim must clear the failed-load flag"
+        room.load_failed(),
+        "the flag must stay set during the retry (cleared only on completion)"
     );
-    room.finish_loading();
 
-    // The room is still empty, but the flag is cleared, so the empty state
-    // writes through (guard does not fire).
+    // Recovery completes (a successful load / watcher reconcile / save calls
+    // clear_load_failed). Now the empty state writes through.
+    room.clear_load_failed();
+    room.finish_loading();
     save_notebook_to_disk(&room, None)
         .await
-        .expect("empty save after a cleared retry flag must write");
+        .expect("empty save after recovery completion must write");
     assert_eq!(
         disk_cell_count(&notebook_path),
         0,
-        "a retried room with the flag cleared writes its empty state"
+        "a recovered room writes its empty state"
     );
 }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -9257,6 +9257,47 @@ async fn save_based_recovery_clears_failed_flag() {
     );
 }
 
+/// Codex P1: a same-path explicit save (MCP/SDK `save(current_path)`) is an
+/// in-place save, not a Save As, so a failed-load empty room must NOT zero the
+/// file through it. Only a Save As to a DIFFERENT path bypasses the guard.
+#[tokio::test]
+async fn same_path_explicit_save_is_in_place_and_protected() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "inplace.ipynb");
+    write_two_cell_notebook(&notebook_path).await;
+    {
+        let mut doc = room.doc.write().await;
+        doc.clear_all_cells().unwrap();
+    }
+    room.mark_load_failed();
+
+    // Same-path Some save == in-place == must be skipped; the file is preserved.
+    save_notebook_to_disk(&room, Some(notebook_path.to_str().unwrap()))
+        .await
+        .expect("in-place save no-ops cleanly");
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        2,
+        "a same-path save of a failed-load empty room must not zero the file"
+    );
+
+    // A Save As to a DIFFERENT path is deliberate and bypasses the guard.
+    let other = tmp.path().join("saveas.ipynb");
+    save_notebook_to_disk(&room, Some(other.to_str().unwrap()))
+        .await
+        .expect("Save As to a new path writes");
+    assert_eq!(
+        disk_cell_count(&other),
+        0,
+        "Save As to a new path writes the (empty) doc through"
+    );
+    assert_eq!(
+        disk_cell_count(&notebook_path),
+        2,
+        "the original file is untouched after a Save As elsewhere"
+    );
+}
+
 /// A file that is only whitespace carries no cells to lose, so the guard must
 /// not fire: an empty doc over a whitespace-only file still writes through.
 #[tokio::test]


### PR DESCRIPTION
A failed or incomplete streaming load empties the room doc (`peer_session` calls
`clear_all_cells()` on load failure). Autosave and kernel-teardown both save with
`target_path = None`, so an empty room would overwrite a populated `.ipynb` and zero
the notebook on disk - the production data-loss mechanism behind this investigation.

`save_notebook_to_disk` now skips the write, on the automatic-save path, only when a
**failed load** emptied the room and the on-disk file still has content:

```
target_path.is_none() && cell_count == 0 && room.load_failed() && disk_has_content
```

`load_failed` is set at exactly one point - **the hazard itself**: right where the
streaming-load Err branch calls `clear_all_cells()` (`peer_session.rs`). It is cleared
on a fresh load attempt (`try_start_loading`). Because the flag is set only where a
failed load dangerously empties a room, a **legitimately-empty notebook via any
init path is never flagged and always saves** - that's what makes this converge where
an earlier set-on-success latch did not (it had to instrument every "room is good"
path, and kept missing some).

`disk_has_content` keys on **"disk has non-whitespace bytes," not "parses to ≥1
cell"** - the most common load-failure cause is a corrupt file (jiter parse error,
"not a JSON object", missing/invalid `cells`), exactly where a parse-and-count reads 0
and would let the empty doc through. (Relatedly, a notebook with no `cells` key now
*fails* the load instead of silently loading empty - it's malformed per nbformat - so
that file is protected too.) The guard returns `Ok` with a warning, never
`SaveError::Unrecoverable` (which would disable the autosave debouncer).

No wire-protocol / `InitialLoadPhaseWire` / TypeScript changes.

## Behavior

| Scenario | `load_failed` | Result |
|---|---|---|
| streaming load failed (incl. corrupt / missing-`cells`) over a non-empty file | true | **skip, file preserved** |
| legitimately-empty notebook, no failed load (any init path) | false | normal write |
| delete the last cell / metadata edit on a loaded notebook | false | normal write |
| brand-new untitled notebook | false (+ no bound file) | normal write |
| normal populated save | false (cell_count ≠ 0) | normal write |
| retry after a failed load (`try_start_loading`) | cleared | normal write |

## Tests

The failed-load skip tests (`after_failed_load`, `over_corrupt_file`,
`when_disk_cells_not_array`) drive `clear_all_cells()` + `mark_load_failed()`;
`retry_load_clears_failed_flag_so_empty_save_writes`, the legit-empty writes,
populated writes, whitespace/absent-file writes, and
`parse_notebook_jiter_errors_on_missing_or_invalid_cells` round it out.

## Known follow-up (Step 1, stacked)

An explicit in-place Save (Cmd+S / SDK `save()`) also passes `target_path = None`, so
for a failed-load room it is skipped here too: the file is preserved (no data loss),
but the save reports success without writing. Surfacing the failed load to the client,
and distinguishing autosave from an explicit in-place save, is the honest-failure-
messaging work stacked on this PR.
