### PR TITLE
ci: force Pullfrog OpenCode for Opus 4.8

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -30,5 +30,6 @@ jobs:
         with:
           prompt: ${{ inputs.prompt }}
         env:
+          PULLFROG_AGENT: opencode
           AWS_REGION: us-east-1
           BEDROCK_MODEL_ID: us.anthropic.claude-opus-4-8


### PR DESCRIPTION
## Summary

- force Pullfrog to use its OpenCode harness for Bedrock-backed reviews
- keep the Opus 4.8 Bedrock model ID now that the Claude Code route rejects its thinking payload

## Verification

- `cargo xtask lint --fix`
- `AWS_REGION=us-east-1 PULLFROG_AGENT=opencode /tmp/opencode-install.If3rnJ/node_modules/.bin/opencode run --model amazon-bedrock/us.anthropic.claude-opus-4-8 --thinking --format json --title "pullfrog-opencode-48-env-smoke" "Reply with exactly: OK"`
- Pullfrog workflow smoke on this branch: https://github.com/nteract/nteract/actions/runs/26696283427
