### PR TITLE
feat(notebook-cloud): add shared notebook rail shell

### DIFF
--- a/apps/notebook-cloud/test/viewer-notebook-outline.test.ts
+++ b/apps/notebook-cloud/test/viewer-notebook-outline.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { deriveCloudNotebookOutlineItems } from "../viewer/notebook-outline.ts";
+
+test("cloud notebook outline derives headings from live materialized cells", () => {
+  const outline = deriveCloudNotebookOutlineItems([
+    {
+      id: "intro",
+      cellType: "markdown",
+      source: "# Intro\n\n## Setup",
+      executionCount: null,
+    },
+    {
+      id: "code-1",
+      cellType: "code",
+      source: "print('ok')",
+      executionCount: 3,
+    },
+  ]);
+
+  assert.deepEqual(
+    outline.map((item) => [item.id, item.cellId, item.title, item.level]),
+    [
+      ["intro:heading:0", "intro", "Intro", 1],
+      ["intro:heading:1", "intro", "Setup", 2],
+    ],
+  );
+});
+
+test("cloud notebook outline follows live cell source updates", () => {
+  const first = deriveCloudNotebookOutlineItems([
+    {
+      id: "section",
+      cellType: "markdown",
+      source: "# Draft",
+      executionCount: null,
+    },
+  ]);
+  const updated = deriveCloudNotebookOutlineItems([
+    {
+      id: "section",
+      cellType: "markdown",
+      source: "# Published\n\n## Details",
+      executionCount: null,
+    },
+  ]);
+
+  assert.deepEqual(
+    first.map((item) => item.title),
+    ["Draft"],
+  );
+  assert.deepEqual(
+    updated.map((item) => item.title),
+    ["Published", "Details"],
+  );
+});
+
+test("cloud notebook outline falls back to cells when headings are absent", () => {
+  const outline = deriveCloudNotebookOutlineItems([
+    {
+      id: "code-1",
+      cellType: "code",
+      source: "print('ok')",
+      executionCount: 7,
+    },
+  ]);
+
+  assert.equal(outline.length, 1);
+  assert.equal(outline[0].cellId, "code-1");
+  assert.equal(outline[0].statusLabel, "In [7]");
+});

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -41,3 +41,22 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
 });
+
+test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /NotebookRail/);
+  assert.match(sourceText, /deriveCloudNotebookOutlineItems\(cells\)/);
+  assert.match(sourceText, /<NotebookRail[\s\S]*outlineItems=\{outlineItems\}/);
+  assert.match(sourceText, /onNavigateOutlineItem=\{handleNavigateOutlineItem\}/);
+});
+
+test("cloud viewer shell keeps render endpoints out of the interactive load path", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.doesNotMatch(sourceText, /renderEndpoint/);
+  assert.doesNotMatch(sourceText, /pinnedRenderBasePath/);
+  assert.doesNotMatch(sourceText, /api\/n\/[^"`']+\/render/);
+});

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -16,6 +16,46 @@ body {
   margin: 0;
 }
 
+.cloud-notebook-shell {
+  display: flex;
+  min-height: 100vh;
+  min-width: 0;
+  background: var(--background);
+}
+
+.cloud-notebook-rail {
+  position: sticky;
+  top: 0;
+  z-index: 15;
+  height: 100vh;
+}
+
+.cloud-notebook-stage {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  padding-block: 1.5rem;
+}
+
+.cloud-notebook-stage > .cloud-state {
+  margin-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+}
+
+.cloud-rail-panel-note {
+  border: 1px dashed color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 8px;
+  padding: 0.75rem;
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-rail-panel-note p {
+  margin: 0;
+}
+
 .cloud-state {
   border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
   border-radius: 8px;
@@ -710,6 +750,25 @@ body {
 
   .cloud-share-badge {
     justify-self: end;
+  }
+}
+
+@media (max-width: 820px) {
+  .cloud-notebook-shell {
+    flex-direction: column;
+  }
+
+  .cloud-notebook-rail {
+    position: relative;
+    height: auto;
+    max-height: 45vh;
+  }
+
+  .cloud-notebook-rail [data-slot="notebook-rail-panel"] {
+    width: auto;
+    max-width: none;
+    min-width: 0;
+    flex: 1;
   }
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -34,13 +34,14 @@ import {
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { NotebookRail, type NotebookRailPanelId } from "@/components/notebook-rail/NotebookRail";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
-import { isTextAttributionEvent } from "runtimed";
+import { isTextAttributionEvent, type NotebookOutlineItem } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import { snapshotWidgetCommsFromRuntimeState } from "../src/widget-comms";
 import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable-markdown-cell";
@@ -81,6 +82,7 @@ import {
 import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
+import { deriveCloudNotebookOutlineItems } from "./notebook-outline";
 import {
   cloudViewerPresenceDisplay,
   type CloudViewerPresenceState,
@@ -601,6 +603,9 @@ function NotebookViewer({
   });
   const [cells, setCells] = useState<ResolvedCell[]>([]);
   const [showCode, setShowCode] = useState(true);
+  const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
+  const [railCollapsed, setRailCollapsed] = useState(false);
+  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const cellsRef = useRef<ResolvedCell[]>([]);
   const notebookLanguageRef = useRef("python");
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
@@ -1073,6 +1078,13 @@ function NotebookViewer({
     () => readOnlyCells.filter((cell) => cell.cellType === "code").length,
     [readOnlyCells],
   );
+  const outlineItems = useMemo(() => deriveCloudNotebookOutlineItems(cells), [cells]);
+  useEffect(() => {
+    if (!selectedOutlineItemId) return;
+    if (!outlineItems.some((item) => item.id === selectedOutlineItemId)) {
+      setSelectedOutlineItemId(null);
+    }
+  }, [outlineItems, selectedOutlineItemId]);
   const tracebackTargets = useMemo(() => {
     const targets = new Map<string, TracebackCellTarget>();
     for (const cell of cells) {
@@ -1092,6 +1104,17 @@ function NotebookViewer({
       behavior: "smooth",
       block: "center",
     });
+  }, []);
+  const handleSelectOutlineItem = useCallback((item: NotebookOutlineItem) => {
+    setSelectedOutlineItemId(item.id);
+  }, []);
+  const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem) => {
+    setSelectedOutlineItemId(item.id);
+    findCellElement(item.cellId)?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+    return true;
   }, []);
   const canEditMarkdown = canEditLiveNotebook(connectionScope);
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
@@ -1132,137 +1155,160 @@ function NotebookViewer({
   }, [refreshAuthState]);
 
   return (
-    <main className="flex min-h-screen w-full flex-col py-6">
+    <main className="cloud-notebook-shell">
       <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
 
-      <div className="cloud-report-toolbar" aria-label="Notebook view status and controls">
-        <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
+      <NotebookRail
+        activePanelId={activeRailPanel}
+        collapsed={railCollapsed}
+        outlineItems={outlineItems}
+        selectedOutlineItemId={selectedOutlineItemId}
+        packagesPanel={<CloudRailPackagesPanel />}
+        onActivePanelChange={setActiveRailPanel}
+        onCollapsedChange={setRailCollapsed}
+        onSelectOutlineItem={handleSelectOutlineItem}
+        onNavigateOutlineItem={handleNavigateOutlineItem}
+        className="cloud-notebook-rail"
+      />
 
-        <div className="cloud-toolbar-actions">
-          <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
+      <section className="cloud-notebook-stage" aria-label="Hosted notebook">
+        <div className="cloud-report-toolbar" aria-label="Notebook view status and controls">
+          <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
 
-          {connectionScope === "owner" ? (
-            <CloudSharingControls
-              aclEndpoint={config.aclEndpoint}
-              invitesEndpoint={config.invitesEndpoint}
+          <div className="cloud-toolbar-actions">
+            <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
+
+            {connectionScope === "owner" ? (
+              <CloudSharingControls
+                aclEndpoint={config.aclEndpoint}
+                invitesEndpoint={config.invitesEndpoint}
+                authState={authState}
+              />
+            ) : null}
+
+            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+
+            <CloudNotebookEditModeButton
               authState={authState}
+              connectionScope={connectionScope}
+              onAuthStateChange={refreshAuthState}
             />
-          ) : null}
 
-          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+            <CloudAuthControls
+              authConfig={authConfig}
+              authState={authState}
+              connectionActorLabel={connectionActorLabel}
+              connectionError={connectionError}
+              connectionScope={connectionScope}
+              onAuthStateChange={refreshAuthState}
+            />
 
-          <CloudNotebookEditModeButton
-            authState={authState}
-            connectionScope={connectionScope}
-            onAuthStateChange={refreshAuthState}
-          />
-
-          <CloudAuthControls
-            authConfig={authConfig}
-            authState={authState}
-            connectionActorLabel={connectionActorLabel}
-            connectionError={connectionError}
-            connectionScope={connectionScope}
-            onAuthStateChange={refreshAuthState}
-          />
-
-          {status.kind === "ready" && codeCellCount > 0 ? (
-            <button
-              type="button"
-              className="cloud-code-toggle"
-              aria-pressed={showCode}
-              aria-label={showCode ? "Hide code cells" : "Show code cells"}
-              title={showCode ? "Hide code cells" : "Show code cells"}
-              onClick={() => setShowCode((current) => !current)}
-            >
-              {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
-              <Code2 aria-hidden="true" />
-            </button>
-          ) : null}
+            {status.kind === "ready" && codeCellCount > 0 ? (
+              <button
+                type="button"
+                className="cloud-code-toggle"
+                aria-pressed={showCode}
+                aria-label={showCode ? "Hide code cells" : "Show code cells"}
+                title={showCode ? "Hide code cells" : "Show code cells"}
+                onClick={() => setShowCode((current) => !current)}
+              >
+                {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
+                <Code2 aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
         </div>
-      </div>
 
-      {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
-        <div className="cloud-state cloud-auth-state mx-8 mr-4" data-kind="error">
-          <span>{prototypeAuthSummary(authState)}</span>
-          <button type="button" onClick={resetPrototypeAuth}>
-            <RotateCcw aria-hidden="true" />
-            Reset to anonymous
-          </button>
-        </div>
-      ) : null}
-
-      {authRenewal.kind !== "idle" ? (
-        <div
-          className="cloud-state cloud-auth-state mx-8 mr-4"
-          data-kind={authRenewal.kind === "failed" ? "error" : "loading"}
-        >
-          <span>{authRenewal.message}</span>
-          {authRenewal.kind === "failed" ? (
+        {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
+          <div className="cloud-state cloud-auth-state" data-kind="error">
+            <span>{prototypeAuthSummary(authState)}</span>
             <button type="button" onClick={resetPrototypeAuth}>
               <RotateCcw aria-hidden="true" />
               Reset to anonymous
             </button>
-          ) : null}
-        </div>
-      ) : null}
+          </div>
+        ) : null}
 
-      {connectionError ? (
-        <div className="cloud-state cloud-auth-state mx-8 mr-4" data-kind="error">
-          <span>Live room connection failed: {connectionError}</span>
-          <button type="button" onClick={resetPrototypeAuth}>
-            <RotateCcw aria-hidden="true" />
-            Reset to anonymous
-          </button>
-        </div>
-      ) : null}
+        {authRenewal.kind !== "idle" ? (
+          <div
+            className="cloud-state cloud-auth-state"
+            data-kind={authRenewal.kind === "failed" ? "error" : "loading"}
+          >
+            <span>{authRenewal.message}</span>
+            {authRenewal.kind === "failed" ? (
+              <button type="button" onClick={resetPrototypeAuth}>
+                <RotateCcw aria-hidden="true" />
+                Reset to anonymous
+              </button>
+            ) : null}
+          </div>
+        ) : null}
 
-      {status.kind === "ready" ? null : (
-        <div className="cloud-state mx-8 mr-4" data-kind={status.kind}>
-          {status.message}
-        </div>
-      )}
+        {connectionError ? (
+          <div className="cloud-state cloud-auth-state" data-kind="error">
+            <span>Live room connection failed: {connectionError}</span>
+            <button type="button" onClick={resetPrototypeAuth}>
+              <RotateCcw aria-hidden="true" />
+              Reset to anonymous
+            </button>
+          </div>
+        ) : null}
 
-      {canEditMarkdown ? (
-        <CloudLiveNotebook
-          cells={cells}
-          priority={CLOUD_VIEWER_PRIORITY}
-          hostContext={outputHostContext}
-          showCode={showCode}
-          livePresence={livePresence}
-          getHandle={getLiveNotebookHandle}
-          localActorLabel={connectionActorLabel}
-          textAttributionQueue={textAttributionQueue}
-          onMarkdownSourceChange={handleMarkdownSourceChange}
-          onMarkdownSyncNeeded={handleMarkdownSyncNeeded}
-          onPresenceCursor={handlePresenceCursor}
-          onPresenceSelection={handlePresenceSelection}
-          resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-          onNavigateToTracebackCell={handleTracebackCellNavigate}
-        />
-      ) : (
-        <ReadOnlyNotebook
-          cells={readOnlyCells}
-          priority={CLOUD_VIEWER_PRIORITY}
-          hostContext={outputHostContext}
-          displayMode="report"
-          showCode={showCode}
-          className="cloud-report-notebook"
-          cellClassName="cloud-cell"
-          sourceClassName="cloud-source-block"
-          outputClassName="cloud-output-block"
-          deferIsolatedFrameUntilVisible
-          deferredIsolatedFrameRootMargin="600px 0px"
-          resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-          onNavigateToTracebackCell={handleTracebackCellNavigate}
-          renderCellError={(error, _cell, index) => (
-            <div className="cloud-state" data-kind="error">
-              Unable to render cell {index + 1}: {error.message}
-            </div>
-          )}
-        />
-      )}
+        {status.kind === "ready" ? null : (
+          <div className="cloud-state" data-kind={status.kind}>
+            {status.message}
+          </div>
+        )}
+
+        {canEditMarkdown ? (
+          <CloudLiveNotebook
+            cells={cells}
+            priority={CLOUD_VIEWER_PRIORITY}
+            hostContext={outputHostContext}
+            showCode={showCode}
+            livePresence={livePresence}
+            getHandle={getLiveNotebookHandle}
+            localActorLabel={connectionActorLabel}
+            textAttributionQueue={textAttributionQueue}
+            onMarkdownSourceChange={handleMarkdownSourceChange}
+            onMarkdownSyncNeeded={handleMarkdownSyncNeeded}
+            onPresenceCursor={handlePresenceCursor}
+            onPresenceSelection={handlePresenceSelection}
+            resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+            onNavigateToTracebackCell={handleTracebackCellNavigate}
+          />
+        ) : (
+          <ReadOnlyNotebook
+            cells={readOnlyCells}
+            priority={CLOUD_VIEWER_PRIORITY}
+            hostContext={outputHostContext}
+            displayMode="report"
+            showCode={showCode}
+            className="cloud-report-notebook"
+            cellClassName="cloud-cell"
+            sourceClassName="cloud-source-block"
+            outputClassName="cloud-output-block"
+            deferIsolatedFrameUntilVisible
+            deferredIsolatedFrameRootMargin="600px 0px"
+            resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+            onNavigateToTracebackCell={handleTracebackCellNavigate}
+            renderCellError={(error, _cell, index) => (
+              <div className="cloud-state" data-kind="error">
+                Unable to render cell {index + 1}: {error.message}
+              </div>
+            )}
+          />
+        )}
+      </section>
     </main>
+  );
+}
+
+function CloudRailPackagesPanel() {
+  return (
+    <div className="cloud-rail-panel-note">
+      <p>Package details are not surfaced in the hosted viewer yet.</p>
+    </div>
   );
 }
 

--- a/apps/notebook-cloud/viewer/notebook-outline.ts
+++ b/apps/notebook-cloud/viewer/notebook-outline.ts
@@ -1,0 +1,25 @@
+import { projectNotebookOutline, type NotebookOutlineItem } from "runtimed";
+
+export interface CloudNotebookOutlineCell {
+  id: string;
+  cellType: string;
+  source: string;
+  executionCount?: number | null;
+}
+
+export function deriveCloudNotebookOutlineItems(
+  cells: readonly CloudNotebookOutlineCell[],
+): NotebookOutlineItem[] {
+  return projectNotebookOutline(cells, {
+    getStatusLabel: (cell) => {
+      if (
+        cell.cellType === "code" &&
+        cell.executionCount !== null &&
+        cell.executionCount !== undefined
+      ) {
+        return `In [${cell.executionCount}]`;
+      }
+      return null;
+    },
+  }).items;
+}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -81,7 +81,10 @@ export function NotebookRail({
       </div>
 
       {!collapsed && (
-        <div className="flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background">
+        <div
+          className="flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background"
+          data-slot="notebook-rail-panel"
+        >
           <div className="border-b px-4 py-3">
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0">

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -80,6 +80,23 @@ describe("NotebookRail", () => {
     expect(onActivePanelChange).toHaveBeenCalledWith("packages");
   });
 
+  it("exposes a stable panel slot for host shell layout adapters", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
+    ).toBeInTheDocument();
+  });
+
   it("lets the host handle anchor navigation without browser default navigation", () => {
     const onSelectOutlineItem = vi.fn();
     const onNavigateOutlineItem = vi.fn(() => true);


### PR DESCRIPTION
## Summary

- wraps the hosted notebook viewer in a cloud shell that includes the shared `NotebookRail`
- derives cloud outline items from live/snapshot materialized cells via a small adapter around `projectNotebookOutline`
- keeps the cloud toolbar minimal while leaving auth, sharing, theme, edit-mode, and code visibility controls in the hosted frame
- adds tests covering live outline updates, shared rail usage, and the absence of render endpoint config in the viewer path

## Notes

This is the first slice of the hosted shell convergence work. It intentionally does not pull in desktop `NotebookView` wholesale and does not touch the separate profile/presence enrichment or shared editable markdown extraction tracks.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notebook-outline.test.ts test/viewer-shared-cell-surface.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
