### PR TITLE
refactor(notebook): share editable code cell primitive

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,11 +1,10 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
 import { ChevronRight, Code2, EyeOff } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
-import { OutputArea } from "@/components/cell/OutputArea";
-import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
+import { EditableCodeCell } from "@/components/cell/EditableCodeCell";
+import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
@@ -385,11 +384,88 @@ export const CodeCell = memo(function CodeCell({
     />
   );
 
+  const collapsedSourceContent = bothHidden ? (
+    <div className="flex items-center justify-start mt-0.5">
+      <button
+        type="button"
+        onClick={() => {
+          if (onExpandHiddenGroup) {
+            onExpandHiddenGroup();
+          } else {
+            onToggleSourceHidden?.(false);
+            onToggleOutputsHidden?.(false);
+          }
+        }}
+        className={cn(
+          "inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
+          (isExecuting || isGroupExecuting) && "animate-pulse",
+        )}
+        title={
+          hiddenGroupCount && hiddenGroupCount > 1 ? `Show ${hiddenGroupCount} cells` : "Show cell"
+        }
+      >
+        <span>
+          {hiddenGroupCount && hiddenGroupCount > 1
+            ? `${hiddenGroupCount} cells hidden`
+            : "Cell hidden"}
+        </span>
+        {hiddenGroupErrorCount ? (
+          <span className="text-destructive font-medium">
+            {hiddenGroupErrorCount === 1 ? "1 error" : `${hiddenGroupErrorCount} errors`}
+          </span>
+        ) : null}
+        <ChevronRight className="h-3 w-3" />
+      </button>
+    </div>
+  ) : isSourceHidden ? (
+    <>
+      <div className="flex items-center justify-start mt-0.5">
+        <button
+          type="button"
+          onClick={() => onToggleSourceHidden?.(false)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+          title="Show source"
+        >
+          <Code2 className="h-3 w-3" />
+          <span className="font-mono truncate max-w-48">
+            {cell.source.split("\n")[0] || "source"}
+          </span>
+          <ChevronRight className="h-3 w-3" />
+        </button>
+      </div>
+      {currentLine}
+    </>
+  ) : undefined;
+
+  const collapsedOutputContent =
+    isOutputsHidden && outputs.length > 0 ? (
+      <div className={cn("flex items-center justify-start mt-0.5", cellOutputInnerInset)}>
+        <button
+          type="button"
+          onClick={() => onToggleOutputsHidden?.(false)}
+          className="inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+          title="Show outputs"
+        >
+          <span>
+            {outputs.length} output
+            {outputs.length !== 1 ? "s" : ""}
+          </span>
+          <ChevronRight className="h-3 w-3" />
+        </button>
+      </div>
+    ) : undefined;
+
   return (
     <>
-      <CellContainer
+      <EditableCodeCell
         id={cell.id}
-        cellType="code"
+        source={cell.source}
+        language={language}
+        outputs={outputs}
+        executionCount={executionCount}
+        editorRef={editorRef}
+        editorKeyMap={keyMap}
+        editorExtensions={editorExtensions}
         isFocused={isFocused}
         isPreviousCellFromFocused={isPreviousCellFromFocused}
         isNextCellFromFocused={isNextCellFromFocused}
@@ -399,113 +475,10 @@ export const CodeCell = memo(function CodeCell({
         rightGutterContent={rightGutterContent}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
-        codeContent={
-          <>
-            {/* Source visibility toggle + Editor */}
-            {bothHidden ? (
-              <div className="flex items-center justify-start mt-0.5">
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (onExpandHiddenGroup) {
-                      onExpandHiddenGroup();
-                    } else {
-                      onToggleSourceHidden?.(false);
-                      onToggleOutputsHidden?.(false);
-                    }
-                  }}
-                  className={cn(
-                    "inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
-                    (isExecuting || isGroupExecuting) && "animate-pulse",
-                  )}
-                  title={
-                    hiddenGroupCount && hiddenGroupCount > 1
-                      ? `Show ${hiddenGroupCount} cells`
-                      : "Show cell"
-                  }
-                >
-                  <span>
-                    {hiddenGroupCount && hiddenGroupCount > 1
-                      ? `${hiddenGroupCount} cells hidden`
-                      : "Cell hidden"}
-                  </span>
-                  {hiddenGroupErrorCount ? (
-                    <span className="text-destructive font-medium">
-                      {hiddenGroupErrorCount === 1 ? "1 error" : `${hiddenGroupErrorCount} errors`}
-                    </span>
-                  ) : null}
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-              </div>
-            ) : isSourceHidden ? (
-              <>
-                <div className="flex items-center justify-start mt-0.5">
-                  <button
-                    type="button"
-                    onClick={() => onToggleSourceHidden?.(false)}
-                    className="inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
-                    title="Show source"
-                  >
-                    <Code2 className="h-3 w-3" />
-                    <span className="font-mono truncate max-w-48">
-                      {cell.source.split("\n")[0] || "source"}
-                    </span>
-                    <ChevronRight className="h-3 w-3" />
-                  </button>
-                </div>
-                {currentLine}
-              </>
-            ) : (
-              <>
-                <CodeMirrorEditor
-                  ref={editorRef}
-                  initialValue={cell.source}
-                  language={language}
-                  keyMap={keyMap}
-                  extensions={editorExtensions}
-                  placeholder="Enter code..."
-                  autoFocus={isFocused}
-                />
-                {currentLine}
-              </>
-            )}
-          </>
-        }
-        outputContent={
-          isOutputsHidden && outputs.length > 0 ? (
-            <div className={cn("flex items-center justify-start mt-0.5", cellOutputInnerInset)}>
-              <button
-                type="button"
-                onClick={() => onToggleOutputsHidden?.(false)}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
-                title="Show outputs"
-              >
-                <span>
-                  {outputs.length} output
-                  {outputs.length !== 1 ? "s" : ""}
-                </span>
-                <ChevronRight className="h-3 w-3" />
-              </button>
-            </div>
-          ) : (
-            <OutputArea
-              outputs={outputs}
-              cellId={cell.id}
-              executionCount={executionCount}
-              preloadIframe
-              searchQuery={searchQuery}
-              onSearchMatchCount={onSearchMatchCount}
-              onLinkClick={handleLinkClick}
-              onIframeMouseDown={handleOutputMouseDown}
-              onDiagnostic={logNotebookIsolatedDiagnostic}
-              layoutInset="cell-output"
-              resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-              onNavigateToTracebackCell={handleTracebackCellNavigate}
-              focused={outputFocused}
-              useOutputWell={showOutputChrome}
-            />
-          )
-        }
+        gutterContent={null}
+        codeContentOverride={collapsedSourceContent}
+        editorFooterContent={currentLine}
+        outputContentOverride={collapsedOutputContent}
         outputRightGutterContent={
           outputs.length > 0 && !isOutputsHidden && onToggleOutputsHidden ? (
             <button
@@ -520,6 +493,16 @@ export const CodeCell = memo(function CodeCell({
           ) : undefined
         }
         hideOutput={outputs.length === 0 || bothHidden}
+        preloadIframe
+        searchQuery={searchQuery}
+        onSearchMatchCount={onSearchMatchCount}
+        onOutputLinkClick={handleLinkClick}
+        onOutputIframeMouseDown={handleOutputMouseDown}
+        onOutputDiagnostic={logNotebookIsolatedDiagnostic}
+        resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+        onNavigateToTracebackCell={handleTracebackCellNavigate}
+        focusOutputs={outputFocused}
+        useOutputWell={showOutputChrome}
       />
 
       {/* History Search Dialog (Ctrl+R) */}

--- a/src/components/cell/EditableCodeCell.tsx
+++ b/src/components/cell/EditableCodeCell.tsx
@@ -3,6 +3,7 @@ import { type KeyBinding } from "@codemirror/view";
 import { type ReactNode, type RefObject, useMemo } from "react";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { type SupportedLanguage } from "@/components/editor/languages";
+import type { IsolatedDiagnosticHandler } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type {
   TracebackCellNavigator,
@@ -38,10 +39,25 @@ export interface EditableCodeCellProps {
   rightGutterContent?: ReactNode;
   outputRightGutterContent?: ReactNode;
   editorFooterContent?: ReactNode;
+  codeContentOverride?: ReactNode;
+  outputContentOverride?: ReactNode;
+  gutterContent?: ReactNode;
+  hideOutput?: boolean;
+  isPreviousCellFromFocused?: boolean;
+  isNextCellFromFocused?: boolean;
+  outputFocused?: boolean;
+  outputDimmed?: boolean;
+  dragHandleProps?: Record<string, unknown>;
+  isDragging?: boolean;
   deferIsolatedFrameUntilVisible?: boolean;
   deferredIsolatedFrameRootMargin?: string;
+  preloadIframe?: boolean;
+  searchQuery?: string;
+  onSearchMatchCount?: (count: number) => void;
   onOutputLinkClick?: (url: string, newTab: boolean) => void;
   onOutputIframeMouseDown?: () => void;
+  onOutputDiagnostic?: IsolatedDiagnosticHandler;
+  useOutputWell?: boolean;
   resolveTracebackExecutionTarget?: TracebackExecutionResolver;
   onNavigateToTracebackCell?: TracebackCellNavigator;
 }
@@ -71,10 +87,25 @@ export function EditableCodeCell({
   rightGutterContent,
   outputRightGutterContent,
   editorFooterContent,
+  codeContentOverride,
+  outputContentOverride,
+  gutterContent = <ExecutionCount count={executionCount} />,
+  hideOutput,
+  isPreviousCellFromFocused = false,
+  isNextCellFromFocused = false,
+  outputFocused = false,
+  outputDimmed = false,
+  dragHandleProps,
+  isDragging = false,
   deferIsolatedFrameUntilVisible,
   deferredIsolatedFrameRootMargin,
+  preloadIframe,
+  searchQuery,
+  onSearchMatchCount,
   onOutputLinkClick,
   onOutputIframeMouseDown,
+  onOutputDiagnostic,
+  useOutputWell,
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
 }: EditableCodeCellProps) {
@@ -89,24 +120,27 @@ export function EditableCodeCell({
   );
   const resolvedLanguage = language ?? "plain";
 
-  const codeContent = showSource ? (
-    <div className={sourceClassName}>
-      <CodeMirrorEditor
-        ref={editorRef}
-        initialValue={source}
-        language={resolvedLanguage}
-        keyMap={editorKeyMapArray}
-        extensions={editorExtensionArray}
-        placeholder={placeholder}
-        autoFocus={isFocused}
-        className={editorClassName}
-      />
-      {editorFooterContent}
-    </div>
-  ) : null;
+  const codeContent =
+    codeContentOverride ??
+    (showSource ? (
+      <div className={sourceClassName}>
+        <CodeMirrorEditor
+          ref={editorRef}
+          initialValue={source}
+          language={resolvedLanguage}
+          keyMap={editorKeyMapArray}
+          extensions={editorExtensionArray}
+          placeholder={placeholder}
+          autoFocus={isFocused}
+          className={editorClassName}
+        />
+        {editorFooterContent}
+      </div>
+    ) : null);
 
   const outputContent =
-    outputArray.length > 0 ? (
+    outputContentOverride ??
+    (outputArray.length > 0 ? (
       <OutputArea
         cellId={id}
         executionCount={executionCount}
@@ -117,14 +151,19 @@ export function EditableCodeCell({
         hostContext={hostContext}
         className={outputClassName}
         layoutInset="cell-output"
+        preloadIframe={preloadIframe}
+        searchQuery={searchQuery}
+        onSearchMatchCount={onSearchMatchCount}
         deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
         deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
         onLinkClick={onOutputLinkClick}
         onIframeMouseDown={onOutputIframeMouseDown}
+        onDiagnostic={onOutputDiagnostic}
+        useOutputWell={useOutputWell}
         resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
         onNavigateToTracebackCell={onNavigateToTracebackCell}
       />
-    ) : null;
+    ) : null);
 
   return (
     <CellContainer
@@ -132,14 +171,20 @@ export function EditableCodeCell({
       elementId={elementId}
       cellType="code"
       isFocused={isFocused}
+      isPreviousCellFromFocused={isPreviousCellFromFocused}
+      isNextCellFromFocused={isNextCellFromFocused}
+      outputFocused={outputFocused}
+      outputDimmed={outputDimmed}
       onFocus={onFocus}
       codeContent={codeContent}
       outputContent={outputContent}
-      hideOutput={outputArray.length === 0}
-      gutterContent={<ExecutionCount count={executionCount} />}
+      hideOutput={hideOutput ?? outputContent == null}
+      gutterContent={gutterContent}
       rightGutterContent={rightGutterContent}
       outputRightGutterContent={outputRightGutterContent}
       presenceIndicators={presenceIndicators}
+      dragHandleProps={dragHandleProps}
+      isDragging={isDragging}
       className={className}
     />
   );

--- a/src/components/cell/__tests__/EditableCodeCell.test.tsx
+++ b/src/components/cell/__tests__/EditableCodeCell.test.tsx
@@ -12,7 +12,10 @@ const outputAreaCalls = vi.hoisted(() => ({
     className?: string;
     executionCount?: number | null;
     hostContext?: unknown;
+    preloadIframe?: boolean;
     priority?: readonly string[];
+    searchQuery?: string;
+    useOutputWell?: boolean;
     outputs: JupyterOutput[];
   }>,
 }));
@@ -23,7 +26,10 @@ vi.mock("@/components/cell/OutputArea", () => ({
     className?: string;
     executionCount?: number | null;
     hostContext?: unknown;
+    preloadIframe?: boolean;
     priority?: readonly string[];
+    searchQuery?: string;
+    useOutputWell?: boolean;
     outputs: JupyterOutput[];
   }) => {
     outputAreaCalls.props.push(props);
@@ -34,8 +40,11 @@ vi.mock("@/components/cell/OutputArea", () => ({
         data-execution-count={props.executionCount ?? ""}
         data-host-context={JSON.stringify(props.hostContext ?? null)}
         data-output-count={props.outputs.length}
+        data-preload-iframe={props.preloadIframe ? "true" : "false"}
         data-priority={props.priority?.join(",") ?? ""}
+        data-search-query={props.searchQuery ?? ""}
         data-testid="output-area"
+        data-use-output-well={props.useOutputWell ? "true" : "false"}
       />
     );
   },
@@ -128,6 +137,37 @@ describe("EditableCodeCell", () => {
     expect(screen.getByTestId("output-area")).toHaveAttribute("data-cell-id", "code-2");
     expect(document.querySelector('[data-slot="cell-output-content"]')).not.toBeNull();
   });
+
+  it("forwards desktop cell state and output controls through the shared primitive", () => {
+    const output: JupyterOutput = {
+      output_id: "output-3",
+      output_type: "stream",
+      name: "stdout",
+      text: "shared",
+    };
+
+    render(
+      <Harness
+        id="code-3"
+        source="value"
+        outputs={[output]}
+        executionCount={3}
+        focusOutputs
+        isFocused
+        isPreviousCellFromFocused
+        outputFocused
+        preloadIframe
+        searchQuery="needle"
+        useOutputWell
+      />,
+    );
+
+    const cell = document.querySelector('[data-slot="cell-container"]');
+    expect(cell).toHaveAttribute("data-focus-state", "focused");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-preload-iframe", "true");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-search-query", "needle");
+    expect(screen.getByTestId("output-area")).toHaveAttribute("data-use-output-well", "true");
+  });
 });
 
 function Harness({
@@ -142,6 +182,13 @@ function Harness({
   sourceClassName,
   outputClassName,
   showSource,
+  focusOutputs,
+  isFocused,
+  isPreviousCellFromFocused,
+  outputFocused,
+  preloadIframe,
+  searchQuery,
+  useOutputWell,
 }: {
   id: string;
   elementId?: string;
@@ -154,6 +201,13 @@ function Harness({
   sourceClassName?: string;
   outputClassName?: string;
   showSource?: boolean;
+  focusOutputs?: boolean;
+  isFocused?: boolean;
+  isPreviousCellFromFocused?: boolean;
+  outputFocused?: boolean;
+  preloadIframe?: boolean;
+  searchQuery?: string;
+  useOutputWell?: boolean;
 }) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
 
@@ -171,6 +225,13 @@ function Harness({
       sourceClassName={sourceClassName}
       outputClassName={outputClassName}
       showSource={showSource}
+      focusOutputs={focusOutputs}
+      isFocused={isFocused}
+      isPreviousCellFromFocused={isPreviousCellFromFocused}
+      outputFocused={outputFocused}
+      preloadIframe={preloadIframe}
+      searchQuery={searchQuery}
+      useOutputWell={useOutputWell}
     />
   );
 }


### PR DESCRIPTION
## Summary
- extend the shared `EditableCodeCell` primitive with the host-neutral hooks desktop already needs: output focus, search, diagnostics, hidden source/output overrides, drag state, and output well controls
- refactor desktop `CodeCell` to compose `EditableCodeCell` instead of directly assembling `CellContainer`, `CodeMirrorEditor`, and `OutputArea`
- add coverage that the shared primitive forwards desktop output controls while preserving existing desktop code-cell output-focus tests

## Stack order
1. #3215 `quod/notebook-shared-markdown-cell-surface`
2. #3220 `quod/notebook-readonly-markdown-frame-names`
3. #3221 `quod/notebook-cloud-editable-code-cells`
4. This PR

Merge in stack order. If lower PRs are merged and GitHub retargets this branch, re-check CI before marking ready.

## Validation
- `pnpm exec vp test run src/components/cell/__tests__/EditableCodeCell.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
