### PR TITLE
refactor(notebook): share editable view frame

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -95,10 +95,10 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
   const sourcePath = new URL("../viewer/cloud-live-notebook.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /NotebookCellList/);
+  assert.match(sourceText, /NotebookEditableView/);
   assert.match(sourceText, /slot="cloud-live-notebook"/);
   assert.match(sourceText, /viewModel: NotebookViewModel<ResolvedCell>/);
-  assert.match(sourceText, /const cells = viewModel\.cells;/);
+  assert.match(sourceText, /<NotebookEditableView[\s\S]*viewModel=\{viewModel\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*hostContext=\{hostContext\}/);
 });
@@ -108,7 +108,7 @@ test("cloud live notebook routes editor code cells through the shared editable c
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /import \{ EditableCodeCell \} from "\.\/editable-code-cell";/);
-  assert.match(sourceText, /cell\.cellType === "code" \? \(/);
+  assert.match(sourceText, /renderCodeCell=\{\(cell\) => \(/);
   assert.match(sourceText, /<EditableCodeCell[\s\S]*showSource=\{showCode\}/);
   assert.match(sourceText, /<EditableCodeCell[\s\S]*onSourceChange=\{onCellSourceChange\}/);
   assert.match(sourceText, /<EditableCodeCell[\s\S]*onSyncNeeded=\{onCellSyncNeeded\}/);

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -1,7 +1,7 @@
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import type { RemoteCellPresence } from "@/components/editor/presence-state";
-import { NotebookCellList, type NotebookViewModel } from "@/components/notebook-shell";
+import { NotebookEditableView, type NotebookViewModel } from "@/components/notebook-shell";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import type { CloudTextAttributionQueue } from "./cloud-cell-editing";
 import { EditableCodeCell } from "./editable-code-cell";
@@ -50,11 +50,9 @@ export function CloudLiveNotebook({
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
 }: CloudLiveNotebookProps) {
-  const cells = viewModel.cells;
-
   return (
-    <NotebookCellList
-      cells={cells}
+    <NotebookEditableView
+      viewModel={viewModel}
       className="cloud-report-notebook"
       slot="cloud-live-notebook"
       renderCellError={(error, _cell, index) => (
@@ -62,64 +60,64 @@ export function CloudLiveNotebook({
           Unable to render cell {index + 1}: {error.message}
         </div>
       )}
-      renderCell={(cell) =>
-        cell.cellType === "markdown" ? (
-          <EditableMarkdownCell
-            cell={cell}
-            className="cloud-cell cloud-editable-markdown-cell"
-            sourceClassName="cloud-source-block"
-            priority={priority}
-            hostContext={hostContext}
-            onSourceChange={onCellSourceChange}
-            onSyncNeeded={onCellSyncNeeded}
-            getHandle={getHandle}
-            localActorLabel={localActorLabel}
-            textAttributionQueue={textAttributionQueue}
-            remotePresence={presenceForCell(livePresence, cell.id)}
-            onPresenceCursor={onPresenceCursor}
-            onPresenceSelection={onPresenceSelection}
-          />
-        ) : cell.cellType === "code" ? (
-          <EditableCodeCell
-            cell={cell}
-            className="cloud-cell cloud-editable-code-cell"
-            sourceClassName="cloud-source-block"
-            outputClassName="cloud-output-block"
-            priority={priority}
-            hostContext={hostContext}
-            showSource={showCode}
-            onSourceChange={onCellSourceChange}
-            onSyncNeeded={onCellSyncNeeded}
-            getHandle={getHandle}
-            localActorLabel={localActorLabel}
-            textAttributionQueue={textAttributionQueue}
-            remotePresence={presenceForCell(livePresence, cell.id)}
-            onPresenceCursor={onPresenceCursor}
-            onPresenceSelection={onPresenceSelection}
-            resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-            onNavigateToTracebackCell={onNavigateToTracebackCell}
-          />
-        ) : (
-          <ReadOnlyNotebookCell
-            id={cell.id}
-            cellType={cell.cellType}
-            source={cell.source}
-            language={cloudSourceLanguage(cell.language)}
-            outputs={cell.outputs}
-            executionCount={cell.executionCount}
-            priority={priority}
-            hostContext={hostContext}
-            showSource
-            className="cloud-cell"
-            sourceClassName="cloud-source-block"
-            outputClassName="cloud-output-block"
-            deferIsolatedFrameUntilVisible
-            deferredIsolatedFrameRootMargin="600px 0px"
-            resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
-            onNavigateToTracebackCell={onNavigateToTracebackCell}
-          />
-        )
-      }
+      renderMarkdownCell={(cell) => (
+        <EditableMarkdownCell
+          cell={cell}
+          className="cloud-cell cloud-editable-markdown-cell"
+          sourceClassName="cloud-source-block"
+          priority={priority}
+          hostContext={hostContext}
+          onSourceChange={onCellSourceChange}
+          onSyncNeeded={onCellSyncNeeded}
+          getHandle={getHandle}
+          localActorLabel={localActorLabel}
+          textAttributionQueue={textAttributionQueue}
+          remotePresence={presenceForCell(livePresence, cell.id)}
+          onPresenceCursor={onPresenceCursor}
+          onPresenceSelection={onPresenceSelection}
+        />
+      )}
+      renderCodeCell={(cell) => (
+        <EditableCodeCell
+          cell={cell}
+          className="cloud-cell cloud-editable-code-cell"
+          sourceClassName="cloud-source-block"
+          outputClassName="cloud-output-block"
+          priority={priority}
+          hostContext={hostContext}
+          showSource={showCode}
+          onSourceChange={onCellSourceChange}
+          onSyncNeeded={onCellSyncNeeded}
+          getHandle={getHandle}
+          localActorLabel={localActorLabel}
+          textAttributionQueue={textAttributionQueue}
+          remotePresence={presenceForCell(livePresence, cell.id)}
+          onPresenceCursor={onPresenceCursor}
+          onPresenceSelection={onPresenceSelection}
+          resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+          onNavigateToTracebackCell={onNavigateToTracebackCell}
+        />
+      )}
+      renderFallbackCell={(cell) => (
+        <ReadOnlyNotebookCell
+          id={cell.id}
+          cellType={cell.cellType}
+          source={cell.source}
+          language={cloudSourceLanguage(cell.language)}
+          outputs={cell.outputs}
+          executionCount={cell.executionCount}
+          priority={priority}
+          hostContext={hostContext}
+          showSource
+          className="cloud-cell"
+          sourceClassName="cloud-source-block"
+          outputClassName="cloud-output-block"
+          deferIsolatedFrameUntilVisible
+          deferredIsolatedFrameRootMargin="600px 0px"
+          resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}
+          onNavigateToTracebackCell={onNavigateToTracebackCell}
+        />
+      )}
     />
   );
 }

--- a/src/components/notebook-shell/NotebookEditableView.tsx
+++ b/src/components/notebook-shell/NotebookEditableView.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { NotebookCellList } from "./NotebookCellList";
+import type { NotebookViewCell, NotebookViewModel } from "./view-model";
+
+export interface NotebookEditableViewProps<TCell extends NotebookViewCell = NotebookViewCell> {
+  viewModel: Pick<NotebookViewModel<TCell>, "cells">;
+  className?: string;
+  slot?: string;
+  renderMarkdownCell: (cell: TCell, index: number) => ReactNode;
+  renderCodeCell: (cell: TCell, index: number) => ReactNode;
+  renderFallbackCell: (cell: TCell, index: number) => ReactNode;
+  renderCellError?: (error: Error, cell: TCell, index: number) => ReactNode;
+}
+
+export function NotebookEditableView<TCell extends NotebookViewCell = NotebookViewCell>({
+  viewModel,
+  className,
+  slot = "notebook-editable-view",
+  renderMarkdownCell,
+  renderCodeCell,
+  renderFallbackCell,
+  renderCellError,
+}: NotebookEditableViewProps<TCell>) {
+  return (
+    <NotebookCellList
+      cells={viewModel.cells}
+      className={className}
+      slot={slot}
+      renderCellError={renderCellError}
+      renderCell={(cell, index) => {
+        if (cell.cellType === "markdown") {
+          return renderMarkdownCell(cell, index);
+        }
+        if (cell.cellType === "code") {
+          return renderCodeCell(cell, index);
+        }
+        return renderFallbackCell(cell, index);
+      }}
+    />
+  );
+}

--- a/src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookEditableView } from "../NotebookEditableView";
+import type { NotebookViewModel } from "../view-model";
+
+const viewModel: Pick<NotebookViewModel, "cells"> = {
+  cells: [
+    {
+      id: "intro",
+      cellType: "markdown",
+      source: "# Intro",
+      language: null,
+      executionId: null,
+      executionCount: null,
+      outputs: [],
+      metadata: {},
+    },
+    {
+      id: "code-1",
+      cellType: "code",
+      source: "print('ok')",
+      language: "python",
+      executionId: "exec-1",
+      executionCount: 1,
+      outputs: [],
+      metadata: {},
+    },
+    {
+      id: "raw-1",
+      cellType: "raw",
+      source: "raw body",
+      language: null,
+      executionId: null,
+      executionCount: null,
+      outputs: [],
+      metadata: {},
+    },
+  ],
+};
+
+describe("NotebookEditableView", () => {
+  it("routes view-model cells through host-provided editable renderers", () => {
+    render(
+      <NotebookEditableView
+        viewModel={viewModel}
+        slot="host-editable-cells"
+        renderMarkdownCell={(cell) => <article>markdown:{cell.source}</article>}
+        renderCodeCell={(cell) => <article>code:{cell.source}</article>}
+        renderFallbackCell={(cell) => <article>fallback:{cell.source}</article>}
+      />,
+    );
+
+    expect(screen.getByLabelText("Notebook cells")).toHaveAttribute(
+      "data-slot",
+      "host-editable-cells",
+    );
+    expect(screen.getByText("markdown:# Intro")).toBeVisible();
+    expect(screen.getByText("code:print('ok')")).toBeVisible();
+    expect(screen.getByText("fallback:raw body")).toBeVisible();
+  });
+
+  it("keeps host error rendering at the shared cell-list boundary", () => {
+    render(
+      <NotebookEditableView
+        viewModel={viewModel}
+        renderMarkdownCell={() => <ThrowingCell />}
+        renderCodeCell={(cell) => <article>{cell.source}</article>}
+        renderFallbackCell={(cell) => <article>{cell.source}</article>}
+        renderCellError={(error, _cell, index) => (
+          <p>
+            cell {index + 1}: {error.message}
+          </p>
+        )}
+      />,
+    );
+
+    expect(screen.getByText("cell 1: markdown failed")).toBeVisible();
+    expect(screen.getByText("print('ok')")).toBeVisible();
+  });
+});
+
+function ThrowingCell() {
+  throw new Error("markdown failed");
+}

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -10,6 +10,7 @@ export type { NotebookCellListItem, ReadOnlyNotebookCellData } from "./cell-data
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
+export { NotebookEditableView, type NotebookEditableViewProps } from "./NotebookEditableView";
 export {
   NotebookPackageSummaryPanel,
   type NotebookPackageSummaryPanelProps,


### PR DESCRIPTION
## Summary

- add `NotebookEditableView` as the shared shell frame for host-provided editable cell rendering
- move cloud's markdown/code/fallback cell-type routing into the shared notebook-shell layer
- leave cloud-specific renderer callbacks, live-sync writes, presence projection, and hosted output policy in the cloud adapter

## Stack order

1. #3215
2. #3220
3. #3221
4. #3222
5. #3223
6. #3224
7. This PR

Merge bottom-up. This PR is intentionally stacked on #3224 and should be retargeted by GitHub as lower PRs merge.

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx src/components/notebook-shell/__tests__/NotebookCellList.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
