### PR TITLE
refactor(notebook-cloud): bind rail through shell view model

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -67,18 +67,27 @@ test("cloud package rail renders package metadata through the shared shell panel
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookPackageSummaryPanel/);
-  assert.match(sourceText, /packagesSummary=\{notebookViewModel\.packages\.summary\}/);
+  assert.match(sourceText, /<NotebookDocumentRail[\s\S]*viewModel=\{notebookViewModel\}/);
   assert.match(sourceText, /packages=\{notebookViewModel\.packages\}/);
   assert.doesNotMatch(sourceText, /Package details are not surfaced/);
+});
+
+test("cloud rail binds through the shared document rail adapter", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /NotebookDocumentRail/);
+  assert.match(sourceText, /<NotebookDocumentRail[\s\S]*viewModel=\{notebookViewModel\}/);
+  assert.doesNotMatch(sourceText, /<NotebookRail[\s>]/);
 });
 
 test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /NotebookRail/);
+  assert.match(sourceText, /NotebookDocumentRail/);
   assert.match(sourceText, /createNotebookViewModel\(cells/);
-  assert.match(sourceText, /<NotebookRail[\s\S]*outlineItems=\{outlineItems\}/);
+  assert.match(sourceText, /<NotebookDocumentRail[\s\S]*viewModel=\{notebookViewModel\}/);
   assert.match(sourceText, /onNavigateOutlineItem=\{handleNavigateOutlineItem\}/);
   assert.match(sourceText, /navigateNotebookOutlineItem\(item, href/);
   assert.doesNotMatch(sourceText, /findCellElement: \(outlineItem\)/);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -29,10 +29,11 @@ import {
 } from "lucide-react";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
-import { NotebookRail, type NotebookRailPanelId } from "@/components/notebook-rail/NotebookRail";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   createNotebookViewModel,
   navigateNotebookOutlineItem,
+  NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookReadOnlyView,
@@ -1137,12 +1138,11 @@ function NotebookViewer({
   }, [refreshAuthState]);
 
   const rail = (
-    <NotebookRail
+    <NotebookDocumentRail
+      viewModel={notebookViewModel}
       activePanelId={activeRailPanel}
       collapsed={railCollapsed}
-      outlineItems={outlineItems}
       selectedOutlineItemId={selectedOutlineItemId}
-      packagesSummary={notebookViewModel.packages.summary}
       packagesPanel={
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}

--- a/src/components/notebook-shell/NotebookDocumentRail.tsx
+++ b/src/components/notebook-shell/NotebookDocumentRail.tsx
@@ -1,0 +1,46 @@
+import { NotebookRail, type NotebookRailPanelId } from "@/components/notebook-rail";
+import type { ReactNode } from "react";
+import type { NotebookOutlineItem } from "runtimed";
+import type { NotebookViewModel } from "./view-model";
+
+export interface NotebookDocumentRailProps {
+  viewModel: Pick<NotebookViewModel, "outlineItems" | "packages">;
+  activePanelId: NotebookRailPanelId;
+  collapsed: boolean;
+  selectedOutlineItemId?: string | null;
+  packagesPanel: ReactNode;
+  onActivePanelChange: (panelId: NotebookRailPanelId) => void;
+  onCollapsedChange: (collapsed: boolean) => void;
+  onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
+  onNavigateOutlineItem?: (item: NotebookOutlineItem, href: string) => boolean | void;
+  className?: string;
+}
+
+export function NotebookDocumentRail({
+  viewModel,
+  activePanelId,
+  collapsed,
+  selectedOutlineItemId = null,
+  packagesPanel,
+  onActivePanelChange,
+  onCollapsedChange,
+  onSelectOutlineItem,
+  onNavigateOutlineItem,
+  className,
+}: NotebookDocumentRailProps) {
+  return (
+    <NotebookRail
+      activePanelId={activePanelId}
+      collapsed={collapsed}
+      outlineItems={viewModel.outlineItems}
+      selectedOutlineItemId={selectedOutlineItemId}
+      packagesSummary={viewModel.packages.summary}
+      packagesPanel={packagesPanel}
+      onActivePanelChange={onActivePanelChange}
+      onCollapsedChange={onCollapsedChange}
+      onSelectOutlineItem={onSelectOutlineItem}
+      onNavigateOutlineItem={onNavigateOutlineItem}
+      className={className}
+    />
+  );
+}

--- a/src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookDocumentRail } from "../NotebookDocumentRail";
+import type { NotebookViewModel } from "../view-model";
+
+describe("NotebookDocumentRail", () => {
+  it("binds shared notebook view model projections to the notebook rail", () => {
+    const viewModel: Pick<NotebookViewModel, "outlineItems" | "packages"> = {
+      outlineItems: [
+        {
+          id: "intro:heading:0",
+          kind: "heading",
+          cellId: "intro",
+          title: "Intro",
+          level: 1,
+          order: 0,
+          statusLabel: null,
+          href: "#intro",
+          anchor: "intro",
+          headingAnchorId: "notebook-cell-intro-heading-intro",
+        },
+      ],
+      packages: {
+        summary: "uv · 2 packages",
+        sections: [],
+      },
+    };
+
+    render(
+      <NotebookDocumentRail
+        viewModel={viewModel}
+        activePanelId="packages"
+        collapsed={false}
+        packagesPanel={<p>Package details</p>}
+        onActivePanelChange={() => {}}
+        onCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "false");
+    expect(screen.getByText("uv · 2 packages")).toBeVisible();
+    expect(screen.getByText("Package details")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -12,6 +12,7 @@ export {
   NotebookPackageSummaryPanel,
   type NotebookPackageSummaryPanelProps,
 } from "./NotebookPackageSummaryPanel";
+export { NotebookDocumentRail, type NotebookDocumentRailProps } from "./NotebookDocumentRail";
 export { NotebookReadOnlyView, type NotebookReadOnlyViewProps } from "./NotebookReadOnlyView";
 export {
   navigateNotebookOutlineItem,


### PR DESCRIPTION
## Summary

- add shared `NotebookDocumentRail` to bind `NotebookViewModel` outline/package projections into `NotebookRail`
- route notebook-cloud rail through that shared adapter instead of threading outline/package props by hand
- keep cloud-specific package rendering in the host-provided package panel

## Stack

Depends on #3207. Merge #3207 first, then retarget this PR to `main`.

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx src/components/notebook-shell/__tests__/view-model.test.ts apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/cloud-view-model.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
