### PR TITLE
docs(elements): clarify hosted output frame handoff

### DIFF
--- a/apps/elements/components/isolated-output-surfaces-example.tsx
+++ b/apps/elements/components/isolated-output-surfaces-example.tsx
@@ -290,6 +290,10 @@ const daemonRendererAssetCspSamples = [
   },
 ];
 
+const productionOutputFrameUrl = daemonOutputFrameUrl(daemonBlobBaseUrl, {
+  frameDomains: ["https://outputs.example.test", "http://localhost:*"],
+});
+
 const daemonRendererPluginLoadMimes = [
   "text/markdown",
   "application/vnd.plotly.v1+json",
@@ -563,6 +567,26 @@ export function IsolatedOutputSurfacesExample() {
               </div>
               <div className="mt-1 break-words font-mono text-xs [overflow-wrap:anywhere]">
                 {docsRendererPluginBaseUrl}/renderer-plugins
+              </div>
+            </div>
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-emerald-950 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-100">
+              <div className="text-[11px] font-medium uppercase text-emerald-700 dark:text-emerald-300">
+                production hosted frame
+              </div>
+              <p className="mt-2 text-xs leading-5">
+                If the host CSP lists the daemon blob origin in{" "}
+                <code className="rounded bg-emerald-100 px-1 py-0.5 dark:bg-emerald-950">
+                  frameDomains
+                </code>
+                , the app passes this URL as the isolated output document instead of depending on
+                inline{" "}
+                <code className="rounded bg-emerald-100 px-1 py-0.5 dark:bg-emerald-950">
+                  srcdoc
+                </code>
+                .
+              </p>
+              <div className="mt-2 break-words font-mono text-xs [overflow-wrap:anywhere]">
+                {productionOutputFrameUrl ?? "null"}
               </div>
             </div>
           </div>

--- a/apps/elements/content/docs/isolated-output-surfaces.mdx
+++ b/apps/elements/content/docs/isolated-output-surfaces.mdx
@@ -8,7 +8,10 @@ import { IsolatedOutputSurfacesExample } from "@/components/isolated-output-surf
 Notebook output isolation is nteract-owned UI infrastructure. It decides which
 outputs stay in the notebook DOM, which move into sandboxed frames, how hosted
 output documents receive theme and asset context, and how MCP app structured
-content becomes shared output manifests.
+content becomes shared output manifests. It also documents the production hosted
+frame path added in #3142: when an MCP host advertises the daemon blob origin in
+`frameDomains`, nteract should use the daemon `/output-frame` document instead
+of relying on inline `srcdoc` inside the host CSP.
 
 <IsolatedOutputSurfacesExample />
 
@@ -16,20 +19,22 @@ content becomes shared output manifests.
 
 The page imports current helpers from `src/components/isolated/**`: output lane
 policy, frame sizing, host-context theme variables, MCP host-context conversion,
-MCP structured content conversion, and the production `McpAppOutputFrame`
-wrapper. Frame document selection and sandbox policy use a docs-local alias for
-the production helper so Next does not import the raw Tauri `frame.html?raw`
-bundle. The MCP frame surface uses a fixture renderer bundle for resolved
-HTML/text payloads, while the docs-local `IsolatedFrame` adapter keeps payload
-shape and host context visible without Vite virtual renderer artifacts. The
-daemon renderer asset section imports the production MIME-to-plugin metadata,
-output-frame CSP gate, renderer asset URL helpers, and plugin loader. It fetches
-tiny docs-served renderer-plugin fixtures instead of daemon-generated artifacts.
+MCP structured content conversion, daemon output-frame CSP gating, and the
+production `McpAppOutputFrame` wrapper. Frame document selection and sandbox
+policy use a docs-local alias for the production helper so Next does not import
+the raw Tauri `frame.html?raw` bundle. The MCP frame surface uses a fixture
+renderer bundle for resolved HTML/text payloads, while the docs-local
+`IsolatedFrame` adapter keeps payload shape and host context visible without
+Vite virtual renderer artifacts. The daemon renderer asset section imports the
+production MIME-to-plugin metadata, output-frame CSP gate, renderer asset URL
+helpers, and plugin loader. It fetches tiny docs-served renderer-plugin fixtures
+instead of daemon-generated artifacts.
 
 ## What stays behind adapters
 
 The production frame runtime still owns JavaScript evaluation, renderer plugin
 execution, widget comm replay, untrusted raw HTML execution, generated asset hash
-injection, and daemon blob-route authorization. The catalog should keep those as
-explicit adapters until they can be exercised without importing desktop runtime
-state or executing untrusted output code in the docs app.
+injection, daemon blob-route authorization, and the actual `/output-frame`
+document served from the daemon. The catalog should keep those as explicit
+adapters until they can be exercised without importing desktop runtime state or
+executing untrusted output code in the docs app.


### PR DESCRIPTION
## Summary

- Clarify that the elements isolated-output catalog is static and fixture-backed, while production can use the daemon `/output-frame` document when MCP hosts allow the daemon blob origin in `frameDomains`.
- Add a visual "production hosted frame" card to the daemon renderer asset handoff surface using the production `daemonOutputFrameUrl` helper.
- Keep daemon-served `/output-frame` execution, blob authorization, and renderer runtime behavior behind adapters instead of importing runtime state into the docs app.

## Verification

- `pnpm elements:build`
- `cargo xtask lint --fix`
- `git diff --check`
- Playwright smoke against `http://127.0.0.1:5176/docs/isolated-output-surfaces` verified `frameDomains`, `/output-frame`, and `srcdoc` guidance render without horizontal overflow at 1280px.
