### PR TITLE
fix(notebook-cloud): normalize browser OIDC profile labels

### DIFF
--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -135,9 +135,12 @@ interface JwtPayload {
   email?: string;
   email_verified?: boolean;
   exp?: number;
+  family_name?: string;
+  given_name?: string;
   iss?: string;
   name?: string;
   nbf?: number;
+  preferred_username?: string;
   sub?: string;
   ver?: string;
 }
@@ -274,8 +277,10 @@ export async function authenticateOidcRequest(
 
   const url = new URL(request.url);
   const principal = `${config.principalNamespace}:${encodePrincipalComponent(subject)}`;
-  const operator = headerOrQuery(request, url, "x-operator", "operator") ?? defaultOperator();
+  const operator =
+    headerOrQuery(request, url, "x-operator", "operator") ?? defaultBrowserOperator(request, url);
   const scope = parseScope(headerOrQuery(request, url, "x-scope", "scope") ?? "viewer");
+  const profile = profileFromOidcPayload(payload);
 
   validatePrincipal(principal);
   validateOperator(operator);
@@ -289,16 +294,34 @@ export async function authenticateOidcRequest(
       provider: "oidc" as const,
       transport: credential.transport,
       principalNamespace: config.principalNamespace,
-      ...(payload.name?.trim() || payload.email?.trim()
-        ? { displayName: payload.name?.trim() || payload.email?.trim() || undefined }
-        : {}),
-      ...(payload.email?.trim() ? { email: payload.email.trim() } : {}),
-      ...(payload.email?.trim() ? { emailVerified: payload.email_verified === true } : {}),
+      ...(profile.displayName ? { displayName: profile.displayName } : {}),
+      ...(profile.email ? { email: profile.email } : {}),
+      ...(profile.email ? { emailVerified: payload.email_verified === true } : {}),
     },
   };
   return credential.webSocketProtocol
     ? { ...identity, webSocketProtocol: credential.webSocketProtocol }
     : identity;
+}
+
+function profileFromOidcPayload(payload: JwtPayload): {
+  displayName?: string;
+  email?: string;
+} {
+  const email = payload.email?.trim() || undefined;
+  const displayName =
+    payload.name?.trim() ||
+    [payload.given_name, payload.family_name]
+      .map((part) => part?.trim())
+      .filter((part): part is string => Boolean(part))
+      .join(" ") ||
+    payload.preferred_username?.trim() ||
+    email;
+
+  return {
+    ...(displayName ? { displayName } : {}),
+    ...(email ? { email } : {}),
+  };
 }
 
 export async function authenticateAnacondaApiKeyRequest(
@@ -1256,6 +1279,14 @@ function decodeBase64UrlBytes(value: string): Uint8Array {
 
 function defaultOperator(): string {
   return `desktop:${crypto.randomUUID()}`;
+}
+
+function defaultBrowserOperator(request: Request, url: URL): string {
+  const session =
+    headerOrQuery(request, url, "x-viewer-session", "viewer_session") ??
+    headerOrQuery(request, url, "x-session", "session") ??
+    crypto.randomUUID();
+  return `browser:${encodePrincipalComponent(session.trim() || crypto.randomUUID())}`;
 }
 
 function timingSafeStringEqual(presented: string | undefined, expected: string): boolean {

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -711,6 +711,58 @@ describe("OIDC identity", () => {
     });
   });
 
+  it("uses standard OIDC profile claims and browser operators for web sessions", async () => {
+    const { env, token } = await oidcTokenFixture({
+      email: "alice@example.com",
+      extraPayload: {
+        email_verified: true,
+        family_name: "Example",
+        given_name: "Alice",
+        preferred_username: "alice-demo",
+      },
+      subject: "alice-subject",
+    });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?viewer_session=tab/session&scope=editor", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      env,
+    );
+
+    assert.equal(identity.operator, "browser:tab%2Fsession");
+    assert.equal(identity.actorLabel, "user:anaconda:alice-subject/browser:tab%2Fsession");
+    assert.equal(identity.metadata.displayName, "Alice Example");
+    assert.equal(identity.metadata.email, "alice@example.com");
+    assert.equal(identity.metadata.emailVerified, true);
+  });
+
+  it("falls back through preferred username and email for OIDC profile labels", async () => {
+    const { env, token } = await oidcTokenFixture({
+      email: "alice@example.com",
+      extraPayload: {
+        email_verified: true,
+        preferred_username: "alice-demo",
+      },
+      subject: "alice-subject",
+    });
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/demo/sync?scope=viewer", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      env,
+    );
+
+    assert.match(identity.operator, /^browser:/);
+    assert.equal(identity.metadata.displayName, "alice-demo");
+    assert.equal(identity.metadata.email, "alice@example.com");
+  });
+
   it("fetches remote OIDC JWKS with Anaconda-compatible headers", async (t) => {
     const { env, token } = await oidcTokenFixture({ subject: "remote-jwks-user" });
     const calls: Array<{ accept: string | null; url: string; userAgent: string | null }> = [];


### PR DESCRIPTION
## Summary

- Use standard OIDC profile claims (`name`, `given_name`/`family_name`, `preferred_username`, then email) when deriving cloud identity display labels.
- Default authenticated OIDC browser sessions to `browser:<viewer_session>` operators when the caller omits an explicit operator.
- Add focused identity coverage for the OIDC profile fallback order and browser operator default.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts test/worker-routes.test.ts test/live-sync.test.ts test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

This is a narrow follow-up to the profile/presence work already on `main`: OIDC claims remain the default profile source, Anaconda API-key `whoami` enrichment remains provider-specific, and stable principal identity is unchanged. The change only improves resolved display metadata and browser operator labeling for OIDC-authenticated web sessions.
