### PR TITLE
feat(notebook): add contextual outline tree

### DIFF
--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -36,6 +36,7 @@ import type {
 } from "../../../../src/components/isolated/frame-bridge";
 import type { IsolatedDiagnosticHandler } from "../../../../src/components/isolated/diagnostics";
 import type { NteractEmbedHostContextPatch } from "../../../../src/components/isolated/host-context";
+import type { NteractMeasureElementResult } from "../../../../src/components/isolated/rpc-methods";
 
 export {
   anyOutputNeedsIsolation,
@@ -97,6 +98,7 @@ export interface IsolatedFrameHandle {
   clear: () => void;
   search: (query: string, caseSensitive?: boolean) => void;
   searchNavigate: (matchIndex: number) => void;
+  measureElement: (anchorId: string) => Promise<NteractMeasureElementResult | null>;
   isReady: boolean;
   isIframeReady: boolean;
 }
@@ -216,6 +218,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         clear: () => setOutputs([]),
         search: () => {},
         searchNavigate: () => {},
+        measureElement: async () => ({ found: false }),
         isReady: true,
         isIframeReady: true,
       }),

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import {
+  openNotebookRoom,
+  waitForCellCount,
+  waitForCodeCellContaining,
+  waitForKernelStatus,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test.describe("notebook rail outline", () => {
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("renders nested headings and keeps code cells in their markdown section", async ({
+    page,
+  }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.createCell("# Load data\n\nRead raw CSV files.", "markdown");
+    await mcp.createCell('print("extract")', "code");
+    await mcp.createCell("## Clean columns\n\nTighten types and null handling.", "markdown");
+    await mcp.createCell("### Validate ranges\n\nCheck outliers before model fitting.", "markdown");
+    await mcp.createCell('print("validate")', "code");
+    await waitForCellCount(page, 6);
+
+    await expect(page.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "true");
+    await page.getByLabel("Outline").click();
+
+    const validateHeading = page.getByRole("link", { name: "Validate ranges" });
+    await expect(validateHeading).toBeVisible();
+    await expect(page.locator('li[data-outline-level="2"] li[data-outline-level="3"]')).toHaveCount(
+      1,
+    );
+
+    const validateCell = await waitForCodeCellContaining(page, 'print("validate")');
+    await validateCell.scrollIntoViewIfNeeded();
+    await validateCell.locator('.cm-content[contenteditable="true"]').click();
+
+    await expect(validateHeading).toHaveAttribute("aria-current", "location");
+  });
+});

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -46,4 +46,48 @@ test.describe("notebook rail outline", () => {
 
     await expect(validateHeading).toHaveAttribute("aria-current", "location");
   });
+
+  test("scrolls to a nested heading inside a markdown cell through the iframe bridge", async ({
+    page,
+  }) => {
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.createCell(
+      [
+        "# Parent section",
+        "",
+        ...Array.from({ length: 48 }, (_, index) => `Filler paragraph ${index + 1}.`),
+        "",
+        "## Deep child",
+        "",
+        "The outline should land here, not only at the cell top.",
+      ].join("\n\n"),
+      "markdown",
+    );
+    await waitForCellCount(page, 2);
+
+    const childHeading = page
+      .frameLocator('iframe[data-slot="isolated-frame"][name^="md-"]')
+      .getByRole("heading", { name: "Deep child" });
+    await expect(childHeading).toBeAttached();
+    const beforeClickY = (await childHeading.boundingBox())?.y ?? Infinity;
+
+    await page.getByLabel("Outline").click();
+    await page.getByRole("link", { name: "Deep child" }).click();
+
+    await expect
+      .poll(async () => page.evaluate(() => window.location.hash))
+      .not.toContain("-heading-");
+
+    await expect
+      .poll(async () => (await childHeading.boundingBox())?.y ?? Infinity)
+      .toBeLessThan(beforeClickY - 400);
+    await expect
+      .poll(async () => (await childHeading.boundingBox())?.y ?? Infinity)
+      .toBeLessThan(480);
+  });
 });

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -10,7 +10,9 @@ import {
 import {
   deriveEnvManager,
   deriveRuntimeKind,
+  notebookCellAnchorId,
   projectNotebookOutline,
+  resolveNotebookOutlineSelection,
   type DependencyGuard,
   type GuardedNotebookProvenance,
   NotebookClient,
@@ -169,6 +171,122 @@ function resolveCommOutputs(
       store.updateModel(commId, { outputs: resolvedOutputs });
     }
   })();
+}
+
+function useActiveOutlineItemId(
+  items: readonly NotebookOutlineItem[],
+  cellIds: readonly string[],
+  enabled: boolean,
+): string | null {
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const itemsRef = useRef(items);
+  const cellIdsRef = useRef(cellIds);
+  const itemIdsKey = useMemo(() => items.map((item) => item.id).join("\n"), [items]);
+  const cellIdsKey = useMemo(() => cellIds.join("\n"), [cellIds]);
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    cellIdsRef.current = cellIds;
+  }, [cellIds]);
+
+  useEffect(() => {
+    if (!enabled || itemIdsKey.length === 0 || cellIdsKey.length === 0) {
+      setActiveItemId(null);
+      return;
+    }
+
+    let frame: number | null = null;
+    const visibleCellIds = new Set<string>();
+    const observedCellIds = new Map<Element, string>();
+    const anchorTop = 96;
+
+    const measure = () => {
+      frame = null;
+      let currentCellId: string | null = null;
+      let firstUpcomingCellId: string | null = null;
+      let firstUpcomingTop = Number.POSITIVE_INFINITY;
+      const currentCellIds = cellIdsRef.current;
+      const candidateCellIds =
+        visibleCellIds.size > 0
+          ? currentCellIds.filter((cellId) => visibleCellIds.has(cellId))
+          : currentCellIds;
+
+      for (const cellId of candidateCellIds) {
+        const target = document.getElementById(notebookCellAnchorId(cellId));
+        if (!target) continue;
+
+        const rect = target.getBoundingClientRect();
+        if (rect.bottom < anchorTop) continue;
+
+        if (rect.top <= anchorTop) {
+          currentCellId = cellId;
+        } else if (rect.top < firstUpcomingTop) {
+          firstUpcomingTop = rect.top;
+          firstUpcomingCellId = cellId;
+        }
+      }
+
+      const nextCellId = currentCellId ?? firstUpcomingCellId;
+      const nextItemId = nextCellId
+        ? resolveNotebookOutlineSelection(itemsRef.current, {
+            selectedCellId: nextCellId,
+            cellIds: currentCellIds,
+          })
+        : null;
+      setActiveItemId((current) => (current === nextItemId ? current : nextItemId));
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+    const observer =
+      "IntersectionObserver" in window
+        ? new IntersectionObserver(
+            (entries) => {
+              for (const entry of entries) {
+                const cellId = observedCellIds.get(entry.target);
+                if (!cellId) continue;
+                if (entry.isIntersecting) {
+                  visibleCellIds.add(cellId);
+                } else {
+                  visibleCellIds.delete(cellId);
+                }
+              }
+              scheduleMeasure();
+            },
+            { rootMargin: `-${anchorTop}px 0px 0px 0px`, threshold: [0, 0.01] },
+          )
+        : null;
+
+    if (observer) {
+      for (const cellId of cellIdsRef.current) {
+        const target = document.getElementById(notebookCellAnchorId(cellId));
+        if (!target) continue;
+        observedCellIds.set(target, cellId);
+        observer.observe(target);
+      }
+    }
+
+    document.addEventListener("scroll", scheduleMeasure, true);
+    window.addEventListener("resize", scheduleMeasure);
+
+    return () => {
+      observer?.disconnect();
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+      document.removeEventListener("scroll", scheduleMeasure, true);
+      window.removeEventListener("resize", scheduleMeasure);
+    };
+  }, [cellIdsKey, enabled, itemIdsKey]);
+
+  return activeItemId;
 }
 
 function AppContent() {
@@ -633,6 +751,11 @@ function AppContent() {
     notebookQueueProjection.executing_cell_id,
     notebookQueueProjection.queued_cell_ids,
   ]);
+  const activeOutlineItemId = useActiveOutlineItemId(
+    outlineItems,
+    cellIds,
+    !railCollapsed && activeRailPanel === "outline",
+  );
 
   // ── Sync transient UI state into the cell-ui-state store ────────────
   // Two-phase update for StrictMode safety:
@@ -1814,6 +1937,8 @@ function AppContent() {
             activePanelId={activeRailPanel}
             collapsed={railCollapsed}
             outlineItems={outlineItems}
+            outlineCellIds={cellIds}
+            activeOutlineItemId={activeOutlineItemId}
             selectedOutlineItemId={selectedOutlineItemId}
             selectedOutlineCellId={focusedCellId}
             packagesSummary={railPackageSummary}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -22,6 +22,7 @@ import {
 } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
+import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import { SavedWidgetStateProvider } from "@/components/widgets/saved-widget-state-context";
 import {
@@ -86,6 +87,7 @@ import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kerne
 import { type PendingTrustAction } from "./lib/trust-actions";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
+import { navigateMarkdownHeading } from "./lib/markdown-heading-navigation";
 import { getNotebookCellsSnapshot, useSourceVersion } from "./lib/notebook-cells";
 import { useNotebookQueueProjection } from "./lib/notebook-executions";
 import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
@@ -751,6 +753,22 @@ function AppContent() {
     notebookQueueProjection.executing_cell_id,
     notebookQueueProjection.queued_cell_ids,
   ]);
+  const markdownHeadingAnchorsByCellId = useMemo(() => {
+    const map = new Map<string, MarkdownHeadingAnchor[]>();
+    for (const item of outlineItems) {
+      if (item.kind !== "heading" || item.headingAnchorId === null) continue;
+      const anchors = map.get(item.cellId) ?? [];
+      anchors.push({
+        itemId: item.id,
+        title: item.title,
+        level: item.level,
+        anchor: item.anchor ?? null,
+        headingAnchorId: item.headingAnchorId,
+      });
+      map.set(item.cellId, anchors);
+    }
+    return map;
+  }, [outlineItems]);
   const activeOutlineItemId = useActiveOutlineItemId(
     outlineItems,
     cellIds,
@@ -935,16 +953,31 @@ function AppContent() {
     [setFocusedCellId],
   );
 
-  const handleNavigateOutlineItem = useCallback((_item: NotebookOutlineItem, href: string) => {
+  const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
     if (!href.startsWith("#")) return false;
-    const target = document.getElementById(href.slice(1));
+    const fallbackHref = `#${item.cellAnchorId}`;
+    const target = document.getElementById(
+      item.headingAnchorId ? item.cellAnchorId : href.slice(1),
+    );
     if (!target) return false;
 
-    target.scrollIntoView({ block: "start", behavior: "smooth" });
+    if (item.headingAnchorId) {
+      void navigateMarkdownHeading(item.cellId, item.headingAnchorId, { behavior: "smooth" }).then(
+        (handled) => {
+          if (!handled) {
+            target.scrollIntoView({ block: "start", behavior: "smooth" });
+          }
+        },
+      );
+    } else {
+      target.scrollIntoView({ block: "start", behavior: "smooth" });
+    }
     window.history.replaceState(
       null,
       "",
-      `${window.location.pathname}${window.location.search}${href}`,
+      `${window.location.pathname}${window.location.search}${
+        item.headingAnchorId ? fallbackHref : href
+      }`,
     );
     return true;
   }, []);
@@ -2088,6 +2121,7 @@ function AppContent() {
                 onReportOutputMatchCount={globalFind.reportOutputMatchCount}
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}
+                markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
               />
             </CrdtBridgeProvider>
           </div>

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -17,6 +17,8 @@ import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { injectPluginsForMimes } from "@/components/isolated/iframe-libraries";
+import { findVerticalScrollAncestor } from "@/components/isolated/scroll-boundary";
+import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
@@ -33,6 +35,10 @@ import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
 import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
 import { logger } from "../lib/logger";
+import {
+  isMeasuredElementFound,
+  registerMarkdownHeadingNavigator,
+} from "../lib/markdown-heading-navigation";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
@@ -41,6 +47,7 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
+const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
 
 function formatPluginLoadError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -60,6 +67,7 @@ interface MarkdownCellProps {
   isDragging?: boolean;
   /** Content for the right gutter (e.g., delete button) */
   rightGutterContent?: ReactNode;
+  headingAnchors?: readonly MarkdownHeadingAnchor[];
 }
 
 export const MarkdownCell = memo(function MarkdownCell({
@@ -73,6 +81,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   dragHandleProps,
   isDragging,
   rightGutterContent,
+  headingAnchors = EMPTY_HEADING_ANCHORS,
 }: MarkdownCellProps) {
   const isFocused = useIsCellFocused(cell.id);
   const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
@@ -213,6 +222,15 @@ export const MarkdownCell = memo(function MarkdownCell({
   colorThemeRef.current = colorTheme;
 
   const blobResolver = useBlobResolver();
+  const markdownMetadata = useMemo(
+    () =>
+      headingAnchors.length > 0
+        ? {
+            nteractMarkdownHeadingAnchors: headingAnchors,
+          }
+        : undefined,
+    [headingAnchors],
+  );
 
   const handleDoubleClick = useCallback(() => {
     setEditing(true);
@@ -279,11 +297,12 @@ export const MarkdownCell = memo(function MarkdownCell({
     frameRef.current.render({
       mimeType: "text/markdown",
       data: processedSource,
+      metadata: markdownMetadata,
       outputId: `markdown:${cell.id}`,
       cellId: cell.id,
       replace: true,
     });
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver]);
+  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
 
   // Sync markdown to iframe whenever source or resolved assets change (supports RTC updates)
   useEffect(() => {
@@ -300,6 +319,7 @@ export const MarkdownCell = memo(function MarkdownCell({
           frame.render({
             mimeType: "text/markdown",
             data: processedSource,
+            metadata: markdownMetadata,
             outputId: `markdown:${cell.id}`,
             cellId: cell.id,
             replace: true,
@@ -316,7 +336,53 @@ export const MarkdownCell = memo(function MarkdownCell({
           });
         });
     }
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver]);
+  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
+
+  const scrollToHeading = useCallback(
+    async (headingAnchorId: string, options?: { behavior?: ScrollBehavior }) => {
+      if (editing || !headingAnchorId || !frameRef.current?.isReady) return false;
+
+      const measurement = await frameRef.current.measureElement(headingAnchorId);
+      if (!isMeasuredElementFound(measurement)) return false;
+
+      const iframe = viewRef.current?.querySelector<HTMLIFrameElement>(
+        'iframe[data-slot="isolated-frame"]',
+      );
+      if (!iframe) return false;
+
+      const behavior = options?.behavior ?? "smooth";
+      const topPadding = 16;
+      const iframeRect = iframe.getBoundingClientRect();
+      const scrollContainer = findVerticalScrollAncestor(iframe.parentElement ?? iframe);
+
+      if (scrollContainer) {
+        const containerRect = scrollContainer.getBoundingClientRect();
+        scrollContainer.scrollTo({
+          top: Math.max(
+            0,
+            scrollContainer.scrollTop +
+              iframeRect.top -
+              containerRect.top +
+              measurement.top -
+              topPadding,
+          ),
+          behavior,
+        });
+        return true;
+      }
+
+      window.scrollTo({
+        top: Math.max(0, window.scrollY + iframeRect.top + measurement.top - topPadding),
+        behavior,
+      });
+      return true;
+    },
+    [editing],
+  );
+
+  useEffect(() => {
+    return registerMarkdownHeadingNavigator(cell.id, scrollToHeading);
+  }, [cell.id, scrollToHeading]);
 
   // Handle link clicks from iframe - open in system browser
   const handleLinkClick = useCallback((url: string) => {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -20,6 +20,7 @@ import { Code2, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId } from "runtimed";
 import { Button } from "@/components/ui/button";
+import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import type { Runtime } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
@@ -58,6 +59,7 @@ export interface NotebookViewProps {
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
   onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
+  markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
 }
 
 /** Tailwind classes for cell adder ribbon colors — must be static strings for tree-shaking. */
@@ -369,6 +371,7 @@ function NotebookViewContent({
   onReportOutputMatchCount,
   onSetCellSourceHidden,
   onSetCellOutputsHidden,
+  markdownHeadingAnchorsByCellId,
 }: NotebookViewProps) {
   const presence = usePresenceContext();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -881,6 +884,7 @@ function NotebookViewContent({
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
             rightGutterContent={rightGutterContent}
+            headingAnchors={markdownHeadingAnchorsByCellId?.get(cell.id)}
           />
         );
       }
@@ -915,6 +919,7 @@ function NotebookViewContent({
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,
+      markdownHeadingAnchorsByCellId,
       outputFocusedCellId,
       focusCell,
       handleOutputFocusChange,

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -19,6 +19,7 @@ const mockFrameHandle = {
   clear: vi.fn(),
   search: vi.fn(),
   searchNavigate: vi.fn(),
+  measureElement: vi.fn(async () => null),
   isReady: true,
   isIframeReady: true,
 };
@@ -46,7 +47,13 @@ vi.mock("@/components/isolated", async () => {
       props.onReady?.();
     }, [props.onReady]);
 
-    return <div data-testid="markdown-frame" onMouseDown={props.onMouseDown} />;
+    return (
+      <iframe
+        data-testid="markdown-frame"
+        data-slot="isolated-frame"
+        onMouseDown={props.onMouseDown}
+      />
+    );
   });
 
   return {
@@ -178,6 +185,7 @@ describe("MarkdownCell theme sync", () => {
     mockFrameHandle.clear.mockClear();
     mockFrameHandle.search.mockClear();
     mockFrameHandle.searchNavigate.mockClear();
+    mockFrameHandle.measureElement.mockClear();
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
   });
 
@@ -217,6 +225,38 @@ describe("MarkdownCell theme sync", () => {
         mimeType: "text/plain",
         data: "Failed to load markdown renderer: chunk failed",
         outputId: "markdown-error:md-1",
+        cellId: "md-1",
+        replace: true,
+      });
+    });
+  });
+
+  it("passes heading anchors to the markdown renderer metadata", async () => {
+    const headingAnchors = [
+      {
+        itemId: "md-1:heading:0",
+        title: "Load data",
+        level: 1,
+        anchor: "load-data",
+        headingAnchorId: "notebook-cell-md-1-heading-load-data",
+      },
+    ];
+
+    render(
+      <MarkdownCell
+        cell={{ ...makeCell(), source: "# Load data" }}
+        headingAnchors={headingAnchors}
+        onFocus={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFrameHandle.render).toHaveBeenCalledWith({
+        mimeType: "text/markdown",
+        data: "# Load data",
+        metadata: { nteractMarkdownHeadingAnchors: headingAnchors },
+        outputId: "markdown:md-1",
         cellId: "md-1",
         replace: true,
       });

--- a/apps/notebook/src/lib/markdown-heading-navigation.ts
+++ b/apps/notebook/src/lib/markdown-heading-navigation.ts
@@ -1,0 +1,50 @@
+import type { NteractMeasureElementResult } from "@/components/isolated/rpc-methods";
+
+export interface MarkdownHeadingNavigatorOptions {
+  behavior?: ScrollBehavior;
+}
+
+export type MarkdownHeadingNavigator = (
+  headingAnchorId: string,
+  options?: MarkdownHeadingNavigatorOptions,
+) => Promise<boolean>;
+
+const navigators = new Map<string, MarkdownHeadingNavigator>();
+
+export function registerMarkdownHeadingNavigator(
+  cellId: string,
+  navigator: MarkdownHeadingNavigator,
+): () => void {
+  navigators.set(cellId, navigator);
+  return () => {
+    if (navigators.get(cellId) === navigator) {
+      navigators.delete(cellId);
+    }
+  };
+}
+
+export async function navigateMarkdownHeading(
+  cellId: string,
+  headingAnchorId: string,
+  options?: MarkdownHeadingNavigatorOptions,
+): Promise<boolean> {
+  const navigator = navigators.get(cellId);
+  if (!navigator) return false;
+  try {
+    return await navigator(headingAnchorId, options);
+  } catch {
+    return false;
+  }
+}
+
+export function isMeasuredElementFound(
+  result: NteractMeasureElementResult | null,
+): result is NteractMeasureElementResult & { found: true; top: number; height: number } {
+  return (
+    result?.found === true &&
+    typeof result.top === "number" &&
+    Number.isFinite(result.top) &&
+    typeof result.height === "number" &&
+    Number.isFinite(result.height)
+  );
+}

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -132,6 +132,7 @@ export {
 
 // Notebook outline projection
 export {
+  buildNotebookOutlineTree,
   deriveNotebookOutlineItems,
   notebookCellAnchorHref,
   notebookCellAnchorId,
@@ -140,6 +141,7 @@ export {
   notebookOutlineItemHref,
   parseMarkdownHeadings,
   projectNotebookOutline,
+  resolveNotebookOutlineContextItemId,
   resolveNotebookOutlineSelection,
   slugifyNotebookHeading,
   type NotebookOutlineHrefTarget,
@@ -148,6 +150,7 @@ export {
   type NotebookOutlineProjection,
   type NotebookOutlineSelectionInput,
   type NotebookOutlineSourceCell,
+  type NotebookOutlineTreeNode,
   type ParsedNotebookHeading,
   type ProjectNotebookOutlineOptions,
 } from "./notebook-outline";

--- a/packages/runtimed/src/notebook-outline.ts
+++ b/packages/runtimed/src/notebook-outline.ts
@@ -41,6 +41,11 @@ export interface NotebookOutlineProjection {
   source: "headings" | "cells" | "empty";
 }
 
+export interface NotebookOutlineTreeNode {
+  item: NotebookOutlineItem;
+  children: NotebookOutlineTreeNode[];
+}
+
 export interface ProjectNotebookOutlineOptions<TCell extends NotebookOutlineSourceCell> {
   getStatusLabel?: (cell: TCell) => string | null | undefined;
   fallbackToCells?: boolean;
@@ -50,6 +55,7 @@ export interface ProjectNotebookOutlineOptions<TCell extends NotebookOutlineSour
 export interface NotebookOutlineSelectionInput {
   selectedItemId?: string | null;
   selectedCellId?: string | null;
+  cellIds?: readonly string[];
 }
 
 export interface ParsedNotebookHeading {
@@ -160,6 +166,30 @@ export function deriveNotebookOutlineItems<TCell extends NotebookOutlineSourceCe
   return projectNotebookOutline(cells, options).items;
 }
 
+export function buildNotebookOutlineTree(
+  items: readonly NotebookOutlineItem[],
+): NotebookOutlineTreeNode[] {
+  const roots: NotebookOutlineTreeNode[] = [];
+  const stack: NotebookOutlineTreeNode[] = [];
+
+  for (const item of items) {
+    const node: NotebookOutlineTreeNode = { item, children: [] };
+    while (stack.length > 0 && stack[stack.length - 1].item.level >= item.level) {
+      stack.pop();
+    }
+
+    const parent = stack.at(-1);
+    if (parent) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+    stack.push(node);
+  }
+
+  return roots;
+}
+
 export function slugifyNotebookHeading(title: string): string {
   const slug = cleanOutlineTitle(title)
     .normalize("NFKD")
@@ -203,10 +233,43 @@ export function resolveNotebookOutlineSelection(
   }
 
   if (selection.selectedCellId) {
-    return items.find((item) => item.cellId === selection.selectedCellId)?.id ?? null;
+    const exactItem = items.find((item) => item.cellId === selection.selectedCellId);
+    if (exactItem) return exactItem.id;
+
+    if (selection.cellIds) {
+      return resolveNotebookOutlineContextItemId(
+        items,
+        selection.cellIds,
+        selection.selectedCellId,
+      );
+    }
   }
 
   return null;
+}
+
+export function resolveNotebookOutlineContextItemId(
+  items: readonly NotebookOutlineItem[],
+  cellIds: readonly string[],
+  cellId: string,
+): string | null {
+  const cellIndexById = new Map(cellIds.map((id, index) => [id, index]));
+  const selectedCellIndex = cellIndexById.get(cellId);
+  if (selectedCellIndex == null) return null;
+
+  let contextItem: NotebookOutlineItem | null = null;
+  let contextCellIndex = -1;
+
+  for (const item of items) {
+    const itemCellIndex = cellIndexById.get(item.cellId);
+    if (itemCellIndex == null || itemCellIndex > selectedCellIndex) continue;
+    if (itemCellIndex >= contextCellIndex) {
+      contextItem = item;
+      contextCellIndex = itemCellIndex;
+    }
+  }
+
+  return contextItem?.id ?? null;
 }
 
 function nextHeadingAnchor(title: string, anchorCounts: Map<string, number>): string {

--- a/packages/runtimed/tests/notebook-outline.test.ts
+++ b/packages/runtimed/tests/notebook-outline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  buildNotebookOutlineTree,
   notebookCellAnchorHref,
   notebookCellAnchorId,
   notebookHeadingAnchorHref,
@@ -8,6 +9,7 @@ import {
   parseMarkdownHeadings,
   projectNotebookOutline,
   resolveNotebookOutlineSelection,
+  resolveNotebookOutlineContextItemId,
   slugifyNotebookHeading,
 } from "../src/notebook-outline";
 
@@ -235,5 +237,54 @@ describe("resolveNotebookOutlineSelection", () => {
     ]).items;
 
     expect(resolveNotebookOutlineSelection(items, { selectedCellId: "a" })).toBe("a:heading:0");
+  });
+
+  it("resolves focused code cells to the nearest preceding heading when cell order is available", () => {
+    const items = projectNotebookOutline([
+      { id: "intro", cell_type: "markdown", source: "# Load data" },
+      { id: "load", cell_type: "code", source: "df = pandas.read_csv(path)" },
+      { id: "clean-heading", cell_type: "markdown", source: "## Clean columns" },
+      { id: "clean", cell_type: "code", source: "df = df.dropna()" },
+    ]).items;
+
+    const cellIds = ["intro", "load", "clean-heading", "clean"];
+
+    expect(resolveNotebookOutlineContextItemId(items, cellIds, "load")).toBe("intro:heading:0");
+    expect(
+      resolveNotebookOutlineSelection(items, {
+        selectedCellId: "clean",
+        cellIds,
+      }),
+    ).toBe("clean-heading:heading:0");
+  });
+
+  it("keeps following code cells in the deepest trailing heading from a multi-heading cell", () => {
+    const items = projectNotebookOutline([
+      { id: "intro", cell_type: "markdown", source: "# Load data\n\n## CSV import" },
+      { id: "load", cell_type: "code", source: "df = pandas.read_csv(path)" },
+    ]).items;
+
+    expect(
+      resolveNotebookOutlineSelection(items, {
+        selectedCellId: "load",
+        cellIds: ["intro", "load"],
+      }),
+    ).toBe("intro:heading:1");
+  });
+});
+
+describe("buildNotebookOutlineTree", () => {
+  it("nests headings by markdown level without losing document order", () => {
+    const items = projectNotebookOutline([
+      { id: "a", cell_type: "markdown", source: "# Load data\n\n## CSV\n\n### Schema" },
+      { id: "b", cell_type: "markdown", source: "## Warehouse" },
+      { id: "c", cell_type: "markdown", source: "# Model" },
+    ]).items;
+
+    const tree = buildNotebookOutlineTree(items);
+
+    expect(tree.map((node) => node.item.title)).toEqual(["Load data", "Model"]);
+    expect(tree[0].children.map((node) => node.item.title)).toEqual(["CSV", "Warehouse"]);
+    expect(tree[0].children[0].children.map((node) => node.item.title)).toEqual(["Schema"]);
   });
 });

--- a/packages/runtimed/tests/notebook-outline.test.ts
+++ b/packages/runtimed/tests/notebook-outline.test.ts
@@ -184,6 +184,21 @@ describe("projectNotebookOutline", () => {
       href: "#notebook-cell-cell_3a_1-heading-load-data",
     });
   });
+
+  it("keeps multiple markdown headings in one cell on the cell href by default", () => {
+    const projection = projectNotebookOutline([
+      { id: "a", cell_type: "markdown", source: "# Load data\n\n## Clean columns" },
+    ]);
+
+    expect(projection.items.map((item) => item.href)).toEqual([
+      "#notebook-cell-a",
+      "#notebook-cell-a",
+    ]);
+    expect(projection.items.map((item) => item.headingAnchorId)).toEqual([
+      "notebook-cell-a-heading-load-data",
+      "notebook-cell-a-heading-clean-columns",
+    ]);
+  });
 });
 
 describe("slugifyNotebookHeading", () => {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -19,6 +19,7 @@ const mockFrameHandle = {
   clear: vi.fn(),
   search: vi.fn(),
   searchNavigate: vi.fn(),
+  measureElement: vi.fn(async () => null),
   isReady: false,
   isIframeReady: true,
 };
@@ -207,6 +208,7 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.clear.mockClear();
     mockFrameHandle.search.mockClear();
     mockFrameHandle.searchNavigate.mockClear();
+    mockFrameHandle.measureElement.mockClear();
     lastFrameMessageHandler = undefined;
     isolatedFrameMountCount = 0;
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);

--- a/src/components/isolated/__tests__/comm-bridge-manager.test.ts
+++ b/src/components/isolated/__tests__/comm-bridge-manager.test.ts
@@ -67,11 +67,15 @@ function createMockFrame(): {
   const frame: IsolatedFrameHandle = {
     send: vi.fn((msg) => sendCalls.push(msg)),
     render: vi.fn(),
+    renderBatch: vi.fn(),
     eval: vi.fn(),
+    installRenderer: vi.fn(),
     setTheme: vi.fn(),
+    setHostContext: vi.fn(),
     clear: vi.fn(),
     search: vi.fn(),
     searchNavigate: vi.fn(),
+    measureElement: vi.fn(async () => null),
     isReady: true,
     isIframeReady: true,
   };

--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   MCP_UI_HOST_CONTEXT_CHANGED,
   MCP_UI_RESOURCE_TEARDOWN,
   MCP_UI_SIZE_CHANGED,
+  NTERACT_MEASURE_ELEMENT,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
   NTERACT_THEME,
@@ -201,6 +202,26 @@ describe("IsolatedFrameRuntime", () => {
       { type: "theme", payload: { isDark: true, colorTheme: "dark-theme" } },
       "*",
     );
+  });
+
+  it("requests renderer element measurements only after renderer ready", async () => {
+    const { frameWindow, runtime } = createRuntime();
+
+    await expect(runtime.measureElement("heading-a")).resolves.toBeNull();
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    const transport = MockJsonRpcTransport.instances[0];
+    transport.request.mockResolvedValueOnce({ found: true, top: 120, height: 32 });
+    transport.notificationHandlers.get(NTERACT_RENDERER_READY)?.({});
+
+    await expect(runtime.measureElement("heading-a")).resolves.toEqual({
+      found: true,
+      top: 120,
+      height: 32,
+    });
+    expect(transport.request).toHaveBeenCalledWith(NTERACT_MEASURE_ELEMENT, {
+      anchorId: "heading-a",
+    });
   });
 
   it("recreates transport and reports reloads on a second bootstrap ready", () => {

--- a/src/components/isolated/__tests__/rpc-methods.test.ts
+++ b/src/components/isolated/__tests__/rpc-methods.test.ts
@@ -24,6 +24,7 @@ import {
   NTERACT_EVAL,
   NTERACT_EVAL_RESULT,
   NTERACT_LINK_CLICK,
+  NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
   NTERACT_PING,
   NTERACT_PONG,
@@ -48,6 +49,7 @@ describe("nteract JSON-RPC method constants", () => {
   const ALL_METHODS = [
     NTERACT_EVAL,
     NTERACT_SEARCH,
+    NTERACT_MEASURE_ELEMENT,
     NTERACT_RENDER_OUTPUT,
     NTERACT_CLEAR_OUTPUTS,
     NTERACT_SEARCH_NAVIGATE,
@@ -107,6 +109,7 @@ describe("nteract JSON-RPC method constants", () => {
   it("request methods return expected names", () => {
     expect(NTERACT_EVAL).toBe("nteract/eval");
     expect(NTERACT_SEARCH).toBe("nteract/search");
+    expect(NTERACT_MEASURE_ELEMENT).toBe("nteract/measureElement");
   });
 
   it("notification methods return expected names", () => {

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -20,6 +20,7 @@ import {
   NTERACT_EVAL_RESULT,
   NTERACT_INSTALL_RENDERER,
   NTERACT_LINK_CLICK,
+  NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
   NTERACT_PING,
   NTERACT_RENDER_BATCH,
@@ -38,6 +39,7 @@ import {
   NTERACT_WIDGET_STATE,
   NTERACT_WIDGET_UPDATE,
   NTERACT_WHEEL_BOUNDARY,
+  type NteractMeasureElementResult,
 } from "./rpc-methods";
 
 export const TYPE_TO_METHOD: Record<string, string> = {
@@ -279,6 +281,26 @@ export class IsolatedFrameRuntime {
     // The bootstrap document owns search navigation before the React renderer is
     // ready, so search commands bypass the renderer-ready queue.
     this.deliver({ type: "search_navigate", payload: { matchIndex } });
+  }
+
+  async measureElement(anchorId: string): Promise<NteractMeasureElementResult | null> {
+    const transport = this.rendererTransport();
+    if (!transport || !anchorId) return null;
+
+    const result = await transport.request(NTERACT_MEASURE_ELEMENT, { anchorId });
+    if (typeof result !== "object" || result === null) return null;
+    const record = result as Partial<NteractMeasureElementResult>;
+    if (record.found !== true) {
+      return { found: false };
+    }
+    if (typeof record.top !== "number" || typeof record.height !== "number") {
+      return null;
+    }
+    return {
+      found: true,
+      top: record.top,
+      height: record.height,
+    };
   }
 
   handleWindowMessage(event: MessageEvent): boolean {

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import type { IframeToParentMessage, ParentToIframeMessage, RenderPayload } from "./frame-bridge";
+import type { NteractMeasureElementResult } from "./rpc-methods";
 import { logIsolatedDiagnostic, type IsolatedDiagnosticHandler } from "./diagnostics";
 import {
   createIsolatedFrameDocument,
@@ -225,6 +226,11 @@ export interface IsolatedFrameHandle {
    * Navigate to a specific search match by index.
    */
   searchNavigate: (matchIndex: number) => void;
+
+  /**
+   * Measure a renderer-owned element by deterministic anchor ID.
+   */
+  measureElement: (anchorId: string) => Promise<NteractMeasureElementResult | null>;
 
   /**
    * Whether the iframe is ready to receive messages.
@@ -634,6 +640,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
         search: (query: string, caseSensitive?: boolean) =>
           runtimeRef.current?.search(query, caseSensitive),
         searchNavigate: (matchIndex: number) => runtimeRef.current?.searchNavigate(matchIndex),
+        measureElement: (anchorId: string) =>
+          runtimeRef.current?.measureElement(anchorId) ?? Promise.resolve(null),
         isReady,
         isIframeReady,
       }),

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -21,6 +21,7 @@
 export const NTERACT_EVAL = "nteract/eval" as const;
 export const NTERACT_INSTALL_RENDERER = "nteract/installRenderer" as const;
 export const NTERACT_SEARCH = "nteract/search" as const;
+export const NTERACT_MEASURE_ELEMENT = "nteract/measureElement" as const;
 
 // Host → Iframe (Notifications — fire-and-forget)
 export const NTERACT_RENDER_OUTPUT = "nteract/renderOutput" as const;
@@ -90,6 +91,16 @@ export interface NteractSearchParams {
 
 export interface NteractSearchResult {
   count: number;
+}
+
+export interface NteractMeasureElementParams {
+  anchorId: string;
+}
+
+export interface NteractMeasureElementResult {
+  found: boolean;
+  top?: number;
+  height?: number;
 }
 
 // ── Host → Iframe: Notification Params ──────────────────────────────

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -1,6 +1,11 @@
 import { ChevronLeft, ChevronRight, ListTree, Package, type LucideIcon } from "lucide-react";
-import type { MouseEvent, ReactNode } from "react";
-import { resolveNotebookOutlineSelection, type NotebookOutlineItem } from "runtimed";
+import { useMemo, type MouseEvent, type ReactNode } from "react";
+import {
+  buildNotebookOutlineTree,
+  resolveNotebookOutlineSelection,
+  type NotebookOutlineItem,
+  type NotebookOutlineTreeNode,
+} from "runtimed";
 import { cn } from "@/lib/utils";
 
 export type NotebookRailPanelId = "outline" | "packages";
@@ -9,6 +14,8 @@ export interface NotebookRailProps {
   activePanelId: NotebookRailPanelId;
   collapsed: boolean;
   outlineItems: readonly NotebookOutlineItem[];
+  outlineCellIds?: readonly string[];
+  activeOutlineItemId?: string | null;
   selectedOutlineItemId?: string | null;
   selectedOutlineCellId?: string | null;
   packagesSummary?: string | null;
@@ -34,6 +41,8 @@ export function NotebookRail({
   activePanelId,
   collapsed,
   outlineItems,
+  outlineCellIds,
+  activeOutlineItemId = null,
   selectedOutlineItemId = null,
   selectedOutlineCellId = null,
   packagesSummary = null,
@@ -101,6 +110,8 @@ export function NotebookRail({
             {activePanelId === "outline" ? (
               <NotebookOutlinePanel
                 items={outlineItems}
+                cellIds={outlineCellIds}
+                activeItemId={activeOutlineItemId}
                 selectedItemId={selectedOutlineItemId}
                 selectedCellId={selectedOutlineCellId}
                 onSelectItem={onSelectOutlineItem}
@@ -156,6 +167,8 @@ export function NotebookRailButton({
 
 export interface NotebookOutlinePanelProps {
   items: readonly NotebookOutlineItem[];
+  cellIds?: readonly string[];
+  activeItemId?: string | null;
   selectedItemId?: string | null;
   selectedCellId?: string | null;
   onSelectItem?: (item: NotebookOutlineItem) => void;
@@ -165,12 +178,16 @@ export interface NotebookOutlinePanelProps {
 
 export function NotebookOutlinePanel({
   items,
+  cellIds,
+  activeItemId = null,
   selectedItemId = null,
   selectedCellId = null,
   onSelectItem,
   onNavigateItem,
   getItemHref,
 }: NotebookOutlinePanelProps) {
+  const tree = useMemo(() => buildNotebookOutlineTree(items), [items]);
+
   if (items.length === 0) {
     return (
       <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
@@ -182,84 +199,128 @@ export function NotebookOutlinePanel({
   const resolvedSelectedItemId = resolveNotebookOutlineSelection(items, {
     selectedItemId,
     selectedCellId,
+    cellIds,
   });
+  const activeSelectedItemId =
+    activeItemId && items.some((item) => item.id === activeItemId) ? activeItemId : null;
+  const currentItemId = resolvedSelectedItemId ?? activeSelectedItemId;
 
   return (
-    <nav className="space-y-1" aria-label="Notebook outline" data-testid="notebook-outline-panel">
-      {items.map((item) => {
-        const selected = resolvedSelectedItemId === item.id;
-        const itemHref = getItemHref?.(item) ?? item.href ?? null;
-        const className = cn(
-          "flex min-h-8 w-full items-center gap-2 rounded-md py-1.5 pr-2 text-left text-sm transition-colors",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          selected
-            ? "bg-primary text-primary-foreground"
-            : "text-muted-foreground hover:bg-muted hover:text-foreground",
-        );
-        const style = {
-          paddingLeft: `${8 + Math.min(Math.max(item.level - 1, 0), 4) * 14}px`,
-        };
-        const content = (
-          <>
-            <span className="min-w-0 flex-1 truncate">{item.title}</span>
-            {item.statusLabel ? (
-              <span
-                className={cn(
-                  "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
-                  selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
-                )}
-              >
-                {item.statusLabel}
-              </span>
-            ) : item.detail ? (
-              <span
-                className={cn(
-                  "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
-                  selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
-                )}
-              >
-                {item.detail}
-              </span>
-            ) : null}
-          </>
-        );
-
-        if (itemHref) {
-          const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-            onSelectItem?.(item);
-            if (onNavigateItem?.(item, itemHref) === true) {
-              event.preventDefault();
-            }
-          };
-
-          return (
-            <a
-              key={item.id}
-              href={itemHref}
-              aria-current={selected ? "location" : undefined}
-              onClick={handleClick}
-              className={className}
-              style={style}
-            >
-              {content}
-            </a>
-          );
-        }
-
-        return (
-          <button
-            key={item.id}
-            type="button"
-            aria-current={selected ? "location" : undefined}
-            onClick={() => onSelectItem?.(item)}
-            className={className}
-            style={style}
-          >
-            {content}
-          </button>
-        );
-      })}
+    <nav aria-label="Notebook outline" data-testid="notebook-outline-panel">
+      <ol className="space-y-0.5">
+        {tree.map((node) => (
+          <NotebookOutlineNode
+            key={node.item.id}
+            node={node}
+            selectedItemId={currentItemId}
+            onSelectItem={onSelectItem}
+            onNavigateItem={onNavigateItem}
+            getItemHref={getItemHref}
+          />
+        ))}
+      </ol>
     </nav>
+  );
+}
+
+function NotebookOutlineNode({
+  node,
+  selectedItemId,
+  onSelectItem,
+  onNavigateItem,
+  getItemHref,
+}: {
+  node: NotebookOutlineTreeNode;
+  selectedItemId: string | null;
+  onSelectItem?: (item: NotebookOutlineItem) => void;
+  onNavigateItem?: (item: NotebookOutlineItem, href: string) => boolean | void;
+  getItemHref?: (item: NotebookOutlineItem) => string | null | undefined;
+}) {
+  const item = node.item;
+  const selected = selectedItemId === item.id;
+  const itemHref = getItemHref?.(item) ?? item.href ?? null;
+  const className = cn(
+    "flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+    selected
+      ? "bg-primary text-primary-foreground"
+      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+  );
+  const content = (
+    <>
+      <span className="min-w-0 flex-1 truncate">{item.title}</span>
+      {item.statusLabel ? (
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
+            selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
+          )}
+        >
+          {item.statusLabel}
+        </span>
+      ) : item.detail ? (
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
+            selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
+          )}
+        >
+          {item.detail}
+        </span>
+      ) : null}
+    </>
+  );
+  const children =
+    node.children.length > 0 ? (
+      <ol className="ml-3 border-l border-border/70 pl-2">
+        {node.children.map((child) => (
+          <NotebookOutlineNode
+            key={child.item.id}
+            node={child}
+            selectedItemId={selectedItemId}
+            onSelectItem={onSelectItem}
+            onNavigateItem={onNavigateItem}
+            getItemHref={getItemHref}
+          />
+        ))}
+      </ol>
+    ) : null;
+
+  if (itemHref) {
+    const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+      onSelectItem?.(item);
+      if (onNavigateItem?.(item, itemHref) === true) {
+        event.preventDefault();
+      }
+    };
+
+    return (
+      <li data-outline-level={item.level}>
+        <a
+          href={itemHref}
+          aria-current={selected ? "location" : undefined}
+          onClick={handleClick}
+          className={className}
+        >
+          {content}
+        </a>
+        {children}
+      </li>
+    );
+  }
+
+  return (
+    <li data-outline-level={item.level}>
+      <button
+        type="button"
+        aria-current={selected ? "location" : undefined}
+        onClick={() => onSelectItem?.(item)}
+        className={className}
+      >
+        {content}
+      </button>
+      {children}
+    </li>
   );
 }
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -138,6 +138,91 @@ describe("NotebookRail", () => {
     expect(screen.getByRole("link", { name: "Load details" })).not.toHaveAttribute("aria-current");
   });
 
+  it("prefers an explicitly selected outline item over scroll-spy context", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        activeOutlineItemId="cell-a:heading:0"
+        selectedOutlineItemId="cell-b:heading:0"
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Clean columns" })).toHaveAttribute(
+      "aria-current",
+      "location",
+    );
+    expect(screen.getByRole("link", { name: "Load data" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("uses notebook cell order to keep code cells in their markdown section context", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        activeOutlineItemId="cell-a:heading:0"
+        outlineCellIds={["cell-a", "cell-b", "cell-c", "cell-d"]}
+        outlineItems={[
+          outlineItems[0],
+          {
+            id: "cell-c:heading:0",
+            cellId: "cell-c",
+            title: "Clean columns",
+            level: 2,
+            kind: "heading" as const,
+            cellAnchorId: "notebook-cell-cell-c",
+            headingAnchorId: "notebook-cell-cell-c-heading-clean-columns",
+            href: "#notebook-cell-cell-c",
+            anchor: "clean-columns",
+          },
+        ]}
+        selectedOutlineCellId="cell-d"
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Clean columns" })).toHaveAttribute(
+      "aria-current",
+      "location",
+    );
+  });
+
+  it("renders nested outline levels instead of a flat indented list", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[
+          outlineItems[0],
+          {
+            id: "cell-a:heading:1",
+            cellId: "cell-a",
+            title: "Load details",
+            level: 2,
+            kind: "heading" as const,
+            cellAnchorId: "notebook-cell-cell-a",
+            headingAnchorId: "notebook-cell-cell-a-heading-load-details",
+            href: "#notebook-cell-cell-a",
+            anchor: "load-details",
+          },
+        ]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      container.querySelector('li[data-outline-level="1"] ol li[data-outline-level="2"]'),
+    ).not.toBeNull();
+  });
+
   it("renders the adapter-provided package panel when packages is active", () => {
     render(
       <NotebookRail

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -223,6 +223,37 @@ describe("NotebookRail", () => {
     ).not.toBeNull();
   });
 
+  it("keeps nested same-cell markdown headings on the cell href by default", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[
+          outlineItems[0],
+          {
+            id: "cell-a:heading:1",
+            cellId: "cell-a",
+            title: "Load details",
+            level: 2,
+            kind: "heading" as const,
+            cellAnchorId: "notebook-cell-cell-a",
+            headingAnchorId: "notebook-cell-cell-a-heading-load-details",
+            href: "#notebook-cell-cell-a",
+            anchor: "load-details",
+          },
+        ]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Load details" })).toHaveAttribute(
+      "href",
+      "#notebook-cell-cell-a",
+    );
+  });
+
   it("renders the adapter-provided package panel when packages is active", () => {
     render(
       <NotebookRail

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { MarkdownOutput } from "../markdown-output";
+
+describe("MarkdownOutput heading anchors", () => {
+  const originalTop = Object.getOwnPropertyDescriptor(window, "top");
+  const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
+
+  beforeEach(() => {
+    Object.defineProperty(window, "top", {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    if (originalTop) {
+      Object.defineProperty(window, "top", originalTop);
+    }
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", originalMatchMedia);
+    } else {
+      delete (window as Partial<Window>).matchMedia;
+    }
+  });
+
+  it("applies deterministic outline anchor ids to rendered markdown headings", () => {
+    render(
+      <MarkdownOutput
+        content={"# Load data\n\n## Clean columns"}
+        headingAnchors={[
+          {
+            itemId: "cell-a:heading:0",
+            title: "Load data",
+            level: 1,
+            anchor: "load-data",
+            headingAnchorId: "notebook-cell-cell-a-heading-load-data",
+          },
+          {
+            itemId: "cell-a:heading:1",
+            title: "Clean columns",
+            level: 2,
+            anchor: "clean-columns",
+            headingAnchorId: "notebook-cell-cell-a-heading-clean-columns",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Load data" })).toHaveAttribute(
+      "id",
+      "notebook-cell-cell-a-heading-load-data",
+    );
+    expect(screen.getByRole("heading", { name: "Clean columns" })).toHaveAttribute(
+      "data-nteract-outline-item-id",
+      "cell-a:heading:1",
+    );
+  });
+});

--- a/src/components/outputs/markdown-heading-anchors.ts
+++ b/src/components/outputs/markdown-heading-anchors.ts
@@ -1,0 +1,37 @@
+export interface MarkdownHeadingAnchor {
+  itemId: string;
+  title: string;
+  level: number;
+  anchor?: string | null;
+  headingAnchorId: string;
+}
+
+export function markdownHeadingAnchorsFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): MarkdownHeadingAnchor[] {
+  const raw = metadata?.nteractMarkdownHeadingAnchors;
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((entry) => {
+    if (typeof entry !== "object" || entry === null) return [];
+    const record = entry as Record<string, unknown>;
+    if (
+      typeof record.itemId !== "string" ||
+      typeof record.title !== "string" ||
+      typeof record.level !== "number" ||
+      typeof record.headingAnchorId !== "string"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        itemId: record.itemId,
+        title: record.title,
+        level: record.level,
+        anchor: typeof record.anchor === "string" ? record.anchor : null,
+        headingAnchorId: record.headingAnchorId,
+      },
+    ];
+  });
+}

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -1,7 +1,8 @@
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
 import { StaticCodeBlock } from "@/components/editor/static-highlight";
+import type { MarkdownHeadingAnchor } from "./markdown-heading-anchors";
 import type { Options as RehypeKatexOptions } from "rehype-katex";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
@@ -26,6 +27,7 @@ interface MarkdownOutputProps {
    * Enable copy button on code blocks
    */
   enableCopyCode?: boolean;
+  headingAnchors?: readonly MarkdownHeadingAnchor[];
 }
 
 const remarkPlugins: NonNullable<ReactMarkdownOptions["remarkPlugins"]> = [remarkGfm, remarkMath];
@@ -92,6 +94,20 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
   );
 }
 
+function textFromReactNode(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textFromReactNode).join("");
+  if (typeof node === "object" && "props" in node) {
+    return textFromReactNode((node as { props?: { children?: ReactNode } }).props?.children);
+  }
+  return "";
+}
+
+function normalizeHeadingText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
 /**
  * MarkdownOutput component for rendering Markdown content in notebook outputs.
  *
@@ -109,8 +125,46 @@ export function MarkdownOutput({
   content,
   className = "",
   enableCopyCode = true,
+  headingAnchors = [],
 }: MarkdownOutputProps) {
   const isDark = useDarkMode();
+  let headingCursor = 0;
+
+  const takeHeadingAnchor = (level: number, children: ReactNode): MarkdownHeadingAnchor | null => {
+    if (headingCursor >= headingAnchors.length) return null;
+
+    const renderedTitle = normalizeHeadingText(textFromReactNode(children));
+    const matchingIndex = headingAnchors.findIndex((anchor, index) => {
+      return (
+        index >= headingCursor &&
+        anchor.level === level &&
+        normalizeHeadingText(anchor.title) === renderedTitle
+      );
+    });
+    if (matchingIndex >= 0) {
+      headingCursor = matchingIndex + 1;
+      return headingAnchors[matchingIndex];
+    }
+
+    const nextAnchor = headingAnchors[headingCursor];
+    if (nextAnchor?.level === level) {
+      headingCursor += 1;
+      return nextAnchor;
+    }
+
+    return null;
+  };
+
+  const headingAttributes = (level: number, children: ReactNode) => {
+    const anchor = takeHeadingAnchor(level, children);
+    if (!anchor) return {};
+
+    return {
+      id: anchor.headingAnchorId,
+      "data-nteract-heading-anchor": anchor.headingAnchorId,
+      "data-nteract-outline-item-id": anchor.itemId,
+    };
+  };
 
   if (!content) {
     return null;
@@ -231,42 +285,66 @@ export function MarkdownOutput({
           // Headings
           h1({ children, ...props }) {
             return (
-              <h1 className="mb-4 mt-6 text-2xl font-bold" {...props}>
+              <h1
+                className="mb-4 mt-6 text-2xl font-bold"
+                {...props}
+                {...headingAttributes(1, children)}
+              >
                 {children}
               </h1>
             );
           },
           h2({ children, ...props }) {
             return (
-              <h2 className="mb-3 mt-5 text-xl font-bold" {...props}>
+              <h2
+                className="mb-3 mt-5 text-xl font-bold"
+                {...props}
+                {...headingAttributes(2, children)}
+              >
                 {children}
               </h2>
             );
           },
           h3({ children, ...props }) {
             return (
-              <h3 className="mb-2 mt-4 text-lg font-semibold" {...props}>
+              <h3
+                className="mb-2 mt-4 text-lg font-semibold"
+                {...props}
+                {...headingAttributes(3, children)}
+              >
                 {children}
               </h3>
             );
           },
           h4({ children, ...props }) {
             return (
-              <h4 className="mb-2 mt-3 text-base font-semibold" {...props}>
+              <h4
+                className="mb-2 mt-3 text-base font-semibold"
+                {...props}
+                {...headingAttributes(4, children)}
+              >
                 {children}
               </h4>
             );
           },
           h5({ children, ...props }) {
             return (
-              <h5 className="mb-1 mt-2 text-sm font-semibold" {...props}>
+              <h5
+                className="mb-1 mt-2 text-sm font-semibold"
+                {...props}
+                {...headingAttributes(5, children)}
+              >
                 {children}
               </h5>
             );
           },
           h6({ children, ...props }) {
             return (
-              <h6 className="mb-1 mt-2 text-sm font-medium" {...props}>
+              <h6
+                className="mb-1 mt-2 text-sm font-medium"
+                {...props}
+                {...headingAttributes(6, children)}
+              >
                 {children}
               </h6>
             );

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -36,6 +36,7 @@ import {
   NTERACT_CLEAR_OUTPUTS,
   NTERACT_DIAGNOSTIC,
   NTERACT_INSTALL_RENDERER,
+  NTERACT_MEASURE_ELEMENT,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
@@ -431,6 +432,29 @@ function setupMessageListener() {
     }
     layoutPulseTimers = [];
     return {};
+  });
+  rpcTransport.onRequest(NTERACT_MEASURE_ELEMENT, (params) => {
+    const anchorId =
+      typeof params === "object" && params && "anchorId" in params
+        ? String((params as { anchorId?: unknown }).anchorId ?? "")
+        : "";
+    const element = anchorId
+      ? (document.getElementById(anchorId) ??
+        Array.from(document.querySelectorAll("[data-nteract-heading-anchor]")).find(
+          (candidate) => candidate.getAttribute("data-nteract-heading-anchor") === anchorId,
+        ))
+      : null;
+
+    if (!(element instanceof HTMLElement)) {
+      return { found: false };
+    }
+
+    const rect = element.getBoundingClientRect();
+    return {
+      found: true,
+      top: rect.top + window.scrollY,
+      height: rect.height,
+    };
   });
   rpcTransport.onNotification(NTERACT_INSTALL_RENDERER, (params) => {
     const { code, css } = params as { code: string; css?: string };

--- a/src/isolated-renderer/markdown-renderer.tsx
+++ b/src/isolated-renderer/markdown-renderer.tsx
@@ -10,6 +10,7 @@
 
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
 import { MathOutput } from "@/components/outputs/math-output";
+import { markdownHeadingAnchorsFromMetadata } from "@/components/outputs/markdown-heading-anchors";
 
 interface RendererProps {
   data: unknown;
@@ -17,8 +18,13 @@ interface RendererProps {
   mimeType: string;
 }
 
-function MarkdownRenderer({ data }: RendererProps) {
-  return <MarkdownOutput content={String(data)} />;
+function MarkdownRenderer({ data, metadata }: RendererProps) {
+  return (
+    <MarkdownOutput
+      content={String(data)}
+      headingAnchors={markdownHeadingAnchorsFromMetadata(metadata)}
+    />
+  );
 }
 
 function LatexRenderer({ data }: RendererProps) {


### PR DESCRIPTION
## Summary

- Adds host-neutral outline tree and section-context helpers in `runtimed`.
- Renders the notebook rail outline as a nested tree instead of a flat indented list.
- Keeps focused code cells inside the nearest preceding markdown heading context, while preserving explicit outline selections.
- Tracks the visible outline section only while the outline rail is open, using visible cell anchors to avoid scanning every cell on each scroll frame.
- Adds deterministic markdown heading anchors to the isolated markdown renderer and a typed measure-element bridge so outline clicks can land on headings inside markdown cells.
- Keeps nested heading links cell-href based by default, with exact heading scrolling as an enhanced click path and cell-anchor fallback when the markdown frame cannot handle it.
- Adds a focused browser E2E for default-collapsed rail behavior, nested headings, and code-cell section context.

## Notes

- The rail still exposes cell-level `href`s for nested headings so normal browser anchors do not point at inaccessible iframe internals. The notebook app now passes heading anchor metadata into markdown renders, asks the isolated renderer to measure the target heading over JSON-RPC, and scrolls the notebook container from the host side.
- I looked at `@pierre/trees` for the tree surface. It looks promising for a future file browser or a heavier outline tree, but this slice keeps the existing rail renderer to avoid adding a beta dependency while the anchor boundary is still settling.
- Local screenshots from the visual smoke are saved at `/tmp/notebook-rail-nested-outline.png` and `/tmp/notebook-rail-packages-panel.png`.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run packages/runtimed/tests/notebook-outline.test.ts src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/outputs/__tests__/markdown-output.test.tsx src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/components/isolated/__tests__/rpc-methods.test.ts src/components/isolated/__tests__/comm-bridge-manager.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1 e2e/notebook-rail-outline.spec.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1 --grep-invert "jupyter-scatter"`: 8 passed
- `uv run pr-review https://github.com/nteract/nteract/pull/3182 --max-turns 120 --out .context/reviews/pr-3182-markdown-anchors-final.json`: clear

## Known Local E2E Issue

- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1` hit the existing `e2e/jscatter-lasso.spec.ts` gesture assertion twice locally. The widget rendered, but the lasso selected 0 points. This appears unrelated to the notebook rail changes.
