### PR TITLE
fix(notebook-cloud): persist authenticated profile labels

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -46,10 +46,10 @@ import { cloudLog, durationMs } from "./observability.ts";
 import {
   createPendingNotebookInvite,
   getPrincipalProfiles,
-  getPendingNotebookInvitesForLogin,
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
   revokePendingNotebookInvite,
+  upsertPrincipalProfile,
   type ListedPendingNotebookInviteRow,
   type PendingNotebookInviteRow,
   type PrincipalProfileRow,
@@ -1472,7 +1472,7 @@ async function authenticateRequestOrResponse(
 ): Promise<AuthenticatedConnection | Response> {
   try {
     const identity = await authenticateRequestWithProviders(request, env);
-    await resolveLoginInvites(env, identity);
+    await syncAuthenticatedProfile(env, identity);
     return identity;
   } catch (error) {
     if (error instanceof AuthError) {
@@ -1498,27 +1498,37 @@ async function authenticateRequestOrResponse(
   }
 }
 
-async function resolveLoginInvites(env: Env, identity: AuthenticatedConnection): Promise<void> {
-  if (identity.metadata.provider !== "oidc") {
+async function syncAuthenticatedProfile(
+  env: Env,
+  identity: AuthenticatedConnection,
+): Promise<void> {
+  if (identity.metadata.provider !== "oidc" && identity.metadata.provider !== "anaconda-api-key") {
     return;
   }
 
   try {
-    // The identity provider has already authenticated this email claim; use it
-    // only to resolve pending invite rows into principal ACL rows before
-    // authorization.
-    const login = {
+    const profile = {
       principal: identity.principal,
       provider: identity.metadata.provider,
       email: identity.metadata.email ?? null,
-      emailVerified: identity.metadata.emailVerified === true,
       displayName: identity.metadata.displayName ?? null,
     };
-    const pendingInvites = await getPendingNotebookInvitesForLogin(env, login);
-    if (pendingInvites.length === 0) {
+
+    if (identity.metadata.provider === "anaconda-api-key") {
+      await upsertPrincipalProfile(env, {
+        ...profile,
+        emailVerified: Boolean(identity.metadata.email),
+      });
       return;
     }
-    const resolution = await resolveNotebookInvitesForLogin(env, login);
+
+    // The identity provider has already authenticated this email claim; use it
+    // to keep profile labels current and resolve pending invite rows into
+    // principal ACL rows before authorization.
+    const resolution = await resolveNotebookInvitesForLogin(env, {
+      ...profile,
+      emailVerified: identity.metadata.emailVerified === true,
+    });
     if (resolution.acceptedInvites.length === 0 && resolution.aclGrants.length === 0) {
       return;
     }
@@ -1531,11 +1541,11 @@ async function resolveLoginInvites(env: Env, identity: AuthenticatedConnection):
       counter_delta: resolution.acceptedInvites.length,
     });
   } catch (error) {
-    cloudLog("warn", "invites.resolution.failed", {
+    cloudLog("warn", "profile.sync.failed", {
       principal: identity.principal,
       provider: identity.metadata.provider,
       reason: error instanceof Error ? error.message : String(error),
-      counter: "invite_resolution_failures",
+      counter: "profile_sync_failures",
       counter_delta: 1,
     });
   }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -490,6 +490,9 @@ describe("Worker artifact routes", () => {
       seenAuthorizations.push(request.headers.get("authorization") ?? "");
       return jsonResponse(
         anacondaWhoami({
+          email: "rgbkrk@gmail.com",
+          firstName: "Kyle",
+          lastName: "Kelley",
           userId: "fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
           scopes: ["cloud:write"],
         }),
@@ -533,6 +536,19 @@ describe("Worker artifact routes", () => {
       ),
       true,
     );
+    const profile = env.DB.profiles.get("user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0");
+    assert.deepEqual(profile, {
+      principal: "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
+      provider: "anaconda-api-key",
+      provider_subject: null,
+      email_normalized: "rgbkrk@gmail.com",
+      email_verified: 1,
+      display_name: "Kyle Kelley",
+      avatar_url: null,
+      first_seen_at: profile?.first_seen_at,
+      last_seen_at: profile?.last_seen_at,
+      raw_claims_json: null,
+    });
   });
 
   it("requires RuntimeStateDoc ids for snapshot publishes", async () => {
@@ -1520,6 +1536,51 @@ describe("Worker artifact routes", () => {
       forwardedRequest.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER),
       NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
     );
+  });
+
+  it("stores OIDC profile labels even when there are no pending invites", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      email: "kkelley@anaconda.com",
+      extraPayload: { email_verified: true },
+      name: "Kyle Kelley",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => new Response("room ok"),
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "oidc-profile-demo");
+    seedAcl(env, {
+      notebookId: "oidc-profile-demo",
+      subject: "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/oidc-profile-demo/sync?operator=browser:tab&scope=viewer", {
+        headers: {
+          Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+            token,
+          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const profile = env.DB.profiles.get("user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375");
+    assert.equal(profile?.provider, "oidc");
+    assert.equal(profile?.email_normalized, "kkelley@anaconda.com");
+    assert.equal(profile?.email_verified, 1);
+    assert.equal(profile?.display_name, "Kyle Kelley");
   });
 
   it("resolves pending email invites for OIDC editor WebSocket requests", async () => {


### PR DESCRIPTION
## Stack order

Depends on #3184 (`quod/notebook-cloud-shared-shell`). Merge #3184 first, then this PR after GitHub retargets the branch.

## Summary

- persist OIDC profile labels on authenticated notebook requests even when there are no pending invites
- persist Anaconda API-key profile labels from the configured whoami hop during publish/write flows
- keep pending invite resolution on the same authenticated profile path so sharing grants still resolve before authorization

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts test/identity.test.ts test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud test`
