### PR TITLE
fix(notebook): preserve read-only markdown frame names

### DIFF
--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -214,6 +214,7 @@ function ReadOnlyMarkdownSource({
     <div ref={viewRef} data-slot="read-only-markdown-source">
       <OutputArea
         cellId={cellId}
+        isolatedFrameName={`md-${cellId}`}
         outputs={[output]}
         isolated="auto"
         priority={priority}

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -28,6 +28,7 @@ vi.mock("../OutputArea", () => ({
     executionCount,
     focused,
     hostContext,
+    isolatedFrameName,
     onIsolatedFrameHandleChange,
     onNavigateToTracebackCell,
     outputs,
@@ -39,6 +40,7 @@ vi.mock("../OutputArea", () => ({
     executionCount?: number | null;
     focused?: boolean;
     hostContext?: unknown;
+    isolatedFrameName?: string;
     onIsolatedFrameHandleChange?: (
       handle: {
         isReady: boolean;
@@ -63,6 +65,7 @@ vi.mock("../OutputArea", () => ({
         data-execution-count={executionCount ?? ""}
         data-focused={String(focused)}
         data-host-context={JSON.stringify(hostContext ?? null)}
+        data-isolated-frame-name={isolatedFrameName ?? ""}
         data-has-traceback-navigator={String(Boolean(onNavigateToTracebackCell))}
         data-has-traceback-resolver={String(Boolean(resolveTracebackExecutionTarget))}
         data-mimes={outputs
@@ -209,6 +212,7 @@ describe("ReadOnlyNotebookCell", () => {
 
     const outputArea = screen.getByTestId("output-area");
     expect(outputArea).toHaveAttribute("data-cell-id", "cell-markdown");
+    expect(outputArea).toHaveAttribute("data-isolated-frame-name", "md-cell-markdown");
     expect(outputArea).toHaveAttribute("data-mimes", "text/markdown");
     expect(outputArea).toHaveAttribute("data-priority", "text/markdown,text/plain");
     expect(outputArea).toHaveAttribute("data-class-name", "pl-0 pr-0 markdown-source");


### PR DESCRIPTION
## Summary

- preserve `md-{cellId}` iframe names for shared read-only markdown cells
- keep outline/heading navigation using the same markdown frame contract across editable and read-only notebook surfaces
- add focused coverage on `ReadOnlyNotebookCell`

## Stack

Merge order:
1. #3213
2. #3214
3. #3215
4. this PR

This targets #3215 because it builds on the shared `OutputArea.isolatedFrameName` prop added there.

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
