### PR TITLE
refactor(notebook-cloud): share editable markdown cell shell

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -6,18 +6,24 @@ test("cloud editable markdown cells use shared cell and output rendering surface
   const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /import \{ CellContainer \} from "@\/components\/cell\/CellContainer";/);
-  assert.match(sourceText, /import \{ OutputArea \} from "@\/components\/cell\/OutputArea";/);
-  assert.match(sourceText, /<CellContainer/);
-  assert.match(sourceText, /<OutputArea/);
-  assert.match(sourceText, /isolated="auto"/);
+  assert.match(
+    sourceText,
+    /import \{ EditableMarkdownCell as SharedEditableMarkdownCell \} from "@\/components\/cell\/EditableMarkdownCell";/,
+  );
+  assert.match(sourceText, /<SharedEditableMarkdownCell/);
   assert.match(sourceText, /priority=\{priority\}/);
   assert.match(sourceText, /hostContext=\{hostContext\}/);
-  assert.match(sourceText, /<CodeMirrorEditor/);
+  assert.match(sourceText, /editorExtensions=\{extensions\}/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/cell\/CellContainer"/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/cell\/OutputArea"/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/editor\/codemirror-editor"/);
 });
 
 test("cloud markdown edit toggle avoids blur and stale-source races", () => {
-  const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
+  const sourcePath = new URL(
+    "../../../src/components/cell/EditableMarkdownCell.tsx",
+    import.meta.url,
+  );
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /editorRef\.current\?\.getEditor\(\)\?\.state\.doc\.toString\(\)/);

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -1,18 +1,5 @@
-import { Check, Pencil } from "lucide-react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-  type MouseEvent,
-} from "react";
-import { CellContainer } from "@/components/cell/CellContainer";
-import { OutputArea } from "@/components/cell/OutputArea";
-import type { JupyterOutput } from "@/components/cell/jupyter-output";
-import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { EditableMarkdownCell as SharedEditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import {
   remoteCursorsExtension,
@@ -21,7 +8,6 @@ import {
 } from "@/components/editor/remote-cursors";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
-import { cn } from "@/lib/utils";
 import {
   createCrdtBridge,
   remoteChangesFromTextAttributions,
@@ -79,7 +65,6 @@ export function EditableMarkdownCell({
 }: EditableMarkdownCellProps) {
   const [editing, setEditing] = useState(cell.source.trim().length === 0);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
-  const suppressNextToggleClickRef = useRef(false);
   const getHandleRef = useRef(getHandle);
   const onSourceChangeRef = useRef(onSourceChange);
   const onSyncNeededRef = useRef(onSyncNeeded);
@@ -116,63 +101,6 @@ export function EditableMarkdownCell({
     return editorExtensions;
   }, [bridge.extension, cell.id, onPresenceCursor, onPresenceSelection]);
 
-  const markdownOutput = useMemo<JupyterOutput>(
-    () => ({
-      output_id: `markdown-source:${cell.id}`,
-      output_type: "display_data",
-      data: { "text/markdown": cell.source },
-      metadata: {},
-    }),
-    [cell.id, cell.source],
-  );
-
-  const enterEditing = useCallback(() => {
-    setEditing(true);
-  }, []);
-
-  const exitEditing = useCallback(() => {
-    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? cell.source;
-    if (currentSource.trim().length > 0) {
-      setEditing(false);
-    }
-  }, [cell.source]);
-
-  const handleActionMouseDown = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      if (!editing) return;
-      event.preventDefault();
-      suppressNextToggleClickRef.current = true;
-      exitEditing();
-    },
-    [editing, exitEditing],
-  );
-
-  const handleActionClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      if (suppressNextToggleClickRef.current) {
-        suppressNextToggleClickRef.current = false;
-        event.preventDefault();
-        return;
-      }
-      if (editing) {
-        exitEditing();
-      } else {
-        enterEditing();
-      }
-    },
-    [editing, enterEditing, exitEditing],
-  );
-
-  const handlePreviewKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
-        event.preventDefault();
-        enterEditing();
-      }
-    },
-    [enterEditing],
-  );
-
   useLayoutEffect(() => {
     if (!textAttributionQueue) return;
 
@@ -201,14 +129,6 @@ export function EditableMarkdownCell({
   }, [cell.source, editing]);
 
   useEffect(() => {
-    if (!editing) return;
-    const frame = requestAnimationFrame(() => {
-      editorRef.current?.focus();
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [editing]);
-
-  useEffect(() => {
     const view = editorRef.current?.getEditor();
     if (!view) return;
     setRemoteCursors(view, remotePresence?.cursors ?? []);
@@ -216,58 +136,22 @@ export function EditableMarkdownCell({
   }, [editing, remotePresence]);
 
   return (
-    <CellContainer
+    <SharedEditableMarkdownCell
       id={cell.id}
-      cellType="markdown"
+      source={cell.source}
+      editing={editing}
+      onEditingChange={setEditing}
+      editorRef={editorRef}
       className={className}
+      sourceClassName={sourceClassName}
+      editorClassName="cloud-markdown-editor"
+      previewClassName="cloud-markdown-preview"
+      previewOutputClassName="cloud-markdown-preview-output"
+      actionClassName="cloud-markdown-cell-action"
+      priority={priority}
+      hostContext={hostContext}
+      editorExtensions={extensions}
       presenceIndicators={<CloudMarkdownPresenceIndicators presence={remotePresence} />}
-      rightGutterContent={
-        <button
-          type="button"
-          className="cloud-markdown-cell-action"
-          aria-label={editing ? "Render markdown" : "Edit markdown"}
-          title={editing ? "Render markdown" : "Edit markdown"}
-          onMouseDown={handleActionMouseDown}
-          onClick={handleActionClick}
-        >
-          {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
-        </button>
-      }
-      codeContent={
-        editing ? (
-          <div className={sourceClassName} data-slot="cloud-editable-markdown-source">
-            <CodeMirrorEditor
-              ref={editorRef}
-              initialValue={cell.source}
-              language="markdown"
-              lineWrapping
-              onBlur={exitEditing}
-              extensions={extensions}
-              placeholder="Markdown"
-              className="cloud-markdown-editor min-h-[2rem]"
-            />
-          </div>
-        ) : (
-          <div
-            className={cn("cloud-markdown-preview", sourceClassName)}
-            data-slot="cloud-editable-markdown-preview"
-            role="textbox"
-            aria-readonly
-            tabIndex={0}
-            onDoubleClick={enterEditing}
-            onKeyDown={handlePreviewKeyDown}
-          >
-            <OutputArea
-              cellId={cell.id}
-              outputs={[markdownOutput]}
-              isolated="auto"
-              priority={priority}
-              hostContext={hostContext}
-              className="cloud-markdown-preview-output"
-            />
-          </div>
-        )
-      }
     />
   );
 }

--- a/src/components/cell/EditableMarkdownCell.tsx
+++ b/src/components/cell/EditableMarkdownCell.tsx
@@ -1,0 +1,191 @@
+import { type Extension } from "@codemirror/state";
+import { type KeyBinding } from "@codemirror/view";
+import { Check, Pencil } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { cn } from "@/lib/utils";
+import { CellContainer } from "./CellContainer";
+import { OutputArea } from "./OutputArea";
+import type { JupyterOutput } from "./jupyter-output";
+
+export interface EditableMarkdownCellProps {
+  id: string;
+  source: string;
+  editing: boolean;
+  onEditingChange: (editing: boolean) => void;
+  editorRef: RefObject<CodeMirrorEditorRef | null>;
+  className?: string;
+  sourceClassName?: string;
+  editorClassName?: string;
+  previewClassName?: string;
+  previewOutputClassName?: string;
+  actionClassName?: string;
+  placeholder?: string;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  editorExtensions?: readonly Extension[];
+  editorKeyMap?: readonly KeyBinding[];
+  presenceIndicators?: ReactNode;
+}
+
+export function EditableMarkdownCell({
+  id,
+  source,
+  editing,
+  onEditingChange,
+  editorRef,
+  className,
+  sourceClassName,
+  editorClassName,
+  previewClassName,
+  previewOutputClassName,
+  actionClassName,
+  placeholder = "Markdown",
+  priority,
+  hostContext,
+  editorExtensions,
+  editorKeyMap,
+  presenceIndicators,
+}: EditableMarkdownCellProps) {
+  const suppressNextToggleClickRef = useRef(false);
+
+  const markdownOutput = useMemo<JupyterOutput>(
+    () => ({
+      output_id: `markdown-source:${id}`,
+      output_type: "display_data",
+      data: { "text/markdown": source },
+      metadata: {},
+    }),
+    [id, source],
+  );
+  const editorExtensionArray = useMemo(
+    () => (editorExtensions ? [...editorExtensions] : undefined),
+    [editorExtensions],
+  );
+  const editorKeyMapArray = useMemo(
+    () => (editorKeyMap ? [...editorKeyMap] : undefined),
+    [editorKeyMap],
+  );
+
+  const enterEditing = useCallback(() => {
+    onEditingChange(true);
+  }, [onEditingChange]);
+
+  const exitEditing = useCallback(() => {
+    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? source;
+    if (currentSource.trim().length > 0) {
+      onEditingChange(false);
+    }
+  }, [editorRef, onEditingChange, source]);
+
+  const handleActionMouseDown = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (!editing) return;
+      event.preventDefault();
+      suppressNextToggleClickRef.current = true;
+      exitEditing();
+    },
+    [editing, exitEditing],
+  );
+
+  const handleActionClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (suppressNextToggleClickRef.current) {
+        suppressNextToggleClickRef.current = false;
+        event.preventDefault();
+        return;
+      }
+      if (editing) {
+        exitEditing();
+      } else {
+        enterEditing();
+      }
+    },
+    [editing, enterEditing, exitEditing],
+  );
+
+  const handlePreviewKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
+        event.preventDefault();
+        enterEditing();
+      }
+    },
+    [enterEditing],
+  );
+
+  useEffect(() => {
+    if (!editing) return;
+    const frame = requestAnimationFrame(() => {
+      editorRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editing, editorRef]);
+
+  return (
+    <CellContainer
+      id={id}
+      cellType="markdown"
+      className={className}
+      presenceIndicators={presenceIndicators}
+      rightGutterContent={
+        <button
+          type="button"
+          className={actionClassName}
+          aria-label={editing ? "Render markdown" : "Edit markdown"}
+          title={editing ? "Render markdown" : "Edit markdown"}
+          onMouseDown={handleActionMouseDown}
+          onClick={handleActionClick}
+        >
+          {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+        </button>
+      }
+      codeContent={
+        editing ? (
+          <div className={sourceClassName} data-slot="editable-markdown-source">
+            <CodeMirrorEditor
+              ref={editorRef}
+              initialValue={source}
+              language="markdown"
+              lineWrapping
+              onBlur={exitEditing}
+              keyMap={editorKeyMapArray}
+              extensions={editorExtensionArray}
+              placeholder={placeholder}
+              className={cn("min-h-[2rem]", editorClassName)}
+            />
+          </div>
+        ) : (
+          <div
+            className={cn(previewClassName, sourceClassName)}
+            data-slot="editable-markdown-preview"
+            role="textbox"
+            aria-readonly
+            tabIndex={0}
+            onDoubleClick={enterEditing}
+            onKeyDown={handlePreviewKeyDown}
+          >
+            <OutputArea
+              cellId={id}
+              outputs={[markdownOutput]}
+              isolated="auto"
+              priority={priority}
+              hostContext={hostContext}
+              className={previewOutputClassName}
+            />
+          </div>
+        )
+      }
+    />
+  );
+}

--- a/src/components/cell/__tests__/EditableMarkdownCell.test.tsx
+++ b/src/components/cell/__tests__/EditableMarkdownCell.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { forwardRef, useImperativeHandle, useRef } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { EditableMarkdownCell } from "../EditableMarkdownCell";
+import type { CodeMirrorEditorRef } from "@/components/editor";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+
+const outputAreaCalls = vi.hoisted(() => ({
+  props: [] as Array<{
+    cellId?: string;
+    className?: string;
+    hostContext?: unknown;
+    priority?: readonly string[];
+    outputs: Array<{ data?: Record<string, unknown>; output_type?: string }>;
+  }>,
+}));
+
+vi.mock("@/components/cell/OutputArea", () => ({
+  OutputArea: (props: {
+    cellId?: string;
+    className?: string;
+    hostContext?: unknown;
+    priority?: readonly string[];
+    outputs: Array<{ data?: Record<string, unknown>; output_type?: string }>;
+  }) => {
+    outputAreaCalls.props.push(props);
+    return (
+      <div
+        data-cell-id={props.cellId}
+        data-class-name={props.className ?? ""}
+        data-host-context={JSON.stringify(props.hostContext ?? null)}
+        data-mimes={Object.keys(props.outputs[0]?.data ?? {}).join(",")}
+        data-priority={props.priority?.join(",") ?? ""}
+        data-testid="output-area"
+      />
+    );
+  },
+}));
+
+vi.mock("@/components/editor/codemirror-editor", () => ({
+  CodeMirrorEditor: forwardRef<
+    CodeMirrorEditorRef,
+    {
+      className?: string;
+      initialValue?: string;
+      onBlur?: () => void;
+      placeholder?: string;
+    }
+  >(function MockCodeMirrorEditor({ className, initialValue = "", onBlur, placeholder }, ref) {
+    useImperativeHandle(ref, () => ({
+      focus: vi.fn(),
+      setCursorPosition: vi.fn(),
+      getEditor: () =>
+        ({
+          state: {
+            doc: {
+              toString: () => initialValue,
+            },
+          },
+        }) as ReturnType<CodeMirrorEditorRef["getEditor"]>,
+    }));
+
+    return (
+      <textarea
+        className={className}
+        data-testid="codemirror-editor"
+        onBlur={onBlur}
+        placeholder={placeholder}
+        readOnly
+        value={initialValue}
+      />
+    );
+  }),
+}));
+
+describe("EditableMarkdownCell", () => {
+  it("renders markdown preview through the shared output surface", () => {
+    render(
+      <Harness
+        id="markdown-1"
+        source="## Shared"
+        editing={false}
+        onEditingChange={() => undefined}
+        priority={["text/markdown", "text/plain"]}
+        hostContext={{
+          nteract: {
+            rendererAssetsBaseUrl: "https://assets.example.test/renderer-assets/",
+          },
+        }}
+        previewClassName="preview"
+        previewOutputClassName="preview-output"
+      />,
+    );
+
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "markdown-1");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-mimes", "text/markdown");
+    expect(screen.getByTestId("output-area")).toHaveAttribute(
+      "data-priority",
+      "text/markdown,text/plain",
+    );
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-class-name", "preview-output");
+    expect(screen.getByTestId("output-area").getAttribute("data-host-context")).toContain(
+      "https://assets.example.test/renderer-assets/",
+    );
+    expect(outputAreaCalls.props.at(-1)?.outputs[0]?.data?.["text/markdown"]).toBe("## Shared");
+  });
+
+  it("enters edit mode from the preview", () => {
+    const onEditingChange = vi.fn();
+
+    render(
+      <Harness
+        id="markdown-2"
+        source="## Editable"
+        editing={false}
+        onEditingChange={onEditingChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit markdown" }));
+
+    expect(onEditingChange).toHaveBeenCalledWith(true);
+  });
+
+  it("exits edit mode using the current editor source", () => {
+    const onEditingChange = vi.fn();
+
+    render(
+      <Harness id="markdown-3" source="## Current" editing onEditingChange={onEditingChange} />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Render markdown" }));
+
+    expect(onEditingChange).toHaveBeenCalledWith(false);
+  });
+});
+
+function Harness({
+  id,
+  source,
+  editing,
+  onEditingChange,
+  priority,
+  hostContext,
+  previewClassName,
+  previewOutputClassName,
+}: {
+  id: string;
+  source: string;
+  editing: boolean;
+  onEditingChange: (editing: boolean) => void;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  previewClassName?: string;
+  previewOutputClassName?: string;
+}) {
+  const editorRef = useRef<CodeMirrorEditorRef>(null);
+
+  return (
+    <EditableMarkdownCell
+      id={id}
+      source={source}
+      editing={editing}
+      onEditingChange={onEditingChange}
+      editorRef={editorRef}
+      priority={priority}
+      hostContext={hostContext}
+      previewClassName={previewClassName}
+      previewOutputClassName={previewOutputClassName}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- extract the generic editable markdown cell shell into `src/components/cell/EditableMarkdownCell`
- keep the cloud markdown cell as the CRDT/presence/render-policy adapter
- add shared component coverage plus cloud guardrails that prevent the adapter from re-owning cell/output/editor chrome

## Stack

Depends on #3188 (`quod/notebook-cloud-presence-profiles`), which depends on #3184.

Merge order:
1. #3184
2. #3188
3. this PR

## Verification

- `pnpm exec vp test run src/components/cell/__tests__/EditableMarkdownCell.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

This is intentionally a small convergence slice. It does not try to transplant the full desktop markdown cell yet; it moves the reusable edit/preview shell first so cloud-specific sync and auth behavior stays outside the shared component.
