### PR TITLE
fix(notebook-cloud): allow canonical schema seed sync

### DIFF
--- a/crates/notebook-doc/src/diff.rs
+++ b/crates/notebook-doc/src/diff.rs
@@ -445,6 +445,31 @@ pub fn extract_change_actors(doc: &mut AutoCommit, before: &[ChangeHash]) -> Vec
     actors.into_iter().collect()
 }
 
+/// Actor label and hash for a change introduced after a baseline head set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeActor {
+    pub actor_label: String,
+    pub hash: ChangeHash,
+}
+
+/// Extract actor labels and hashes from the changes between a baseline and
+/// the document's current heads.
+///
+/// Use this when authorization needs to distinguish the canonical schema seed
+/// change from arbitrary writes under the same actor label.
+pub fn extract_change_actor_hashes(
+    doc: &mut AutoCommit,
+    before: &[ChangeHash],
+) -> Vec<ChangeActor> {
+    doc.get_changes(before)
+        .into_iter()
+        .map(|change| ChangeActor {
+            actor_label: crate::actor_label_from_id(change.actor_id()),
+            hash: change.hash(),
+        })
+        .collect()
+}
+
 /// Merge two changesets (e.g., when coalescing multiple sync frames).
 ///
 /// Used by the frontend's `scheduleMaterialize` to accumulate changes across

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -78,7 +78,6 @@ pub const SCHEMA_VERSION: u64 = 5;
 /// This actor authors only the shared root skeleton. Peers load that same
 /// history and then switch to their real actor before writing notebook-specific
 /// content. Do not reuse this actor for live peer edits.
-#[cfg(test)]
 const SCHEMA_SEED_ACTOR: &str = "nteract:notebook-schema:v5";
 // Frozen Automerge genesis document for notebook schema v5.
 // This shared root skeleton lets fresh clients create cells immediately while
@@ -2272,6 +2271,37 @@ impl NotebookDoc {
         seen.into_iter().collect()
     }
 
+    /// Return the canonical schema seed change hashes embedded in this build.
+    pub fn canonical_schema_seed_change_hashes() -> Vec<automerge::ChangeHash> {
+        static SEED_HASHES: std::sync::OnceLock<Vec<automerge::ChangeHash>> =
+            std::sync::OnceLock::new();
+
+        SEED_HASHES
+            .get_or_init(|| {
+                Self::schema_seed_doc(TextEncoding::UnicodeCodePoint)
+                    .get_changes(&[])
+                    .into_iter()
+                    .map(|change| change.hash())
+                    .collect()
+            })
+            .clone()
+    }
+
+    /// True when an actor/hash pair is the frozen schema seed change.
+    ///
+    /// Room hosts use this as a narrow authorization exception: the seed actor
+    /// is allowed to converge canonical root objects, but only for the exact
+    /// change hashes embedded in the genesis asset.
+    pub fn is_canonical_schema_seed_change(
+        actor_label: &str,
+        hash: &automerge::ChangeHash,
+    ) -> bool {
+        actor_label == SCHEMA_SEED_ACTOR
+            && Self::canonical_schema_seed_change_hashes()
+                .iter()
+                .any(|seed_hash| seed_hash == hash)
+    }
+
     #[cfg(test)]
     fn change_hashes_for_actor(&mut self, actor_label: &str) -> Vec<automerge::ChangeHash> {
         self.doc
@@ -3029,6 +3059,24 @@ mod tests {
             generated.get_metadata_snapshot(),
             frozen.get_metadata_snapshot()
         );
+    }
+
+    #[test]
+    fn canonical_schema_seed_change_is_hash_bound() {
+        let hashes = NotebookDoc::canonical_schema_seed_change_hashes();
+        assert_eq!(hashes.len(), 1);
+        assert!(NotebookDoc::is_canonical_schema_seed_change(
+            SCHEMA_SEED_ACTOR,
+            &hashes[0]
+        ));
+        assert!(!NotebookDoc::is_canonical_schema_seed_change(
+            SCHEMA_SEED_ACTOR,
+            &automerge::ChangeHash([1; 32])
+        ));
+        assert!(!NotebookDoc::is_canonical_schema_seed_change(
+            "user:dev:alice/desktop:a",
+            &hashes[0]
+        ));
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -10,7 +10,10 @@
 
 use automerge::sync;
 use automerge::sync::SyncDoc;
-use notebook_doc::diff::{diff_doc, extract_change_actors, CellChangeset, TextPatch};
+use notebook_doc::diff::{
+    diff_doc, extract_change_actor_hashes, extract_change_actors, CellChangeset, ChangeActor,
+    TextPatch,
+};
 use notebook_doc::mime::{is_binary_mime, ResolvedContentRef};
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
@@ -606,10 +609,10 @@ impl RoomHostHandle {
                     "cloud-room-doc-auth-preview",
                 )
                 .map_err(|e| JsError::new(&format!("notebook auth preview failed: {e}")))?;
-            let actors = extract_change_actors(preview.doc_mut(), &heads_before);
-            validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+            let actors = extract_change_actor_hashes(preview.doc_mut(), &heads_before);
+            validate_room_notebook_change_actors(principal, actors.iter())?;
             if !can_write_all_notebook_changes {
-                validate_markdown_source_only_changes(&mut preview, &heads_before)?;
+                validate_markdown_source_only_changes(&mut preview, &heads_before, actors.iter())?;
             }
         }
 
@@ -855,12 +858,61 @@ fn validate_room_actor_labels<'a>(
     Ok(())
 }
 
-fn validate_markdown_source_only_changes(
+fn validate_room_notebook_change_actors<'a>(
+    principal: &str,
+    changes: impl IntoIterator<Item = &'a ChangeActor>,
+) -> Result<(), JsError> {
+    validate_room_notebook_change_actors_inner(principal, changes)
+        .map_err(|error| JsError::new(&error))
+}
+
+fn validate_room_notebook_change_actors_inner<'a>(
+    principal: &str,
+    changes: impl IntoIterator<Item = &'a ChangeActor>,
+) -> Result<(), String> {
+    let expected = Principal::new(principal.to_string())
+        .map_err(|e| format!("authenticated principal is invalid: {e}"))?;
+    for change in changes {
+        if NotebookDoc::is_canonical_schema_seed_change(&change.actor_label, &change.hash) {
+            continue;
+        }
+
+        match ActorLabel::parse(change.actor_label.clone()) {
+            Ok(actor) if actor.principal() == expected.as_str() => {}
+            Ok(actor) => {
+                return Err(format!(
+                    "actor principal {} is not authorized for authenticated principal {}",
+                    actor.principal(),
+                    expected
+                ));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "actor label {:?} is invalid: {error}",
+                    change.actor_label
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_markdown_source_only_changes<'a>(
     preview: &mut NotebookDoc,
     heads_before: &[automerge::ChangeHash],
+    allowed_changes: impl IntoIterator<Item = &'a ChangeActor>,
 ) -> Result<(), JsError> {
+    let mut effective_heads_before = heads_before.to_vec();
+    for change in allowed_changes {
+        if NotebookDoc::is_canonical_schema_seed_change(&change.actor_label, &change.hash)
+            && !effective_heads_before.contains(&change.hash)
+        {
+            effective_heads_before.push(change.hash);
+        }
+    }
+
     let heads_after = preview.get_heads();
-    let changeset = diff_doc(preview.doc_mut(), heads_before, &heads_after);
+    let changeset = diff_doc(preview.doc_mut(), &effective_heads_before, &heads_after);
     if changeset.metadata_changed {
         return Err(JsError::new(
             "editor scope cannot change notebook metadata in hosted markdown-only mode",
@@ -3019,6 +3071,59 @@ mod tests {
         val: serde_json::Value,
     ) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
         resolve_comm_state_for_frontend(&val, 1234, true)
+    }
+
+    #[test]
+    fn notebook_actor_validation_accepts_only_the_canonical_schema_seed_hash() {
+        let seed_hash = NotebookDoc::canonical_schema_seed_change_hashes()
+            .into_iter()
+            .next()
+            .expect("seed hash");
+
+        validate_room_notebook_change_actors_inner(
+            "user:dev:alice",
+            [ChangeActor {
+                actor_label: "nteract:notebook-schema:v5".to_string(),
+                hash: seed_hash,
+            }]
+            .iter(),
+        )
+        .expect("canonical seed change is allowed");
+
+        let error = validate_room_notebook_change_actors_inner(
+            "user:dev:alice",
+            [ChangeActor {
+                actor_label: "nteract:notebook-schema:v5".to_string(),
+                hash: automerge::ChangeHash([1; 32]),
+            }]
+            .iter(),
+        )
+        .expect_err("spoofed seed actor must remain rejected");
+
+        assert!(error.contains("actor label"));
+    }
+
+    #[test]
+    fn markdown_only_policy_ignores_canonical_schema_seed_maps() {
+        let seed_hash = NotebookDoc::canonical_schema_seed_change_hashes()
+            .into_iter()
+            .next()
+            .expect("seed hash");
+        let mut preview = NotebookDoc::bootstrap(
+            notebook_doc::TextEncoding::UnicodeCodePoint,
+            "user:dev:alice/desktop:a",
+        );
+
+        validate_markdown_source_only_changes(
+            &mut preview,
+            &[],
+            [ChangeActor {
+                actor_label: "nteract:notebook-schema:v5".to_string(),
+                hash: seed_hash,
+            }]
+            .iter(),
+        )
+        .expect("canonical schema seed maps are not editor metadata edits");
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -1,3 +1,4 @@
+use notebook_doc::diff::ChangeActor;
 use nteract_identity::{
     ActorLabel, AuthenticatedConnection, ConnectionScope, Credential, IdentityProvider,
     LocalPeerCredential, Operator,
@@ -61,23 +62,47 @@ impl RoomConnectionIdentity {
         labels: impl IntoIterator<Item = &'a str>,
     ) -> anyhow::Result<()> {
         for label in labels {
-            match ActorLabel::parse(label.to_string()) {
-                Ok(actor) if actor.principal() == self.auth.principal().as_str() => {}
-                Ok(actor) => anyhow::bail!(
-                    "actor principal {} is not authorized for authenticated principal {}",
-                    actor.principal(),
-                    self.auth.principal()
-                ),
-                Err(nteract_identity::AuthError::ActorLabelMissingDelimiter)
-                    if self
-                        .legacy_operator_actor_policy
-                        .allows_operator_only(&self.auth)
-                        && Operator::new(label.to_string()).is_ok() => {}
-                Err(error) => anyhow::bail!("actor label {label:?} is invalid: {error}"),
-            }
+            self.validate_actor_label(label)?;
         }
 
         Ok(())
+    }
+
+    pub(crate) fn validate_notebook_change_actors<'a>(
+        &self,
+        changes: impl IntoIterator<Item = &'a ChangeActor>,
+    ) -> anyhow::Result<()> {
+        for change in changes {
+            if notebook_doc::NotebookDoc::is_canonical_schema_seed_change(
+                &change.actor_label,
+                &change.hash,
+            ) {
+                continue;
+            }
+            self.validate_actor_label(&change.actor_label)?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_actor_label(&self, label: &str) -> anyhow::Result<()> {
+        match ActorLabel::parse(label.to_string()) {
+            Ok(actor) if actor.principal() == self.auth.principal().as_str() => Ok(()),
+            Ok(actor) => anyhow::bail!(
+                "actor principal {} is not authorized for authenticated principal {}",
+                actor.principal(),
+                self.auth.principal()
+            ),
+            Err(nteract_identity::AuthError::ActorLabelMissingDelimiter)
+                if self
+                    .legacy_operator_actor_policy
+                    .allows_operator_only(&self.auth)
+                    && Operator::new(label.to_string()).is_ok() =>
+            {
+                Ok(())
+            }
+            Err(error) => anyhow::bail!("actor label {label:?} is invalid: {error}"),
+        }
     }
 }
 
@@ -216,6 +241,47 @@ mod tests {
         let error = identity
             .validate_actor_labels(["human:legacy-session"])
             .expect_err("remote rooms must reject legacy operator-only actors");
+
+        assert!(error.to_string().contains("actor label"));
+    }
+
+    #[test]
+    fn non_local_identity_allows_only_canonical_schema_seed_change() {
+        let principal =
+            nteract_identity::Principal::new("user:anaconda:550e".to_string()).expect("principal");
+        let operator = Operator::new("desktop:window-1".to_string()).expect("operator");
+        let auth = AuthenticatedConnection::new(principal, ConnectionScope::Editor);
+        let actor_label = auth.actor_label_for(operator.clone()).expect("actor label");
+        let identity = RoomConnectionIdentity {
+            auth,
+            actor_label,
+            fallback_operator: operator,
+            legacy_operator_actor_policy: LegacyOperatorActorPolicy::Reject,
+        };
+        let seed_hash = notebook_doc::NotebookDoc::canonical_schema_seed_change_hashes()
+            .into_iter()
+            .next()
+            .expect("seed hash");
+
+        identity
+            .validate_notebook_change_actors(
+                [ChangeActor {
+                    actor_label: "nteract:notebook-schema:v5".to_string(),
+                    hash: seed_hash,
+                }]
+                .iter(),
+            )
+            .expect("canonical schema seed change is allowed");
+
+        let error = identity
+            .validate_notebook_change_actors(
+                [ChangeActor {
+                    actor_label: "nteract:notebook-schema:v5".to_string(),
+                    hash: automerge::ChangeHash([1; 32]),
+                }]
+                .iter(),
+            )
+            .expect_err("spoofed seed actor must be rejected");
 
         assert!(error.to_string().contains("actor label"));
     }

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -8,7 +8,7 @@ use super::{
     check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
     NotebookRoom, RoomConnectionIdentity,
 };
-use notebook_doc::diff::{diff_metadata_touched, extract_change_actors};
+use notebook_doc::diff::{diff_metadata_touched, extract_change_actor_hashes};
 
 pub(super) async fn handle_notebook_doc_frame(
     room: &NotebookRoom,
@@ -37,9 +37,8 @@ pub(super) async fn handle_notebook_doc_frame(
                 "doc-auth-preview",
             ) {
                 Ok(()) => {
-                    let actors = extract_change_actors(preview.doc_mut(), &heads_before);
-                    connection_identity
-                        .validate_actor_labels(actors.iter().map(std::string::String::as_str))?;
+                    let actors = extract_change_actor_hashes(preview.doc_mut(), &heads_before);
+                    connection_identity.validate_notebook_change_actors(actors.iter())?;
                 }
                 Err(e) => {
                     warn!("[notebook-sync] doc auth preview failed: {}", e);


### PR DESCRIPTION
## Summary

- allow notebook sync auth to accept the embedded schema seed change even though it is authored by the reserved schema seed actor
- bind that exception to the frozen genesis change hash so arbitrary writes under the seed actor are still rejected
- apply the same notebook-change validation shape in the desktop daemon and Cloudflare WASM room host

## Stack

- Targets `main`; #3184, #3188, and #3191 have already merged.

## Validation

- `cargo test -p notebook-doc --lib`
- `cargo test -p runtimed notebook_sync_server::identity::tests::non_local_identity_allows_only_canonical_schema_seed_change --lib`
- `cargo test -p runtimed-wasm --lib`
- `cargo xtask wasm`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
