### PR TITLE
docs(elements): add shared notebook scenarios

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -19,16 +19,16 @@ import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import {
+  getElementsNotebookPrimaryCodeCell,
   getElementsNotebookScenario,
   resolveElementsNotebookLanguage,
 } from "@/components/notebook-scenarios";
-import type { NotebookViewCell } from "@/components/notebook-shell";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 
 const anatomyScenario = getElementsNotebookScenario("desktop-local-owner");
-const primaryCell = getPrimaryAnatomyCell(anatomyScenario.cells);
+const primaryCell = getElementsNotebookPrimaryCodeCell(anatomyScenario.cells);
 const primaryCellId = primaryCell.id;
 const sourceFixture = primaryCell.source;
 const outputFixtures = primaryCell.outputs;
@@ -36,19 +36,6 @@ const executionCount = primaryCell.executionCount;
 const languageLabel =
   primaryCell.language === "python" ? "Python" : (primaryCell.language ?? "Cell");
 const editorLanguage = resolveElementsNotebookLanguage(primaryCell.language) ?? "plain";
-
-function getPrimaryAnatomyCell(cells: readonly NotebookViewCell[]) {
-  const cell =
-    cells.find((item) => item.id === "cell-model-code") ??
-    cells.find((item) => item.cellType === "code") ??
-    cells[0];
-  if (!cell) {
-    throw new Error(
-      "Elements notebook scenario needs at least one cell for the cell anatomy page.",
-    );
-  }
-  return cell;
-}
 
 const layers = [
   {

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -16,34 +16,39 @@ import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
-import { OutputArea, type JupyterOutput } from "@/components/cell/OutputArea";
+import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import {
+  getElementsNotebookScenario,
+  resolveElementsNotebookLanguage,
+} from "@/components/notebook-scenarios";
+import type { NotebookViewCell } from "@/components/notebook-shell";
 import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 
-const primaryCellId = "fixture-code-cell";
-const sourceFixture = `features = orders.assign(month=orders.date.dt.month)
-model.fit(features[columns], target)
-predictions = model.predict(features_holdout)`;
+const anatomyScenario = getElementsNotebookScenario("desktop-local-owner");
+const primaryCell = getPrimaryAnatomyCell(anatomyScenario.cells);
+const primaryCellId = primaryCell.id;
+const sourceFixture = primaryCell.source;
+const outputFixtures = primaryCell.outputs;
+const executionCount = primaryCell.executionCount;
+const languageLabel =
+  primaryCell.language === "python" ? "Python" : (primaryCell.language ?? "Cell");
+const editorLanguage = resolveElementsNotebookLanguage(primaryCell.language) ?? "plain";
 
-const outputFixtures: JupyterOutput[] = [
-  {
-    output_id: "cell-anatomy-stream",
-    output_type: "stream",
-    name: "stdout",
-    text: "training fold=01 mae=8.91\nvalidating fold=02 mae=8.42",
-  },
-  {
-    output_id: "cell-anatomy-result",
-    output_type: "execute_result",
-    execution_count: 12,
-    data: {
-      "text/plain": "MAE=8.42  MAPE=6.8%  Backtest=16 weeks",
-    },
-    metadata: {},
-  },
-];
+function getPrimaryAnatomyCell(cells: readonly NotebookViewCell[]) {
+  const cell =
+    cells.find((item) => item.id === "cell-model-code") ??
+    cells.find((item) => item.cellType === "code") ??
+    cells[0];
+  if (!cell) {
+    throw new Error(
+      "Elements notebook scenario needs at least one cell for the cell anatomy page.",
+    );
+  }
+  return cell;
+}
 
 const layers = [
   {
@@ -371,15 +376,15 @@ function SourceFixture() {
       <div className="overflow-hidden rounded-md border border-border bg-background">
         <CodeMirrorEditor
           initialValue={sourceFixture}
-          language="python"
+          language={editorLanguage}
           lineWrapping
           maxHeight="190px"
           readOnly
         />
       </div>
       <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
+        languageLabel={languageLabel}
+        count={executionCount}
         elapsedMs={1476}
         isFocused
         activityContent={
@@ -403,7 +408,7 @@ function OutputFixture() {
         <OutputArea
           outputs={outputFixtures}
           cellId={primaryCellId}
-          executionCount={12}
+          executionCount={executionCount}
           isolated={false}
           useOutputWell={false}
         />
@@ -447,8 +452,8 @@ function BoundarySourceFixture({ sourceHidden = false }: { sourceHidden?: boolea
         </pre>
       )}
       <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
+        languageLabel={languageLabel}
+        count={executionCount}
         elapsedMs={1476}
         isFocused
         onExecute={() => {}}

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -30,8 +30,21 @@ import {
   textAttributionExtension,
 } from "@/components/editor/text-attribution";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
+import {
+  getElementsNotebookPrimaryCodeCell,
+  getElementsNotebookScenario,
+  resolveElementsNotebookLanguage,
+} from "@/components/notebook-scenarios";
 
 type SampleKey = "python" | "sql" | "markdown" | "json";
+
+const editorScenario = getElementsNotebookScenario("desktop-local-owner");
+const scenarioCodeCell = getElementsNotebookPrimaryCodeCell(editorScenario.cells);
+const scenarioCodeLanguage = resolveElementsNotebookLanguage(scenarioCodeCell.language) ?? "plain";
+const readOnlyScenarioCell =
+  editorScenario.cells.find((cell) => cell.id === "cell-findings") ?? scenarioCodeCell;
+const readOnlyScenarioLanguage =
+  resolveElementsNotebookLanguage(readOnlyScenarioCell.language) ?? "plain";
 
 const codeSamples: Record<
   SampleKey,
@@ -39,12 +52,9 @@ const codeSamples: Record<
 > = {
   python: {
     label: "Python",
-    language: "python",
+    language: scenarioCodeLanguage,
     search: "features",
-    source: `features = orders.assign(month=orders.date.dt.month)
-model.fit(features[columns], target)
-predictions = model.predict(features_holdout)
-display(predictions.head())`,
+    source: scenarioCodeCell.source,
   },
   sql: {
     label: "SQL",
@@ -139,6 +149,24 @@ const adapterBoundaries = [
   },
 ];
 
+const scenarioFacts = [
+  {
+    label: "scenario",
+    value: editorScenario.title,
+  },
+  {
+    label: "cell",
+    value: scenarioCodeCell.id,
+  },
+  {
+    label: "execution",
+    value:
+      scenarioCodeCell.executionCount === null
+        ? "not run"
+        : `In [${scenarioCodeCell.executionCount}]`,
+  },
+];
+
 const magicSource = `%%sql
 select country, count(*) as notebooks
 from public_sessions
@@ -146,6 +174,11 @@ group by country
 order by notebooks desc`;
 
 const languageMatrix: { filename: string; language: SupportedLanguage; note: string }[] = [
+  {
+    filename: `${scenarioCodeCell.id}.py`,
+    language: scenarioCodeLanguage,
+    note: "Shared Elements notebook scenario model cell",
+  },
   { filename: "analysis.py", language: "python", note: "PEP 8 indentation and Python parser" },
   { filename: "query.sql", language: "sql", note: "SQL parser for cell magics and database cells" },
   { filename: "notes.md", language: "markdown", note: "Markdown parser for source previews" },
@@ -279,9 +312,10 @@ export function EditorSurfacesExample() {
           <div>
             <h2 className="text-sm font-semibold">Editor fixture adapter</h2>
             <p className="mt-1 text-xs leading-5">
-              This page renders current editor components with static source fixtures. Runtime sync,
-              presence sending, kernel completion, and focus registry behavior stay documented as
-              adapter boundaries until they can be fed without notebook host state.
+              This page renders current editor components from the shared Elements notebook
+              scenario. Runtime sync, presence sending, kernel completion, and focus registry
+              behavior stay documented as adapter boundaries until they can be fed without notebook
+              host state.
             </p>
           </div>
         </div>
@@ -315,6 +349,19 @@ export function EditorSurfacesExample() {
             <span className="text-xs font-medium capitalize text-fd-muted-foreground">
               {mode} / {colorTheme}
             </span>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {scenarioFacts.map((fact) => (
+              <div
+                key={fact.label}
+                className="rounded-md border border-fd-border bg-fd-background px-3 py-2"
+              >
+                <div className="text-[10px] font-medium uppercase text-fd-muted-foreground">
+                  {fact.label}
+                </div>
+                <div className="mt-1 break-words font-mono text-[11px] leading-4">{fact.value}</div>
+              </div>
+            ))}
           </div>
 
           <div className="overflow-hidden rounded-lg border border-border bg-background">
@@ -353,10 +400,8 @@ export function EditorSurfacesExample() {
           <div className="p-4">
             <div className="overflow-hidden rounded-lg border border-border bg-background">
               <ReadOnlyCodeMirror
-                value={`# Report cell
-print("source is visible but not editable")
-display(summary_table)`}
-                language="python"
+                value={readOnlyScenarioCell.source}
+                language={readOnlyScenarioLanguage}
                 lineWrapping
                 className="min-h-36"
               />

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -7,6 +7,7 @@ import { MarkdownCell } from "@/notebook-components/MarkdownCell";
 import { NotebookView } from "@/notebook-components/NotebookView";
 import { RawCell } from "@/notebook-components/RawCell";
 import {
+  getElementsNotebookPrimaryCodeCell,
   getElementsNotebookScenario,
   resolveElementsNotebookLanguage,
 } from "@/components/notebook-scenarios";
@@ -36,7 +37,7 @@ import type {
 } from "../../notebook/src/types";
 
 const fullCellScenario = getElementsNotebookScenario("desktop-local-owner");
-const primaryScenarioCodeCell = getPrimaryFullCellScenarioCodeCell(fullCellScenario.cells);
+const primaryScenarioCodeCell = getElementsNotebookPrimaryCodeCell(fullCellScenario.cells);
 const standaloneCodeCellId = "elements-full-code-cell";
 const standaloneCodeCellExecutionId = "elements-full-code-execution";
 const standaloneCodeCellOutputs = primaryScenarioCodeCell.outputs.map((output, index) => ({
@@ -147,16 +148,6 @@ const fullCellBoundaryRows = [
 ];
 
 const noop = () => {};
-
-function getPrimaryFullCellScenarioCodeCell(cells: readonly NotebookViewCell[]) {
-  const cell =
-    cells.find((item) => item.id === "cell-model-code") ??
-    cells.find((item) => item.cellType === "code");
-  if (!cell) {
-    throw new Error("Elements notebook scenario needs a code cell for full-cell previews.");
-  }
-  return cell;
-}
 
 function standaloneCodeCellOutputId(output: { output_id?: string }, index: number) {
   return `elements-full-code:${output.output_id ?? `output-${index}`}`;

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -6,7 +6,10 @@ import { CodeCell } from "@/notebook-components/CodeCell";
 import { MarkdownCell } from "@/notebook-components/MarkdownCell";
 import { NotebookView } from "@/notebook-components/NotebookView";
 import { RawCell } from "@/notebook-components/RawCell";
-import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+import {
+  getElementsNotebookScenario,
+  resolveElementsNotebookLanguage,
+} from "@/components/notebook-scenarios";
 import type { NotebookViewCell } from "@/components/notebook-shell";
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import {
@@ -32,18 +35,22 @@ import type {
   RawCell as RawCellType,
 } from "../../notebook/src/types";
 
-const codeCell: CodeCellType = {
-  cell_type: "code",
-  id: "elements-full-code-cell",
-  source: [
-    "features = orders.assign(month=orders.date.dt.month)",
-    "model.fit(features[columns], target)",
-    "predictions = model.predict(features_holdout)",
-  ].join("\n"),
-  execution_count: 12,
-  outputs: [],
-  metadata: {},
-};
+const fullCellScenario = getElementsNotebookScenario("desktop-local-owner");
+const primaryScenarioCodeCell = getPrimaryFullCellScenarioCodeCell(fullCellScenario.cells);
+const standaloneCodeCellId = "elements-full-code-cell";
+const standaloneCodeCellExecutionId = "elements-full-code-execution";
+const standaloneCodeCellOutputs = primaryScenarioCodeCell.outputs.map((output, index) => ({
+  ...output,
+  output_id: standaloneCodeCellOutputId(output, index),
+})) as JupyterOutput[];
+const codeCellLanguage =
+  resolveElementsNotebookLanguage(primaryScenarioCodeCell.language) ?? "plain";
+
+const codeCell: CodeCellType = scenarioCodeCellToStandaloneCodeCell(
+  primaryScenarioCodeCell,
+  standaloneCodeCellId,
+  standaloneCodeCellOutputs,
+);
 
 const markdownFixtureSource = [
   "## Forecast review",
@@ -70,7 +77,6 @@ const rawCell: RawCellType = {
   },
 };
 
-const fullCellScenario = getElementsNotebookScenario("desktop-local-owner");
 const notebookViewCells = fullCellScenario.cells.map(scenarioCellToNotebookCell);
 const initialNotebookViewCellIds = fullCellScenario.viewModel.cellIds;
 
@@ -142,6 +148,35 @@ const fullCellBoundaryRows = [
 
 const noop = () => {};
 
+function getPrimaryFullCellScenarioCodeCell(cells: readonly NotebookViewCell[]) {
+  const cell =
+    cells.find((item) => item.id === "cell-model-code") ??
+    cells.find((item) => item.cellType === "code");
+  if (!cell) {
+    throw new Error("Elements notebook scenario needs a code cell for full-cell previews.");
+  }
+  return cell;
+}
+
+function standaloneCodeCellOutputId(output: { output_id?: string }, index: number) {
+  return `elements-full-code:${output.output_id ?? `output-${index}`}`;
+}
+
+function scenarioCodeCellToStandaloneCodeCell(
+  cell: NotebookViewCell,
+  id: string,
+  outputs: JupyterOutput[],
+): CodeCellType {
+  return {
+    cell_type: "code",
+    id,
+    source: cell.source,
+    execution_count: cell.executionCount,
+    outputs,
+    metadata: cell.metadata,
+  };
+}
+
 function scenarioCellToNotebookCell(cell: NotebookViewCell): NotebookCell {
   if (cell.cellType === "code") {
     return {
@@ -176,29 +211,20 @@ function seedFullCellFixtures() {
   resetNotebookOutputs();
   resetNotebookExecutions();
 
-  setOutput("elements-output-stream", {
-    output_id: "elements-output-stream",
-    output_type: "stream",
-    name: "stdout",
-    text: "loaded 22,767 rows\nvalidated 16 week backtest window\n",
-  });
-  setOutput("elements-output-result", {
-    output_id: "elements-output-result",
-    output_type: "execute_result",
-    execution_count: 12,
-    data: {
-      "text/plain": "MAE 8.42\nMAPE 6.8%\nBacktest 16 weeks",
-    },
-    metadata: {},
-  });
-  setExecution("elements-execution", {
-    execution_count: 12,
-    status: "done",
-    success: true,
-    output_ids: ["elements-output-stream", "elements-output-result"],
+  for (const output of standaloneCodeCellOutputs) {
+    if (!output.output_id) continue;
+    setOutput(output.output_id, output);
+  }
+  setExecution(standaloneCodeCellExecutionId, {
+    execution_count: primaryScenarioCodeCell.executionCount,
+    status: primaryScenarioCodeCell.executionCount === null ? "queued" : "done",
+    success: primaryScenarioCodeCell.executionCount === null ? null : true,
+    output_ids: standaloneCodeCellOutputs
+      .map((output) => output.output_id)
+      .filter((outputId): outputId is string => Boolean(outputId)),
     submitted_by_actor_label: "local:kyle",
   });
-  setCellExecutionPointer(codeCell.id, "elements-execution");
+  setCellExecutionPointer(codeCell.id, standaloneCodeCellExecutionId);
 
   for (const cell of fullCellScenario.cells) {
     if (cell.cellType !== "code" || !cell.executionId) continue;
@@ -300,7 +326,7 @@ export function FullCellSurfacesExample() {
           <div className="bg-background py-4 pl-4 pr-2">
             <CodeCell
               cell={codeCell}
-              language="python"
+              language={codeCellLanguage}
               onFocus={() => focusFixtureCell(codeCell.id)}
               onExecute={noop}
               onInterrupt={noop}
@@ -427,41 +453,34 @@ export function FullCellSurfacesExample() {
           in production, then stops before notebook documents, kernel execution, iframe bootstrap,
           or Automerge sync can run.
         </p>
-        <div className="mt-4 overflow-hidden rounded-md border border-fd-border">
-          <div className="hidden grid-cols-[180px_220px_230px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
-            <span>Surface</span>
-            <span>Catalog path</span>
-            <span>Production boundary</span>
-            <span>Notes</span>
-          </div>
+        <div className="mt-4 grid gap-2">
           {fullCellBoundaryRows.map((row) => (
             <div
               key={row.surface}
-              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[180px_220px_230px_minmax(0,1fr)] xl:gap-3"
+              className="rounded-md border border-fd-border bg-fd-card p-3 text-xs"
             >
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Surface
-                </div>
+              <div className="grid gap-3 md:grid-cols-[150px_minmax(0,1fr)]">
                 <div className="font-semibold">{row.surface}</div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                      Catalog path
+                    </div>
+                    <div className="mt-1 break-words font-mono text-[11px] leading-4 text-emerald-700 dark:text-emerald-300">
+                      {row.catalogPath}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                      Production boundary
+                    </div>
+                    <div className="mt-1 break-words font-mono text-[11px] leading-4 text-amber-700 dark:text-amber-300">
+                      {row.productionBoundary}
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Catalog path
-                </div>
-                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
-                  {row.catalogPath}
-                </div>
-              </div>
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Production boundary
-                </div>
-                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
-                  {row.productionBoundary}
-                </div>
-              </div>
-              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+              <p className="mt-3 leading-5 text-fd-muted-foreground">{row.detail}</p>
             </div>
           ))}
         </div>

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -6,6 +6,8 @@ import { CodeCell } from "@/notebook-components/CodeCell";
 import { MarkdownCell } from "@/notebook-components/MarkdownCell";
 import { NotebookView } from "@/notebook-components/NotebookView";
 import { RawCell } from "@/notebook-components/RawCell";
+import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+import type { NotebookViewCell } from "@/components/notebook-shell";
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import {
   flushCellUIState,
@@ -24,7 +26,9 @@ import {
 import { resetNotebookOutputs, setOutput } from "../../notebook/src/lib/notebook-outputs";
 import type {
   CodeCell as CodeCellType,
+  JupyterOutput,
   MarkdownCell as MarkdownCellType,
+  NotebookCell,
   RawCell as RawCellType,
 } from "../../notebook/src/types";
 
@@ -66,59 +70,9 @@ const rawCell: RawCellType = {
   },
 };
 
-const viewCodeCell: CodeCellType = {
-  cell_type: "code",
-  id: "elements-view-code-cell",
-  source: [
-    "features = orders.assign(month=orders.date.dt.month)",
-    "predictions = model.predict(features_holdout)",
-    "display(predictions.head())",
-  ].join("\n"),
-  execution_count: 18,
-  outputs: [],
-  metadata: {},
-};
-
-const viewMarkdownCell: MarkdownCellType = {
-  cell_type: "markdown",
-  id: "elements-view-markdown-cell",
-  source: [
-    "## Model notes",
-    "",
-    "The workspace fixture renders through the production `NotebookView` shell.",
-  ].join("\n"),
-  metadata: {},
-};
-
-const viewHiddenCodeCell: CodeCellType = {
-  cell_type: "code",
-  id: "elements-view-hidden-code-cell",
-  source: "cached = features.sample(2000, random_state=42)",
-  execution_count: 17,
-  outputs: [],
-  metadata: {
-    jupyter: {
-      source_hidden: true,
-      outputs_hidden: true,
-    },
-  },
-};
-
-const viewRawCell: RawCellType = {
-  cell_type: "raw",
-  id: "elements-view-raw-cell",
-  source: "runtime: python\nowner: forecasting",
-  metadata: {
-    format: "yaml",
-  },
-};
-
-const initialNotebookViewCellIds = [
-  viewMarkdownCell.id,
-  viewCodeCell.id,
-  viewHiddenCodeCell.id,
-  viewRawCell.id,
-];
+const fullCellScenario = getElementsNotebookScenario("desktop-local-owner");
+const notebookViewCells = fullCellScenario.cells.map(scenarioCellToNotebookCell);
+const initialNotebookViewCellIds = fullCellScenario.viewModel.cellIds;
 
 const fullCellRows = [
   {
@@ -144,17 +98,17 @@ const fullCellRows = [
 const fullCellBoundaryRows = [
   {
     surface: "Cell document state",
-    catalogPath: "replaceNotebookCells fixture seed",
+    catalogPath: "ElementsNotebookScenario -> replaceNotebookCells",
     productionBoundary: "NotebookView document projection",
     detail:
-      "The catalog writes direct-cell and workspace-shell fixtures into the notebook cell store so the production cells can subscribe normally without opening a notebook document.",
+      "The catalog writes shared scenario cells into the notebook cell store so the production cells can subscribe normally without opening a notebook document.",
   },
   {
     surface: "Execution and output state",
-    catalogPath: "setExecution and setOutput fixtures",
+    catalogPath: "scenario outputs -> setExecution/setOutput",
     productionBoundary: "runtimed execution pipeline",
     detail:
-      "The code cell sees the same execution pointer and output IDs as production, but queueing, kernel lifecycle, and output mutation still stay outside the docs runtime.",
+      "Scenario code cells seed the same execution pointer and output ID stores as production, but queueing, kernel lifecycle, and output mutation still stay outside the docs runtime.",
   },
   {
     surface: "Transient cell UI state",
@@ -188,16 +142,37 @@ const fullCellBoundaryRows = [
 
 const noop = () => {};
 
+function scenarioCellToNotebookCell(cell: NotebookViewCell): NotebookCell {
+  if (cell.cellType === "code") {
+    return {
+      cell_type: "code",
+      id: cell.id,
+      source: cell.source,
+      execution_count: cell.executionCount,
+      outputs: cell.outputs as JupyterOutput[],
+      metadata: cell.metadata,
+    };
+  }
+
+  if (cell.cellType === "markdown") {
+    return {
+      cell_type: "markdown",
+      id: cell.id,
+      source: cell.source,
+      metadata: cell.metadata,
+    };
+  }
+
+  return {
+    cell_type: "raw",
+    id: cell.id,
+    source: cell.source,
+    metadata: cell.metadata,
+  };
+}
+
 function seedFullCellFixtures() {
-  replaceNotebookCells([
-    codeCell,
-    markdownCell,
-    rawCell,
-    viewMarkdownCell,
-    viewCodeCell,
-    viewHiddenCodeCell,
-    viewRawCell,
-  ]);
+  replaceNotebookCells([codeCell, markdownCell, rawCell, ...notebookViewCells]);
   resetNotebookOutputs();
   resetNotebookExecutions();
 
@@ -225,29 +200,25 @@ function seedFullCellFixtures() {
   });
   setCellExecutionPointer(codeCell.id, "elements-execution");
 
-  setOutput("elements-view-output-stream", {
-    output_id: "elements-view-output-stream",
-    output_type: "stream",
-    name: "stdout",
-    text: "workspace fixture rendered through NotebookView\n",
-  });
-  setOutput("elements-view-output-result", {
-    output_id: "elements-view-output-result",
-    output_type: "execute_result",
-    execution_count: 18,
-    data: {
-      "text/plain": "3 rows x 8 columns",
-    },
-    metadata: {},
-  });
-  setExecution("elements-view-execution", {
-    execution_count: 18,
-    status: "done",
-    success: true,
-    output_ids: ["elements-view-output-stream", "elements-view-output-result"],
-    submitted_by_actor_label: "local:kyle",
-  });
-  setCellExecutionPointer(viewCodeCell.id, "elements-view-execution");
+  for (const cell of fullCellScenario.cells) {
+    if (cell.cellType !== "code" || !cell.executionId) continue;
+    const outputIds = cell.outputs
+      .map((output, index) => output.output_id ?? `${cell.executionId}:output:${index}`)
+      .filter((outputId): outputId is string => outputId.length > 0);
+
+    cell.outputs.forEach((output, index) => {
+      const outputId = output.output_id ?? `${cell.executionId}:output:${index}`;
+      setOutput(outputId, { ...output, output_id: outputId } as JupyterOutput);
+    });
+    setExecution(cell.executionId, {
+      execution_count: cell.executionCount,
+      status: cell.executionCount === null ? "queued" : "done",
+      success: cell.executionCount === null ? null : true,
+      output_ids: outputIds,
+      submitted_by_actor_label: fullCellScenario.capabilities.access.actorLabel,
+    });
+    setCellExecutionPointer(cell.id, cell.executionId);
+  }
 
   setFocusedCellId(codeCell.id);
   setExecutingCellIds(new Set());
@@ -422,10 +393,10 @@ export function FullCellSurfacesExample() {
               <h2 className="text-sm font-semibold">NotebookView workspace shell</h2>
             </div>
             <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-              This fixture imports the production workspace renderer, seeds the split cell and
-              output stores, then hands `NotebookView` a local visual order. Stable DOM ordering,
-              hidden-cell grouping, adders, and cell navigation remain visible without opening a
-              notebook document or WASM handle.
+              This fixture imports the production workspace renderer, seeds it from the shared
+              Elements notebook scenario, then hands `NotebookView` a local visual order. Stable DOM
+              ordering, adders, and cell navigation remain visible without opening a notebook
+              document or WASM handle.
             </p>
           </div>
           <div className="bg-background p-3">

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -5,6 +5,13 @@ import {
   type NotebookViewCell,
   type NotebookViewModel,
 } from "@/components/notebook-shell";
+import type {
+  EnvSyncState,
+  PyProjectDeps,
+  PyProjectInfo,
+  TrustInfo,
+  TyposquatWarning,
+} from "@/notebook-components/runtime-surface-types";
 
 export type ElementsNotebookScenarioId =
   | "desktop-local-owner"
@@ -22,9 +29,24 @@ export interface ElementsNotebookScenario {
   viewModel: NotebookViewModel;
   runtimeLabel: string;
   packageSummary: string;
-  dependencies: readonly string[];
+  packageState: ElementsNotebookPackageState;
+  trustState: ElementsNotebookTrustState;
   variables: readonly ElementsNotebookVariable[];
   renderers: readonly ElementsNotebookRenderer[];
+}
+
+export interface ElementsNotebookPackageState {
+  dependencies: readonly string[];
+  requiresPython: string;
+  syncState: EnvSyncState;
+  pyprojectInfo: PyProjectInfo;
+  pyprojectDeps: PyProjectDeps;
+}
+
+export interface ElementsNotebookTrustState {
+  trustInfo: TrustInfo;
+  typosquatWarnings: readonly TyposquatWarning[];
+  approvalError: string | null;
 }
 
 export interface ElementsNotebookVariable {
@@ -166,7 +188,56 @@ const viewModel = createNotebookViewModel(notebookCells, {
   resolveLanguage: resolveElementsNotebookLanguage,
 });
 
-const dependencies = ["pandas>=2", "polars", "plotly", "scikit-learn"] as const;
+const packageState: ElementsNotebookPackageState = {
+  dependencies: ["pandas>=2", "polars", "plotly", "scikit-learn"],
+  requiresPython: ">=3.13",
+  syncState: { status: "dirty", added: ["altair"], removed: [] },
+  pyprojectInfo: {
+    path: "/Users/kyle/notebooks/pyproject.toml",
+    relative_path: "pyproject.toml",
+    project_name: "mathnet",
+    has_dependencies: true,
+    dependency_count: 4,
+    has_dev_dependencies: true,
+    requires_python: ">=3.13",
+    has_venv: true,
+  },
+  pyprojectDeps: {
+    path: "/Users/kyle/notebooks/pyproject.toml",
+    relative_path: "pyproject.toml",
+    project_name: "mathnet",
+    dependencies: ["pandas>=2", "polars", "plotly", "scikit-learn"],
+    dev_dependencies: ["pytest", "ruff"],
+    requires_python: ">=3.13",
+    index_url: null,
+  },
+};
+
+const trustState: ElementsNotebookTrustState = {
+  trustInfo: {
+    status: "untrusted",
+    uv_dependencies: ["pandas>=2", "reqeusts[security]>=2.0"],
+    approved_uv_dependencies: ["pandas>=2"],
+    conda_dependencies: ["python=3.13", "scikit-learn"],
+    approved_conda_dependencies: [],
+    conda_channels: ["conda-forge"],
+    approved_conda_channels: ["conda-forge"],
+    pixi_dependencies: ["numpy"],
+    approved_pixi_dependencies: [],
+    pixi_pypi_dependencies: ["polars"],
+    approved_pixi_pypi_dependencies: [],
+    pixi_channels: ["conda-forge"],
+    approved_pixi_channels: ["conda-forge"],
+  },
+  typosquatWarnings: [
+    {
+      package: "reqeusts",
+      similar_to: "requests",
+      distance: 2,
+    },
+  ],
+  approvalError: "Typosquat check completed with one warning. Review before trusting.",
+};
 
 const variables: readonly ElementsNotebookVariable[] = [
   { name: "orders", type: "DataFrame", value: "2,148 rows x 18 columns" },
@@ -351,7 +422,8 @@ function createScenario({
     viewModel,
     runtimeLabel,
     packageSummary,
-    dependencies,
+    packageState,
+    trustState,
     variables,
     renderers,
   };

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -403,6 +403,18 @@ export function getElementsNotebookScenario(id: ElementsNotebookScenarioId) {
   return elementsNotebookScenarios[id];
 }
 
+export function getElementsNotebookPrimaryCodeCell(
+  cells: readonly NotebookViewCell[] = notebookCells,
+) {
+  const cell =
+    cells.find((item) => item.id === "cell-model-code") ??
+    cells.find((item) => item.cellType === "code");
+  if (!cell) {
+    throw new Error("Elements notebook scenario needs at least one code cell.");
+  }
+  return cell;
+}
+
 export function resolveElementsNotebookLanguage(
   language: string | null | undefined,
 ): SupportedLanguage | null {

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -166,10 +166,27 @@ const notebookCells: readonly NotebookViewCell[] = [
     id: "cell-model-code",
     cellType: "code",
     language: "python",
-    source: "model.fit(features[columns], target)",
+    source:
+      "features = orders.assign(month=orders.date.dt.month)\nmodel.fit(features[columns], target)\npredictions = model.predict(features_holdout)",
     executionId: "execution-model-run",
-    executionCount: null,
-    outputs: [],
+    executionCount: 15,
+    outputs: [
+      {
+        output_id: "output-model-run-stream",
+        output_type: "stream",
+        name: "stdout",
+        text: "training fold=01 mae=8.91\nvalidating fold=02 mae=8.42",
+      },
+      {
+        output_id: "output-model-run-result",
+        output_type: "execute_result",
+        execution_count: 15,
+        data: {
+          "text/plain": "MAE=8.42  MAPE=6.8%  Backtest=16 weeks",
+        },
+        metadata: {},
+      },
+    ],
     metadata: {},
   },
   {

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -1,0 +1,358 @@
+import type { SupportedLanguage } from "@/components/editor/languages";
+import {
+  createNotebookViewModel,
+  type NotebookShellCapabilities,
+  type NotebookViewCell,
+  type NotebookViewModel,
+} from "@/components/notebook-shell";
+
+export type ElementsNotebookScenarioId =
+  | "desktop-local-owner"
+  | "cloud-public-viewer"
+  | "cloud-editor"
+  | "runtime-unavailable";
+
+export interface ElementsNotebookScenario {
+  id: ElementsNotebookScenarioId;
+  title: string;
+  eyebrow: string;
+  summary: string;
+  capabilities: NotebookShellCapabilities;
+  cells: readonly NotebookViewCell[];
+  viewModel: NotebookViewModel;
+  runtimeLabel: string;
+  packageSummary: string;
+  dependencies: readonly string[];
+  variables: readonly ElementsNotebookVariable[];
+  renderers: readonly ElementsNotebookRenderer[];
+}
+
+export interface ElementsNotebookVariable {
+  name: string;
+  type: string;
+  value: string;
+}
+
+export interface ElementsNotebookRenderer {
+  name: string;
+  state: string;
+}
+
+const supportedLanguages = new Set<SupportedLanguage>([
+  "python",
+  "ipython",
+  "markdown",
+  "sql",
+  "html",
+  "javascript",
+  "typescript",
+  "json",
+  "yaml",
+  "toml",
+  "plain",
+]);
+
+const notebookCells: readonly NotebookViewCell[] = [
+  {
+    id: "cell-load-data",
+    cellType: "markdown",
+    language: "markdown",
+    source: "# Load data\n\nImport the order history and make dates explicit.",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-load-code",
+    cellType: "code",
+    language: "python",
+    source: "orders = pandas.read_csv('orders.csv', parse_dates=['date'])",
+    executionId: "execution-load-data",
+    executionCount: 12,
+    outputs: [
+      {
+        output_id: "output-load-data",
+        output_type: "stream",
+        name: "stdout",
+        text: "loaded 2,148 orders\n",
+      },
+    ],
+    metadata: {},
+  },
+  {
+    id: "cell-clean-columns",
+    cellType: "markdown",
+    language: "markdown",
+    source: "## Clean columns\n\nNormalize status values before joining lookup tables.",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-clean-code",
+    cellType: "code",
+    language: "python",
+    source: "orders = clean_columns(orders)",
+    executionId: "execution-clean-columns",
+    executionCount: 13,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-explore-shape",
+    cellType: "markdown",
+    language: "markdown",
+    source: "# Explore shape\n\nCheck the model-ready feature table.",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-shape-output",
+    cellType: "code",
+    language: "python",
+    source: "features.shape",
+    executionId: "execution-feature-shape",
+    executionCount: 14,
+    outputs: [
+      {
+        output_id: "output-feature-shape",
+        output_type: "execute_result",
+        execution_count: 14,
+        data: {
+          "text/plain": "(2148, 32)",
+        },
+        metadata: {},
+      },
+    ],
+    metadata: {},
+  },
+  {
+    id: "cell-model-run",
+    cellType: "markdown",
+    language: "markdown",
+    source: "# Model run\n\nTrain the weekly backtest model.",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-model-code",
+    cellType: "code",
+    language: "python",
+    source: "model.fit(features[columns], target)",
+    executionId: "execution-model-run",
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+  {
+    id: "cell-findings",
+    cellType: "markdown",
+    language: "markdown",
+    source: "## Findings\n\nSummarize the backtest before export.",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  },
+];
+
+const viewModel = createNotebookViewModel(notebookCells, {
+  resolveLanguage: resolveElementsNotebookLanguage,
+});
+
+const dependencies = ["pandas>=2", "polars", "plotly", "scikit-learn"] as const;
+
+const variables: readonly ElementsNotebookVariable[] = [
+  { name: "orders", type: "DataFrame", value: "2,148 rows x 18 columns" },
+  { name: "features", type: "DataFrame", value: "2,148 rows x 32 columns" },
+  { name: "model", type: "Pipeline", value: "StandardScaler -> Ridge" },
+  { name: "mae", type: "float", value: "8.42" },
+];
+
+const renderers: readonly ElementsNotebookRenderer[] = [
+  { name: "text/html", state: "isolated" },
+  { name: "application/vnd.apache.arrow.file", state: "sift" },
+  { name: "image/png", state: "inline" },
+];
+
+export const elementsNotebookScenarios: Record<
+  ElementsNotebookScenarioId,
+  ElementsNotebookScenario
+> = {
+  "desktop-local-owner": createScenario({
+    id: "desktop-local-owner",
+    title: "Desktop local owner",
+    eyebrow: "local fixture",
+    summary:
+      "Local desktop editing with packages and execution available, backed by inert catalog callbacks.",
+    runtimeLabel: "Python · local runtime ready",
+    packageSummary: "uv:inline · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: true,
+      canExecute: true,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: true,
+      canManageSharing: false,
+      access: {
+        level: "owner",
+        source: "local",
+        isPublic: false,
+        actorLabel: "local:kyle",
+        identityLabel: "Kyle",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: false,
+        needsAttention: false,
+      },
+    },
+  }),
+  "cloud-public-viewer": createScenario({
+    id: "cloud-public-viewer",
+    title: "Cloud public viewer",
+    eyebrow: "hosted fixture",
+    summary:
+      "Published read-only access with outline, outputs, and packages visible but no editing or execution.",
+    runtimeLabel: "Published artifact · no kernel",
+    packageSummary: "read-only · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canExecute: false,
+      canToggleCode: false,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "viewer",
+        source: "cloud",
+        isPublic: true,
+        actorLabel: "public viewer",
+        identityLabel: null,
+      },
+      auth: {
+        canSignIn: true,
+        canUseAuthenticatedIdentity: false,
+        needsAttention: false,
+      },
+    },
+  }),
+  "cloud-editor": createScenario({
+    id: "cloud-editor",
+    title: "Cloud editor",
+    eyebrow: "hosted fixture",
+    summary:
+      "Authenticated cloud editing where the shell can edit cells and share, while execution still waits for a runtime.",
+    runtimeLabel: "Cloud notebook · runtime detached",
+    packageSummary: "managed · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: true,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: true,
+      canManageSharing: true,
+      access: {
+        level: "owner",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: "cloud:kyle",
+        identityLabel: "Kyle",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+    },
+  }),
+  "runtime-unavailable": createScenario({
+    id: "runtime-unavailable",
+    title: "Runtime unavailable",
+    eyebrow: "runtime fixture",
+    summary:
+      "Readable notebook state with package metadata present but execution and package mutation disabled.",
+    runtimeLabel: "Python · runtime unavailable",
+    packageSummary: "blocked · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: true,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "fixture",
+        isPublic: false,
+        actorLabel: "fixture editor",
+        identityLabel: "Elements fixture",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: false,
+        needsAttention: true,
+      },
+    },
+  }),
+};
+
+export function getElementsNotebookScenario(id: ElementsNotebookScenarioId) {
+  return elementsNotebookScenarios[id];
+}
+
+export function resolveElementsNotebookLanguage(
+  language: string | null | undefined,
+): SupportedLanguage | null {
+  if (!language) return null;
+  return supportedLanguages.has(language as SupportedLanguage)
+    ? (language as SupportedLanguage)
+    : "plain";
+}
+
+function createScenario({
+  id,
+  title,
+  eyebrow,
+  summary,
+  runtimeLabel,
+  packageSummary,
+  capabilities,
+}: {
+  id: ElementsNotebookScenarioId;
+  title: string;
+  eyebrow: string;
+  summary: string;
+  runtimeLabel: string;
+  packageSummary: string;
+  capabilities: NotebookShellCapabilities;
+}): ElementsNotebookScenario {
+  return {
+    id,
+    title,
+    eyebrow,
+    summary,
+    capabilities,
+    cells: notebookCells,
+    viewModel,
+    runtimeLabel,
+    packageSummary,
+    dependencies,
+    variables,
+    renderers,
+  };
+}

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -8,6 +8,11 @@ import {
   RUNTIME_STATUS,
   type EnvProgressState,
 } from "runtimed";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+  type ElementsNotebookScenarioId,
+} from "@/components/notebook-scenarios";
 import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
 
 type ToolbarProps = ComponentProps<typeof NotebookToolbar>;
@@ -33,7 +38,21 @@ const condaProgress: EnvProgressState = {
 const condaEnvMissingDetails =
   "environment.yml declares conda env 'analysis', which is not built on this machine. Run: conda env create -f /work/notebooks/environment.yml";
 
-function toolbarProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
+interface ToolbarSurface {
+  title: string;
+  source: string;
+  role: string;
+  scenario: ElementsNotebookScenario;
+  props: ToolbarProps;
+}
+
+function toolbarProps(
+  scenario: ElementsNotebookScenario,
+  overrides: Partial<ToolbarProps> = {},
+): ToolbarProps {
+  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
+  const cellIds = scenario.viewModel.cellIds;
+
   return {
     kernelStatus: KERNEL_STATUS.IDLE,
     statusKey: RUNTIME_STATUS.RUNNING_IDLE,
@@ -44,8 +63,8 @@ function toolbarProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
     envTypeHint: "uv",
     envProgress: null,
     runtime: "python",
-    focusedCellId: "cell-clean-columns",
-    lastCellId: "cell-findings",
+    focusedCellId: firstRunnableCell?.id ?? cellIds[0] ?? null,
+    lastCellId: cellIds[cellIds.length - 1] ?? null,
     onStartKernel: noop,
     onInterruptKernel: noop,
     onRestartKernel: noop,
@@ -57,109 +76,142 @@ function toolbarProps(overrides: Partial<ToolbarProps> = {}): ToolbarProps {
   };
 }
 
-const statusSurfaces = [
-  {
-    title: "Idle Python notebook",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Normal editing state with uv inline dependency metadata and running kernel controls.",
-    props: toolbarProps(),
-  },
-  {
-    title: "Busy with dependency restart",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Execution state with the interrupt affordance highlighted and restart-and-run-all marked by dirty dependencies.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.BUSY,
-      statusKey: RUNTIME_STATUS.RUNNING_BUSY,
-      lifecycle: runningBusy,
-      envSource: "conda:inline",
-      depsOutOfSync: true,
-      isDepsOpen: true,
-    }),
-  },
-  {
-    title: "Environment preparation",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Conda solve/install progress shown through the toolbar status slot without live daemon state.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.STARTING,
-      statusKey: RUNTIME_STATUS.PREPARING_ENV,
-      lifecycle: { lifecycle: "PreparingEnv" },
-      envSource: null,
-      envTypeHint: "conda",
-      envProgress: condaProgress,
-    }),
-  },
-  {
-    title: "Awaiting trust approval",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Pre-launch approval state using the same runtime vocabulary as the notebook app.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.STARTING,
-      statusKey: RUNTIME_STATUS.AWAITING_TRUST,
-      lifecycle: { lifecycle: "AwaitingTrust" },
-      envSource: null,
-      envTypeHint: "uv",
-    }),
-  },
-  {
-    title: "Deno runtime unavailable",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Deno install remediation banner driven by fixture error text and inert callbacks.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.ERROR,
-      statusKey: RUNTIME_STATUS.ERROR,
-      lifecycle: errorLifecycle,
-      runtime: "deno",
-      envSource: "deno:imports",
-      envTypeHint: null,
-      kernelErrorMessage: "deno executable not found on PATH",
-    }),
-  },
-  {
-    title: "Pixi missing ipykernel",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel dependency.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.ERROR,
-      statusKey: RUNTIME_STATUS.ERROR,
-      lifecycle: errorLifecycle,
-      errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
-      envSource: "pixi:toml",
-      envTypeHint: "pixi",
-    }),
-  },
-  {
-    title: "Conda environment.yml missing",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Copyable environment creation hint surfaced by the toolbar when the declared conda env is absent.",
-    props: toolbarProps({
-      kernelStatus: KERNEL_STATUS.ERROR,
-      statusKey: RUNTIME_STATUS.ERROR,
-      lifecycle: errorLifecycle,
-      errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
-      envSource: "conda:env_yml",
-      envTypeHint: "conda",
-      kernelErrorMessage: condaEnvMissingDetails,
-    }),
-  },
-  {
-    title: "Update ready",
-    source: "apps/notebook/src/components/NotebookToolbar.tsx",
-    role: "Desktop update action rendered beside runtime status while the notebook remains idle.",
-    props: toolbarProps({
-      updateStatus: "available",
-      updateVersion: "2.5.3",
-      onRestartToUpdate: noop,
-    }),
-  },
-];
+function scenario(id: ElementsNotebookScenarioId) {
+  return getElementsNotebookScenario(id);
+}
+
+function createStatusSurfaces(): ToolbarSurface[] {
+  const desktopOwner = scenario("desktop-local-owner");
+  const cloudViewer = scenario("cloud-public-viewer");
+  const cloudEditor = scenario("cloud-editor");
+  const runtimeUnavailable = scenario("runtime-unavailable");
+
+  return [
+    {
+      title: "Idle Python notebook",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: desktopOwner,
+      role: `${desktopOwner.runtimeLabel}; normal editing state with uv inline dependency metadata and running kernel controls.`,
+      props: toolbarProps(desktopOwner),
+    },
+    {
+      title: "Busy with dependency restart",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: desktopOwner,
+      role: `Execution state from ${desktopOwner.title}; restart-and-run-all is marked by ${desktopOwner.packageState.syncState.status} dependency metadata.`,
+      props: toolbarProps(desktopOwner, {
+        kernelStatus: KERNEL_STATUS.BUSY,
+        statusKey: RUNTIME_STATUS.RUNNING_BUSY,
+        lifecycle: runningBusy,
+        envSource: "conda:inline",
+        depsOutOfSync: desktopOwner.packageState.syncState.status === "dirty",
+        isDepsOpen: desktopOwner.capabilities.canViewPackages,
+      }),
+    },
+    {
+      title: "Environment preparation",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: cloudEditor,
+      role: `${cloudEditor.title} can edit cells, but this fixture keeps execution detached while conda solve/install progress renders.`,
+      props: toolbarProps(cloudEditor, {
+        kernelStatus: KERNEL_STATUS.STARTING,
+        statusKey: RUNTIME_STATUS.PREPARING_ENV,
+        lifecycle: { lifecycle: "PreparingEnv" },
+        envSource: null,
+        envTypeHint: "conda",
+        envProgress: condaProgress,
+      }),
+    },
+    {
+      title: "Awaiting trust approval",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: runtimeUnavailable,
+      role: `${runtimeUnavailable.title} reuses the shared trust fixture before launch instead of opening a live runtime.`,
+      props: toolbarProps(runtimeUnavailable, {
+        kernelStatus: KERNEL_STATUS.STARTING,
+        statusKey: RUNTIME_STATUS.AWAITING_TRUST,
+        lifecycle: { lifecycle: "AwaitingTrust" },
+        envSource: null,
+        envTypeHint: "uv",
+      }),
+    },
+    {
+      title: "Published viewer with no kernel",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: cloudViewer,
+      role: `${cloudViewer.title} uses the same fixture notebook IDs while exposing read-only, published access context.`,
+      props: toolbarProps(cloudViewer, {
+        kernelStatus: KERNEL_STATUS.ERROR,
+        statusKey: RUNTIME_STATUS.ERROR,
+        lifecycle: errorLifecycle,
+        envSource: null,
+        envTypeHint: null,
+        kernelErrorMessage: cloudViewer.runtimeLabel,
+      }),
+    },
+    {
+      title: "Deno runtime unavailable",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: runtimeUnavailable,
+      role: "Deno install remediation banner driven by fixture error text and inert callbacks.",
+      props: toolbarProps(runtimeUnavailable, {
+        kernelStatus: KERNEL_STATUS.ERROR,
+        statusKey: RUNTIME_STATUS.ERROR,
+        lifecycle: errorLifecycle,
+        runtime: "deno",
+        envSource: "deno:imports",
+        envTypeHint: null,
+        kernelErrorMessage: "deno executable not found on PATH",
+      }),
+    },
+    {
+      title: "Pixi missing ipykernel",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: runtimeUnavailable,
+      role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel dependency.",
+      props: toolbarProps(runtimeUnavailable, {
+        kernelStatus: KERNEL_STATUS.ERROR,
+        statusKey: RUNTIME_STATUS.ERROR,
+        lifecycle: errorLifecycle,
+        errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
+        envSource: "pixi:toml",
+        envTypeHint: "pixi",
+      }),
+    },
+    {
+      title: "Conda environment.yml missing",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: runtimeUnavailable,
+      role: "Copyable environment creation hint surfaced by the toolbar when the declared conda env is absent.",
+      props: toolbarProps(runtimeUnavailable, {
+        kernelStatus: KERNEL_STATUS.ERROR,
+        statusKey: RUNTIME_STATUS.ERROR,
+        lifecycle: errorLifecycle,
+        errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
+        envSource: "conda:env_yml",
+        envTypeHint: "conda",
+        kernelErrorMessage: condaEnvMissingDetails,
+      }),
+    },
+    {
+      title: "Update ready",
+      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      scenario: desktopOwner,
+      role: "Desktop update action rendered beside runtime status while the notebook remains idle.",
+      props: toolbarProps(desktopOwner, {
+        updateStatus: "available",
+        updateVersion: "2.5.3",
+        onRestartToUpdate: noop,
+      }),
+    },
+  ];
+}
 
 const contractItems = [
   {
     icon: BadgeCheck,
     title: "Current source",
-    body: "Every preview imports NotebookToolbar from the notebook app and feeds it fixture props only.",
+    body: "Every preview imports NotebookToolbar from the notebook app and starts from a shared Elements scenario.",
   },
   {
     icon: PlayCircle,
@@ -176,10 +228,10 @@ const contractItems = [
 const toolbarBoundaryRows = [
   {
     boundary: "Runtime status projection",
-    catalogPath: "toolbarProps(status fixtures)",
+    catalogPath: "ElementsNotebookScenario -> toolbarProps(status overrides)",
     productionBoundary: "RuntimeStateDoc + kernel lifecycle",
     detail:
-      "The catalog passes deterministic status props. Production derives them from runtime state, kernel lifecycle, environment progress, and launch errors.",
+      "The catalog starts with deterministic scenario facts, then applies runtime status overrides. Production derives those fields from runtime state, kernel lifecycle, environment progress, and launch errors.",
   },
   {
     boundary: "Kernel actions",
@@ -190,17 +242,17 @@ const toolbarBoundaryRows = [
   },
   {
     boundary: "Dependency drawer",
-    catalogPath: "isDepsOpen + depsOutOfSync props",
+    catalogPath: "scenario.packageState + inert toggle",
     productionBoundary: "Package rail and notebook metadata",
     detail:
-      "The fixture toggles visual dependency state only. Production opens package UI, writes notebook metadata, and coordinates environment rebuild decisions.",
+      "The fixture reads package sync state from the shared scenario and toggles visual dependency state only. Production opens package UI, writes notebook metadata, and coordinates environment rebuild decisions.",
   },
   {
     boundary: "Cell insertion",
-    catalogPath: "focusedCellId + lastCellId fixtures",
+    catalogPath: "scenario.viewModel.cellIds",
     productionBoundary: "NotebookView focus and CRDT mutation",
     detail:
-      "The add-cell affordance receives stable fixture IDs. Production inserts new cells through the notebook document and restores editor focus.",
+      "The add-cell affordance receives stable IDs from the shared scenario projection. Production inserts new cells through the notebook document and restores editor focus.",
   },
   {
     boundary: "Desktop update restart",
@@ -212,6 +264,8 @@ const toolbarBoundaryRows = [
 ];
 
 export function NotebookToolbarSurfacesExample() {
+  const statusSurfaces = createStatusSurfaces();
+
   return (
     <div className="not-prose space-y-6" data-elements-slot="notebook-toolbar-surfaces">
       <section className="grid gap-3 md:grid-cols-3">
@@ -242,6 +296,20 @@ export function NotebookToolbarSurfacesExample() {
                 <p className="max-w-3xl text-xs leading-5 text-fd-muted-foreground">
                   {surface.role}
                 </p>
+                <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-fd-muted-foreground">
+                  <ScenarioPill label={surface.scenario.title} />
+                  <ScenarioPill
+                    label={`${surface.scenario.capabilities.access.source}:${surface.scenario.capabilities.access.level}`}
+                  />
+                  <ScenarioPill
+                    label={
+                      surface.scenario.capabilities.canExecute
+                        ? "execution available"
+                        : "execution disabled"
+                    }
+                  />
+                  <ScenarioPill label={`${surface.scenario.viewModel.codeCellCount} code cells`} />
+                </div>
               </div>
               <div className="break-words font-mono text-[11px] leading-5 text-fd-muted-foreground [overflow-wrap:anywhere] md:max-w-72 md:text-right">
                 {surface.source}
@@ -266,45 +334,46 @@ export function NotebookToolbarSurfacesExample() {
           status props and inert callbacks. Runtime state, kernel controls, dependency writes, cell
           insertion, and desktop update restarts stay behind the notebook app adapters.
         </p>
-        <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
-          <div className="hidden grid-cols-[190px_220px_240px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
-            <span>Boundary</span>
-            <span>Catalog path</span>
-            <span>Production boundary</span>
-            <span>Notes</span>
-          </div>
+        <div className="mt-4 grid gap-2">
           {toolbarBoundaryRows.map((row) => (
             <div
               key={row.boundary}
-              className="grid gap-2 border-b border-fd-border px-3 py-3 text-xs last:border-b-0 xl:grid-cols-[190px_220px_240px_minmax(0,1fr)] xl:gap-3"
+              className="rounded-md border border-fd-border bg-fd-card p-3 text-xs"
             >
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Boundary
-                </div>
+              <div className="grid gap-3 md:grid-cols-[150px_minmax(0,1fr)]">
                 <div className="font-semibold">{row.boundary}</div>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                      Catalog path
+                    </div>
+                    <div className="mt-1 break-words font-mono text-[11px] leading-4 text-emerald-700 dark:text-emerald-300">
+                      {row.catalogPath}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
+                      Production boundary
+                    </div>
+                    <div className="mt-1 break-words font-mono text-[11px] leading-4 text-amber-700 dark:text-amber-300">
+                      {row.productionBoundary}
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Catalog path
-                </div>
-                <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
-                  {row.catalogPath}
-                </div>
-              </div>
-              <div>
-                <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                  Production boundary
-                </div>
-                <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
-                  {row.productionBoundary}
-                </div>
-              </div>
-              <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>
+              <p className="mt-3 leading-5 text-fd-muted-foreground">{row.detail}</p>
             </div>
           ))}
         </div>
       </section>
     </div>
+  );
+}
+
+function ScenarioPill({ label }: { label: string }) {
+  return (
+    <span className="rounded-full border border-fd-border bg-fd-background px-2 py-0.5">
+      {label}
+    </span>
   );
 }

--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -14,6 +14,7 @@ import type { ReactNode } from "react";
 import { CondaDependencyHeader } from "@/notebook-components/CondaDependencyHeader";
 import { DenoDependencyHeader } from "@/notebook-components/DenoDependencyHeader";
 import { DependencyHeader } from "@/notebook-components/DependencyHeader";
+import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
 
 const PixiDependencyHeader = dynamic(
   () =>
@@ -92,6 +93,8 @@ const packageBoundaryRows = [
 ];
 
 export function PackageManagerSurfacesExample() {
+  const scenario = getElementsNotebookScenario("desktop-local-owner");
+
   return (
     <div className="not-prose space-y-6" data-elements-slot="package-manager-surfaces">
       <section className="grid gap-3 md:grid-cols-2 2xl:grid-cols-4">
@@ -120,36 +123,19 @@ export function PackageManagerSurfacesExample() {
         <SurfaceFrame
           icon={<PackageCheck className="size-4 text-fuchsia-500" aria-hidden="true" />}
           title="uv inline and project"
-          detail="Fixture notebook metadata plus detected pyproject.toml state."
+          detail="Elements scenario package metadata plus detected pyproject.toml state."
         >
           <DependencyHeader
-            dependencies={["pandas>=2", "polars", "matplotlib"]}
-            requiresPython=">=3.13"
+            dependencies={[...scenario.packageState.dependencies]}
+            requiresPython={scenario.packageState.requiresPython}
             loading={false}
             onAdd={asyncNoop}
             onRemove={asyncNoop}
             onSetRequiresPython={asyncNoop}
-            syncState={{ status: "dirty", added: ["scikit-learn"], removed: [] }}
+            syncState={scenario.packageState.syncState}
             onSyncNow={asyncTrue}
-            pyprojectInfo={{
-              path: "/Users/kyle/notebooks/pyproject.toml",
-              relative_path: "pyproject.toml",
-              project_name: "mathnet",
-              has_dependencies: true,
-              dependency_count: 3,
-              has_dev_dependencies: true,
-              requires_python: ">=3.13",
-              has_venv: true,
-            }}
-            pyprojectDeps={{
-              path: "/Users/kyle/notebooks/pyproject.toml",
-              relative_path: "pyproject.toml",
-              project_name: "mathnet",
-              dependencies: ["pandas>=2", "polars", "matplotlib"],
-              dev_dependencies: ["pytest", "ruff"],
-              requires_python: ">=3.13",
-              index_url: null,
-            }}
+            pyprojectInfo={scenario.packageState.pyprojectInfo}
+            pyprojectDeps={scenario.packageState.pyprojectDeps}
             onImportFromPyproject={asyncNoop}
             onUseProjectEnv={asyncNoop}
             isUsingProjectEnv={false}

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -341,8 +341,8 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
       </div>
       <div className="overflow-hidden rounded-md border border-fd-border bg-fd-card">
         <DependencyHeader
-          dependencies={[...scenario.dependencies]}
-          requiresPython=">=3.13"
+          dependencies={[...scenario.packageState.dependencies]}
+          requiresPython={scenario.packageState.requiresPython}
           loading={false}
           variant="rail"
           onAdd={asyncNoop}
@@ -350,12 +350,12 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
           onSetRequiresPython={asyncNoop}
           syncState={
             scenario.capabilities.canManagePackages
-              ? { status: "dirty", added: ["altair"], removed: [] }
+              ? scenario.packageState.syncState
               : { status: "synced" }
           }
           onSyncNow={asyncTrue}
-          pyprojectInfo={null}
-          pyprojectDeps={null}
+          pyprojectInfo={scenario.packageState.pyprojectInfo}
+          pyprojectDeps={scenario.packageState.pyprojectDeps}
           isUsingProjectEnv={false}
           justSynced={false}
         />

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -5,12 +5,15 @@ import { useState } from "react";
 import {
   KERNEL_STATUS,
   RUNTIME_STATUS,
-  projectNotebookOutline,
   resolveNotebookOutlineSelection,
-  type NotebookOutlineItem,
-  type NotebookOutlineSourceCell,
   type RuntimeLifecycle,
 } from "runtimed";
+import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
+import {
+  NotebookCellList,
+  NotebookDocumentShell,
+  type NotebookViewCell,
+} from "@/components/notebook-shell";
 import {
   NotebookPackagesPanel,
   NotebookRail,
@@ -19,6 +22,12 @@ import {
 import { cn } from "@/lib/utils";
 import { DependencyHeader } from "@/notebook-components/DependencyHeader";
 import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
+import {
+  getElementsNotebookScenario,
+  resolveElementsNotebookLanguage,
+  type ElementsNotebookScenario,
+  type ElementsNotebookScenarioId,
+} from "@/components/notebook-scenarios";
 
 const noop = () => {};
 const asyncNoop = async () => {};
@@ -29,111 +38,40 @@ const runningIdleLifecycle: RuntimeLifecycle = {
   activity: "Idle",
 };
 
-const notebookCells: NotebookOutlineSourceCell[] = [
-  {
-    id: "cell-load-data",
-    cell_type: "markdown",
-    source: "# Load data\n\nImport the order history and make dates explicit.",
-  },
-  {
-    id: "cell-load-code",
-    cell_type: "code",
-    source: "orders = pandas.read_csv('orders.csv', parse_dates=['date'])",
-    execution_count: 12,
-  },
-  {
-    id: "cell-clean-columns",
-    cell_type: "markdown",
-    source: "## Clean columns\n\nNormalize status values before joining lookup tables.",
-  },
-  {
-    id: "cell-clean-code",
-    cell_type: "code",
-    source: "orders = clean_columns(orders)",
-    execution_count: 13,
-  },
-  {
-    id: "cell-explore-shape",
-    cell_type: "markdown",
-    source: "# Explore shape\n\nCheck the model-ready feature table.",
-  },
-  {
-    id: "cell-shape-output",
-    cell_type: "code",
-    source: "features.shape",
-    execution_count: 14,
-  },
-  {
-    id: "cell-model-run",
-    cell_type: "markdown",
-    source: "# Model run\n\nTrain the weekly backtest model.",
-  },
-  {
-    id: "cell-model-code",
-    cell_type: "code",
-    source: "model.fit(features[columns], target)",
-    execution_count: null,
-  },
-  {
-    id: "cell-findings",
-    cell_type: "markdown",
-    source: "## Findings\n\nSummarize the backtest before export.",
-  },
+const scenarioIds: ElementsNotebookScenarioId[] = [
+  "desktop-local-owner",
+  "cloud-public-viewer",
+  "cloud-editor",
+  "runtime-unavailable",
 ];
 
 const executingCellId = "cell-model-code";
 const queuedCellIds = new Set(["cell-shape-output"]);
 
-const outlineItems: NotebookOutlineItem[] = projectNotebookOutline(notebookCells, {
-  getStatusLabel: (cell) => {
-    if (cell.id === executingCellId) return "Running";
-    if (queuedCellIds.has(cell.id)) return "Queued";
-    if (cell.cell_type === "code" && cell.execution_count !== null) {
-      return `In [${cell.execution_count}]`;
-    }
-    return null;
-  },
-}).items;
-const outlineCellIds = notebookCells.map((cell) => cell.id);
-const activeOutlineItemId = "cell-explore-shape:heading:0";
-
-const notebookCellCards = notebookCells.map((cell) => {
-  const firstLine = cell.source
-    ?.split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
-  const title = firstLine?.replace(/^#{1,6}\s+/, "") ?? cell.id;
-  const kind = cell.cell_type === "markdown" ? "Markdown" : "Code";
-  const status =
-    cell.id === executingCellId ? "Running" : queuedCellIds.has(cell.id) ? "Queued" : null;
-  return {
-    id: cell.id,
-    label: kind,
-    title,
-    body: cell.source ?? "",
-    status,
-  };
-});
-
 const outlineBoundaryRows = [
   {
     label: "Projection source",
-    catalog: "projectNotebookOutline(fixture cells)",
-    production: "getNotebookCellsSnapshot() + RuntimeStateDoc cell materialization",
+    catalog: "createNotebookViewModel(fixture cells)",
+    production: "host adapter materializes cells before the shared shell projection",
+  },
+  {
+    label: "Shell capabilities",
+    catalog: "ElementsNotebookScenario.capabilities",
+    production: "desktop local state or cloud ACL/auth adapter",
   },
   {
     label: "Context selection",
-    catalog: "focusedCellId fixture + outlineCellIds",
-    production: "useActiveOutlineItemId + resolveNotebookOutlineSelection",
+    catalog: "focusedCellId fixture + viewModel.cellIds",
+    production: "NotebookView focus state + shared outline selection",
   },
   {
     label: "Heading anchors",
-    catalog: "static cards with generated outline ids",
-    production: "NotebookView passes markdownHeadingAnchorsByCellId into MarkdownCell",
+    catalog: "viewModel.markdownHeadingAnchorsByCellId",
+    production: "MarkdownCell receives anchors from the shell view model",
   },
   {
     label: "Heading navigation",
-    catalog: "inert anchor callback",
+    catalog: "inert outline callback updates fixture focus",
     production: "navigateMarkdownHeading, scrollIntoView, and history.replaceState",
   },
   {
@@ -143,87 +81,70 @@ const outlineBoundaryRows = [
   },
 ];
 
-const variableItems = [
-  { name: "orders", type: "DataFrame", value: "2,148 rows x 18 columns" },
-  { name: "features", type: "DataFrame", value: "2,148 rows x 32 columns" },
-  { name: "model", type: "Pipeline", value: "StandardScaler -> Ridge" },
-  { name: "mae", type: "float", value: "8.42" },
-];
-
-const rendererItems = [
-  { name: "text/html", state: "isolated" },
-  { name: "application/vnd.apache.arrow.file", state: "sift" },
-  { name: "image/png", state: "inline" },
-];
-
-const plannedRailPanels = [
-  {
-    icon: Variable,
-    title: "Variables",
-    detail: `${variableItems.length} fixture names`,
-    body: "A future rail sibling for live namespace inspection once the app has a current variable surface.",
-  },
-  {
-    icon: Boxes,
-    title: "Renderers",
-    detail: `${rendererItems.length} fixture MIME lanes`,
-    body: "A future diagnostics panel for output MIME routing, plugin loading, and renderer health.",
-  },
-];
-
 export function RailOutlineExample() {
+  const [scenarioId, setScenarioId] = useState<ElementsNotebookScenarioId>("desktop-local-owner");
+  const scenario = getElementsNotebookScenario(scenarioId);
   const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const [focusedCellId, setFocusedCellId] = useState("cell-clean-code");
-  const resolvedOutlineItemId = resolveNotebookOutlineSelection(outlineItems, {
+  const { viewModel } = scenario;
+  const activeOutlineItemId =
+    viewModel.outlineItems.find((item) => item.cellId === "cell-explore-shape")?.id ?? null;
+  const resolvedOutlineItemId = resolveNotebookOutlineSelection(viewModel.outlineItems, {
     selectedItemId: selectedOutlineItemId,
     selectedCellId: focusedCellId,
-    cellIds: outlineCellIds,
+    cellIds: viewModel.cellIds,
   });
   const selectedOutlineItem =
-    outlineItems.find((item) => item.id === resolvedOutlineItemId) ?? outlineItems[0];
+    viewModel.outlineItems.find((item) => item.id === resolvedOutlineItemId) ??
+    viewModel.outlineItems[0];
 
   return (
-    <div
-      className="not-prose overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm"
-      data-elements-slot="rail-outline-example"
-    >
-      <NotebookToolbar
-        kernelStatus={KERNEL_STATUS.IDLE}
-        statusKey={RUNTIME_STATUS.RUNNING_IDLE}
-        lifecycle={runningIdleLifecycle}
-        errorReason={null}
-        kernelErrorMessage={null}
-        envSource="uv:inline"
-        envTypeHint="uv"
-        envProgress={null}
-        runtime="python"
-        focusedCellId={focusedCellId}
-        lastCellId="cell-findings"
-        onStartKernel={noop}
-        onInterruptKernel={noop}
-        onRestartKernel={noop}
-        onRunAllCells={noop}
-        onRestartAndRunAll={noop}
-        onAddCell={noop}
-        onToggleDependencies={noop}
-        isDepsOpen={false}
-        depsOutOfSync={false}
-      />
-      <div className="grid min-h-[500px] grid-cols-[auto_minmax(320px,1fr)] overflow-x-auto">
+    <NotebookDocumentShell
+      className="not-prose min-h-[700px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm"
+      stageClassName="min-w-[320px] bg-fd-muted/20"
+      toolbarClassName="border-b border-fd-border"
+      toolbarLabel="Notebook fixture toolbar"
+      stageLabel="Elements notebook scenario"
+      capabilities={scenario.capabilities}
+      toolbar={
+        <NotebookToolbar
+          kernelStatus={KERNEL_STATUS.IDLE}
+          statusKey={RUNTIME_STATUS.RUNNING_IDLE}
+          lifecycle={runningIdleLifecycle}
+          errorReason={scenario.capabilities.canExecute ? null : scenario.runtimeLabel}
+          kernelErrorMessage={null}
+          envSource="uv:inline"
+          envTypeHint="uv"
+          envProgress={null}
+          runtime="python"
+          focusedCellId={focusedCellId}
+          lastCellId="cell-findings"
+          onStartKernel={noop}
+          onInterruptKernel={noop}
+          onRestartKernel={noop}
+          onRunAllCells={noop}
+          onRestartAndRunAll={noop}
+          onAddCell={noop}
+          onToggleDependencies={() => setActivePanel("packages")}
+          isDepsOpen={activePanel === "packages"}
+          depsOutOfSync={!scenario.capabilities.canManagePackages}
+        />
+      }
+      rail={
         <NotebookRail
           activePanelId={activePanel}
           collapsed={railCollapsed}
-          outlineItems={outlineItems}
-          outlineCellIds={outlineCellIds}
+          outlineItems={viewModel.outlineItems}
+          outlineCellIds={viewModel.cellIds}
           activeOutlineItemId={activeOutlineItemId}
           selectedOutlineItemId={selectedOutlineItemId}
           selectedOutlineCellId={focusedCellId}
-          packagesSummary="uv:inline · 4 packages"
+          packagesSummary={scenario.packageSummary}
           packagesPanel={
-            <NotebookPackagesPanel>
-              <PackagePanelContent />
+            <NotebookPackagesPanel readOnly={!scenario.capabilities.canManagePackages}>
+              <PackagePanelContent scenario={scenario} />
             </NotebookPackagesPanel>
           }
           onActivePanelChange={setActivePanel}
@@ -232,140 +153,206 @@ export function RailOutlineExample() {
             setSelectedOutlineItemId(item.id);
             setFocusedCellId(item.cellId);
           }}
-          onNavigateOutlineItem={() => true}
+          onNavigateOutlineItem={(item) => {
+            setFocusedCellId(item.cellId);
+            return true;
+          }}
         />
+      }
+      notices={
+        <ScenarioNotice
+          scenario={scenario}
+          focusedCellId={focusedCellId}
+          selectedOutlineTitle={selectedOutlineItem?.title}
+          onScenarioChange={setScenarioId}
+        />
+      }
+      noticesClassName="border-b border-fd-border bg-fd-muted/20 p-4"
+    >
+      <NotebookCellList
+        cells={viewModel.cells}
+        label="Notebook scenario cells"
+        slot="elements-notebook-scenario-cell-list"
+        className="gap-3 overflow-y-auto p-4"
+        renderCell={(cell) => (
+          <ScenarioNotebookCell
+            cell={cell}
+            focused={focusedCellId === cell.id}
+            onFocus={() => {
+              setFocusedCellId(cell.id);
+              setSelectedOutlineItemId(null);
+            }}
+          />
+        )}
+      />
+    </NotebookDocumentShell>
+  );
+}
 
-        <main className="min-w-[320px] bg-fd-muted/20 p-6">
-          <div className="mx-auto max-w-2xl space-y-3">
-            <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
-              <div className="mb-1 flex items-center gap-2 font-semibold">
-                <ShieldCheck className="size-3.5" aria-hidden="true" />
-                NotebookToolbar, NotebookRail, and DependencyHeader render from current sources.
-              </div>
-              <p>
-                The docs app owns fixture state only: focused cell, active scroll item, collapsed
-                state, package callbacks, and inert anchor navigation.
-              </p>
-            </div>
-            <div className="rounded-lg border border-fd-border bg-fd-background p-3 text-xs leading-5 text-fd-muted-foreground">
-              <span className="font-medium text-fd-foreground">Context selection:</span> focused
-              cell <code className="rounded bg-fd-muted px-1 py-0.5">{focusedCellId}</code> resolves
-              to{" "}
-              <span className="font-medium text-fd-foreground">{selectedOutlineItem?.title}</span>.
-            </div>
-            {notebookCellCards.map((cell) => (
-              <section
-                key={cell.id}
-                role="button"
-                tabIndex={0}
-                onClick={() => {
-                  setFocusedCellId(cell.id);
-                  setSelectedOutlineItemId(null);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter" && event.key !== " ") return;
-                  event.preventDefault();
-                  setFocusedCellId(cell.id);
-                  setSelectedOutlineItemId(null);
-                }}
+function ScenarioNotice({
+  scenario,
+  focusedCellId,
+  selectedOutlineTitle,
+  onScenarioChange,
+}: {
+  scenario: ElementsNotebookScenario;
+  focusedCellId: string;
+  selectedOutlineTitle?: string;
+  onScenarioChange: (scenarioId: ElementsNotebookScenarioId) => void;
+}) {
+  return (
+    <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
+      <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
+        <div className="mb-1 flex items-center gap-2 font-semibold">
+          <ShieldCheck className="size-3.5" aria-hidden="true" />
+          NotebookDocumentShell, NotebookRail, NotebookCellList, and ReadOnlyNotebookCell render
+          from current sources.
+        </div>
+        <p>
+          The docs app owns only scenario facts: capabilities, fixture cells, package metadata,
+          focused cell, active panel, and inert navigation callbacks.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-fd-border bg-fd-background p-3 text-xs leading-5 text-fd-muted-foreground">
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {scenarioIds.map((id) => {
+            const option = getElementsNotebookScenario(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onScenarioChange(id)}
                 className={cn(
-                  "rounded-lg border border-fd-border bg-fd-background p-4 shadow-sm transition-colors",
-                  "focus:outline-none focus:ring-2 focus:ring-fd-primary/30",
-                  focusedCellId === cell.id && "border-fd-primary/60 bg-fd-primary/5",
+                  "rounded-md border px-2 py-1 text-[11px] font-medium transition-colors",
+                  scenario.id === id
+                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                    : "border-fd-border bg-fd-card text-fd-muted-foreground hover:text-fd-foreground",
                 )}
               >
-                <div className="mb-2 flex items-center justify-between gap-3">
-                  <h4 className="text-sm font-semibold">{cell.title}</h4>
-                  <div className="flex items-center gap-1.5">
-                    {cell.status ? (
-                      <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[11px] text-amber-800 dark:text-amber-300">
-                        {cell.status}
-                      </span>
-                    ) : null}
-                    <span className="rounded-full bg-fd-muted px-2 py-0.5 text-[11px] text-fd-muted-foreground">
-                      {cell.label}
-                    </span>
-                  </div>
-                </div>
-                <p className="font-mono text-xs leading-6 text-fd-muted-foreground">{cell.body}</p>
-              </section>
-            ))}
-            <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
-              <div className="mb-3 flex items-center gap-2">
-                <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-                <h4 className="text-sm font-semibold">Adapter boundary</h4>
-              </div>
-              <div className="space-y-2">
-                {outlineBoundaryRows.map((row) => (
-                  <div
-                    key={row.label}
-                    className="space-y-2 rounded-md border border-fd-border p-3 text-xs leading-5"
-                  >
-                    <div className="font-medium text-fd-foreground">{row.label}</div>
-                    <div className="min-w-0">
-                      <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                        Catalog
-                      </span>
-                      <span className="break-words text-fd-muted-foreground">{row.catalog}</span>
-                    </div>
-                    <div className="min-w-0">
-                      <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                        Production
-                      </span>
-                      <span className="break-words text-fd-muted-foreground">{row.production}</span>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-            <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
-              <div className="mb-3 flex items-center gap-2">
-                <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-                <h4 className="text-sm font-semibold">Planned sibling panels</h4>
-              </div>
-              <div className="grid gap-2">
-                {plannedRailPanels.map((panel) => (
-                  <div key={panel.title} className="rounded-md border border-fd-border p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex items-center gap-2">
-                        <panel.icon
-                          className="size-4 text-fd-muted-foreground"
-                          aria-hidden="true"
-                        />
-                        <h5 className="text-sm font-medium">{panel.title}</h5>
-                      </div>
-                      <span className="shrink-0 rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
-                        {panel.detail}
-                      </span>
-                    </div>
-                    <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{panel.body}</p>
-                  </div>
-                ))}
-              </div>
-            </section>
-          </div>
-        </main>
+                {option.title}
+              </button>
+            );
+          })}
+        </div>
+        <div className="font-medium text-fd-foreground">{scenario.summary}</div>
+        <div className="mt-2">
+          <span className="font-medium text-fd-foreground">Context selection:</span> focused cell{" "}
+          <code className="rounded bg-fd-muted px-1 py-0.5">{focusedCellId}</code> resolves to{" "}
+          <span className="font-medium text-fd-foreground">{selectedOutlineTitle}</span>.
+        </div>
+        <div className="mt-1">
+          <span className="font-medium text-fd-foreground">Runtime:</span> {scenario.runtimeLabel}
+        </div>
       </div>
     </div>
   );
 }
 
-function PackagePanelContent() {
+function ScenarioNotebookCell({
+  cell,
+  focused,
+  onFocus,
+}: {
+  cell: NotebookViewCell;
+  focused: boolean;
+  onFocus: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onFocus}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        onFocus();
+      }}
+      className="relative rounded-lg focus:outline-none focus:ring-2 focus:ring-fd-primary/30"
+    >
+      <div className="pointer-events-none absolute right-3 top-3 z-20">
+        <ScenarioCellBadge cell={cell} />
+      </div>
+      <ReadOnlyNotebookCell
+        id={cell.id}
+        cellType={cell.cellType}
+        source={cell.source}
+        language={resolveElementsNotebookLanguage(cell.language)}
+        executionCount={cell.executionCount}
+        outputs={cell.outputs}
+        displayMode="notebook"
+        className={cn(
+          "rounded-lg border border-fd-border bg-fd-background transition-colors",
+          focused && "border-fd-primary/60 bg-fd-primary/5",
+        )}
+        outputClassName="rounded-md"
+      />
+    </div>
+  );
+}
+
+function ScenarioCellBadge({ cell }: { cell: NotebookViewCell }) {
+  const label =
+    cell.id === executingCellId
+      ? "Running"
+      : queuedCellIds.has(cell.id)
+        ? "Queued"
+        : cell.cellType === "code"
+          ? cell.executionCount === null
+            ? "Ready"
+            : `Run ${cell.executionCount}`
+          : "Markdown";
+
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-2 py-1 text-[11px] font-medium",
+        cell.id === executingCellId || queuedCellIds.has(cell.id)
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+          : "border-fd-border bg-fd-background text-fd-muted-foreground",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario }) {
+  const plannedRailPanels = [
+    {
+      icon: Variable,
+      title: "Variables",
+      detail: `${scenario.variables.length} fixture names`,
+      body: "A future rail sibling for live namespace inspection once the app has a current variable surface.",
+    },
+    {
+      icon: Boxes,
+      title: "Renderers",
+      detail: `${scenario.renderers.length} fixture MIME lanes`,
+      body: "A future diagnostics panel for output MIME routing, plugin loading, and renderer health.",
+    },
+  ];
+
   return (
     <div className="space-y-3">
       <div className="rounded-md border border-fd-border bg-fd-muted/40 p-3 text-xs leading-5 text-fd-muted-foreground">
         This uses the current notebook dependency panel in a rail-sized frame. The catalog owns only
-        the fixture state and inert callbacks.
+        scenario metadata and inert callbacks.
       </div>
       <div className="overflow-hidden rounded-md border border-fd-border bg-fd-card">
         <DependencyHeader
-          dependencies={["pandas>=2", "polars", "plotly", "scikit-learn"]}
+          dependencies={[...scenario.dependencies]}
           requiresPython=">=3.13"
           loading={false}
+          variant="rail"
           onAdd={asyncNoop}
           onRemove={asyncNoop}
           onSetRequiresPython={asyncNoop}
-          syncState={{ status: "dirty", added: ["altair"], removed: [] }}
+          syncState={
+            scenario.capabilities.canManagePackages
+              ? { status: "dirty", added: ["altair"], removed: [] }
+              : { status: "synced" }
+          }
           onSyncNow={asyncTrue}
           pyprojectInfo={null}
           pyprojectDeps={null}
@@ -373,6 +360,56 @@ function PackagePanelContent() {
           justSynced={false}
         />
       </div>
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h4 className="text-sm font-semibold">Adapter boundary</h4>
+        </div>
+        <div className="space-y-2">
+          {outlineBoundaryRows.map((row) => (
+            <div
+              key={row.label}
+              className="space-y-2 rounded-md border border-fd-border p-3 text-xs leading-5"
+            >
+              <div className="font-medium text-fd-foreground">{row.label}</div>
+              <div className="min-w-0">
+                <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  Catalog
+                </span>
+                <span className="break-words text-fd-muted-foreground">{row.catalog}</span>
+              </div>
+              <div className="min-w-0">
+                <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  Production
+                </span>
+                <span className="break-words text-fd-muted-foreground">{row.production}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h4 className="text-sm font-semibold">Planned sibling panels</h4>
+        </div>
+        <div className="grid gap-2">
+          {plannedRailPanels.map((panel) => (
+            <div key={panel.title} className="rounded-md border border-fd-border p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-2">
+                  <panel.icon className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+                  <h5 className="text-sm font-medium">{panel.title}</h5>
+                </div>
+                <span className="shrink-0 rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
+                  {panel.detail}
+                </span>
+              </div>
+              <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{panel.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/elements/components/read-only-notebook-surfaces-example.tsx
+++ b/apps/elements/components/read-only-notebook-surfaces-example.tsx
@@ -2,96 +2,18 @@
 
 import { Cloud, Eye, FileCode2, Loader2, Rows3 } from "lucide-react";
 import { CellSkeleton } from "@/notebook-components/CellSkeleton";
-import {
-  ReadOnlyNotebook,
-  type ReadOnlyNotebookCellData,
-} from "@/components/cell/ReadOnlyNotebook";
+import { ReadOnlyNotebook } from "@/components/cell/ReadOnlyNotebook";
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
-
-const notebookCells: ReadOnlyNotebookCellData[] = [
-  {
-    id: "hosted-intro",
-    cellType: "markdown",
-    source: [
-      "## Hosted forecast report",
-      "",
-      "Read-only notebook surfaces keep notebook structure and output rendering without a live kernel.",
-    ].join("\n"),
-  },
-  {
-    id: "hosted-model",
-    cellType: "code",
-    language: "python",
-    source: [
-      "features = orders.assign(month=orders.date.dt.month)",
-      "predictions = model.predict(features[columns])",
-      "display(metrics)",
-    ].join("\n"),
-    executionCount: 12,
-    outputs: [
-      {
-        output_id: "hosted-model-stream",
-        output_type: "stream",
-        name: "stdout",
-        text: "validated 16 week backtest window\n",
-      },
-      {
-        output_id: "hosted-model-json",
-        output_type: "execute_result",
-        execution_count: 12,
-        data: {
-          "application/json": {
-            mae: 8.42,
-            mape: "6.8%",
-            holdout_weeks: 16,
-          },
-          "text/plain": "MAE 8.42, MAPE 6.8%, holdout 16 weeks",
-        },
-        metadata: {},
-      },
-    ],
-  },
-  {
-    id: "hosted-summary",
-    cellType: "code",
-    language: "python",
-    source: "display(summary_markdown)",
-    executionCount: 13,
-    outputs: [
-      {
-        output_id: "hosted-summary-markdown",
-        output_type: "display_data",
-        data: {
-          "text/markdown": [
-            "### Summary",
-            "",
-            "- Forecast error stayed within the review threshold.",
-            "- The hosted renderer uses the docs isolated-frame adapter.",
-          ].join("\n"),
-        },
-        metadata: {},
-      },
-    ],
-  },
-];
-
-const singleCellOutputs = [
-  {
-    output_id: "single-cell-json",
-    output_type: "display_data" as const,
-    data: {
-      "application/json": {
-        renderer: "cell",
-        displayMode: "report",
-        outputs: 1,
-      },
-      "text/plain": "ReadOnlyNotebookCell report mode",
-    },
-    metadata: {},
-  },
-];
+import {
+  getElementsNotebookScenario,
+  resolveElementsNotebookLanguage,
+} from "@/components/notebook-scenarios";
 
 export function ReadOnlyNotebookSurfacesExample() {
+  const scenario = getElementsNotebookScenario("cloud-public-viewer");
+  const reportCell =
+    scenario.cells.find((cell) => cell.id === "cell-shape-output") ?? scenario.cells[0];
+
   return (
     <div className="not-prose space-y-6" data-testid="read-only-notebook-surfaces-example">
       <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
@@ -101,8 +23,9 @@ export function ReadOnlyNotebookSurfacesExample() {
             <h2 className="text-sm font-semibold">Hosted notebook fixture</h2>
             <p className="mt-1 text-xs leading-5">
               These examples render the shared read-only notebook components used by cloud and
-              published artifact paths. Outputs are static nbformat fixtures, and markdown uses the
-              docs app isolated-frame adapter instead of a runtime iframe bundle.
+              published artifact paths. Cells come from the Elements notebook scenario projection,
+              outputs are static nbformat fixtures, and markdown uses the docs app isolated-frame
+              adapter instead of a runtime iframe bundle.
             </p>
           </div>
         </div>
@@ -125,11 +48,11 @@ export function ReadOnlyNotebookSurfacesExample() {
         </div>
         <div className="bg-background p-4">
           <ReadOnlyNotebook
-            cells={notebookCells}
+            cells={scenario.viewModel.readOnlyCells}
             displayMode="notebook"
             className="gap-3"
             cellClassName="rounded-lg border border-fd-border bg-fd-background pl-1"
-            label="Hosted notebook fixture"
+            label={`${scenario.title} notebook fixture`}
           />
         </div>
       </section>
@@ -152,12 +75,12 @@ export function ReadOnlyNotebookSurfacesExample() {
           </div>
           <div className="bg-background p-4">
             <ReadOnlyNotebookCell
-              id="single-read-only-cell"
-              cellType="code"
-              source="summary = {'renderer': 'cell'}"
-              language="python"
-              executionCount={7}
-              outputs={singleCellOutputs}
+              id={reportCell.id}
+              cellType={reportCell.cellType}
+              source={reportCell.source}
+              language={resolveElementsNotebookLanguage(reportCell.language)}
+              executionCount={reportCell.executionCount}
+              outputs={reportCell.outputs}
               displayMode="report"
               className="rounded-lg border border-fd-border bg-fd-background p-3"
             />
@@ -193,9 +116,9 @@ export function ReadOnlyNotebookSurfacesExample() {
           <div>
             <h2 className="text-sm font-semibold">Adapter boundary</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-              The production components still route through `OutputArea`. The catalog uses the local
-              isolated-frame adapter for markdown output, so this page stays runtime-free while
-              exercising the same read-only cell composition path.
+              The production components still route through `OutputArea`. The catalog receives the
+              same read-only cells the shared shell view model produces, then uses the local
+              isolated-frame adapter for markdown output so this page stays runtime-free.
             </p>
           </div>
         </div>

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -27,6 +27,10 @@ import { PoolErrorBanner } from "@/notebook-components/PoolErrorBanner";
 import { RuntimeDecisionDialog } from "@/notebook-components/RuntimeDecisionDialog";
 import { TrustDialog } from "@/notebook-components/TrustDialog";
 import { UntrustedBanner } from "@/notebook-components/UntrustedBanner";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+} from "@/components/notebook-scenarios";
 
 const runtimePieces = [
   {
@@ -111,30 +115,6 @@ const runtimeAdapterRows = [
 
 const fixtureHost = createFixtureNotebookHost();
 
-const trustInfo = {
-  status: "untrusted" as const,
-  uv_dependencies: ["pandas>=2", "reqeusts[security]>=2.0"],
-  approved_uv_dependencies: ["pandas>=2"],
-  conda_dependencies: ["python=3.13", "scikit-learn"],
-  approved_conda_dependencies: [],
-  conda_channels: ["conda-forge"],
-  approved_conda_channels: ["conda-forge"],
-  pixi_dependencies: ["numpy"],
-  approved_pixi_dependencies: [],
-  pixi_pypi_dependencies: ["polars"],
-  approved_pixi_pypi_dependencies: [],
-  pixi_channels: ["conda-forge"],
-  approved_pixi_channels: ["conda-forge"],
-};
-
-const typosquatWarnings = [
-  {
-    package: "reqeusts",
-    similar_to: "requests",
-    distance: 2,
-  },
-];
-
 const envBuildDetails = `Environment named "mathnet" was not found.
 
 conda env create -f /Users/kyle/notebooks/environment.yml
@@ -148,7 +128,7 @@ const kernelLaunchError = [
   "hint: rebuild the environment or verify the project interpreter.",
 ].join("\n");
 
-function RuntimeDialogs() {
+function RuntimeDialogs({ scenario }: { scenario: ElementsNotebookScenario }) {
   const [trustOpen, setTrustOpen] = useState(false);
   const [envOpen, setEnvOpen] = useState(false);
   const [decisionShellOpen, setDecisionShellOpen] = useState(false);
@@ -167,13 +147,13 @@ function RuntimeDialogs() {
         <TrustDialog
           open={trustOpen}
           onOpenChange={setTrustOpen}
-          trustInfo={trustInfo}
-          typosquatWarnings={typosquatWarnings}
+          trustInfo={scenario.trustState.trustInfo}
+          typosquatWarnings={[...scenario.trustState.typosquatWarnings]}
           onApprove={asyncTrue}
           onApproveOnly={asyncTrue}
           onDecline={noop}
           daemonMode
-          approvalError="Typosquat check completed with one warning. Review before trusting."
+          approvalError={scenario.trustState.approvalError}
         />
       </div>
 
@@ -230,7 +210,7 @@ function RuntimeDialogs() {
   );
 }
 
-function DependencyHeaderFixture() {
+function DependencyHeaderFixture({ scenario }: { scenario: ElementsNotebookScenario }) {
   return (
     <section
       className="overflow-hidden rounded-lg border border-fd-border bg-fd-card"
@@ -243,33 +223,16 @@ function DependencyHeaderFixture() {
         </p>
       </div>
       <DependencyHeader
-        dependencies={["pandas>=2", "polars", "matplotlib"]}
-        requiresPython=">=3.13"
+        dependencies={[...scenario.packageState.dependencies]}
+        requiresPython={scenario.packageState.requiresPython}
         loading={false}
         onAdd={asyncNoop}
         onRemove={asyncNoop}
         onSetRequiresPython={asyncNoop}
-        syncState={{ status: "dirty", added: ["scikit-learn"], removed: [] }}
+        syncState={scenario.packageState.syncState}
         onSyncNow={asyncTrue}
-        pyprojectInfo={{
-          path: "/Users/kyle/notebooks/pyproject.toml",
-          relative_path: "pyproject.toml",
-          project_name: "mathnet",
-          has_dependencies: true,
-          dependency_count: 3,
-          has_dev_dependencies: true,
-          requires_python: ">=3.13",
-          has_venv: true,
-        }}
-        pyprojectDeps={{
-          path: "/Users/kyle/notebooks/pyproject.toml",
-          relative_path: "pyproject.toml",
-          project_name: "mathnet",
-          dependencies: ["pandas>=2", "polars"],
-          dev_dependencies: ["pytest"],
-          requires_python: ">=3.13",
-          index_url: null,
-        }}
+        pyprojectInfo={scenario.packageState.pyprojectInfo}
+        pyprojectDeps={scenario.packageState.pyprojectDeps}
         onImportFromPyproject={asyncNoop}
         onUseProjectEnv={asyncNoop}
         isUsingProjectEnv={false}
@@ -411,6 +374,8 @@ function BannerFixture({
 }
 
 export function RuntimeSurfacesExample() {
+  const scenario = getElementsNotebookScenario("runtime-unavailable");
+
   return (
     <div className="not-prose space-y-6">
       <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-900">
@@ -427,7 +392,7 @@ export function RuntimeSurfacesExample() {
         </div>
       </section>
 
-      <DependencyHeaderFixture />
+      <DependencyHeaderFixture scenario={scenario} />
 
       <RuntimeBanners />
 
@@ -439,7 +404,7 @@ export function RuntimeSurfacesExample() {
             existing components.
           </p>
         </div>
-        <RuntimeDialogs />
+        <RuntimeDialogs scenario={scenario} />
       </section>
 
       <section className="grid gap-3">

--- a/apps/elements/components/search-surfaces-example.tsx
+++ b/apps/elements/components/search-surfaces-example.tsx
@@ -6,38 +6,16 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import type { HistoryEntry, NotebookRequest, NotebookResponse } from "runtimed";
 import { Button } from "@/components/ui/button";
 import { createFixtureNotebookHost } from "@/components/fixture-notebook-host";
+import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
 import { GlobalFindBar } from "@/notebook-components/GlobalFindBar";
 import { HistorySearchDialog } from "@/notebook-components/HistorySearchDialog";
 
-const notebookCells = [
-  {
-    id: "cell-imports",
-    label: "cell 1",
-    source: [
-      "from datasets import load_dataset",
-      "import pandas as pd",
-      "from sklearn.ensemble import RandomForestRegressor",
-    ].join("\n"),
-  },
-  {
-    id: "cell-features",
-    label: "cell 2",
-    source: [
-      "features = orders.assign(month=orders.date.dt.month)",
-      "model.fit(features[columns], target)",
-      "predictions = model.predict(features_holdout)",
-      "display(predictions.head())",
-    ].join("\n"),
-  },
-  {
-    id: "cell-review",
-    label: "cell 3",
-    source: [
-      "summary = predictions.groupby(features.region).mean()",
-      "summary.sort_values('forecast_error').tail()",
-    ].join("\n"),
-  },
-];
+const searchScenario = getElementsNotebookScenario("desktop-local-owner");
+const notebookCells = searchScenario.cells.map((cell, index) => ({
+  id: cell.id,
+  label: `${cell.cellType} ${index + 1}`,
+  source: cell.source,
+}));
 
 const fixtureHistoryEntries: HistoryEntry[] = [
   {
@@ -122,10 +100,10 @@ const historyFixtureHost = createFixtureNotebookHost({
 const searchBoundaryRows = [
   {
     boundary: "Find state projection",
-    catalogPath: "notebookCells[] + GlobalFindBar props",
+    catalogPath: "ElementsNotebookScenario.cells + GlobalFindBar props",
     productionBoundary: "NotebookView cell sources, focus, and selection",
     detail:
-      "The catalog owns static cell text and match counts. The notebook app still owns live cell projection, keyboard shortcuts, focus restoration, and editor selections.",
+      "The catalog reads shared scenario cell text and owns match counts. The notebook app still owns live cell projection, keyboard shortcuts, focus restoration, and editor selections.",
   },
   {
     boundary: "History transport",
@@ -227,7 +205,7 @@ export function SearchSurfacesExample() {
               <h2 className="text-sm font-semibold text-fd-foreground">GlobalFindBar</h2>
             </div>
             <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-              Rendered from the notebook app with fixture notebook text and inert navigation
+              Rendered from the notebook app with shared scenario notebook text and inert navigation
               callbacks.
             </p>
           </div>
@@ -334,8 +312,8 @@ export function SearchSurfacesExample() {
         </div>
         <p className="text-xs leading-5 text-fd-muted-foreground">
           Search is rendered through current notebook components, but the docs app owns only static
-          cell text, deterministic history entries, and inert handoff callbacks. Live notebook
-          projection, daemon history, focus, and editor insertion stay behind app adapters.
+          scenario cell text, deterministic history entries, and inert handoff callbacks. Live
+          notebook projection, daemon history, focus, and editor insertion stay behind app adapters.
         </p>
         <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
           <div className="hidden grid-cols-[190px_230px_230px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">

--- a/apps/elements/content/docs/editor-surfaces.mdx
+++ b/apps/elements/content/docs/editor-surfaces.mdx
@@ -14,7 +14,7 @@ extensions, and notebook palettes.
 
 ## Adapter notes
 
-This page renders current editor components and pure CodeMirror extensions with
-static fixture state. Runtime-backed behavior stays outside the docs app until
-there are thin adapters for CRDT source sync, kernel completion, presence
-sending, and app-level editor focus registration.
+This page renders current editor components and pure CodeMirror extensions from
+the shared Elements notebook scenario. Runtime-backed behavior stays outside the
+docs app until there are thin adapters for CRDT source sync, kernel completion,
+presence sending, and app-level editor focus registration.

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -15,6 +15,8 @@
         "./components/isolated/iframe-libraries.ts"
       ],
       "@/components/isolated/*": ["../../src/components/isolated/*"],
+      "@/components/notebook-shell": ["../../src/components/notebook-shell/index.ts"],
+      "@/components/notebook-shell/*": ["../../src/components/notebook-shell/*"],
       "@/components/notebook-rail": ["../../src/components/notebook-rail/index.ts"],
       "@/components/notebook-rail/*": ["../../src/components/notebook-rail/*"],
       "@/components/outputs/*": ["../../src/components/outputs/*"],


### PR DESCRIPTION
## Summary

- adds a docs-local Elements notebook scenario fixture layer with shared shell capabilities, fixture cells, packages, variables, and renderer metadata
- refactors the notebook outline rail page to compose `NotebookDocumentShell`, `NotebookRail`, `NotebookCellList`, and `ReadOnlyNotebookCell`
- moves the read-only notebook surfaces page onto the same scenario projection
- centralizes uv package metadata, pyproject state, trust info, and typosquat warnings in the scenario layer for package/runtime pages
- seeds the full-cell `NotebookView` workspace fixture from the shared scenario cells and output/execution records
- reuses the shared scenario cells for search surface match-count fixtures
- derives the `NotebookToolbar` catalog states from the shared scenario cell IDs, package state, and access capabilities
- moves the primary cell anatomy source/output preview onto the shared scenario model cell
- derives the standalone full-cell preview from that same scenario model cell and output records
- moves the editor surface Python/read-only previews onto the shared scenario model/findings cells
- keeps the new scenario work catalog-only and avoids the #3203 shared view-model/App surface

## Validation

- `pnpm --dir apps/elements build`
- browser spot checks of `/docs/notebook-outline`, `/docs/read-only-notebook-surfaces`, `/docs/package-manager-surfaces`, `/docs/runtime-surfaces`, `/docs/cell-anatomy`, and `/docs/search-surfaces`
- Playwright spot check of `/docs/notebook-toolbar-surfaces`
- Playwright spot checks of `/docs/cell-anatomy`, `/docs/notebook-outline`, and `/docs/search-surfaces` after the shared scenario model-cell update
- Playwright spot checks of `/docs/cell-anatomy` and `/docs/notebook-outline` after deriving the full-cell preview from the scenario model cell
- Playwright spot checks of `/docs/editor-surfaces` and `/docs/cell-anatomy` after moving editor previews onto shared scenario cells
- `cargo xtask lint --fix`

## Notes

- This is the first slice for the refreshed Elements goal. It stays catalog-only while we continue folding more catalog pages into the scenario layer.
