### PR TITLE
refactor(notebook): reshape cell ribbon language

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -12,7 +12,6 @@ import {
 import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
-import { ExecutionCount } from "@/components/cell/ExecutionCount";
 import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
@@ -46,25 +45,25 @@ const layers = [
   {
     name: "CellContainer",
     source: "src/components/cell/CellContainer.tsx",
-    role: "Frame, focus state, gutter ribbon, drag handle, and segmented source/output layout.",
+    role: "Frame, focus state, ribbon separator, drag handle, and segmented source/output layout.",
     status: "rendered",
   },
   {
     name: "CompactExecutionButton",
     source: "src/components/cell/CompactExecutionButton.tsx",
-    role: "Run/interrupt affordance that belongs to code cells, not a generic button variant.",
+    role: "Legacy side-marker exploration retained while execution moves into the code-cell current line.",
     status: "rendered",
   },
   {
     name: "ExecutionCount",
     source: "src/components/cell/ExecutionCount.tsx",
-    role: "Read-only gutter count used when notebook cells are rendered without execution controls.",
+    role: "Read-only execution marker used by report-style notebook renders.",
     status: "rendered",
   },
   {
     name: "CellPresenceIndicators",
     source: "apps/notebook/src/components/cell/CellPresenceIndicators.tsx",
-    role: "Remote peer markers in the cell gutter, backed by the cursor registry and presence bus.",
+    role: "Remote peer markers backed by the cursor registry and presence bus.",
     status: "rendered",
   },
   {
@@ -87,21 +86,44 @@ const cellTypeFixtures = [
     type: "code",
     label: "Code cell",
     count: 7,
-    body: "Read-only code cells use the execution count while editable code cells use the compact run control.",
+    body: "Editable code cells keep the ribbon clean and move execution state into a quiet current line.",
   },
   {
     id: "fixture-markdown-count",
     type: "markdown",
     label: "Markdown cell",
     count: null,
-    body: "Markdown keeps the same container contract but shifts to the markdown gutter accent when focused.",
+    body: "Markdown keeps the same container contract but shifts to the markdown ribbon accent when focused.",
   },
   {
     id: "fixture-raw-count",
     type: "raw",
     label: "Raw cell",
     count: null,
-    body: "Raw cells use the raw gutter accent while sharing the same frame and drag affordance.",
+    body: "Raw cells use the raw ribbon accent while sharing the same frame and drag affordance.",
+  },
+];
+
+const executionStateFixtures = [
+  {
+    label: "Never run",
+    detail: "play",
+    control: <CompactExecutionButton count={null} />,
+  },
+  {
+    label: "Ran",
+    detail: "count",
+    control: <CompactExecutionButton count={12} />,
+  },
+  {
+    label: "Queued",
+    detail: "waiting",
+    control: <CompactExecutionButton count={12} isQueued submittedByActorLabel="local:kyle" />,
+  },
+  {
+    label: "Busy",
+    detail: "interrupt",
+    control: <CompactExecutionButton count={12} isExecuting submittedByActorLabel="local:kyle" />,
   },
 ];
 
@@ -110,6 +132,7 @@ const contracts = [
   "Fixture content may stand in for runtime/editor/output systems until an adapter exists.",
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
+  "The rail owns notebook navigation; the ribbon owns type/focus; the code-cell current line owns run state.",
 ];
 
 const presenceSnapshot = {
@@ -250,19 +273,18 @@ export function CellAnatomyExample() {
       </section>
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[96px_1fr_190px]">
-          <div>gutter</div>
+        <div className="grid border-b border-fd-border bg-fd-muted/20 px-4 py-3 text-xs text-fd-muted-foreground sm:grid-cols-[72px_1fr_190px]">
+          <div>ribbon</div>
           <div>source and output</div>
           <div className="hidden text-right sm:block">real shell, fixture content</div>
         </div>
-        <div className="bg-background py-4 pl-12 pr-2">
+        <div className="bg-background py-4 pl-4 pr-2">
           <PresenceFixtureProvider>
             <CellContainer
               id={primaryCellId}
               cellType="code"
               isFocused
               className="mx-0 px-0"
-              gutterContent={<CompactExecutionButton count={12} />}
               codeContent={<SourceFixture />}
               outputContent={<OutputFixture />}
               rightGutterContent={
@@ -284,28 +306,16 @@ export function CellAnatomyExample() {
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Cell Type Gutters</h2>
+          <h2 className="text-sm font-semibold">Cell Type Ribbons</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            These rows reuse the current CellContainer gutter colors and ExecutionCount component,
-            with fixture content standing in for the editor or renderer.
+            These rows reuse the current CellContainer ribbon colors with fixture content standing
+            in for the editor or renderer.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background py-2">
           {cellTypeFixtures.map((cell) => (
-            <div key={cell.id} className="py-2 pl-12 pr-2">
-              <CellContainer
-                id={cell.id}
-                cellType={cell.type}
-                isFocused
-                className="mx-0 px-0"
-                gutterContent={
-                  cell.type === "code" ? (
-                    <ExecutionCount count={cell.count} />
-                  ) : (
-                    <ExecutionCount count={cell.count} className="opacity-50" />
-                  )
-                }
-              >
+            <div key={cell.id} className="py-2 pl-4 pr-2">
+              <CellContainer id={cell.id} cellType={cell.type} isFocused className="mx-0 px-0">
                 <div className="min-w-0">
                   <div className="flex min-w-0 items-center justify-between gap-3">
                     <h3 className="truncate text-sm font-semibold">{cell.label}</h3>
@@ -318,28 +328,30 @@ export function CellAnatomyExample() {
               </CellContainer>
             </div>
           ))}
-          <div className="py-2 pl-12 pr-2">
-            <CellContainer
-              id="fixture-executing-count"
-              cellType="code"
-              isFocused
-              className="mx-0 px-0"
-              gutterContent={<ExecutionCount count={null} isExecuting />}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Execution Marker Alternatives</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            These side markers are kept separate from the main cell anatomy while the executable
+            state moves toward the code-cell current line at the source/result boundary.
+          </p>
+        </div>
+        <div className="grid gap-3 bg-background p-4 sm:grid-cols-2 lg:grid-cols-4">
+          {executionStateFixtures.map((state) => (
+            <div
+              key={state.label}
+              className="flex items-center gap-3 rounded-md border border-fd-border bg-fd-card p-3"
             >
+              <div className="flex w-7 justify-end">{state.control}</div>
               <div className="min-w-0">
-                <div className="flex min-w-0 items-center justify-between gap-3">
-                  <h3 className="truncate text-sm font-semibold">Executing count state</h3>
-                  <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-[11px] font-medium text-sky-700 dark:text-sky-300">
-                    running
-                  </span>
-                </div>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-                  ExecutionCount renders the notebook convention for active read-only cells without
-                  requiring kernel state in the catalog.
-                </p>
+                <div className="text-sm font-medium">{state.label}</div>
+                <div className="mt-1 text-xs text-fd-muted-foreground">{state.detail}</div>
               </div>
-            </CellContainer>
-          </div>
+            </div>
+          ))}
         </div>
       </section>
 

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -2,6 +2,8 @@
 
 import {
   Braces,
+  ChevronRight,
+  Code2,
   CheckCircle2,
   CircleDot,
   FileText,
@@ -12,7 +14,7 @@ import {
 import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
-import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
+import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
@@ -50,9 +52,9 @@ const layers = [
     status: "rendered",
   },
   {
-    name: "CompactExecutionButton",
-    source: "src/components/cell/CompactExecutionButton.tsx",
-    role: "Legacy side-marker exploration retained while execution moves into the code-cell current line.",
+    name: "CodeCellCurrentLine",
+    source: "src/components/cell/CodeCellCurrentLine.tsx",
+    role: "Natural-language run state, execution count, and bottom run/stop affordance.",
     status: "rendered",
   },
   {
@@ -105,26 +107,72 @@ const cellTypeFixtures = [
   },
 ];
 
-const executionStateFixtures = [
+const currentLineStateFixtures = [
   {
-    label: "Never run",
-    detail: "play",
-    control: <CompactExecutionButton count={null} />,
+    label: "Idle",
+    detail: "Quiet until hover, focus, or keyboard focus.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={null}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
   },
   {
-    label: "Ran",
-    detail: "count",
-    control: <CompactExecutionButton count={12} />,
+    label: "Focused idle",
+    detail: "Language becomes readable when the cell owns focus.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={null}
+        isFocused
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
   },
   {
     label: "Queued",
-    detail: "waiting",
-    control: <CompactExecutionButton count={12} isQueued submittedByActorLabel="local:kyle" />,
+    detail: "Waiting uses the queue accent without becoming an error.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        isQueued
+        submittedByActorLabel="local:kyle"
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
   },
   {
-    label: "Busy",
-    detail: "interrupt",
-    control: <CompactExecutionButton count={12} isExecuting submittedByActorLabel="local:kyle" />,
+    label: "Running",
+    detail: "Status reads active; the stop control carries danger.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        isExecuting
+        submittedByActorLabel="local:kyle"
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
+  },
+  {
+    label: "Completed",
+    detail: "The finished state leads with language, then compact run metadata.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        elapsedMs={1476}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
   },
 ];
 
@@ -134,7 +182,8 @@ const contracts = [
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
   "The rail owns notebook navigation; the ribbon owns type, focus, insertion intent, and document continuity.",
-  "The code-cell current line owns run state.",
+  "The code-cell current line owns the source/result boundary and run state.",
+  "Hidden source keeps the current line when output remains visible; fully hidden cells collapse to one reveal affordance.",
 ];
 
 const insertionRibbonRows = [
@@ -150,6 +199,33 @@ const insertionRibbonRows = [
       "The final add row keeps the action line in place while the spine fades into whitespace.",
     activeType: "code" as const,
     terminal: true,
+  },
+];
+
+const hiddenBoundaryRows = [
+  {
+    id: "source-hidden-output-visible",
+    label: "Input hidden",
+    detail: "The source reveal sits above the current line; output still follows the boundary.",
+    codeContent: <BoundarySourceFixture sourceHidden />,
+    outputContent: <BoundaryOutputFixture />,
+    hideOutput: false,
+  },
+  {
+    id: "output-hidden-source-visible",
+    label: "Output hidden",
+    detail: "The current line stays with the source; the hidden output reveal owns the output row.",
+    codeContent: <BoundarySourceFixture />,
+    outputContent: <HiddenOutputFixture />,
+    hideOutput: false,
+  },
+  {
+    id: "both-hidden",
+    label: "Input and output hidden",
+    detail: "When both sides disappear, the cell collapses to one reveal affordance.",
+    codeContent: <HiddenCellFixture />,
+    outputContent: <HiddenOutputFixture />,
+    hideOutput: true,
   },
 ];
 
@@ -221,7 +297,7 @@ function PresenceFixtureProvider({ children }: { children: ReactNode }) {
 
 function SourceFixture() {
   return (
-    <div className="min-w-0">
+    <div className="group min-w-0">
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Rows3 className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
@@ -250,6 +326,14 @@ function SourceFixture() {
           readOnly
         />
       </div>
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        elapsedMs={1476}
+        isFocused
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
     </div>
   );
 }
@@ -288,6 +372,69 @@ function InsertionRibbonFixture({
       forceActionsVisible
       onInsert={() => undefined}
     />
+  );
+}
+
+function BoundarySourceFixture({ sourceHidden = false }: { sourceHidden?: boolean }) {
+  return (
+    <div className="group min-w-0">
+      {sourceHidden ? (
+        <button
+          type="button"
+          className="inline-flex max-w-full items-center gap-1 rounded bg-muted/50 px-2 py-0.5 font-mono text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <Code2 className="size-3 flex-none" aria-hidden="true" />
+          <span className="truncate">{sourceFixture.split("\n")[0]}</span>
+          <ChevronRight className="size-3 flex-none" aria-hidden="true" />
+        </button>
+      ) : (
+        <pre className="m-0 overflow-hidden rounded border border-border bg-background px-3 py-2 font-mono text-xs leading-5 text-foreground">
+          {sourceFixture.split("\n").slice(0, 2).join("\n")}
+        </pre>
+      )}
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        elapsedMs={1476}
+        isFocused
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    </div>
+  );
+}
+
+function BoundaryOutputFixture() {
+  return (
+    <div className="px-3 py-2 text-xs leading-5 text-fd-muted-foreground">
+      MAE=8.42&nbsp;&nbsp;MAPE=6.8%&nbsp;&nbsp;Backtest=16 weeks
+    </div>
+  );
+}
+
+function HiddenOutputFixture() {
+  return (
+    <div className="px-3 py-2">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 rounded bg-muted/50 px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <span>2 outputs</span>
+        <ChevronRight className="size-3" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+function HiddenCellFixture() {
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1 rounded bg-muted/50 px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+    >
+      <span>Cell hidden</span>
+      <ChevronRight className="size-3" aria-hidden="true" />
+    </button>
   );
 }
 
@@ -391,23 +538,52 @@ export function CellAnatomyExample() {
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Execution Marker Alternatives</h2>
+          <h2 className="text-sm font-semibold">Current Line States</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            These side markers are kept separate from the main cell anatomy while the executable
-            state moves toward the code-cell current line at the source/result boundary.
+            Execution state sits at the source/result boundary. The language leads as cell identity,
+            and the run state reads as compact metadata.
           </p>
         </div>
-        <div className="grid gap-3 bg-background p-4 sm:grid-cols-2 lg:grid-cols-4">
-          {executionStateFixtures.map((state) => (
+        <div className="grid gap-3 bg-background p-4 lg:grid-cols-2">
+          {currentLineStateFixtures.map((state) => (
             <div
               key={state.label}
-              className="flex items-center gap-3 rounded-md border border-fd-border bg-fd-card p-3"
+              className="group rounded-md border border-fd-border bg-fd-card p-3"
             >
-              <div className="flex w-7 justify-end">{state.control}</div>
               <div className="min-w-0">
                 <div className="text-sm font-medium">{state.label}</div>
                 <div className="mt-1 text-xs text-fd-muted-foreground">{state.detail}</div>
               </div>
+              <div className="mt-3 min-w-0">{state.line}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Hidden Boundaries</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The current line belongs to the source/result boundary. It remains when either side is
+            still visible and disappears only when the whole cell is intentionally collapsed.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background py-2">
+          {hiddenBoundaryRows.map((row) => (
+            <div key={row.id} className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+              <div>
+                <h3 className="text-sm font-semibold">{row.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
+              </div>
+              <CellContainer
+                id={row.id}
+                cellType="code"
+                isFocused
+                className="mx-0 px-0"
+                codeContent={row.codeContent}
+                outputContent={row.outputContent}
+                hideOutput={row.hideOutput}
+              />
             </div>
           ))}
         </div>

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -5,15 +5,18 @@ import {
   CheckCircle2,
   CircleDot,
   FileText,
+  Plus,
   Rows3,
   Search,
   ShieldCheck,
 } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
+import { cellContentColumnOffset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import { cn } from "@/lib/utils";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
@@ -132,7 +135,24 @@ const contracts = [
   "Fixture content may stand in for runtime/editor/output systems until an adapter exists.",
   "Cell identity and stable DOM order stay outside the visual component.",
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
-  "The rail owns notebook navigation; the ribbon owns type/focus; the code-cell current line owns run state.",
+  "The rail owns notebook navigation; the ribbon owns type, focus, insertion intent, and document continuity.",
+  "The code-cell current line owns run state.",
+];
+
+const insertionRibbonRows = [
+  {
+    label: "Between cells",
+    detail: "The neutral spine stays continuous; the active add action supplies the color.",
+    activeType: "markdown" as const,
+    terminal: false,
+  },
+  {
+    label: "Document tail",
+    detail:
+      "The final add row keeps the action line in place while the spine fades into whitespace.",
+    activeType: "code" as const,
+    terminal: true,
+  },
 ];
 
 const presenceSnapshot = {
@@ -256,6 +276,80 @@ function OutputFixture() {
   );
 }
 
+function InsertionRibbonFixture({
+  activeType,
+  terminal,
+}: {
+  activeType: "code" | "markdown";
+  terminal?: boolean;
+}) {
+  const intentClass =
+    activeType === "code"
+      ? terminal
+        ? "bg-gradient-to-b from-sky-400 via-sky-400/60 to-sky-400/0 dark:from-sky-600 dark:via-sky-600/60 dark:to-sky-600/0"
+        : "bg-sky-400 dark:bg-sky-600"
+      : terminal
+        ? "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0"
+        : "bg-emerald-400 dark:bg-emerald-600";
+
+  return (
+    <div
+      className={cn(
+        "flex w-full select-none",
+        terminal ? "h-24 items-start" : "h-7 items-center",
+        notebookCellLayoutVars,
+      )}
+    >
+      <div
+        className={cn(
+          "relative h-full w-1 shrink-0 overflow-hidden",
+          terminal &&
+            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]",
+        )}
+      >
+        <div
+          className={cn(
+            "absolute inset-0 dark:bg-gray-700/55",
+            terminal ? "bg-gray-200/70" : "bg-gray-200/55",
+          )}
+        />
+        <div
+          className={cn("absolute left-0 top-0 w-full", terminal ? "h-14" : "h-full", intentClass)}
+        />
+      </div>
+      <div
+        className={cn(
+          "flex items-center gap-1 text-xs",
+          terminal && "pt-0.5",
+          cellContentColumnOffset,
+        )}
+      >
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 font-medium",
+            activeType === "code" ? "text-fd-foreground" : "text-fd-muted-foreground/45",
+          )}
+        >
+          <Plus className="size-3" aria-hidden="true" />
+          Add code
+        </span>
+        <span className="text-fd-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 font-medium",
+            activeType === "markdown" ? "text-fd-foreground" : "text-fd-muted-foreground/45",
+          )}
+        >
+          <Plus className="size-3" aria-hidden="true" />
+          Add markdown
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function CellAnatomyExample() {
   return (
     <div className="not-prose space-y-6">
@@ -326,6 +420,29 @@ export function CellAnatomyExample() {
                   <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{cell.body}</p>
                 </div>
               </CellContainer>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Insertion Ribbon</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            Add-cell rows are part of the same document spine. The quiet continuation stays neutral,
+            while the hovered or focused action paints the insertion intent.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background py-2">
+          {insertionRibbonRows.map((row) => (
+            <div key={row.label} className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+              <div>
+                <h3 className="text-sm font-semibold">{row.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
+              </div>
+              <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+                <InsertionRibbonFixture activeType={row.activeType} terminal={row.terminal} />
+              </div>
             </div>
           ))}
         </div>

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircle2,
   CircleDot,
   FileText,
+  Play,
   Rows3,
   Search,
   ShieldCheck,
@@ -169,9 +170,59 @@ const currentLineStateFixtures = [
         languageLabel="Python"
         count={12}
         elapsedMs={1476}
+        activityContent={<StaticPresenceActivity />}
         onExecute={() => {}}
         onInterrupt={() => {}}
       />
+    ),
+  },
+];
+
+const currentLineConceptFixtures = [
+  {
+    label: "Production",
+    detail: "Control, language, run state, activity, and rule in one boundary line.",
+    line: (
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={26}
+        elapsedMs={1476}
+        isFocused
+        activityContent={<StaticPresenceActivity />}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+      />
+    ),
+  },
+  {
+    label: "Run state chip",
+    detail: "Makes completion feel like metadata instead of sentence copy.",
+    line: (
+      <CurrentLineConcept>
+        <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
+          Python
+        </span>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-medium tabular-nums text-foreground/65">
+          Run 26
+        </span>
+        <span className="text-muted-foreground/55">completed in 1.5s</span>
+        <StaticPresenceDots />
+      </CurrentLineConcept>
+    ),
+  },
+  {
+    label: "Activity edge",
+    detail: "Keeps the run text shorter and lets peer activity sit against the rule.",
+    line: (
+      <CurrentLineConcept>
+        <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
+          Python
+        </span>
+        <span className="font-medium tabular-nums text-foreground/65">Run 26</span>
+        <span className="text-muted-foreground/45">completed</span>
+        <div className="h-px min-w-8 flex-1 rounded-full bg-border/45" />
+        <StaticPresenceDots />
+      </CurrentLineConcept>
     ),
   },
 ];
@@ -331,6 +382,9 @@ function SourceFixture() {
         count={12}
         elapsedMs={1476}
         isFocused
+        activityContent={
+          <CellPresenceIndicators cellId={primaryCellId} variant="inline" prefixSeparator />
+        }
         onExecute={() => {}}
         onInterrupt={() => {}}
       />
@@ -479,7 +533,6 @@ export function CellAnatomyExample() {
                   fixture
                 </span>
               }
-              presenceIndicators={<CellPresenceIndicators cellId={primaryCellId} />}
               dragHandleProps={{ "aria-label": "Fixture drag handle" }}
             />
           </PresenceFixtureProvider>
@@ -562,6 +615,30 @@ export function CellAnatomyExample() {
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Current Line Studio</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            These are low-risk composition sketches for the source/result boundary. They keep the
+            production run button and layout nearby while letting the activity and completion copy
+            move around.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background">
+          {currentLineConceptFixtures.map((concept) => (
+            <div key={concept.label} className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+              <div>
+                <h3 className="text-sm font-semibold">{concept.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{concept.detail}</p>
+              </div>
+              <div className="group min-w-0 rounded-md border border-fd-border bg-fd-card px-3 py-4">
+                {concept.line}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
           <h2 className="text-sm font-semibold">Hidden Boundaries</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             The current line belongs to the source/result boundary. It remains when either side is
@@ -635,6 +712,46 @@ export function CellAnatomyExample() {
           </div>
         </div>
       </section>
+    </div>
+  );
+}
+
+function StaticPresenceDots() {
+  return (
+    <span
+      className="inline-flex items-center gap-0.5"
+      title="forecast reviewer, runtime analyst, output reviewer"
+      aria-label="forecast reviewer, runtime analyst, output reviewer"
+    >
+      <span className="size-2 rounded-full bg-emerald-500" />
+      <span className="size-2 rounded-full bg-sky-500" />
+      <span className="size-2 rounded-full bg-violet-500" />
+    </span>
+  );
+}
+
+function StaticPresenceActivity() {
+  return (
+    <>
+      <span className="text-muted-foreground/30" aria-hidden="true">
+        ·
+      </span>
+      <StaticPresenceDots />
+    </>
+  );
+}
+
+function CurrentLineConcept({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-6 min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
+      <button
+        type="button"
+        className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
+        aria-label="Run cell"
+      >
+        <Play className="size-2.5 fill-current" aria-hidden="true" />
+      </button>
+      {children}
     </div>
   );
 }

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -5,18 +5,16 @@ import {
   CheckCircle2,
   CircleDot,
   FileText,
-  Plus,
   Rows3,
   Search,
   ShieldCheck,
 } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
-import { cellContentColumnOffset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
-import { cn } from "@/lib/utils";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
@@ -283,70 +281,13 @@ function InsertionRibbonFixture({
   activeType: "code" | "markdown";
   terminal?: boolean;
 }) {
-  const intentClass =
-    activeType === "code"
-      ? terminal
-        ? "bg-gradient-to-b from-sky-400 via-sky-400/60 to-sky-400/0 dark:from-sky-600 dark:via-sky-600/60 dark:to-sky-600/0"
-        : "bg-sky-400 dark:bg-sky-600"
-      : terminal
-        ? "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0"
-        : "bg-emerald-400 dark:bg-emerald-600";
-
   return (
-    <div
-      className={cn(
-        "flex w-full select-none",
-        terminal ? "h-24 items-start" : "h-7 items-center",
-        notebookCellLayoutVars,
-      )}
-    >
-      <div
-        className={cn(
-          "relative h-full w-1 shrink-0 overflow-hidden",
-          terminal &&
-            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]",
-        )}
-      >
-        <div
-          className={cn(
-            "absolute inset-0 dark:bg-gray-700/55",
-            terminal ? "bg-gray-200/70" : "bg-gray-200/55",
-          )}
-        />
-        <div
-          className={cn("absolute left-0 top-0 w-full", terminal ? "h-14" : "h-full", intentClass)}
-        />
-      </div>
-      <div
-        className={cn(
-          "flex items-center gap-1 text-xs",
-          terminal && "pt-0.5",
-          cellContentColumnOffset,
-        )}
-      >
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 font-medium",
-            activeType === "code" ? "text-fd-foreground" : "text-fd-muted-foreground/45",
-          )}
-        >
-          <Plus className="size-3" aria-hidden="true" />
-          Add code
-        </span>
-        <span className="text-fd-muted-foreground/30" aria-hidden="true">
-          ·
-        </span>
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 font-medium",
-            activeType === "markdown" ? "text-fd-foreground" : "text-fd-muted-foreground/45",
-          )}
-        >
-          <Plus className="size-3" aria-hidden="true" />
-          Add markdown
-        </span>
-      </div>
-    </div>
+    <CellInsertionRibbon
+      activeType={activeType}
+      terminal={terminal}
+      forceActionsVisible
+      onInsert={() => undefined}
+    />
   );
 }
 

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -125,7 +125,7 @@ const fullCellRows = [
     label: "CodeCell",
     source: "apps/notebook/src/components/CodeCell.tsx",
     detail:
-      "Rendered with seeded execution and output stores, real CodeMirror source, CompactExecutionButton, and OutputArea.",
+      "Rendered with seeded execution and output stores, ribbon-first CellContainer, code-cell current line, and OutputArea.",
   },
   {
     label: "MarkdownCell",
@@ -322,11 +322,11 @@ export function FullCellSurfacesExample() {
               <h2 className="text-sm font-semibold">CodeCell</h2>
             </div>
             <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-              The output count, execution button, and rendered text outputs come from the same
-              stores the notebook app consumes.
+              The code-cell current line and rendered text outputs come from the same stores the
+              notebook app consumes.
             </p>
           </div>
-          <div className="bg-background py-4 pl-12 pr-2">
+          <div className="bg-background py-4 pl-4 pr-2">
             <CodeCell
               cell={codeCell}
               language="python"
@@ -358,7 +358,7 @@ export function FullCellSurfacesExample() {
             </p>
           </div>
           <div className="grid gap-4 bg-background p-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-            <div className="min-w-0 pl-8 pr-2">
+            <div className="min-w-0 pl-6 pr-2">
               <MarkdownCell
                 cell={markdownCell}
                 onFocus={() => focusFixtureCell(markdownCell.id)}
@@ -396,7 +396,7 @@ export function FullCellSurfacesExample() {
               component.
             </p>
           </div>
-          <div className="bg-background py-4 pl-12 pr-2">
+          <div className="bg-background py-4 pl-4 pr-2">
             <RawCell
               cell={rawCell}
               onFocus={() => focusFixtureCell(rawCell.id)}

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -9,7 +9,10 @@ import { FullCellSurfacesClient } from "@/components/full-cell-surfaces-client";
 The first component family to document is the existing cell frame. This page
 now renders the production-used cell shell pieces with fixture content, so the
 catalog starts from current imports instead of a new visual fork or outdated
-helpers.
+helpers. The left edge is currently ribbon-first: the ribbon carries cell type
+and focus color without reserving permanent layout space for execution state.
+Editable code cells place execution identity in a quiet current line at the
+source/result boundary.
 
 <CellAnatomyExample />
 
@@ -35,7 +38,8 @@ contract while preserving the existing `NotebookView` DOM-order invariant.
 
 This docs site should keep moving component by component toward runtime-free
 fixtures. The cell frame, compact execution button, execution count,
-cell-type gutter accents, `CodeMirrorEditor`, `OutputArea`, cell-level presence
+cell-type ribbon accents, code-cell current line, `CodeMirrorEditor`,
+`OutputArea`, cell-level presence
 indicators, and the full code/markdown/raw cell components now render from
 current source. The presence example seeds the notebook cursor registry through
 a fixture presence snapshot, without connecting runtimed or generated WASM.

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -12,7 +12,10 @@ catalog starts from current imports instead of a new visual fork or outdated
 helpers. The left edge is currently ribbon-first: the ribbon carries cell type
 and focus color without reserving permanent layout space for execution state.
 Editable code cells place execution identity in a quiet current line at the
-source/result boundary.
+source/result boundary. Add-cell rows now belong to the same spine: they keep a
+neutral continuation visible between cells, paint only the hovered or focused
+insertion action, and fade the terminal spine into the notebook tail instead of
+ending with a hard marker.
 
 <CellAnatomyExample />
 
@@ -39,10 +42,10 @@ contract while preserving the existing `NotebookView` DOM-order invariant.
 This docs site should keep moving component by component toward runtime-free
 fixtures. The cell frame, compact execution button, execution count,
 cell-type ribbon accents, code-cell current line, `CodeMirrorEditor`,
-`OutputArea`, cell-level presence
-indicators, and the full code/markdown/raw cell components now render from
-current source. The presence example seeds the notebook cursor registry through
-a fixture presence snapshot, without connecting runtimed or generated WASM.
+`OutputArea`, cell-level presence indicators, focused edge controls, insertion
+rows, and the full code/markdown/raw cell components now render from current
+source. The presence example seeds the notebook cursor registry through a
+fixture presence snapshot, without connecting runtimed or generated WASM.
 The full `MarkdownCell` fixture now starts in preview mode and sends its
 `text/markdown` payload through the docs `IsolatedFrame` adapter, keeping the
 production component path visible while the runtime iframe bundle stays outside

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -8,6 +8,9 @@ import { RailOutlineExample } from "@/components/rail-outline-example";
 The rail outline is the first production direction for a notebook table of
 contents. It keeps reading navigation available while leaving clear sibling
 slots for packages, variables, renderers, and future notebook tools.
+The rail owns notebook-level navigation and tools; the ribbon and code-cell
+chrome remain inside the notebook surface for per-cell focus and execution
+state.
 
 This fixture now renders the current notebook app toolbar and shared
 `NotebookRail` directly. The outline is projected with the same

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -327,12 +327,12 @@ async function main() {
             "[data-slot='read-only-report-cell']",
           ).length;
           const counts = Array.from(document.querySelectorAll("[data-slot='execution-count']")).map(
-            (node) => node.textContent?.trim() ?? "",
+            (node) => node.getAttribute("data-execution-count") ?? node.textContent?.trim() ?? "",
           );
           if (expected) {
             return counts.includes(expected);
           }
-          return reportCellCount > 0 || counts.some((count) => /^\[\d+\]:$/.test(count));
+          return reportCellCount > 0 || counts.some((count) => /^\d+$/.test(count));
         },
         expectedExecutionCount,
         { timeout: timeoutMs },

--- a/apps/notebook/src/components/CellSkeleton.tsx
+++ b/apps/notebook/src/components/CellSkeleton.tsx
@@ -5,6 +5,9 @@
  * The staggered animation delays give a subtle wave effect while loading.
  */
 
+import { cellContentColumnInset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { cn } from "@/lib/utils";
+
 const skeletonCells = [
   { height: "2.5rem", delay: "0ms" },
   { height: "5rem", delay: "75ms" },
@@ -13,12 +16,12 @@ const skeletonCells = [
 
 function SkeletonCell({ height, delay }: { height: string; delay: string }) {
   return (
-    <div className="flex py-4">
+    <div className={cn("flex py-4", notebookCellLayoutVars)}>
       {/* Ribbon — self-stretch to fill container height */}
       <div className="w-1 self-stretch rounded-sm bg-muted/40" />
 
       {/* Editor area placeholder */}
-      <div className="min-w-0 flex-1 py-3 pl-[3.25rem] pr-3">
+      <div className={cn("min-w-0 flex-1 py-3 pr-3", cellContentColumnInset)}>
         <div
           className="rounded bg-muted/30 animate-pulse"
           style={{ minHeight: height, animationDelay: delay }}

--- a/apps/notebook/src/components/CellSkeleton.tsx
+++ b/apps/notebook/src/components/CellSkeleton.tsx
@@ -14,14 +14,11 @@ const skeletonCells = [
 function SkeletonCell({ height, delay }: { height: string; delay: string }) {
   return (
     <div className="flex py-4">
-      {/* Gutter area — matches CellContainer's w-10 gutter */}
-      <div className="w-10 flex-shrink-0" />
-
       {/* Ribbon — self-stretch to fill container height */}
       <div className="w-1 self-stretch rounded-sm bg-muted/40" />
 
       {/* Editor area placeholder */}
-      <div className="min-w-0 flex-1 py-3 pl-6 pr-3">
+      <div className="min-w-0 flex-1 py-3 pl-[3.25rem] pr-3">
         <div
           className="rounded bg-muted/30 animate-pulse"
           style={{ minHeight: height, animationDelay: delay }}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,11 +1,10 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff } from "lucide-react";
+import { ChevronRight, Code2, EyeOff, Play, Square } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
-import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
-import type { SupportedLanguage } from "@/components/editor/languages";
+import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
@@ -137,6 +136,188 @@ function needsOutputChrome(outputs: readonly JupyterOutput[]): boolean {
   }
 
   return totalChars > SIMPLE_OUTPUT_MAX_CHARS || totalLines > SIMPLE_OUTPUT_MAX_LINES;
+}
+
+function formatExecutionCount(count: number): string {
+  return count > 999 ? "999+" : String(count);
+}
+
+function executionPhrase({
+  count,
+  isExecuting,
+  isQueued,
+  languageLabel,
+}: {
+  count: number | null;
+  isExecuting: boolean;
+  isQueued: boolean;
+  languageLabel: string;
+}): string {
+  if (isExecuting) return `Running in ${languageLabel}`;
+  if (isQueued) return `Queued to run in ${languageLabel}`;
+  if (count !== null) return `Completed in ${languageLabel}`;
+  return `Ready to run in ${languageLabel}`;
+}
+
+function visibleExecutionCountLabel(count: number | null): string | null {
+  return count === null ? null : `run ${formatExecutionCount(count)}`;
+}
+
+function executionCountLabel(count: number | null): string | null {
+  return count === null ? null : `Execution ${formatExecutionCount(count)}`;
+}
+
+function executionLineClass({
+  isExecuting,
+  isQueued,
+  isFocused,
+}: {
+  isExecuting: boolean;
+  isQueued: boolean;
+  isFocused: boolean;
+}) {
+  if (isExecuting) {
+    return "bg-gradient-to-r from-destructive/45 via-destructive/20 to-border/40";
+  }
+
+  if (isQueued) {
+    return "bg-gradient-to-r from-sky-400/45 via-sky-400/20 to-border/40";
+  }
+
+  if (isFocused) {
+    return "bg-gradient-to-r from-primary/35 via-primary/20 to-border/45";
+  }
+
+  return "bg-gradient-to-r from-border/70 via-border/45 to-transparent";
+}
+
+function CodeCellCurrentLine({
+  language,
+  count,
+  isExecuting,
+  isQueued,
+  isFocused,
+  submittedByActorLabel,
+  onExecute,
+  onInterrupt,
+}: {
+  language: SupportedLanguage;
+  count: number | null;
+  isExecuting: boolean;
+  isQueued: boolean;
+  isFocused: boolean;
+  submittedByActorLabel: string | null;
+  onExecute: () => void;
+  onInterrupt: () => void;
+}) {
+  const languageLabel =
+    language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
+  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const statusLabel = executionPhrase({ count, isExecuting, isQueued, languageLabel });
+  const countLabel = executionCountLabel(count);
+  const visibleCountLabel = visibleExecutionCountLabel(count);
+  const actionTitle = isExecuting
+    ? submittedByActorLabel
+      ? `Stop execution submitted by ${submittedByActorLabel}`
+      : "Stop execution"
+    : isQueued
+      ? submittedByActorLabel
+        ? `Queued for execution by ${submittedByActorLabel}`
+        : "Queued for execution"
+      : count !== null
+        ? `Run cell again; last execution ${count}`
+        : "Run cell";
+
+  const handleClick = () => {
+    if (isQueued) return;
+    if (isExecuting) {
+      onInterrupt();
+    } else {
+      onExecute();
+    }
+  };
+
+  return (
+    <div
+      data-slot="code-cell-current-line"
+      data-execution-state={state}
+      data-execution-count={count ?? undefined}
+      data-execution-label={countLabel ?? undefined}
+      className="mt-2 flex h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65"
+    >
+      <div
+        className={cn(
+          "h-px w-4 shrink-0 rounded-full transition-colors duration-150",
+          executionLineClass({ isExecuting, isQueued, isFocused }),
+        )}
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isQueued}
+        title={actionTitle}
+        aria-label={actionTitle}
+        aria-busy={isExecuting || undefined}
+        data-testid="execute-button"
+        data-execution-state={state}
+        data-execution-count={count ?? undefined}
+        className={cn(
+          "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+          "transition-colors duration-150",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+          !isFocused && state === "idle" && "opacity-55 group-hover:opacity-100",
+          state === "idle" && "hover:bg-muted hover:text-foreground",
+          state === "ran" && "hover:bg-primary/5 hover:text-primary",
+          state === "queued" && "cursor-default text-sky-600 dark:text-sky-400",
+          state === "running" && "text-destructive hover:bg-destructive/10",
+        )}
+      >
+        {isExecuting ? (
+          <Square className="size-3 fill-current animate-exec-squish" aria-hidden="true" />
+        ) : isQueued ? (
+          <span
+            className="block size-1.5 rounded-full bg-current animate-queue-breathe"
+            aria-hidden="true"
+          />
+        ) : (
+          <Play className="size-3 fill-current" aria-hidden="true" />
+        )}
+      </button>
+      <span
+        className={cn(
+          "shrink-0 font-medium transition-colors duration-150",
+          isFocused && "text-foreground/70",
+          isExecuting && "text-destructive/80",
+          isQueued && "text-sky-700 dark:text-sky-300",
+        )}
+      >
+        {statusLabel}
+      </span>
+      {visibleCountLabel && (
+        <>
+          <span className="shrink-0 text-muted-foreground/35" aria-hidden="true">
+            ·
+          </span>
+          <span
+            className={cn(
+              "shrink-0 tabular-nums transition-colors duration-150",
+              isFocused && "text-foreground/75",
+              isExecuting && "text-destructive/80",
+              isQueued && "text-sky-700 dark:text-sky-300",
+            )}
+          >
+            {visibleCountLabel}
+          </span>
+        </>
+      )}
+      <div
+        className={cn(
+          "h-px min-w-4 flex-1 rounded-full transition-colors duration-150",
+          executionLineClass({ isExecuting, isQueued, isFocused }),
+        )}
+      />
+    </div>
+  );
 }
 
 export const CodeCell = memo(function CodeCell({
@@ -366,17 +547,6 @@ export const CodeCell = memo(function CodeCell({
     [onNavigateToCell],
   );
 
-  const gutterContent = bothHidden ? null : (
-    <CompactExecutionButton
-      count={executionCount}
-      isExecuting={isExecuting}
-      isQueued={isQueued}
-      submittedByActorLabel={submittedByActorLabel}
-      onExecute={onExecute}
-      onInterrupt={onInterrupt}
-    />
-  );
-
   return (
     <>
       <CellContainer
@@ -388,7 +558,6 @@ export const CodeCell = memo(function CodeCell({
         outputFocused={outputFocused}
         outputDimmed={outputDimmed}
         onFocus={onFocus}
-        gutterContent={gutterContent}
         rightGutterContent={rightGutterContent}
         presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
         dragHandleProps={dragHandleProps}
@@ -447,21 +616,33 @@ export const CodeCell = memo(function CodeCell({
                 </button>
               </div>
             ) : (
-              <CodeMirrorEditor
-                ref={editorRef}
-                initialValue={cell.source}
-                language={language}
-                keyMap={keyMap}
-                extensions={editorExtensions}
-                placeholder="Enter code..."
-                autoFocus={isFocused}
-              />
+              <>
+                <CodeMirrorEditor
+                  ref={editorRef}
+                  initialValue={cell.source}
+                  language={language}
+                  keyMap={keyMap}
+                  extensions={editorExtensions}
+                  placeholder="Enter code..."
+                  autoFocus={isFocused}
+                />
+                <CodeCellCurrentLine
+                  language={language}
+                  count={executionCount}
+                  isExecuting={isExecuting}
+                  isQueued={isQueued}
+                  isFocused={isFocused}
+                  submittedByActorLabel={submittedByActorLabel}
+                  onExecute={onExecute}
+                  onInterrupt={onInterrupt}
+                />
+              </>
             )}
           </>
         }
         outputContent={
           isOutputsHidden && outputs.length > 0 ? (
-            <div className="flex items-center justify-start mt-0.5 pl-6">
+            <div className="flex items-center justify-start mt-0.5 pl-5">
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,8 +1,9 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff, Play, Square } from "lucide-react";
+import { ChevronRight, Code2, EyeOff } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
+import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
@@ -139,188 +140,6 @@ function needsOutputChrome(outputs: readonly JupyterOutput[]): boolean {
   return totalChars > SIMPLE_OUTPUT_MAX_CHARS || totalLines > SIMPLE_OUTPUT_MAX_LINES;
 }
 
-function formatExecutionCount(count: number): string {
-  return count > 999 ? "999+" : String(count);
-}
-
-function executionPhrase({
-  count,
-  isExecuting,
-  isQueued,
-  languageLabel,
-}: {
-  count: number | null;
-  isExecuting: boolean;
-  isQueued: boolean;
-  languageLabel: string;
-}): string {
-  if (isExecuting) return `Running in ${languageLabel}`;
-  if (isQueued) return `Queued to run in ${languageLabel}`;
-  if (count !== null) return `Completed in ${languageLabel}`;
-  return `Ready to run in ${languageLabel}`;
-}
-
-function visibleExecutionCountLabel(count: number | null): string | null {
-  return count === null ? null : `run ${formatExecutionCount(count)}`;
-}
-
-function executionCountLabel(count: number | null): string | null {
-  return count === null ? null : `Execution ${formatExecutionCount(count)}`;
-}
-
-function executionLineClass({
-  isExecuting,
-  isQueued,
-  isFocused,
-}: {
-  isExecuting: boolean;
-  isQueued: boolean;
-  isFocused: boolean;
-}) {
-  if (isExecuting) {
-    return "bg-primary/45";
-  }
-
-  if (isQueued) {
-    return "bg-sky-400/35";
-  }
-
-  if (isFocused) {
-    return "bg-border/70";
-  }
-
-  return "bg-transparent group-hover:bg-border/45";
-}
-
-function CodeCellCurrentLine({
-  language,
-  count,
-  isExecuting,
-  isQueued,
-  isFocused,
-  submittedByActorLabel,
-  onExecute,
-  onInterrupt,
-}: {
-  language: SupportedLanguage;
-  count: number | null;
-  isExecuting: boolean;
-  isQueued: boolean;
-  isFocused: boolean;
-  submittedByActorLabel: string | null;
-  onExecute: () => void;
-  onInterrupt: () => void;
-}) {
-  const languageLabel =
-    language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
-  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
-  const isQuietIdle = state === "idle" && !isFocused;
-  const statusLabel = executionPhrase({ count, isExecuting, isQueued, languageLabel });
-  const countLabel = executionCountLabel(count);
-  const visibleCountLabel = visibleExecutionCountLabel(count);
-  const actionTitle = isExecuting
-    ? submittedByActorLabel
-      ? `Stop execution submitted by ${submittedByActorLabel}`
-      : "Stop execution"
-    : isQueued
-      ? submittedByActorLabel
-        ? `Queued for execution by ${submittedByActorLabel}`
-        : "Queued for execution"
-      : count !== null
-        ? `Run cell again; last execution ${count}`
-        : "Run cell";
-
-  const handleClick = () => {
-    if (isQueued) return;
-    if (isExecuting) {
-      onInterrupt();
-    } else {
-      onExecute();
-    }
-  };
-
-  return (
-    <div
-      data-slot="code-cell-current-line"
-      data-execution-state={state}
-      data-execution-count={count ?? undefined}
-      data-execution-label={countLabel ?? undefined}
-      className="mt-2 flex min-h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65"
-    >
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={isQueued}
-        title={actionTitle}
-        aria-label={actionTitle}
-        aria-busy={isExecuting || undefined}
-        data-testid="execute-button"
-        data-execution-state={state}
-        data-execution-count={count ?? undefined}
-        className={cn(
-          "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
-          "transition-colors duration-150",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          !isFocused && state === "idle" && "opacity-55 group-hover:opacity-100",
-          state === "idle" && "hover:bg-muted hover:text-foreground",
-          state === "ran" && "hover:bg-primary/5 hover:text-primary",
-          state === "queued" && "cursor-default text-sky-600 dark:text-sky-400",
-          state === "running" && "text-destructive hover:bg-destructive/10",
-        )}
-      >
-        {isExecuting ? (
-          <Square className="size-3 fill-current animate-exec-squish" aria-hidden="true" />
-        ) : isQueued ? (
-          <span
-            className="block size-1.5 rounded-full bg-current animate-queue-breathe"
-            aria-hidden="true"
-          />
-        ) : (
-          <Play className="size-3 fill-current" aria-hidden="true" />
-        )}
-      </button>
-      <span
-        data-slot="code-cell-current-line-status"
-        className={cn(
-          "shrink-0 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
-          isQuietIdle
-            ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-40 group-hover:opacity-100 group-focus-within:max-w-40 group-focus-within:opacity-100"
-            : "max-w-40 opacity-100",
-          isFocused && "text-foreground/70",
-          isExecuting && "text-primary",
-          isQueued && "text-sky-700 dark:text-sky-300",
-        )}
-      >
-        {statusLabel}
-      </span>
-      {visibleCountLabel && (
-        <>
-          <span className="shrink-0 text-muted-foreground/35" aria-hidden="true">
-            ·
-          </span>
-          <span
-            className={cn(
-              "shrink-0 tabular-nums transition-colors duration-150",
-              isFocused && "text-foreground/75",
-              isExecuting && "text-primary/90",
-              isQueued && "text-sky-700 dark:text-sky-300",
-            )}
-          >
-            {visibleCountLabel}
-          </span>
-        </>
-      )}
-      <div
-        data-slot="code-cell-current-line-rule"
-        className={cn(
-          "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
-          executionLineClass({ isExecuting, isQueued, isFocused }),
-        )}
-      />
-    </div>
-  );
-}
-
 export const CodeCell = memo(function CodeCell({
   cell,
   language = "python",
@@ -369,6 +188,8 @@ export const CodeCell = memo(function CodeCell({
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
   const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
+  const languageLabel =
+    language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
   const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
 
   // Check cell metadata for visibility (JupyterLab convention)
@@ -548,6 +369,19 @@ export const CodeCell = memo(function CodeCell({
     [onNavigateToCell],
   );
 
+  const currentLine = (
+    <CodeCellCurrentLine
+      languageLabel={languageLabel}
+      count={executionCount}
+      isExecuting={isExecuting}
+      isQueued={isQueued}
+      isFocused={isFocused}
+      submittedByActorLabel={submittedByActorLabel}
+      onExecute={onExecute}
+      onInterrupt={onInterrupt}
+    />
+  );
+
   return (
     <>
       <CellContainer
@@ -602,20 +436,23 @@ export const CodeCell = memo(function CodeCell({
                 </button>
               </div>
             ) : isSourceHidden ? (
-              <div className="flex items-center justify-start mt-0.5">
-                <button
-                  type="button"
-                  onClick={() => onToggleSourceHidden?.(false)}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
-                  title="Show source"
-                >
-                  <Code2 className="h-3 w-3" />
-                  <span className="font-mono truncate max-w-48">
-                    {cell.source.split("\n")[0] || "source"}
-                  </span>
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-              </div>
+              <>
+                <div className="flex items-center justify-start mt-0.5">
+                  <button
+                    type="button"
+                    onClick={() => onToggleSourceHidden?.(false)}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                    title="Show source"
+                  >
+                    <Code2 className="h-3 w-3" />
+                    <span className="font-mono truncate max-w-48">
+                      {cell.source.split("\n")[0] || "source"}
+                    </span>
+                    <ChevronRight className="h-3 w-3" />
+                  </button>
+                </div>
+                {currentLine}
+              </>
             ) : (
               <>
                 <CodeMirrorEditor
@@ -627,16 +464,7 @@ export const CodeCell = memo(function CodeCell({
                   placeholder="Enter code..."
                   autoFocus={isFocused}
                 />
-                <CodeCellCurrentLine
-                  language={language}
-                  count={executionCount}
-                  isExecuting={isExecuting}
-                  isQueued={isQueued}
-                  isFocused={isFocused}
-                  submittedByActorLabel={submittedByActorLabel}
-                  onExecute={onExecute}
-                  onInterrupt={onInterrupt}
-                />
+                {currentLine}
               </>
             )}
           </>

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -379,6 +379,7 @@ export const CodeCell = memo(function CodeCell({
       isFocused={isFocused}
       compactIdle={isSourceEmpty}
       submittedByActorLabel={submittedByActorLabel}
+      activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" prefixSeparator />}
       onExecute={onExecute}
       onInterrupt={onInterrupt}
     />
@@ -396,7 +397,6 @@ export const CodeCell = memo(function CodeCell({
         outputDimmed={outputDimmed}
         onFocus={onFocus}
         rightGutterContent={rightGutterContent}
-        presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
         codeContent={

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -2,6 +2,7 @@ import type { EditorView, KeyBinding } from "@codemirror/view";
 import { ChevronRight, Code2, EyeOff, Play, Square } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
+import { cellOutputInnerInset } from "@/components/cell/cell-layout";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
@@ -177,18 +178,18 @@ function executionLineClass({
   isFocused: boolean;
 }) {
   if (isExecuting) {
-    return "bg-gradient-to-r from-destructive/45 via-destructive/20 to-border/40";
+    return "bg-destructive/35";
   }
 
   if (isQueued) {
-    return "bg-gradient-to-r from-sky-400/45 via-sky-400/20 to-border/40";
+    return "bg-sky-400/35";
   }
 
   if (isFocused) {
-    return "bg-gradient-to-r from-primary/35 via-primary/20 to-border/45";
+    return "bg-border/70";
   }
 
-  return "bg-gradient-to-r from-border/70 via-border/45 to-transparent";
+  return "bg-transparent group-hover:bg-border/45";
 }
 
 function CodeCellCurrentLine({
@@ -243,14 +244,8 @@ function CodeCellCurrentLine({
       data-execution-state={state}
       data-execution-count={count ?? undefined}
       data-execution-label={countLabel ?? undefined}
-      className="mt-2 flex h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65"
+      className="mt-2 flex min-h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65"
     >
-      <div
-        className={cn(
-          "h-px w-4 shrink-0 rounded-full transition-colors duration-150",
-          executionLineClass({ isExecuting, isQueued, isFocused }),
-        )}
-      />
       <button
         type="button"
         onClick={handleClick}
@@ -312,7 +307,7 @@ function CodeCellCurrentLine({
       )}
       <div
         className={cn(
-          "h-px min-w-4 flex-1 rounded-full transition-colors duration-150",
+          "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
           executionLineClass({ isExecuting, isQueued, isFocused }),
         )}
       />
@@ -642,7 +637,7 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && outputs.length > 0 ? (
-            <div className="flex items-center justify-start mt-0.5 pl-6">
+            <div className={cn("flex items-center justify-start mt-0.5", cellOutputInnerInset)}>
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}
@@ -667,6 +662,7 @@ export const CodeCell = memo(function CodeCell({
               onLinkClick={handleLinkClick}
               onIframeMouseDown={handleOutputMouseDown}
               onDiagnostic={logNotebookIsolatedDiagnostic}
+              layoutInset="cell-output"
               resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
               onNavigateToTracebackCell={handleTracebackCellNavigate}
               focused={outputFocused}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -178,7 +178,7 @@ function executionLineClass({
   isFocused: boolean;
 }) {
   if (isExecuting) {
-    return "bg-destructive/35";
+    return "bg-primary/45";
   }
 
   if (isQueued) {
@@ -279,10 +279,11 @@ function CodeCellCurrentLine({
         )}
       </button>
       <span
+        data-slot="code-cell-current-line-status"
         className={cn(
           "shrink-0 font-medium transition-colors duration-150",
           isFocused && "text-foreground/70",
-          isExecuting && "text-destructive/80",
+          isExecuting && "text-primary",
           isQueued && "text-sky-700 dark:text-sky-300",
         )}
       >
@@ -297,7 +298,7 @@ function CodeCellCurrentLine({
             className={cn(
               "shrink-0 tabular-nums transition-colors duration-150",
               isFocused && "text-foreground/75",
-              isExecuting && "text-destructive/80",
+              isExecuting && "text-primary/90",
               isQueued && "text-sky-700 dark:text-sky-300",
             )}
           >
@@ -306,6 +307,7 @@ function CodeCellCurrentLine({
         </>
       )}
       <div
+        data-slot="code-cell-current-line-rule"
         className={cn(
           "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
           executionLineClass({ isExecuting, isQueued, isFocused }),

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -214,6 +214,7 @@ function CodeCellCurrentLine({
   const languageLabel =
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const isQuietIdle = state === "idle" && !isFocused;
   const statusLabel = executionPhrase({ count, isExecuting, isQueued, languageLabel });
   const countLabel = executionCountLabel(count);
   const visibleCountLabel = visibleExecutionCountLabel(count);
@@ -281,7 +282,10 @@ function CodeCellCurrentLine({
       <span
         data-slot="code-cell-current-line-status"
         className={cn(
-          "shrink-0 font-medium transition-colors duration-150",
+          "shrink-0 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
+          isQuietIdle
+            ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-40 group-hover:opacity-100 group-focus-within:max-w-40 group-focus-within:opacity-100"
+            : "max-w-40 opacity-100",
           isFocused && "text-foreground/70",
           isExecuting && "text-primary",
           isQueued && "text-sky-700 dark:text-sky-300",

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -642,7 +642,7 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && outputs.length > 0 ? (
-            <div className="flex items-center justify-start mt-0.5 pl-5">
+            <div className="flex items-center justify-start mt-0.5 pl-6">
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -190,6 +190,7 @@ export const CodeCell = memo(function CodeCell({
   const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
   const languageLabel =
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
+  const isSourceEmpty = cell.source.trim().length === 0;
   const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
 
   // Check cell metadata for visibility (JupyterLab convention)
@@ -376,6 +377,7 @@ export const CodeCell = memo(function CodeCell({
       isExecuting={isExecuting}
       isQueued={isQueued}
       isFocused={isFocused}
+      compactIdle={isSourceEmpty}
       submittedByActorLabel={submittedByActorLabel}
       onExecute={onExecute}
       onInterrupt={onInterrupt}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -101,8 +101,7 @@ function CellAdder({
       <div
         data-slot="cell-adder-ribbon"
         className={cn(
-          "h-full w-1 shrink-0 bg-gray-200 opacity-0 transition-colors duration-150 dark:bg-gray-700",
-          "group-hover/adder:opacity-100 group-focus-within/adder:opacity-100",
+          "h-full w-1 shrink-0 bg-gray-200/55 transition-colors duration-150 dark:bg-gray-700/55",
           ribbonClass,
         )}
       />

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -863,7 +863,7 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 -ml-8 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth pt-0 pb-4 pl-8 pr-2"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth pt-0 pb-4 pl-0 pr-2"
       style={{
         contain: "paint",
         overflowAnchor: "none",

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -94,10 +94,8 @@ function CellAdder({
 
   return (
     <div className="flex h-7 w-full items-center select-none">
-      {/* Hover zone limited to gutter + ribbon area */}
+      {/* Hover zone limited to the ribbon area */}
       <div className="group/adder flex h-full flex-shrink-0 items-center pr-3">
-        {/* Gutter spacer — matches cell gutter w-10 */}
-        <div className="w-10" />
         {/* Ribbon zone — widens on hover to reveal cell type options */}
         <div
           className={cn(
@@ -430,7 +428,7 @@ function NotebookViewContent({
   // cell's iframe (Sift, HTML) never fires onFocusCell because the iframe
   // absorbs the event. Same goes for clicks on page chrome between cells.
   // Scope the dismiss to the focused cell's container so clicks on its own
-  // gutter buttons (focus, expand, eye) still hit their handlers.
+  // right-gutter buttons (focus, expand, eye) still hit their handlers.
   useEffect(() => {
     if (outputFocusedCellId === null) return;
     const handleMouseDown = (event: MouseEvent) => {
@@ -930,7 +928,7 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth py-4 pl-8 pr-2"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth py-4 pl-0 pr-2"
       style={{
         contain: "paint",
         overflowAnchor: "none",

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -93,46 +93,44 @@ function CellAdder({
   const ribbonClass = adderRibbonClasses[cellType] ?? defaultAdderRibbonClass;
 
   return (
-    <div className="flex h-7 w-full items-center select-none">
-      {/* Hover zone limited to the ribbon area */}
-      <div className="group/adder flex h-full flex-shrink-0 items-center pr-3">
-        {/* Ribbon zone — widens on hover to reveal cell type options */}
-        <div
-          className={cn(
-            "flex h-full flex-shrink-0 items-center overflow-hidden",
-            "w-1 bg-gray-200 transition-all duration-200 ease-out dark:bg-gray-700",
-            "group-hover/adder:w-auto group-hover/adder:rounded-r-sm group-hover/adder:pr-1",
-            "group-focus-within/adder:w-auto group-focus-within/adder:rounded-r-sm group-focus-within/adder:pr-1",
-            ribbonClass,
-          )}
+    <div data-slot="cell-adder" className="group/adder flex h-7 w-full items-center select-none">
+      <div
+        data-slot="cell-adder-ribbon"
+        className={cn(
+          "h-full w-1 shrink-0 bg-gray-200 transition-colors duration-150 dark:bg-gray-700",
+          ribbonClass,
+        )}
+      />
+      <div
+        data-slot="cell-adder-actions"
+        className={cn(
+          "ml-[3.25rem] flex items-center gap-1 opacity-0 transition-opacity duration-150",
+          "group-hover/adder:opacity-100 group-hover/adder:delay-75",
+          "group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
+        )}
+      >
+        <button
+          type="button"
+          title="Add code cell"
+          onClick={() => onAdd("code", afterCellId)}
+          className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
         >
-          <div
-            className={cn(
-              "flex items-center gap-0.5 pl-1.5 opacity-0 transition-opacity duration-150",
-              "group-hover/adder:opacity-100 group-hover/adder:delay-75",
-              "group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
-            )}
-          >
-            <button
-              type="button"
-              title="Add code cell"
-              onClick={() => onAdd("code", afterCellId)}
-              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-            >
-              + Code
-            </button>
-            <button
-              type="button"
-              title="Add markdown cell"
-              onClick={() => onAdd("markdown", afterCellId)}
-              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-            >
-              + Markdown
-            </button>
-          </div>
-        </div>
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add code
+        </button>
+        <span className="text-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+        <button
+          type="button"
+          title="Add markdown cell"
+          onClick={() => onAdd("markdown", afterCellId)}
+          className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add markdown
+        </button>
       </div>
-      {/* Content area — no hover trigger */}
       <div className="flex-1" />
     </div>
   );

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -712,10 +712,11 @@ function NotebookViewContent({
         const isOutputsHidden =
           (cell.metadata?.jupyter as { outputs_hidden?: boolean })?.outputs_hidden === true;
         const bothHidden = isSourceHidden && isOutputsHidden;
+        const hasSourceText = cell.source.trim().length > 0;
 
         rightGutterContent = (
           <div className="flex flex-col gap-0.5">
-            {onSetCellSourceHidden && !bothHidden && (
+            {onSetCellSourceHidden && !bothHidden && hasSourceText && (
               <button
                 type="button"
                 tabIndex={-1}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -19,7 +19,7 @@ import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Code2, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId } from "runtimed";
-import { cellContentColumnOffset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
 import { Button } from "@/components/ui/button";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import type { Runtime } from "@/hooks/useSyncedSettings";
@@ -42,7 +42,7 @@ import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
 
 type AddCellResult = NotebookCell | null;
-type AddCellHandler = (type: "code" | "markdown", afterCellId?: string | null) => AddCellResult;
+type AddCellHandler = (type: CellInsertionType, afterCellId?: string | null) => AddCellResult;
 
 export interface NotebookViewProps {
   cellIds: string[];
@@ -63,17 +63,7 @@ export interface NotebookViewProps {
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
 }
 
-/** Tailwind classes for cell adder ribbon colors — must be static strings for tree-shaking. */
-const adderRibbonClasses: Record<string, string> = {
-  code: "bg-sky-400 dark:bg-sky-600",
-  markdown: "bg-emerald-400 dark:bg-emerald-600",
-};
-const terminalAdderRibbonClasses: Record<string, string> = {
-  code: "bg-gradient-to-b from-sky-400 via-sky-400/60 to-sky-400/0 dark:from-sky-600 dark:via-sky-600/60 dark:to-sky-600/0",
-  markdown:
-    "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0",
-};
-const NOTEBOOK_TAIL_SPACE = "clamp(12rem, 35vh, 22rem)";
+const NOTEBOOK_TAIL_SPACE = "clamp(6rem, 18vh, 12rem)";
 const NOTEBOOK_TAIL_PIN_THRESHOLD_PX = 96;
 
 function CellAdder({
@@ -85,95 +75,7 @@ function CellAdder({
   onAdd: AddCellHandler;
   terminal?: boolean;
 }) {
-  const [activeCellType, setActiveCellType] = useState<"code" | "markdown" | null>(null);
-  const ribbonClass = activeCellType
-    ? terminal
-      ? terminalAdderRibbonClasses[activeCellType]
-      : adderRibbonClasses[activeCellType]
-    : undefined;
-
-  return (
-    <div
-      data-slot="cell-adder"
-      data-terminal={terminal || undefined}
-      className={cn(
-        "group/adder flex w-full select-none",
-        terminal ? "h-32 items-start" : "h-7 items-center",
-        notebookCellLayoutVars,
-      )}
-      onPointerLeave={() => setActiveCellType(null)}
-      onBlur={(event) => {
-        const nextTarget = event.relatedTarget;
-        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
-          setActiveCellType(null);
-        }
-      }}
-    >
-      <div
-        data-slot="cell-adder-ribbon"
-        className={cn(
-          "relative h-full w-1 shrink-0 overflow-hidden",
-          terminal &&
-            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2rem),transparent_100%)]",
-        )}
-      >
-        <div
-          data-slot="cell-adder-ribbon-continuation"
-          className={cn(
-            "absolute inset-0 dark:bg-gray-700/55",
-            terminal ? "bg-gray-200/70" : "bg-gray-200/55",
-          )}
-        />
-        {ribbonClass ? (
-          <div
-            data-slot="cell-adder-ribbon-intent"
-            className={cn(
-              "absolute left-0 top-0 w-full transition-colors duration-150",
-              terminal ? "h-16" : "h-full",
-              ribbonClass,
-            )}
-          />
-        ) : null}
-      </div>
-      <div
-        data-slot="cell-adder-actions"
-        className={cn(
-          "flex items-center gap-1 opacity-0 transition-opacity duration-150",
-          terminal && "pt-0.5",
-          cellContentColumnOffset,
-          "group-hover/adder:opacity-100 group-hover/adder:delay-75",
-          "group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
-        )}
-      >
-        <button
-          type="button"
-          title="Add code cell"
-          onPointerEnter={() => setActiveCellType("code")}
-          onFocus={() => setActiveCellType("code")}
-          onClick={() => onAdd("code", afterCellId)}
-          className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-        >
-          <Plus className="h-3 w-3" aria-hidden="true" />
-          Add code
-        </button>
-        <span className="text-muted-foreground/30" aria-hidden="true">
-          ·
-        </span>
-        <button
-          type="button"
-          title="Add markdown cell"
-          onPointerEnter={() => setActiveCellType("markdown")}
-          onFocus={() => setActiveCellType("markdown")}
-          onClick={() => onAdd("markdown", afterCellId)}
-          className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-        >
-          <Plus className="h-3 w-3" aria-hidden="true" />
-          Add markdown
-        </button>
-      </div>
-      <div className="flex-1" />
-    </div>
-  );
+  return <CellInsertionRibbon terminal={terminal} onInsert={(type) => onAdd(type, afterCellId)} />;
 }
 
 function CellErrorFallback({

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -863,7 +863,7 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth pt-0 pb-4 pl-0 pr-2"
+      className="flex-1 -ml-8 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth pt-0 pb-4 pl-8 pr-2"
       style={{
         contain: "paint",
         overflowAnchor: "none",

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -716,7 +716,7 @@ function NotebookViewContent({
 
         rightGutterContent = (
           <div className="flex flex-col gap-0.5">
-            {onSetCellSourceHidden && !bothHidden && hasSourceText && (
+            {onSetCellSourceHidden && !bothHidden && (hasSourceText || isSourceHidden) && (
               <button
                 type="button"
                 tabIndex={-1}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -19,6 +19,7 @@ import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Code2, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId } from "runtimed";
+import { cellContentColumnOffset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
 import { Button } from "@/components/ui/button";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import type { Runtime } from "@/hooks/useSyncedSettings";
@@ -93,18 +94,23 @@ function CellAdder({
   const ribbonClass = adderRibbonClasses[cellType] ?? defaultAdderRibbonClass;
 
   return (
-    <div data-slot="cell-adder" className="group/adder flex h-7 w-full items-center select-none">
+    <div
+      data-slot="cell-adder"
+      className={cn("group/adder flex h-7 w-full items-center select-none", notebookCellLayoutVars)}
+    >
       <div
         data-slot="cell-adder-ribbon"
         className={cn(
-          "h-full w-1 shrink-0 bg-gray-200 transition-colors duration-150 dark:bg-gray-700",
+          "h-full w-1 shrink-0 bg-gray-200 opacity-0 transition-colors duration-150 dark:bg-gray-700",
+          "group-hover/adder:opacity-100 group-focus-within/adder:opacity-100",
           ribbonClass,
         )}
       />
       <div
         data-slot="cell-adder-actions"
         className={cn(
-          "ml-[3.25rem] flex items-center gap-1 opacity-0 transition-opacity duration-150",
+          "flex items-center gap-1 opacity-0 transition-opacity duration-150",
+          cellContentColumnOffset,
           "group-hover/adder:opacity-100 group-hover/adder:delay-75",
           "group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
         )}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -65,50 +65,81 @@ export interface NotebookViewProps {
 
 /** Tailwind classes for cell adder ribbon colors — must be static strings for tree-shaking. */
 const adderRibbonClasses: Record<string, string> = {
-  code: [
-    "group-hover/adder:bg-sky-400 dark:group-hover/adder:bg-sky-600",
-    "group-focus-within/adder:bg-sky-400 dark:group-focus-within/adder:bg-sky-600",
-  ].join(" "),
-  markdown: [
-    "group-hover/adder:bg-emerald-400 dark:group-hover/adder:bg-emerald-600",
-    "group-focus-within/adder:bg-emerald-400 dark:group-focus-within/adder:bg-emerald-600",
-  ].join(" "),
-  raw: [
-    "group-hover/adder:bg-rose-400 dark:group-hover/adder:bg-rose-600",
-    "group-focus-within/adder:bg-rose-400 dark:group-focus-within/adder:bg-rose-600",
-  ].join(" "),
+  code: "bg-sky-400 dark:bg-sky-600",
+  markdown: "bg-emerald-400 dark:bg-emerald-600",
 };
-const defaultAdderRibbonClass = adderRibbonClasses.code;
+const terminalAdderRibbonClasses: Record<string, string> = {
+  code: "bg-gradient-to-b from-sky-400 via-sky-400/60 to-sky-400/0 dark:from-sky-600 dark:via-sky-600/60 dark:to-sky-600/0",
+  markdown:
+    "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0",
+};
 const NOTEBOOK_TAIL_SPACE = "clamp(12rem, 35vh, 22rem)";
 const NOTEBOOK_TAIL_PIN_THRESHOLD_PX = 96;
 
 function CellAdder({
   afterCellId,
   onAdd,
-  cellType = "code",
+  terminal = false,
 }: {
   afterCellId?: string | null;
   onAdd: AddCellHandler;
-  cellType?: string;
+  terminal?: boolean;
 }) {
-  const ribbonClass = adderRibbonClasses[cellType] ?? defaultAdderRibbonClass;
+  const [activeCellType, setActiveCellType] = useState<"code" | "markdown" | null>(null);
+  const ribbonClass = activeCellType
+    ? terminal
+      ? terminalAdderRibbonClasses[activeCellType]
+      : adderRibbonClasses[activeCellType]
+    : undefined;
 
   return (
     <div
       data-slot="cell-adder"
-      className={cn("group/adder flex h-7 w-full items-center select-none", notebookCellLayoutVars)}
+      data-terminal={terminal || undefined}
+      className={cn(
+        "group/adder flex w-full select-none",
+        terminal ? "h-32 items-start" : "h-7 items-center",
+        notebookCellLayoutVars,
+      )}
+      onPointerLeave={() => setActiveCellType(null)}
+      onBlur={(event) => {
+        const nextTarget = event.relatedTarget;
+        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          setActiveCellType(null);
+        }
+      }}
     >
       <div
         data-slot="cell-adder-ribbon"
         className={cn(
-          "h-full w-1 shrink-0 bg-gray-200/55 transition-colors duration-150 dark:bg-gray-700/55",
-          ribbonClass,
+          "relative h-full w-1 shrink-0 overflow-hidden",
+          terminal &&
+            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2rem),transparent_100%)]",
         )}
-      />
+      >
+        <div
+          data-slot="cell-adder-ribbon-continuation"
+          className={cn(
+            "absolute inset-0 dark:bg-gray-700/55",
+            terminal ? "bg-gray-200/70" : "bg-gray-200/55",
+          )}
+        />
+        {ribbonClass ? (
+          <div
+            data-slot="cell-adder-ribbon-intent"
+            className={cn(
+              "absolute left-0 top-0 w-full transition-colors duration-150",
+              terminal ? "h-16" : "h-full",
+              ribbonClass,
+            )}
+          />
+        ) : null}
+      </div>
       <div
         data-slot="cell-adder-actions"
         className={cn(
           "flex items-center gap-1 opacity-0 transition-opacity duration-150",
+          terminal && "pt-0.5",
           cellContentColumnOffset,
           "group-hover/adder:opacity-100 group-hover/adder:delay-75",
           "group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
@@ -117,6 +148,8 @@ function CellAdder({
         <button
           type="button"
           title="Add code cell"
+          onPointerEnter={() => setActiveCellType("code")}
+          onFocus={() => setActiveCellType("code")}
           onClick={() => onAdd("code", afterCellId)}
           className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
         >
@@ -129,6 +162,8 @@ function CellAdder({
         <button
           type="button"
           title="Add markdown cell"
+          onPointerEnter={() => setActiveCellType("markdown")}
+          onFocus={() => setActiveCellType("markdown")}
           onClick={() => onAdd("markdown", afterCellId)}
           className="inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium text-muted-foreground/55 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
         >
@@ -283,15 +318,14 @@ const CellRenderer = memo(function CellRenderer({
 /** Wrapper component for sortable cells */
 function SortableCell({
   cellId,
-  nextCellId,
   index,
   renderCell,
   onAddCell,
   onDeleteCell,
+  isLastCell,
   isHiddenInGroup,
 }: {
   cellId: string;
-  nextCellId?: string;
   index: number;
   renderCell: (
     cell: NotebookCell,
@@ -301,10 +335,9 @@ function SortableCell({
   ) => React.ReactNode;
   onAddCell: AddCellHandler;
   onDeleteCell: (cellId: string) => void;
+  isLastCell?: boolean;
   isHiddenInGroup?: boolean;
 }) {
-  const cell = useCell(cellId);
-  const nextCell = useCell(nextCellId ?? "");
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: cellId,
   });
@@ -327,13 +360,9 @@ function SortableCell({
     return <div id={anchorId} ref={setNodeRef} style={style} />;
   }
 
-  const cellType = cell?.cell_type ?? "code";
-  // Adder color matches the cell below; for the last cell, fall back to its own type
-  const nextCellType = nextCell?.cell_type ?? cellType;
-
   return (
     <div id={anchorId} ref={setNodeRef} style={style}>
-      {index === 0 && <CellAdder afterCellId={null} onAdd={onAddCell} cellType={cellType} />}
+      {index === 0 && <CellAdder afterCellId={null} onAdd={onAddCell} />}
       <ErrorBoundary
         fallback={(error, resetErrorBoundary) => (
           <CellErrorFallback
@@ -351,7 +380,7 @@ function SortableCell({
           isDragging={isDragging}
         />
       </ErrorBoundary>
-      <CellAdder afterCellId={cellId} onAdd={onAddCell} cellType={nextCellType} />
+      <CellAdder afterCellId={cellId} onAdd={onAddCell} terminal={isLastCell} />
     </div>
   );
 }
@@ -931,12 +960,12 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth py-4 pl-0 pr-2"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain scroll-smooth pt-0 pb-4 pl-0 pr-2"
       style={{
         contain: "paint",
         overflowAnchor: "none",
         paddingBottom: NOTEBOOK_TAIL_SPACE,
-        scrollPaddingBlock: `1rem ${NOTEBOOK_TAIL_SPACE}`,
+        scrollPaddingBlock: `0rem ${NOTEBOOK_TAIL_SPACE}`,
       }}
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
@@ -999,11 +1028,11 @@ function NotebookViewContent({
                   <SortableCell
                     key={cellId}
                     cellId={cellId}
-                    nextCellId={cellIds[index + 1]}
                     index={index}
                     renderCell={renderCell}
                     onAddCell={onAddCell}
                     onDeleteCell={onDeleteCell}
+                    isLastCell={index === cellIds.length - 1}
                     isHiddenInGroup={group != null && !group.isFirst}
                   />
                 );

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -63,7 +63,7 @@ export interface NotebookViewProps {
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
 }
 
-const NOTEBOOK_TAIL_SPACE = "clamp(6rem, 18vh, 12rem)";
+const NOTEBOOK_TAIL_SPACE = "clamp(4rem, 10vh, 6rem)";
 const NOTEBOOK_TAIL_PIN_THRESHOLD_PX = 96;
 
 function CellAdder({

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -10,6 +10,7 @@ let mockExecution: {
   submitted_by_actor_label?: string | null;
 } | null = null;
 let mockIsExecuting = false;
+let mockIsFocused = false;
 let mockIsQueued = false;
 const mockEditorBlur = vi.fn();
 
@@ -104,7 +105,7 @@ vi.mock("../../hooks/useCrdtBridge", () => ({
 
 vi.mock("../../lib/cell-ui-state", () => ({
   useIsCellExecuting: () => mockIsExecuting,
-  useIsCellFocused: () => false,
+  useIsCellFocused: () => mockIsFocused,
   useIsCellQueued: () => mockIsQueued,
   useIsGroupExecuting: () => false,
   useIsNextCellFromFocused: () => false,
@@ -169,6 +170,7 @@ describe("CodeCell output focus", () => {
   beforeEach(() => {
     mockExecution = null;
     mockIsExecuting = false;
+    mockIsFocused = false;
     mockIsQueued = false;
     mockOutputs = [
       {
@@ -266,6 +268,55 @@ describe("CodeCell output focus", () => {
     expect(status).not.toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("bg-primary/45");
     expect(stopButton).toHaveClass("text-destructive");
+  });
+
+  it("keeps idle footer language quiet until the cell is engaged", () => {
+    mockOutputs = [];
+    mockExecution = null;
+
+    const { container } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer?.getAttribute("data-execution-state")).toBe("idle");
+    expect(status?.textContent).toBe("Ready to run in Python");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("group-hover:max-w-40");
+    expect(rule).toHaveClass("bg-transparent");
+  });
+
+  it("shows idle footer language when the cell is focused", () => {
+    mockOutputs = [];
+    mockExecution = null;
+    mockIsFocused = true;
+
+    const { container } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+
+    expect(status?.textContent).toBe("Ready to run in Python");
+    expect(status).toHaveClass("max-w-40");
+    expect(status).toHaveClass("opacity-100");
+    expect(status).not.toHaveClass("max-w-0");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -155,7 +155,7 @@ vi.mock("../cell/CellPresenceIndicators", () => ({
 
 import { CodeCell } from "../CodeCell";
 
-function makeCell(): CodeCellType {
+function makeCell(overrides: Partial<CodeCellType> = {}): CodeCellType {
   return {
     cell_type: "code",
     execution_count: null,
@@ -163,6 +163,7 @@ function makeCell(): CodeCellType {
     source: "import polars as pl\n\npl.DataFrame({'x': [1]})",
     metadata: {},
     outputs: [],
+    ...overrides,
   };
 }
 
@@ -238,7 +239,7 @@ describe("CodeCell output focus", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("CompletedinPython·run12");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12,completed");
     expect(footer?.textContent).not.toContain("In [12]");
   });
 
@@ -263,7 +264,7 @@ describe("CodeCell output focus", () => {
     const stopButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("running");
-    expect(status?.textContent).toBe("Running in Python");
+    expect(status?.textContent).toBe("Python·Running");
     expect(status).toHaveClass("text-primary");
     expect(status).not.toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("bg-primary/45");
@@ -289,10 +290,10 @@ describe("CodeCell output focus", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer?.getAttribute("data-execution-state")).toBe("idle");
-    expect(status?.textContent).toBe("Ready to run in Python");
+    expect(status?.textContent).toBe("Python·Ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
-    expect(status).toHaveClass("group-hover:max-w-40");
+    expect(status).toHaveClass("group-hover:max-w-64");
     expect(rule).toHaveClass("bg-transparent");
   });
 
@@ -313,10 +314,37 @@ describe("CodeCell output focus", () => {
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
-    expect(status?.textContent).toBe("Ready to run in Python");
-    expect(status).toHaveClass("max-w-40");
+    expect(status?.textContent).toBe("Python·Ready");
+    expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
     expect(status).not.toHaveClass("max-w-0");
+  });
+
+  it("keeps the current line visible when source is hidden but output remains visible", () => {
+    mockOutputs = [
+      {
+        output_type: "stream",
+        name: "stdout",
+        text: "visible output\n",
+      },
+    ];
+    mockExecution = { execution_count: 4, submitted_by_actor_label: null };
+
+    const { container, queryByTestId } = render(
+      <CodeCell
+        cell={makeCell({ metadata: { jupyter: { source_hidden: true } } })}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleSourceHidden={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+
+    expect(queryByTestId("editor")).toBeNull();
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4,completed");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -239,7 +239,7 @@ describe("CodeCell output focus", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12,completed");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·completed");
     expect(footer?.textContent).not.toContain("In [12]");
   });
 
@@ -368,7 +368,7 @@ describe("CodeCell output focus", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(queryByTestId("editor")).toBeNull();
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4,completed");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4·completed");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -294,7 +294,31 @@ describe("CodeCell output focus", () => {
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveClass("group-hover:max-w-64");
-    expect(rule).toHaveClass("bg-transparent");
+    expect(rule).toHaveClass("bg-border/25");
+  });
+
+  it("uses compact current-line chrome for empty idle code cells", () => {
+    mockOutputs = [];
+    mockExecution = null;
+    mockIsFocused = true;
+
+    const { container } = render(
+      <CodeCell
+        cell={makeCell({ source: "" })}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer).toHaveClass("min-h-5");
+    expect(detail).toHaveClass("sr-only");
+    expect(rule).toBeNull();
   });
 
   it("shows idle footer language when the cell is focused", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -9,6 +9,8 @@ let mockExecution: {
   execution_count: number | null;
   submitted_by_actor_label?: string | null;
 } | null = null;
+let mockIsExecuting = false;
+let mockIsQueued = false;
 const mockEditorBlur = vi.fn();
 
 vi.mock("@/components/cell/CellContainer", () => ({
@@ -101,9 +103,9 @@ vi.mock("../../hooks/useCrdtBridge", () => ({
 }));
 
 vi.mock("../../lib/cell-ui-state", () => ({
-  useIsCellExecuting: () => false,
+  useIsCellExecuting: () => mockIsExecuting,
   useIsCellFocused: () => false,
-  useIsCellQueued: () => false,
+  useIsCellQueued: () => mockIsQueued,
   useIsGroupExecuting: () => false,
   useIsNextCellFromFocused: () => false,
   useIsPreviousCellFromFocused: () => false,
@@ -166,6 +168,8 @@ function makeCell(): CodeCellType {
 describe("CodeCell output focus", () => {
   beforeEach(() => {
     mockExecution = null;
+    mockIsExecuting = false;
+    mockIsQueued = false;
     mockOutputs = [
       {
         output_type: "display_data",
@@ -234,6 +238,34 @@ describe("CodeCell output focus", () => {
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("CompletedinPython·run12");
     expect(footer?.textContent).not.toContain("In [12]");
+  });
+
+  it("keeps running status active while the stop control carries danger", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: null, submitted_by_actor_label: null };
+    mockIsExecuting = true;
+
+    const { container, getByTestId } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+    const stopButton = getByTestId("execute-button");
+
+    expect(footer?.getAttribute("data-execution-state")).toBe("running");
+    expect(status?.textContent).toBe("Running in Python");
+    expect(status).toHaveClass("text-primary");
+    expect(status).not.toHaveClass("text-destructive/80");
+    expect(rule).toHaveClass("bg-primary/45");
+    expect(stopButton).toHaveClass("text-destructive");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { CodeCell as CodeCellType } from "../../types";
 
 let mockOutputs: unknown[] = [];
+let mockExecution: {
+  execution_count: number | null;
+  submitted_by_actor_label?: string | null;
+} | null = null;
 const mockEditorBlur = vi.fn();
 
 vi.mock("@/components/cell/CellContainer", () => ({
@@ -27,10 +31,6 @@ vi.mock("@/components/cell/CellContainer", () => ({
       {outputRightGutterContent}
     </div>
   ),
-}));
-
-vi.mock("@/components/cell/CompactExecutionButton", () => ({
-  CompactExecutionButton: () => null,
 }));
 
 vi.mock("@/components/cell/OutputArea", () => ({
@@ -126,8 +126,8 @@ vi.mock("../../lib/kernel-completion", () => ({
 }));
 
 vi.mock("../../lib/notebook-executions", () => ({
-  useCellExecutionId: () => null,
-  useExecution: () => null,
+  useCellExecutionId: () => (mockExecution ? "execution-1" : null),
+  useExecution: () => mockExecution,
 }));
 
 vi.mock("../../lib/notebook-outputs", () => ({
@@ -165,6 +165,7 @@ function makeCell(): CodeCellType {
 
 describe("CodeCell output focus", () => {
   beforeEach(() => {
+    mockExecution = null;
     mockOutputs = [
       {
         output_type: "display_data",
@@ -212,6 +213,27 @@ describe("CodeCell output focus", () => {
     );
 
     expect(getByTestId("output").getAttribute("data-focused")).toBe("true");
+  });
+
+  it("labels completed execution state with readable footer language", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: 12, submitted_by_actor_label: null };
+
+    const { container } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+
+    expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("CompletedinPython·run12");
+    expect(footer?.textContent).not.toContain("In [12]");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
+++ b/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
@@ -6,16 +6,27 @@
  */
 
 import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
 import { getPeersForCell, type PeerCursorInfo, subscribeToCell } from "../../lib/cursor-registry";
 
 interface CellPresenceIndicatorsProps {
   cellId: string;
+  variant?: "stack" | "inline";
+  maxVisible?: number;
+  prefixSeparator?: boolean;
+  className?: string;
 }
 
 /** Maximum visible indicators before showing overflow count */
 const MAX_VISIBLE = 3;
 
-export function CellPresenceIndicators({ cellId }: CellPresenceIndicatorsProps) {
+export function CellPresenceIndicators({
+  cellId,
+  variant = "stack",
+  maxVisible = MAX_VISIBLE,
+  prefixSeparator = false,
+  className,
+}: CellPresenceIndicatorsProps) {
   const [peers, setPeers] = useState<PeerCursorInfo[]>([]);
 
   // Subscribe to presence changes for this cell
@@ -35,16 +46,30 @@ export function CellPresenceIndicators({ cellId }: CellPresenceIndicatorsProps) 
     return null;
   }
 
-  const visiblePeers = peers.slice(0, MAX_VISIBLE);
-  const overflowCount = peers.length - MAX_VISIBLE;
+  const visiblePeers = peers.slice(0, maxVisible);
+  const overflowCount = peers.length - maxVisible;
 
   return (
-    <div className="flex flex-col items-center gap-0.5" title={formatTooltip(peers)}>
+    <div
+      data-slot="cell-presence-indicators"
+      className={cn(
+        "flex items-center gap-0.5",
+        variant === "stack" ? "flex-col" : "flex-row",
+        className,
+      )}
+      title={formatTooltip(peers)}
+      aria-label={formatTooltip(peers)}
+    >
+      {prefixSeparator && (
+        <span className="text-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+      )}
       {visiblePeers.map((peer) => (
         <PresenceDot key={peer.peerId} peer={peer} />
       ))}
       {overflowCount > 0 && (
-        <span className="text-[9px] font-medium text-muted-foreground leading-none">
+        <span className="text-[9px] leading-none font-medium text-muted-foreground">
           +{overflowCount}
         </span>
       )}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -135,10 +135,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
           className,
         )}
       >
-        {/* Optional state lane - floats outside layout so the ribbon can lead the cell surface. */}
+        {/* Optional state lane - lives inside the source inset so clipped scroll containers do not hide it. */}
         <div
           data-slot="cell-state-lane"
-          className="absolute left-0 top-0 z-10 flex -translate-x-full flex-col items-end justify-start gap-0.5 pr-1 pt-3.5 select-none"
+          className="absolute left-1 top-0 z-10 flex w-[var(--cell-content-column-inset,3.25rem)] flex-col items-center justify-start gap-0.5 pt-3.5 select-none"
           onMouseDown={onFocus}
         >
           {gutterContent}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -49,6 +49,25 @@ interface CellContainerProps {
   className?: string;
 }
 
+function CellActionOverlay({ children, dataSlot }: { children?: ReactNode; dataSlot: string }) {
+  if (!children) return null;
+
+  return (
+    <div
+      data-slot={dataSlot}
+      className={cn(
+        "absolute right-2 top-1 z-20 flex flex-col items-center gap-0.5 rounded-sm px-0.5 py-0.5 select-none",
+        "bg-background/80 shadow-sm ring-1 ring-border/40 backdrop-blur-sm",
+        "pointer-events-none opacity-0 transition-opacity duration-150",
+        "group-hover:pointer-events-auto group-hover:opacity-100",
+        "focus-within:pointer-events-auto focus-within:opacity-100",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
 export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
   (
     {
@@ -120,7 +139,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {useSegmentedRibbon ? (
           <div className="flex min-w-0 flex-1 flex-col">
             {/* Code row - ribbon + content + right gutter */}
-            <div className="flex" onMouseDown={onFocus}>
+            <div className="relative flex" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
                 data-slot="cell-ribbon"
@@ -140,21 +159,14 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               >
                 {codeContent}
               </div>
-              {/* Code row right gutter — always rendered as spacer for consistent width */}
-              <div
-                className={cn(
-                  "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
-                  rightGutterContent &&
-                    "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
-                )}
-              >
+              <CellActionOverlay dataSlot="cell-action-overlay">
                 {rightGutterContent}
-              </div>
+              </CellActionOverlay>
             </div>
             {/* Output row - ribbon + content + right gutter
                 onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
-              <div className={cn("flex", hideOutput && "hidden")} onMouseDown={onFocus}>
+              <div className={cn("relative flex", hideOutput && "hidden")} onMouseDown={onFocus}>
                 <div
                   data-slot="cell-output-ribbon"
                   className={cn("w-1 transition-colors duration-150", outputRibbonColor)}
@@ -176,23 +188,16 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 >
                   {outputContent}
                 </div>
-                {/* Output row right gutter — always rendered as spacer for consistent width */}
-                <div
-                  className={cn(
-                    "sticky top-2 flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
-                    outputRightGutterContent &&
-                      "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
-                  )}
-                >
+                <CellActionOverlay dataSlot="cell-output-action-overlay">
                   {outputRightGutterContent}
-                </div>
+                </CellActionOverlay>
               </div>
             )}
           </div>
         ) : (
           <>
             {/* Legacy layout - ribbon + content side by side */}
-            <div className="flex min-w-0 flex-1" onMouseDown={onFocus}>
+            <div className="relative flex min-w-0 flex-1" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
                 data-slot="cell-ribbon"
@@ -206,16 +211,9 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               <div className={cn("min-w-0 flex-1 pt-1.5 pb-3 pr-3", cellContentColumnInset)}>
                 {children}
               </div>
-            </div>
-            {/* Right margin for legacy layout — always rendered as spacer */}
-            <div
-              className={cn(
-                "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none sm:w-10",
-                rightGutterContent &&
-                  "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
-              )}
-            >
-              {rightGutterContent}
+              <CellActionOverlay dataSlot="cell-action-overlay">
+                {rightGutterContent}
+              </CellActionOverlay>
             </div>
           </>
         )}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -16,7 +16,7 @@ interface CellContainerProps {
   hideOutput?: boolean;
   /** Legacy children prop - use codeContent/outputContent for segmented ribbon support */
   children?: ReactNode;
-  /** Content to render in the left gutter action area (e.g., play button, execution count) */
+  /** Content to render in the left state lane (e.g., play button, execution marker) */
   gutterContent?: ReactNode;
   /** Content to render in the right margin aligned with code row (e.g., cell controls) */
   rightGutterContent?: ReactNode;
@@ -94,9 +94,9 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         data-cell-type={cellType}
         data-focus-state={focusState}
         className={cn(
-          "cell-container group flex transition-colors duration-150",
+          "cell-container group relative flex transition-colors duration-150",
           bgColor,
-          isFocused && "-mx-16 px-16",
+          isFocused && "-mx-4 px-4",
           isDragging && "opacity-50",
           // Output focus dim wins over the existing opacity-70 dim on the
           // output row. Applied to the whole cell container so the editor
@@ -105,9 +105,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
           className,
         )}
       >
-        {/* Gutter area - action content only (ribbon moves to content rows for segmented) */}
+        {/* Optional state lane - floats outside layout so the ribbon can lead the cell surface. */}
         <div
-          className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-3.5 select-none"
+          data-slot="cell-state-lane"
+          className="absolute left-0 top-0 z-10 flex -translate-x-full flex-col items-end justify-start gap-0.5 pr-1 pt-3.5 select-none"
           onMouseDown={onFocus}
         >
           {gutterContent}
@@ -120,6 +121,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             <div className="flex" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
+                data-slot="cell-ribbon"
                 className={cn(
                   "w-1 transition-colors duration-150",
                   ribbonColor,
@@ -127,7 +129,14 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-6 pr-3">{codeContent}</div>
+              <div
+                className={cn(
+                  "min-w-0 flex-1 pt-1.5 pl-[3.25rem] pr-3",
+                  hasOutput && !hideOutput ? "pb-1.5" : "pb-3",
+                )}
+              >
+                {codeContent}
+              </div>
               {/* Code row right gutter — always rendered as spacer for consistent width */}
               <div
                 className={cn(
@@ -145,19 +154,21 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
               <div className={cn("flex", hideOutput && "hidden")} onMouseDown={onFocus}>
-                <div className={cn("w-1 transition-colors duration-150", outputRibbonColor)} />
+                <div
+                  data-slot="cell-output-ribbon"
+                  className={cn("w-1 transition-colors duration-150", outputRibbonColor)}
+                />
                 <div
                   className={cn(
-                    "min-w-0 flex-1 py-2 transition-opacity duration-150",
+                    "min-w-0 flex-1 pt-1 pb-2 pl-7 transition-opacity duration-150",
                     !outputFocused &&
                       !isFocused &&
                       !isPreviousCellFromFocused &&
                       !isNextCellFromFocused &&
                       "opacity-70",
-                    // Elevate via top + bottom edges only. The cell's
-                    // existing left ribbon (line 145 above) plus this slab
-                    // forms a three-sided frame that reads as "this row is
-                    // the active one" without the card-like ring aesthetic.
+                    // Elevate via top + bottom edges only. The cell's left
+                    // ribbon plus this slab forms a three-sided frame that
+                    // reads as active without the card-like ring aesthetic.
                     outputFocused && "border-y border-primary/40 bg-primary/5",
                   )}
                 >
@@ -184,6 +195,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             <div className="flex min-w-0 flex-1" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
+                data-slot="cell-ribbon"
                 className={cn(
                   "w-1 self-stretch transition-colors duration-150",
                   ribbonColor,
@@ -191,7 +203,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-6 pr-3">{children}</div>
+              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-[3.25rem] pr-3">{children}</div>
             </div>
             {/* Right margin for legacy layout — always rendered as spacer */}
             <div

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -96,7 +96,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         className={cn(
           "cell-container group relative flex transition-colors duration-150",
           bgColor,
-          isFocused && "-mx-4 px-4",
+          isFocused && "-mr-4 pr-4",
           isDragging && "opacity-50",
           // Output focus dim wins over the existing opacity-70 dim on the
           // output row. Applied to the whole cell container so the editor

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -160,9 +160,11 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 )}
               />
               <div
+                data-slot="cell-code-content"
                 className={cn(
-                  "min-w-0 flex-1 pt-1.5 pr-3",
+                  "min-w-0 flex-1 pt-1.5",
                   cellContentColumnInset,
+                  rightGutterContent ? "pr-14" : "pr-3",
                   hasOutput && !hideOutput ? "pb-1.5" : "pb-3",
                 )}
               >
@@ -181,9 +183,11 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   className={cn("w-1 transition-colors duration-150", outputRibbonColor)}
                 />
                 <div
+                  data-slot="cell-output-content"
                   className={cn(
                     "min-w-0 flex-1 pt-1 pb-2 transition-opacity duration-150",
                     cellOutputRowInset,
+                    outputRightGutterContent ? "pr-14" : "pr-3",
                     !outputFocused &&
                       !isFocused &&
                       !isPreviousCellFromFocused &&
@@ -217,7 +221,14 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className={cn("min-w-0 flex-1 pt-1.5 pb-3 pr-3", cellContentColumnInset)}>
+              <div
+                data-slot="cell-code-content"
+                className={cn(
+                  "min-w-0 flex-1 pt-1.5 pb-3",
+                  cellContentColumnInset,
+                  rightGutterContent ? "pr-14" : "pr-3",
+                )}
+              >
                 {children}
               </div>
               <CellActionOverlay dataSlot="cell-action-overlay" visible={isFocused}>

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -49,7 +49,15 @@ interface CellContainerProps {
   className?: string;
 }
 
-function CellActionOverlay({ children, dataSlot }: { children?: ReactNode; dataSlot: string }) {
+function CellActionOverlay({
+  children,
+  dataSlot,
+  visible = false,
+}: {
+  children?: ReactNode;
+  dataSlot: string;
+  visible?: boolean;
+}) {
   if (!children) return null;
 
   return (
@@ -61,6 +69,7 @@ function CellActionOverlay({ children, dataSlot }: { children?: ReactNode; dataS
         "pointer-events-none opacity-0 transition-opacity duration-150",
         "group-hover:pointer-events-auto group-hover:opacity-100",
         "focus-within:pointer-events-auto focus-within:opacity-100",
+        visible && "pointer-events-auto opacity-100",
       )}
     >
       {children}
@@ -159,7 +168,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               >
                 {codeContent}
               </div>
-              <CellActionOverlay dataSlot="cell-action-overlay">
+              <CellActionOverlay dataSlot="cell-action-overlay" visible={isFocused}>
                 {rightGutterContent}
               </CellActionOverlay>
             </div>
@@ -188,7 +197,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 >
                   {outputContent}
                 </div>
-                <CellActionOverlay dataSlot="cell-output-action-overlay">
+                <CellActionOverlay dataSlot="cell-output-action-overlay" visible={isFocused}>
                   {outputRightGutterContent}
                 </CellActionOverlay>
               </div>
@@ -211,7 +220,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               <div className={cn("min-w-0 flex-1 pt-1.5 pb-3 pr-3", cellContentColumnInset)}>
                 {children}
               </div>
-              <CellActionOverlay dataSlot="cell-action-overlay">
+              <CellActionOverlay dataSlot="cell-action-overlay" visible={isFocused}>
                 {rightGutterContent}
               </CellActionOverlay>
             </div>

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { cellContentColumnInset, cellOutputRowInset, notebookCellLayoutVars } from "./cell-layout";
 import { type GutterColorConfig, getGutterColors } from "./gutter-colors";
 
 interface CellContainerProps {
@@ -95,6 +96,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         data-focus-state={focusState}
         className={cn(
           "cell-container group relative flex transition-colors duration-150",
+          notebookCellLayoutVars,
           bgColor,
           isFocused && "-mr-4 pr-4",
           isDragging && "opacity-50",
@@ -131,7 +133,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               />
               <div
                 className={cn(
-                  "min-w-0 flex-1 pt-1.5 pl-[3.25rem] pr-3",
+                  "min-w-0 flex-1 pt-1.5 pr-3",
+                  cellContentColumnInset,
                   hasOutput && !hideOutput ? "pb-1.5" : "pb-3",
                 )}
               >
@@ -140,7 +143,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               {/* Code row right gutter — always rendered as spacer for consistent width */}
               <div
                 className={cn(
-                  "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
+                  "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
                   rightGutterContent && "opacity-100 transition-opacity duration-150",
                   rightGutterContent &&
                     "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
@@ -160,7 +163,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 />
                 <div
                   className={cn(
-                    "min-w-0 flex-1 pt-1 pb-2 pl-7 transition-opacity duration-150",
+                    "min-w-0 flex-1 pt-1 pb-2 transition-opacity duration-150",
+                    cellOutputRowInset,
                     !outputFocused &&
                       !isFocused &&
                       !isPreviousCellFromFocused &&
@@ -177,7 +181,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 {/* Output row right gutter — always rendered as spacer for consistent width */}
                 <div
                   className={cn(
-                    "sticky top-2 flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
+                    "sticky top-2 flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
                     outputRightGutterContent && "opacity-100 transition-opacity duration-150",
                     outputRightGutterContent &&
                       "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
@@ -203,12 +207,14 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-[3.25rem] pr-3">{children}</div>
+              <div className={cn("min-w-0 flex-1 pt-1.5 pb-3 pr-3", cellContentColumnInset)}>
+                {children}
+              </div>
             </div>
             {/* Right margin for legacy layout — always rendered as spacer */}
             <div
               className={cn(
-                "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none",
+                "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none sm:w-10",
                 rightGutterContent && "opacity-100 transition-opacity duration-150",
                 rightGutterContent &&
                   "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -144,10 +144,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
               <div
                 className={cn(
                   "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
-                  rightGutterContent && "opacity-100 transition-opacity duration-150",
                   rightGutterContent &&
-                    "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
-                  rightGutterContent && isFocused && "sm:opacity-100",
+                    "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
                 )}
               >
                 {rightGutterContent}
@@ -182,10 +180,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 <div
                   className={cn(
                     "sticky top-2 flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none sm:w-10",
-                    outputRightGutterContent && "opacity-100 transition-opacity duration-150",
                     outputRightGutterContent &&
-                      "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
-                    outputRightGutterContent && isFocused && "sm:opacity-100",
+                      "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
                   )}
                 >
                   {outputRightGutterContent}
@@ -215,10 +211,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             <div
               className={cn(
                 "flex w-7 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none sm:w-10",
-                rightGutterContent && "opacity-100 transition-opacity duration-150",
                 rightGutterContent &&
-                  "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
-                rightGutterContent && isFocused && "sm:opacity-100",
+                  "pointer-events-none opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
               )}
             >
               {rightGutterContent}

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -56,7 +56,7 @@ export function CellInsertionRibbon({
       data-terminal={terminal || undefined}
       className={cn(
         "group/adder flex w-full select-none",
-        terminal ? "h-[clamp(5rem,16vh,8rem)] items-start" : "h-7 items-center",
+        terminal ? "h-[clamp(3.5rem,9vh,5.5rem)] items-start" : "h-7 items-center",
         notebookCellLayoutVars,
         className,
       )}
@@ -73,7 +73,7 @@ export function CellInsertionRibbon({
         className={cn(
           "relative h-full w-1 shrink-0 overflow-hidden",
           terminal &&
-            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2.25rem),transparent_100%)]",
+            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]",
         )}
       >
         <div
@@ -88,7 +88,7 @@ export function CellInsertionRibbon({
             data-slot="cell-adder-ribbon-intent"
             className={cn(
               "absolute left-0 top-0 w-full transition-colors duration-150",
-              terminal ? "h-10" : "h-full",
+              terminal ? "h-7" : "h-full",
               ribbonClass,
             )}
           />

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -1,0 +1,149 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { cellContentColumnOffset, notebookCellLayoutVars } from "./cell-layout";
+
+export type CellInsertionType = "code" | "markdown";
+
+interface CellInsertionRibbonProps {
+  terminal?: boolean;
+  activeType?: CellInsertionType | null;
+  onActiveTypeChange?: (type: CellInsertionType | null) => void;
+  onInsert: (type: CellInsertionType) => void;
+  forceActionsVisible?: boolean;
+  className?: string;
+}
+
+const insertionRibbonClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-400 dark:bg-sky-600",
+  markdown: "bg-emerald-400 dark:bg-emerald-600",
+};
+
+const terminalInsertionRibbonClasses: Record<CellInsertionType, string> = {
+  code: "bg-gradient-to-b from-sky-400 via-sky-400/60 to-sky-400/0 dark:from-sky-600 dark:via-sky-600/60 dark:to-sky-600/0",
+  markdown:
+    "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0",
+};
+
+export function CellInsertionRibbon({
+  terminal = false,
+  activeType,
+  onActiveTypeChange,
+  onInsert,
+  forceActionsVisible = false,
+  className,
+}: CellInsertionRibbonProps) {
+  const [uncontrolledActiveType, setUncontrolledActiveType] = useState<CellInsertionType | null>(
+    null,
+  );
+  const resolvedActiveType = activeType === undefined ? uncontrolledActiveType : activeType;
+  const ribbonClass = resolvedActiveType
+    ? terminal
+      ? terminalInsertionRibbonClasses[resolvedActiveType]
+      : insertionRibbonClasses[resolvedActiveType]
+    : undefined;
+
+  const setActiveType = (type: CellInsertionType | null) => {
+    if (activeType === undefined) {
+      setUncontrolledActiveType(type);
+    }
+    onActiveTypeChange?.(type);
+  };
+
+  return (
+    <div
+      data-slot="cell-adder"
+      data-terminal={terminal || undefined}
+      className={cn(
+        "group/adder flex w-full select-none",
+        terminal ? "h-[clamp(5rem,16vh,8rem)] items-start" : "h-7 items-center",
+        notebookCellLayoutVars,
+        className,
+      )}
+      onPointerLeave={() => setActiveType(null)}
+      onBlur={(event) => {
+        const nextTarget = event.relatedTarget;
+        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          setActiveType(null);
+        }
+      }}
+    >
+      <div
+        data-slot="cell-adder-ribbon"
+        className={cn(
+          "relative h-full w-1 shrink-0 overflow-hidden",
+          terminal &&
+            "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2.25rem),transparent_100%)]",
+        )}
+      >
+        <div
+          data-slot="cell-adder-ribbon-continuation"
+          className={cn(
+            "absolute inset-0 dark:bg-gray-700/55",
+            terminal ? "bg-gray-200/70" : "bg-gray-200/55",
+          )}
+        />
+        {ribbonClass ? (
+          <div
+            data-slot="cell-adder-ribbon-intent"
+            className={cn(
+              "absolute left-0 top-0 w-full transition-colors duration-150",
+              terminal ? "h-10" : "h-full",
+              ribbonClass,
+            )}
+          />
+        ) : null}
+      </div>
+      <div
+        data-slot="cell-adder-actions"
+        className={cn(
+          "flex items-center gap-1 transition-opacity duration-150",
+          terminal && "pt-0.5",
+          cellContentColumnOffset,
+          forceActionsVisible
+            ? "opacity-100"
+            : "opacity-0 group-hover/adder:opacity-100 group-hover/adder:delay-75 group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
+        )}
+      >
+        <button
+          type="button"
+          title="Add code cell"
+          onPointerEnter={() => setActiveType("code")}
+          onFocus={() => setActiveType("code")}
+          onClick={() => onInsert("code")}
+          className={cn(
+            "inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+            forceActionsVisible && resolvedActiveType === "code"
+              ? "text-foreground hover:text-foreground"
+              : "text-muted-foreground/55 hover:text-foreground",
+          )}
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add code
+        </button>
+        <span className="text-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+        <button
+          type="button"
+          title="Add markdown cell"
+          onPointerEnter={() => setActiveType("markdown")}
+          onFocus={() => setActiveType("markdown")}
+          onClick={() => onInsert("markdown")}
+          className={cn(
+            "inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+            forceActionsVisible && resolvedActiveType === "markdown"
+              ? "text-foreground hover:text-foreground"
+              : "text-muted-foreground/55 hover:text-foreground",
+          )}
+        >
+          <Plus className="h-3 w-3" aria-hidden="true" />
+          Add markdown
+        </button>
+      </div>
+      <div className="flex-1" />
+    </div>
+  );
+}

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { cellContentColumnOffset, notebookCellLayoutVars } from "./cell-layout";
+import { notebookCellLayoutVars } from "./cell-layout";
 
 export type CellInsertionType = "code" | "markdown";
 
@@ -94,12 +94,28 @@ export function CellInsertionRibbon({
           />
         ) : null}
       </div>
+      <button
+        type="button"
+        data-slot="cell-adder-primary-hit-target"
+        title="Add code cell from insertion margin"
+        aria-label="Add code cell from insertion margin"
+        onPointerEnter={() => setActiveType("code")}
+        onFocus={() => setActiveType("code")}
+        onClick={() => onInsert("code")}
+        className={cn(
+          "h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 rounded-none transition-colors duration-150",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
+          resolvedActiveType === "code" ? "bg-sky-400/5" : "hover:bg-muted/20",
+          terminal && "h-7",
+        )}
+      >
+        <span className="sr-only">Add code cell</span>
+      </button>
       <div
         data-slot="cell-adder-actions"
         className={cn(
           "flex items-center gap-1 transition-opacity duration-150",
           terminal && "pt-0.5",
-          cellContentColumnOffset,
           forceActionsVisible
             ? "opacity-100"
             : "opacity-0 group-hover/adder:opacity-100 group-hover/adder:delay-75 group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -1,4 +1,5 @@
 import { Play, Square } from "lucide-react";
+import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 export interface CodeCellCurrentLineProps {
@@ -10,6 +11,7 @@ export interface CodeCellCurrentLineProps {
   isFocused?: boolean;
   compactIdle?: boolean;
   submittedByActorLabel?: string | null;
+  activityContent?: ReactNode;
   onExecute: () => void;
   onInterrupt: () => void;
   className?: string;
@@ -48,8 +50,8 @@ function executionDetail({
   if (isQueued) return "Queued";
   if (count !== null) {
     return elapsedMs === null
-      ? `${runPrefix}, completed`
-      : `${runPrefix}, completed in ${formatElapsedMs(elapsedMs)}`;
+      ? `${runPrefix} · completed`
+      : `${runPrefix} · completed in ${formatElapsedMs(elapsedMs)}`;
   }
 
   return "Ready";
@@ -92,6 +94,7 @@ export function CodeCellCurrentLine({
   isFocused = false,
   compactIdle = false,
   submittedByActorLabel = null,
+  activityContent,
   onExecute,
   onInterrupt,
   className,
@@ -208,13 +211,16 @@ export function CodeCellCurrentLine({
         </span>
       </span>
       {!isCompactIdle && (
-        <div
-          data-slot="code-cell-current-line-rule"
-          className={cn(
-            "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
-            executionLineClass({ isExecuting, isQueued, isFocused }),
-          )}
-        />
+        <>
+          {activityContent}
+          <div
+            data-slot="code-cell-current-line-rule"
+            className={cn(
+              "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
+              executionLineClass({ isExecuting, isQueued, isFocused }),
+            )}
+          />
+        </>
       )}
     </div>
   );

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -1,0 +1,194 @@
+import { Play, Square } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface CodeCellCurrentLineProps {
+  languageLabel: string;
+  count: number | null;
+  elapsedMs?: number | null;
+  isExecuting?: boolean;
+  isQueued?: boolean;
+  isFocused?: boolean;
+  submittedByActorLabel?: string | null;
+  onExecute: () => void;
+  onInterrupt: () => void;
+  className?: string;
+}
+
+function formatExecutionCount(count: number): string {
+  return count > 999 ? "999+" : String(count);
+}
+
+function formatElapsedMs(elapsedMs: number): string {
+  if (elapsedMs < 1_000) return `${Math.max(1, Math.round(elapsedMs))}ms`;
+
+  const seconds = elapsedMs / 1_000;
+  if (seconds < 10) return `${seconds.toFixed(1)}s`;
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return remainingSeconds === 0 ? `${minutes}m` : `${minutes}m ${remainingSeconds}s`;
+}
+
+function executionDetail({
+  count,
+  elapsedMs,
+  isExecuting,
+  isQueued,
+}: {
+  count: number | null;
+  elapsedMs: number | null;
+  isExecuting: boolean;
+  isQueued: boolean;
+}): string {
+  const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
+
+  if (isExecuting) return runPrefix ? `${runPrefix}, running` : "Running";
+  if (isQueued) return runPrefix ? `${runPrefix}, queued` : "Queued";
+  if (count !== null) {
+    return elapsedMs === null
+      ? `${runPrefix}, completed`
+      : `${runPrefix}, completed in ${formatElapsedMs(elapsedMs)}`;
+  }
+
+  return "Ready";
+}
+
+function executionCountLabel(count: number | null): string | null {
+  return count === null ? null : `Execution ${formatExecutionCount(count)}`;
+}
+
+function executionLineClass({
+  isExecuting,
+  isQueued,
+  isFocused,
+}: {
+  isExecuting: boolean;
+  isQueued: boolean;
+  isFocused: boolean;
+}) {
+  if (isExecuting) {
+    return "bg-primary/45";
+  }
+
+  if (isQueued) {
+    return "bg-sky-400/35";
+  }
+
+  if (isFocused) {
+    return "bg-border/70";
+  }
+
+  return "bg-transparent group-hover:bg-border/45";
+}
+
+export function CodeCellCurrentLine({
+  languageLabel,
+  count,
+  elapsedMs = null,
+  isExecuting = false,
+  isQueued = false,
+  isFocused = false,
+  submittedByActorLabel = null,
+  onExecute,
+  onInterrupt,
+  className,
+}: CodeCellCurrentLineProps) {
+  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const isQuietIdle = state === "idle" && !isFocused;
+  const detailLabel = executionDetail({ count, elapsedMs, isExecuting, isQueued });
+  const countLabel = executionCountLabel(count);
+  const actionTitle = isExecuting
+    ? submittedByActorLabel
+      ? `Stop execution submitted by ${submittedByActorLabel}`
+      : "Stop execution"
+    : isQueued
+      ? submittedByActorLabel
+        ? `Queued for execution by ${submittedByActorLabel}`
+        : "Queued for execution"
+      : count !== null
+        ? `Run cell again; last execution ${count}`
+        : "Run cell";
+
+  const handleClick = () => {
+    if (isQueued) return;
+    if (isExecuting) {
+      onInterrupt();
+    } else {
+      onExecute();
+    }
+  };
+
+  return (
+    <div
+      data-slot="code-cell-current-line"
+      data-execution-state={state}
+      data-execution-count={count ?? undefined}
+      data-execution-label={countLabel ?? undefined}
+      className={cn(
+        "mt-2 flex min-h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isQueued}
+        title={actionTitle}
+        aria-label={actionTitle}
+        aria-busy={isExecuting || undefined}
+        data-testid="execute-button"
+        data-execution-state={state}
+        data-execution-count={count ?? undefined}
+        className={cn(
+          "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+          "transition-colors duration-150",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+          !isFocused && state === "idle" && "opacity-55 group-hover:opacity-100",
+          state === "idle" && "hover:bg-muted hover:text-foreground",
+          state === "ran" && "hover:bg-primary/5 hover:text-primary",
+          state === "queued" && "cursor-default text-sky-600 dark:text-sky-400",
+          state === "running" && "text-destructive hover:bg-destructive/10",
+        )}
+      >
+        {isExecuting ? (
+          <Square className="size-3 fill-current animate-exec-squish" aria-hidden="true" />
+        ) : isQueued ? (
+          <span
+            className="block size-1.5 rounded-full bg-current animate-queue-breathe"
+            aria-hidden="true"
+          />
+        ) : (
+          <Play className="size-3 fill-current" aria-hidden="true" />
+        )}
+      </button>
+      <span
+        data-slot="code-cell-current-line-status"
+        className={cn(
+          "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
+          isQuietIdle
+            ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-64 group-hover:opacity-100 group-focus-within:max-w-64 group-focus-within:opacity-100"
+            : "max-w-64 opacity-100",
+          isFocused && "text-foreground/70",
+          isExecuting && "text-primary",
+          isQueued && "text-sky-700 dark:text-sky-300",
+        )}
+      >
+        <span data-slot="code-cell-current-line-language">{languageLabel}</span>
+        <span className="text-muted-foreground/35" aria-hidden="true">
+          ·
+        </span>
+        <span data-slot="code-cell-current-line-detail" className="tabular-nums">
+          {detailLabel}
+        </span>
+      </span>
+      <div
+        data-slot="code-cell-current-line-rule"
+        className={cn(
+          "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
+          executionLineClass({ isExecuting, isQueued, isFocused }),
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -8,6 +8,7 @@ export interface CodeCellCurrentLineProps {
   isExecuting?: boolean;
   isQueued?: boolean;
   isFocused?: boolean;
+  compactIdle?: boolean;
   submittedByActorLabel?: string | null;
   onExecute: () => void;
   onInterrupt: () => void;
@@ -43,8 +44,8 @@ function executionDetail({
 }): string {
   const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
 
-  if (isExecuting) return runPrefix ? `${runPrefix}, running` : "Running";
-  if (isQueued) return runPrefix ? `${runPrefix}, queued` : "Queued";
+  if (isExecuting) return "Running";
+  if (isQueued) return "Queued";
   if (count !== null) {
     return elapsedMs === null
       ? `${runPrefix}, completed`
@@ -76,10 +77,10 @@ function executionLineClass({
   }
 
   if (isFocused) {
-    return "bg-border/70";
+    return "bg-border/50";
   }
 
-  return "bg-transparent group-hover:bg-border/45";
+  return "bg-border/25 group-hover:bg-border/45";
 }
 
 export function CodeCellCurrentLine({
@@ -89,12 +90,14 @@ export function CodeCellCurrentLine({
   isExecuting = false,
   isQueued = false,
   isFocused = false,
+  compactIdle = false,
   submittedByActorLabel = null,
   onExecute,
   onInterrupt,
   className,
 }: CodeCellCurrentLineProps) {
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const isCompactIdle = compactIdle && state === "idle";
   const isQuietIdle = state === "idle" && !isFocused;
   const detailLabel = executionDetail({ count, elapsedMs, isExecuting, isQueued });
   const countLabel = executionCountLabel(count);
@@ -126,7 +129,8 @@ export function CodeCellCurrentLine({
       data-execution-count={count ?? undefined}
       data-execution-label={countLabel ?? undefined}
       className={cn(
-        "mt-2 flex min-h-6 items-center gap-2 text-[11px] leading-none text-muted-foreground/65",
+        "mt-1.5 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
+        isCompactIdle ? "min-h-5" : "min-h-6",
         className,
       )}
     >
@@ -141,10 +145,12 @@ export function CodeCellCurrentLine({
         data-execution-state={state}
         data-execution-count={count ?? undefined}
         className={cn(
-          "inline-flex size-5 shrink-0 items-center justify-center rounded-full",
+          "inline-flex size-4 shrink-0 items-center justify-center rounded-full",
           "transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
           !isFocused && state === "idle" && "opacity-55 group-hover:opacity-100",
+          !isExecuting && state !== "queued" && "text-muted-foreground/55",
+          isCompactIdle && "opacity-45 hover:opacity-100",
           state === "idle" && "hover:bg-muted hover:text-foreground",
           state === "ran" && "hover:bg-primary/5 hover:text-primary",
           state === "queued" && "cursor-default text-sky-600 dark:text-sky-400",
@@ -152,18 +158,20 @@ export function CodeCellCurrentLine({
         )}
       >
         {isExecuting ? (
-          <Square className="size-3 fill-current animate-exec-squish" aria-hidden="true" />
+          <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
         ) : isQueued ? (
           <span
             className="block size-1.5 rounded-full bg-current animate-queue-breathe"
             aria-hidden="true"
           />
         ) : (
-          <Play className="size-3 fill-current" aria-hidden="true" />
+          <Play className="size-2.5 fill-current" aria-hidden="true" />
         )}
       </button>
       <span
         data-slot="code-cell-current-line-status"
+        aria-label={`${languageLabel}: ${detailLabel}`}
+        aria-live={isExecuting || isQueued ? "polite" : undefined}
         className={cn(
           "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
           isQuietIdle
@@ -174,21 +182,40 @@ export function CodeCellCurrentLine({
           isQueued && "text-sky-700 dark:text-sky-300",
         )}
       >
-        <span data-slot="code-cell-current-line-language">{languageLabel}</span>
-        <span className="text-muted-foreground/35" aria-hidden="true">
+        <span
+          data-slot="code-cell-current-line-language"
+          className={cn(
+            "rounded-sm px-0.5 py-0.5 text-foreground/60 transition-colors duration-150",
+            "group-hover:bg-muted/50 group-hover:text-foreground/70 group-focus-within:bg-muted/50 group-focus-within:text-foreground/70",
+            isFocused && "bg-muted/45 text-foreground/70",
+            isExecuting && "bg-primary/10 text-primary",
+            isQueued && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+          )}
+        >
+          {languageLabel}
+        </span>
+        <span
+          className={cn("text-muted-foreground/35", isCompactIdle && "sr-only")}
+          aria-hidden="true"
+        >
           ·
         </span>
-        <span data-slot="code-cell-current-line-detail" className="tabular-nums">
+        <span
+          data-slot="code-cell-current-line-detail"
+          className={cn("tabular-nums", isCompactIdle && "sr-only")}
+        >
           {detailLabel}
         </span>
       </span>
-      <div
-        data-slot="code-cell-current-line-rule"
-        className={cn(
-          "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
-          executionLineClass({ isExecuting, isQueued, isFocused }),
-        )}
-      />
+      {!isCompactIdle && (
+        <div
+          data-slot="code-cell-current-line-rule"
+          className={cn(
+            "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
+            executionLineClass({ isExecuting, isQueued, isFocused }),
+          )}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -1,3 +1,4 @@
+import { Play, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface CompactExecutionButtonProps {
@@ -9,6 +10,8 @@ interface CompactExecutionButtonProps {
   isQueued?: boolean;
   /** Authenticated actor label for the client that submitted the active execution */
   submittedByActorLabel?: string | null;
+  /** Whether the owning cell currently has notebook focus */
+  isCellFocused?: boolean;
   /** Called when user clicks to execute */
   onExecute?: () => void;
   /** Called when user clicks to interrupt */
@@ -17,23 +20,28 @@ interface CompactExecutionButtonProps {
   className?: string;
 }
 
+function formatExecutionCount(count: number): string {
+  return count > 999 ? "999" : String(count);
+}
+
 /**
- * Compact execution button combining play + execution count into one element.
+ * Compact execution button for the cell state lane.
  *
- * - Never run: `[ ▶ ]` - click to execute
- * - Queued: `[·]` - breathing dot, waiting in execution queue
- * - Running: `[■]` with pulse - click to stop
- * - Executed: `[1]` - hover to show play, click to re-run
+ * The button keeps execution state visible without reserving the old
+ * bracket-counter width in every cell state lane.
  */
 export function CompactExecutionButton({
   count,
   isExecuting = false,
   isQueued = false,
   submittedByActorLabel = null,
+  isCellFocused = false,
   onExecute,
   onInterrupt,
   className,
 }: CompactExecutionButtonProps) {
+  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const displayCount = count === null ? null : formatExecutionCount(count);
   const handleClick = () => {
     if (isQueued) return; // already in queue — no-op
     if (isExecuting) {
@@ -51,48 +59,73 @@ export function CompactExecutionButton({
       ? submittedByActorLabel
         ? `Queued for execution by ${submittedByActorLabel}`
         : "Queued for execution"
-      : "Run cell";
+      : count !== null
+        ? `Run cell again; last execution ${count}`
+        : "Run cell";
 
   return (
     <button
       type="button"
       onClick={handleClick}
       className={cn(
-        "group/exec inline-flex items-center font-mono text-sm tabular-nums",
-        "text-muted-foreground hover:text-foreground",
+        "group/exec inline-flex h-6 min-w-9 items-center justify-end rounded-sm",
+        "font-mono text-[11px] leading-none tabular-nums",
         "transition-colors duration-150",
+        "focus-visible:outline-none focus-visible:text-primary",
+        state === "idle" &&
+          "text-muted-foreground/45 opacity-0 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
+        state === "idle" && isCellFocused && "opacity-100",
+        state === "ran" && "text-muted-foreground/70 hover:text-primary",
+        state === "queued" && "text-sky-600 dark:text-sky-400",
+        state === "running" && "text-destructive",
         isQueued ? "cursor-default" : "cursor-pointer",
         className,
       )}
       title={title}
+      aria-label={title}
       aria-disabled={isQueued || undefined}
+      aria-busy={isExecuting || undefined}
+      data-execution-state={state}
+      data-execution-count={count ?? undefined}
       data-testid="execute-button"
     >
-      <span className="opacity-60">[</span>
-      <span className="relative inline-flex min-w-4 items-center justify-center">
-        {isExecuting ? (
-          // Running state: squish-breathe stop indicator with anticipation +
-          // overshoot. 1s delay so quick runs stay static.
-          <span className="text-destructive animate-exec-squish">■</span>
-        ) : isQueued ? (
-          // Queued state: small dot with slow breathe animation
-          <span className="flex items-center justify-center">
-            <span className="block h-1.5 w-1.5 rounded-full bg-muted-foreground animate-queue-breathe" />
+      <span className="relative inline-flex min-w-[5ch] items-center justify-end">
+        {state === "running" ? (
+          <span className="inline-flex items-center gap-0">
+            <span className="text-muted-foreground/50">[</span>
+            <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
+            <span className="text-muted-foreground/50">]</span>
           </span>
-        ) : count !== null ? (
-          // Has count: show count, play on hover
+        ) : state === "queued" ? (
+          <span className="inline-flex items-center gap-0">
+            <span className="text-muted-foreground/50">[</span>
+            <span
+              className="mx-[0.2ch] block size-1.5 rounded-full bg-current animate-queue-breathe"
+              aria-hidden="true"
+            />
+            <span className="text-muted-foreground/50">]</span>
+          </span>
+        ) : state === "ran" && displayCount !== null ? (
           <>
-            <span className="group-hover/exec:opacity-0 transition-opacity">{count}</span>
-            <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/exec:opacity-100 transition-opacity">
-              ▶
+            <span className="transition-opacity group-hover/exec:opacity-0">
+              <span className="text-muted-foreground/50">[</span>
+              {displayCount}
+              <span className="text-muted-foreground/50">]</span>
+            </span>
+            <span className="absolute inset-0 flex items-center justify-end opacity-0 transition-opacity group-hover/exec:opacity-100">
+              <span className="text-muted-foreground/50">[</span>
+              <Play className="size-3 fill-current" aria-hidden="true" />
+              <span className="text-muted-foreground/50">]</span>
             </span>
           </>
         ) : (
-          // Never run: show play
-          <span>▶</span>
+          <span className="inline-flex items-center gap-0">
+            <span className="text-muted-foreground/50">[</span>
+            <Play className="size-3 fill-current" aria-hidden="true" />
+            <span className="text-muted-foreground/50">]</span>
+          </span>
         )}
       </span>
-      <span className="opacity-60">]:</span>
     </button>
   );
 }

--- a/src/components/cell/ExecutionCount.tsx
+++ b/src/components/cell/ExecutionCount.tsx
@@ -6,14 +6,54 @@ interface ExecutionCountProps {
   className?: string;
 }
 
+function formatExecutionCount(count: number): string {
+  return count > 999 ? "999" : String(count);
+}
+
 export function ExecutionCount({ count, isExecuting, className }: ExecutionCountProps) {
-  const display = isExecuting ? "*" : (count ?? " ");
+  const state = isExecuting ? "running" : count !== null ? "ran" : "idle";
+  const display = count === null ? null : formatExecutionCount(count);
+  const title = isExecuting
+    ? "Execution running"
+    : count !== null
+      ? `Last execution ${count}`
+      : "Cell has not run";
+
   return (
     <span
       data-slot="execution-count"
-      className={cn("font-mono text-sm tabular-nums text-muted-foreground", className)}
+      data-execution-state={state}
+      data-execution-count={count ?? undefined}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "inline-flex h-6 min-w-9 items-center justify-end",
+        "font-mono text-[11px] leading-none tabular-nums transition-colors",
+        state === "idle" && "text-muted-foreground/45",
+        state === "ran" && "text-muted-foreground/70",
+        state === "running" && "text-destructive",
+        className,
+      )}
     >
-      [{display}]:
+      {state === "running" ? (
+        <span className="inline-flex min-w-[5ch] items-center justify-end">
+          <span className="text-muted-foreground/50">[</span>
+          <span className="block size-2 rounded-sm bg-current animate-exec-squish" aria-hidden />
+          <span className="text-muted-foreground/50">]</span>
+        </span>
+      ) : display !== null ? (
+        <span className="inline-flex min-w-[5ch] items-center justify-end">
+          <span className="text-muted-foreground/50">[</span>
+          {display}
+          <span className="text-muted-foreground/50">]</span>
+        </span>
+      ) : (
+        <span className="inline-flex min-w-[5ch] items-center justify-end">
+          <span className="text-muted-foreground/50">[</span>
+          <span className="mx-[0.2ch] block size-1.5 rounded-full bg-current" aria-hidden />
+          <span className="text-muted-foreground/50">]</span>
+        </span>
+      )}
     </span>
   );
 }

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -52,6 +52,7 @@ import { ErrorBoundary } from "@/lib/error-boundary";
 import { highlightTextInDom } from "@/lib/highlight-text";
 import { OutputErrorFallback } from "@/lib/output-error-fallback";
 import { cn } from "@/lib/utils";
+import { cellOutputInnerInset } from "./cell-layout";
 
 const handleIframeError = (err: { message: string; stack?: string }) =>
   console.error("[OutputArea] iframe error:", err);
@@ -88,6 +89,17 @@ const DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT = 96;
 const SIFT_VIEWPORT_TOP_INSET_PX = 96;
 const SIFT_VIEWPORT_BOTTOM_INSET_PX = 32;
 const DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN = "1200px 0px";
+
+function outputAreaInsetClass(layoutInset: NonNullable<OutputAreaProps["layoutInset"]>) {
+  switch (layoutInset) {
+    case "cell-output":
+      return cellOutputInnerInset;
+    case "none":
+      return undefined;
+    case "standalone":
+      return "pl-6";
+  }
+}
 
 function siftFocusAccent(isDark: boolean, colorTheme?: string): string {
   if (colorTheme === "cream") {
@@ -218,6 +230,13 @@ interface OutputAreaProps {
    * Additional CSS classes for the container.
    */
   className?: string;
+  /**
+   * Left inset behavior for the output content.
+   *
+   * `standalone` preserves the default renderer padding. `cell-output` aligns
+   * output content with a surrounding CellContainer's content column.
+   */
+  layoutInset?: "standalone" | "cell-output" | "none";
   /**
    * Custom renderers passed to MediaRouter.
    */
@@ -593,6 +612,7 @@ function OutputAreaSingle({
   focused = false,
   useOutputWell = true,
   className,
+  layoutInset = "standalone",
   renderers,
   priority = DEFAULT_PRIORITY,
   isolated = "auto",
@@ -1002,7 +1022,12 @@ function OutputAreaSingle({
   return (
     <div
       data-slot="output-area"
-      className={cn("output-area pl-6 pr-3", isPreloadOnly && "hidden", className)}
+      className={cn(
+        "output-area pr-3",
+        outputAreaInsetClass(layoutInset),
+        isPreloadOnly && "hidden",
+        className,
+      )}
     >
       {/* Collapse toggle */}
       {hasCollapseControl && (

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -996,10 +996,9 @@ function OutputAreaSingle({
   // Hide the entire output area when only preloading (no visible outputs)
   const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
 
-  // pl-6 pr-3 matches the code editor row padding so outputs align
-  // flush with the editor content. The CellContainer output wrapper
-  // has no horizontal padding — it must live here because the iframe
-  // ignores padding on its parent container.
+  // Keep the output's own inset here because isolated iframes ignore
+  // padding on parent wrappers. CellContainer may add row-level inset
+  // outside this component to align the output text with the editor.
   return (
     <div
       data-slot="output-area"

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -64,11 +64,7 @@ export function ReadOnlyNotebook({
   return (
     <section
       aria-label={label}
-      className={cn(
-        "flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain",
-        displayMode === "notebook" && "-ml-8 pl-8",
-        className,
-      )}
+      className={cn("flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain", className)}
       data-cell-count={cells.length}
       data-slot="read-only-notebook"
     >

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -64,7 +64,11 @@ export function ReadOnlyNotebook({
   return (
     <section
       aria-label={label}
-      className={cn("flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain", className)}
+      className={cn(
+        "flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain",
+        displayMode === "notebook" && "-ml-8 pl-8",
+        className,
+      )}
       data-cell-count={cells.length}
       data-slot="read-only-notebook"
     >

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -159,7 +159,6 @@ function renderReadOnlyCellSource({
         source={source}
         priority={priority}
         hostContext={hostContext}
-        layoutInset="none"
         className={cn("pl-0 pr-0", sourceClassName)}
       />
     );
@@ -219,6 +218,7 @@ function ReadOnlyMarkdownSource({
         isolated="auto"
         priority={priority}
         hostContext={hostContext}
+        layoutInset="none"
         className={className}
         onIsolatedFrameHandleChange={handleFrameHandleChange}
       />

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -88,6 +88,7 @@ export function ReadOnlyNotebookCell({
         priority={priority}
         hostContext={hostContext}
         className={outputClassName}
+        layoutInset={displayMode === "notebook" ? "cell-output" : "standalone"}
         deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
         deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
         resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
@@ -158,6 +159,7 @@ function renderReadOnlyCellSource({
         source={source}
         priority={priority}
         hostContext={hostContext}
+        layoutInset="none"
         className={cn("pl-0 pr-0", sourceClassName)}
       />
     );

--- a/src/components/cell/__tests__/CellContainer.test.tsx
+++ b/src/components/cell/__tests__/CellContainer.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { CellContainer } from "../CellContainer";
+
+describe("CellContainer", () => {
+  it("shows right edge controls when the cell is focused", () => {
+    const { container } = render(
+      <CellContainer
+        id="focused-cell"
+        cellType="code"
+        isFocused
+        codeContent={<div>source</div>}
+        rightGutterContent={<button type="button">Delete cell</button>}
+      />,
+    );
+
+    const overlay = container.querySelector('[data-slot="cell-action-overlay"]');
+    expect(overlay).toHaveClass("opacity-100");
+    expect(overlay).toHaveClass("pointer-events-auto");
+  });
+
+  it("keeps right edge controls hidden until hover or focus for unfocused cells", () => {
+    const { container } = render(
+      <CellContainer
+        id="unfocused-cell"
+        cellType="code"
+        codeContent={<div>source</div>}
+        rightGutterContent={<button type="button">Delete cell</button>}
+      />,
+    );
+
+    const overlay = container.querySelector('[data-slot="cell-action-overlay"]');
+    expect(overlay).toHaveClass("opacity-0");
+    expect(overlay).toHaveClass("pointer-events-none");
+    expect(overlay).not.toHaveClass("opacity-100");
+    expect(overlay).not.toHaveClass("pointer-events-auto");
+  });
+});

--- a/src/components/cell/__tests__/CellContainer.test.tsx
+++ b/src/components/cell/__tests__/CellContainer.test.tsx
@@ -15,8 +15,27 @@ describe("CellContainer", () => {
     );
 
     const overlay = container.querySelector('[data-slot="cell-action-overlay"]');
+    const codeContent = container.querySelector('[data-slot="cell-code-content"]');
     expect(overlay).toHaveClass("opacity-100");
     expect(overlay).toHaveClass("pointer-events-auto");
+    expect(codeContent).toHaveClass("pr-14");
+  });
+
+  it("reserves output row space for output edge controls", () => {
+    const { container } = render(
+      <CellContainer
+        id="output-cell"
+        cellType="code"
+        isFocused
+        codeContent={<div>source</div>}
+        outputContent={<div>long output</div>}
+        outputRightGutterContent={<button type="button">Hide output</button>}
+      />,
+    );
+
+    const outputContent = container.querySelector('[data-slot="cell-output-content"]');
+
+    expect(outputContent).toHaveClass("pr-14");
   });
 
   it("keeps right edge controls hidden until hover or focus for unfocused cells", () => {

--- a/src/components/cell/__tests__/CellContainer.test.tsx
+++ b/src/components/cell/__tests__/CellContainer.test.tsx
@@ -3,6 +3,23 @@ import { describe, expect, it } from "vite-plus/test";
 import { CellContainer } from "../CellContainer";
 
 describe("CellContainer", () => {
+  it("keeps state lane inside the cell surface instead of outside the rail edge", () => {
+    const { container } = render(
+      <CellContainer
+        id="presence-cell"
+        cellType="code"
+        codeContent={<div>source</div>}
+        presenceIndicators={<span>peer</span>}
+      />,
+    );
+
+    const lane = container.querySelector('[data-slot="cell-state-lane"]');
+
+    expect(lane).toHaveClass("left-1");
+    expect(lane).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
+    expect(lane).not.toHaveClass("-translate-x-full");
+  });
+
   it("shows right edge controls when the cell is focused", () => {
     const { container } = render(
       <CellContainer

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -46,11 +46,11 @@ describe("CellInsertionRibbon", () => {
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
 
     expect(adder).toHaveAttribute("data-terminal", "true");
-    expect(adder).toHaveClass("h-[clamp(5rem,16vh,8rem)]");
+    expect(adder).toHaveClass("h-[clamp(3.5rem,9vh,5.5rem)]");
     expect(ribbon).toHaveClass(
-      "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2.25rem),transparent_100%)]",
+      "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]",
     );
-    expect(intent).toHaveClass("h-10");
+    expect(intent).toHaveClass("h-7");
     expect(intent).toHaveClass("bg-gradient-to-b");
   });
 });

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -18,6 +18,21 @@ describe("CellInsertionRibbon", () => {
     expect(onInsert).toHaveBeenCalledWith("code");
   });
 
+  it("uses the left insertion channel as a primary code target", () => {
+    const onInsert = vi.fn();
+    const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
+
+    const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
+
+    fireEvent.pointerEnter(hitTarget!);
+    fireEvent.click(hitTarget!);
+
+    const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
+    expect(intent).toHaveClass("bg-sky-400");
+    expect(onInsert).toHaveBeenCalledWith("code");
+  });
+
   it("uses the controlled active type for catalog fixtures", () => {
     const { container } = render(
       <CellInsertionRibbon activeType="markdown" forceActionsVisible onInsert={() => undefined} />,

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { CellInsertionRibbon } from "../CellInsertionRibbon";
+
+describe("CellInsertionRibbon", () => {
+  it("reveals code insertion intent and calls the insert handler", () => {
+    const onInsert = vi.fn();
+    const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
+
+    expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
+
+    const addCodeButton = screen.getByTitle("Add code cell");
+    fireEvent.pointerEnter(addCodeButton);
+    fireEvent.click(addCodeButton);
+
+    const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
+    expect(intent).toHaveClass("bg-sky-400");
+    expect(onInsert).toHaveBeenCalledWith("code");
+  });
+
+  it("uses the controlled active type for catalog fixtures", () => {
+    const { container } = render(
+      <CellInsertionRibbon activeType="markdown" forceActionsVisible onInsert={() => undefined} />,
+    );
+
+    const actions = container.querySelector('[data-slot="cell-adder-actions"]');
+    const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
+
+    expect(actions).toHaveClass("opacity-100");
+    expect(intent).toHaveClass("bg-emerald-400");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-foreground");
+  });
+
+  it("softens the terminal row into a document tail", () => {
+    const { container } = render(
+      <CellInsertionRibbon
+        activeType="code"
+        terminal
+        forceActionsVisible
+        onInsert={() => undefined}
+      />,
+    );
+
+    const adder = container.querySelector('[data-slot="cell-adder"]');
+    const ribbon = container.querySelector('[data-slot="cell-adder-ribbon"]');
+    const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
+
+    expect(adder).toHaveAttribute("data-terminal", "true");
+    expect(adder).toHaveClass("h-[clamp(5rem,16vh,8rem)]");
+    expect(ribbon).toHaveClass(
+      "[mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-2.25rem),transparent_100%)]",
+    );
+    expect(intent).toHaveClass("h-10");
+    expect(intent).toHaveClass("bg-gradient-to-b");
+  });
+});

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -111,7 +111,24 @@ describe("CodeCellCurrentLine", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12,completedin1.5s");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·completedin1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
+  });
+
+  it("can carry activity context after the run state", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        activityContent={<span data-testid="peer-activity">Kyle</span>}
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+
+    expect(footer).toHaveTextContent("Kyle");
+    expect(screen.getByTestId("peer-activity")).toBeInTheDocument();
   });
 });

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -21,7 +21,28 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveTextContent("Python·Ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
-    expect(rule).toHaveClass("bg-transparent");
+    expect(rule).toHaveClass("bg-border/25");
+  });
+
+  it("keeps blank idle cells slim without separator chrome", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={null}
+        compactIdle
+        isFocused
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer).toHaveClass("min-h-5");
+    expect(detail).toHaveClass("sr-only");
+    expect(rule).toBeNull();
   });
 
   it("shows idle language when the cell is focused", () => {
@@ -64,7 +85,9 @@ describe("CodeCellCurrentLine", () => {
     });
 
     expect(footer).toHaveAttribute("data-execution-state", "running");
-    expect(status).toHaveTextContent("Python·Run 12, running");
+    expect(status).toHaveTextContent("Python·Running");
+    expect(status).toHaveAttribute("aria-label", "Python: Running");
+    expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveClass("text-primary");
     expect(rule).toHaveClass("bg-primary/45");
     expect(stopButton).toHaveClass("text-destructive");

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { CodeCellCurrentLine } from "../CodeCellCurrentLine";
+
+describe("CodeCellCurrentLine", () => {
+  it("keeps idle language quiet until the cell is engaged", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={null}
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer).toHaveAttribute("data-execution-state", "idle");
+    expect(status).toHaveTextContent("Python·Ready");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(rule).toHaveClass("bg-transparent");
+  });
+
+  it("shows idle language when the cell is focused", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={null}
+        isFocused
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+
+    expect(status).toHaveTextContent("Python·Ready");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
+    expect(status).not.toHaveClass("max-w-0");
+  });
+
+  it("separates active running status from the destructive stop control", () => {
+    const onInterrupt = vi.fn();
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        isExecuting
+        submittedByActorLabel="local:kyle"
+        onExecute={() => undefined}
+        onInterrupt={onInterrupt}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+    const stopButton = screen.getByRole("button", {
+      name: "Stop execution submitted by local:kyle",
+    });
+
+    expect(footer).toHaveAttribute("data-execution-state", "running");
+    expect(status).toHaveTextContent("Python·Run 12, running");
+    expect(status).toHaveClass("text-primary");
+    expect(rule).toHaveClass("bg-primary/45");
+    expect(stopButton).toHaveClass("text-destructive");
+
+    fireEvent.click(stopButton);
+
+    expect(onInterrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps completed runs readable without notebook prompt syntax", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        elapsedMs={1476}
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+
+    expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12,completedin1.5s");
+    expect(footer).not.toHaveTextContent("In [12]");
+  });
+});

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -190,6 +190,14 @@ function getOutputContent(container: HTMLElement): HTMLElement {
   return outputContent;
 }
 
+function getOutputArea(container: HTMLElement): HTMLElement {
+  const outputArea = container.querySelector('[data-slot="output-area"]');
+  if (!(outputArea instanceof HTMLElement)) {
+    throw new Error("Expected output area to render");
+  }
+  return outputArea;
+}
+
 describe("OutputArea iframe theme sync", () => {
   beforeEach(() => {
     Object.defineProperty(window, "innerHeight", {
@@ -524,6 +532,30 @@ describe("OutputArea iframe theme sync", () => {
     const outputContent = getOutputContent(container);
     expect(outputContent.getAttribute("class") ?? "").not.toContain("overflow-y-auto");
     expect(outputContent.style.maxHeight).toBe("");
+  });
+
+  it("keeps standalone output padding by default", () => {
+    const { container } = render(<OutputArea outputs={makeStreamOutput()} />);
+
+    expect(getOutputArea(container).getAttribute("class") ?? "").toContain("pl-6");
+  });
+
+  it("opts into cell output inset without applying standalone padding", () => {
+    const { container } = render(
+      <OutputArea outputs={makeStreamOutput()} layoutInset="cell-output" />,
+    );
+
+    const className = getOutputArea(container).getAttribute("class") ?? "";
+    expect(className).toContain("pl-[var(--cell-output-inner-inset,1.5rem)]");
+    expect(className).not.toContain("pl-6");
+  });
+
+  it("can render with no left output inset", () => {
+    const { container } = render(<OutputArea outputs={makeStreamOutput()} layoutInset="none" />);
+
+    const className = getOutputArea(container).getAttribute("class") ?? "";
+    expect(className).not.toContain("pl-6");
+    expect(className).not.toContain("cell-output-inner-inset");
   });
 
   it("segments mixed auto outputs into DOM, interactive iframe, and standalone sift iframe lanes", async () => {

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -113,8 +113,6 @@ describe("ReadOnlyNotebook", () => {
     expect(notebook).toHaveAttribute("aria-label", "Notebook cells");
     expect(notebook).toHaveAttribute("data-cell-count", "2");
     expect(notebook).toHaveClass("notebook-shell");
-    expect(notebook).toHaveClass("-ml-8");
-    expect(notebook).toHaveClass("pl-8");
 
     const cells = screen.getAllByTestId("read-only-cell");
     expect(cells).toHaveLength(2);

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -113,6 +113,8 @@ describe("ReadOnlyNotebook", () => {
     expect(notebook).toHaveAttribute("aria-label", "Notebook cells");
     expect(notebook).toHaveAttribute("data-cell-count", "2");
     expect(notebook).toHaveClass("notebook-shell");
+    expect(notebook).toHaveClass("-ml-8");
+    expect(notebook).toHaveClass("pl-8");
 
     const cells = screen.getAllByTestId("read-only-cell");
     expect(cells).toHaveLength(2);

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -148,7 +148,9 @@ describe("ReadOnlyNotebookCell", () => {
     expect(screen.getByTestId("readonly-codemirror")).toHaveAttribute("data-line-wrapping", "true");
     expect(screen.getByTestId("readonly-codemirror")).toHaveClass("cloud-source");
 
-    expect(screen.getByText("[7]:")).toHaveAttribute("data-slot", "execution-count");
+    const executionCount = document.querySelector('[data-slot="execution-count"]');
+    expect(executionCount).toHaveAttribute("data-execution-count", "7");
+    expect(executionCount).toHaveAttribute("data-execution-state", "ran");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "cell-code");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-execution-count", "7");
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-focused", "false");

--- a/src/components/cell/cell-layout.ts
+++ b/src/components/cell/cell-layout.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared notebook cell geometry.
+ *
+ * The ribbon sits flush against the notebook rail. Source, markdown, outputs,
+ * and insertion controls align to the document column defined here.
+ */
+export const notebookCellLayoutVars =
+  "[--cell-content-column-inset:2rem] [--cell-output-row-inset:1rem] [--cell-output-inner-inset:1rem] sm:[--cell-content-column-inset:3.25rem] sm:[--cell-output-row-inset:1.75rem] sm:[--cell-output-inner-inset:1.5rem]";
+
+export const cellContentColumnInset = "pl-[var(--cell-content-column-inset,3.25rem)]";
+export const cellContentColumnOffset = "ml-[var(--cell-content-column-inset,3.25rem)]";
+export const cellOutputRowInset = "pl-[var(--cell-output-row-inset,1.75rem)]";
+export const cellOutputInnerInset = "pl-[var(--cell-output-inner-inset,1.5rem)]";

--- a/src/components/cell/gutter-colors.ts
+++ b/src/components/cell/gutter-colors.ts
@@ -13,7 +13,7 @@ export interface GutterColorConfig {
 }
 
 /**
- * Default gutter colors for built-in cell types.
+ * Default ribbon colors for built-in cell types.
  * Colors are designed to keep cell-type ribbons visually consistent.
  */
 export const defaultGutterColors: Record<string, GutterColorConfig> = {
@@ -112,7 +112,7 @@ export const fallbackGutterColors: GutterColorConfig = {
 };
 
 /**
- * Get gutter colors for a cell type.
+ * Get ribbon colors for a cell type.
  * Falls back to neutral gray for unknown types.
  *
  * @param cellType - The cell type to get colors for

--- a/src/components/cell/gutter-colors.ts
+++ b/src/components/cell/gutter-colors.ts
@@ -19,13 +19,14 @@ export interface GutterColorConfig {
 export const defaultGutterColors: Record<string, GutterColorConfig> = {
   code: {
     ribbon: {
-      default: "bg-gray-200 dark:bg-gray-700",
-      focused: "bg-sky-400 dark:bg-sky-600",
+      default: "bg-gray-200/75 dark:bg-gray-700/70",
+      focused: "bg-sky-400/80 dark:bg-sky-600/80",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
-      focused: "bg-gradient-to-b from-sky-400/60 to-sky-400 dark:from-sky-600/60 dark:to-sky-600",
+        "bg-gradient-to-b from-gray-200/30 to-gray-200/65 dark:from-gray-700/30 dark:to-gray-700/65",
+      focused:
+        "bg-gradient-to-b from-sky-400/30 to-sky-400/70 dark:from-sky-600/35 dark:to-sky-600/75",
     },
     background: {
       focused: "bg-sky-50/20 dark:bg-sky-900/10",
@@ -33,14 +34,14 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
   },
   markdown: {
     ribbon: {
-      default: "bg-gray-200 dark:bg-gray-700",
-      focused: "bg-emerald-400 dark:bg-emerald-600",
+      default: "bg-gray-200/75 dark:bg-gray-700/70",
+      focused: "bg-emerald-400/80 dark:bg-emerald-600/80",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
+        "bg-gradient-to-b from-gray-200/30 to-gray-200/65 dark:from-gray-700/30 dark:to-gray-700/65",
       focused:
-        "bg-gradient-to-b from-emerald-400/60 to-emerald-400 dark:from-emerald-600/60 dark:to-emerald-600",
+        "bg-gradient-to-b from-emerald-400/30 to-emerald-400/70 dark:from-emerald-600/35 dark:to-emerald-600/75",
     },
     background: {
       focused: "bg-emerald-50/20 dark:bg-emerald-900/10",
@@ -48,14 +49,14 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
   },
   sql: {
     ribbon: {
-      default: "bg-amber-200 dark:bg-amber-800",
-      focused: "bg-amber-400 dark:bg-amber-600",
+      default: "bg-amber-200/75 dark:bg-amber-800/70",
+      focused: "bg-amber-400/80 dark:bg-amber-600/80",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-amber-200/60 to-amber-200 dark:from-amber-800/60 dark:to-amber-800",
+        "bg-gradient-to-b from-amber-200/30 to-amber-200/65 dark:from-amber-800/30 dark:to-amber-800/65",
       focused:
-        "bg-gradient-to-b from-amber-400/60 to-amber-400 dark:from-amber-600/60 dark:to-amber-600",
+        "bg-gradient-to-b from-amber-400/30 to-amber-400/70 dark:from-amber-600/35 dark:to-amber-600/75",
     },
     background: {
       focused: "bg-amber-50/20 dark:bg-amber-900/10",
@@ -63,14 +64,14 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
   },
   ai: {
     ribbon: {
-      default: "bg-purple-200 dark:bg-purple-800",
-      focused: "bg-purple-400 dark:bg-purple-600",
+      default: "bg-purple-200/75 dark:bg-purple-800/70",
+      focused: "bg-purple-400/80 dark:bg-purple-600/80",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-purple-200/60 to-purple-200 dark:from-purple-800/60 dark:to-purple-800",
+        "bg-gradient-to-b from-purple-200/30 to-purple-200/65 dark:from-purple-800/30 dark:to-purple-800/65",
       focused:
-        "bg-gradient-to-b from-purple-400/60 to-purple-400 dark:from-purple-600/60 dark:to-purple-600",
+        "bg-gradient-to-b from-purple-400/30 to-purple-400/70 dark:from-purple-600/35 dark:to-purple-600/75",
     },
     background: {
       focused: "bg-purple-50/20 dark:bg-purple-900/10",
@@ -78,14 +79,14 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
   },
   raw: {
     ribbon: {
-      default: "bg-gray-200 dark:bg-gray-700",
-      focused: "bg-rose-400 dark:bg-rose-600",
+      default: "bg-gray-200/75 dark:bg-gray-700/70",
+      focused: "bg-rose-400/80 dark:bg-rose-600/80",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
+        "bg-gradient-to-b from-gray-200/30 to-gray-200/65 dark:from-gray-700/30 dark:to-gray-700/65",
       focused:
-        "bg-gradient-to-b from-rose-400/60 to-rose-400 dark:from-rose-600/60 dark:to-rose-600",
+        "bg-gradient-to-b from-rose-400/30 to-rose-400/70 dark:from-rose-600/35 dark:to-rose-600/75",
     },
     background: {
       focused: "bg-rose-50/20 dark:bg-rose-900/10",
@@ -99,12 +100,14 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
  */
 export const fallbackGutterColors: GutterColorConfig = {
   ribbon: {
-    default: "bg-gray-200 dark:bg-gray-700",
-    focused: "bg-gray-400 dark:bg-gray-500",
+    default: "bg-gray-200/75 dark:bg-gray-700/70",
+    focused: "bg-gray-400/80 dark:bg-gray-500/80",
   },
   outputRibbon: {
-    default: "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
-    focused: "bg-gradient-to-b from-gray-400/60 to-gray-400 dark:from-gray-500/60 dark:to-gray-500",
+    default:
+      "bg-gradient-to-b from-gray-200/30 to-gray-200/65 dark:from-gray-700/30 dark:to-gray-700/65",
+    focused:
+      "bg-gradient-to-b from-gray-400/30 to-gray-400/70 dark:from-gray-500/35 dark:to-gray-500/75",
   },
   background: {
     focused: "bg-gray-50/50 dark:bg-gray-900/30",


### PR DESCRIPTION
## Summary

This draft PR reshapes the notebook cell gutter/current-line design around the new left rail and ribbon language.

- moves code-cell execution state out of the old prompt-style gutter into a shared current-line surface between source and output
- keeps the ribbon continuous through cells, insertion rows, focused cells, and output segments
- gives execution count metadata context such as `Python · Run 4 · completed`
- moves code-cell peer/activity indicators into the current-line context instead of spending left-inset width
- makes the left insertion channel between the ribbon and source column a hover/click target for adding code cells
- makes empty idle code cells slimmer by hiding the separator/detail chrome and suppressing the source-hide action when there is no source
- reserves right-side source/output space when edge controls are present so overlays do not cover long code or output text
- documents the design language in the Elements cell anatomy examples, including hidden input/output boundary states and a current-line studio for alternatives

## Impact

The notebook reads less like a legacy Jupyter prompt column and more like a continuous document spine. The current line now acts as the source/result boundary while preserving execution affordances, focus state, peer activity context, and future room for cell type/language controls.

## Validation

- `pnpm test:run src/components/cell/__tests__/CellInsertionRibbon.test.tsx src/components/cell/__tests__/CodeCellCurrentLine.test.tsx src/components/cell/__tests__/CellContainer.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- live smoke against `http://localhost:9866/` for completed current-line copy, insertion margin hover intent, state-lane width, and rail-safe ribbon placement
