### PR TITLE
test(notebook-doc): cross-version sync forward-compat + schema-evolution ADR

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -4288,6 +4288,91 @@ mod tests {
         assert_eq!(server_ids, client_ids); // Same order after merge
     }
 
+    // ── Cross-version sync (the cloud topology) ───────────────────────
+    //
+    // Desktop ships daemon + frontend as one build, so every peer in a room
+    // runs the same schema version and none of the below can happen. Cloud
+    // (prototype) lets external, independently-versioned peers share a room
+    // through the host. These tests model that: two peers built from the
+    // *byte-identical* frozen genesis (NOTEBOOK_GENESIS_V5_BYTES), so they
+    // share a common ancestor and merge cleanly. A future vX that regenerates
+    // the genesis breaks this precondition — that is the original data-loss
+    // incident, at the sync layer.
+
+    /// Additive forward-compat across a live sync: a current (v5) peer keeps a
+    /// future (vX) peer's fields it cannot interpret. Sync exchanges ops keyed
+    /// by ObjId, not typed structs, so unknown keys merge and survive.
+    #[test]
+    fn test_cross_version_sync_preserves_additive_future_fields() {
+        let mut v5 = NotebookDoc::new_with_actor("room-nb", "peer-v5");
+        let mut future = NotebookDoc::new_with_actor("room-nb", "peer-future");
+
+        // v5 peer authors an ordinary cell.
+        v5.add_cell(0, "c-v5", "code").unwrap();
+        v5.update_source("c-v5", "print('v5')").unwrap();
+
+        // Future peer bumps the version and writes additive data a vX build
+        // might introduce: a new top-level key, and a new key inside a cell's
+        // metadata map. Cell metadata (not a bare cell field) is the additive
+        // surface — bare cell fields have no extras bag and die at the .ipynb
+        // boundary.
+        let future_version = SCHEMA_VERSION + 1;
+        future
+            .doc
+            .put(automerge::ROOT, "schema_version", future_version)
+            .unwrap();
+        future
+            .doc
+            .put(automerge::ROOT, "workspace_id", "ws-42")
+            .unwrap();
+        future.add_cell(0, "c-future", "code").unwrap();
+        future.update_source("c-future", "print('future')").unwrap();
+        future
+            .set_cell_metadata("c-future", &serde_json::json!({ "vx_pin": "abc123" }))
+            .unwrap();
+
+        // Live sync, both directions, to convergence.
+        let mut s_v5 = sync::State::new();
+        let mut s_future = sync::State::new();
+        sync_docs(&mut v5, &mut s_v5, &mut future, &mut s_future, 20);
+
+        // Cells from both peers merged cleanly, shared root not doubled.
+        let v5_ids: Vec<String> = v5.get_cells().iter().map(|c| c.id.clone()).collect();
+        let future_ids: Vec<String> = future.get_cells().iter().map(|c| c.id.clone()).collect();
+        assert_eq!(
+            v5_ids.len(),
+            2,
+            "both peers' cells present, genesis not doubled"
+        );
+        assert!(v5_ids.contains(&"c-v5".to_string()));
+        assert!(v5_ids.contains(&"c-future".to_string()));
+        assert_eq!(
+            v5_ids, future_ids,
+            "both peers converge to the same cell order"
+        );
+
+        // Only the future peer wrote schema_version (its write causally
+        // succeeds the seed), so the bump propagates cleanly — no conflict.
+        // Concurrent conflicting writes are Part 2's subject.
+        assert_eq!(v5.schema_version(), Some(future_version));
+
+        // The future peer's additive top-level key survives on the v5 peer,
+        // which has no code that reads it.
+        assert!(
+            matches!(
+                v5.doc.get(automerge::ROOT, "workspace_id"),
+                Ok(Some((automerge::Value::Scalar(_), _)))
+            ),
+            "unknown future top-level key preserved on the v5 peer"
+        );
+
+        // The future peer's additive cell metadata survives on the v5 peer.
+        let meta = v5
+            .get_cell_metadata("c-future")
+            .expect("future cell metadata present");
+        assert_eq!(meta["vx_pin"], "abc123");
+    }
+
     #[test]
     #[cfg(feature = "persistence")]
     fn test_notebook_doc_filename_deterministic() {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -4373,6 +4373,60 @@ mod tests {
         assert_eq!(meta["vx_pin"], "abc123");
     }
 
+    /// Reproduction of the multi-writer `schema_version` hazard for cloud.
+    ///
+    /// `schema_version` is a single LWW scalar, single-writer only by
+    /// *convention* (the migrate-on-load path is the lone writer, and desktop
+    /// rooms are single-version). In a mixed-version cloud room two peers can
+    /// write it concurrently: two upgraded peers migrating a stale room doc,
+    /// or a stale peer re-stamping its old version. There is no monotonic/max
+    /// merge: the CRDT picks an LWW winner by (lamport, actor), unrelated to
+    /// which schema is newer, so a stale peer's lower version can win and stamp
+    /// the shared doc backward.
+    ///
+    /// Characterization test: it pins today's (undesirable) behavior so it is
+    /// reproducible. When the fix lands (host-enforced single-writer auth, or
+    /// monotonic-max merge semantics) this test should be updated to assert the
+    /// new guarantee.
+    #[test]
+    fn test_cross_version_schema_version_is_lww_not_monotonic() {
+        let mut old = NotebookDoc::new_with_actor("room-nb", "peer-old");
+        let mut new = NotebookDoc::new_with_actor("room-nb", "peer-new");
+
+        // Concurrent, conflicting writes (neither peer has seen the other).
+        old.doc
+            .put(automerge::ROOT, "schema_version", 4u64)
+            .unwrap();
+        new.doc
+            .put(automerge::ROOT, "schema_version", 6u64)
+            .unwrap();
+
+        let mut s_old = sync::State::new();
+        let mut s_new = sync::State::new();
+        sync_docs(&mut old, &mut s_old, &mut new, &mut s_new, 20);
+
+        // CRDT determinism holds: both peers converge to the SAME value...
+        assert_eq!(
+            old.schema_version(),
+            new.schema_version(),
+            "peers converge to a single value"
+        );
+        // ...but it is an LWW pick of one of the two written values, never
+        // their max. There is no merge rule that says "higher schema wins."
+        //
+        // Here the *older* peer wins: the converged value is 4, not 6. The tie
+        // is broken by actor id (concurrent writes have equal lamport counter),
+        // and "peer-old" sorts above "peer-new" by bytes, so the stale peer
+        // stamps the shared doc backward; v6 is silently downgraded to v4.
+        // The winner is decided by actor bytes, not by which schema is newer;
+        // swapping the labels flips it. That arbitrariness is the hazard.
+        let converged = old.schema_version().unwrap();
+        assert_eq!(
+            converged, 4,
+            "stale peer's lower version wins the LWW tie, stamping the doc backward"
+        );
+    }
+
     #[test]
     #[cfg(feature = "persistence")]
     fn test_notebook_doc_filename_deterministic() {

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,6 +31,7 @@ These entries define the center of gravity for the system:
 | Identity, actors, scopes | [Identity and Trust](identity-and-trust.md) | Accepted |
 | Wire format | [Typed-frame v4 wire protocol](typed-frame-v4-wire-protocol.md) | Draft |
 | Document boundaries | [The Three-Document Split](three-document-split.md) | Draft |
+| Schema evolution | [Notebook Schema Evolution and the Frozen Genesis](schema-evolution-and-genesis.md) | Draft |
 | Runtime-state identity | [Runtime State Document Identity](runtime-state-document-identity.md) | Draft |
 | Notebook host shell | [Notebook Host Shell Convergence](notebook-host-shell-convergence.md) | Draft |
 | Execution ordering | [Cell Execution Pipeline and Control-Plane Separation](execution-pipeline.md) | Draft |
@@ -47,6 +48,7 @@ These entries define the center of gravity for the system:
 | [Typed-frame v4 wire protocol](typed-frame-v4-wire-protocol.md) | Draft | Frame bytes, channels, caps, and compatibility. |
 | [The Three-Document Split](three-document-split.md) | Draft | NotebookDoc, RuntimeStateDoc, and PoolDoc responsibility boundaries. |
 | [Runtime State Document Identity](runtime-state-document-identity.md) | Draft | NotebookDoc-owned pointer to the RuntimeStateDoc identity and checkpoint-head split. |
+| [Notebook Schema Evolution and the Frozen Genesis](schema-evolution-and-genesis.md) | Draft | Frozen genesis seed, freeze-and-layer evolution, forward-tolerant reader, and cross-version sync hazards. |
 | [Notebook Host Shell Convergence](notebook-host-shell-convergence.md) | Draft | Shared notebook shell, capability vocabulary, and host adapter boundary across desktop, cloud, and elements. |
 | [Cell Execution Pipeline and Control-Plane Separation](execution-pipeline.md) | Draft | Execution state, output ordering, and lifecycle priority. |
 | [Execution Liveness](execution-liveness.md) | Design memo | Divergence-detection framing; not a recovery decision yet. |

--- a/docs/architecture/cleanup-punchlist.md
+++ b/docs/architecture/cleanup-punchlist.md
@@ -79,6 +79,12 @@ Severity legend:
 | HCA-5 | Blob hash representation is not a single contract across local CAS, blob-ref manifests, hosted artifact examples, and cloud storage keys. Choose bare lowercase SHA-256 hex, `sha256:<hex>`, or another durable syntax, then update examples and validators together. | Design | `docs/architecture/blob-storage-and-content-addressing.md`, `docs/architecture/blob-ref-and-chunk-manifest-protocol.md`, `docs/architecture/hosted-notebook-artifacts.md`, `apps/notebook-cloud/src/storage.ts` |
 | HCA-6 | Private hosted blob-read authority is split between future capability URLs and current viewer-authenticated app-origin routes with public CORS. Before private sharing ships, choose and enforce the credential/CORS or signed-capability policy for `/api/n/:id/blobs/:hash`. | Design | `docs/architecture/hosted-room-authorization.md`, `docs/architecture/hosted-output-origin-isolation.md`, `apps/notebook-cloud/src/index.ts` |
 
+## Schema evolution
+
+| ID | Smell | Severity | Where |
+|----|-------|----------|-------|
+| SE-1 | `schema_version` is a single LWW scalar, single-writer only by convention (the migrate-on-load path is the lone writer, and desktop rooms are single-version). In a mixed-version cloud room two peers can write it concurrently and the CRDT picks an LWW winner by `(lamport, actor)`, unrelated to which schema is newer, so a stale peer can stamp the shared doc backward. Reproduced by `test_cross_version_schema_version_is_lww_not_monotonic`. Needs host-enforced single-writer auth or monotonic-max merge semantics before cloud ships mixed versions in one room. | Design | `crates/notebook-doc/src/lib.rs`, `docs/architecture/schema-evolution-and-genesis.md`, `docs/architecture/hosted-room-authorization.md` |
+
 ## Environment lifecycle
 
 | ID | Smell | Severity | Where |
@@ -111,7 +117,7 @@ Severity legend:
 - **Done:** WP-1, WP-2, WP-3, WP-5, WP-9, EP-2, EP-7, EP-12, BS-1, BS-8, BS-11. Eleven landed across #2813, cleanup/inline-pass, and targeted cleanup stacks.
 - **Refuted:** EP-4 (log levels are correct per `.claude/rules/logging.md`), EP-13 (warn/debug asymmetry matches the actual severity of `Full` vs `Closed`).
 - **Targeted PRs (one per smell):** WP-6, WP-7, WP-11, WP-12, 3D-1, 3D-2, EP-1, EP-8, EP-10, EP-11, BS-3, BS-7, TMD-1, TMD-2, MSL-1, MSL-3, FSB-1, FSB-2, HCA-1. Nineteen open.
-- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1, CEL-1. Twenty-nine open.
+- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1, CEL-1, SE-1. Thirty open.
 
 ## Next steps
 

--- a/docs/architecture/schema-evolution-and-genesis.md
+++ b/docs/architecture/schema-evolution-and-genesis.md
@@ -1,0 +1,156 @@
+# Notebook Schema Evolution and the Frozen Genesis
+
+**Status:** Draft, 2026-05-30.
+
+## Context
+
+A `NotebookDoc` is an Automerge CRDT. Every notebook document descends from a
+**genesis seed**: a frozen root change that creates the `cells` and `metadata`
+maps and stamps `schema_version`. The seed bytes are committed as an asset and
+loaded verbatim:
+
+- `SCHEMA_VERSION: u64 = 5` (`crates/notebook-doc/src/lib.rs:74`)
+- `NOTEBOOK_GENESIS_V5_BYTES` from `assets/notebook_genesis_v5.am` (`:85`)
+- attributed to `SCHEMA_SEED_ACTOR = "nteract:notebook-schema:v5"` (`:81`)
+
+Two documents that load the same seed bytes share a byte-identical root change,
+so they share a common ancestor and merge cleanly. That shared ancestor is the
+load-bearing property behind both persistence and cross-peer sync. The cloud
+room host pins the seed by change hash (`canonical_schema_seed_change_hashes`,
+`:2370`, from #3192) so only the canonical root is accepted into a room.
+
+### The incident this register entry exists to prevent
+
+The schema bump v4 -> v5 (#3086) **regenerated the genesis seed** along with the
+version stamp. The daemon shipped the v5 seed; the gitignored frontend wasm
+still embedded the v4 seed. A notebook opened by the frontend started from the
+v4 root while the daemon worked from the v5 root, two **divergent roots** with
+no common ancestor. They did not hard-fail; Automerge merged them last-write-
+wins into a doc that neither side read correctly, and an autosave footgun then
+zeroed the file. The fixes that landed:
+
+- #3134: `cargo xtask verify-genesis` + `wasm-ensure` assert the built wasm
+  embeds the current seed bytes. The drift guard that keeps daemon and frontend
+  seeds matched. See [Automerge Fork Patches](automerge-fork-patches.md) for the
+  related validation work.
+- #3179: autosave-zeroing data-loss guard (`load_failed` set-on-hazard). The
+  safety net for failed loads.
+- #3192: canonical seed cross-peer sync auth, hash-pinned. See
+  [Hosted Room Authorization](hosted-room-authorization.md).
+- #3195: forward-tolerant schema reader (below).
+
+## Decision: freeze and layer
+
+**Never regenerate the genesis.** The frozen v5 root is permanent. Schema
+evolution layers on top of it:
+
+1. **Additive changes** (new metadata keys, new cell-metadata keys, new
+   top-level keys) are written by ordinary principal-authored ops on the frozen
+   root. Unknown keys round-trip through `extras` / `#[serde(default)]` on the
+   metadata path, and survive structurally on the `.automerge` path because save
+   is a raw CRDT dump. Old readers tolerate them.
+2. **Structural changes** (reshaping `cells`, re-keying outputs) do **not** go
+   in place. A CRDT merge of two different shapes of the same logical data
+   produces a document neither version reads correctly. Structural change needs
+   a sidecar document, never an in-place reshape of the frozen root.
+3. **`schema_version`** is bumped by a normal layered write, not by re-rooting.
+   The v4 -> v5 diff (`git show e385d806`) changed only the version scalar and
+   the seed actor label; it never needed a new root. No future bump does either.
+
+### Why "additive" is safe and "structural" is not
+
+Sync exchanges Automerge ops keyed by `ObjId`, not typed notebook structs. A
+peer that cannot interpret a key still stores and forwards its ops. So additive
+data authored by a newer peer lands in an older peer's document and survives,
+even though the old peer's code never reads it. That is real forward
+compatibility: *preserve what you do not understand.* It holds only while both
+peers share the frozen root and only write **new** locations. The moment two
+versions write **different shapes** of the same location, the merge is garbage.
+
+## The forward-tolerant reader (#3195)
+
+`load_or_create_inner` reads the raw `schema_version` into a tri-state and
+dispatches:
+
+| `schema_version` | Behavior |
+|---|---|
+| **Absent** + has v5 skeleton (`cells`/`metadata` Maps) | load as current (not v1) |
+| **Absent** + no v5 skeleton | reject -> `.corrupt` |
+| **Valid(v)** >= `SCHEMA_VERSION` (newer build) | load tolerantly: no downgrade, no migrate |
+| **Valid(3 \| 4)** | migrate in place (real 2.0.x docs) |
+| **Valid(v)** < 3 (v1/v2 prototype) | reject -> `.corrupt` |
+| **Invalid** (non-integer / negative) | reject -> `.corrupt` |
+
+The "newer build loads tolerantly" row is the prerequisite for ever bumping the
+schema: until v5 builds tolerate a v6 doc, a bump would `.corrupt`-rename files
+on every not-yet-updated install. We must **not** write our older
+`SCHEMA_VERSION` over a newer one (loses the version, risks a concurrent LWW
+downgrade) and must **not** migrate a newer doc.
+
+## Migration
+
+v3 (2.0 launch, Mar 2026) and v4 (#2760, mid-May) are real on-disk documents.
+They migrate in place on load: add `runtime_state_doc_id`, stamp
+`schema_version = SCHEMA_VERSION`. v1/v2 are pre-2.0 prototype formats that do
+not exist in the field; their reject branch is a harmless guard.
+
+`crates/notebook-doc/src/lib.rs` tests:
+
+- `test_load_v4_doc_migrates_runtime_state_doc_id`: the migration mechanism.
+- `test_v4_to_v5_migration_preserves_realistic_notebook` (#3199): a realistic
+  v4 doc (mixed cells, sources, cell metadata, conda/uv deps) survives the
+  migrate-in-place with nothing dropped and no `.corrupt`. The confidence check
+  for the stable v4 -> v5 release.
+
+Migration is a **load-time write**. That is fine on desktop, where a room has a
+single version. It is **not** fine in a mixed-version room (below).
+
+## Cross-version sync (the cloud topology)
+
+Desktop ships the daemon and frontend as one build, so every peer in a room runs
+the same schema version. See [Deployment Topology](deployment-topology.md).
+Cloud (prototype) lets independently-versioned peers share a room through the
+host. Three behaviors then matter, demonstrated by tests in
+`crates/notebook-doc/src/lib.rs`:
+
+1. **Additive fields survive** (`test_cross_version_sync_preserves_additive_future_fields`).
+   A current (v5) peer and a future (vX) peer build from the same frozen genesis,
+   sync, and the v5 peer keeps the vX peer's unknown top-level key and unknown
+   cell-metadata key. Cells merge cleanly; the root is not doubled.
+
+2. **`schema_version` is LWW, not monotonic**
+   (`test_cross_version_schema_version_is_lww_not_monotonic`). Two peers writing
+   different versions concurrently converge to a single value, but it is an LWW
+   pick decided by `(lamport, actor)`, unrelated to which schema is newer. In the
+   test the *stale* peer wins and stamps the shared doc backward (v6 -> v4). This
+   is single-writer by **convention** only (the migrate-on-load path is the lone
+   writer, and desktop rooms are single-version). Cloud breaks the convention.
+   Tracked as **SE-1** in [cleanup-punchlist.md](cleanup-punchlist.md).
+
+3. **Divergent genesis breaks sync.** The original incident, at the sync layer.
+   Guarded by #3134 (build-time drift) and #3192 (host hash-pinning). Any future
+   vX that regenerates the seed re-breaks every mixed-version room.
+
+The cell-level asymmetry: notebook metadata has an `extras` bag, so unknown
+metadata keys round-trip through `.ipynb` export. Cells do **not**: a bare
+unknown field directly on a cell survives the `.automerge` round-trip but is
+dropped at the `.ipynb` boundary. Additive cell data must live under
+`cells/{id}/metadata`, never as a bare cell field.
+
+## Invariants
+
+1. The genesis seed is frozen. Do not regenerate it on a schema bump.
+2. A schema bump is one layered write to `schema_version` plus additive fields.
+3. Additive cell data goes under `cells/{id}/metadata`, never a bare cell field.
+4. A v5 build must tolerate a v6 doc (no downgrade, no migrate, no `.corrupt`).
+   The bump cannot ship until that reader has propagated through the fleet.
+5. Structural change uses a sidecar, never an in-place reshape of the root.
+6. `.ipynb` is the truth on disk for saved notebooks; the `.automerge` is the
+   sole copy for untitled notebooks and the live sync substrate.
+
+## Open question
+
+`schema_version` as a single LWW scalar has no mixed-version semantics. Before
+cloud ships mixed versions in one room it needs either host-enforced
+single-writer auth (does #3192's room-host auth let a peer update
+`schema_version`?) or monotonic-max merge semantics. See SE-1.


### PR DESCRIPTION
Tests for the cloud topology nobody runs yet: independently-versioned peers sharing a room through the host. Desktop ships the daemon and frontend as one build, so every peer in a room is the same schema version and none of this can happen. Cloud changes that. These tests pin what survives and what breaks before it ships, and an ADR records the design.

## What forward-compatible can mean

Two different properties, and they have different answers:

- **Tolerate** (already covered by #3195): a v5 build opens a v6 doc without panicking, downgrading, or quarantining it.
- **Preserve under sync** (new here): a v5 peer in a live room with a vX peer keeps the data it cannot interpret. This is the one that backs "bump schema in nightly without hurting people."

Sync exchanges Automerge ops keyed by `ObjId`, not typed structs, so a peer that cannot read a key still stores and forwards its ops. That makes additive change forward-compatible. It holds only while both peers share the frozen genesis root and only write *new* locations.

## The two tests (commits 1 and 2)

`test_cross_version_sync_preserves_additive_future_fields` - a current v5 peer and a hypothetical future vX peer build from the byte-identical frozen genesis, sync, and the v5 peer keeps the vX peer's unknown top-level key and unknown cell-metadata key. Cells merge cleanly, the shared root is not doubled. Passes: this is the guarantee.

`test_cross_version_schema_version_is_lww_not_monotonic` - a characterization test for the multi-writer hazard. Two peers write different `schema_version` values concurrently and sync. They converge to one value, but it is an LWW pick decided by `(lamport, actor)`, not the max. In the test the *stale* peer wins and stamps the shared doc backward (v6 to v4). `schema_version` is single-writer only by convention (migrate-on-load is the lone writer, desktop rooms are single-version); a mixed-version cloud room breaks that convention. The test pins today's behavior so it is reproducible. When the fix lands (host-enforced single-writer auth, or monotonic-max merge), the test should be updated to assert the new guarantee.

## ADR (commit 3)

`docs/architecture/schema-evolution-and-genesis.md` (Draft) is the durable home for the schema-evolution work that has lived in scratch until now: the frozen genesis and why it must never be regenerated, freeze-and-layer evolution, the forward-tolerant reader, the migration ladder, and the cross-version sync hazards these tests reproduce. Adds **SE-1** to the cleanup punchlist (the `schema_version` multi-writer LWW smell) and registers the ADR in the architecture README.

## Why a backward-stamp matters for cloud

The LWW winner is decided by actor bytes, not by which schema is newer. Swap the actor labels and the winner flips. So in a mixed-version room a stale peer can silently downgrade the shared doc's version. Before cloud ships mixed versions, `schema_version` needs either host-enforced single-writer auth or monotonic-max merge semantics. Open question for the room-host work (does #3192's auth let a peer update `schema_version`?), tracked as SE-1.

## Test plan

- [ ] `cargo test -p notebook-doc --features persistence` (the cross-version tests are not feature-gated, but run there with the full suite; runs in CI via `cargo test --workspace`)
- [ ] `cargo clippy -p notebook-doc --all-targets --features persistence -- -D warnings`

Follows the v4->v5 migration confidence test (#3199) in the schema-evolution work.
