### PR TITLE
refactor(notebook): share markdown cell surface

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -37,7 +37,8 @@ test("cloud markdown editor remounts with latest source state", () => {
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /if \(!editing\) return;\s+bridge\.applyFullSource\(cell\.source\);/);
-  assert.match(sourceText, /cell\.source\.trim\(\)\.length === 0 && !editing/);
+  assert.match(sourceText, /shouldStartMarkdownEditMode\(cell\.source\) && !editing/);
+  assert.match(sourceText, /@\/components\/cell\/markdown-editor-keymap/);
 });
 
 test("cloud live notebook passes renderer policy into editable markdown cells", () => {

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { EditableMarkdownCell as SharedEditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
+import { shouldStartMarkdownEditMode } from "@/components/cell/markdown-editor-keymap";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import {
   remoteCursorsExtension,
@@ -63,7 +64,7 @@ export function EditableMarkdownCell({
   onPresenceCursor,
   onPresenceSelection,
 }: EditableMarkdownCellProps) {
-  const [editing, setEditing] = useState(cell.source.trim().length === 0);
+  const [editing, setEditing] = useState(shouldStartMarkdownEditMode(cell.source));
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const getHandleRef = useRef(getHandle);
   const onSourceChangeRef = useRef(onSourceChange);
@@ -123,7 +124,7 @@ export function EditableMarkdownCell({
   }, [bridge, cell.source, editing]);
 
   useEffect(() => {
-    if (cell.source.trim().length === 0 && !editing) {
+    if (shouldStartMarkdownEditMode(cell.source) && !editing) {
       setEditing(true);
     }
   }, [cell.source, editing]);

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,26 +1,12 @@
-import type { EditorView, KeyBinding } from "@codemirror/view";
+import type { EditorView } from "@codemirror/view";
 import { Pencil } from "lucide-react";
-import {
-  memo,
-  type PointerEvent,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { CellContainer } from "@/components/cell/CellContainer";
-import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
+import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
-import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
-import { injectPluginsForMimes } from "@/components/isolated/iframe-libraries";
-import { findVerticalScrollAncestor } from "@/components/isolated/scroll-boundary";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
-import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
-import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
@@ -34,28 +20,14 @@ import {
 import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
 import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
-import { logger } from "../lib/logger";
-import {
-  isMeasuredElementFound,
-  registerMarkdownHeadingNavigator,
-} from "@/components/cell/markdown-heading-navigation";
-import {
-  createMarkdownFormattingKeyMap,
-  shouldStartMarkdownEditMode,
-} from "@/components/cell/markdown-editor-keymap";
+import { shouldStartMarkdownEditMode } from "@/components/cell/markdown-editor-keymap";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
-const handleIframeError = (err: { message: string; stack?: string }) =>
-  logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
-
-function formatPluginLoadError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 interface MarkdownCellProps {
   cell: MarkdownCellType;
@@ -95,10 +67,6 @@ export const MarkdownCell = memo(function MarkdownCell({
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const presence = usePresenceContext();
   const { extension: crdtBridgeExt } = useCrdtBridge(cell.id);
-  const frameRef = useRef<IsolatedFrameHandle>(null);
-  const injectedLibsRef = useRef(new Set<string>());
-  const viewRef = useRef<HTMLDivElement>(null);
-  const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
 
   // Register EditorView with the cursor registry when in edit mode.
   const registeredViewRef = useRef<EditorView | null>(null);
@@ -151,14 +119,11 @@ export const MarkdownCell = memo(function MarkdownCell({
     };
   }, [cell.id, editing]);
 
-  const darkMode = useDarkMode();
-  const colorTheme = useColorTheme();
-  const darkModeRef = useRef(darkMode);
-  darkModeRef.current = darkMode;
-  const colorThemeRef = useRef(colorTheme);
-  colorThemeRef.current = colorTheme;
-
   const blobResolver = useBlobResolver();
+  const renderedSource = useMemo(
+    () => rewriteMarkdownAssetRefs(cell.source, cell.resolvedAssets, blobResolver),
+    [blobResolver, cell.resolvedAssets, cell.source],
+  );
   const markdownMetadata = useMemo(
     () =>
       headingAnchors.length > 0
@@ -168,158 +133,6 @@ export const MarkdownCell = memo(function MarkdownCell({
         : undefined,
     [headingAnchors],
   );
-
-  const handleDoubleClick = useCallback(() => {
-    setEditing(true);
-  }, []);
-
-  const activatePreviewFrameInteraction = useCallback(() => {
-    setPreviewFrameInteractionActive(true);
-    onFocus();
-  }, [onFocus]);
-
-  const deactivatePreviewFrameInteractionWhenIdle = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
-      if (
-        event.relatedTarget instanceof Node &&
-        event.currentTarget.contains(event.relatedTarget)
-      ) {
-        return;
-      }
-      if (!(event.buttons > 0)) {
-        setPreviewFrameInteractionActive(false);
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (!isFocused || editing) {
-      setPreviewFrameInteractionActive(false);
-    }
-  }, [isFocused, editing]);
-
-  const handleBlur = useCallback(() => {
-    if (cell.source.trim()) {
-      setEditing(false);
-    }
-  }, [cell.source]);
-
-  // Render markdown content when iframe is ready
-  const handleFrameReady = useCallback(async () => {
-    if (!frameRef.current || !cell.source) return;
-    // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
-    frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
-    // Clear injected set — a reloaded iframe has a fresh renderer registry
-    injectedLibsRef.current.clear();
-    // Inject markdown renderer plugin before rendering (idempotent, cached after first load)
-    try {
-      await injectPluginsForMimes(frameRef.current, ["text/markdown"], injectedLibsRef.current);
-    } catch (error) {
-      logger.warn("[MarkdownCell] Failed to load markdown renderer plugin:", error);
-      frameRef.current.render({
-        mimeType: "text/plain",
-        data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
-        outputId: `markdown-error:${cell.id}`,
-        cellId: cell.id,
-        replace: true,
-      });
-      return;
-    }
-    const processedSource = rewriteMarkdownAssetRefs(
-      cell.source,
-      cell.resolvedAssets,
-      blobResolver,
-    );
-    frameRef.current.render({
-      mimeType: "text/markdown",
-      data: processedSource,
-      metadata: markdownMetadata,
-      outputId: `markdown:${cell.id}`,
-      cellId: cell.id,
-      replace: true,
-    });
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
-
-  // Sync markdown to iframe whenever source or resolved assets change (supports RTC updates)
-  useEffect(() => {
-    if (frameRef.current?.isReady && cell.source) {
-      const frame = frameRef.current;
-      // Inject markdown renderer plugin (idempotent) then render
-      injectPluginsForMimes(frame, ["text/markdown"], injectedLibsRef.current)
-        .then(() => {
-          const processedSource = rewriteMarkdownAssetRefs(
-            cell.source,
-            cell.resolvedAssets,
-            blobResolver,
-          );
-          frame.render({
-            mimeType: "text/markdown",
-            data: processedSource,
-            metadata: markdownMetadata,
-            outputId: `markdown:${cell.id}`,
-            cellId: cell.id,
-            replace: true,
-          });
-        })
-        .catch((error) => {
-          logger.warn("[MarkdownCell] Failed to load markdown renderer plugin:", error);
-          frame.render({
-            mimeType: "text/plain",
-            data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
-            outputId: `markdown-error:${cell.id}`,
-            cellId: cell.id,
-            replace: true,
-          });
-        });
-    }
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
-
-  const scrollToHeading = useCallback(
-    async (headingAnchorId: string, options?: { behavior?: ScrollBehavior }) => {
-      if (editing || !headingAnchorId || !frameRef.current?.isReady) return false;
-
-      const measurement = await frameRef.current.measureElement(headingAnchorId);
-      if (!isMeasuredElementFound(measurement)) return false;
-
-      const iframe = viewRef.current?.querySelector<HTMLIFrameElement>(
-        'iframe[data-slot="isolated-frame"]',
-      );
-      if (!iframe) return false;
-
-      const behavior = options?.behavior ?? "smooth";
-      const topPadding = 16;
-      const iframeRect = iframe.getBoundingClientRect();
-      const scrollContainer = findVerticalScrollAncestor(iframe.parentElement ?? iframe);
-
-      if (scrollContainer) {
-        const containerRect = scrollContainer.getBoundingClientRect();
-        scrollContainer.scrollTo({
-          top: Math.max(
-            0,
-            scrollContainer.scrollTop +
-              iframeRect.top -
-              containerRect.top +
-              measurement.top -
-              topPadding,
-          ),
-          behavior,
-        });
-        return true;
-      }
-
-      window.scrollTo({
-        top: Math.max(0, window.scrollY + iframeRect.top + measurement.top - topPadding),
-        behavior,
-      });
-      return true;
-    },
-    [editing],
-  );
-
-  useEffect(() => {
-    return registerMarkdownHeadingNavigator(cell.id, scrollToHeading);
-  }, [cell.id, scrollToHeading]);
 
   // Handle link clicks from iframe - open in system browser
   const handleLinkClick = useCallback((url: string) => {
@@ -404,153 +217,49 @@ export const MarkdownCell = memo(function MarkdownCell({
     cellId: cell.id,
   });
 
-  // Combine navigation with markdown-specific keys
-  const keyMap: KeyBinding[] = useMemo(
-    () => [
-      {
-        key: "Ctrl-Enter",
-        run: () => {
-          setEditing(false);
-          return true;
-        },
-      },
-      ...navigationKeyMap,
-      {
-        key: "Escape",
-        run: () => {
-          if (cell.source.trim()) {
-            setEditing(false);
-          }
-          return true;
-        },
-      },
-      ...createMarkdownFormattingKeyMap(),
-    ],
-    [navigationKeyMap, cell.source],
+  const rightGutter = editing ? (
+    rightGutterContent
+  ) : (
+    <div className="flex flex-col gap-0.5">
+      <button
+        type="button"
+        tabIndex={-1}
+        onClick={() => setEditing(true)}
+        className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+        title="Edit"
+      >
+        <Pencil className="h-3.5 w-3.5" />
+      </button>
+      {rightGutterContent}
+    </div>
   );
 
-  // Focus editor when entering edit mode (after initial mount)
-  const initialMountRef = useRef(true);
-  useEffect(() => {
-    if (initialMountRef.current) {
-      initialMountRef.current = false;
-      return;
-    }
-    if (editing) {
-      requestAnimationFrame(() => {
-        editorRef.current?.focus();
-      });
-    }
-  }, [editing]);
-
-  // Forward search query to the markdown iframe
-  useEffect(() => {
-    if (!editing && frameRef.current?.isReady) {
-      frameRef.current.search(searchQuery || "");
-    }
-  }, [searchQuery, editing]);
-
-  // Focus view section when cell becomes focused but not editing
-  useEffect(() => {
-    if (isFocused && !editing) {
-      requestAnimationFrame(() => {
-        viewRef.current?.focus({ preventScroll: true });
-      });
-    }
-  }, [isFocused, editing]);
-
   return (
-    <CellContainer
+    <EditableMarkdownCell
       id={cell.id}
-      cellType="markdown"
+      source={cell.source}
+      renderedSource={renderedSource}
+      markdownMetadata={markdownMetadata}
+      editing={editing}
+      onEditingChange={setEditing}
+      editorRef={editorRef}
       isFocused={isFocused}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
       isNextCellFromFocused={isNextCellFromFocused}
       onFocus={onFocus}
-      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
+      focusPreview={isFocused}
+      previewClassName="py-2 cursor-text outline-none"
+      rightGutterContent={rightGutter}
       dragHandleProps={dragHandleProps}
       isDragging={isDragging}
-      rightGutterContent={
-        editing ? (
-          rightGutterContent
-        ) : (
-          <div className="flex flex-col gap-0.5">
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => setEditing(true)}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
-              title="Edit"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </button>
-            {rightGutterContent}
-          </div>
-        )
-      }
-      codeContent={
-        <>
-          {/* Editor section - hidden when not editing */}
-          <div className={editing ? "block" : "hidden"}>
-            <div className="flex items-center gap-1 py-1">
-              <span className="text-xs text-muted-foreground font-mono">md</span>
-            </div>
-            <div>
-              <CodeMirrorEditor
-                ref={editorRef}
-                initialValue={cell.source}
-                language="markdown"
-                lineWrapping
-                onBlur={handleBlur}
-                keyMap={keyMap}
-                extensions={[crdtBridgeExt, ...searchExtensions]}
-                placeholder="Enter markdown..."
-                className="min-h-[2rem]"
-                autoFocus={editing}
-              />
-            </div>
-          </div>
-
-          {/* View section - hidden when editing */}
-          <div
-            ref={viewRef}
-            role="textbox"
-            aria-readonly
-            aria-label="Markdown cell content"
-            tabIndex={0}
-            className={cn("py-2 cursor-text outline-none", editing && "hidden")}
-            onDoubleClick={handleDoubleClick}
-            onKeyDown={handleViewKeyDown}
-          >
-            {/* Always render IsolatedFrame to preload it (hidden when no content) */}
-            <div
-              className={cell.source ? undefined : "hidden"}
-              onPointerDown={activatePreviewFrameInteraction}
-              onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
-            >
-              <IsolatedFrame
-                ref={frameRef}
-                name={`md-${cell.id}`}
-                darkMode={darkMode}
-                colorTheme={colorTheme}
-                minHeight={24}
-                autoHeight
-                scrollPassthrough={!previewFrameInteractionActive}
-                allowWheelBoundaryScroll={previewFrameInteractionActive}
-                revealOnRender
-                onReady={handleFrameReady}
-                onLinkClick={handleLinkClick}
-                onMouseDown={activatePreviewFrameInteraction}
-                onDoubleClick={handleDoubleClick}
-                onError={handleIframeError}
-                onDiagnostic={logNotebookIsolatedDiagnostic}
-                className="w-full"
-              />
-            </div>
-            {!cell.source && <p className="text-muted-foreground italic">Double-click to edit</p>}
-          </div>
-        </>
-      }
+      editorExtensions={[crdtBridgeExt, ...searchExtensions]}
+      editorKeyMap={navigationKeyMap}
+      searchQuery={searchQuery || ""}
+      onPreviewKeyDown={handleViewKeyDown}
+      onLinkClick={handleLinkClick}
+      onIframeMouseDown={onFocus}
+      onDiagnostic={logNotebookIsolatedDiagnostic}
+      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
     />
   );
 });

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -39,6 +39,10 @@ import {
   isMeasuredElementFound,
   registerMarkdownHeadingNavigator,
 } from "@/components/cell/markdown-heading-navigation";
+import {
+  createMarkdownFormattingKeyMap,
+  shouldStartMarkdownEditMode,
+} from "@/components/cell/markdown-editor-keymap";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
@@ -87,74 +91,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
   const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
   const searchQuery = useSearchQuery();
-  const applyInlineFormatting = useCallback(
-    (prefix: string, suffix = prefix) =>
-      (view: EditorView) => {
-        const selection = view.state.selection.main;
-        const selectedText = view.state.doc.sliceString(selection.from, selection.to);
-        const wrappedText = `${prefix}${selectedText}${suffix}`;
-
-        view.dispatch({
-          changes: {
-            from: selection.from,
-            to: selection.to,
-            insert: wrappedText,
-          },
-          selection: {
-            anchor: selection.from + prefix.length,
-            head: selection.from + prefix.length + selectedText.length,
-          },
-        });
-        return true;
-      },
-    [],
-  );
-
-  const applyLinkFormatting = useCallback((view: EditorView) => {
-    const selection = view.state.selection.main;
-    const selectedText = view.state.doc.sliceString(selection.from, selection.to);
-    const linkText = selectedText || "link text";
-    const formattedText = `[${linkText}](https://)`;
-
-    view.dispatch({
-      changes: {
-        from: selection.from,
-        to: selection.to,
-        insert: formattedText,
-      },
-      selection: selectedText
-        ? {
-            anchor: selection.from + 1,
-            head: selection.from + 1 + linkText.length,
-          }
-        : {
-            anchor: selection.from + 1,
-            head: selection.from + 1 + "link text".length,
-          },
-    });
-    return true;
-  }, []);
-
-  const applyQuoteFormatting = useCallback((view: EditorView) => {
-    const selection = view.state.selection.main;
-    const selectedText = view.state.doc.sliceString(selection.from, selection.to);
-    const text = selectedText || "quote";
-    const quotedText = text
-      .split("\n")
-      .map((line) => `> ${line}`)
-      .join("\n");
-
-    view.dispatch({
-      changes: { from: selection.from, to: selection.to, insert: quotedText },
-      selection: {
-        anchor: selection.from,
-        head: selection.from + quotedText.length,
-      },
-    });
-    return true;
-  }, []);
-
-  const [editing, setEditing] = useState(cell.source === "");
+  const [editing, setEditing] = useState(shouldStartMarkdownEditMode(cell.source));
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const presence = usePresenceContext();
   const { extension: crdtBridgeExt } = useCrdtBridge(cell.id);
@@ -487,38 +424,9 @@ export const MarkdownCell = memo(function MarkdownCell({
           return true;
         },
       },
-      {
-        key: "Mod-b",
-        run: applyInlineFormatting("**"),
-      },
-      {
-        key: "Mod-i",
-        run: applyInlineFormatting("*"),
-      },
-      {
-        key: "Mod-u",
-        run: applyInlineFormatting("<u>", "</u>"),
-      },
-      {
-        key: "Mod-k",
-        run: applyLinkFormatting,
-      },
-      {
-        key: "Mod-Shift-.",
-        run: applyQuoteFormatting,
-      },
-      {
-        key: "Mod-Shift->",
-        run: applyQuoteFormatting,
-      },
+      ...createMarkdownFormattingKeyMap(),
     ],
-    [
-      navigationKeyMap,
-      cell.source,
-      applyInlineFormatting,
-      applyLinkFormatting,
-      applyQuoteFormatting,
-    ],
+    [navigationKeyMap, cell.source],
   );
 
   // Focus editor when entering edit mode (after initial mount)

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,79 +1,89 @@
-import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { MarkdownCell as MarkdownCellType } from "../../types";
 
-let mockDarkMode = false;
-let mockColorTheme: string | undefined;
 let mockIsFocused = false;
-const isolatedFrameProps: Array<Record<string, unknown>> = [];
+let mockSearchQuery = "";
 
-const mockFrameHandle = {
-  send: vi.fn(),
-  render: vi.fn(),
-  renderBatch: vi.fn(),
-  eval: vi.fn(),
-  installRenderer: vi.fn(),
-  setTheme: vi.fn(),
-  setHostContext: vi.fn(),
-  clear: vi.fn(),
-  search: vi.fn(),
-  searchNavigate: vi.fn(),
-  measureElement: vi.fn(async () => null),
-  isReady: true,
-  isIframeReady: true,
-};
-
-vi.mock("@/lib/dark-mode", () => ({
-  useDarkMode: () => mockDarkMode,
-  useColorTheme: () => mockColorTheme,
+const outputAreaCalls = vi.hoisted(() => ({
+  props: [] as Array<{
+    cellId?: string;
+    className?: string;
+    onIframeMouseDown?: () => void;
+    onLinkClick?: (url: string, newTab: boolean) => void;
+    outputs: JupyterOutput[];
+    searchQuery?: string;
+  }>,
 }));
 
-vi.mock("@/components/isolated/iframe-libraries", () => ({
-  injectPluginsForMimes: vi.fn(async () => {}),
-}));
-
-vi.mock("@/components/isolated", async () => {
-  const React = await import("react");
-
-  const MockIsolatedFrame = React.forwardRef<
-    typeof mockFrameHandle,
-    Record<string, unknown> & { onMouseDown?: () => void; onReady?: () => void }
-  >(function MockIsolatedFrame(props, ref) {
-    isolatedFrameProps.push(props);
-    React.useImperativeHandle(ref, () => mockFrameHandle);
-
-    React.useEffect(() => {
-      props.onReady?.();
-    }, [props.onReady]);
-
+vi.mock("@/components/cell/OutputArea", () => ({
+  OutputArea: (props: {
+    cellId?: string;
+    className?: string;
+    onIframeMouseDown?: () => void;
+    onLinkClick?: (url: string, newTab: boolean) => void;
+    outputs: JupyterOutput[];
+    searchQuery?: string;
+  }) => {
+    outputAreaCalls.props.push(props);
     return (
-      <iframe
-        data-testid="markdown-frame"
-        data-slot="isolated-frame"
-        onMouseDown={props.onMouseDown}
+      <div
+        data-cell-id={props.cellId}
+        data-class-name={props.className ?? ""}
+        data-search-query={props.searchQuery ?? ""}
+        data-testid="markdown-output-area"
       />
     );
-  });
-
-  return {
-    IsolatedFrame: MockIsolatedFrame,
-  };
-});
+  },
+}));
 
 vi.mock("@/components/cell/CellContainer", () => ({
-  CellContainer: ({ codeContent }: { codeContent: React.ReactNode }) => <div>{codeContent}</div>,
+  CellContainer: ({
+    codeContent,
+    onFocus,
+    rightGutterContent,
+  }: {
+    codeContent: React.ReactNode;
+    onFocus?: () => void;
+    rightGutterContent?: React.ReactNode;
+  }) => (
+    <div onMouseDown={onFocus}>
+      {codeContent}
+      {rightGutterContent}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/editor/codemirror-editor", () => ({
   CodeMirrorEditor: React.forwardRef(function CodeMirrorEditor(
-    props: { keyMap?: Array<{ key: string; run: () => boolean }> },
-    _ref,
+    props: {
+      initialValue?: string;
+      keyMap?: Array<{ key: string; run: () => boolean }>;
+      onBlur?: () => void;
+      placeholder?: string;
+    },
+    ref,
   ) {
+    React.useImperativeHandle(ref, () => ({
+      focus: vi.fn(),
+      setCursorPosition: vi.fn(),
+      getEditor: () => ({
+        state: {
+          doc: {
+            toString: () => props.initialValue ?? "",
+          },
+        },
+      }),
+    }));
+
     return (
       <div
+        data-placeholder={props.placeholder}
         data-testid="markdown-editor"
         tabIndex={0}
+        onBlur={props.onBlur}
         onKeyDown={(event) => {
           const key = event.ctrlKey && event.key === "Enter" ? "Ctrl-Enter" : event.key;
           const binding = props.keyMap?.find((entry) => entry.key === key);
@@ -115,7 +125,7 @@ vi.mock("../../hooks/useCrdtBridge", () => ({
 }));
 
 vi.mock("../../lib/blob-port", () => ({
-  useBlobResolver: () => null,
+  useBlobResolver: () => new Map([["asset.png", "blob://asset.png"]]),
   useBlobPort: () => null,
 }));
 
@@ -123,7 +133,7 @@ vi.mock("../../lib/cell-ui-state", () => ({
   useIsCellFocused: () => mockIsFocused,
   useIsNextCellFromFocused: () => false,
   useIsPreviousCellFromFocused: () => false,
-  useSearchQuery: () => "",
+  useSearchQuery: () => mockSearchQuery,
 }));
 
 vi.mock("../../lib/cursor-registry", () => ({
@@ -136,16 +146,21 @@ vi.mock("../../lib/editor-registry", () => ({
   unregisterCellEditor: vi.fn(),
 }));
 
-vi.mock("../../lib/logger", () => ({
-  logger: { error: vi.fn(), warn: vi.fn() },
+vi.mock("../../lib/isolated-diagnostics", () => ({
+  logNotebookIsolatedDiagnostic: vi.fn(),
 }));
 
 vi.mock("../../lib/markdown-assets", () => ({
-  rewriteMarkdownAssetRefs: (source: string) => source,
+  rewriteMarkdownAssetRefs: (
+    source: string,
+    resolvedAssets: Record<string, string> | undefined,
+    blobResolver: Map<string, string>,
+  ) => source.replace("asset.png", resolvedAssets?.["asset.png"] ?? blobResolver.get("asset.png")),
 }));
 
+const openUrlMock = vi.hoisted(() => vi.fn());
 vi.mock("../../lib/open-url", () => ({
-  openUrl: vi.fn(),
+  openUrl: openUrlMock,
 }));
 
 vi.mock("../../lib/presence-sender", () => ({
@@ -153,85 +168,37 @@ vi.mock("../../lib/presence-sender", () => ({
 }));
 
 import { MarkdownCell } from "../MarkdownCell";
-import { injectPluginsForMimes } from "@/components/isolated/iframe-libraries";
 
 function makeCell(): MarkdownCellType {
   return {
     cell_type: "markdown",
     id: "md-1",
-    source: "```python\nprint('hello')\n```",
+    source: "![asset](asset.png)",
     metadata: {},
+    resolvedAssets: { "asset.png": "blob://resolved-asset.png" },
   };
 }
 
-function pointerOutWithButtons(element: HTMLElement, buttons: number) {
-  const event = createEvent.pointerOut(element);
-  Object.defineProperty(event, "buttons", { value: buttons });
-  fireEvent(element, event);
-}
-
-describe("MarkdownCell theme sync", () => {
+describe("MarkdownCell shared surface adapter", () => {
   beforeEach(() => {
-    mockDarkMode = false;
-    mockColorTheme = undefined;
     mockIsFocused = false;
-    isolatedFrameProps.length = 0;
-    mockFrameHandle.send.mockClear();
-    mockFrameHandle.render.mockClear();
-    mockFrameHandle.renderBatch.mockClear();
-    mockFrameHandle.eval.mockClear();
-    mockFrameHandle.installRenderer.mockClear();
-    mockFrameHandle.setTheme.mockClear();
-    mockFrameHandle.clear.mockClear();
-    mockFrameHandle.search.mockClear();
-    mockFrameHandle.searchNavigate.mockClear();
-    mockFrameHandle.measureElement.mockClear();
-    vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
+    mockSearchQuery = "";
+    outputAreaCalls.props.length = 0;
+    openUrlMock.mockClear();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it("passes the current color theme to the markdown iframe and re-syncs it on ready", async () => {
-    mockColorTheme = "cream";
-
+  it("passes resolved markdown source into the shared output surface", () => {
     render(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
 
-    await waitFor(() => {
-      expect(mockFrameHandle.setTheme).toHaveBeenCalledWith(false, "cream");
-    });
-
-    expect(isolatedFrameProps.at(-1)?.colorTheme).toBe("cream");
-
-    await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/markdown",
-        data: "```python\nprint('hello')\n```",
-        outputId: "markdown:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
-    });
+    const markdownOutput = outputAreaCalls.props.at(-1)?.outputs[0];
+    expect(markdownOutput?.data["text/markdown"]).toBe("![asset](blob://resolved-asset.png)");
   });
 
-  it("renders a contained fallback when the markdown renderer plugin fails to load", async () => {
-    vi.mocked(injectPluginsForMimes).mockRejectedValue(new Error("chunk failed"));
-
-    render(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
-
-    await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/plain",
-        data: "Failed to load markdown renderer: chunk failed",
-        outputId: "markdown-error:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
-    });
-  });
-
-  it("passes heading anchors to the markdown renderer metadata", async () => {
+  it("passes heading anchors to the shared markdown output metadata", () => {
     const headingAnchors = [
       {
         itemId: "md-1:heading:0",
@@ -251,15 +218,8 @@ describe("MarkdownCell theme sync", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/markdown",
-        data: "# Load data",
-        metadata: { nteractMarkdownHeadingAnchors: headingAnchors },
-        outputId: "markdown:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
+    expect(outputAreaCalls.props.at(-1)?.outputs[0]?.metadata).toEqual({
+      nteractMarkdownHeadingAnchors: headingAnchors,
     });
   });
 
@@ -280,36 +240,23 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
-  it("activates markdown iframe pointer interaction after clicking the preview", () => {
+  it("passes search, iframe focus, and link opening through the shared output surface", () => {
+    mockSearchQuery = "needle";
     const onFocus = vi.fn();
 
-    const { getByTestId } = render(
-      <MarkdownCell cell={makeCell()} onFocus={onFocus} onDelete={() => {}} />,
-    );
+    render(<MarkdownCell cell={makeCell()} onFocus={onFocus} onDelete={() => {}} />);
 
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+    const props = outputAreaCalls.props.at(-1);
+    expect(props?.searchQuery).toBe("needle");
 
-    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
-
-    fireEvent.pointerDown(previewWrapper);
-
+    props?.onIframeMouseDown?.();
     expect(onFocus).toHaveBeenCalled();
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
 
-    pointerOutWithButtons(previewWrapper, 1);
-
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
-
-    pointerOutWithButtons(previewWrapper, 0);
-
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+    props?.onLinkClick?.("https://example.test", true);
+    expect(openUrlMock).toHaveBeenCalledWith("https://example.test");
   });
 
-  it("Ctrl+Enter exits edit mode for markdown cells", async () => {
+  it("Ctrl+Enter exits edit mode for empty markdown cells", async () => {
     const cell = { ...makeCell(), source: "" };
 
     const { getByLabelText, getByTestId } = render(

--- a/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
+++ b/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
@@ -5,110 +5,32 @@
  * - Quote formatting prefixes each line with "> "
  * - Edit/view toggle conditions (empty cell stays in edit, non-empty exits on blur)
  *
- * These test the pure formatting functions extracted from MarkdownCell,
- * not the React component itself.
+ * These test the shared pure formatting functions used by MarkdownCell and
+ * cloud/shared editable markdown cells, not the React components themselves.
  */
 
 import { describe, expect, it } from "vite-plus/test";
-
-// ── Extracted formatting logic from MarkdownCell.tsx ─────────────
-
-interface MockSelection {
-  from: number;
-  to: number;
-}
-
-interface FormatResult {
-  insert: string;
-  from: number;
-  to: number;
-  /** New selection anchor (start) */
-  selectionAnchor: number;
-  /** New selection head (end) */
-  selectionHead: number;
-}
-
-/**
- * Mirrors applyInlineFormatting from MarkdownCell.tsx.
- * Wraps the selected text with prefix/suffix and positions cursor
- * to select the original text (for chaining formats).
- */
-function applyInlineFormatting(
-  docText: string,
-  selection: MockSelection,
-  prefix: string,
-  suffix = prefix,
-): FormatResult {
-  const selectedText = docText.slice(selection.from, selection.to);
-  const wrappedText = `${prefix}${selectedText}${suffix}`;
-
-  return {
-    insert: wrappedText,
-    from: selection.from,
-    to: selection.to,
-    selectionAnchor: selection.from + prefix.length,
-    selectionHead: selection.from + prefix.length + selectedText.length,
-  };
-}
-
-/**
- * Mirrors applyLinkFormatting from MarkdownCell.tsx.
- * With selected text: [selectedText](https://)
- * Without: [link text](https://)
- */
-function applyLinkFormatting(docText: string, selection: MockSelection): FormatResult {
-  const selectedText = docText.slice(selection.from, selection.to);
-  const linkText = selectedText || "link text";
-  const formattedText = `[${linkText}](https://)`;
-
-  const anchor = selection.from + 1;
-  const head = selectedText
-    ? selection.from + 1 + linkText.length
-    : selection.from + 1 + "link text".length;
-
-  return {
-    insert: formattedText,
-    from: selection.from,
-    to: selection.to,
-    selectionAnchor: anchor,
-    selectionHead: head,
-  };
-}
-
-/**
- * Mirrors applyQuoteFormatting from MarkdownCell.tsx.
- * Prefixes each line with "> " and selects the result.
- */
-function applyQuoteFormatting(docText: string, selection: MockSelection): FormatResult {
-  const selectedText = docText.slice(selection.from, selection.to);
-  const text = selectedText || "quote";
-  const quotedText = text
-    .split("\n")
-    .map((line) => `> ${line}`)
-    .join("\n");
-
-  return {
-    insert: quotedText,
-    from: selection.from,
-    to: selection.to,
-    selectionAnchor: selection.from,
-    selectionHead: selection.from + quotedText.length,
-  };
-}
+import {
+  applyInlineMarkdownFormatting,
+  applyLinkMarkdownFormatting,
+  applyQuoteMarkdownFormatting,
+  shouldExitMarkdownEditOnBlur,
+  shouldStartMarkdownEditMode,
+} from "@/components/cell/markdown-editor-keymap";
 
 // ── Tests ──────────────────────────────────────────────────────────
 
 describe("applyInlineFormatting", () => {
   it("wraps selected text with bold markers (**)", () => {
     const doc = "hello world";
-    const result = applyInlineFormatting(doc, { from: 6, to: 11 }, "**");
+    const result = applyInlineMarkdownFormatting(doc, { from: 6, to: 11 }, "**");
     expect(result.insert).toBe("**world**");
   });
 
   it("places cursor inside markers when nothing is selected", () => {
     const doc = "hello world";
     // Cursor at position 5 (no selection, from === to)
-    const result = applyInlineFormatting(doc, { from: 5, to: 5 }, "**");
+    const result = applyInlineMarkdownFormatting(doc, { from: 5, to: 5 }, "**");
     expect(result.insert).toBe("****");
     // Cursor should be between the markers
     expect(result.selectionAnchor).toBe(7);
@@ -117,7 +39,7 @@ describe("applyInlineFormatting", () => {
 
   it("selects the wrapped text after formatting", () => {
     const doc = "hello world";
-    const result = applyInlineFormatting(doc, { from: 6, to: 11 }, "**");
+    const result = applyInlineMarkdownFormatting(doc, { from: 6, to: 11 }, "**");
     // Selection should cover "world" inside the markers
     expect(result.selectionAnchor).toBe(8); // after "**"
     expect(result.selectionHead).toBe(13); // before "**"
@@ -125,7 +47,7 @@ describe("applyInlineFormatting", () => {
 
   it("handles asymmetric markers (e.g. <u>...</u>)", () => {
     const doc = "hello world";
-    const result = applyInlineFormatting(doc, { from: 0, to: 5 }, "<u>", "</u>");
+    const result = applyInlineMarkdownFormatting(doc, { from: 0, to: 5 }, "<u>", "</u>");
     expect(result.insert).toBe("<u>hello</u>");
     // Selection covers "hello" between <u> and </u>
     expect(result.selectionAnchor).toBe(3); // after "<u>"
@@ -134,7 +56,7 @@ describe("applyInlineFormatting", () => {
 
   it("handles italic formatting (*)", () => {
     const doc = "emphasis";
-    const result = applyInlineFormatting(doc, { from: 0, to: 8 }, "*");
+    const result = applyInlineMarkdownFormatting(doc, { from: 0, to: 8 }, "*");
     expect(result.insert).toBe("*emphasis*");
     expect(result.selectionAnchor).toBe(1);
     expect(result.selectionHead).toBe(9);
@@ -142,14 +64,14 @@ describe("applyInlineFormatting", () => {
 
   it("works at the beginning of the document", () => {
     const doc = "text";
-    const result = applyInlineFormatting(doc, { from: 0, to: 4 }, "**");
+    const result = applyInlineMarkdownFormatting(doc, { from: 0, to: 4 }, "**");
     expect(result.from).toBe(0);
     expect(result.insert).toBe("**text**");
   });
 
   it("works with multi-word selections", () => {
     const doc = "one two three";
-    const result = applyInlineFormatting(doc, { from: 0, to: 13 }, "**");
+    const result = applyInlineMarkdownFormatting(doc, { from: 0, to: 13 }, "**");
     expect(result.insert).toBe("**one two three**");
     expect(result.selectionAnchor).toBe(2);
     expect(result.selectionHead).toBe(15);
@@ -159,13 +81,13 @@ describe("applyInlineFormatting", () => {
 describe("applyLinkFormatting", () => {
   it("wraps selected text in link syntax", () => {
     const doc = "click here";
-    const result = applyLinkFormatting(doc, { from: 0, to: 10 });
+    const result = applyLinkMarkdownFormatting(doc, { from: 0, to: 10 });
     expect(result.insert).toBe("[click here](https://)");
   });
 
   it("selects the link text after formatting (existing selection)", () => {
     const doc = "click here";
-    const result = applyLinkFormatting(doc, { from: 0, to: 10 });
+    const result = applyLinkMarkdownFormatting(doc, { from: 0, to: 10 });
     // Should select "click here" inside the brackets
     expect(result.selectionAnchor).toBe(1);
     expect(result.selectionHead).toBe(11);
@@ -173,13 +95,13 @@ describe("applyLinkFormatting", () => {
 
   it("inserts placeholder text when nothing is selected", () => {
     const doc = "hello world";
-    const result = applyLinkFormatting(doc, { from: 5, to: 5 });
+    const result = applyLinkMarkdownFormatting(doc, { from: 5, to: 5 });
     expect(result.insert).toBe("[link text](https://)");
   });
 
   it("selects 'link text' placeholder when nothing was selected", () => {
     const doc = "hello world";
-    const result = applyLinkFormatting(doc, { from: 5, to: 5 });
+    const result = applyLinkMarkdownFormatting(doc, { from: 5, to: 5 });
     // Should select "link text" inside the brackets
     expect(result.selectionAnchor).toBe(6); // 5 + 1 (after "[")
     expect(result.selectionHead).toBe(15); // 6 + "link text".length
@@ -189,32 +111,32 @@ describe("applyLinkFormatting", () => {
 describe("applyQuoteFormatting", () => {
   it("prefixes a single line with '> '", () => {
     const doc = "hello world";
-    const result = applyQuoteFormatting(doc, { from: 0, to: 11 });
+    const result = applyQuoteMarkdownFormatting(doc, { from: 0, to: 11 });
     expect(result.insert).toBe("> hello world");
   });
 
   it("prefixes each line of a multi-line selection", () => {
     const doc = "line1\nline2\nline3";
-    const result = applyQuoteFormatting(doc, { from: 0, to: 17 });
+    const result = applyQuoteMarkdownFormatting(doc, { from: 0, to: 17 });
     expect(result.insert).toBe("> line1\n> line2\n> line3");
   });
 
   it("selects the entire quoted result", () => {
     const doc = "line1\nline2";
-    const result = applyQuoteFormatting(doc, { from: 0, to: 11 });
+    const result = applyQuoteMarkdownFormatting(doc, { from: 0, to: 11 });
     expect(result.selectionAnchor).toBe(0);
     expect(result.selectionHead).toBe("> line1\n> line2".length);
   });
 
   it("uses placeholder 'quote' when nothing is selected", () => {
     const doc = "some text";
-    const result = applyQuoteFormatting(doc, { from: 4, to: 4 });
+    const result = applyQuoteMarkdownFormatting(doc, { from: 4, to: 4 });
     expect(result.insert).toBe("> quote");
   });
 
   it("handles empty lines in selection", () => {
     const doc = "line1\n\nline3";
-    const result = applyQuoteFormatting(doc, { from: 0, to: 12 });
+    const result = applyQuoteMarkdownFormatting(doc, { from: 0, to: 12 });
     expect(result.insert).toBe("> line1\n> \n> line3");
   });
 });
@@ -226,24 +148,20 @@ describe("edit/view toggle conditions", () => {
    * This prevents empty cells from being "stuck" in view mode
    * with no content and no way to type.
    */
-  function shouldExitEditOnBlur(source: string): boolean {
-    return source.trim().length > 0;
-  }
-
   it("exits edit mode when cell has content", () => {
-    expect(shouldExitEditOnBlur("# Hello")).toBe(true);
+    expect(shouldExitMarkdownEditOnBlur("# Hello")).toBe(true);
   });
 
   it("stays in edit mode when cell is empty", () => {
-    expect(shouldExitEditOnBlur("")).toBe(false);
+    expect(shouldExitMarkdownEditOnBlur("")).toBe(false);
   });
 
   it("stays in edit mode when cell is only whitespace", () => {
-    expect(shouldExitEditOnBlur("   \n\t  ")).toBe(false);
+    expect(shouldExitMarkdownEditOnBlur("   \n\t  ")).toBe(false);
   });
 
   it("exits edit mode for single character content", () => {
-    expect(shouldExitEditOnBlur("a")).toBe(true);
+    expect(shouldExitMarkdownEditOnBlur("a")).toBe(true);
   });
 
   /**
@@ -251,21 +169,15 @@ describe("edit/view toggle conditions", () => {
    * const [editing, setEditing] = useState(cell.source === "");
    * Empty cells start in edit mode.
    */
-  function shouldStartInEditMode(source: string): boolean {
-    return source === "";
-  }
-
   it("starts in edit mode for empty cells", () => {
-    expect(shouldStartInEditMode("")).toBe(true);
+    expect(shouldStartMarkdownEditMode("")).toBe(true);
   });
 
   it("starts in view mode for cells with content", () => {
-    expect(shouldStartInEditMode("# Title")).toBe(false);
+    expect(shouldStartMarkdownEditMode("# Title")).toBe(false);
   });
 
-  it("starts in view mode for whitespace-only cells (strict equality)", () => {
-    // Note: this is intentionally strict equality (===), not .trim()
-    // A cell with only spaces starts in view mode, which might be a quirk
-    expect(shouldStartInEditMode("  ")).toBe(false);
+  it("starts in edit mode for whitespace-only cells", () => {
+    expect(shouldStartMarkdownEditMode("  ")).toBe(true);
   });
 });

--- a/src/components/cell/EditableMarkdownCell.tsx
+++ b/src/components/cell/EditableMarkdownCell.tsx
@@ -12,6 +12,7 @@ import {
   type RefObject,
 } from "react";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import type { IsolatedDiagnosticHandler } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
 import { cn } from "@/lib/utils";
@@ -30,44 +31,75 @@ import type { JupyterOutput } from "./jupyter-output";
 export interface EditableMarkdownCellProps {
   id: string;
   source: string;
+  renderedSource?: string;
+  markdownMetadata?: Record<string, unknown>;
   editing: boolean;
   onEditingChange: (editing: boolean) => void;
   editorRef: RefObject<CodeMirrorEditorRef | null>;
+  isFocused?: boolean;
+  isPreviousCellFromFocused?: boolean;
+  isNextCellFromFocused?: boolean;
+  onFocus?: () => void;
+  focusPreview?: boolean;
   className?: string;
   sourceClassName?: string;
   editorClassName?: string;
   previewClassName?: string;
   previewOutputClassName?: string;
   actionClassName?: string;
+  rightGutterContent?: ReactNode;
+  dragHandleProps?: Record<string, unknown>;
+  isDragging?: boolean;
   placeholder?: string;
   priority?: readonly string[];
   hostContext?: NteractEmbedHostContextPatch;
   editorExtensions?: readonly Extension[];
   editorKeyMap?: readonly KeyBinding[];
+  searchQuery?: string;
+  onPreviewKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+  onLinkClick?: (url: string, newTab: boolean) => void;
+  onIframeMouseDown?: () => void;
+  onDiagnostic?: IsolatedDiagnosticHandler;
   presenceIndicators?: ReactNode;
 }
 
 export function EditableMarkdownCell({
   id,
   source,
+  renderedSource = source,
+  markdownMetadata,
   editing,
   onEditingChange,
   editorRef,
+  isFocused,
+  isPreviousCellFromFocused,
+  isNextCellFromFocused,
+  onFocus,
+  focusPreview,
   className,
   sourceClassName,
   editorClassName,
   previewClassName,
   previewOutputClassName,
   actionClassName,
+  rightGutterContent,
+  dragHandleProps,
+  isDragging,
   placeholder = "Enter markdown...",
   priority,
   hostContext,
   editorExtensions,
   editorKeyMap,
+  searchQuery,
+  onPreviewKeyDown,
+  onLinkClick,
+  onIframeMouseDown,
+  onDiagnostic,
   presenceIndicators,
 }: EditableMarkdownCellProps) {
   const suppressNextToggleClickRef = useRef(false);
   const viewRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
   const previewFrameRef = useRef<IsolatedFrameHandle | null>(null);
   const sourceRef = useRef(source);
   sourceRef.current = source;
@@ -76,10 +108,10 @@ export function EditableMarkdownCell({
     () => ({
       output_id: `markdown-source:${id}`,
       output_type: "display_data",
-      data: { "text/markdown": source },
-      metadata: {},
+      data: { "text/markdown": renderedSource },
+      metadata: markdownMetadata ?? {},
     }),
-    [id, source],
+    [id, markdownMetadata, renderedSource],
   );
   const editorExtensionArray = useMemo(
     () => (editorExtensions ? [...editorExtensions] : undefined),
@@ -89,16 +121,23 @@ export function EditableMarkdownCell({
     onEditingChange(true);
   }, [onEditingChange]);
 
-  const exitEditing = useCallback(() => {
-    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? sourceRef.current;
-    if (shouldExitMarkdownEditOnBlur(currentSource)) {
-      onEditingChange(false);
-    }
-  }, [editorRef, onEditingChange]);
+  const exitEditing = useCallback(
+    (options?: { force?: boolean }) => {
+      const currentSource =
+        editorRef.current?.getEditor()?.state.doc.toString() ?? sourceRef.current;
+      if (options?.force || shouldExitMarkdownEditOnBlur(currentSource)) {
+        onEditingChange(false);
+      }
+    },
+    [editorRef, onEditingChange],
+  );
 
   const editorKeyMapArray = useMemo(() => {
     return [
-      ...createMarkdownEditModeKeyMap({ exitEditing }),
+      ...createMarkdownEditModeKeyMap({
+        exitEditing,
+        forceExitEditing: () => exitEditing({ force: true }),
+      }),
       ...(editorKeyMap ? [...editorKeyMap] : []),
     ];
   }, [editorKeyMap, exitEditing]);
@@ -131,12 +170,15 @@ export function EditableMarkdownCell({
 
   const handlePreviewKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
+      onPreviewKeyDown?.(event);
+      if (event.defaultPrevented) return;
+
       if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
         event.preventDefault();
         enterEditing();
       }
     },
-    [enterEditing],
+    [enterEditing, onPreviewKeyDown],
   );
 
   const handlePreviewFrameHandleChange = useCallback((handle: IsolatedFrameHandle | null) => {
@@ -168,28 +210,47 @@ export function EditableMarkdownCell({
     return () => cancelAnimationFrame(frame);
   }, [editing, editorRef]);
 
+  useEffect(() => {
+    if (!focusPreview || editing) return;
+    const frame = requestAnimationFrame(() => {
+      previewRef.current?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editing, focusPreview]);
+
+  const defaultRightGutterContent = (
+    <button
+      type="button"
+      className={actionClassName}
+      aria-label={editing ? "Render markdown" : "Edit markdown"}
+      title={editing ? "Render markdown" : "Edit markdown"}
+      onMouseDown={handleActionMouseDown}
+      onClick={handleActionClick}
+    >
+      {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+    </button>
+  );
+
   return (
     <CellContainer
       ref={viewRef}
       id={id}
       cellType="markdown"
+      isFocused={isFocused}
+      isPreviousCellFromFocused={isPreviousCellFromFocused}
+      isNextCellFromFocused={isNextCellFromFocused}
+      onFocus={onFocus}
       className={className}
       presenceIndicators={presenceIndicators}
-      rightGutterContent={
-        <button
-          type="button"
-          className={actionClassName}
-          aria-label={editing ? "Render markdown" : "Edit markdown"}
-          title={editing ? "Render markdown" : "Edit markdown"}
-          onMouseDown={handleActionMouseDown}
-          onClick={handleActionClick}
-        >
-          {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
-        </button>
-      }
+      dragHandleProps={dragHandleProps}
+      isDragging={isDragging}
+      rightGutterContent={rightGutterContent ?? defaultRightGutterContent}
       codeContent={
-        editing ? (
-          <div className={sourceClassName} data-slot="editable-markdown-source">
+        <>
+          <div
+            className={cn(!editing && "hidden", sourceClassName)}
+            data-slot="editable-markdown-source"
+          >
             <div className="flex items-center gap-1 py-1">
               <span className="font-mono text-xs text-muted-foreground">md</span>
             </div>
@@ -205,11 +266,13 @@ export function EditableMarkdownCell({
               className={cn("min-h-[2rem]", editorClassName)}
             />
           </div>
-        ) : (
+
           <div
-            className={cn(previewClassName, sourceClassName)}
+            ref={previewRef}
+            className={cn(editing && "hidden", previewClassName, sourceClassName)}
             data-slot="editable-markdown-preview"
             role="textbox"
+            aria-label="Markdown cell content"
             aria-readonly
             tabIndex={0}
             onDoubleClick={enterEditing}
@@ -222,10 +285,14 @@ export function EditableMarkdownCell({
               priority={priority}
               hostContext={hostContext}
               className={previewOutputClassName}
+              searchQuery={searchQuery}
+              onLinkClick={onLinkClick}
+              onIframeMouseDown={onIframeMouseDown}
               onIsolatedFrameHandleChange={handlePreviewFrameHandleChange}
+              onDiagnostic={onDiagnostic}
             />
           </div>
-        )
+        </>
       }
     />
   );

--- a/src/components/cell/EditableMarkdownCell.tsx
+++ b/src/components/cell/EditableMarkdownCell.tsx
@@ -20,6 +20,10 @@ import {
   registerMarkdownHeadingNavigator,
   scrollIsolatedMarkdownHeading,
 } from "./markdown-heading-navigation";
+import {
+  createMarkdownEditModeKeyMap,
+  shouldExitMarkdownEditOnBlur,
+} from "./markdown-editor-keymap";
 import { OutputArea } from "./OutputArea";
 import type { JupyterOutput } from "./jupyter-output";
 
@@ -55,7 +59,7 @@ export function EditableMarkdownCell({
   previewClassName,
   previewOutputClassName,
   actionClassName,
-  placeholder = "Markdown",
+  placeholder = "Enter markdown...",
   priority,
   hostContext,
   editorExtensions,
@@ -65,6 +69,8 @@ export function EditableMarkdownCell({
   const suppressNextToggleClickRef = useRef(false);
   const viewRef = useRef<HTMLDivElement>(null);
   const previewFrameRef = useRef<IsolatedFrameHandle | null>(null);
+  const sourceRef = useRef(source);
+  sourceRef.current = source;
 
   const markdownOutput = useMemo<JupyterOutput>(
     () => ({
@@ -79,21 +85,23 @@ export function EditableMarkdownCell({
     () => (editorExtensions ? [...editorExtensions] : undefined),
     [editorExtensions],
   );
-  const editorKeyMapArray = useMemo(
-    () => (editorKeyMap ? [...editorKeyMap] : undefined),
-    [editorKeyMap],
-  );
-
   const enterEditing = useCallback(() => {
     onEditingChange(true);
   }, [onEditingChange]);
 
   const exitEditing = useCallback(() => {
-    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? source;
-    if (currentSource.trim().length > 0) {
+    const currentSource = editorRef.current?.getEditor()?.state.doc.toString() ?? sourceRef.current;
+    if (shouldExitMarkdownEditOnBlur(currentSource)) {
       onEditingChange(false);
     }
-  }, [editorRef, onEditingChange, source]);
+  }, [editorRef, onEditingChange]);
+
+  const editorKeyMapArray = useMemo(() => {
+    return [
+      ...createMarkdownEditModeKeyMap({ exitEditing }),
+      ...(editorKeyMap ? [...editorKeyMap] : []),
+    ];
+  }, [editorKeyMap, exitEditing]);
 
   const handleActionMouseDown = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -182,6 +190,9 @@ export function EditableMarkdownCell({
       codeContent={
         editing ? (
           <div className={sourceClassName} data-slot="editable-markdown-source">
+            <div className="flex items-center gap-1 py-1">
+              <span className="font-mono text-xs text-muted-foreground">md</span>
+            </div>
             <CodeMirrorEditor
               ref={editorRef}
               initialValue={source}

--- a/src/components/cell/__tests__/EditableMarkdownCell.test.tsx
+++ b/src/components/cell/__tests__/EditableMarkdownCell.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { KeyBinding } from "@codemirror/view";
 import { forwardRef, useImperativeHandle, useRef } from "react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { EditableMarkdownCell } from "../EditableMarkdownCell";
@@ -57,10 +58,14 @@ vi.mock("@/components/editor/codemirror-editor", () => ({
     {
       className?: string;
       initialValue?: string;
+      keyMap?: readonly KeyBinding[];
       onBlur?: () => void;
       placeholder?: string;
     }
-  >(function MockCodeMirrorEditor({ className, initialValue = "", onBlur, placeholder }, ref) {
+  >(function MockCodeMirrorEditor(
+    { className, initialValue = "", keyMap, onBlur, placeholder },
+    ref,
+  ) {
     useImperativeHandle(ref, () => ({
       focus: vi.fn(),
       setCursorPosition: vi.fn(),
@@ -77,6 +82,7 @@ vi.mock("@/components/editor/codemirror-editor", () => ({
     return (
       <textarea
         className={className}
+        data-keymap={keyMap?.map((binding) => binding.key).join(",") ?? ""}
         data-testid="codemirror-editor"
         onBlur={onBlur}
         placeholder={placeholder}
@@ -146,6 +152,21 @@ describe("EditableMarkdownCell", () => {
     fireEvent.mouseDown(screen.getByRole("button", { name: "Render markdown" }));
 
     expect(onEditingChange).toHaveBeenCalledWith(false);
+  });
+
+  it("uses the shared desktop markdown editing affordances", () => {
+    render(<Harness id="markdown-keys" source="## Current" editing onEditingChange={() => {}} />);
+
+    expect(screen.getByText("md")).toBeInTheDocument();
+    expect(screen.getByTestId("codemirror-editor")).toHaveAttribute(
+      "placeholder",
+      "Enter markdown...",
+    );
+    expect(screen.getByTestId("codemirror-editor").getAttribute("data-keymap")).toContain("Mod-b");
+    expect(screen.getByTestId("codemirror-editor").getAttribute("data-keymap")).toContain("Mod-k");
+    expect(screen.getByTestId("codemirror-editor").getAttribute("data-keymap")).toContain(
+      "Ctrl-Enter",
+    );
   });
 
   it("registers isolated markdown heading navigation for outline links", async () => {

--- a/src/components/cell/markdown-editor-keymap.ts
+++ b/src/components/cell/markdown-editor-keymap.ts
@@ -1,0 +1,163 @@
+import type { EditorView, KeyBinding } from "@codemirror/view";
+
+export interface MarkdownTextSelection {
+  from: number;
+  to: number;
+}
+
+export interface MarkdownFormatResult {
+  insert: string;
+  from: number;
+  to: number;
+  selectionAnchor: number;
+  selectionHead: number;
+}
+
+export function applyInlineMarkdownFormatting(
+  docText: string,
+  selection: MarkdownTextSelection,
+  prefix: string,
+  suffix = prefix,
+): MarkdownFormatResult {
+  const selectedText = docText.slice(selection.from, selection.to);
+  const wrappedText = `${prefix}${selectedText}${suffix}`;
+
+  return {
+    insert: wrappedText,
+    from: selection.from,
+    to: selection.to,
+    selectionAnchor: selection.from + prefix.length,
+    selectionHead: selection.from + prefix.length + selectedText.length,
+  };
+}
+
+export function applyLinkMarkdownFormatting(
+  docText: string,
+  selection: MarkdownTextSelection,
+): MarkdownFormatResult {
+  const selectedText = docText.slice(selection.from, selection.to);
+  const linkText = selectedText || "link text";
+  const formattedText = `[${linkText}](https://)`;
+
+  return {
+    insert: formattedText,
+    from: selection.from,
+    to: selection.to,
+    selectionAnchor: selection.from + 1,
+    selectionHead: selection.from + 1 + linkText.length,
+  };
+}
+
+export function applyQuoteMarkdownFormatting(
+  docText: string,
+  selection: MarkdownTextSelection,
+): MarkdownFormatResult {
+  const selectedText = docText.slice(selection.from, selection.to);
+  const text = selectedText || "quote";
+  const quotedText = text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+
+  return {
+    insert: quotedText,
+    from: selection.from,
+    to: selection.to,
+    selectionAnchor: selection.from,
+    selectionHead: selection.from + quotedText.length,
+  };
+}
+
+export function shouldExitMarkdownEditOnBlur(source: string): boolean {
+  return source.trim().length > 0;
+}
+
+export function shouldStartMarkdownEditMode(source: string): boolean {
+  return source.trim().length === 0;
+}
+
+function dispatchMarkdownFormat(
+  view: EditorView,
+  formatter: (docText: string, selection: MarkdownTextSelection) => MarkdownFormatResult,
+) {
+  const selection = view.state.selection.main;
+  const result = formatter(view.state.doc.toString(), {
+    from: selection.from,
+    to: selection.to,
+  });
+
+  view.dispatch({
+    changes: {
+      from: result.from,
+      to: result.to,
+      insert: result.insert,
+    },
+    selection: {
+      anchor: result.selectionAnchor,
+      head: result.selectionHead,
+    },
+  });
+  return true;
+}
+
+export function createMarkdownFormattingKeyMap(): KeyBinding[] {
+  return [
+    {
+      key: "Mod-b",
+      run: (view) =>
+        dispatchMarkdownFormat(view, (docText, selection) =>
+          applyInlineMarkdownFormatting(docText, selection, "**"),
+        ),
+    },
+    {
+      key: "Mod-i",
+      run: (view) =>
+        dispatchMarkdownFormat(view, (docText, selection) =>
+          applyInlineMarkdownFormatting(docText, selection, "*"),
+        ),
+    },
+    {
+      key: "Mod-u",
+      run: (view) =>
+        dispatchMarkdownFormat(view, (docText, selection) =>
+          applyInlineMarkdownFormatting(docText, selection, "<u>", "</u>"),
+        ),
+    },
+    {
+      key: "Mod-k",
+      run: (view) => dispatchMarkdownFormat(view, applyLinkMarkdownFormatting),
+    },
+    {
+      key: "Mod-Shift-.",
+      run: (view) => dispatchMarkdownFormat(view, applyQuoteMarkdownFormatting),
+    },
+    {
+      key: "Mod-Shift->",
+      run: (view) => dispatchMarkdownFormat(view, applyQuoteMarkdownFormatting),
+    },
+  ];
+}
+
+export function createMarkdownEditModeKeyMap({
+  exitEditing,
+}: {
+  exitEditing: () => void;
+}): KeyBinding[] {
+  return [
+    {
+      key: "Ctrl-Enter",
+      run: () => {
+        exitEditing();
+        return true;
+      },
+    },
+    {
+      key: "Escape",
+      run: () => {
+        exitEditing();
+        return true;
+      },
+    },
+    ...createMarkdownFormattingKeyMap(),
+  ];
+}

--- a/src/components/cell/markdown-editor-keymap.ts
+++ b/src/components/cell/markdown-editor-keymap.ts
@@ -140,14 +140,16 @@ export function createMarkdownFormattingKeyMap(): KeyBinding[] {
 
 export function createMarkdownEditModeKeyMap({
   exitEditing,
+  forceExitEditing = exitEditing,
 }: {
   exitEditing: () => void;
+  forceExitEditing?: () => void;
 }): KeyBinding[] {
   return [
     {
       key: "Ctrl-Enter",
       run: () => {
-        exitEditing();
+        forceExitEditing();
         return true;
       },
     },


### PR DESCRIPTION
## Summary

- extracts markdown formatting/edit-mode helpers into a shared cell module
- routes desktop `MarkdownCell` through the shared `EditableMarkdownCell` primitive that cloud already uses
- keeps host behavior in adapters: desktop still owns CRDT bridge, search, focus, drag, presence, link opening, diagnostics, and resolved asset rewriting
- preserves shared markdown heading navigation, output rendering, and search forwarding through the shared cell surface

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/EditableMarkdownCell.test.tsx apps/notebook/src/components/__tests__/markdown-formatting.test.ts apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3197 --max-turns 120 --out .context/reviews/pr-3197-shared-markdown-surface.json`

## Notes

- This is the markdown-cell convergence slice. It does not attempt full desktop `NotebookView` adoption in cloud.
- Cloud-specific Automerge/sync/auth behavior remains in `apps/notebook-cloud/viewer/editable-markdown-cell.tsx`; the shared cell primitive remains host-neutral.
