### PR TITLE
refactor(notebook): route desktop rail through shell adapter

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -32,14 +32,11 @@ import { type BlobUploader, WidgetUpdateManager } from "@/components/widgets/wid
 import { WidgetView } from "@/components/widgets/widget-view";
 import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
-import {
-  NotebookPackagesPanel,
-  NotebookRail,
-  type NotebookRailPanelId,
-} from "@/components/notebook-rail";
+import { NotebookPackagesPanel, type NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   createNotebookViewModel,
   navigateNotebookOutlineItem,
+  NotebookDocumentRail,
   NotebookDocumentShell,
   type NotebookViewCell,
 } from "@/components/notebook-shell";
@@ -1946,10 +1943,10 @@ function AppContent() {
           stageLabel="Notebook editor"
           stageClassName="flex-row min-w-0 flex-1"
           rail={
-            <NotebookRail
+            <NotebookDocumentRail
+              viewModel={notebookViewModel}
               activePanelId={activeRailPanel}
               collapsed={railCollapsed}
-              outlineItems={outlineItems}
               outlineCellIds={cellIds}
               activeOutlineItemId={activeOutlineItemId}
               selectedOutlineItemId={selectedOutlineItemId}

--- a/src/components/notebook-shell/NotebookDocumentRail.tsx
+++ b/src/components/notebook-shell/NotebookDocumentRail.tsx
@@ -7,7 +7,11 @@ export interface NotebookDocumentRailProps {
   viewModel: Pick<NotebookViewModel, "outlineItems" | "packages">;
   activePanelId: NotebookRailPanelId;
   collapsed: boolean;
+  outlineCellIds?: readonly string[];
+  activeOutlineItemId?: string | null;
   selectedOutlineItemId?: string | null;
+  selectedOutlineCellId?: string | null;
+  packagesSummary?: string | null;
   packagesPanel: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -20,7 +24,11 @@ export function NotebookDocumentRail({
   viewModel,
   activePanelId,
   collapsed,
+  outlineCellIds,
+  activeOutlineItemId = null,
   selectedOutlineItemId = null,
+  selectedOutlineCellId = null,
+  packagesSummary,
   packagesPanel,
   onActivePanelChange,
   onCollapsedChange,
@@ -33,8 +41,11 @@ export function NotebookDocumentRail({
       activePanelId={activePanelId}
       collapsed={collapsed}
       outlineItems={viewModel.outlineItems}
+      outlineCellIds={outlineCellIds}
+      activeOutlineItemId={activeOutlineItemId}
       selectedOutlineItemId={selectedOutlineItemId}
-      packagesSummary={viewModel.packages.summary}
+      selectedOutlineCellId={selectedOutlineCellId}
+      packagesSummary={packagesSummary ?? viewModel.packages.summary}
       packagesPanel={packagesPanel}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}

--- a/src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx
@@ -31,6 +31,7 @@ describe("NotebookDocumentRail", () => {
         viewModel={viewModel}
         activePanelId="packages"
         collapsed={false}
+        packagesSummary="Runtime packages"
         packagesPanel={<p>Package details</p>}
         onActivePanelChange={() => {}}
         onCollapsedChange={() => {}}
@@ -38,7 +39,45 @@ describe("NotebookDocumentRail", () => {
     );
 
     expect(screen.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "false");
-    expect(screen.getByText("uv · 2 packages")).toBeVisible();
+    expect(screen.getByText("Runtime packages")).toBeVisible();
     expect(screen.getByText("Package details")).toBeVisible();
+  });
+
+  it("forwards host outline selection state", () => {
+    const viewModel: Pick<NotebookViewModel, "outlineItems" | "packages"> = {
+      outlineItems: [
+        {
+          id: "intro:heading:0",
+          kind: "heading",
+          cellId: "intro",
+          title: "Intro",
+          level: 1,
+          order: 0,
+          statusLabel: null,
+          href: "#intro",
+          anchor: "intro",
+          headingAnchorId: "notebook-cell-intro-heading-intro",
+        },
+      ],
+      packages: {
+        summary: "uv · 2 packages",
+        sections: [],
+      },
+    };
+
+    render(
+      <NotebookDocumentRail
+        viewModel={viewModel}
+        activePanelId="outline"
+        collapsed={false}
+        outlineCellIds={["intro"]}
+        activeOutlineItemId="intro:heading:0"
+        packagesPanel={<p>Package details</p>}
+        onActivePanelChange={() => {}}
+        onCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Intro" })).toHaveAttribute("aria-current", "location");
   });
 });


### PR DESCRIPTION
## Summary

- extend the shared `NotebookDocumentRail` adapter with the active/selected outline props desktop needs
- keep desktop's runtime-derived package summary override while routing desktop through the shared shell rail adapter
- cover the adapter forwarding behavior with a focused shell unit test

## Stack state

Originally stacked on #3208 after #3207. Both are now merged, and this branch has
been rebased/retargeted onto `main` with only the desktop rail adapter commit.

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Review

Draft until local `pr-reviewer` and GitHub CI are clear.
