### PR TITLE
refactor(notebook): share cell presence dots

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -74,6 +74,23 @@ test("cloud editable cells share hosted CRDT and presence bridge plumbing", () =
   );
 });
 
+test("cloud editable cells render presence through shared cell dots", () => {
+  const adapterPath = new URL("../viewer/cell-presence.tsx", import.meta.url);
+  const adapterSource = readFileSync(adapterPath, "utf8");
+  const markdownPath = new URL("../viewer/editable-markdown-cell.tsx", import.meta.url);
+  const markdownSource = readFileSync(markdownPath, "utf8");
+  const codePath = new URL("../viewer/editable-code-cell.tsx", import.meta.url);
+  const codeSource = readFileSync(codePath, "utf8");
+
+  assert.match(
+    adapterSource,
+    /import \{ CellPresenceDots, type CellPresencePeer \} from "@\/components\/cell\/CellPresenceDots";/,
+  );
+  assert.match(adapterSource, /<CellPresenceDots peers=\{peers\} maxVisible=\{4\}/);
+  assert.match(markdownSource, /presenceIndicators=\{<CloudCellPresenceIndicators/);
+  assert.match(codeSource, /presenceIndicators=\{<CloudCellPresenceIndicators/);
+});
+
 test("cloud live notebook passes renderer policy into editable markdown cells", () => {
   const sourcePath = new URL("../viewer/cloud-live-notebook.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/cell-presence.tsx
+++ b/apps/notebook-cloud/viewer/cell-presence.tsx
@@ -1,0 +1,31 @@
+import { CellPresenceDots, type CellPresencePeer } from "@/components/cell/CellPresenceDots";
+import type { RemoteCellPresence } from "@/components/editor/presence-state";
+import { useMemo } from "react";
+
+export interface CloudCellPresenceIndicatorsProps {
+  presence?: RemoteCellPresence;
+}
+
+export function CloudCellPresenceIndicators({ presence }: CloudCellPresenceIndicatorsProps) {
+  const peers = useMemo(() => remotePresencePeers(presence), [presence]);
+  return <CellPresenceDots peers={peers} maxVisible={4} />;
+}
+
+function remotePresencePeers(presence?: RemoteCellPresence): CellPresencePeer[] {
+  const byPeer = new Map<string, CellPresencePeer>();
+  for (const cursor of presence?.cursors ?? []) {
+    byPeer.set(cursor.peerId, {
+      peerId: cursor.peerId,
+      peerLabel: cursor.peerLabel,
+      color: cursor.color,
+    });
+  }
+  for (const selection of presence?.selections ?? []) {
+    byPeer.set(selection.peerId, {
+      peerId: selection.peerId,
+      peerLabel: selection.peerLabel,
+      color: selection.color,
+    });
+  }
+  return Array.from(byPeer.values());
+}

--- a/apps/notebook-cloud/viewer/editable-code-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-code-cell.tsx
@@ -13,6 +13,7 @@ import { type CloudTextAttributionQueue, useCloudEditableCellBridge } from "./cl
 import type { ResolvedCell } from "./render-resolution";
 import type { NotebookHandle } from "./runtimed-wasm-client";
 import { cloudSourceLanguage } from "./source-language";
+import { CloudCellPresenceIndicators } from "./cell-presence";
 
 export interface EditableCodeCellProps {
   cell: ResolvedCell;
@@ -99,45 +100,11 @@ export function EditableCodeCell({
       sourceClassName={sourceClassName}
       outputClassName={outputClassName}
       editorClassName="cloud-code-editor"
-      presenceIndicators={<CloudCodePresenceIndicators presence={remotePresence} />}
+      presenceIndicators={<CloudCellPresenceIndicators presence={remotePresence} />}
       deferIsolatedFrameUntilVisible
       deferredIsolatedFrameRootMargin="600px 0px"
       resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
       onNavigateToTracebackCell={onNavigateToTracebackCell}
     />
-  );
-}
-
-function CloudCodePresenceIndicators({ presence }: { presence?: RemoteCellPresence }) {
-  const peersById = new Map<string, { label: string; color: string }>();
-  for (const cursor of presence?.cursors ?? []) {
-    peersById.set(cursor.peerId, {
-      label: cursor.peerLabel,
-      color: cursor.color,
-    });
-  }
-  for (const selection of presence?.selections ?? []) {
-    peersById.set(selection.peerId, {
-      label: selection.peerLabel,
-      color: selection.color,
-    });
-  }
-  const peers = Array.from(peersById.entries()).map(([peerId, peer]) => ({ peerId, ...peer }));
-
-  if (peers.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="cloud-markdown-presence" aria-label="Remote editors">
-      {peers.slice(0, 4).map((peer) => (
-        <span
-          key={peer.peerId}
-          style={{ backgroundColor: peer.color }}
-          title={peer.label}
-          aria-label={peer.label}
-        />
-      ))}
-    </div>
   );
 }

--- a/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
+++ b/apps/notebook-cloud/viewer/editable-markdown-cell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { EditableMarkdownCell as SharedEditableMarkdownCell } from "@/components/cell/EditableMarkdownCell";
 import type { CodeMirrorEditorRef } from "@/components/editor";
 import { setRemoteCursors, setRemoteSelections } from "@/components/editor/remote-cursors";
@@ -6,6 +6,7 @@ import type { RemoteCellPresence } from "@/components/editor/presence-state";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { notebookCellAnchorId } from "runtimed";
 import { type CloudTextAttributionQueue, useCloudEditableCellBridge } from "./cloud-cell-editing";
+import { CloudCellPresenceIndicators } from "./cell-presence";
 import type { ResolvedCell } from "./render-resolution";
 import type { NotebookHandle } from "./runtimed-wasm-client";
 
@@ -94,43 +95,7 @@ export function EditableMarkdownCell({
       priority={priority}
       hostContext={hostContext}
       editorExtensions={editorExtensions}
-      presenceIndicators={<CloudMarkdownPresenceIndicators presence={remotePresence} />}
+      presenceIndicators={<CloudCellPresenceIndicators presence={remotePresence} />}
     />
-  );
-}
-
-function CloudMarkdownPresenceIndicators({ presence }: { presence?: RemoteCellPresence }) {
-  const peers = useMemo(() => {
-    const byPeer = new Map<string, { label: string; color: string }>();
-    for (const cursor of presence?.cursors ?? []) {
-      byPeer.set(cursor.peerId, {
-        label: cursor.peerLabel,
-        color: cursor.color,
-      });
-    }
-    for (const selection of presence?.selections ?? []) {
-      byPeer.set(selection.peerId, {
-        label: selection.peerLabel,
-        color: selection.color,
-      });
-    }
-    return Array.from(byPeer.entries()).map(([peerId, peer]) => ({ peerId, ...peer }));
-  }, [presence]);
-
-  if (peers.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="cloud-markdown-presence" aria-label="Remote editors">
-      {peers.slice(0, 4).map((peer) => (
-        <span
-          key={peer.peerId}
-          style={{ backgroundColor: peer.color }}
-          title={peer.label}
-          aria-label={peer.label}
-        />
-      ))}
-    </div>
   );
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -817,21 +817,6 @@ body {
   height: 1rem;
 }
 
-.cloud-markdown-presence {
-  display: inline-flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  align-items: center;
-  padding-top: 0.25rem;
-}
-
-.cloud-markdown-presence span {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 999px;
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--background) 80%, transparent);
-}
-
 .cloud-editable-markdown-cell .cm-editor {
   border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 6px;

--- a/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
+++ b/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { cn } from "@/lib/utils";
+import { CellPresenceDots } from "@/components/cell/CellPresenceDots";
 import { getPeersForCell, type PeerCursorInfo, subscribeToCell } from "../../lib/cursor-registry";
 
 interface CellPresenceIndicatorsProps {
@@ -17,7 +17,6 @@ interface CellPresenceIndicatorsProps {
   className?: string;
 }
 
-/** Maximum visible indicators before showing overflow count */
 const MAX_VISIBLE = 3;
 
 export function CellPresenceIndicators({
@@ -46,62 +45,13 @@ export function CellPresenceIndicators({
     return null;
   }
 
-  const visiblePeers = peers.slice(0, maxVisible);
-  const overflowCount = peers.length - maxVisible;
-
   return (
-    <div
-      data-slot="cell-presence-indicators"
-      className={cn(
-        "flex items-center gap-0.5",
-        variant === "stack" ? "flex-col" : "flex-row",
-        className,
-      )}
-      title={formatTooltip(peers)}
-      aria-label={formatTooltip(peers)}
-    >
-      {prefixSeparator && (
-        <span className="text-muted-foreground/30" aria-hidden="true">
-          ·
-        </span>
-      )}
-      {visiblePeers.map((peer) => (
-        <PresenceDot key={peer.peerId} peer={peer} />
-      ))}
-      {overflowCount > 0 && (
-        <span className="text-[9px] leading-none font-medium text-muted-foreground">
-          +{overflowCount}
-        </span>
-      )}
-    </div>
-  );
-}
-
-interface PresenceDotProps {
-  peer: PeerCursorInfo;
-}
-
-function PresenceDot({ peer }: PresenceDotProps) {
-  return (
-    <div
-      className="w-2 h-2 rounded-full shrink-0 transition-colors"
-      style={{ backgroundColor: peer.color }}
-      title={peer.peerLabel || "Peer"}
+    <CellPresenceDots
+      peers={peers}
+      variant={variant}
+      maxVisible={maxVisible}
+      prefixSeparator={prefixSeparator}
+      className={className}
     />
   );
-}
-
-function formatTooltip(peers: PeerCursorInfo[]): string {
-  if (peers.length === 0) return "";
-  if (peers.length === 1) {
-    return peers[0].peerLabel || "1 peer";
-  }
-  const labels = peers
-    .map((p) => p.peerLabel)
-    .filter(Boolean)
-    .join(", ");
-  if (labels) {
-    return labels;
-  }
-  return `${peers.length} peers`;
 }

--- a/src/components/cell/CellPresenceDots.tsx
+++ b/src/components/cell/CellPresenceDots.tsx
@@ -1,0 +1,82 @@
+import { cn } from "@/lib/utils";
+
+export interface CellPresencePeer {
+  peerId: string;
+  peerLabel?: string | null;
+  color: string;
+}
+
+export interface CellPresenceDotsProps {
+  peers: readonly CellPresencePeer[];
+  variant?: "stack" | "inline";
+  maxVisible?: number;
+  prefixSeparator?: boolean;
+  className?: string;
+}
+
+const DEFAULT_MAX_VISIBLE = 3;
+
+export function CellPresenceDots({
+  peers,
+  variant = "stack",
+  maxVisible = DEFAULT_MAX_VISIBLE,
+  prefixSeparator = false,
+  className,
+}: CellPresenceDotsProps) {
+  if (peers.length === 0) {
+    return null;
+  }
+
+  const visiblePeers = peers.slice(0, maxVisible);
+  const overflowCount = peers.length - maxVisible;
+  const label = formatTooltip(peers);
+
+  return (
+    <div
+      data-slot="cell-presence-indicators"
+      className={cn(
+        "flex items-center gap-0.5",
+        variant === "stack" ? "flex-col" : "flex-row",
+        className,
+      )}
+      title={label}
+      aria-label={label}
+    >
+      {prefixSeparator ? (
+        <span className="text-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+      ) : null}
+      {visiblePeers.map((peer) => (
+        <PresenceDot key={peer.peerId} peer={peer} />
+      ))}
+      {overflowCount > 0 ? (
+        <span className="text-[9px] leading-none font-medium text-muted-foreground">
+          +{overflowCount}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function PresenceDot({ peer }: { peer: CellPresencePeer }) {
+  return (
+    <span
+      className="h-2 w-2 shrink-0 rounded-full transition-colors"
+      style={{ backgroundColor: peer.color }}
+      title={peer.peerLabel || "Peer"}
+    />
+  );
+}
+
+function formatTooltip(peers: readonly CellPresencePeer[]): string {
+  if (peers.length === 0) return "";
+  if (peers.length === 1) {
+    return peers[0].peerLabel || "1 peer";
+  }
+  const labels = peers
+    .map((peer) => peer.peerLabel)
+    .filter(Boolean)
+    .join(", ");
+  return labels || `${peers.length} peers`;
+}

--- a/src/components/cell/__tests__/CellPresenceDots.test.tsx
+++ b/src/components/cell/__tests__/CellPresenceDots.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { CellPresenceDots } from "../CellPresenceDots";
+
+const peers = [
+  { peerId: "alice", peerLabel: "Alice", color: "#0ea5e9" },
+  { peerId: "bob", peerLabel: "Bob", color: "#22c55e" },
+  { peerId: "carol", peerLabel: "Carol", color: "#f97316" },
+  { peerId: "dana", peerLabel: "Dana", color: "#a855f7" },
+] as const;
+
+describe("CellPresenceDots", () => {
+  it("renders labeled peer dots with overflow", () => {
+    render(<CellPresenceDots peers={peers} maxVisible={2} />);
+
+    expect(screen.getByLabelText("Alice, Bob, Carol, Dana")).toBeVisible();
+    expect(screen.getByTitle("Alice")).toBeVisible();
+    expect(screen.getByTitle("Bob")).toBeVisible();
+    expect(screen.getByText("+2")).toBeVisible();
+  });
+
+  it("can render inline with a prefix separator", () => {
+    const { container } = render(
+      <CellPresenceDots peers={peers.slice(0, 1)} variant="inline" prefixSeparator />,
+    );
+
+    expect(screen.getByLabelText("Alice")).toBeVisible();
+    expect(container.textContent).toContain("·");
+  });
+
+  it("renders nothing without peers", () => {
+    const { container } = render(<CellPresenceDots peers={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- extract the cell presence dot renderer into shared `src/components/cell`
- keep desktop cursor-registry subscription logic in the desktop host wrapper while delegating rendering to the shared dots
- replace cloud's duplicated markdown/code presence dot renderers with one cloud adapter over the shared dots

## Stack order

1. #3215
2. #3220
3. #3221
4. #3222
5. #3223
6. This PR

Merge bottom-up. This PR is intentionally stacked on #3223 and should be retargeted by GitHub as lower PRs merge.

## Validation

- `pnpm exec vp test run src/components/cell/__tests__/CellPresenceDots.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
