### PR TITLE
refactor(notebook-cloud): feed live editor from shell view model

### DIFF
--- a/apps/notebook-cloud/test/cloud-view-model.test.ts
+++ b/apps/notebook-cloud/test/cloud-view-model.test.ts
@@ -32,7 +32,14 @@ describe("cloud notebook view model materialization", () => {
           ],
         },
       ],
-      metadata: { language_info: { name: "python" } },
+      metadata: {
+        language_info: { name: "python" },
+        runt: {
+          uv: {
+            dependencies: ["pandas>=2"],
+          },
+        },
+      },
       runtimeState: {
         comms: {
           "slider-1": {
@@ -53,6 +60,14 @@ describe("cloud notebook view model materialization", () => {
     });
 
     assert.equal(materialized.notebookLanguage, "python");
+    assert.deepEqual(materialized.metadata, {
+      language_info: { name: "python" },
+      runt: {
+        uv: {
+          dependencies: ["pandas>=2"],
+        },
+      },
+    });
     assert.equal(materialized.rawCellCount, 2);
     assert.deepEqual(
       materialized.cells.map((cell) => [cell.id, cell.cellType, cell.language]),

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -62,6 +62,16 @@ test("cloud read-only notebook renders from the shared notebook view model", () 
   assert.doesNotMatch(sourceText, /cells=\{readOnlyCells\}/);
 });
 
+test("cloud package rail renders package metadata through the shared shell panel", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /NotebookPackageSummaryPanel/);
+  assert.match(sourceText, /packagesSummary=\{notebookViewModel\.packages\.summary\}/);
+  assert.match(sourceText, /packages=\{notebookViewModel\.packages\}/);
+  assert.doesNotMatch(sourceText, /Package details are not surfaced/);
+});
+
 test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -53,6 +53,15 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
 });
 
+test("cloud read-only notebook renders from the shared notebook view model", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /NotebookReadOnlyView/);
+  assert.match(sourceText, /<NotebookReadOnlyView[\s\S]*viewModel=\{notebookViewModel\}/);
+  assert.doesNotMatch(sourceText, /cells=\{readOnlyCells\}/);
+});
+
 test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -47,6 +47,8 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
 
   assert.match(sourceText, /NotebookCellList/);
   assert.match(sourceText, /slot="cloud-live-notebook"/);
+  assert.match(sourceText, /viewModel: NotebookViewModel<ResolvedCell>/);
+  assert.match(sourceText, /const cells = viewModel\.cells;/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
 });

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -1,7 +1,7 @@
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
-import { NotebookCellList } from "@/components/notebook-shell";
+import { NotebookCellList, type NotebookViewModel } from "@/components/notebook-shell";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable-markdown-cell";
 import type { CloudLivePresenceSnapshot } from "./live-presence";
@@ -10,7 +10,7 @@ import type { ResolvedCell } from "./render-resolution";
 import { cloudSourceLanguage } from "./source-language";
 
 export interface CloudLiveNotebookProps {
-  cells: ResolvedCell[];
+  viewModel: NotebookViewModel<ResolvedCell>;
   priority: readonly string[];
   hostContext: NteractEmbedHostContextPatch;
   showCode: boolean;
@@ -33,7 +33,7 @@ export interface CloudLiveNotebookProps {
 }
 
 export function CloudLiveNotebook({
-  cells,
+  viewModel,
   priority,
   hostContext,
   showCode,
@@ -48,6 +48,8 @@ export function CloudLiveNotebook({
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
 }: CloudLiveNotebookProps) {
+  const cells = viewModel.cells;
+
   return (
     <NotebookCellList
       cells={cells}

--- a/apps/notebook-cloud/viewer/cloud-view-model.ts
+++ b/apps/notebook-cloud/viewer/cloud-view-model.ts
@@ -11,6 +11,7 @@ export interface CloudNotebookViewMaterialization {
   cells: ResolvedCell[];
   widgetComms: SnapshotWidgetComm[];
   notebookLanguage: string;
+  metadata: unknown;
   rawCellCount: number;
 }
 
@@ -26,7 +27,9 @@ export async function materializeCloudNotebookView(
   options: MaterializeCloudNotebookViewOptions,
 ): Promise<CloudNotebookViewMaterialization> {
   const rawCells = JSON.parse(handle.get_cells_json()) as RenderCell[];
-  const notebookLanguage = cloudNotebookLanguageFromHandle(handle, options.defaultNotebookLanguage);
+  const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json?.());
+  const notebookLanguage =
+    languageFromNotebookMetadata(metadata) ?? options.defaultNotebookLanguage;
   const widgetComms = snapshotWidgetCommsFromRuntimeState(
     handle.get_runtime_state(),
     options.blobResolver,
@@ -43,6 +46,7 @@ export async function materializeCloudNotebookView(
     cells,
     widgetComms,
     notebookLanguage,
+    metadata,
     rawCellCount: rawCells.length,
   };
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -34,6 +34,7 @@ import {
   createNotebookViewModel,
   navigateNotebookOutlineItem,
   NotebookDocumentShell,
+  NotebookPackageSummaryPanel,
   NotebookReadOnlyView,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -593,6 +594,7 @@ function NotebookViewer({
     message: loadingPolicy.initialStatusMessage,
   });
   const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
   const [showCode, setShowCode] = useState(true);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(false);
@@ -774,6 +776,7 @@ function NotebookViewer({
         });
         if (cancelled || liveMaterializedRef.current) return;
         notebookLanguageRef.current = materialized.notebookLanguage;
+        setNotebookMetadata(materialized.metadata);
 
         snapshotResolvedRef.current = true;
         await projectCloudWidgetComms(
@@ -905,6 +908,7 @@ function NotebookViewer({
       }
       if (disposed || sequence !== materializeSequence) return;
       notebookLanguageRef.current = materialized.notebookLanguage;
+      setNotebookMetadata(materialized.metadata);
 
       await projectCloudWidgetComms(
         widgetStore,
@@ -1053,8 +1057,12 @@ function NotebookViewer({
   ]);
 
   const notebookViewModel = useMemo(
-    () => createNotebookViewModel(cells, { resolveLanguage: cloudSourceLanguage }),
-    [cells],
+    () =>
+      createNotebookViewModel(cells, {
+        metadata: notebookMetadata,
+        resolveLanguage: cloudSourceLanguage,
+      }),
+    [cells, notebookMetadata],
   );
   const { codeCellCount, outlineItems, tracebackTargetsByExecutionId } = notebookViewModel;
   useEffect(() => {
@@ -1134,7 +1142,13 @@ function NotebookViewer({
       collapsed={railCollapsed}
       outlineItems={outlineItems}
       selectedOutlineItemId={selectedOutlineItemId}
-      packagesPanel={<CloudRailPackagesPanel />}
+      packagesSummary={notebookViewModel.packages.summary}
+      packagesPanel={
+        <NotebookPackageSummaryPanel
+          packages={notebookViewModel.packages}
+          readOnly={!shellCapabilities.canManagePackages}
+        />
+      }
       onActivePanelChange={setActiveRailPanel}
       onCollapsedChange={setRailCollapsed}
       onSelectOutlineItem={handleSelectOutlineItem}
@@ -1287,14 +1301,6 @@ function NotebookViewer({
         />
       )}
     </NotebookDocumentShell>
-  );
-}
-
-function CloudRailPackagesPanel() {
-  return (
-    <div className="cloud-rail-panel-note">
-      <p>Package details are not surfaced in the hosted viewer yet.</p>
-    </div>
   );
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1250,7 +1250,7 @@ function NotebookViewer({
 
       {canEditMarkdown ? (
         <CloudLiveNotebook
-          cells={cells}
+          viewModel={notebookViewModel}
           priority={CLOUD_VIEWER_PRIORITY}
           hostContext={outputHostContext}
           showCode={showCode}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -27,7 +27,6 @@ import {
   UserRound,
   UsersRound,
 } from "lucide-react";
-import { ReadOnlyNotebook } from "@/components/cell/ReadOnlyNotebook";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { NotebookRail, type NotebookRailPanelId } from "@/components/notebook-rail/NotebookRail";
@@ -35,6 +34,7 @@ import {
   createNotebookViewModel,
   navigateNotebookOutlineItem,
   NotebookDocumentShell,
+  NotebookReadOnlyView,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
@@ -1056,8 +1056,7 @@ function NotebookViewer({
     () => createNotebookViewModel(cells, { resolveLanguage: cloudSourceLanguage }),
     [cells],
   );
-  const { readOnlyCells, codeCellCount, outlineItems, tracebackTargetsByExecutionId } =
-    notebookViewModel;
+  const { codeCellCount, outlineItems, tracebackTargetsByExecutionId } = notebookViewModel;
   useEffect(() => {
     if (!selectedOutlineItemId) return;
     if (!outlineItems.some((item) => item.id === selectedOutlineItemId)) {
@@ -1266,8 +1265,8 @@ function NotebookViewer({
           onNavigateToTracebackCell={handleTracebackCellNavigate}
         />
       ) : (
-        <ReadOnlyNotebook
-          cells={readOnlyCells}
+        <NotebookReadOnlyView
+          viewModel={notebookViewModel}
           priority={CLOUD_VIEWER_PRIORITY}
           hostContext={outputHostContext}
           displayMode="report"

--- a/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
+++ b/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
@@ -71,8 +71,8 @@ export function NotebookPackageSummaryPanel({
 function PackageValueList({ values }: { values: readonly string[] }) {
   return (
     <div className="flex flex-wrap gap-1">
-      {values.map((value) => (
-        <code key={value} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">
+      {values.map((value, index) => (
+        <code key={`${value}:${index}`} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">
           {value}
         </code>
       ))}

--- a/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
+++ b/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
@@ -1,0 +1,81 @@
+import { NotebookPackagesPanel } from "@/components/notebook-rail";
+import { cn } from "@/lib/utils";
+import type { NotebookPackageViewModel } from "./view-model";
+
+export interface NotebookPackageSummaryPanelProps {
+  packages: NotebookPackageViewModel;
+  readOnly?: boolean;
+  className?: string;
+}
+
+export function NotebookPackageSummaryPanel({
+  packages,
+  readOnly = true,
+  className,
+}: NotebookPackageSummaryPanelProps) {
+  return (
+    <NotebookPackagesPanel readOnly={readOnly}>
+      <div className={cn("space-y-3", className)} data-slot="notebook-package-summary-panel">
+        {packages.sections.length === 0 ? (
+          <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
+            No package metadata in this notebook.
+          </div>
+        ) : (
+          packages.sections.map((section) => (
+            <section
+              key={section.manager}
+              className="rounded-md border bg-background px-3 py-3 shadow-sm shadow-black/[0.02]"
+            >
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold">{section.label}</h3>
+                  <p className="text-xs text-muted-foreground">
+                    {section.dependencies.length === 1
+                      ? "1 dependency"
+                      : `${section.dependencies.length} dependencies`}
+                  </p>
+                </div>
+                {readOnly ? (
+                  <span className="shrink-0 rounded-full border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                    Read only
+                  </span>
+                ) : null}
+              </div>
+
+              {section.dependencies.length > 0 ? (
+                <PackageValueList values={section.dependencies} />
+              ) : (
+                <p className="text-xs text-muted-foreground">No inline dependencies.</p>
+              )}
+
+              {section.details.length > 0 ? (
+                <dl className="mt-3 space-y-2 text-xs">
+                  {section.details.map((detail) => (
+                    <div key={detail.label} className="space-y-1">
+                      <dt className="font-medium text-muted-foreground">{detail.label}</dt>
+                      <dd>
+                        <PackageValueList values={detail.values} />
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+            </section>
+          ))
+        )}
+      </div>
+    </NotebookPackagesPanel>
+  );
+}
+
+function PackageValueList({ values }: { values: readonly string[] }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      {values.map((value) => (
+        <code key={value} className="rounded bg-muted px-1.5 py-0.5 text-[11px]">
+          {value}
+        </code>
+      ))}
+    </div>
+  );
+}

--- a/src/components/notebook-shell/NotebookReadOnlyView.tsx
+++ b/src/components/notebook-shell/NotebookReadOnlyView.tsx
@@ -1,0 +1,10 @@
+import { ReadOnlyNotebook, type ReadOnlyNotebookProps } from "@/components/cell/ReadOnlyNotebook";
+import type { NotebookViewModel } from "./view-model";
+
+export interface NotebookReadOnlyViewProps extends Omit<ReadOnlyNotebookProps, "cells"> {
+  viewModel: Pick<NotebookViewModel, "readOnlyCells">;
+}
+
+export function NotebookReadOnlyView({ viewModel, ...props }: NotebookReadOnlyViewProps) {
+  return <ReadOnlyNotebook cells={viewModel.readOnlyCells} {...props} />;
+}

--- a/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookPackageSummaryPanel } from "../NotebookPackageSummaryPanel";
+import type { NotebookPackageViewModel } from "../view-model";
+
+describe("NotebookPackageSummaryPanel", () => {
+  it("renders package metadata in a read-only shared rail panel", () => {
+    const packages: NotebookPackageViewModel = {
+      summary: "uv · 2 packages",
+      sections: [
+        {
+          manager: "uv",
+          label: "uv",
+          dependencies: ["pandas>=2", "polars"],
+          details: [{ label: "Python", values: [">=3.12"] }],
+        },
+      ],
+    };
+
+    render(<NotebookPackageSummaryPanel packages={packages} readOnly />);
+
+    expect(screen.getByTestId("notebook-packages-panel")).toHaveAttribute("data-read-only", "true");
+    expect(screen.getByRole("heading", { name: "uv" })).toBeVisible();
+    expect(screen.getByText("pandas>=2")).toBeVisible();
+    expect(screen.getByText("polars")).toBeVisible();
+    expect(screen.getByText(">=3.12")).toBeVisible();
+    expect(screen.getByText("Read only")).toBeVisible();
+  });
+
+  it("shows an empty package metadata state", () => {
+    render(<NotebookPackageSummaryPanel packages={{ summary: null, sections: [] }} />);
+
+    expect(screen.getByText("No package metadata in this notebook.")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookReadOnlyView.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookReadOnlyView.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookReadOnlyView } from "../NotebookReadOnlyView";
+import type { NotebookViewModel } from "../view-model";
+
+vi.mock("@/components/cell/ReadOnlyNotebook", () => ({
+  ReadOnlyNotebook: ({
+    cells,
+    label,
+  }: {
+    cells: readonly { id: string; source: string }[];
+    label?: string;
+  }) => (
+    <section aria-label={label ?? "Notebook cells"} data-cell-count={cells.length}>
+      {cells.map((cell) => (
+        <article key={cell.id}>{cell.source}</article>
+      ))}
+    </section>
+  ),
+}));
+
+describe("NotebookReadOnlyView", () => {
+  it("renders read-only cells from the shared notebook view model", () => {
+    const viewModel: Pick<NotebookViewModel, "readOnlyCells"> = {
+      readOnlyCells: [
+        {
+          id: "intro",
+          cellType: "markdown",
+          source: "# Intro",
+          language: null,
+          outputs: [],
+          executionId: null,
+          executionCount: null,
+        },
+      ],
+    };
+
+    render(<NotebookReadOnlyView viewModel={viewModel} label="Hosted cells" />);
+
+    expect(screen.getByLabelText("Hosted cells")).toHaveAttribute("data-cell-count", "1");
+    expect(screen.getByText("# Intro")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/__tests__/view-model.test.ts
+++ b/src/components/notebook-shell/__tests__/view-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   createNotebookViewModel,
+  notebookMetadataToPackageViewModel,
   notebookOutlineItemsToMarkdownHeadingAnchors,
   notebookViewCellsToOutlineItems,
   notebookViewCellsToReadOnlyCells,
@@ -147,6 +148,42 @@ describe("notebook shell view model", () => {
       label: "In [7]",
     });
     expect(viewModel.markdownHeadingAnchorsByCellId.get("code-1")).toBeUndefined();
+    expect(viewModel.packages.sections).toEqual([]);
+  });
+
+  it("projects notebook dependency metadata for shared package panels", () => {
+    const packageView = notebookMetadataToPackageViewModel({
+      runt: {
+        uv: {
+          dependencies: ["pandas>=2", "polars"],
+          "requires-python": ">=3.12",
+        },
+        pixi: {
+          dependencies: ["numpy"],
+          pypi_dependencies: ["altair"],
+          channels: ["conda-forge"],
+        },
+      },
+    });
+
+    expect(packageView.summary).toBe("uv + pixi · 4 packages");
+    expect(packageView.sections).toMatchObject([
+      {
+        manager: "uv",
+        label: "uv",
+        dependencies: ["pandas>=2", "polars"],
+        details: [{ label: "Python", values: [">=3.12"] }],
+      },
+      {
+        manager: "pixi",
+        label: "pixi",
+        dependencies: ["numpy"],
+        details: [
+          { label: "PyPI", values: ["altair"] },
+          { label: "Channels", values: ["conda-forge"] },
+        ],
+      },
+    ]);
   });
 
   it("can build outline-only projections without a read-only language resolver", () => {

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -8,6 +8,10 @@ export {
 } from "./capabilities";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
+export {
+  NotebookPackageSummaryPanel,
+  type NotebookPackageSummaryPanelProps,
+} from "./NotebookPackageSummaryPanel";
 export { NotebookReadOnlyView, type NotebookReadOnlyViewProps } from "./NotebookReadOnlyView";
 export {
   navigateNotebookOutlineItem,
@@ -21,6 +25,9 @@ export {
   notebookViewCellsToTracebackTargets,
   notebookOutlineItemsToMarkdownHeadingAnchors,
   type CreateNotebookViewModelOptions,
+  type NotebookPackageManager,
+  type NotebookPackageSection,
+  type NotebookPackageViewModel,
   type NotebookViewModel,
   type NotebookViewCell,
   type NotebookViewCellType,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./capabilities";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
+export { NotebookReadOnlyView, type NotebookReadOnlyViewProps } from "./NotebookReadOnlyView";
 export {
   navigateNotebookOutlineItem,
   type NavigateNotebookOutlineItemOptions,

--- a/src/components/notebook-shell/view-model.ts
+++ b/src/components/notebook-shell/view-model.ts
@@ -22,6 +22,23 @@ export interface NotebookTracebackCellTarget {
   label?: string;
 }
 
+export type NotebookPackageManager = "uv" | "conda" | "pixi" | "deno";
+
+export interface NotebookPackageSection {
+  manager: NotebookPackageManager;
+  label: string;
+  dependencies: string[];
+  details: Array<{
+    label: string;
+    values: string[];
+  }>;
+}
+
+export interface NotebookPackageViewModel {
+  summary: string | null;
+  sections: NotebookPackageSection[];
+}
+
 export type NotebookViewLanguageResolver = (
   language: string | null | undefined,
 ) => SupportedLanguage | null;
@@ -33,12 +50,14 @@ export interface NotebookViewModel<TCell extends NotebookViewCell = NotebookView
   outlineItems: NotebookOutlineItem[];
   markdownHeadingAnchorsByCellId: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   tracebackTargetsByExecutionId: ReadonlyMap<string, NotebookTracebackCellTarget>;
+  packages: NotebookPackageViewModel;
   codeCellCount: number;
 }
 
 export interface CreateNotebookViewModelOptions {
   resolveLanguage?: NotebookViewLanguageResolver;
   getOutlineStatusLabel?: (cell: NotebookViewCell) => string | null;
+  metadata?: unknown;
 }
 
 /**
@@ -64,6 +83,7 @@ export function createNotebookViewModel<TCell extends NotebookViewCell = Noteboo
     outlineItems,
     markdownHeadingAnchorsByCellId: notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems),
     tracebackTargetsByExecutionId: notebookViewCellsToTracebackTargets(cells),
+    packages: notebookMetadataToPackageViewModel(options.metadata),
     codeCellCount: cells.filter((cell) => cell.cellType === "code").length,
   };
 }
@@ -139,4 +159,140 @@ function notebookViewCellOutlineStatusLabel(cell: NotebookViewCell): string | nu
     return `In [${cell.executionCount}]`;
   }
   return null;
+}
+
+export function notebookMetadataToPackageViewModel(metadata: unknown): NotebookPackageViewModel {
+  const runt = metadataRecord(metadata)?.runt;
+  const sections: NotebookPackageSection[] = [];
+
+  if (isRecord(runt)) {
+    const uv = metadataRecord(runt.uv);
+    const uvDependencies = stringArray(uv?.dependencies);
+    if (uvDependencies.length > 0 || typeof uv?.["requires-python"] === "string") {
+      sections.push({
+        manager: "uv",
+        label: "uv",
+        dependencies: uvDependencies,
+        details: [
+          detail(
+            "Python",
+            typeof uv?.["requires-python"] === "string" ? [uv["requires-python"]] : [],
+          ),
+          detail("Prerelease", typeof uv?.prerelease === "string" ? [uv.prerelease] : []),
+        ].filter(hasValues),
+      });
+    }
+
+    const conda = metadataRecord(runt.conda);
+    const condaDependencies = stringArray(conda?.dependencies);
+    const condaChannels = stringArray(conda?.channels);
+    if (
+      condaDependencies.length > 0 ||
+      condaChannels.length > 0 ||
+      typeof conda?.python === "string"
+    ) {
+      sections.push({
+        manager: "conda",
+        label: "conda",
+        dependencies: condaDependencies,
+        details: [
+          detail("Python", typeof conda?.python === "string" ? [conda.python] : []),
+          detail("Channels", condaChannels),
+        ].filter(hasValues),
+      });
+    }
+
+    const pixi = metadataRecord(runt.pixi);
+    const pixiDependencies = stringArray(pixi?.dependencies);
+    const pixiPyPiDependencies = stringArray(pixi?.pypi_dependencies);
+    const pixiChannels = stringArray(pixi?.channels);
+    if (
+      pixiDependencies.length > 0 ||
+      pixiPyPiDependencies.length > 0 ||
+      pixiChannels.length > 0 ||
+      typeof pixi?.python === "string"
+    ) {
+      sections.push({
+        manager: "pixi",
+        label: "pixi",
+        dependencies: pixiDependencies,
+        details: [
+          detail("PyPI", pixiPyPiDependencies),
+          detail("Python", typeof pixi?.python === "string" ? [pixi.python] : []),
+          detail("Channels", pixiChannels),
+        ].filter(hasValues),
+      });
+    }
+
+    const deno = metadataRecord(runt.deno);
+    const denoPermissions = stringArray(deno?.permissions);
+    if (
+      denoPermissions.length > 0 ||
+      typeof deno?.import_map === "string" ||
+      typeof deno?.config === "string" ||
+      typeof deno?.flexible_npm_imports === "boolean"
+    ) {
+      sections.push({
+        manager: "deno",
+        label: "Deno",
+        dependencies: [],
+        details: [
+          detail("Permissions", denoPermissions),
+          detail("Import map", typeof deno?.import_map === "string" ? [deno.import_map] : []),
+          detail("Config", typeof deno?.config === "string" ? [deno.config] : []),
+          detail(
+            "Flexible npm imports",
+            typeof deno?.flexible_npm_imports === "boolean"
+              ? [deno.flexible_npm_imports ? "enabled" : "disabled"]
+              : [],
+          ),
+        ].filter(hasValues),
+      });
+    }
+  }
+
+  return {
+    summary: packageSummary(sections),
+    sections,
+  };
+}
+
+function metadataRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function detail(label: string, values: string[]): NotebookPackageSection["details"][number] {
+  return { label, values };
+}
+
+function hasValues(detail: NotebookPackageSection["details"][number]): boolean {
+  return detail.values.length > 0;
+}
+
+function packageSummary(sections: readonly NotebookPackageSection[]): string | null {
+  if (sections.length === 0) return null;
+  const dependencyCount = sections.reduce(
+    (total, section) =>
+      total +
+      section.dependencies.length +
+      section.details
+        .filter((detail) => detail.label === "PyPI")
+        .reduce((detailTotal, detail) => detailTotal + detail.values.length, 0),
+    0,
+  );
+  if (dependencyCount === 0) {
+    return sections.map((section) => section.label).join(" + ");
+  }
+  const packageLabel = dependencyCount === 1 ? "package" : "packages";
+  return `${sections.map((section) => section.label).join(" + ")} · ${dependencyCount} ${packageLabel}`;
 }

--- a/src/components/notebook-shell/view-model.ts
+++ b/src/components/notebook-shell/view-model.ts
@@ -26,8 +26,8 @@ export type NotebookViewLanguageResolver = (
   language: string | null | undefined,
 ) => SupportedLanguage | null;
 
-export interface NotebookViewModel {
-  cells: readonly NotebookViewCell[];
+export interface NotebookViewModel<TCell extends NotebookViewCell = NotebookViewCell> {
+  cells: readonly TCell[];
   cellIds: string[];
   readOnlyCells: ReadOnlyNotebookCellData[];
   outlineItems: NotebookOutlineItem[];
@@ -49,10 +49,10 @@ export interface CreateNotebookViewModelOptions {
  * live/snapshot Automerge handle adapter. This function should remain free of
  * transport, WASM, blob-fetch, and host side effects.
  */
-export function createNotebookViewModel(
-  cells: readonly NotebookViewCell[],
+export function createNotebookViewModel<TCell extends NotebookViewCell = NotebookViewCell>(
+  cells: readonly TCell[],
   options: CreateNotebookViewModelOptions = {},
-): NotebookViewModel {
+): NotebookViewModel<TCell> {
   const resolveLanguage = options.resolveLanguage ?? (() => null);
   const outlineItems = notebookViewCellsToOutlineItems(cells, {
     getStatusLabel: options.getOutlineStatusLabel,


### PR DESCRIPTION
## Summary

- preserve the concrete materialized cell type through `NotebookViewModel`
- pass the shared shell view model into cloud's live notebook editor path
- add a shared `NotebookReadOnlyView` wrapper that renders read-only cells from the view model
- route cloud's read-only hosted path through that shared view-model wrapper
- project notebook package metadata in the shared view model
- add a shared read-only package summary panel and use it in notebook-cloud's rail
- keep cloud-specific `ResolvedCell` handling at the host adapter edge

## Stack

Base: `main` after #3203.

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/view-model.test.ts src/components/notebook-shell/__tests__/NotebookCellList.test.tsx src/components/notebook-shell/__tests__/NotebookReadOnlyView.test.tsx src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/cloud-view-model.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
