### PR TITLE
fix(notebook-cloud): use shared cell chrome

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -85,3 +85,24 @@ test("cloud viewer defers supplemental CSS loading until the notebook surface mo
     /function CloudNotebookProviders[\s\S]*useEffect\(\(\) => \{\s*loadSupplementalViewerCss\(\);\s*\}, \[\]\);/,
   );
 });
+
+test("cloud notebook shell keeps the rail and toolbar outside the cell scroller", () => {
+  const sourcePath = new URL("../viewer/index.css", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(
+    sourceText,
+    /html,\s*\nbody,\s*\n#root\s*\{[\s\S]*height: 100%;[\s\S]*overflow: hidden;/,
+  );
+  assert.match(
+    sourceText,
+    /\.cloud-notebook-shell\s*\{[\s\S]*height: 100%;[\s\S]*overflow: hidden;/,
+  );
+  assert.match(sourceText, /\.cloud-notebook-rail\s*\{[\s\S]*height: 100%;/);
+  assert.match(sourceText, /\.cloud-report-toolbar\s*\{[\s\S]*top: 0;[\s\S]*border-bottom:/);
+  assert.match(sourceText, /\.cloud-report-notebook\s*\{[\s\S]*overflow-y: auto;/);
+  assert.doesNotMatch(
+    sourceText.match(/\.cloud-notebook-shell\s*\{[^}]*\}/)?.[0] ?? "",
+    /flex-direction: column;/,
+  );
+});

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -3,50 +3,52 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import * as ts from "typescript";
 
-test("cloud report-mode rendering leaves output iframes unfocused for page scrolling", () => {
-  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
-  const sourceText = readFileSync(sourcePath, "utf8");
-  const sourceFile = ts.createSourceFile(
-    sourcePath.pathname,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TSX,
-  );
+test("cloud notebook rendering uses shared cell chrome instead of report-mode cells", () => {
+  const sourcePaths = [
+    new URL("../viewer/index.tsx", import.meta.url),
+    new URL("../viewer/cloud-live-notebook.tsx", import.meta.url),
+  ];
   const offenders: string[] = [];
 
-  const visit = (node: ts.Node) => {
-    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
-      const tagName = node.tagName.getText(sourceFile);
-      if (tagName === "ReadOnlyNotebook" || tagName === "ReadOnlyNotebookCell") {
-        const attributes = node.attributes.properties;
-        const hasReportMode = attributes.some(
-          (attribute) =>
-            ts.isJsxAttribute(attribute) &&
-            attribute.name.getText(sourceFile) === "displayMode" &&
-            attribute.initializer?.getText(sourceFile) === '"report"',
-        );
-        const focusesOutputs = attributes.some(
-          (attribute) =>
-            ts.isJsxAttribute(attribute) && attribute.name.getText(sourceFile) === "focusOutputs",
-        );
+  for (const sourcePath of sourcePaths) {
+    const sourceText = readFileSync(sourcePath, "utf8");
+    const sourceFile = ts.createSourceFile(
+      sourcePath.pathname,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
 
-        if (hasReportMode && focusesOutputs) {
-          const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-          offenders.push(`${tagName}:${position.line + 1}`);
+    const visit = (node: ts.Node) => {
+      if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+        const tagName = node.tagName.getText(sourceFile);
+        if (tagName === "ReadOnlyNotebook" || tagName === "ReadOnlyNotebookCell") {
+          const attributes = node.attributes.properties;
+          const hasReportMode = attributes.some(
+            (attribute) =>
+              ts.isJsxAttribute(attribute) &&
+              attribute.name.getText(sourceFile) === "displayMode" &&
+              attribute.initializer?.getText(sourceFile) === '"report"',
+          );
+
+          if (hasReportMode) {
+            const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+            offenders.push(`${sourcePath.pathname}:${tagName}:${position.line + 1}`);
+          }
         }
       }
-    }
 
-    ts.forEachChild(node, visit);
-  };
+      ts.forEachChild(node, visit);
+    };
 
-  visit(sourceFile);
+    visit(sourceFile);
+  }
 
   assert.deepEqual(
     offenders,
     [],
-    "cloud report rendering should not focus output iframes; focused iframes trap page scroll",
+    "cloud notebook rendering should stay on notebook-mode cells so shared cell lanes and ribbons render",
   );
 });
 

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -87,7 +87,6 @@ export function CloudLiveNotebook({
             executionCount={cell.executionCount}
             priority={priority}
             hostContext={hostContext}
-            displayMode="report"
             showSource={cell.cellType !== "code" || showCode}
             className="cloud-cell"
             sourceClassName="cloud-source-block"

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -7,9 +7,8 @@
 html,
 body,
 #root {
-  min-height: 100%;
-  height: auto;
-  overflow: visible;
+  height: 100%;
+  overflow: hidden;
 }
 
 body {
@@ -18,24 +17,25 @@ body {
 
 .cloud-notebook-shell {
   display: flex;
-  min-height: 100vh;
+  height: 100%;
+  min-height: 0;
   min-width: 0;
+  overflow: hidden;
   background: var(--background);
 }
 
 .cloud-notebook-rail {
-  position: sticky;
-  top: 0;
   z-index: 15;
-  height: 100vh;
+  height: 100%;
 }
 
 .cloud-notebook-stage {
   display: flex;
+  min-height: 0;
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  padding-block: 1.5rem;
+  overflow: hidden;
 }
 
 .cloud-notebook-stage > .cloud-state {
@@ -191,13 +191,17 @@ body {
 
 .cloud-report-toolbar {
   position: sticky;
-  top: 0.5rem;
+  top: 0;
   z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  padding-block: 0.5rem;
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+  background: color-mix(in srgb, var(--background) 94%, transparent);
+  backdrop-filter: blur(12px);
   pointer-events: none;
 }
 
@@ -753,27 +757,13 @@ body {
   }
 }
 
-@media (max-width: 820px) {
-  .cloud-notebook-shell {
-    flex-direction: column;
-  }
-
-  .cloud-notebook-rail {
-    position: relative;
-    height: auto;
-    max-height: 45vh;
-  }
-
-  .cloud-notebook-rail [data-slot="notebook-rail-panel"] {
-    width: auto;
-    max-width: none;
-    min-width: 0;
-    flex: 1;
-  }
-}
-
 .cloud-report-notebook {
+  min-height: 0;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+  overscroll-behavior: contain;
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 0.75rem);
+  padding-block: 1rem 2rem;
 }
 
 .cloud-cell {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -784,6 +784,10 @@ body {
   padding-block: 0.25rem 1rem;
 }
 
+.cloud-cell[data-slot="cell-container"] {
+  padding-block: 0;
+}
+
 .cloud-editable-markdown-cell {
   padding-block: 0.25rem 1rem;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1283,7 +1283,6 @@ function NotebookViewer({
           viewModel={notebookViewModel}
           priority={CLOUD_VIEWER_PRIORITY}
           hostContext={outputHostContext}
-          displayMode="report"
           showCode={showCode}
           className="cloud-report-notebook"
           cellClassName="cloud-cell"

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -97,7 +97,7 @@ export function ReadOnlyNotebook({
                 priority={priority}
                 hostContext={hostContext}
                 displayMode={displayMode}
-                showSource={displayMode === "report" ? cell.cellType !== "code" || showCode : true}
+                showSource={cell.cellType !== "code" || showCode}
                 focusOutputs={focusOutputs}
                 deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
                 deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -207,6 +207,33 @@ describe("ReadOnlyNotebook", () => {
     expect(cells[1]).toHaveAttribute("data-show-source", "true");
   });
 
+  it("supports notebook display mode with local code visibility", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "code-cell",
+            cellType: "code",
+            source: "print('hidden')",
+            outputs: [{ output_type: "stream", name: "stdout", text: "visible\n" }],
+          },
+          {
+            id: "markdown-cell",
+            cellType: "markdown",
+            source: "# Still visible",
+          },
+        ]}
+        showCode={false}
+      />,
+    );
+
+    const cells = screen.getAllByTestId("read-only-cell");
+    expect(cells[0]).toHaveAttribute("data-display-mode", "notebook");
+    expect(cells[0]).toHaveAttribute("data-show-source", "false");
+    expect(cells[1]).toHaveAttribute("data-display-mode", "notebook");
+    expect(cells[1]).toHaveAttribute("data-show-source", "true");
+  });
+
   it("does not reset errored cells when unchanged cell data is remapped", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const output = { output_type: "stream", name: "stdout", text: "hi\n" } as const;


### PR DESCRIPTION
## Summary
- keep hosted cloud notebook rendering on shared notebook-mode cell chrome instead of report-mode cell wrappers
- preserve code hiding in notebook mode so the hosted viewer can hide code without opting out of shared cell lanes/ribbons
- align cloud shell geometry with the desktop-style fixed frame: left rail and toolbar outside the scrolling cell list

## Validation
- `pnpm exec vp test run src/components/cell/__tests__/ReadOnlyNotebook.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/cloud-view-model.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build`

## Notes
- This is still an incremental slice toward making cloud a host over the shared notebook shell. It does not claim full desktop `CodeCell` parity yet; it removes the report-mode branch that was bypassing shared cell chrome and fixes the shell scroll frame needed for desktop-like rail/header behavior.
