### PR TITLE
docs(elements): map output renderer boundaries

### DIFF
--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -932,6 +932,44 @@ const adapterBoundaries = [
   },
 ];
 
+const rendererBoundaryRows = [
+  {
+    surface: "Main DOM outputs",
+    catalogPath: "direct component render",
+    productionBoundary: "none",
+    detail:
+      "ANSI, JSON, image, math, SVG, audio, PDF, video, and traceback examples render through the current output components with static nbformat-like fixtures.",
+  },
+  {
+    surface: "JavaScript output",
+    catalogPath: "JavaScriptOutput fallback",
+    productionBoundary: "isolated execution frame",
+    detail:
+      "The catalog shows the safe placeholder path only. It does not evaluate notebook JavaScript in the docs app.",
+  },
+  {
+    surface: "Plotly, Vega, and GeoJSON",
+    catalogPath: "docs fixture globals",
+    productionBoundary: "renderer plugin execution",
+    detail:
+      "The component wrappers run against tiny deterministic Plotly, vegaEmbed, and Leaflet fixtures. Production renderer library loading remains an isolated-frame concern.",
+  },
+  {
+    surface: "Sift parquet and Arrow",
+    catalogPath: "docs-served WASM and fixture assets",
+    productionBoundary: "daemon blobs and frame bootstrap",
+    detail:
+      "The visible SiftTable path is real, including the HuggingFace URL and Arrow stream manifest loaders; daemon blob URL signing stays outside this runtime-free page.",
+  },
+  {
+    surface: "Widget-view outputs",
+    catalogPath: "fixture WidgetStore",
+    productionBoundary: "live comm capture and replay",
+    detail:
+      "OutputArea resolves widget-view MIME against local widget state. RuntimeStateDoc capture, comm replay, and shell transport are handled by the widget catalog boundary.",
+  },
+];
+
 function RendererCard({
   title,
   source,
@@ -1445,6 +1483,52 @@ export function OutputRenderersExample() {
               </div>
             );
           })}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card p-4">
+        <h2 className="text-sm font-semibold">Renderer Boundary Map</h2>
+        <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+          The catalog separates visible component paths from production execution surfaces so output
+          examples stay inspectable without booting notebook runtime, daemon, or iframe bundles.
+        </p>
+        <div className="mt-4 overflow-hidden rounded-md border border-fd-border">
+          <div className="hidden grid-cols-[170px_180px_190px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+            <span>Surface</span>
+            <span>Catalog path</span>
+            <span>Production boundary</span>
+            <span>Notes</span>
+          </div>
+          {rendererBoundaryRows.map((row) => (
+            <div
+              key={row.surface}
+              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[170px_180px_190px_minmax(0,1fr)] xl:gap-3"
+            >
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Surface
+                </div>
+                <div className="font-semibold">{row.surface}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Catalog path
+                </div>
+                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                  {row.catalogPath}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Production boundary
+                </div>
+                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                  {row.productionBoundary}
+                </div>
+              </div>
+              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+            </div>
+          ))}
         </div>
       </section>
 

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -34,7 +34,10 @@ Parquet URL used by the Sift demo, then lets `SiftTable` detect and decode it
 through the docs static WASM asset; the Arrow manifest section points at a
 static Arrow IPC chunk and exercises `create_arrow_stream_store` /
 `append_arrow_stream_chunk`. The MIME selection table uses the same priority
-helper the notebook uses before rendering.
+helper the notebook uses before rendering. The renderer boundary map separates
+direct component rendering from docs fixture adapters and production-only
+execution paths, so JavaScript execution and third-party renderer library
+execution stay visible as adapter boundaries rather than silent catalog behavior.
 
 ## What still needs an adapter
 
@@ -42,11 +45,12 @@ The [output isolation surfaces](/docs/isolated-output-surfaces) page now covers
 frame policy, host-context conversion, sizing, lane routing, MCP structured
 output mapping, daemon renderer asset URLs, renderer plugin metadata, and the
 production MCP output-frame wrapper with a fixture renderer bundle for resolved
-HTML/text payloads. Executable JavaScript, raw HTML and markdown runtime
-execution, real third-party renderer execution, and live output-widget comm
-transport still need fixture-backed iframe, widget-store, or generated asset
-adapters before this docs app should own those runtime paths. The Sift Parquet
-URL path now has a docs-owned static WASM asset, and the Arrow stream manifest
-path now runs through a docs-served Arrow IPC chunk. The widget catalog covers
-local `OutputModel` replay through `WidgetStore`; the remaining output-widget
-boundary is the live kernel capture and comm transport.
+HTML/text payloads. This page intentionally does not execute notebook
+JavaScript, raw HTML, markdown with raw HTML, or third-party renderer libraries
+inside the docs runtime. The visible Plotly, Vega, and GeoJSON paths use
+deterministic fixture globals, while production renderer plugin execution stays
+behind the isolated-frame adapter. The Sift Parquet URL path now has a
+docs-owned static WASM asset, and the Arrow stream manifest path now runs
+through a docs-served Arrow IPC chunk. The widget catalog covers local
+`OutputModel` replay through `WidgetStore`; the remaining output-widget boundary
+is the live kernel capture and comm transport.


### PR DESCRIPTION
## Summary

- add a renderer boundary map to the output renderers catalog page
- separate direct component renders, docs fixture adapters, and production-only execution paths
- make JavaScript execution, third-party renderer library execution, Sift assets, and widget comm replay boundaries explicit

## Verification

- `pnpm elements:build`
- Playwright smoke for `http://127.0.0.1:5176/docs/output-renderers` with boundary-map assertions
- `cargo xtask lint --fix`
- `git diff --check`
