### PR TITLE
fix(notebook-doc): resolve schema_version over conflict-set max (SE-1)

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -119,6 +119,23 @@ pub fn default_runtime_state_doc_id(notebook_id: &str) -> RuntimeStateDocId {
     format!("runtime:{notebook_id}")
 }
 
+/// Extract a non-negative schema version from an Automerge scalar value.
+///
+/// Returns `None` for non-integer scalars and negative `Int`s, so a malformed
+/// `schema_version` value is ignored rather than misread. Shared by the
+/// `schema_version()` accessor and the load-time classifier, which both resolve
+/// `schema_version` over its full conflict set (see SE-1).
+fn schema_version_scalar(value: &automerge::Value<'_>) -> Option<u64> {
+    match value {
+        automerge::Value::Scalar(s) => match s.as_ref() {
+            automerge::ScalarValue::Uint(v) => Some(*v),
+            automerge::ScalarValue::Int(v) if *v >= 0 => Some(*v as u64),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Snapshot of a single cell's state, suitable for serialization.
 ///
 /// `CellSnapshot` represents only the fields that live in the notebook
@@ -1026,15 +1043,20 @@ impl NotebookDoc {
     ///
     /// Returns `None` for documents created before schema versioning was added.
     /// Callers can treat `None` as schema version 1 (the original format).
+    ///
+    /// Resolves over the full Automerge conflict set, not the LWW winner: two
+    /// peers in a mixed-version room can write `schema_version` concurrently
+    /// (SE-1), and the `(lamport, actor)` winner can be the *older* value, which
+    /// would make a reader see the doc as stamped backward. Taking the max keeps
+    /// the observed version monotonic. The fix is read-side: the CRDT still
+    /// records the LWW pick, so there is no write-back and no op-history growth.
     pub fn schema_version(&self) -> Option<u64> {
-        match self.doc.get(automerge::ROOT, "schema_version").ok()?? {
-            (automerge::Value::Scalar(s), _) => match s.as_ref() {
-                automerge::ScalarValue::Uint(v) => Some(*v),
-                automerge::ScalarValue::Int(v) => Some(*v as u64),
-                _ => None,
-            },
-            _ => None,
-        }
+        self.doc
+            .get_all(automerge::ROOT, "schema_version")
+            .ok()?
+            .into_iter()
+            .filter_map(|(value, _)| schema_version_scalar(&value))
+            .max()
     }
 
     /// Create a client-side bootstrap document for sync.
@@ -1132,28 +1154,37 @@ impl NotebookDoc {
                 Ok(data) => match AutoCommit::load(&data) {
                     Ok(doc) => {
                         let mut loaded = Self { doc };
-                        // Classify the persisted `schema_version`. `schema_version()`
-                        // collapses both "key absent" and "key present but not a
-                        // non-negative integer" to None, and casts a negative Int
-                        // to a huge u64 — so read the raw value here to tell a
-                        // version-less doc (treat as current) apart from a
-                        // malformed one (quarantine).
+                        // Classify the persisted `schema_version` over its full
+                        // Automerge conflict set, not just the LWW winner: two
+                        // peers in a mixed-version room can write it concurrently
+                        // (SE-1), and the `(lamport, actor)` winner can be the
+                        // older value, which would misclassify the doc and stamp
+                        // it backward. Resolve to the max instead. Keep the
+                        // absent-vs-malformed distinction the classifier draws:
+                        // an empty conflict set is a missing key (a v5-skeleton
+                        // doc is then current); a non-empty set with no
+                        // non-negative integer is malformed (quarantine).
                         #[derive(Clone, Copy)]
                         enum SchemaState {
                             Absent,
                             Valid(u64),
                             Invalid,
                         }
-                        let state = match loaded.doc.get(automerge::ROOT, "schema_version") {
-                            Ok(None) => SchemaState::Absent,
-                            Ok(Some((automerge::Value::Scalar(s), _))) => match s.as_ref() {
-                                automerge::ScalarValue::Uint(v) => SchemaState::Valid(*v),
-                                automerge::ScalarValue::Int(v) if *v >= 0 => {
-                                    SchemaState::Valid(*v as u64)
-                                }
-                                _ => SchemaState::Invalid,
-                            },
-                            _ => SchemaState::Invalid,
+                        let conflicts = loaded
+                            .doc
+                            .get_all(automerge::ROOT, "schema_version")
+                            .unwrap_or_default();
+                        let state = if conflicts.is_empty() {
+                            SchemaState::Absent
+                        } else {
+                            match conflicts
+                                .iter()
+                                .filter_map(|(value, _)| schema_version_scalar(value))
+                                .max()
+                            {
+                                Some(v) => SchemaState::Valid(v),
+                                None => SchemaState::Invalid,
+                            }
                         };
 
                         // An absent version is only "current" if the doc actually
@@ -4373,23 +4404,22 @@ mod tests {
         assert_eq!(meta["vx_pin"], "abc123");
     }
 
-    /// Reproduction of the multi-writer `schema_version` hazard for cloud.
+    /// SE-1 guarantee: a concurrent multi-writer `schema_version` resolves to
+    /// the newest version on read, not to the raw LWW pick.
     ///
-    /// `schema_version` is a single LWW scalar, single-writer only by
-    /// *convention* (the migrate-on-load path is the lone writer, and desktop
-    /// rooms are single-version). In a mixed-version cloud room two peers can
-    /// write it concurrently: two upgraded peers migrating a stale room doc,
-    /// or a stale peer re-stamping its old version. There is no monotonic/max
-    /// merge: the CRDT picks an LWW winner by (lamport, actor), unrelated to
-    /// which schema is newer, so a stale peer's lower version can win and stamp
-    /// the shared doc backward.
+    /// `schema_version` is an Automerge LWW scalar. In a mixed-version cloud
+    /// room two peers can write it concurrently: two upgraded peers migrating a
+    /// stale room doc, or a stale peer re-stamping its old version. The CRDT
+    /// picks an LWW winner by (lamport, actor), unrelated to which schema is
+    /// newer, so a stale peer's lower version can win the raw tie-break. The
+    /// `schema_version()` accessor resolves over the full conflict set and
+    /// returns the max, so the observed version is monotonic. The fix is
+    /// read-side: the CRDT still records the LWW pick (no write-back, no op
+    /// growth), but every reader sees the newest version.
     ///
-    /// Characterization test: it pins today's (undesirable) behavior so it is
-    /// reproducible. When the fix lands (host-enforced single-writer auth, or
-    /// monotonic-max merge semantics) this test should be updated to assert the
-    /// new guarantee.
+    /// See SE-1 in `docs/architecture/cleanup-punchlist.md`.
     #[test]
-    fn test_cross_version_schema_version_is_lww_not_monotonic() {
+    fn test_cross_version_schema_version_resolves_to_max_not_lww() {
         let mut old = NotebookDoc::new_with_actor("room-nb", "peer-old");
         let mut new = NotebookDoc::new_with_actor("room-nb", "peer-new");
 
@@ -4405,25 +4435,140 @@ mod tests {
         let mut s_new = sync::State::new();
         sync_docs(&mut old, &mut s_old, &mut new, &mut s_new, 20);
 
-        // CRDT determinism holds: both peers converge to the SAME value...
+        // The raw CRDT still records the LWW winner, and it is the *stale*
+        // value: actor ordering is by raw bytes, "peer-old" sorts above
+        // "peer-new", so the older write (4) wins the tie. The fix does not
+        // change this — it resolves the conflict on read, not by writing back.
+        let raw_lww = |doc: &NotebookDoc| {
+            doc.doc
+                .get(automerge::ROOT, "schema_version")
+                .expect("get")
+                .and_then(|(value, _)| match value {
+                    automerge::Value::Scalar(s) => match s.as_ref() {
+                        automerge::ScalarValue::Uint(n) => Some(*n),
+                        _ => None,
+                    },
+                    _ => None,
+                })
+        };
+        assert_eq!(
+            raw_lww(&old),
+            Some(4),
+            "raw LWW still picks the stale peer's version; the fix is read-side"
+        );
+
+        // But the accessor resolves the conflict set to the max on both peers,
+        // so the observed version is monotonic: the newer schema (6) wins.
         assert_eq!(
             old.schema_version(),
             new.schema_version(),
-            "peers converge to a single value"
+            "peers converge to a single resolved value"
         );
-        // ...but it is an LWW pick of one of the two written values, never
-        // their max. There is no merge rule that says "higher schema wins."
-        //
-        // Here the *older* peer wins: the converged value is 4, not 6. The tie
-        // is broken by actor id (concurrent writes have equal lamport counter),
-        // and "peer-old" sorts above "peer-new" by bytes, so the stale peer
-        // stamps the shared doc backward; v6 is silently downgraded to v4.
-        // The winner is decided by actor bytes, not by which schema is newer;
-        // swapping the labels flips it. That arbitrariness is the hazard.
-        let converged = old.schema_version().unwrap();
         assert_eq!(
-            converged, 4,
-            "stale peer's lower version wins the LWW tie, stamping the doc backward"
+            old.schema_version(),
+            Some(6),
+            "schema_version() must resolve the conflict set to the newest version"
+        );
+    }
+
+    /// SE-1 at the load site: a persisted doc whose `schema_version` conflict
+    /// set was backward-stamped by LWW must classify by the conflict-set max,
+    /// not the LWW winner. The forward-tolerant path then keeps it without a
+    /// downgrade, migration, or quarantine.
+    #[test]
+    #[cfg(feature = "persistence")]
+    fn test_load_resolves_schema_version_conflict_to_max() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("notebook.automerge");
+
+        // The stale writer (value 4) takes the lexically-higher actor so it
+        // wins the raw LWW tie-break: under the old behavior the persisted doc
+        // classifies as v4 and is migrated/downgraded. The fix classifies by
+        // the conflict-set max (6).
+        let mut stale = NotebookDoc::new_with_actor("room-nb", "z-stale");
+        let mut fresh = NotebookDoc::new_with_actor("room-nb", "a-fresh");
+        stale.add_cell(0, "c1", "code").unwrap();
+        stale.update_source("c1", "print('hi')").unwrap();
+
+        let mut s_stale = sync::State::new();
+        let mut s_fresh = sync::State::new();
+        // Share the cell first, then bump schema_version concurrently.
+        sync_docs(&mut stale, &mut s_stale, &mut fresh, &mut s_fresh, 20);
+        stale
+            .doc
+            .put(automerge::ROOT, "schema_version", 4u64)
+            .unwrap();
+        fresh
+            .doc
+            .put(automerge::ROOT, "schema_version", 6u64)
+            .unwrap();
+        sync_docs(&mut stale, &mut s_stale, &mut fresh, &mut s_fresh, 20);
+
+        stale.save_to_file(&path).unwrap();
+
+        let loaded = NotebookDoc::load_or_create(&path, "room-nb");
+        assert_eq!(
+            loaded.schema_version(),
+            Some(6),
+            "load must classify by the conflict-set max (6), not the LWW winner (4)"
+        );
+        assert_eq!(
+            loaded.cell_count(),
+            1,
+            "the document must be preserved, not migrated-over or reset"
+        );
+        assert!(
+            !path.with_extension("automerge.corrupt").exists(),
+            "a forward-resolved doc must not be quarantined"
+        );
+    }
+
+    /// A `schema_version` conflict set with one malformed (non-`u64`) value and
+    /// one valid version classifies as the valid max, not as corrupt. A doc that
+    /// still holds a usable version must not be quarantined.
+    #[test]
+    #[cfg(feature = "persistence")]
+    fn test_load_malformed_in_conflict_set_uses_valid_max() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("notebook.automerge");
+
+        // The malformed writer takes the lexically-higher actor so it wins the
+        // raw LWW tie-break: under the old behavior the doc is rejected as
+        // corrupt. The fix ignores the malformed value and keeps the valid one.
+        // The valid writer uses 6 (not the genesis 5) so its write is a real
+        // concurrent op, not a no-op that collapses into the genesis ancestor.
+        let mut bad = NotebookDoc::new_with_actor("room-nb", "z-bad");
+        let mut good = NotebookDoc::new_with_actor("room-nb", "a-good");
+        bad.add_cell(0, "c1", "code").unwrap();
+        bad.update_source("c1", "print('hi')").unwrap();
+
+        let mut s_bad = sync::State::new();
+        let mut s_good = sync::State::new();
+        sync_docs(&mut bad, &mut s_bad, &mut good, &mut s_good, 20);
+        bad.doc
+            .put(automerge::ROOT, "schema_version", "not-a-number")
+            .unwrap();
+        good.doc
+            .put(automerge::ROOT, "schema_version", 6u64)
+            .unwrap();
+        sync_docs(&mut bad, &mut s_bad, &mut good, &mut s_good, 20);
+
+        bad.save_to_file(&path).unwrap();
+
+        let loaded = NotebookDoc::load_or_create(&path, "room-nb");
+        assert_eq!(
+            loaded.schema_version(),
+            Some(6),
+            "the valid version wins over the malformed one in the conflict set"
+        );
+        assert_eq!(
+            loaded.cell_count(),
+            1,
+            "a doc with one usable version must not be discarded as corrupt"
+        );
+        assert!(
+            !path.with_extension("automerge.corrupt").exists(),
+            "a doc with a usable version must not be quarantined"
         );
     }
 

--- a/docs/architecture/cleanup-punchlist.md
+++ b/docs/architecture/cleanup-punchlist.md
@@ -83,7 +83,7 @@ Severity legend:
 
 | ID | Smell | Severity | Where |
 |----|-------|----------|-------|
-| SE-1 | `schema_version` is a single LWW scalar, single-writer only by convention (the migrate-on-load path is the lone writer, and desktop rooms are single-version). In a mixed-version cloud room two peers can write it concurrently and the CRDT picks an LWW winner by `(lamport, actor)`, unrelated to which schema is newer, so a stale peer can stamp the shared doc backward. Reproduced by `test_cross_version_schema_version_is_lww_not_monotonic`. Needs host-enforced single-writer auth or monotonic-max merge semantics before cloud ships mixed versions in one room. | Design | `crates/notebook-doc/src/lib.rs`, `docs/architecture/schema-evolution-and-genesis.md`, `docs/architecture/hosted-room-authorization.md` |
+| ~~SE-1~~ | **Done** in fix/se1-schema-version-monotonic-read. `schema_version` is now resolved read-side over its full Automerge conflict set (max of `get_all`) at both read sites: the `schema_version()` accessor and the `load_or_create_inner` classifier. A stale peer's concurrent write still lands in the CRDT, but every reader sees the newest version, so a backward stamp is never observed or persisted to `.ipynb`. The classifier keeps its tri-state (empty = absent, non-empty-no-integer = malformed, else max = valid). Chosen over write-back reconciliation (op-history growth on every restart, daemon-authored merge change desyncs peer sync state) and host-only write auth (no room-host concept exists; nothing for desktop or already-diverged docs). Guarded by `test_cross_version_schema_version_resolves_to_max_not_lww`, `test_load_resolves_schema_version_conflict_to_max`, `test_load_malformed_in_conflict_set_uses_valid_max`. | Done | `crates/notebook-doc/src/lib.rs`, `docs/architecture/schema-evolution-and-genesis.md` |
 
 ## Environment lifecycle
 
@@ -114,10 +114,10 @@ Severity legend:
 
 **Status legend:** Done = landed; Refuted = examined and rejected with rationale; Inline / Targeted / Design = open.
 
-- **Done:** WP-1, WP-2, WP-3, WP-5, WP-9, EP-2, EP-7, EP-12, BS-1, BS-8, BS-11. Eleven landed across #2813, cleanup/inline-pass, and targeted cleanup stacks.
+- **Done:** WP-1, WP-2, WP-3, WP-5, WP-9, EP-2, EP-7, EP-12, BS-1, BS-8, BS-11, SE-1. Twelve landed across #2813, cleanup/inline-pass, targeted cleanup stacks, and the SE-1 read-side fix.
 - **Refuted:** EP-4 (log levels are correct per `.claude/rules/logging.md`), EP-13 (warn/debug asymmetry matches the actual severity of `Full` vs `Closed`).
 - **Targeted PRs (one per smell):** WP-6, WP-7, WP-11, WP-12, 3D-1, 3D-2, EP-1, EP-8, EP-10, EP-11, BS-3, BS-7, TMD-1, TMD-2, MSL-1, MSL-3, FSB-1, FSB-2, HCA-1. Nineteen open.
-- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1, CEL-1, SE-1. Thirty open.
+- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1, CEL-1. Twenty-nine open.
 
 ## Next steps
 

--- a/docs/architecture/schema-evolution-and-genesis.md
+++ b/docs/architecture/schema-evolution-and-genesis.md
@@ -118,14 +118,16 @@ host. Three behaviors then matter, demonstrated by tests in
    sync, and the v5 peer keeps the vX peer's unknown top-level key and unknown
    cell-metadata key. Cells merge cleanly; the root is not doubled.
 
-2. **`schema_version` is LWW, not monotonic**
-   (`test_cross_version_schema_version_is_lww_not_monotonic`). Two peers writing
-   different versions concurrently converge to a single value, but it is an LWW
-   pick decided by `(lamport, actor)`, unrelated to which schema is newer. In the
-   test the *stale* peer wins and stamps the shared doc backward (v6 -> v4). This
-   is single-writer by **convention** only (the migrate-on-load path is the lone
-   writer, and desktop rooms are single-version). Cloud breaks the convention.
-   Tracked as **SE-1** in [cleanup-punchlist.md](cleanup-punchlist.md).
+2. **`schema_version` resolves to the conflict-set max, not the LWW winner**
+   (`test_cross_version_schema_version_resolves_to_max_not_lww`). Two peers
+   writing different versions concurrently leave an Automerge conflict set. A
+   plain `get` returns the `(lamport, actor)` winner, which can be the *older*
+   value, stamping the doc backward (v6 -> v4). Both read sites — the
+   `schema_version()` accessor and the load-time classifier — instead resolve
+   over the full conflict set (`get_all`) and take the max, so the observed
+   version is monotonic. The fix is read-side: the CRDT still records the LWW
+   pick, so there is no write-back and no op-history growth. This was **SE-1**;
+   see [cleanup-punchlist.md](cleanup-punchlist.md).
 
 3. **Divergent genesis breaks sync.** The original incident, at the sync layer.
    Guarded by #3134 (build-time drift) and #3192 (host hash-pinning). Any future
@@ -147,10 +149,25 @@ dropped at the `.ipynb` boundary. Additive cell data must live under
 5. Structural change uses a sidecar, never an in-place reshape of the root.
 6. `.ipynb` is the truth on disk for saved notebooks; the `.automerge` is the
    sole copy for untitled notebooks and the live sync substrate.
+7. `schema_version` is read through conflict-set max resolution, never a bare
+   `get`. A new read site must use `schema_version()` (or the same `get_all` +
+   max), or a concurrent stale write can be read as a backward stamp.
 
-## Open question
+## Resolution: read-side monotonic-max (SE-1)
 
-`schema_version` as a single LWW scalar has no mixed-version semantics. Before
-cloud ships mixed versions in one room it needs either host-enforced
-single-writer auth (does #3192's room-host auth let a peer update
-`schema_version`?) or monotonic-max merge semantics. See SE-1.
+`schema_version` stays a plain LWW scalar on the wire, but every reader resolves
+it over its full Automerge conflict set and takes the max. Both read sites carry
+the fix: the `schema_version()` accessor and the load-time classifier in
+`load_or_create_inner`. The classifier keeps its tri-state — an empty conflict
+set is absent (a v5-skeleton doc is current), a non-empty set with no
+non-negative integer is malformed (quarantine), otherwise the max is the version.
+
+Read-side resolution was chosen over write-back reconciliation (re-stamping the
+doc to the max on load/merge) and over host-enforced single-writer auth. Re-stamp
+mutates a doc on load, grows op history on every daemon restart, and at the sync
+merge point injects a daemon-authored change that desynchronizes peer sync state.
+Host auth needs a room-host concept that does not exist yet and does nothing for
+desktop or already-diverged docs. Read-side max is deterministic (the conflict
+set is identical across converged peers), needs no auth, heals already-diverged
+docs on read, and never writes. The `.am` binary keeps the conflict; that is
+harmless because `.ipynb` is the on-disk truth and every reader resolves the max.


### PR DESCRIPTION
`schema_version` is an Automerge LWW scalar. In a mixed-version room two peers can write it concurrently, and the `(lamport, actor)` winner can be the *older* value, stamping the doc backward (v6 -> v4). Both read sites trusted that raw winner: the `schema_version()` accessor and the `load_or_create_inner` classifier. Resolve `schema_version` over its full conflict set (`get_all`) and take the max at both sites.

This is SE-1 from `docs/architecture/cleanup-punchlist.md`.

## Design decision

The fix is read-side. The CRDT still records the LWW pick, so there is no write-back, no op-history growth, and no sync-state churn. The `.am` binary keeps the conflict; that is harmless because `.ipynb` is the on-disk truth and every reader resolves the max.

Two alternatives were rejected:

- **Write-back reconciliation** (re-stamp the doc to the max on load/merge). Mutates a doc on load, grows op history on every daemon restart, and at the sync merge point injects a daemon-authored change that desynchronizes peer sync state.
- **Host-only write auth.** Needs a room-host concept that does not exist yet, and does nothing for desktop or already-diverged docs.

Read-side max is deterministic (the conflict set is identical across converged peers), needs no auth, heals already-diverged docs on read, and never writes.

The load classifier keeps its tri-state. An empty conflict set is absent (a v5-skeleton doc is then current); a non-empty set with no non-negative integer is malformed (quarantine); otherwise the max is the version. This preserves the forward-tolerance, migration, and absent-vs-malformed invariants.

## Behavioral coverage

| `schema_version` conflict set | Resolved version | Outcome |
|---|---|---|
| `{4, 6}` (stale LWW winner = 4) | 6 | forward-tolerant load, no downgrade |
| `{"not-a-number", 6}` (malformed LWW winner) | 6 | valid value wins, not quarantined |
| singleton malformed (`"not-a-number"`) | None | still quarantined as `.corrupt` |
| absent + v5 skeleton | None | loads as current |
| singleton `{3}` / `{4}` | 3 / 4 | migrates in place, unchanged |

## Tests

- `test_cross_version_schema_version_resolves_to_max_not_lww` (accessor; also asserts the raw LWW pick is unchanged, documenting that the fix is read-side)
- `test_load_resolves_schema_version_conflict_to_max` (load classifier)
- `test_load_malformed_in_conflict_set_uses_valid_max` (malformed + valid in one set)

`cargo test -p notebook-doc --features persistence`, `cargo clippy --all-targets --features persistence -D warnings`, and `cargo fmt --check` pass. Genesis seed and the #3192 canonical-seed allowlist are untouched.
