### PR TITLE
refactor(notebook): share markdown cell surface

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,7 +1,7 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { Pencil } from "lucide-react";
 import {
   memo,
+  type KeyboardEvent,
   type PointerEvent,
   type ReactNode,
   useCallback,
@@ -10,17 +10,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { CellContainer } from "@/components/cell/CellContainer";
-import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import { EditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
+import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
-import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
-import { injectPluginsForMimes } from "@/components/isolated/iframe-libraries";
-import { findVerticalScrollAncestor } from "@/components/isolated/scroll-boundary";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
-import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
-import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
@@ -33,25 +28,13 @@ import {
 } from "../lib/cell-ui-state";
 import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
-import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
-import { logger } from "../lib/logger";
-import {
-  isMeasuredElementFound,
-  registerMarkdownHeadingNavigator,
-} from "@/components/cell/markdown-heading-navigation";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
-const handleIframeError = (err: { message: string; stack?: string }) =>
-  logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
-
-function formatPluginLoadError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 interface MarkdownCellProps {
   cell: MarkdownCellType;
@@ -87,6 +70,13 @@ export const MarkdownCell = memo(function MarkdownCell({
   const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
   const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
   const searchQuery = useSearchQuery();
+  const [editing, setEditing] = useState(cell.source === "");
+  const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
+  const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const presence = usePresenceContext();
+  const { extension: crdtBridgeExt } = useCrdtBridge(cell.id);
+  const blobResolver = useBlobResolver();
+
   const applyInlineFormatting = useCallback(
     (prefix: string, suffix = prefix) =>
       (view: EditorView) => {
@@ -154,15 +144,6 @@ export const MarkdownCell = memo(function MarkdownCell({
     return true;
   }, []);
 
-  const [editing, setEditing] = useState(cell.source === "");
-  const editorRef = useRef<CodeMirrorEditorRef>(null);
-  const presence = usePresenceContext();
-  const { extension: crdtBridgeExt } = useCrdtBridge(cell.id);
-  const frameRef = useRef<IsolatedFrameHandle>(null);
-  const injectedLibsRef = useRef(new Set<string>());
-  const viewRef = useRef<HTMLDivElement>(null);
-  const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
-
   // Register EditorView with the cursor registry when in edit mode.
   const registeredViewRef = useRef<EditorView | null>(null);
   useEffect(() => {
@@ -214,14 +195,6 @@ export const MarkdownCell = memo(function MarkdownCell({
     };
   }, [cell.id, editing]);
 
-  const darkMode = useDarkMode();
-  const colorTheme = useColorTheme();
-  const darkModeRef = useRef(darkMode);
-  darkModeRef.current = darkMode;
-  const colorThemeRef = useRef(colorTheme);
-  colorThemeRef.current = colorTheme;
-
-  const blobResolver = useBlobResolver();
   const markdownMetadata = useMemo(
     () =>
       headingAnchors.length > 0
@@ -231,203 +204,9 @@ export const MarkdownCell = memo(function MarkdownCell({
         : undefined,
     [headingAnchors],
   );
-
-  const handleDoubleClick = useCallback(() => {
-    setEditing(true);
-  }, []);
-
-  const activatePreviewFrameInteraction = useCallback(() => {
-    setPreviewFrameInteractionActive(true);
-    onFocus();
-  }, [onFocus]);
-
-  const deactivatePreviewFrameInteractionWhenIdle = useCallback(
-    (event: PointerEvent<HTMLDivElement>) => {
-      if (
-        event.relatedTarget instanceof Node &&
-        event.currentTarget.contains(event.relatedTarget)
-      ) {
-        return;
-      }
-      if (!(event.buttons > 0)) {
-        setPreviewFrameInteractionActive(false);
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (!isFocused || editing) {
-      setPreviewFrameInteractionActive(false);
-    }
-  }, [isFocused, editing]);
-
-  const handleBlur = useCallback(() => {
-    if (cell.source.trim()) {
-      setEditing(false);
-    }
-  }, [cell.source]);
-
-  // Render markdown content when iframe is ready
-  const handleFrameReady = useCallback(async () => {
-    if (!frameRef.current || !cell.source) return;
-    // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
-    frameRef.current.setTheme(darkModeRef.current, colorThemeRef.current ?? null);
-    // Clear injected set — a reloaded iframe has a fresh renderer registry
-    injectedLibsRef.current.clear();
-    // Inject markdown renderer plugin before rendering (idempotent, cached after first load)
-    try {
-      await injectPluginsForMimes(frameRef.current, ["text/markdown"], injectedLibsRef.current);
-    } catch (error) {
-      logger.warn("[MarkdownCell] Failed to load markdown renderer plugin:", error);
-      frameRef.current.render({
-        mimeType: "text/plain",
-        data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
-        outputId: `markdown-error:${cell.id}`,
-        cellId: cell.id,
-        replace: true,
-      });
-      return;
-    }
-    const processedSource = rewriteMarkdownAssetRefs(
-      cell.source,
-      cell.resolvedAssets,
-      blobResolver,
-    );
-    frameRef.current.render({
-      mimeType: "text/markdown",
-      data: processedSource,
-      metadata: markdownMetadata,
-      outputId: `markdown:${cell.id}`,
-      cellId: cell.id,
-      replace: true,
-    });
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
-
-  // Sync markdown to iframe whenever source or resolved assets change (supports RTC updates)
-  useEffect(() => {
-    if (frameRef.current?.isReady && cell.source) {
-      const frame = frameRef.current;
-      // Inject markdown renderer plugin (idempotent) then render
-      injectPluginsForMimes(frame, ["text/markdown"], injectedLibsRef.current)
-        .then(() => {
-          const processedSource = rewriteMarkdownAssetRefs(
-            cell.source,
-            cell.resolvedAssets,
-            blobResolver,
-          );
-          frame.render({
-            mimeType: "text/markdown",
-            data: processedSource,
-            metadata: markdownMetadata,
-            outputId: `markdown:${cell.id}`,
-            cellId: cell.id,
-            replace: true,
-          });
-        })
-        .catch((error) => {
-          logger.warn("[MarkdownCell] Failed to load markdown renderer plugin:", error);
-          frame.render({
-            mimeType: "text/plain",
-            data: `Failed to load markdown renderer: ${formatPluginLoadError(error)}`,
-            outputId: `markdown-error:${cell.id}`,
-            cellId: cell.id,
-            replace: true,
-          });
-        });
-    }
-  }, [cell.source, cell.id, cell.resolvedAssets, blobResolver, markdownMetadata]);
-
-  const scrollToHeading = useCallback(
-    async (headingAnchorId: string, options?: { behavior?: ScrollBehavior }) => {
-      if (editing || !headingAnchorId || !frameRef.current?.isReady) return false;
-
-      const measurement = await frameRef.current.measureElement(headingAnchorId);
-      if (!isMeasuredElementFound(measurement)) return false;
-
-      const iframe = viewRef.current?.querySelector<HTMLIFrameElement>(
-        'iframe[data-slot="isolated-frame"]',
-      );
-      if (!iframe) return false;
-
-      const behavior = options?.behavior ?? "smooth";
-      const topPadding = 16;
-      const iframeRect = iframe.getBoundingClientRect();
-      const scrollContainer = findVerticalScrollAncestor(iframe.parentElement ?? iframe);
-
-      if (scrollContainer) {
-        const containerRect = scrollContainer.getBoundingClientRect();
-        scrollContainer.scrollTo({
-          top: Math.max(
-            0,
-            scrollContainer.scrollTop +
-              iframeRect.top -
-              containerRect.top +
-              measurement.top -
-              topPadding,
-          ),
-          behavior,
-        });
-        return true;
-      }
-
-      window.scrollTo({
-        top: Math.max(0, window.scrollY + iframeRect.top + measurement.top - topPadding),
-        behavior,
-      });
-      return true;
-    },
-    [editing],
-  );
-
-  useEffect(() => {
-    return registerMarkdownHeadingNavigator(cell.id, scrollToHeading);
-  }, [cell.id, scrollToHeading]);
-
-  // Handle link clicks from iframe - open in system browser
-  const handleLinkClick = useCallback((url: string) => {
-    openUrl(url);
-  }, []);
-
-  // Handle keyboard navigation in view mode (when not editing)
-  const handleViewKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
-        onFocusNext?.("start");
-        e.preventDefault();
-      } else if (e.key === "ArrowUp") {
-        onFocusPrevious?.("end");
-        e.preventDefault();
-      } else if (e.key === "Enter" && e.ctrlKey && !e.metaKey && !e.altKey) {
-        setEditing(false);
-        e.preventDefault();
-      } else if (e.key === "Enter" && e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        // Shift+Enter: move to next cell (like execute for code cells)
-        onFocusNext?.("start");
-        e.preventDefault();
-      } else if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
-        // Enter: enter edit mode
-        setEditing(true);
-        e.preventDefault();
-      }
-    },
-    [onFocusNext, onFocusPrevious],
-  );
-
-  // Handle focus next, creating a new cell if at the end
-  const handleFocusNextOrCreate = useCallback(
-    (cursorPosition: "start" | "end") => {
-      // For markdown, close edit mode first
-      if (cell.source.trim()) {
-        setEditing(false);
-      }
-      if (isLastCell && onInsertCellAfter) {
-        onInsertCellAfter();
-      } else if (onFocusNext) {
-        onFocusNext(cursorPosition);
-      }
-    },
-    [cell.source, isLastCell, onFocusNext, onInsertCellAfter],
+  const previewSource = useMemo(
+    () => rewriteMarkdownAssetRefs(cell.source, cell.resolvedAssets, blobResolver),
+    [cell.resolvedAssets, cell.source, blobResolver],
   );
 
   // Remote cursors extension (stable — no deps that change)
@@ -458,7 +237,20 @@ export const MarkdownCell = memo(function MarkdownCell({
     [searchQuery, remoteCursorsExt, textAttributionExt, presenceSenderExt],
   );
 
-  // Get keyboard navigation bindings
+  const handleFocusNextOrCreate = useCallback(
+    (cursorPosition: "start" | "end") => {
+      if (cell.source.trim()) {
+        setEditing(false);
+      }
+      if (isLastCell && onInsertCellAfter) {
+        onInsertCellAfter();
+      } else if (onFocusNext) {
+        onFocusNext(cursorPosition);
+      }
+    },
+    [cell.source, isLastCell, onFocusNext, onInsertCellAfter],
+  );
+
   const navigationKeyMap = useCellKeyboardNavigation({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
     onFocusNext: handleFocusNextOrCreate,
@@ -467,7 +259,6 @@ export const MarkdownCell = memo(function MarkdownCell({
     cellId: cell.id,
   });
 
-  // Combine navigation with markdown-specific keys
   const keyMap: KeyBinding[] = useMemo(
     () => [
       {
@@ -521,128 +312,120 @@ export const MarkdownCell = memo(function MarkdownCell({
     ],
   );
 
-  // Focus editor when entering edit mode (after initial mount)
-  const initialMountRef = useRef(true);
-  useEffect(() => {
-    if (initialMountRef.current) {
-      initialMountRef.current = false;
+  const editorExtensions = useMemo(
+    () => [crdtBridgeExt, ...searchExtensions],
+    [crdtBridgeExt, searchExtensions],
+  );
+  const handlePreviewLinkClick = useCallback((url: string) => {
+    openUrl(url);
+  }, []);
+
+  const handlePreviewPointerDown = useCallback(
+    (_event?: PointerEvent<HTMLDivElement>) => {
+      setPreviewFrameInteractionActive(true);
+      onFocus();
+    },
+    [onFocus],
+  );
+
+  const handlePreviewPointerOut = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (event.relatedTarget instanceof Node && event.currentTarget.contains(event.relatedTarget)) {
       return;
     }
-    if (editing) {
-      requestAnimationFrame(() => {
-        editorRef.current?.focus();
-      });
+    if (!(event.buttons > 0)) {
+      setPreviewFrameInteractionActive(false);
     }
-  }, [editing]);
+  }, []);
 
-  // Forward search query to the markdown iframe
-  useEffect(() => {
-    if (!editing && frameRef.current?.isReady) {
-      frameRef.current.search(searchQuery || "");
+  const handlePreviewKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowDown") {
+        onFocusNext?.("start");
+        event.preventDefault();
+        return true;
+      }
+      if (event.key === "ArrowUp") {
+        onFocusPrevious?.("end");
+        event.preventDefault();
+        return true;
+      }
+      if (event.key === "Enter" && event.ctrlKey && !event.metaKey && !event.altKey) {
+        setEditing(false);
+        event.preventDefault();
+        return true;
+      }
+      if (
+        event.key === "Enter" &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey
+      ) {
+        onFocusNext?.("start");
+        event.preventDefault();
+        return true;
+      }
+      return false;
+    },
+    [onFocusNext, onFocusPrevious],
+  );
+
+  const handleEditingChange = useCallback((nextEditing: boolean) => {
+    setEditing(nextEditing);
+    if (nextEditing) {
+      setPreviewFrameInteractionActive(false);
     }
-  }, [searchQuery, editing]);
+  }, []);
+  const handlePreviewIframeDoubleClick = useCallback(() => {
+    handleEditingChange(true);
+  }, [handleEditingChange]);
 
-  // Focus view section when cell becomes focused but not editing
   useEffect(() => {
-    if (isFocused && !editing) {
-      requestAnimationFrame(() => {
-        viewRef.current?.focus({ preventScroll: true });
-      });
+    if (!isFocused || editing) {
+      setPreviewFrameInteractionActive(false);
     }
   }, [isFocused, editing]);
 
   return (
-    <CellContainer
+    <EditableMarkdownCell
       id={cell.id}
-      cellType="markdown"
+      source={cell.source}
+      editing={editing}
+      onEditingChange={handleEditingChange}
+      editorRef={editorRef}
       isFocused={isFocused}
+      onFocus={onFocus}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
       isNextCellFromFocused={isNextCellFromFocused}
-      onFocus={onFocus}
-      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
       dragHandleProps={dragHandleProps}
       isDragging={isDragging}
-      rightGutterContent={
-        editing ? (
-          rightGutterContent
-        ) : (
-          <div className="flex flex-col gap-0.5">
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => setEditing(true)}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
-              title="Edit"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </button>
-            {rightGutterContent}
-          </div>
-        )
+      previewSource={previewSource}
+      previewOutputId={`markdown:${cell.id}`}
+      previewFrameName={`md-${cell.id}`}
+      previewMetadata={markdownMetadata}
+      previewSearchQuery={searchQuery || ""}
+      previewFocused={previewFrameInteractionActive}
+      keepPreviewMounted
+      previewLabel="Markdown cell content"
+      onPreviewKeyDown={handlePreviewKeyDown}
+      onPreviewLinkClick={handlePreviewLinkClick}
+      onPreviewPointerDown={handlePreviewPointerDown}
+      onPreviewPointerOut={handlePreviewPointerOut}
+      onPreviewIframeMouseDown={handlePreviewPointerDown}
+      onPreviewIframeDoubleClick={handlePreviewIframeDoubleClick}
+      editorKeyMap={keyMap}
+      editorExtensions={editorExtensions}
+      placeholder="Enter markdown..."
+      editorClassName="min-h-[2rem]"
+      editorHeaderContent={
+        <div className="flex items-center gap-1 py-1">
+          <span className="text-xs text-muted-foreground font-mono">md</span>
+        </div>
       }
-      codeContent={
-        <>
-          {/* Editor section - hidden when not editing */}
-          <div className={editing ? "block" : "hidden"}>
-            <div className="flex items-center gap-1 py-1">
-              <span className="text-xs text-muted-foreground font-mono">md</span>
-            </div>
-            <div>
-              <CodeMirrorEditor
-                ref={editorRef}
-                initialValue={cell.source}
-                language="markdown"
-                lineWrapping
-                onBlur={handleBlur}
-                keyMap={keyMap}
-                extensions={[crdtBridgeExt, ...searchExtensions]}
-                placeholder="Enter markdown..."
-                className="min-h-[2rem]"
-                autoFocus={editing}
-              />
-            </div>
-          </div>
-
-          {/* View section - hidden when editing */}
-          <div
-            ref={viewRef}
-            role="textbox"
-            aria-readonly
-            aria-label="Markdown cell content"
-            tabIndex={0}
-            className={cn("py-2 cursor-text outline-none", editing && "hidden")}
-            onDoubleClick={handleDoubleClick}
-            onKeyDown={handleViewKeyDown}
-          >
-            {/* Always render IsolatedFrame to preload it (hidden when no content) */}
-            <div
-              className={cell.source ? undefined : "hidden"}
-              onPointerDown={activatePreviewFrameInteraction}
-              onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
-            >
-              <IsolatedFrame
-                ref={frameRef}
-                name={`md-${cell.id}`}
-                darkMode={darkMode}
-                colorTheme={colorTheme}
-                minHeight={24}
-                autoHeight
-                scrollPassthrough={!previewFrameInteractionActive}
-                allowWheelBoundaryScroll={previewFrameInteractionActive}
-                revealOnRender
-                onReady={handleFrameReady}
-                onLinkClick={handleLinkClick}
-                onMouseDown={activatePreviewFrameInteraction}
-                onDoubleClick={handleDoubleClick}
-                onError={handleIframeError}
-                onDiagnostic={logNotebookIsolatedDiagnostic}
-                className="w-full"
-              />
-            </div>
-            {!cell.source && <p className="text-muted-foreground italic">Double-click to edit</p>}
-          </div>
-        </>
-      }
+      previewClassName="cursor-text outline-none"
+      previewOutputClassName="py-2"
+      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
+      rightGutterContent={rightGutterContent}
     />
   );
 });

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,4 +1,4 @@
-import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, createEvent, fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MarkdownCell as MarkdownCellType } from "../../types";
@@ -29,11 +29,16 @@ vi.mock("@/lib/dark-mode", () => ({
   useColorTheme: () => mockColorTheme,
 }));
 
-vi.mock("@/components/isolated/iframe-libraries", () => ({
-  injectPluginsForMimes: vi.fn(async () => {}),
-}));
+vi.mock("@/components/isolated/iframe-libraries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/isolated/iframe-libraries")>();
+  return {
+    ...actual,
+    injectPluginsForMimes: vi.fn(async () => {}),
+  };
+});
 
-vi.mock("@/components/isolated", async () => {
+vi.mock("@/components/isolated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/isolated")>();
   const React = await import("react");
 
   const MockIsolatedFrame = React.forwardRef<
@@ -57,6 +62,7 @@ vi.mock("@/components/isolated", async () => {
   });
 
   return {
+    ...actual,
     IsolatedFrame: MockIsolatedFrame,
   };
 });
@@ -203,15 +209,17 @@ describe("MarkdownCell theme sync", () => {
     });
 
     expect(isolatedFrameProps.at(-1)?.colorTheme).toBe("cream");
+    expect(isolatedFrameProps.at(-1)?.revealOnRender).toBe(true);
 
     await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/markdown",
-        data: "```python\nprint('hello')\n```",
-        outputId: "markdown:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/markdown",
+          data: "```python\nprint('hello')\n```",
+          outputId: "markdown:md-1",
+          cellId: "md-1",
+        }),
+      ]);
     });
   });
 
@@ -221,13 +229,14 @@ describe("MarkdownCell theme sync", () => {
     render(<MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />);
 
     await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/plain",
-        data: "Failed to load markdown renderer: chunk failed",
-        outputId: "markdown-error:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/plain",
+          data: "Failed to load renderer plugin: chunk failed",
+          outputId: "md-1:plugin-load-error",
+          cellId: "md-1",
+        }),
+      ]);
     });
   });
 
@@ -252,14 +261,15 @@ describe("MarkdownCell theme sync", () => {
     );
 
     await waitFor(() => {
-      expect(mockFrameHandle.render).toHaveBeenCalledWith({
-        mimeType: "text/markdown",
-        data: "# Load data",
-        metadata: { nteractMarkdownHeadingAnchors: headingAnchors },
-        outputId: "markdown:md-1",
-        cellId: "md-1",
-        replace: true,
-      });
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/markdown",
+          data: "# Load data",
+          metadata: { nteractMarkdownHeadingAnchors: headingAnchors },
+          outputId: "markdown:md-1",
+          cellId: "md-1",
+        }),
+      ]);
     });
   });
 
@@ -280,53 +290,67 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
-  it("activates markdown iframe pointer interaction after clicking the preview", () => {
+  it("lets the markdown iframe own pointer interaction without entering output-well layout", async () => {
     const onFocus = vi.fn();
 
-    const { getByTestId } = render(
+    const { getByLabelText } = render(
       <MarkdownCell cell={makeCell()} onFocus={onFocus} onDelete={() => {}} />,
     );
 
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+    expect(isolatedFrameProps.at(-1)?.autoHeight).toBe(true);
 
-    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
+    const previewWrapper = getByLabelText("Markdown cell content");
 
     fireEvent.pointerDown(previewWrapper);
 
     expect(onFocus).toHaveBeenCalled();
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+    await waitFor(() => {
+      expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+      expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+      expect(isolatedFrameProps.at(-1)?.autoHeight).toBe(true);
+    });
 
     pointerOutWithButtons(previewWrapper, 1);
-
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
-
     pointerOutWithButtons(previewWrapper, 0);
+    await waitFor(() => {
+      expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
+      expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+    });
+  });
 
-    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
-    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+  it("enters edit mode from double-clicks forwarded by the iframe", async () => {
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    expect(getByTestId("markdown-frame")).toBeVisible();
+
+    act(() => {
+      (isolatedFrameProps.at(-1)?.onDoubleClick as (() => void) | undefined)?.();
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("markdown-editor")).toBeVisible();
+    });
   });
 
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {
     const cell = { ...makeCell(), source: "" };
 
-    const { getByLabelText, getByTestId } = render(
+    const { getByTestId, queryByLabelText, findByLabelText } = render(
       <MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />,
     );
 
-    const preview = getByLabelText("Markdown cell content");
-    expect(preview.className).toContain("hidden");
+    expect(queryByLabelText("Markdown cell content")?.className).toContain("hidden");
 
     fireEvent.keyDown(getByTestId("markdown-editor"), {
       key: "Enter",
       ctrlKey: true,
     });
 
-    await waitFor(() => {
-      expect(preview.className).not.toContain("hidden");
-    });
+    await expect(findByLabelText("Markdown cell content")).resolves.toBeVisible();
   });
 
   it("Ctrl+Enter keeps markdown preview in view mode", () => {

--- a/src/components/cell/EditableMarkdownCell.tsx
+++ b/src/components/cell/EditableMarkdownCell.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
   type KeyboardEvent,
   type MouseEvent,
+  type PointerEvent,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -30,9 +31,16 @@ export interface EditableMarkdownCellProps {
   editing: boolean;
   onEditingChange: (editing: boolean) => void;
   editorRef: RefObject<CodeMirrorEditorRef | null>;
+  isFocused?: boolean;
+  onFocus?: () => void;
+  isPreviousCellFromFocused?: boolean;
+  isNextCellFromFocused?: boolean;
+  dragHandleProps?: Record<string, unknown>;
+  isDragging?: boolean;
   className?: string;
   sourceClassName?: string;
   editorClassName?: string;
+  editorHeaderContent?: ReactNode;
   previewClassName?: string;
   previewOutputClassName?: string;
   actionClassName?: string;
@@ -41,7 +49,24 @@ export interface EditableMarkdownCellProps {
   hostContext?: NteractEmbedHostContextPatch;
   editorExtensions?: readonly Extension[];
   editorKeyMap?: readonly KeyBinding[];
+  previewSource?: string;
+  previewOutputId?: string;
+  previewFrameName?: string;
+  previewMetadata?: Record<string, unknown>;
+  previewSearchQuery?: string;
+  previewFocused?: boolean;
+  keepPreviewMounted?: boolean;
+  revealPreviewOnRender?: boolean;
+  previewLabel?: string;
+  onPreviewSearchMatchCount?: (count: number) => void;
+  onPreviewLinkClick?: (url: string, newTab: boolean) => void;
+  onPreviewKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => boolean | void;
+  onPreviewPointerDown?: (event: PointerEvent<HTMLDivElement>) => void;
+  onPreviewPointerOut?: (event: PointerEvent<HTMLDivElement>) => void;
+  onPreviewIframeMouseDown?: () => void;
+  onPreviewIframeDoubleClick?: () => void;
   presenceIndicators?: ReactNode;
+  rightGutterContent?: ReactNode;
 }
 
 export function EditableMarkdownCell({
@@ -51,9 +76,16 @@ export function EditableMarkdownCell({
   editing,
   onEditingChange,
   editorRef,
+  isFocused = false,
+  onFocus,
+  isPreviousCellFromFocused = false,
+  isNextCellFromFocused = false,
+  dragHandleProps,
+  isDragging = false,
   className,
   sourceClassName,
   editorClassName,
+  editorHeaderContent,
   previewClassName,
   previewOutputClassName,
   actionClassName,
@@ -62,20 +94,38 @@ export function EditableMarkdownCell({
   hostContext,
   editorExtensions,
   editorKeyMap,
+  previewSource = source,
+  previewOutputId = `markdown-source:${id}`,
+  previewFrameName,
+  previewMetadata,
+  previewSearchQuery,
+  previewFocused = false,
+  keepPreviewMounted = false,
+  revealPreviewOnRender = true,
+  previewLabel = "Markdown cell content",
+  onPreviewSearchMatchCount,
+  onPreviewLinkClick,
+  onPreviewKeyDown,
+  onPreviewPointerDown,
+  onPreviewPointerOut,
+  onPreviewIframeMouseDown,
+  onPreviewIframeDoubleClick,
   presenceIndicators,
+  rightGutterContent,
 }: EditableMarkdownCellProps) {
   const suppressNextToggleClickRef = useRef(false);
   const viewRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
   const previewFrameRef = useRef<IsolatedFrameHandle | null>(null);
 
   const markdownOutput = useMemo<JupyterOutput>(
     () => ({
-      output_id: `markdown-source:${id}`,
+      output_id: previewOutputId,
       output_type: "display_data",
-      data: { "text/markdown": source },
-      metadata: {},
+      data: { "text/markdown": previewSource },
+      metadata: previewMetadata ? { "text/markdown": previewMetadata } : {},
     }),
-    [id, source],
+    [previewMetadata, previewOutputId, previewSource],
   );
   const editorExtensionArray = useMemo(
     () => (editorExtensions ? [...editorExtensions] : undefined),
@@ -125,12 +175,13 @@ export function EditableMarkdownCell({
 
   const handlePreviewKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
+      if (onPreviewKeyDown?.(event) || event.defaultPrevented) return;
       if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.altKey) {
         event.preventDefault();
         enterEditing();
       }
     },
-    [enterEditing],
+    [enterEditing, onPreviewKeyDown],
   );
 
   const handlePreviewFrameHandleChange = useCallback((handle: IsolatedFrameHandle | null) => {
@@ -162,62 +213,104 @@ export function EditableMarkdownCell({
     return () => cancelAnimationFrame(frame);
   }, [editing, editorRef]);
 
+  useEffect(() => {
+    if (!isFocused || editing) return;
+    const frame = requestAnimationFrame(() => {
+      previewRef.current?.focus({ preventScroll: true });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editing, isFocused]);
+
+  const actionButton = (
+    <button
+      type="button"
+      className={actionClassName}
+      aria-label={editing ? "Render markdown" : "Edit markdown"}
+      title={editing ? "Render markdown" : "Edit markdown"}
+      onMouseDown={handleActionMouseDown}
+      onClick={handleActionClick}
+    >
+      {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
+    </button>
+  );
+
   return (
     <CellContainer
       ref={viewRef}
       id={id}
       elementId={elementId}
       cellType="markdown"
+      isFocused={isFocused}
+      onFocus={onFocus}
+      isPreviousCellFromFocused={isPreviousCellFromFocused}
+      isNextCellFromFocused={isNextCellFromFocused}
+      dragHandleProps={dragHandleProps}
+      isDragging={isDragging}
       className={className}
       presenceIndicators={presenceIndicators}
       rightGutterContent={
-        <button
-          type="button"
-          className={actionClassName}
-          aria-label={editing ? "Render markdown" : "Edit markdown"}
-          title={editing ? "Render markdown" : "Edit markdown"}
-          onMouseDown={handleActionMouseDown}
-          onClick={handleActionClick}
-        >
-          {editing ? <Check aria-hidden="true" /> : <Pencil aria-hidden="true" />}
-        </button>
-      }
-      codeContent={
-        editing ? (
-          <div className={sourceClassName} data-slot="editable-markdown-source">
-            <CodeMirrorEditor
-              ref={editorRef}
-              initialValue={source}
-              language="markdown"
-              lineWrapping
-              onBlur={exitEditing}
-              keyMap={editorKeyMapArray}
-              extensions={editorExtensionArray}
-              placeholder={placeholder}
-              className={cn("min-h-[2rem]", editorClassName)}
-            />
+        rightGutterContent ? (
+          <div className="flex flex-col gap-0.5">
+            {actionButton}
+            {rightGutterContent}
           </div>
         ) : (
-          <div
-            className={cn(previewClassName, sourceClassName)}
-            data-slot="editable-markdown-preview"
-            role="textbox"
-            aria-readonly
-            tabIndex={0}
-            onDoubleClick={enterEditing}
-            onKeyDown={handlePreviewKeyDown}
-          >
-            <OutputArea
-              cellId={id}
-              outputs={[markdownOutput]}
-              isolated="auto"
-              priority={priority}
-              hostContext={hostContext}
-              className={previewOutputClassName}
-              onIsolatedFrameHandleChange={handlePreviewFrameHandleChange}
-            />
-          </div>
+          actionButton
         )
+      }
+      codeContent={
+        <>
+          {editing ? (
+            <div className={sourceClassName} data-slot="editable-markdown-source">
+              {editorHeaderContent}
+              <CodeMirrorEditor
+                ref={editorRef}
+                initialValue={source}
+                language="markdown"
+                lineWrapping
+                onBlur={exitEditing}
+                keyMap={editorKeyMapArray}
+                extensions={editorExtensionArray}
+                placeholder={placeholder}
+                className={cn("min-h-[2rem]", editorClassName)}
+              />
+            </div>
+          ) : null}
+          {!editing || keepPreviewMounted ? (
+            <div
+              ref={previewRef}
+              className={cn(previewClassName, sourceClassName, editing && "hidden")}
+              data-slot="editable-markdown-preview"
+              role="textbox"
+              aria-readonly
+              aria-label={previewLabel}
+              tabIndex={0}
+              onDoubleClick={enterEditing}
+              onKeyDown={handlePreviewKeyDown}
+              onPointerDown={onPreviewPointerDown}
+              onPointerOut={onPreviewPointerOut}
+            >
+              <OutputArea
+                cellId={id}
+                isolatedFrameName={previewFrameName}
+                outputs={[markdownOutput]}
+                isolated="auto"
+                priority={priority}
+                hostContext={hostContext}
+                className={previewOutputClassName}
+                searchQuery={previewSearchQuery}
+                isolatedFrameScrollPassthrough={!previewFocused}
+                isolatedFrameAllowWheelBoundaryScroll={previewFocused}
+                revealIsolatedFrameOnRender={revealPreviewOnRender}
+                onSearchMatchCount={onPreviewSearchMatchCount}
+                onLinkClick={onPreviewLinkClick}
+                onIframeMouseDown={onPreviewIframeMouseDown}
+                onIframeDoubleClick={onPreviewIframeDoubleClick}
+                onIsolatedFrameHandleChange={handlePreviewFrameHandleChange}
+              />
+            </div>
+          ) : null}
+        </>
       }
     />
   );

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -192,6 +192,11 @@ interface OutputAreaProps {
    */
   cellId?: string;
   /**
+   * Explicit isolated iframe name. Markdown preview surfaces use this to keep
+   * their frame discoverable as `md-{cellId}` for outline heading navigation.
+   */
+  isolatedFrameName?: string;
+  /**
    * Execution count for the cell. Used to label the isolated iframe with
    * `code-Out[N]-{cellId}` so the dev-tools frame picker shows something
    * meaningful instead of a stack of identical `localhost` rows.
@@ -279,6 +284,12 @@ interface OutputAreaProps {
    */
   deferredIsolatedFrameRootMargin?: string;
   /**
+   * Hide the isolated iframe until the first render payload lands. This avoids
+   * a visible empty-frame flash on markdown preview surfaces that keep their
+   * iframe mounted across edit toggles.
+   */
+  revealIsolatedFrameOnRender?: boolean;
+  /**
    * Callback when a link is clicked in isolated outputs.
    */
   onLinkClick?: (url: string, newTab: boolean) => void;
@@ -302,6 +313,23 @@ interface OutputAreaProps {
    * Use to update cell focus when the click is captured by the iframe.
    */
   onIframeMouseDown?: () => void;
+  /**
+   * Override isolated iframe scroll passthrough without opting into the focused
+   * output-well layout. Markdown previews use this while the frame owns pointer
+   * interaction but should keep natural auto-height sizing.
+   */
+  isolatedFrameScrollPassthrough?: boolean;
+  /**
+   * Override whether wheel events at the isolated iframe boundary propagate to
+   * the notebook scroll container.
+   */
+  isolatedFrameAllowWheelBoundaryScroll?: boolean;
+  /**
+   * Callback when the user double-clicks inside an isolated output iframe.
+   * Markdown cells use this to enter edit mode even after the iframe owns
+   * pointer events.
+   */
+  onIframeDoubleClick?: () => void;
   /**
    * Exposes the mounted isolated frame handle to shared cell surfaces that need
    * iframe RPCs, such as markdown heading measurement for outline navigation.
@@ -604,6 +632,7 @@ export function OutputArea({
 function OutputAreaSingle({
   outputs,
   cellId,
+  isolatedFrameName,
   executionCount,
   collapsed = false,
   collapseOutputCount = outputs.length,
@@ -619,11 +648,15 @@ function OutputAreaSingle({
   preloadIframe = false,
   deferIsolatedFrameUntilVisible = false,
   deferredIsolatedFrameRootMargin = DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN,
+  revealIsolatedFrameOnRender = false,
   onLinkClick,
   onWidgetUpdate,
   searchQuery,
   onSearchMatchCount,
   onIframeMouseDown,
+  isolatedFrameScrollPassthrough,
+  isolatedFrameAllowWheelBoundaryScroll,
+  onIframeDoubleClick,
   onIsolatedFrameHandleChange,
   onDiagnostic,
   hostContext,
@@ -689,9 +722,9 @@ function OutputAreaSingle({
   // Jupyter `Out[N]` convention with the cell ID appended so the picker can
   // distinguish reruns and concurrent cells. `*` matches Jupyter's queued /
   // never-run indicator.
-  const frameName = cellId
-    ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}`
-    : undefined;
+  const frameName =
+    isolatedFrameName ??
+    (cellId ? `code-Out[${executionCount == null ? "*" : executionCount}]-${cellId}` : undefined);
 
   // Check if we have widgets and should set up comm bridge
   const hasWidgets = hasWidgetOutputs(outputs, priority);
@@ -703,10 +736,12 @@ function OutputAreaSingle({
     !hasWidgets &&
     outputs.every((output) => outputAllowsScrollPassthrough(output, priority));
   const shouldScrollPassthroughFrame =
-    shouldUseScrollPassthroughFrame && !staticFrameInteractionActive;
+    isolatedFrameScrollPassthrough ??
+    (shouldUseScrollPassthroughFrame && !staticFrameInteractionActive);
   const shouldLockSiftWheelBoundary = hasSiftOutputs && staticFrameInteractionActive;
   const allowWheelBoundaryScroll =
-    !focused && !shouldScrollPassthroughFrame && !shouldLockSiftWheelBoundary;
+    isolatedFrameAllowWheelBoundaryScroll ??
+    (!focused && !shouldScrollPassthroughFrame && !shouldLockSiftWheelBoundary);
   const showSiftInteractionCue =
     shouldMountIsolatedFrame &&
     hasSiftOutputs &&
@@ -1094,10 +1129,12 @@ function OutputAreaSingle({
                   onReady={handleIsolatedFrameReady}
                   onLinkClick={onLinkClick}
                   onMouseDown={activateStaticFrameInteraction}
+                  onDoubleClick={onIframeDoubleClick}
                   onWidgetUpdate={onWidgetUpdate}
                   onMessage={handleIframeMessage}
                   onError={handleIframeError}
                   onDiagnostic={onDiagnostic}
+                  revealOnRender={revealIsolatedFrameOnRender}
                   hostContext={hostContext}
                   outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
                 />


### PR DESCRIPTION
## Summary

- routes desktop `MarkdownCell` through the shared `EditableMarkdownCell` surface
- widens the shared markdown/output primitives for host adapters: focus state, keyboard hooks, preview metadata/search/link handling, iframe double-click forwarding, reveal-on-render, and right-gutter content
- keeps desktop-specific behavior as adapters around the shared cell: CRDT bridge, presence, asset rewriting, search extensions, open-url handling, and notebook navigation keymaps

## Stack

Depends on:

1. #3213 - shared notebook-mode cloud cell chrome
2. #3214 - shared capability-scoped document header

Merge #3213 first, then #3214, then retarget this PR to `main`.

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/EditableMarkdownCell.test.tsx apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm exec vp test run apps/notebook/src/components/__tests__/markdown-formatting.test.ts apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/cell/__tests__/EditableMarkdownCell.test.tsx`
- `cargo xtask lint --fix`
