### PR TITLE
ci: default pullfrog reviews to opus 4.8

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -31,4 +31,4 @@ jobs:
           prompt: ${{ inputs.prompt }}
         env:
           AWS_REGION: us-east-1
-          BEDROCK_MODEL_ID: us.anthropic.claude-opus-4-6-v1
+          BEDROCK_MODEL_ID: us.anthropic.claude-opus-4-8


### PR DESCRIPTION
## Summary

- update the Pullfrog workflow default Bedrock model ID to Claude Opus 4.8
- keep the workflow on the US geo inference ID form already used by Pullfrog

## Verification

- `AWS_REGION=us-east-1 opencode run --model amazon-bedrock/us.anthropic.claude-opus-4-8 --format json --title "bedrock-opus-48-id-smoke" "Reply with exactly: OK"`
- `cargo xtask lint --fix`
