### PR TITLE
fix(notebook): quiet completed cell status

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -164,7 +164,7 @@ const currentLineStateFixtures = [
   },
   {
     label: "Completed",
-    detail: "The finished state leads with language, then compact run metadata.",
+    detail: "Finished cells keep run metadata collapsed until hover or focus.",
     line: (
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -181,13 +181,12 @@ const currentLineStateFixtures = [
 const currentLineConceptFixtures = [
   {
     label: "Production",
-    detail: "Control, language, run state, activity, and rule in one boundary line.",
+    detail: "Default reading mode keeps completed metadata collapsed into the boundary line.",
     line: (
       <CodeCellCurrentLine
         languageLabel="Python"
         count={26}
         elapsedMs={1476}
-        isFocused
         activityContent={<StaticPresenceActivity />}
         onExecute={() => {}}
         onInterrupt={() => {}}
@@ -205,7 +204,7 @@ const currentLineConceptFixtures = [
         <span className="rounded-full border border-border bg-background px-2 py-0.5 font-medium tabular-nums text-foreground/65">
           Run 26
         </span>
-        <span className="text-muted-foreground/55">completed in 1.5s</span>
+        <span className="text-muted-foreground/55">1.5s</span>
         <StaticPresenceDots />
       </CurrentLineConcept>
     ),
@@ -219,7 +218,7 @@ const currentLineConceptFixtures = [
           Python
         </span>
         <span className="font-medium tabular-nums text-foreground/65">Run 26</span>
-        <span className="text-muted-foreground/45">completed</span>
+        <span className="text-muted-foreground/45">1.5s</span>
         <div className="h-px min-w-8 flex-1 rounded-full bg-border/45" />
         <StaticPresenceDots />
       </CurrentLineConcept>

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -222,7 +222,7 @@ describe("CodeCell output focus", () => {
     expect(getByTestId("output").getAttribute("data-focused")).toBe("true");
   });
 
-  it("labels completed execution state with readable footer language", () => {
+  it("keeps completed execution state readable but visually quiet", () => {
     mockOutputs = [];
     mockExecution = { execution_count: 12, submitted_by_actor_label: null };
 
@@ -237,10 +237,14 @@ describe("CodeCell output focus", () => {
     );
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·completed");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12");
     expect(footer?.textContent).not.toContain("In [12]");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
   });
 
   it("keeps running status active while the stop control carries danger", () => {
@@ -368,7 +372,7 @@ describe("CodeCell output focus", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(queryByTestId("editor")).toBeNull();
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4·completed");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -33,7 +33,29 @@ function formatElapsedMs(elapsedMs: number): string {
   return remainingSeconds === 0 ? `${minutes}m` : `${minutes}m ${remainingSeconds}s`;
 }
 
-function executionDetail({
+function visualExecutionDetail({
+  count,
+  elapsedMs,
+  isExecuting,
+  isQueued,
+}: {
+  count: number | null;
+  elapsedMs: number | null;
+  isExecuting: boolean;
+  isQueued: boolean;
+}): string {
+  const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
+
+  if (isExecuting) return "Running";
+  if (isQueued) return "Queued";
+  if (count !== null) {
+    return elapsedMs === null ? `${runPrefix}` : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
+  }
+
+  return "Ready";
+}
+
+function accessibleExecutionDetail({
   count,
   elapsedMs,
   isExecuting,
@@ -50,8 +72,8 @@ function executionDetail({
   if (isQueued) return "Queued";
   if (count !== null) {
     return elapsedMs === null
-      ? `${runPrefix} · completed`
-      : `${runPrefix} · completed in ${formatElapsedMs(elapsedMs)}`;
+      ? `${runPrefix} completed`
+      : `${runPrefix} completed in ${formatElapsedMs(elapsedMs)}`;
   }
 
   return "Ready";
@@ -101,8 +123,14 @@ export function CodeCellCurrentLine({
 }: CodeCellCurrentLineProps) {
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
   const isCompactIdle = compactIdle && state === "idle";
-  const isQuietIdle = state === "idle" && !isFocused;
-  const detailLabel = executionDetail({ count, elapsedMs, isExecuting, isQueued });
+  const isQuietResting = (state === "idle" || state === "ran") && !isFocused;
+  const detailLabel = visualExecutionDetail({ count, elapsedMs, isExecuting, isQueued });
+  const accessibleDetailLabel = accessibleExecutionDetail({
+    count,
+    elapsedMs,
+    isExecuting,
+    isQueued,
+  });
   const countLabel = executionCountLabel(count);
   const actionTitle = isExecuting
     ? submittedByActorLabel
@@ -151,7 +179,9 @@ export function CodeCellCurrentLine({
           "inline-flex size-4 shrink-0 items-center justify-center rounded-full",
           "transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          !isFocused && state === "idle" && "opacity-55 group-hover:opacity-100",
+          !isFocused &&
+            (state === "idle" || state === "ran") &&
+            "opacity-45 group-hover:opacity-100",
           !isExecuting && state !== "queued" && "text-muted-foreground/55",
           isCompactIdle && "opacity-45 hover:opacity-100",
           state === "idle" && "hover:bg-muted hover:text-foreground",
@@ -173,11 +203,11 @@ export function CodeCellCurrentLine({
       </button>
       <span
         data-slot="code-cell-current-line-status"
-        aria-label={`${languageLabel}: ${detailLabel}`}
+        aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
         aria-live={isExecuting || isQueued ? "polite" : undefined}
         className={cn(
           "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
-          isQuietIdle
+          isQuietResting
             ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-64 group-hover:opacity-100 group-focus-within:max-w-64 group-focus-within:opacity-100"
             : "max-w-64 opacity-100",
           isFocused && "text-foreground/70",
@@ -212,7 +242,19 @@ export function CodeCellCurrentLine({
       </span>
       {!isCompactIdle && (
         <>
-          {activityContent}
+          {activityContent ? (
+            <div
+              data-slot="code-cell-current-line-activity"
+              className={cn(
+                "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
+                isQuietResting
+                  ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
+                  : "max-w-24 opacity-100",
+              )}
+            >
+              {activityContent}
+            </div>
+          ) : null}
           <div
             data-slot="code-cell-current-line-rule"
             className={cn(

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -103,6 +103,7 @@ describe("CodeCellCurrentLine", () => {
         languageLabel="Python"
         count={12}
         elapsedMs={1476}
+        isFocused
         onExecute={() => undefined}
         onInterrupt={() => undefined}
       />,
@@ -111,8 +112,30 @@ describe("CodeCellCurrentLine", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·completedin1.5s");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
+  });
+
+  it("keeps completed metadata quiet until the cell is engaged", () => {
+    const { container } = render(
+      <CodeCellCurrentLine
+        languageLabel="Python"
+        count={12}
+        onExecute={() => undefined}
+        onInterrupt={() => undefined}
+      />,
+    );
+
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const button = screen.getByRole("button", {
+      name: "Run cell again; last execution 12",
+    });
+
+    expect(status).toHaveTextContent("Python·Run 12");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
+    expect(button).toHaveClass("opacity-45");
   });
 
   it("can carry activity context after the run state", () => {
@@ -128,7 +151,10 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
+    const activity = container.querySelector('[data-slot="code-cell-current-line-activity"]');
+
     expect(footer).toHaveTextContent("Kyle");
+    expect(activity).toHaveClass("max-w-0");
     expect(screen.getByTestId("peer-activity")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- collapse completed and idle code-cell current-line metadata until hover or focus
- shorten revealed completed copy from sentence text to compact run metadata
- keep full completed state in accessible labels while reducing document noise
- update Elements current-line sketches to reflect the quieter production behavior

## Validation

- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
