### PR TITLE
docs(elements): tighten output renderer boundaries

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -5,9 +5,11 @@ import {
   Cloud,
   FileCode2,
   Frame,
+  PackageCheck,
   Palette,
   PanelLeft,
   PanelTop,
+  Search,
   ShieldCheck,
   SlidersHorizontal,
   TextCursorInput,
@@ -28,6 +30,12 @@ const entries = [
     icon: PanelTop,
   },
   {
+    title: "Package managers",
+    description: "Dependency headers and package-state controls from the notebook app.",
+    href: "/docs/package-manager-surfaces",
+    icon: PackageCheck,
+  },
+  {
     title: "Cell anatomy",
     description: "Inventory map for current nteract cells.",
     href: "/docs/cell-anatomy",
@@ -38,6 +46,12 @@ const entries = [
     description: "CodeMirror fixtures for notebook source editing.",
     href: "/docs/editor-surfaces",
     icon: TextCursorInput,
+  },
+  {
+    title: "Search surfaces",
+    description: "Global find and history search with fixture-backed notebook state.",
+    href: "/docs/search-surfaces",
+    icon: Search,
   },
   {
     title: "Output renderers",

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -106,7 +106,7 @@ const cellTypeFixtures = [
 ];
 
 const contracts = [
-  "Catalog examples import current components before using schematic markup.",
+  "Catalog examples import current components before adding fixture-only wrappers.",
   "Fixture content may stand in for runtime/editor/output systems until an adapter exists.",
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -4,6 +4,7 @@ import { FileCode2, FileText, Rows3, ShieldCheck } from "lucide-react";
 import { useLayoutEffect, useMemo, useState } from "react";
 import { CodeCell } from "@/notebook-components/CodeCell";
 import { MarkdownCell } from "@/notebook-components/MarkdownCell";
+import { NotebookView } from "@/notebook-components/NotebookView";
 import { RawCell } from "@/notebook-components/RawCell";
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import {
@@ -65,6 +66,60 @@ const rawCell: RawCellType = {
   },
 };
 
+const viewCodeCell: CodeCellType = {
+  cell_type: "code",
+  id: "elements-view-code-cell",
+  source: [
+    "features = orders.assign(month=orders.date.dt.month)",
+    "predictions = model.predict(features_holdout)",
+    "display(predictions.head())",
+  ].join("\n"),
+  execution_count: 18,
+  outputs: [],
+  metadata: {},
+};
+
+const viewMarkdownCell: MarkdownCellType = {
+  cell_type: "markdown",
+  id: "elements-view-markdown-cell",
+  source: [
+    "## Model notes",
+    "",
+    "The workspace fixture renders through the production `NotebookView` shell.",
+  ].join("\n"),
+  metadata: {},
+};
+
+const viewHiddenCodeCell: CodeCellType = {
+  cell_type: "code",
+  id: "elements-view-hidden-code-cell",
+  source: "cached = features.sample(2000, random_state=42)",
+  execution_count: 17,
+  outputs: [],
+  metadata: {
+    jupyter: {
+      source_hidden: true,
+      outputs_hidden: true,
+    },
+  },
+};
+
+const viewRawCell: RawCellType = {
+  cell_type: "raw",
+  id: "elements-view-raw-cell",
+  source: "runtime: python\nowner: forecasting",
+  metadata: {
+    format: "yaml",
+  },
+};
+
+const initialNotebookViewCellIds = [
+  viewMarkdownCell.id,
+  viewCodeCell.id,
+  viewHiddenCodeCell.id,
+  viewRawCell.id,
+];
+
 const fullCellRows = [
   {
     label: "CodeCell",
@@ -92,7 +147,7 @@ const fullCellBoundaryRows = [
     catalogPath: "replaceNotebookCells fixture seed",
     productionBoundary: "NotebookView document projection",
     detail:
-      "The catalog writes three static cells into the notebook cell store so CodeCell, MarkdownCell, and RawCell can subscribe normally without opening a notebook document.",
+      "The catalog writes direct-cell and workspace-shell fixtures into the notebook cell store so the production cells can subscribe normally without opening a notebook document.",
   },
   {
     surface: "Execution and output state",
@@ -122,12 +177,27 @@ const fullCellBoundaryRows = [
     detail:
       "The production MarkdownCell preview path stays visible while renderer bootstrapping and untrusted markdown execution remain behind the output adapter.",
   },
+  {
+    surface: "NotebookView shell",
+    catalogPath: "seeded cell store plus local cellIds order",
+    productionBoundary: "Automerge order, DnD mutations, and keyboard navigation",
+    detail:
+      "The catalog can render the production workspace shell with fixture cells, but moving, adding, and deleting cells stop at local state callbacks.",
+  },
 ];
 
 const noop = () => {};
 
 function seedFullCellFixtures() {
-  replaceNotebookCells([codeCell, markdownCell, rawCell]);
+  replaceNotebookCells([
+    codeCell,
+    markdownCell,
+    rawCell,
+    viewMarkdownCell,
+    viewCodeCell,
+    viewHiddenCodeCell,
+    viewRawCell,
+  ]);
   resetNotebookOutputs();
   resetNotebookExecutions();
 
@@ -155,6 +225,30 @@ function seedFullCellFixtures() {
   });
   setCellExecutionPointer(codeCell.id, "elements-execution");
 
+  setOutput("elements-view-output-stream", {
+    output_id: "elements-view-output-stream",
+    output_type: "stream",
+    name: "stdout",
+    text: "workspace fixture rendered through NotebookView\n",
+  });
+  setOutput("elements-view-output-result", {
+    output_id: "elements-view-output-result",
+    output_type: "execute_result",
+    execution_count: 18,
+    data: {
+      "text/plain": "3 rows x 8 columns",
+    },
+    metadata: {},
+  });
+  setExecution("elements-view-execution", {
+    execution_count: 18,
+    status: "done",
+    success: true,
+    output_ids: ["elements-view-output-stream", "elements-view-output-result"],
+    submitted_by_actor_label: "local:kyle",
+  });
+  setCellExecutionPointer(viewCodeCell.id, "elements-view-execution");
+
   setFocusedCellId(codeCell.id);
   setExecutingCellIds(new Set());
   setQueuedCellIds(new Set());
@@ -170,6 +264,7 @@ function focusFixtureCell(cellId: string) {
 
 export function FullCellSurfacesExample() {
   const [fixturesSeeded, setFixturesSeeded] = useState(false);
+  const [notebookViewCellIds, setNotebookViewCellIds] = useState(initialNotebookViewCellIds);
 
   useLayoutEffect(() => {
     seedFullCellFixtures();
@@ -192,6 +287,16 @@ export function FullCellSurfacesExample() {
       </div>
     );
   }
+
+  const moveNotebookViewCell = (cellId: string, afterCellId?: string | null) => {
+    setNotebookViewCellIds((current) => {
+      const withoutMoved = current.filter((id) => id !== cellId);
+      const nextIndex =
+        afterCellId == null ? 0 : withoutMoved.findIndex((id) => id === afterCellId) + 1;
+      if (nextIndex <= 0 && afterCellId != null) return current;
+      return [...withoutMoved.slice(0, nextIndex), cellId, ...withoutMoved.slice(nextIndex)];
+    });
+  };
 
   return (
     <div className="not-prose space-y-6">
@@ -305,6 +410,40 @@ export function FullCellSurfacesExample() {
                 </span>
               }
             />
+          </div>
+        </section>
+      </CrdtBridgeProvider>
+
+      <CrdtBridgeProvider {...adapterValue}>
+        <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">NotebookView workspace shell</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              This fixture imports the production workspace renderer, seeds the split cell and
+              output stores, then hands `NotebookView` a local visual order. Stable DOM ordering,
+              hidden-cell grouping, adders, and cell navigation remain visible without opening a
+              notebook document or WASM handle.
+            </p>
+          </div>
+          <div className="bg-background p-3">
+            <div className="flex h-[560px] flex-col overflow-hidden rounded-lg border border-border bg-background">
+              <NotebookView
+                cellIds={notebookViewCellIds}
+                runtime="python"
+                sessionRuntimeState="ready"
+                onFocusCell={focusFixtureCell}
+                onExecuteCell={noop}
+                onInterruptKernel={noop}
+                onDeleteCell={noop}
+                onAddCell={() => null}
+                onMoveCell={moveNotebookViewCell}
+                onSetCellSourceHidden={noop}
+                onSetCellOutputsHidden={noop}
+              />
+            </div>
           </div>
         </section>
       </CrdtBridgeProvider>

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BadgeCheck, PanelTop, PlayCircle, TimerReset } from "lucide-react";
+import { BadgeCheck, CircleDot, PanelTop, PlayCircle, TimerReset } from "lucide-react";
 import type { ComponentProps } from "react";
 import {
   KERNEL_ERROR_REASON,
@@ -173,6 +173,44 @@ const contractItems = [
   },
 ];
 
+const toolbarBoundaryRows = [
+  {
+    boundary: "Runtime status projection",
+    catalogPath: "toolbarProps(status fixtures)",
+    productionBoundary: "RuntimeStateDoc + kernel lifecycle",
+    detail:
+      "The catalog passes deterministic status props. Production derives them from runtime state, kernel lifecycle, environment progress, and launch errors.",
+  },
+  {
+    boundary: "Kernel actions",
+    catalogPath: "inert callbacks",
+    productionBoundary: "Notebook action handlers",
+    detail:
+      "Start, interrupt, restart, run-all, and restart-and-run-all buttons render here without side effects. The notebook app wires them to execution and runtime control paths.",
+  },
+  {
+    boundary: "Dependency drawer",
+    catalogPath: "isDepsOpen + depsOutOfSync props",
+    productionBoundary: "Package rail and notebook metadata",
+    detail:
+      "The fixture toggles visual dependency state only. Production opens package UI, writes notebook metadata, and coordinates environment rebuild decisions.",
+  },
+  {
+    boundary: "Cell insertion",
+    catalogPath: "focusedCellId + lastCellId fixtures",
+    productionBoundary: "NotebookView focus and CRDT mutation",
+    detail:
+      "The add-cell affordance receives stable fixture IDs. Production inserts new cells through the notebook document and restores editor focus.",
+  },
+  {
+    boundary: "Desktop update restart",
+    catalogPath: "updateStatus + onRestartToUpdate",
+    productionBoundary: "Tauri updater host action",
+    detail:
+      "The update-ready surface renders with a no-op restart callback. Desktop builds still own update installation and app restart behavior outside the docs runtime.",
+  },
+];
+
 export function NotebookToolbarSurfacesExample() {
   return (
     <div className="not-prose space-y-6" data-elements-slot="notebook-toolbar-surfaces">
@@ -216,6 +254,56 @@ export function NotebookToolbarSurfacesExample() {
             </div>
           </article>
         ))}
+      </section>
+
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <CircleDot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Adapter boundary</h2>
+        </div>
+        <p className="text-xs leading-5 text-fd-muted-foreground">
+          NotebookToolbar renders from the production component, but this page owns only static
+          status props and inert callbacks. Runtime state, kernel controls, dependency writes, cell
+          insertion, and desktop update restarts stay behind the notebook app adapters.
+        </p>
+        <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
+          <div className="hidden grid-cols-[190px_220px_240px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+            <span>Boundary</span>
+            <span>Catalog path</span>
+            <span>Production boundary</span>
+            <span>Notes</span>
+          </div>
+          {toolbarBoundaryRows.map((row) => (
+            <div
+              key={row.boundary}
+              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_220px_240px_minmax(0,1fr)] xl:gap-3"
+            >
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Boundary
+                </div>
+                <div className="font-semibold">{row.boundary}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Catalog path
+                </div>
+                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                  {row.catalogPath}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Production boundary
+                </div>
+                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                  {row.productionBoundary}
+                </div>
+              </div>
+              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+            </div>
+          ))}
+        </div>
       </section>
     </div>
   );

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -16,6 +16,7 @@ import {
   FileText,
   FileWarning,
   ListFilter,
+  Palette,
   SlidersHorizontal,
   Table2,
   Terminal,
@@ -860,7 +861,7 @@ const renderedPieces = [
   {
     name: "MathOutput",
     source: "src/components/outputs/math-output.tsx",
-    note: "KaTeX-backed text/latex rendering that is safe in the main output lane.",
+    note: "KaTeX-backed text/latex rendering that is safe in the main output lane; its KaTeX stylesheet is owned by the output component, not the docs app shell.",
   },
   {
     name: "SvgOutput",
@@ -938,7 +939,7 @@ const rendererBoundaryRows = [
     catalogPath: "direct component render",
     productionBoundary: "none",
     detail:
-      "ANSI, JSON, image, math, SVG, audio, PDF, video, and traceback examples render through the current output components with static nbformat-like fixtures.",
+      "ANSI, JSON, image, math, SVG, audio, PDF, video, and traceback examples render through the current output components with static nbformat-like fixtures. MathOutput brings its own KaTeX stylesheet with the component import.",
   },
   {
     surface: "JavaScript output",
@@ -967,6 +968,30 @@ const rendererBoundaryRows = [
     productionBoundary: "live comm capture and replay",
     detail:
       "OutputArea resolves widget-view MIME against local widget state. RuntimeStateDoc capture, comm replay, and shell transport are handled by the widget catalog boundary.",
+  },
+];
+
+const stylesheetBoundaryRows = [
+  {
+    surface: "text/latex in main DOM",
+    catalogPath: "MathOutput import",
+    productionPath: "MathOutput import",
+    detail:
+      "The catalog imports the production component directly, so KaTeX markup and KaTeX CSS travel together. This keeps plain math output independent from global app or docs CSS.",
+  },
+  {
+    surface: "markdown math in iframe",
+    catalogPath: "docs IsolatedFrame adapter",
+    productionPath: "MarkdownOutput inside isolated frame",
+    detail:
+      "MarkdownOutput also imports KaTeX CSS, but it must render inside a sandboxed output frame because markdown may include raw HTML.",
+  },
+  {
+    surface: "renderer plugin CSS",
+    catalogPath: "docs fixture CSS bytes",
+    productionPath: "daemon renderer-plugin CSS route",
+    detail:
+      "The isolated output catalog covers plugin CSS fetch and install with fixture files. Production fetches CSS beside renderer plugin JavaScript from daemon asset routes.",
   },
 ];
 
@@ -1524,6 +1549,52 @@ export function OutputRenderersExample() {
                 </div>
                 <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
                   {row.productionBoundary}
+                </div>
+              </div>
+              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Palette className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Stylesheet Boundaries</h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            Renderer styles stay with the output surface that needs them. The catalog imports those
+            production components or fixture plugin assets directly instead of relying on a global
+            docs stylesheet.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border">
+          {stylesheetBoundaryRows.map((row) => (
+            <div
+              key={row.surface}
+              className="grid gap-2 p-4 text-xs lg:grid-cols-[180px_200px_220px_minmax(0,1fr)] lg:gap-3"
+            >
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground lg:hidden">
+                  Surface
+                </div>
+                <div className="font-semibold">{row.surface}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground lg:hidden">
+                  Catalog path
+                </div>
+                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                  {row.catalogPath}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground lg:hidden">
+                  Production path
+                </div>
+                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                  {row.productionPath}
                 </div>
               </div>
               <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>

--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -67,6 +67,30 @@ const packageSurfaces = [
   },
 ];
 
+const packageBoundaryRows = [
+  {
+    boundary: "Notebook metadata",
+    catalogPath: "static package-manager records",
+    productionBoundary: "Automerge notebook metadata and pyproject/environment files",
+    detail:
+      "uv, Conda, Pixi, and Deno headers receive the same prop shapes they use in the notebook app without mutating notebook documents.",
+  },
+  {
+    boundary: "Manager actions",
+    catalogPath: "inert async callbacks",
+    productionBoundary: "host commands, daemon sync, and environment solves",
+    detail:
+      "Add, remove, import, sync, retry, and restart affordances stay visible while side effects remain outside the docs runtime.",
+  },
+  {
+    boundary: "Trust and rebuild flow",
+    catalogPath: "rendered status fixtures",
+    productionBoundary: "trust re-signing, package pool warming, and kernel restart lifecycle",
+    detail:
+      "Progress and dirty states are fixture-backed here; live trust decisions and environment rebuilds stay with runtime surfaces.",
+  },
+];
+
 export function PackageManagerSurfacesExample() {
   return (
     <div className="not-prose space-y-6" data-elements-slot="package-manager-surfaces">
@@ -235,6 +259,44 @@ export function PackageManagerSurfacesExample() {
           the notebook app, while live notebook metadata writes, daemon sync, and environment
           rebuilding stay outside the docs runtime.
         </p>
+        <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
+          <div className="hidden grid-cols-[190px_210px_240px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+            <span>Boundary</span>
+            <span>Catalog path</span>
+            <span>Production boundary</span>
+            <span>Notes</span>
+          </div>
+          {packageBoundaryRows.map((row) => (
+            <div
+              key={row.boundary}
+              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_210px_240px_minmax(0,1fr)] xl:gap-3"
+            >
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Boundary
+                </div>
+                <div className="font-semibold">{row.boundary}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Catalog path
+                </div>
+                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                  {row.catalogPath}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Production boundary
+                </div>
+                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                  {row.productionBoundary}
+                </div>
+              </div>
+              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+            </div>
+          ))}
+        </div>
       </section>
     </div>
   );

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -5,7 +5,10 @@ import { useState } from "react";
 import {
   KERNEL_STATUS,
   RUNTIME_STATUS,
+  projectNotebookOutline,
+  resolveNotebookOutlineSelection,
   type NotebookOutlineItem,
+  type NotebookOutlineSourceCell,
   type RuntimeLifecycle,
 } from "runtimed";
 import {
@@ -26,81 +29,117 @@ const runningIdleLifecycle: RuntimeLifecycle = {
   activity: "Idle",
 };
 
-const outlineItems: NotebookOutlineItem[] = [
+const notebookCells: NotebookOutlineSourceCell[] = [
   {
-    id: "cell-load-data:heading:0",
-    cellId: "cell-load-data",
-    title: "Load data",
-    level: 1,
-    kind: "heading",
-    cellAnchorId: "notebook-cell-cell-load-data",
-    headingAnchorId: "notebook-cell-cell-load-data-heading-load-data",
-    href: "#notebook-cell-cell-load-data",
-    anchor: "load-data",
-    statusLabel: "markdown",
+    id: "cell-load-data",
+    cell_type: "markdown",
+    source: "# Load data\n\nImport the order history and make dates explicit.",
   },
   {
-    id: "cell-clean-columns:heading:0",
-    cellId: "cell-clean-columns",
-    title: "Clean columns",
-    level: 2,
-    kind: "heading",
-    cellAnchorId: "notebook-cell-cell-clean-columns",
-    headingAnchorId: "notebook-cell-cell-clean-columns-heading-clean-columns",
-    href: "#notebook-cell-cell-clean-columns",
-    anchor: "clean-columns",
-    detail: "code",
+    id: "cell-load-code",
+    cell_type: "code",
+    source: "orders = pandas.read_csv('orders.csv', parse_dates=['date'])",
+    execution_count: 12,
   },
   {
-    id: "cell-explore-shape:heading:0",
-    cellId: "cell-explore-shape",
-    title: "Explore shape",
-    level: 1,
-    kind: "heading",
-    cellAnchorId: "notebook-cell-cell-explore-shape",
-    headingAnchorId: "notebook-cell-cell-explore-shape-heading-explore-shape",
-    href: "#notebook-cell-cell-explore-shape",
-    anchor: "explore-shape",
+    id: "cell-clean-columns",
+    cell_type: "markdown",
+    source: "## Clean columns\n\nNormalize status values before joining lookup tables.",
   },
   {
-    id: "cell-model-run:heading:0",
-    cellId: "cell-model-run",
-    title: "Model run",
-    level: 1,
-    kind: "heading",
-    cellAnchorId: "notebook-cell-cell-model-run",
-    headingAnchorId: "notebook-cell-cell-model-run-heading-model-run",
-    href: "#notebook-cell-cell-model-run",
-    anchor: "model-run",
+    id: "cell-clean-code",
+    cell_type: "code",
+    source: "orders = clean_columns(orders)",
+    execution_count: 13,
   },
   {
-    id: "cell-findings:heading:0",
-    cellId: "cell-findings",
-    title: "Findings",
-    level: 2,
-    kind: "heading",
-    cellAnchorId: "notebook-cell-cell-findings",
-    headingAnchorId: "notebook-cell-cell-findings-heading-findings",
-    href: "#notebook-cell-cell-findings",
-    anchor: "findings",
+    id: "cell-explore-shape",
+    cell_type: "markdown",
+    source: "# Explore shape\n\nCheck the model-ready feature table.",
+  },
+  {
+    id: "cell-shape-output",
+    cell_type: "code",
+    source: "features.shape",
+    execution_count: 14,
+  },
+  {
+    id: "cell-model-run",
+    cell_type: "markdown",
+    source: "# Model run\n\nTrain the weekly backtest model.",
+  },
+  {
+    id: "cell-model-code",
+    cell_type: "code",
+    source: "model.fit(features[columns], target)",
+    execution_count: null,
+  },
+  {
+    id: "cell-findings",
+    cell_type: "markdown",
+    source: "## Findings\n\nSummarize the backtest before export.",
   },
 ];
 
-const cells = [
+const executingCellId = "cell-model-code";
+const queuedCellIds = new Set(["cell-shape-output"]);
+
+const outlineItems: NotebookOutlineItem[] = projectNotebookOutline(notebookCells, {
+  getStatusLabel: (cell) => {
+    if (cell.id === executingCellId) return "Running";
+    if (queuedCellIds.has(cell.id)) return "Queued";
+    if (cell.cell_type === "code" && cell.execution_count !== null) {
+      return `In [${cell.execution_count}]`;
+    }
+    return null;
+  },
+}).items;
+const outlineCellIds = notebookCells.map((cell) => cell.id);
+const activeOutlineItemId = "cell-explore-shape:heading:0";
+
+const notebookCellCards = notebookCells.map((cell) => {
+  const firstLine = cell.source
+    ?.split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  const title = firstLine?.replace(/^#{1,6}\s+/, "") ?? cell.id;
+  const kind = cell.cell_type === "markdown" ? "Markdown" : "Code";
+  const status =
+    cell.id === executingCellId ? "Running" : queuedCellIds.has(cell.id) ? "Queued" : null;
+  return {
+    id: cell.id,
+    label: kind,
+    title,
+    body: cell.source ?? "",
+    status,
+  };
+});
+
+const outlineBoundaryRows = [
   {
-    label: "Markdown",
-    title: "Load data",
-    body: "Notebook sections are derived from markdown headings first. Code-cell section metadata can come later.",
+    label: "Projection source",
+    catalog: "projectNotebookOutline(fixture cells)",
+    production: "getNotebookCellsSnapshot() + RuntimeStateDoc cell materialization",
   },
   {
-    label: "Code",
-    title: "Clean columns",
-    body: "df = pandas.read_csv('runs.csv')",
+    label: "Context selection",
+    catalog: "focusedCellId fixture + outlineCellIds",
+    production: "useActiveOutlineItemId + resolveNotebookOutlineSelection",
   },
   {
-    label: "Output",
-    title: "Explore shape",
-    body: "2,148 rows x 18 columns",
+    label: "Heading anchors",
+    catalog: "static cards with generated outline ids",
+    production: "NotebookView passes markdownHeadingAnchorsByCellId into MarkdownCell",
+  },
+  {
+    label: "Heading navigation",
+    catalog: "inert anchor callback",
+    production: "navigateMarkdownHeading, scrollIntoView, and history.replaceState",
+  },
+  {
+    label: "DOM order",
+    catalog: "fixture cell order",
+    production: "stableDomOrder renders DOM while CSS order controls visual position",
   },
 ];
 
@@ -135,9 +174,15 @@ const plannedRailPanels = [
 export function RailOutlineExample() {
   const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(false);
-  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState(outlineItems[1]?.id ?? null);
+  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
+  const [focusedCellId, setFocusedCellId] = useState("cell-clean-code");
+  const resolvedOutlineItemId = resolveNotebookOutlineSelection(outlineItems, {
+    selectedItemId: selectedOutlineItemId,
+    selectedCellId: focusedCellId,
+    cellIds: outlineCellIds,
+  });
   const selectedOutlineItem =
-    outlineItems.find((item) => item.id === selectedOutlineItemId) ?? outlineItems[0];
+    outlineItems.find((item) => item.id === resolvedOutlineItemId) ?? outlineItems[0];
 
   return (
     <div
@@ -154,7 +199,7 @@ export function RailOutlineExample() {
         envTypeHint="uv"
         envProgress={null}
         runtime="python"
-        focusedCellId="cell-clean-columns"
+        focusedCellId={focusedCellId}
         lastCellId="cell-findings"
         onStartKernel={noop}
         onInterruptKernel={noop}
@@ -171,8 +216,10 @@ export function RailOutlineExample() {
           activePanelId={activePanel}
           collapsed={railCollapsed}
           outlineItems={outlineItems}
+          outlineCellIds={outlineCellIds}
+          activeOutlineItemId={activeOutlineItemId}
           selectedOutlineItemId={selectedOutlineItemId}
-          selectedOutlineCellId={selectedOutlineItem?.cellId ?? null}
+          selectedOutlineCellId={focusedCellId}
           packagesSummary="uv:inline · 4 packages"
           packagesPanel={
             <NotebookPackagesPanel>
@@ -181,7 +228,10 @@ export function RailOutlineExample() {
           }
           onActivePanelChange={setActivePanel}
           onCollapsedChange={setRailCollapsed}
-          onSelectOutlineItem={(item) => setSelectedOutlineItemId(item.id)}
+          onSelectOutlineItem={(item) => {
+            setSelectedOutlineItemId(item.id);
+            setFocusedCellId(item.cellId);
+          }}
           onNavigateOutlineItem={() => true}
         />
 
@@ -193,23 +243,49 @@ export function RailOutlineExample() {
                 NotebookToolbar, NotebookRail, and DependencyHeader render from current sources.
               </div>
               <p>
-                The docs app owns fixture state only: selected outline item, collapsed state,
-                package callbacks, and inert anchor navigation.
+                The docs app owns fixture state only: focused cell, active scroll item, collapsed
+                state, package callbacks, and inert anchor navigation.
               </p>
             </div>
-            {cells.map((cell) => (
+            <div className="rounded-lg border border-fd-border bg-fd-background p-3 text-xs leading-5 text-fd-muted-foreground">
+              <span className="font-medium text-fd-foreground">Context selection:</span> focused
+              cell <code className="rounded bg-fd-muted px-1 py-0.5">{focusedCellId}</code> resolves
+              to{" "}
+              <span className="font-medium text-fd-foreground">{selectedOutlineItem?.title}</span>.
+            </div>
+            {notebookCellCards.map((cell) => (
               <section
-                key={cell.title}
+                key={cell.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  setFocusedCellId(cell.id);
+                  setSelectedOutlineItemId(null);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  setFocusedCellId(cell.id);
+                  setSelectedOutlineItemId(null);
+                }}
                 className={cn(
-                  "rounded-lg border border-fd-border bg-fd-background p-4 shadow-sm",
-                  selectedOutlineItem?.title === cell.title && "border-fd-primary/50",
+                  "rounded-lg border border-fd-border bg-fd-background p-4 shadow-sm transition-colors",
+                  "focus:outline-none focus:ring-2 focus:ring-fd-primary/30",
+                  focusedCellId === cell.id && "border-fd-primary/60 bg-fd-primary/5",
                 )}
               >
                 <div className="mb-2 flex items-center justify-between gap-3">
                   <h4 className="text-sm font-semibold">{cell.title}</h4>
-                  <span className="rounded-full bg-fd-muted px-2 py-0.5 text-[11px] text-fd-muted-foreground">
-                    {cell.label}
-                  </span>
+                  <div className="flex items-center gap-1.5">
+                    {cell.status ? (
+                      <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] text-amber-800 dark:text-amber-300">
+                        {cell.status}
+                      </span>
+                    ) : null}
+                    <span className="rounded-full bg-fd-muted px-2 py-0.5 text-[11px] text-fd-muted-foreground">
+                      {cell.label}
+                    </span>
+                  </div>
                 </div>
                 <p className="font-mono text-xs leading-6 text-fd-muted-foreground">{cell.body}</p>
               </section>
@@ -217,9 +293,37 @@ export function RailOutlineExample() {
             <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
               <div className="mb-3 flex items-center gap-2">
                 <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+                <h4 className="text-sm font-semibold">Adapter boundary</h4>
+              </div>
+              <div className="space-y-2">
+                {outlineBoundaryRows.map((row) => (
+                  <div
+                    key={row.label}
+                    className="space-y-2 rounded-md border border-fd-border p-3 text-xs leading-5"
+                  >
+                    <div className="font-medium text-fd-foreground">{row.label}</div>
+                    <div className="min-w-0">
+                      <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
+                        Catalog
+                      </span>
+                      <span className="break-words text-fd-muted-foreground">{row.catalog}</span>
+                    </div>
+                    <div className="min-w-0">
+                      <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
+                        Production
+                      </span>
+                      <span className="break-words text-fd-muted-foreground">{row.production}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+            <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
                 <h4 className="text-sm font-semibold">Planned sibling panels</h4>
               </div>
-              <div className="grid gap-2 sm:grid-cols-2">
+              <div className="grid gap-2">
                 {plannedRailPanels.map((panel) => (
                   <div key={panel.title} className="rounded-md border border-fd-border p-3">
                     <div className="flex items-start justify-between gap-3">

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -85,6 +85,30 @@ const runtimePieces = [
   },
 ];
 
+const runtimeAdapterRows = [
+  {
+    boundary: "Desktop host actions",
+    catalogPath: "NotebookHostProvider fixture",
+    productionBoundary: "notebook shell host commands",
+    detail:
+      "Pool settings, clipboard, and command callbacks stay inert in the catalog while the production app routes them through the host bridge.",
+  },
+  {
+    boundary: "Runtime side effects",
+    catalogPath: "static decisions with async no-ops",
+    productionBoundary: "daemon and kernel lifecycle",
+    detail:
+      "Trust, environment build, retry, dismiss, and sync actions render with the current components but do not start kernels or mutate runtime state.",
+  },
+  {
+    boundary: "Dependency and trust state",
+    catalogPath: "typed fixture records",
+    productionBoundary: "settings, pyproject, and RuntimeStateDoc updates",
+    detail:
+      "The catalog owns deterministic package, typosquat, and pyproject data; live settings and runtime documents remain outside the docs app.",
+  },
+];
+
 const fixtureHost = createFixtureNotebookHost();
 
 const trustInfo = {
@@ -127,7 +151,7 @@ const kernelLaunchError = [
 function RuntimeDialogs() {
   const [trustOpen, setTrustOpen] = useState(false);
   const [envOpen, setEnvOpen] = useState(false);
-  const [genericOpen, setGenericOpen] = useState(false);
+  const [decisionShellOpen, setDecisionShellOpen] = useState(false);
 
   return (
     <div className="grid gap-3 lg:grid-cols-3" data-elements-slot="runtime-dialog-fixtures">
@@ -176,21 +200,21 @@ function RuntimeDialogs() {
         <p className="mt-2 min-h-[3rem] text-xs leading-5 text-fd-muted-foreground">
           Opens the shared runtime decision shell with catalog-owned fixture content.
         </p>
-        <Button className="mt-4" size="sm" onClick={() => setGenericOpen(true)}>
+        <Button className="mt-4" size="sm" onClick={() => setDecisionShellOpen(true)}>
           Open RuntimeDecisionDialog
         </Button>
         <RuntimeDecisionDialog
-          open={genericOpen}
-          onOpenChange={setGenericOpen}
+          open={decisionShellOpen}
+          onOpenChange={setDecisionShellOpen}
           icon={<PackageCheck className="size-5 text-emerald-600" aria-hidden="true" />}
           title="Use project environment"
           description="This notebook can start with the detected project environment."
           footer={
             <>
-              <Button variant="outline" onClick={() => setGenericOpen(false)}>
+              <Button variant="outline" onClick={() => setDecisionShellOpen(false)}>
                 Cancel
               </Button>
-              <Button onClick={() => setGenericOpen(false)}>Use project env</Button>
+              <Button onClick={() => setDecisionShellOpen(false)}>Use project env</Button>
             </>
           }
         >
@@ -457,9 +481,48 @@ export function RuntimeSurfacesExample() {
             <h2 className="text-sm font-semibold">Adapter Boundary</h2>
           </div>
           <p className="text-xs leading-5 text-fd-muted-foreground">
-            Components that import runtime value constants or host-backed hooks should get a small
-            fixture adapter before they move from adapter needed to rendered.
+            Components that need runtime values, daemon actions, or host-backed hooks should name
+            the boundary first, then move through a small fixture adapter before joining the
+            rendered catalog.
           </p>
+          <div className="mt-4 overflow-hidden rounded-md border border-fd-border">
+            <div className="hidden grid-cols-[190px_210px_230px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+              <span>Boundary</span>
+              <span>Catalog path</span>
+              <span>Production boundary</span>
+              <span>Notes</span>
+            </div>
+            {runtimeAdapterRows.map((row) => (
+              <div
+                key={row.boundary}
+                className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_210px_230px_minmax(0,1fr)] xl:gap-3"
+              >
+                <div>
+                  <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                    Boundary
+                  </div>
+                  <div className="font-semibold">{row.boundary}</div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                    Catalog path
+                  </div>
+                  <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                    {row.catalogPath}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                    Production boundary
+                  </div>
+                  <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                    {row.productionBoundary}
+                  </div>
+                </div>
+                <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
     </div>

--- a/apps/elements/components/search-surfaces-example.tsx
+++ b/apps/elements/components/search-surfaces-example.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { History, Search, TextCursorInput } from "lucide-react";
+import { FileSearch, History, Search, TextCursorInput } from "lucide-react";
 import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { HistoryEntry, NotebookRequest, NotebookResponse } from "runtimed";
 import { Button } from "@/components/ui/button";
@@ -118,6 +118,37 @@ const historyFixtureHost = createFixtureNotebookHost({
     },
   },
 });
+
+const searchBoundaryRows = [
+  {
+    boundary: "Find state projection",
+    catalogPath: "notebookCells[] + GlobalFindBar props",
+    productionBoundary: "NotebookView cell sources, focus, and selection",
+    detail:
+      "The catalog owns static cell text and match counts. The notebook app still owns live cell projection, keyboard shortcuts, focus restoration, and editor selections.",
+  },
+  {
+    boundary: "History transport",
+    catalogPath: "createFixtureNotebookHost(get_history)",
+    productionBoundary: "NotebookHost -> runtimed history request",
+    detail:
+      "HistorySearchDialog stays on the real hook path. The docs host answers only typed get_history requests and never opens a daemon or kernel session.",
+  },
+  {
+    boundary: "Selection handoff",
+    catalogPath: "setSelectedHistorySource",
+    productionBoundary: "focused editor insertion",
+    detail:
+      "Selecting history updates local preview state here. Production inserts the selected source into the focused notebook editor through the notebook host.",
+  },
+  {
+    boundary: "Match navigation",
+    catalogPath: "inert next/previous callbacks",
+    productionBoundary: "cell scroll and active-match focus",
+    detail:
+      "The fixture cycles a counter so the toolbar surface is interactive. Production navigation scrolls to matched cells and keeps active match state synchronized with editors.",
+  },
+];
 
 function countMatches(source: string, query: string) {
   const needle = query.trim().toLowerCase();
@@ -293,6 +324,56 @@ export function SearchSurfacesExample() {
           <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap rounded-md border border-fd-border bg-fd-background p-3 font-mono text-xs leading-6 text-fd-foreground">
             {selectedHistorySource}
           </pre>
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <FileSearch className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Adapter boundary</h2>
+        </div>
+        <p className="text-xs leading-5 text-fd-muted-foreground">
+          Search is rendered through current notebook components, but the docs app owns only static
+          cell text, deterministic history entries, and inert handoff callbacks. Live notebook
+          projection, daemon history, focus, and editor insertion stay behind app adapters.
+        </p>
+        <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
+          <div className="hidden grid-cols-[190px_230px_230px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+            <span>Boundary</span>
+            <span>Catalog path</span>
+            <span>Production boundary</span>
+            <span>Notes</span>
+          </div>
+          {searchBoundaryRows.map((row) => (
+            <div
+              key={row.boundary}
+              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_230px_230px_minmax(0,1fr)] xl:gap-3"
+            >
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Boundary
+                </div>
+                <div className="font-semibold">{row.boundary}</div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Catalog path
+                </div>
+                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                  {row.catalogPath}
+                </div>
+              </div>
+              <div>
+                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                  Production boundary
+                </div>
+                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                  {row.productionBoundary}
+                </div>
+              </div>
+              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+            </div>
+          ))}
         </div>
       </section>
     </div>

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -884,7 +884,7 @@ const fixtureModels: FixtureModel[] = [
     state: {
       _model_name: "CustomResearchWidgetModel",
       _model_module: "lab-extension",
-      value: "adapter needed",
+      value: "unsupported model fallback",
     },
   },
 ];
@@ -1043,6 +1043,30 @@ const widgetBoundaryRows = [
     productionBoundary: "kernel-originated ESM/CSS assets",
     detail:
       "AnyWidgetView mounts against deterministic _esm and _css fixtures. Kernel-originated asset URLs and sandbox policy stay behind the runtime adapter.",
+  },
+];
+
+const nextWidgetAdapters = [
+  {
+    adapter: "Live OutputModel comm capture",
+    catalogPath: "local OutputModel replay",
+    productionBoundary: "SyncEngine.commChanges$ to output frame bridge",
+    nextFixture:
+      "Add a typed fixture script for append, update, clear, and nested widget-view MIME messages so replay remains deterministic.",
+  },
+  {
+    adapter: "Kernel-originated AnyWidget assets",
+    catalogPath: "same-origin public fixture URLs",
+    productionBoundary: "daemon blob resolver and frameDomains policy",
+    nextFixture:
+      "Add a resolver fixture that turns kernel asset references into allowed iframe URLs without importing host runtime policy.",
+  },
+  {
+    adapter: "Production widget blob lifecycle",
+    catalogPath: "docs-local uploader and inert ContentRefs",
+    productionBoundary: "daemon blob URL signing and cleanup lifecycle",
+    nextFixture:
+      "Add fixture lifecycle states for pending, resolved, stale, and revoked blobs before cataloging host resolver UI.",
   },
 ];
 
@@ -1805,13 +1829,51 @@ export function WidgetSurfacesExample() {
       <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
         <div className="flex items-start gap-3">
           <CircleDotDashed className="mt-0.5 size-4 flex-none text-amber-600" aria-hidden="true" />
-          <div>
+          <div className="min-w-0 flex-1">
             <h2 className="text-sm font-semibold">Next widget adapters</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               The remaining widget catalog work is narrower now: live captured-output comm
               transport, kernel-originated anywidget asset URLs, and production daemon blob resolver
               lifecycle need explicit iframe/runtime adapters before they can render here.
             </p>
+            <div className="mt-4 overflow-hidden rounded-md border border-amber-500/25 bg-fd-card/70">
+              <div className="hidden grid-cols-[190px_210px_230px_minmax(0,1fr)] gap-3 border-b border-amber-500/20 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
+                <span>Adapter</span>
+                <span>Catalog path</span>
+                <span>Production boundary</span>
+                <span>Next fixture</span>
+              </div>
+              {nextWidgetAdapters.map((row) => (
+                <div
+                  key={row.adapter}
+                  className="grid gap-2 border-b border-amber-500/20 px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_210px_230px_minmax(0,1fr)] xl:gap-3"
+                >
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                      Adapter
+                    </div>
+                    <div className="font-semibold">{row.adapter}</div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                      Catalog path
+                    </div>
+                    <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
+                      {row.catalogPath}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
+                      Production boundary
+                    </div>
+                    <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
+                      {row.productionBoundary}
+                    </div>
+                  </div>
+                  <p className="leading-5 text-fd-muted-foreground">{row.nextFixture}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -1418,8 +1418,8 @@ function WidgetPersistenceFixture() {
 function ControllerPollingFixture() {
   const [frame, setFrame] = useState(1);
   const frameRef = useRef(frame);
-  const [mockReady, setMockReady] = useState(false);
-  const [mockError, setMockError] = useState<string | null>(null);
+  const [gamepadFixtureReady, setGamepadFixtureReady] = useState(false);
+  const [gamepadFixtureError, setGamepadFixtureError] = useState<string | null>(null);
 
   useEffect(() => {
     frameRef.current = frame;
@@ -1434,11 +1434,13 @@ function ControllerPollingFixture() {
         configurable: true,
         value: () => [fixtureGamepad(frameRef.current), null, null, null],
       });
-      setMockReady(true);
-      setMockError(null);
+      setGamepadFixtureReady(true);
+      setGamepadFixtureError(null);
     } catch (error) {
-      setMockReady(false);
-      setMockError(error instanceof Error ? error.message : "Gamepad API fixture unavailable");
+      setGamepadFixtureReady(false);
+      setGamepadFixtureError(
+        error instanceof Error ? error.message : "Gamepad API fixture unavailable",
+      );
     }
 
     return () => {
@@ -1469,11 +1471,11 @@ function ControllerPollingFixture() {
         </Button>
       </div>
       <div className="rounded-md border border-fd-border bg-fd-background p-3">
-        {mockReady ? (
+        {gamepadFixtureReady ? (
           <WidgetView modelId="widget-controller" />
         ) : (
           <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-fd-muted-foreground">
-            Gamepad fixture unavailable{mockError ? `: ${mockError}` : "."}
+            Gamepad fixture unavailable{gamepadFixtureError ? `: ${gamepadFixtureError}` : "."}
           </div>
         )}
       </div>

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -16,10 +16,13 @@ helpers.
 ## Full cell surfaces
 
 The next cell slice imports the notebook app cell components directly and feeds
-them fixture state through the same stores they use in the desktop app. The
-rendered boundary map makes the split explicit: catalog fixtures seed cell,
-execution, output, focus, and CRDT-provider state, while notebook document
-projection, kernel execution, iframe bootstrap, and Automerge sync remain
+them fixture state through the same stores they use in the desktop app. It also
+mounts the production `NotebookView` workspace shell with local visual order so
+stable DOM ordering, hidden-cell grouping, cell adders, and navigation chrome
+are visible without opening a notebook document. The rendered boundary map makes
+the split explicit: catalog fixtures seed cell, execution, output, focus,
+CRDT-provider state, and local order, while notebook document projection, kernel
+execution, iframe bootstrap, DnD persistence, and Automerge sync remain
 production boundaries.
 
 <FullCellSurfacesClient />
@@ -39,9 +42,10 @@ a fixture presence snapshot, without connecting runtimed or generated WASM.
 The full `MarkdownCell` fixture now starts in preview mode and sends its
 `text/markdown` payload through the docs `IsolatedFrame` adapter, keeping the
 production component path visible while the runtime iframe bundle stays outside
-the catalog. Full cell entries should use the same rule: import production cell
-components, then isolate any notebook document, runtime, sync, or iframe
-responsibility behind a named fixture adapter.
+the catalog. The `NotebookView` fixture uses the same rule at the workspace
+level: import the production shell first, then keep order mutation, notebook
+documents, runtime, sync, and iframe responsibilities behind named fixture
+adapters.
 
 Unused legacy cell helper components should be removed rather than cataloged.
 Catalog entries need to trace to notebook app usage, an active migration target,

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -36,6 +36,8 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Cell anatomy](/docs/cell-anatomy)
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
+- [Package manager surfaces](/docs/package-manager-surfaces)
+- [Search surfaces](/docs/search-surfaces)
 - [Output renderers](/docs/output-renderers)
 - [Output isolation surfaces](/docs/isolated-output-surfaces)
 - [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -10,9 +10,11 @@ contents. It keeps reading navigation available while leaving clear sibling
 slots for packages, variables, renderers, and future notebook tools.
 
 This fixture now renders the current notebook app toolbar and shared
-`NotebookRail` directly. The package panel is supplied through
-`NotebookPackagesPanel` and hosts the current `DependencyHeader` with static
-dependency state.
+`NotebookRail` directly. The outline is projected with the same
+`projectNotebookOutline` helper production uses, then fed `outlineCellIds` so a
+focused code cell resolves to the nearest preceding heading. The package panel
+is supplied through `NotebookPackagesPanel` and hosts the current
+`DependencyHeader` with static dependency state.
 
 <RailOutlineExample />
 
@@ -27,7 +29,16 @@ dependency state.
   outline selection, and inert navigation callbacks.
 - The package panel imports `DependencyHeader` from the notebook app with
   fixture dependency and sync state.
-- The outline should start from materialized markdown headings.
+- The outline starts from `projectNotebookOutline` over fixture cells, matching
+  the production projection path from materialized markdown headings.
+- Contextual selection depends on `outlineCellIds`: a focused code cell inside a
+  section highlights the nearest preceding markdown heading.
+- Production active-section tracking still belongs to the app shell through
+  viewport observation and `resolveNotebookOutlineSelection`; this page only
+  fixtures the active item.
+- Heading navigation remains app-owned. Production routes heading anchors
+  through `navigateMarkdownHeading`, `scrollIntoView`, and history replacement;
+  the catalog keeps the callback inert.
 - Keep the rail icon-led. The current shared rail exposes outline and packages;
   variables, renderers, and future side panels are tracked as planned sibling
   panels until the app has current components for them.

--- a/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
+++ b/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
@@ -16,4 +16,7 @@ surface without importing daemon hooks or notebook state.
 
 Toolbar previews own only props and callbacks. Kernel start, interrupt, restart,
 dependency toggles, update restarts, and cell insertion stay inert in the docs
-app until a host adapter is deliberately introduced.
+app until a host adapter is deliberately introduced. The rendered boundary map
+keeps runtime status projection, kernel actions, dependency drawer state, cell
+insertion, and desktop update restart behavior named separately so future
+toolbar work can move one adapter at a time.

--- a/apps/elements/content/docs/output-renderers.mdx
+++ b/apps/elements/content/docs/output-renderers.mdx
@@ -29,7 +29,10 @@ fixture-backed `WidgetStore`, matching the notebook app's widget MIME handoff
 without booting a live comm bridge. The plugin renderer examples use docs-local
 fixture globals for Plotly, `vegaEmbed`, and Leaflet, so they exercise the
 current nteract components without bundling third-party renderer libraries into
-the catalog. The Sift section fetches the same kind of public HuggingFace
+the catalog. Math output is rendered by the production `MathOutput` component,
+which imports KaTeX CSS itself; markdown math follows the same stylesheet
+ownership but must stay inside the isolated markdown frame because markdown can
+carry raw HTML. The Sift section fetches the same kind of public HuggingFace
 Parquet URL used by the Sift demo, then lets `SiftTable` detect and decode it
 through the docs static WASM asset; the Arrow manifest section points at a
 static Arrow IPC chunk and exercises `create_arrow_stream_store` /
@@ -38,6 +41,9 @@ helper the notebook uses before rendering. The renderer boundary map separates
 direct component rendering from docs fixture adapters and production-only
 execution paths, so JavaScript execution and third-party renderer library
 execution stay visible as adapter boundaries rather than silent catalog behavior.
+The stylesheet boundary map keeps renderer-specific CSS attached to the relevant
+output component or plugin asset path instead of promoting it to global docs
+styling.
 
 ## What still needs an adapter
 
@@ -53,4 +59,7 @@ behind the isolated-frame adapter. The Sift Parquet URL path now has a
 docs-owned static WASM asset, and the Arrow stream manifest path now runs
 through a docs-served Arrow IPC chunk. The widget catalog covers local
 `OutputModel` replay through `WidgetStore`; the remaining output-widget boundary
-is the live kernel capture and comm transport.
+is the live kernel capture and comm transport. Hosted output-frame behavior is
+documented on the isolation page: MCP hosts only use the daemon `/output-frame`
+document when `frameDomains` allows the daemon blob origin, and renderer plugin
+CSS is fetched beside daemon plugin JavaScript rather than from this docs shell.

--- a/apps/elements/content/docs/package-manager-surfaces.mdx
+++ b/apps/elements/content/docs/package-manager-surfaces.mdx
@@ -17,6 +17,7 @@ environment solve.
 - The packages rail should become the notebook home for these manager-specific
   panels.
 - The catalog should keep using existing notebook components, not parallel
-  package-manager mockups.
+  package-manager replicas.
 - Live metadata mutation, trust re-signing, daemon sync, and environment rebuilds
-  stay behind app adapters.
+  stay behind app adapters. The rendered boundary map names those splits so new
+  package surfaces can enter through fixtures before runtime wiring.

--- a/apps/elements/content/docs/runtime-surfaces.mdx
+++ b/apps/elements/content/docs/runtime-surfaces.mdx
@@ -15,4 +15,7 @@ surfaces with fixtures instead of live runtime state.
 
 The current fixtures keep side effects inert. Components that need desktop host
 access, such as the pool settings action, render under a small fixture host
-adapter instead of importing notebook shell state into the docs app.
+adapter instead of importing notebook shell state into the docs app. The adapter
+boundary table names the split between deterministic catalog data, host actions,
+runtime side effects, and live dependency/trust documents before new runtime
+surfaces are marked rendered.

--- a/apps/elements/content/docs/search-surfaces.mdx
+++ b/apps/elements/content/docs/search-surfaces.mdx
@@ -17,4 +17,7 @@ dialog with static notebook text and a docs-local host adapter.
 still uses the real `useHistorySearch` hook, but the docs app supplies a
 `NotebookHost` transport that only answers `get_history` requests with static
 entries. The catalog does not start a daemon, sync a notebook, or import
-generated WASM to render these search surfaces.
+generated WASM to render these search surfaces. The rendered boundary map keeps
+the live search projection, history transport, selection handoff, and match
+navigation responsibilities visible before any future adapter wiring moves them
+closer to production behavior.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -35,7 +35,8 @@ catalog covers the `OutputWidget` state-update path without opening a live comm
 channel. The widget boundary map separates the catalog's deterministic
 `WidgetStore`, `WidgetUpdateManager`, media buffer, and anywidget asset fixtures
 from the production RuntimeStateDoc, live comm bridge, daemon blob resolver, and
-kernel-originated asset paths.
+kernel-originated asset paths. The remaining work is listed as named next
+adapter rows so the catalog keeps runtime gaps explicit and reviewable.
 
 <WidgetSurfacesExample />
 

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -7,6 +7,8 @@
     "jsx": "preserve",
     "paths": {
       "@/components/cell/*": ["../../src/components/cell/*"],
+      "@/bindings": ["../../src/bindings/index.ts"],
+      "@/bindings/*": ["../../src/bindings/*"],
       "@/components/editor/*": ["../../src/components/editor/*"],
       "@/components/isolated": ["./components/isolated/index.tsx"],
       "@/components/isolated/iframe-libraries": [
@@ -18,6 +20,7 @@
       "@/components/outputs/*": ["../../src/components/outputs/*"],
       "@/components/ui/*": ["../../src/components/ui/*"],
       "@/components/widgets/*": ["../../src/components/widgets/*"],
+      "@/hooks/*": ["../../src/hooks/*"],
       "@/lib/dark-mode": ["../../src/lib/dark-mode"],
       "@/lib/error-boundary": ["../../src/lib/error-boundary"],
       "@/lib/highlight-text": ["../../src/lib/highlight-text"],


### PR DESCRIPTION
## Summary

- keep today's `apps/elements` work on one consolidation PR
- document output renderer stylesheet ownership for MathOutput, markdown math, and renderer plugin CSS
- add the existing package-manager and search surfaces to the catalog landing/index entrypoints
- add named next-adapter rows for the remaining widget runtime boundaries
- add runtime adapter rows for host actions, side effects, and live dependency/trust state
- add package-manager adapter rows and remove stale mockup/schematic catalog wording
- add search adapter rows for live find projection, daemon history transport, focused-editor insertion, and active match navigation
- add toolbar adapter rows for runtime status projection, kernel actions, dependency drawer state, cell insertion, and desktop update restarts
- update the notebook outline rail fixture to use `projectNotebookOutline`, `outlineCellIds`, and contextual selection like the production rail
- render the production `NotebookView` shell inside the cell anatomy/full-cell fixture with seeded stores and local order callbacks
- keep the catalog runtime-free by distinguishing component-owned CSS, search/package/widget fixture adapters, docs shell styling, and daemon/plugin routes

## Verification

- `pnpm elements:build`
- browser smoke on `/docs/output-renderers` for the stylesheet boundary section and KaTeX computed styles
- browser smoke on `/` and `/docs` for package/search entrypoint links
- browser smoke on `/docs/widget-surfaces` for the named widget adapter rows and absence of `adapter needed`
- browser smoke on `/docs/runtime-surfaces` for the runtime adapter rows and absence of stale boundary text
- browser smoke on `/docs/package-manager-surfaces`, `/docs/cell-anatomy`, and `/docs/widget-surfaces` for package boundary rows and absence of stale mockup/schematic wording
- browser smoke on `/docs/search-surfaces` for the search adapter rows and history dialog fixture host
- browser smoke on `/docs/notebook-toolbar-surfaces` for the toolbar adapter rows and current NotebookToolbar fixture states
- browser smoke on `/docs/notebook-outline` for contextual outline selection and the outline adapter boundary
- bounded headless Chrome DOM smoke on `/docs/cell-anatomy` for the rendered `NotebookView` fixture, seeded output, and four-cell workspace shell
- `cargo xtask lint --fix`

## Notes

- Draft while more catalog-only commits, `pr-reviewer`, and full CI are pending.
- Merge should stay with Kyle unless explicitly delegated after local verification, review, and full CI are green.
