### PR TITLE
feat(notebook-cloud): share editable code cell surface

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -14,7 +14,26 @@ test("cloud editable markdown cells use shared cell and output rendering surface
   assert.match(sourceText, /elementId=\{notebookCellAnchorId\(cell\.id\)\}/);
   assert.match(sourceText, /priority=\{priority\}/);
   assert.match(sourceText, /hostContext=\{hostContext\}/);
-  assert.match(sourceText, /editorExtensions=\{extensions\}/);
+  assert.match(sourceText, /editorExtensions=\{editorExtensions\}/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/cell\/CellContainer"/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/cell\/OutputArea"/);
+  assert.doesNotMatch(sourceText, /from "@\/components\/editor\/codemirror-editor"/);
+});
+
+test("cloud editable code cells use shared cell and output rendering surfaces", () => {
+  const sourcePath = new URL("../viewer/editable-code-cell.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(
+    sourceText,
+    /import \{ EditableCodeCell as SharedEditableCodeCell \} from "@\/components\/cell\/EditableCodeCell";/,
+  );
+  assert.match(sourceText, /<SharedEditableCodeCell/);
+  assert.match(sourceText, /elementId=\{notebookCellAnchorId\(cell\.id\)\}/);
+  assert.match(sourceText, /priority=\{priority\}/);
+  assert.match(sourceText, /hostContext=\{hostContext\}/);
+  assert.match(sourceText, /editorExtensions=\{editorExtensions\}/);
+  assert.match(sourceText, /outputs=\{cell\.outputs\}/);
   assert.doesNotMatch(sourceText, /from "@\/components\/cell\/CellContainer"/);
   assert.doesNotMatch(sourceText, /from "@\/components\/cell\/OutputArea"/);
   assert.doesNotMatch(sourceText, /from "@\/components\/editor\/codemirror-editor"/);
@@ -37,8 +56,22 @@ test("cloud markdown editor remounts with latest source state", () => {
   const sourcePath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /if \(!editing\) return;\s+bridge\.applyFullSource\(cell\.source\);/);
+  assert.match(sourceText, /if \(!editing\) return;\s+applyFullSource\(cell\.source\);/);
   assert.match(sourceText, /cell\.source\.trim\(\)\.length === 0 && !editing/);
+});
+
+test("cloud editable cells share hosted CRDT and presence bridge plumbing", () => {
+  const sourcePath = new URL("../viewer/cloud-cell-editing.ts", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /createCrdtBridge/);
+  assert.match(sourceText, /remoteChangesFromTextAttributions/);
+  assert.match(sourceText, /remoteCursorsExtension/);
+  assert.match(sourceText, /presenceSenderExtension/);
+  assert.match(
+    sourceText,
+    /onSourceChanged: \(source\) => onSourceChangeRef\.current\(cellId, source\)/,
+  );
 });
 
 test("cloud live notebook passes renderer policy into editable markdown cells", () => {
@@ -51,6 +84,31 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
   assert.match(sourceText, /const cells = viewModel\.cells;/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
+});
+
+test("cloud live notebook routes editor code cells through the shared editable code adapter", () => {
+  const sourcePath = new URL("../viewer/cloud-live-notebook.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /import \{ EditableCodeCell \} from "\.\/editable-code-cell";/);
+  assert.match(sourceText, /cell\.cellType === "code" \? \(/);
+  assert.match(sourceText, /<EditableCodeCell[\s\S]*showSource=\{showCode\}/);
+  assert.match(sourceText, /<EditableCodeCell[\s\S]*onSourceChange=\{onCellSourceChange\}/);
+  assert.match(sourceText, /<EditableCodeCell[\s\S]*onSyncNeeded=\{onCellSyncNeeded\}/);
+});
+
+test("cloud editor capability gates all editable cell source writes", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /const canEditCells = shellCapabilities\.canEditCells;/);
+  assert.match(sourceText, /if \(!canEditCells\) return;/);
+  assert.match(
+    sourceText,
+    /currentCell\?\.cellType !== "markdown" && currentCell\?\.cellType !== "code"/,
+  );
+  assert.match(sourceText, /canEditCells \? \(/);
+  assert.doesNotMatch(sourceText, /canEditMarkdown \? \(/);
 });
 
 test("cloud read-only notebook renders from the shared notebook view model", () => {

--- a/apps/notebook-cloud/viewer/cloud-cell-editing.ts
+++ b/apps/notebook-cloud/viewer/cloud-cell-editing.ts
@@ -1,0 +1,106 @@
+import { type Extension } from "@codemirror/state";
+import { useLayoutEffect, useMemo, useRef } from "react";
+import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
+import {
+  createCrdtBridge,
+  remoteChangesFromTextAttributions,
+  type TextAttributionLike,
+} from "../../notebook/src/lib/crdt-editor-bridge";
+import { presenceSenderExtension } from "../../notebook/src/lib/presence-sender";
+import type { NotebookHandle } from "./runtimed-wasm-client";
+
+export interface CloudTextAttributionBatch {
+  sequence: number;
+  attributions: readonly TextAttributionLike[];
+}
+
+export interface CloudTextAttributionQueue {
+  batches: readonly CloudTextAttributionBatch[];
+}
+
+export interface CloudEditableCellBridgeOptions {
+  cellId: string;
+  getHandle: () => NotebookHandle | null;
+  onSourceChange: (cellId: string, source: string) => void;
+  onSyncNeeded: () => void;
+  localActorLabel?: string | null;
+  textAttributionQueue?: CloudTextAttributionQueue;
+  onPresenceCursor?: (cellId: string, line: number, column: number) => void;
+  onPresenceSelection?: (
+    cellId: string,
+    anchorLine: number,
+    anchorCol: number,
+    headLine: number,
+    headCol: number,
+  ) => void;
+}
+
+export function useCloudEditableCellBridge({
+  cellId,
+  getHandle,
+  onSourceChange,
+  onSyncNeeded,
+  localActorLabel,
+  textAttributionQueue,
+  onPresenceCursor,
+  onPresenceSelection,
+}: CloudEditableCellBridgeOptions): {
+  applyFullSource: (source: string) => void;
+  editorExtensions: readonly Extension[];
+} {
+  const getHandleRef = useRef(getHandle);
+  const onSourceChangeRef = useRef(onSourceChange);
+  const onSyncNeededRef = useRef(onSyncNeeded);
+  const lastAppliedAttributionSequenceRef = useRef(0);
+
+  useLayoutEffect(() => {
+    getHandleRef.current = getHandle;
+    onSourceChangeRef.current = onSourceChange;
+    onSyncNeededRef.current = onSyncNeeded;
+  });
+
+  const bridge = useMemo(
+    () =>
+      createCrdtBridge({
+        getHandle: () => getHandleRef.current(),
+        cellId,
+        onSourceChanged: (source) => onSourceChangeRef.current(cellId, source),
+        onSyncNeeded: () => onSyncNeededRef.current(),
+      }),
+    [cellId],
+  );
+
+  const editorExtensions = useMemo(() => {
+    const extensions = [bridge.extension, ...remoteCursorsExtension()];
+    if (onPresenceCursor && onPresenceSelection) {
+      extensions.push(
+        presenceSenderExtension(cellId, {
+          onCursor: onPresenceCursor,
+          onSelection: onPresenceSelection,
+        }),
+      );
+    }
+    return extensions;
+  }, [bridge.extension, cellId, onPresenceCursor, onPresenceSelection]);
+
+  useLayoutEffect(() => {
+    if (!textAttributionQueue) return;
+
+    for (const batch of textAttributionQueue.batches) {
+      if (batch.sequence <= lastAppliedAttributionSequenceRef.current) continue;
+
+      const changes = remoteChangesFromTextAttributions(
+        batch.attributions,
+        cellId,
+        localActorLabel,
+      );
+      bridge.applyRemoteChanges(changes);
+      lastAppliedAttributionSequenceRef.current = batch.sequence;
+    }
+  }, [bridge, cellId, localActorLabel, textAttributionQueue]);
+
+  return {
+    applyFullSource: bridge.applyFullSource,
+    editorExtensions,
+  };
+}

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -3,7 +3,9 @@ import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import { NotebookCellList, type NotebookViewModel } from "@/components/notebook-shell";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
-import { EditableMarkdownCell, type CloudTextAttributionQueue } from "./editable-markdown-cell";
+import type { CloudTextAttributionQueue } from "./cloud-cell-editing";
+import { EditableCodeCell } from "./editable-code-cell";
+import { EditableMarkdownCell } from "./editable-markdown-cell";
 import type { CloudLivePresenceSnapshot } from "./live-presence";
 import type { CloudSyncRuntime } from "./live-sync";
 import type { ResolvedCell } from "./render-resolution";
@@ -18,8 +20,8 @@ export interface CloudLiveNotebookProps {
   localActorLabel: string | null;
   textAttributionQueue: CloudTextAttributionQueue;
   livePresence: CloudLivePresenceSnapshot;
-  onMarkdownSourceChange: (cellId: string, source: string) => void;
-  onMarkdownSyncNeeded: () => void;
+  onCellSourceChange: (cellId: string, source: string) => void;
+  onCellSyncNeeded: () => void;
   onPresenceCursor: (cellId: string, line: number, column: number) => void;
   onPresenceSelection: (
     cellId: string,
@@ -40,8 +42,8 @@ export function CloudLiveNotebook({
   getHandle,
   localActorLabel,
   textAttributionQueue,
-  onMarkdownSourceChange,
-  onMarkdownSyncNeeded,
+  onCellSourceChange,
+  onCellSyncNeeded,
   livePresence,
   onPresenceCursor,
   onPresenceSelection,
@@ -68,14 +70,34 @@ export function CloudLiveNotebook({
             sourceClassName="cloud-source-block"
             priority={priority}
             hostContext={hostContext}
-            onSourceChange={onMarkdownSourceChange}
-            onSyncNeeded={onMarkdownSyncNeeded}
+            onSourceChange={onCellSourceChange}
+            onSyncNeeded={onCellSyncNeeded}
             getHandle={getHandle}
             localActorLabel={localActorLabel}
             textAttributionQueue={textAttributionQueue}
             remotePresence={presenceForCell(livePresence, cell.id)}
             onPresenceCursor={onPresenceCursor}
             onPresenceSelection={onPresenceSelection}
+          />
+        ) : cell.cellType === "code" ? (
+          <EditableCodeCell
+            cell={cell}
+            className="cloud-cell cloud-editable-code-cell"
+            sourceClassName="cloud-source-block"
+            outputClassName="cloud-output-block"
+            priority={priority}
+            hostContext={hostContext}
+            showSource={showCode}
+            onSourceChange={onCellSourceChange}
+            onSyncNeeded={onCellSyncNeeded}
+            getHandle={getHandle}
+            localActorLabel={localActorLabel}
+            textAttributionQueue={textAttributionQueue}
+            remotePresence={presenceForCell(livePresence, cell.id)}
+            onPresenceCursor={onPresenceCursor}
+            onPresenceSelection={onPresenceSelection}
+            resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+            onNavigateToTracebackCell={onNavigateToTracebackCell}
           />
         ) : (
           <ReadOnlyNotebookCell
@@ -87,7 +109,7 @@ export function CloudLiveNotebook({
             executionCount={cell.executionCount}
             priority={priority}
             hostContext={hostContext}
-            showSource={cell.cellType !== "code" || showCode}
+            showSource
             className="cloud-cell"
             sourceClassName="cloud-source-block"
             outputClassName="cloud-output-block"

--- a/apps/notebook-cloud/viewer/editable-code-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-code-cell.tsx
@@ -1,20 +1,27 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { EditableMarkdownCell as SharedEditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { EditableCodeCell as SharedEditableCodeCell } from "@/components/cell/EditableCodeCell";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import { setRemoteCursors, setRemoteSelections } from "@/components/editor/remote-cursors";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type {
+  TracebackCellNavigator,
+  TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
 import { notebookCellAnchorId } from "runtimed";
 import { type CloudTextAttributionQueue, useCloudEditableCellBridge } from "./cloud-cell-editing";
 import type { ResolvedCell } from "./render-resolution";
 import type { NotebookHandle } from "./runtimed-wasm-client";
+import { cloudSourceLanguage } from "./source-language";
 
-export interface EditableMarkdownCellProps {
+export interface EditableCodeCellProps {
   cell: ResolvedCell;
   className?: string;
   sourceClassName?: string;
+  outputClassName?: string;
   priority?: readonly string[];
   hostContext?: NteractEmbedHostContextPatch;
+  showSource?: boolean;
   onSourceChange: (cellId: string, source: string) => void;
   onSyncNeeded: () => void;
   getHandle: () => NotebookHandle | null;
@@ -29,14 +36,18 @@ export interface EditableMarkdownCellProps {
     headLine: number,
     headCol: number,
   ) => void;
+  resolveTracebackExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToTracebackCell?: TracebackCellNavigator;
 }
 
-export function EditableMarkdownCell({
+export function EditableCodeCell({
   cell,
   className,
   sourceClassName,
+  outputClassName,
   priority,
   hostContext,
+  showSource = true,
   onSourceChange,
   onSyncNeeded,
   getHandle,
@@ -45,8 +56,9 @@ export function EditableMarkdownCell({
   remotePresence,
   onPresenceCursor,
   onPresenceSelection,
-}: EditableMarkdownCellProps) {
-  const [editing, setEditing] = useState(cell.source.trim().length === 0);
+  resolveTracebackExecutionTarget,
+  onNavigateToTracebackCell,
+}: EditableCodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const { applyFullSource, editorExtensions } = useCloudEditableCellBridge({
     cellId: cell.id,
@@ -60,62 +72,57 @@ export function EditableMarkdownCell({
   });
 
   useLayoutEffect(() => {
-    if (!editing) return;
     applyFullSource(cell.source);
-  }, [applyFullSource, cell.source, editing]);
-
-  useEffect(() => {
-    if (cell.source.trim().length === 0 && !editing) {
-      setEditing(true);
-    }
-  }, [cell.source, editing]);
+  }, [applyFullSource, cell.source]);
 
   useEffect(() => {
     const view = editorRef.current?.getEditor();
     if (!view) return;
     setRemoteCursors(view, remotePresence?.cursors ?? []);
     setRemoteSelections(view, remotePresence?.selections ?? []);
-  }, [editing, remotePresence]);
+  }, [remotePresence]);
 
   return (
-    <SharedEditableMarkdownCell
+    <SharedEditableCodeCell
       id={cell.id}
       elementId={notebookCellAnchorId(cell.id)}
       source={cell.source}
-      editing={editing}
-      onEditingChange={setEditing}
+      language={cloudSourceLanguage(cell.language)}
+      outputs={cell.outputs}
+      executionCount={cell.executionCount}
       editorRef={editorRef}
-      className={className}
-      sourceClassName={sourceClassName}
-      editorClassName="cloud-markdown-editor"
-      previewClassName="cloud-markdown-preview"
-      previewOutputClassName="cloud-markdown-preview-output"
-      actionClassName="cloud-markdown-cell-action"
+      editorExtensions={editorExtensions}
       priority={priority}
       hostContext={hostContext}
-      editorExtensions={editorExtensions}
-      presenceIndicators={<CloudMarkdownPresenceIndicators presence={remotePresence} />}
+      showSource={showSource}
+      className={className}
+      sourceClassName={sourceClassName}
+      outputClassName={outputClassName}
+      editorClassName="cloud-code-editor"
+      presenceIndicators={<CloudCodePresenceIndicators presence={remotePresence} />}
+      deferIsolatedFrameUntilVisible
+      deferredIsolatedFrameRootMargin="600px 0px"
+      resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+      onNavigateToTracebackCell={onNavigateToTracebackCell}
     />
   );
 }
 
-function CloudMarkdownPresenceIndicators({ presence }: { presence?: RemoteCellPresence }) {
-  const peers = useMemo(() => {
-    const byPeer = new Map<string, { label: string; color: string }>();
-    for (const cursor of presence?.cursors ?? []) {
-      byPeer.set(cursor.peerId, {
-        label: cursor.peerLabel,
-        color: cursor.color,
-      });
-    }
-    for (const selection of presence?.selections ?? []) {
-      byPeer.set(selection.peerId, {
-        label: selection.peerLabel,
-        color: selection.color,
-      });
-    }
-    return Array.from(byPeer.entries()).map(([peerId, peer]) => ({ peerId, ...peer }));
-  }, [presence]);
+function CloudCodePresenceIndicators({ presence }: { presence?: RemoteCellPresence }) {
+  const peersById = new Map<string, { label: string; color: string }>();
+  for (const cursor of presence?.cursors ?? []) {
+    peersById.set(cursor.peerId, {
+      label: cursor.peerLabel,
+      color: cursor.color,
+    });
+  }
+  for (const selection of presence?.selections ?? []) {
+    peersById.set(selection.peerId, {
+      label: selection.peerLabel,
+      color: selection.color,
+    });
+  }
+  const peers = Array.from(peersById.entries()).map(([peerId, peer]) => ({ peerId, ...peer }));
 
   if (peers.length === 0) {
     return null;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -46,7 +46,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { isTextAttributionEvent, notebookCellAnchorId, type NotebookOutlineItem } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
-import type { CloudTextAttributionQueue } from "./editable-markdown-cell";
+import type { CloudTextAttributionQueue } from "./cloud-cell-editing";
 import {
   clearCloudPrototypeDevAuth,
   cloudNotebookSignInCopy,
@@ -1100,24 +1100,24 @@ function NotebookViewer({
       }),
     [authState, codeCellCount, connectionActorLabel, connectionScope],
   );
-  const canEditMarkdown = shellCapabilities.canEditMarkdown;
+  const canEditCells = shellCapabilities.canEditCells;
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
-  const handleMarkdownSourceChange = useCallback(
+  const handleCellSourceChange = useCallback(
     (cellId: string, source: string) => {
-      if (!canEditMarkdown) return;
+      if (!canEditCells) return;
       const currentCell = cellsRef.current.find((cell) => cell.id === cellId);
-      if (currentCell?.cellType !== "markdown") return;
+      if (currentCell?.cellType !== "markdown" && currentCell?.cellType !== "code") return;
 
       setCells((current) =>
         current.map((cell) => (cell.id === cellId ? { ...cell, source } : cell)),
       );
     },
-    [canEditMarkdown],
+    [canEditCells],
   );
-  const handleMarkdownSyncNeeded = useCallback(() => {
-    if (!canEditMarkdown) return;
+  const handleCellSyncNeeded = useCallback(() => {
+    if (!canEditCells) return;
     liveRuntimeRef.current?.engine.scheduleFlush();
-  }, [canEditMarkdown]);
+  }, [canEditCells]);
   const handlePresenceCursor = useCallback((cellId: string, line: number, column: number) => {
     liveRuntimeRef.current?.sendCursorPresence(cellId, line, column);
   }, []);
@@ -1265,7 +1265,7 @@ function NotebookViewer({
         </div>
       )}
 
-      {canEditMarkdown ? (
+      {canEditCells ? (
         <CloudLiveNotebook
           viewModel={notebookViewModel}
           priority={CLOUD_VIEWER_PRIORITY}
@@ -1275,8 +1275,8 @@ function NotebookViewer({
           getHandle={getLiveNotebookHandle}
           localActorLabel={connectionActorLabel}
           textAttributionQueue={textAttributionQueue}
-          onMarkdownSourceChange={handleMarkdownSourceChange}
-          onMarkdownSyncNeeded={handleMarkdownSyncNeeded}
+          onCellSourceChange={handleCellSourceChange}
+          onCellSyncNeeded={handleCellSyncNeeded}
           onPresenceCursor={handlePresenceCursor}
           onPresenceSelection={handlePresenceSelection}
           resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}

--- a/src/components/cell/EditableCodeCell.tsx
+++ b/src/components/cell/EditableCodeCell.tsx
@@ -1,0 +1,146 @@
+import { type Extension } from "@codemirror/state";
+import { type KeyBinding } from "@codemirror/view";
+import { type ReactNode, type RefObject, useMemo } from "react";
+import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import { type SupportedLanguage } from "@/components/editor/languages";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type {
+  TracebackCellNavigator,
+  TracebackExecutionResolver,
+} from "@/components/outputs/traceback-output";
+import { CellContainer } from "./CellContainer";
+import { ExecutionCount } from "./ExecutionCount";
+import type { JupyterOutput } from "./jupyter-output";
+import { OutputArea } from "./OutputArea";
+
+export interface EditableCodeCellProps {
+  id: string;
+  elementId?: string;
+  source: string;
+  language?: SupportedLanguage | null;
+  outputs?: readonly JupyterOutput[];
+  executionCount?: number | null;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  editorRef: RefObject<CodeMirrorEditorRef | null>;
+  editorExtensions?: readonly Extension[];
+  editorKeyMap?: readonly KeyBinding[];
+  placeholder?: string;
+  showSource?: boolean;
+  focusOutputs?: boolean;
+  isFocused?: boolean;
+  onFocus?: () => void;
+  className?: string;
+  sourceClassName?: string;
+  outputClassName?: string;
+  editorClassName?: string;
+  presenceIndicators?: ReactNode;
+  rightGutterContent?: ReactNode;
+  outputRightGutterContent?: ReactNode;
+  editorFooterContent?: ReactNode;
+  deferIsolatedFrameUntilVisible?: boolean;
+  deferredIsolatedFrameRootMargin?: string;
+  onOutputLinkClick?: (url: string, newTab: boolean) => void;
+  onOutputIframeMouseDown?: () => void;
+  resolveTracebackExecutionTarget?: TracebackExecutionResolver;
+  onNavigateToTracebackCell?: TracebackCellNavigator;
+}
+
+export function EditableCodeCell({
+  id,
+  elementId,
+  source,
+  language = "python",
+  outputs = [],
+  executionCount = null,
+  priority,
+  hostContext,
+  editorRef,
+  editorExtensions,
+  editorKeyMap,
+  placeholder = "Enter code...",
+  showSource = true,
+  focusOutputs = false,
+  isFocused = false,
+  onFocus,
+  className,
+  sourceClassName,
+  outputClassName,
+  editorClassName,
+  presenceIndicators,
+  rightGutterContent,
+  outputRightGutterContent,
+  editorFooterContent,
+  deferIsolatedFrameUntilVisible,
+  deferredIsolatedFrameRootMargin,
+  onOutputLinkClick,
+  onOutputIframeMouseDown,
+  resolveTracebackExecutionTarget,
+  onNavigateToTracebackCell,
+}: EditableCodeCellProps) {
+  const outputArray = useMemo(() => [...outputs], [outputs]);
+  const editorExtensionArray = useMemo(
+    () => (editorExtensions ? [...editorExtensions] : undefined),
+    [editorExtensions],
+  );
+  const editorKeyMapArray = useMemo(
+    () => (editorKeyMap ? [...editorKeyMap] : undefined),
+    [editorKeyMap],
+  );
+  const resolvedLanguage = language ?? "plain";
+
+  const codeContent = showSource ? (
+    <div className={sourceClassName}>
+      <CodeMirrorEditor
+        ref={editorRef}
+        initialValue={source}
+        language={resolvedLanguage}
+        keyMap={editorKeyMapArray}
+        extensions={editorExtensionArray}
+        placeholder={placeholder}
+        autoFocus={isFocused}
+        className={editorClassName}
+      />
+      {editorFooterContent}
+    </div>
+  ) : null;
+
+  const outputContent =
+    outputArray.length > 0 ? (
+      <OutputArea
+        cellId={id}
+        executionCount={executionCount}
+        outputs={outputArray}
+        isolated="auto"
+        focused={focusOutputs}
+        priority={priority}
+        hostContext={hostContext}
+        className={outputClassName}
+        layoutInset="cell-output"
+        deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
+        deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
+        onLinkClick={onOutputLinkClick}
+        onIframeMouseDown={onOutputIframeMouseDown}
+        resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+        onNavigateToTracebackCell={onNavigateToTracebackCell}
+      />
+    ) : null;
+
+  return (
+    <CellContainer
+      id={id}
+      elementId={elementId}
+      cellType="code"
+      isFocused={isFocused}
+      onFocus={onFocus}
+      codeContent={codeContent}
+      outputContent={outputContent}
+      hideOutput={outputArray.length === 0}
+      gutterContent={<ExecutionCount count={executionCount} />}
+      rightGutterContent={rightGutterContent}
+      outputRightGutterContent={outputRightGutterContent}
+      presenceIndicators={presenceIndicators}
+      className={className}
+    />
+  );
+}

--- a/src/components/cell/__tests__/EditableCodeCell.test.tsx
+++ b/src/components/cell/__tests__/EditableCodeCell.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from "@testing-library/react";
+import { forwardRef, useImperativeHandle, useRef } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { EditableCodeCell } from "../EditableCodeCell";
+import type { CodeMirrorEditorRef } from "@/components/editor";
+import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type { JupyterOutput } from "../jupyter-output";
+
+const outputAreaCalls = vi.hoisted(() => ({
+  props: [] as Array<{
+    cellId?: string;
+    className?: string;
+    executionCount?: number | null;
+    hostContext?: unknown;
+    priority?: readonly string[];
+    outputs: JupyterOutput[];
+  }>,
+}));
+
+vi.mock("@/components/cell/OutputArea", () => ({
+  OutputArea: (props: {
+    cellId?: string;
+    className?: string;
+    executionCount?: number | null;
+    hostContext?: unknown;
+    priority?: readonly string[];
+    outputs: JupyterOutput[];
+  }) => {
+    outputAreaCalls.props.push(props);
+    return (
+      <div
+        data-cell-id={props.cellId}
+        data-class-name={props.className ?? ""}
+        data-execution-count={props.executionCount ?? ""}
+        data-host-context={JSON.stringify(props.hostContext ?? null)}
+        data-output-count={props.outputs.length}
+        data-priority={props.priority?.join(",") ?? ""}
+        data-testid="output-area"
+      />
+    );
+  },
+}));
+
+vi.mock("@/components/editor/codemirror-editor", () => ({
+  CodeMirrorEditor: forwardRef<
+    CodeMirrorEditorRef,
+    {
+      className?: string;
+      initialValue?: string;
+      language?: string;
+      placeholder?: string;
+    }
+  >(function MockCodeMirrorEditor({ className, initialValue = "", language, placeholder }, ref) {
+    useImperativeHandle(ref, () => ({
+      focus: vi.fn(),
+      setCursorPosition: vi.fn(),
+      getEditor: () => null,
+    }));
+
+    return (
+      <textarea
+        className={className}
+        data-language={language}
+        data-testid="codemirror-editor"
+        placeholder={placeholder}
+        readOnly
+        value={initialValue}
+      />
+    );
+  }),
+}));
+
+describe("EditableCodeCell", () => {
+  it("renders editable source and outputs through shared cell chrome", () => {
+    const output: JupyterOutput = {
+      output_id: "output-1",
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+
+    render(
+      <Harness
+        id="code-1"
+        elementId="notebook-cell-code-1"
+        source='print("hello")'
+        language="python"
+        outputs={[output]}
+        executionCount={7}
+        priority={["text/plain"]}
+        hostContext={{
+          nteract: {
+            rendererAssetsBaseUrl: "https://assets.example.test/renderer-assets/",
+          },
+        }}
+        sourceClassName="source"
+        outputClassName="output"
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="cell-container"]')).toHaveAttribute(
+      "id",
+      "notebook-cell-code-1",
+    );
+    expect(screen.getByTestId("codemirror-editor")).toHaveValue('print("hello")');
+    expect(screen.getByTestId("codemirror-editor")).toHaveAttribute("data-language", "python");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "code-1");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-output-count", "1");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-execution-count", "7");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-priority", "text/plain");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-class-name", "output");
+    expect(screen.getByTestId("output-area").getAttribute("data-host-context")).toContain(
+      "https://assets.example.test/renderer-assets/",
+    );
+  });
+
+  it("preserves output rendering when code source is hidden", () => {
+    const output: JupyterOutput = {
+      output_id: "output-2",
+      output_type: "stream",
+      name: "stdout",
+      text: "hidden source output",
+    };
+
+    render(<Harness id="code-2" source="1 + 1" outputs={[output]} showSource={false} />);
+
+    expect(screen.queryByTestId("codemirror-editor")).toBeNull();
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "code-2");
+    expect(document.querySelector('[data-slot="cell-output-content"]')).not.toBeNull();
+  });
+});
+
+function Harness({
+  id,
+  elementId,
+  source,
+  language,
+  outputs,
+  executionCount,
+  priority,
+  hostContext,
+  sourceClassName,
+  outputClassName,
+  showSource,
+}: {
+  id: string;
+  elementId?: string;
+  source: string;
+  language?: "python";
+  outputs?: readonly JupyterOutput[];
+  executionCount?: number | null;
+  priority?: readonly string[];
+  hostContext?: NteractEmbedHostContextPatch;
+  sourceClassName?: string;
+  outputClassName?: string;
+  showSource?: boolean;
+}) {
+  const editorRef = useRef<CodeMirrorEditorRef>(null);
+
+  return (
+    <EditableCodeCell
+      id={id}
+      elementId={elementId}
+      source={source}
+      language={language}
+      outputs={outputs}
+      executionCount={executionCount}
+      priority={priority}
+      hostContext={hostContext}
+      editorRef={editorRef}
+      sourceClassName={sourceClassName}
+      outputClassName={outputClassName}
+      showSource={showSource}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- add a shared `EditableCodeCell` primitive built from shared cell chrome, CodeMirror, and `OutputArea`
- move cloud CRDT/presence editing bridge plumbing into a reusable host adapter helper
- route cloud editor-mode code cells through the shared editable code-cell adapter instead of `ReadOnlyNotebookCell`

## Stack order

This PR is stacked on #3220 (`quod/notebook-readonly-markdown-frame-names`).
Merge order:

1. #3215
2. #3220
3. this PR

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/EditableCodeCell.test.tsx src/components/cell/__tests__/EditableMarkdownCell.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
