### PR TITLE
refactor(notebook): project desktop outline through shell view model

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -11,7 +11,6 @@ import {
   deriveEnvManager,
   deriveRuntimeKind,
   notebookCellAnchorId,
-  projectNotebookOutline,
   resolveNotebookOutlineSelection,
   type DependencyGuard,
   type GuardedNotebookProvenance,
@@ -39,9 +38,10 @@ import {
   type NotebookRailPanelId,
 } from "@/components/notebook-rail";
 import {
+  createNotebookViewModel,
   navigateNotebookOutlineItem,
   NotebookDocumentShell,
-  notebookOutlineItemsToMarkdownHeadingAnchors,
+  type NotebookViewCell,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -97,7 +97,7 @@ import { useNotebookQueueProjection } from "./lib/notebook-executions";
 import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
 import { startWindowFocusHandler } from "./lib/window-focus";
-import type { JupyterOutput } from "./types";
+import type { JupyterOutput, NotebookCell } from "./types";
 
 /** MIME bundle type for output data */
 export type MimeBundle = Record<string, unknown>;
@@ -746,31 +746,30 @@ function AppContent() {
   );
   const queuedCellIds = new Set(notebookQueueProjection.queued_cell_ids);
   const sourceVersion = useSourceVersion();
-  const outlineItems = useMemo(() => {
+  const notebookViewModel = useMemo(() => {
     void cellIds;
     void sourceVersion;
     const executingCellId = notebookQueueProjection.executing_cell_id;
     const queuedOutlineCellIds = new Set(notebookQueueProjection.queued_cell_ids);
 
-    return projectNotebookOutline(getNotebookCellsSnapshot(), {
-      getStatusLabel: (cell) => {
+    return createNotebookViewModel(getNotebookCellsSnapshot().map(notebookCellToViewCell), {
+      getOutlineStatusLabel: (cell) => {
         if (cell.id === executingCellId) return "Running";
         if (queuedOutlineCellIds.has(cell.id)) return "Queued";
-        if (cell.cell_type === "code" && cell.execution_count !== null) {
-          return `In [${cell.execution_count}]`;
+        if (cell.cellType === "code" && cell.executionCount !== null) {
+          return `In [${cell.executionCount}]`;
         }
         return null;
       },
-    }).items;
+    });
   }, [
     cellIds,
     sourceVersion,
     notebookQueueProjection.executing_cell_id,
     notebookQueueProjection.queued_cell_ids,
   ]);
-  const markdownHeadingAnchorsByCellId = useMemo(() => {
-    return notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems);
-  }, [outlineItems]);
+  const outlineItems = notebookViewModel.outlineItems;
+  const markdownHeadingAnchorsByCellId = notebookViewModel.markdownHeadingAnchorsByCellId;
   const activeOutlineItemId = useActiveOutlineItemId(
     outlineItems,
     cellIds,
@@ -2113,6 +2112,24 @@ function AppContent() {
       </div>
     </PresenceProvider>
   );
+}
+
+function notebookCellToViewCell(cell: NotebookCell): NotebookViewCell {
+  return {
+    id: cell.id,
+    cellType: cell.cell_type,
+    source: cell.source,
+    language: cell.cell_type === "code" ? notebookCellLanguage(cell.metadata) : null,
+    executionId: null,
+    executionCount: cell.cell_type === "code" ? cell.execution_count : null,
+    outputs: cell.cell_type === "code" ? cell.outputs : [],
+    metadata: cell.metadata,
+  };
+}
+
+function notebookCellLanguage(metadata: Record<string, unknown>): string | null {
+  const language = metadata.language;
+  return typeof language === "string" ? language : null;
 }
 
 function packageCountLabel(count: number): string {

--- a/src/components/notebook-shell/__tests__/view-model.test.ts
+++ b/src/components/notebook-shell/__tests__/view-model.test.ts
@@ -74,16 +74,6 @@ describe("notebook shell view model", () => {
         outputs: [],
         metadata: {},
       },
-      {
-        id: "code-1",
-        cellType: "code",
-        source: "print('ok')",
-        language: "python",
-        executionId: "exec-1",
-        executionCount: 3,
-        outputs: [],
-        metadata: {},
-      },
     ]);
 
     expect(outline.map((item) => [item.id, item.cellId, item.title, item.level])).toEqual([
@@ -94,6 +84,31 @@ describe("notebook shell view model", () => {
       "#notebook-cell-intro-heading-intro",
       "#notebook-cell-intro-heading-setup",
     ]);
+  });
+
+  it("lets host adapters override outline status labels", () => {
+    const outline = notebookViewCellsToOutlineItems(
+      [
+        {
+          id: "code-1",
+          cellType: "code",
+          source: "print('ok')",
+          language: "python",
+          executionId: "exec-1",
+          executionCount: 3,
+          outputs: [],
+          metadata: {},
+        },
+      ],
+      {
+        getStatusLabel: (cell) => (cell.id === "code-1" ? "Running" : null),
+      },
+    );
+
+    expect(outline[0]).toMatchObject({
+      cellId: "code-1",
+      statusLabel: "Running",
+    });
   });
 
   it("builds a normalized view model for host adapters", () => {
@@ -132,6 +147,27 @@ describe("notebook shell view model", () => {
       label: "In [7]",
     });
     expect(viewModel.markdownHeadingAnchorsByCellId.get("code-1")).toBeUndefined();
+  });
+
+  it("can build outline-only projections without a read-only language resolver", () => {
+    const viewModel = createNotebookViewModel([
+      {
+        id: "code-1",
+        cellType: "code",
+        source: "print('ok')",
+        language: "python",
+        executionId: null,
+        executionCount: null,
+        outputs: [],
+        metadata: {},
+      },
+    ]);
+
+    expect(viewModel.outlineItems[0]).toMatchObject({
+      cellId: "code-1",
+      statusLabel: null,
+    });
+    expect(viewModel.readOnlyCells[0].language).toBeNull();
   });
 
   it("projects traceback execution ids to notebook cells", () => {

--- a/src/components/notebook-shell/view-model.ts
+++ b/src/components/notebook-shell/view-model.ts
@@ -37,18 +37,30 @@ export interface NotebookViewModel {
 }
 
 export interface CreateNotebookViewModelOptions {
-  resolveLanguage: NotebookViewLanguageResolver;
+  resolveLanguage?: NotebookViewLanguageResolver;
+  getOutlineStatusLabel?: (cell: NotebookViewCell) => string | null;
 }
 
+/**
+ * Pure shell projection over already-materialized notebook cells.
+ *
+ * The live source of truth stays upstream: desktop feeds this from the
+ * WASM/change-set materialized cell store, and hosted cloud feeds it from a
+ * live/snapshot Automerge handle adapter. This function should remain free of
+ * transport, WASM, blob-fetch, and host side effects.
+ */
 export function createNotebookViewModel(
   cells: readonly NotebookViewCell[],
-  options: CreateNotebookViewModelOptions,
+  options: CreateNotebookViewModelOptions = {},
 ): NotebookViewModel {
-  const outlineItems = notebookViewCellsToOutlineItems(cells);
+  const resolveLanguage = options.resolveLanguage ?? (() => null);
+  const outlineItems = notebookViewCellsToOutlineItems(cells, {
+    getStatusLabel: options.getOutlineStatusLabel,
+  });
   return {
     cells,
     cellIds: cells.map((cell) => cell.id),
-    readOnlyCells: notebookViewCellsToReadOnlyCells(cells, options.resolveLanguage),
+    readOnlyCells: notebookViewCellsToReadOnlyCells(cells, resolveLanguage),
     outlineItems,
     markdownHeadingAnchorsByCellId: notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems),
     tracebackTargetsByExecutionId: notebookViewCellsToTracebackTargets(cells),
@@ -80,10 +92,11 @@ export function notebookViewCellToReadOnlyCell(
 
 export function notebookViewCellsToOutlineItems(
   cells: readonly NotebookViewCell[],
+  options: { getStatusLabel?: (cell: NotebookViewCell) => string | null } = {},
 ): NotebookOutlineItem[] {
   return projectNotebookOutline(cells, {
     hrefTarget: "heading",
-    getStatusLabel: notebookViewCellOutlineStatusLabel,
+    getStatusLabel: options.getStatusLabel ?? notebookViewCellOutlineStatusLabel,
   }).items;
 }
 


### PR DESCRIPTION
## Summary

- routes desktop outline and markdown-heading anchor projection through `createNotebookViewModel`
- lets host adapters provide outline status labels to the shared notebook shell view model
- documents `createNotebookViewModel` as a pure projection over already-materialized cells, with WASM/change-set materialization kept upstream

## Context

Follow-up to #3198. This moves desktop closer to the same shell projection path cloud already uses without changing the live Automerge/WASM source-of-truth boundary.

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/view-model.test.ts src/components/notebook-shell/__tests__/outline-navigation.test.ts src/components/notebook-shell/__tests__/NotebookCellList.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/cloud-view-model.test.ts`
- `cargo xtask lint --fix`
