### PR TITLE
refactor(notebook): share read-only cell list frame

### DIFF
--- a/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
+++ b/apps/notebook-cloud/test/fixtures/cloud-output-parity.ts
@@ -1,5 +1,5 @@
 import type { BlobResolver } from "runtimed";
-import type { ReadOnlyNotebookCellData } from "../../../../src/components/cell/ReadOnlyNotebook";
+import type { ReadOnlyNotebookCellData } from "../../../../src/components/notebook-shell";
 import type { SupportedLanguage } from "../../../../src/components/editor/languages";
 import type { NteractEmbedHostContextPatch } from "../../../../src/components/isolated/host-context";
 import { resolveCell, type RenderCell, type ResolvedCell } from "../../viewer/render-resolution.ts";

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -1,23 +1,12 @@
 import type { ReactNode } from "react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type { ReadOnlyNotebookCellData } from "@/components/notebook-shell/cell-data";
 import { NotebookCellList } from "@/components/notebook-shell/NotebookCellList";
 import type {
   TracebackCellNavigator,
   TracebackExecutionResolver,
 } from "@/components/outputs/traceback-output";
-import type { SupportedLanguage } from "../editor/languages";
-import type { JupyterOutput } from "./jupyter-output";
 import { ReadOnlyNotebookCell } from "./ReadOnlyNotebookCell";
-
-export interface ReadOnlyNotebookCellData {
-  id: string;
-  cellType: string;
-  source: string;
-  language?: SupportedLanguage | null;
-  outputs?: readonly JupyterOutput[];
-  executionId?: string | null;
-  executionCount?: number | null;
-}
 
 export interface ReadOnlyNotebookProps {
   cells: readonly ReadOnlyNotebookCellData[];

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -1,11 +1,10 @@
 import type { ReactNode } from "react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { NotebookCellList } from "@/components/notebook-shell/NotebookCellList";
 import type {
   TracebackCellNavigator,
   TracebackExecutionResolver,
 } from "@/components/outputs/traceback-output";
-import { ErrorBoundary } from "@/lib/error-boundary";
-import { cn } from "@/lib/utils";
 import type { SupportedLanguage } from "../editor/languages";
 import type { JupyterOutput } from "./jupyter-output";
 import { ReadOnlyNotebookCell } from "./ReadOnlyNotebookCell";
@@ -62,55 +61,39 @@ export function ReadOnlyNotebook({
   onNavigateToTracebackCell,
 }: ReadOnlyNotebookProps) {
   return (
-    <section
-      aria-label={label}
-      className={cn("flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain", className)}
-      data-cell-count={cells.length}
-      data-slot="read-only-notebook"
-    >
-      {cells.length === 0
-        ? emptyContent
-        : cells.map((cell, index) => (
-            <ErrorBoundary
-              key={`${cell.id}:${index}`}
-              resetKeys={[
-                cell.id,
-                cell.cellType,
-                cell.source,
-                cell.language,
-                cell.executionCount,
-                cell.outputs?.length ?? 0,
-              ]}
-              fallback={(error) =>
-                renderCellError
-                  ? renderCellError(error, cell, index)
-                  : defaultCellError(error, index)
-              }
-            >
-              <ReadOnlyNotebookCell
-                id={cell.id}
-                cellType={cell.cellType}
-                source={cell.source}
-                language={cell.language}
-                outputs={cell.outputs}
-                executionCount={cell.executionCount}
-                priority={priority}
-                hostContext={hostContext}
-                displayMode={displayMode}
-                showSource={cell.cellType !== "code" || showCode}
-                focusOutputs={focusOutputs}
-                deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
-                deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
-                className={cellClassName}
-                sourceClassName={sourceClassName}
-                outputClassName={outputClassName}
-                lineWrapping={lineWrapping}
-                resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-                onNavigateToTracebackCell={onNavigateToTracebackCell}
-              />
-            </ErrorBoundary>
-          ))}
-    </section>
+    <NotebookCellList
+      cells={cells}
+      label={label}
+      className={className}
+      slot="read-only-notebook"
+      emptyContent={emptyContent}
+      renderCellError={(error, cell, index) =>
+        renderCellError ? renderCellError(error, cell, index) : defaultCellError(error, index)
+      }
+      renderCell={(cell) => (
+        <ReadOnlyNotebookCell
+          id={cell.id}
+          cellType={cell.cellType}
+          source={cell.source}
+          language={cell.language}
+          outputs={cell.outputs}
+          executionCount={cell.executionCount}
+          priority={priority}
+          hostContext={hostContext}
+          displayMode={displayMode}
+          showSource={cell.cellType !== "code" || showCode}
+          focusOutputs={focusOutputs}
+          deferIsolatedFrameUntilVisible={deferIsolatedFrameUntilVisible}
+          deferredIsolatedFrameRootMargin={deferredIsolatedFrameRootMargin}
+          className={cellClassName}
+          sourceClassName={sourceClassName}
+          outputClassName={outputClassName}
+          lineWrapping={lineWrapping}
+          resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+          onNavigateToTracebackCell={onNavigateToTracebackCell}
+        />
+      )}
+    />
   );
 }
 

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -56,6 +56,7 @@ export function ReadOnlyNotebook({
       className={className}
       slot="read-only-notebook"
       emptyContent={emptyContent}
+      keyForCell={(cell, index) => `${cell.id}:${index}`}
       renderCellError={(error, cell, index) =>
         renderCellError ? renderCellError(error, cell, index) : defaultCellError(error, index)
       }

--- a/src/components/notebook-shell/NotebookCellList.tsx
+++ b/src/components/notebook-shell/NotebookCellList.tsx
@@ -9,6 +9,7 @@ export interface NotebookCellListProps<TCell extends NotebookCellListItem = Note
   className?: string;
   slot?: string;
   emptyContent?: ReactNode;
+  keyForCell?: (cell: TCell, index: number) => string;
   resetKeysForCell?: (cell: TCell, index: number) => readonly unknown[];
   renderCell: (cell: TCell, index: number) => ReactNode;
   renderCellError?: (error: Error, cell: TCell, index: number) => ReactNode;
@@ -20,6 +21,7 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
   className,
   slot = "notebook-cell-list",
   emptyContent = null,
+  keyForCell = defaultKeyForCell,
   resetKeysForCell = defaultResetKeysForCell,
   renderCell,
   renderCellError,
@@ -35,7 +37,7 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
         ? emptyContent
         : cells.map((cell, index) => (
             <ErrorBoundary
-              key={cell.id}
+              key={keyForCell(cell, index)}
               resetKeys={resetKeysForCell(cell, index)}
               fallback={(error) =>
                 renderCellError
@@ -48,6 +50,10 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
           ))}
     </section>
   );
+}
+
+function defaultKeyForCell(cell: NotebookCellListItem): string {
+  return cell.id;
 }
 
 function defaultResetKeysForCell(cell: NotebookCellListItem): readonly unknown[] {

--- a/src/components/notebook-shell/NotebookCellList.tsx
+++ b/src/components/notebook-shell/NotebookCellList.tsx
@@ -1,15 +1,7 @@
 import type { ReactNode } from "react";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
-
-export interface NotebookCellListItem {
-  id: string;
-  cellType: string;
-  source: string;
-  language?: string | null;
-  executionCount?: number | null;
-  outputs?: readonly unknown[];
-}
+import type { NotebookCellListItem } from "./cell-data";
 
 export interface NotebookCellListProps<TCell extends NotebookCellListItem = NotebookCellListItem> {
   cells: readonly TCell[];

--- a/src/components/notebook-shell/NotebookCellList.tsx
+++ b/src/components/notebook-shell/NotebookCellList.tsx
@@ -1,9 +1,17 @@
 import type { ReactNode } from "react";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
-import type { NotebookViewCell } from "./view-model";
 
-export interface NotebookCellListProps<TCell extends NotebookViewCell = NotebookViewCell> {
+export interface NotebookCellListItem {
+  id: string;
+  cellType: string;
+  source: string;
+  language?: string | null;
+  executionCount?: number | null;
+  outputs?: readonly unknown[];
+}
+
+export interface NotebookCellListProps<TCell extends NotebookCellListItem = NotebookCellListItem> {
   cells: readonly TCell[];
   label?: string;
   className?: string;
@@ -14,7 +22,7 @@ export interface NotebookCellListProps<TCell extends NotebookViewCell = Notebook
   renderCellError?: (error: Error, cell: TCell, index: number) => ReactNode;
 }
 
-export function NotebookCellList<TCell extends NotebookViewCell = NotebookViewCell>({
+export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCellListItem>({
   cells,
   label = "Notebook cells",
   className,
@@ -50,14 +58,14 @@ export function NotebookCellList<TCell extends NotebookViewCell = NotebookViewCe
   );
 }
 
-function defaultResetKeysForCell(cell: NotebookViewCell): readonly unknown[] {
+function defaultResetKeysForCell(cell: NotebookCellListItem): readonly unknown[] {
   return [
     cell.id,
     cell.cellType,
     cell.source,
     cell.language,
     cell.executionCount,
-    cell.outputs.length,
+    cell.outputs?.length ?? 0,
   ];
 }
 

--- a/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { NotebookCellList } from "../NotebookCellList";
 import type { NotebookViewCell } from "../view-model";
 
@@ -58,5 +58,31 @@ describe("NotebookCellList", () => {
     );
 
     expect(screen.getByText("No cells")).toBeVisible();
+  });
+
+  it("lets read-only hosts keep duplicate cell ids renderable for malformed imported notebooks", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      render(
+        <NotebookCellList
+          cells={[
+            { ...cells[0], id: "duplicate", source: "# First" },
+            { ...cells[1], id: "duplicate", source: "print('second')" },
+          ]}
+          keyForCell={(cell, index) => `${cell.id}:${index}`}
+          renderCell={(cell) => <article>{cell.source}</article>}
+        />,
+      );
+
+      expect(screen.getByText("# First")).toBeVisible();
+      expect(screen.getByText("print('second')")).toBeVisible();
+      expect(
+        consoleError.mock.calls.some((args) =>
+          String(args[0]).includes("Encountered two children with the same key"),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/components/notebook-shell/cell-data.ts
+++ b/src/components/notebook-shell/cell-data.ts
@@ -1,0 +1,17 @@
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import type { SupportedLanguage } from "@/components/editor/languages";
+
+export interface NotebookCellListItem {
+  id: string;
+  cellType: string;
+  source: string;
+  language?: string | null;
+  executionCount?: number | null;
+  outputs?: readonly unknown[];
+}
+
+export interface ReadOnlyNotebookCellData extends NotebookCellListItem {
+  language?: SupportedLanguage | null;
+  outputs?: readonly JupyterOutput[];
+  executionId?: string | null;
+}

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -6,6 +6,7 @@ export {
   type NotebookShellAuthCapabilities,
   type NotebookShellCapabilities,
 } from "./capabilities";
+export type { NotebookCellListItem, ReadOnlyNotebookCellData } from "./cell-data";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";

--- a/src/components/notebook-shell/view-model.ts
+++ b/src/components/notebook-shell/view-model.ts
@@ -1,8 +1,8 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
-import type { ReadOnlyNotebookCellData } from "@/components/cell/ReadOnlyNotebook";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { projectNotebookOutline, type NotebookOutlineItem } from "runtimed";
+import type { ReadOnlyNotebookCellData } from "./cell-data";
 
 export type NotebookViewCellType = "code" | "markdown" | "raw";
 


### PR DESCRIPTION
## Summary

- loosen `NotebookCellList` to a minimal shared cell-list item contract
- route `ReadOnlyNotebook` through `NotebookCellList` instead of maintaining its own duplicated section/error-boundary frame
- move read-only cell list data contracts into `notebook-shell` so shared shell projections no longer import the read-only cell wrapper
- preserve existing read-only cell props, reset keys, empty state, and custom error rendering

## Stack order

1. #3215
2. #3220
3. #3221
4. #3222
5. This PR

Merge bottom-up. This PR is intentionally stacked on #3222 and should be retargeted to `main` by GitHub as lower PRs merge.

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/ReadOnlyNotebook.test.tsx src/components/notebook-shell/__tests__/NotebookCellList.test.tsx src/components/notebook-shell/__tests__/NotebookReadOnlyView.test.tsx src/components/notebook-shell/__tests__/view-model.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
