### PR TITLE
fix(elements): stabilize sift renderer milestones

### DIFF
--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -380,8 +380,27 @@ function visibleSiftMilestones(
   milestones: SiftLoadMilestone[],
   expected: Array<{ phase: string; value: string }>,
 ) {
-  if (milestones.length === 0) return expected;
-  return milestones.slice(-4).map((milestone) => ({
+  if (milestones.length === 0) {
+    return expected.map((milestone, index) => ({
+      key: `expected-${index}-${milestone.phase}`,
+      ...milestone,
+    }));
+  }
+
+  const visible = milestones.slice(-4);
+  const visibleStartIndex = milestones.length - visible.length;
+
+  return visible.map((milestone, index) => ({
+    key: [
+      visibleStartIndex + index,
+      milestone.phase,
+      milestone.format,
+      milestone.chunkIndex,
+      milestone.chunkCount,
+      milestone.rowCount,
+      milestone.byteLength,
+      milestone.elapsedMs,
+    ].join(":"),
     phase: milestone.phase,
     value: [
       milestone.format,
@@ -1291,7 +1310,7 @@ export function OutputRenderersExample() {
           <div className="grid gap-2 md:grid-cols-4">
             {visibleSiftUrlMilestones.map((milestone) => (
               <div
-                key={`${milestone.phase}-${milestone.value}`}
+                key={milestone.key}
                 className="rounded-md border border-fd-border bg-fd-background p-3"
               >
                 <div className="text-xs font-semibold">{milestone.phase}</div>
@@ -1353,7 +1372,7 @@ export function OutputRenderersExample() {
           <div className="grid gap-2 md:grid-cols-4">
             {visibleSiftManifestMilestones.map((milestone) => (
               <div
-                key={`${milestone.phase}-${milestone.value}`}
+                key={milestone.key}
                 className="rounded-md border border-fd-border bg-fd-background p-3"
               >
                 <div className="text-xs font-semibold">{milestone.phase}</div>


### PR DESCRIPTION
## Summary

- stabilize Sift progress milestone keys on the output renderers catalog page
- keep the Sift URL and Arrow stream examples on the current fixture-backed renderer paths
- leave production notebook/runtime code untouched

## Verification

- `pnpm elements:build`
- Playwright smoke for `http://127.0.0.1:5176/docs/output-renderers` with duplicate-key console warning capture
- `cargo xtask lint --fix`
- `git diff --check`
