### PR TITLE
refactor(notebook): share hosted frame layout

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -156,6 +156,16 @@ test("cloud rail binds through the shared document rail adapter", () => {
   assert.doesNotMatch(sourceText, /<NotebookRail[\s>]/);
 });
 
+test("cloud viewer shell uses the shared host header frame above the rail body", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /header=\{toolbar\}/);
+  assert.match(sourceText, /headerClassName="cloud-report-toolbar"/);
+  assert.match(sourceText, /bodyClassName="cloud-notebook-body"/);
+  assert.doesNotMatch(sourceText, /toolbar=\{toolbar\}/);
+});
+
 test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -24,6 +24,14 @@ body {
   background: var(--background);
 }
 
+.cloud-notebook-body {
+  display: flex;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
 .cloud-notebook-rail {
   z-index: 15;
   height: 100%;
@@ -190,10 +198,9 @@ body {
 }
 
 .cloud-report-toolbar {
-  position: sticky;
-  top: 0;
   z-index: 20;
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1214,10 +1214,11 @@ function NotebookViewer({
     <NotebookDocumentShell
       rootElement="main"
       className="cloud-notebook-shell"
+      header={toolbar}
+      headerClassName="cloud-report-toolbar"
+      headerLabel="Notebook view status and controls"
+      bodyClassName="cloud-notebook-body"
       stageClassName="cloud-notebook-stage"
-      toolbar={toolbar}
-      toolbarClassName="cloud-report-toolbar"
-      toolbarLabel="Notebook view status and controls"
       capabilities={shellCapabilities}
       rail={rail}
       stageLabel="Hosted notebook"

--- a/src/components/notebook-shell/NotebookDocumentShell.tsx
+++ b/src/components/notebook-shell/NotebookDocumentShell.tsx
@@ -8,12 +8,16 @@ export interface NotebookDocumentShellProps {
    * landmark already exists.
    */
   rootElement?: "div" | "main";
+  header?: ReactNode;
   rail?: ReactNode;
   toolbar?: ReactNode;
   notices?: ReactNode;
   children: ReactNode;
   capabilities?: NotebookShellCapabilities;
   className?: string;
+  headerClassName?: string;
+  headerLabel?: string;
+  bodyClassName?: string;
   stageClassName?: string;
   toolbarClassName?: string;
   toolbarLabel?: string;
@@ -23,12 +27,16 @@ export interface NotebookDocumentShellProps {
 
 export function NotebookDocumentShell({
   rootElement = "div",
+  header,
   rail,
   toolbar,
   notices,
   children,
   capabilities,
   className,
+  headerClassName,
+  headerLabel,
+  bodyClassName,
   stageClassName,
   toolbarClassName,
   toolbarLabel,
@@ -36,10 +44,50 @@ export function NotebookDocumentShell({
   stageLabel = "Notebook",
 }: NotebookDocumentShellProps) {
   const Root = rootElement as ElementType;
+  const hasHeader = Boolean(header);
+
+  const stage = (
+    <section
+      className={cn("flex min-w-0 flex-1 flex-col", stageClassName)}
+      aria-label={stageLabel}
+      data-slot="notebook-document-stage"
+    >
+      {toolbar ? (
+        <div
+          className={toolbarClassName}
+          aria-label={toolbarLabel}
+          data-slot="notebook-document-toolbar"
+        >
+          {toolbar}
+        </div>
+      ) : null}
+      {notices ? (
+        <div className={noticesClassName} data-slot="notebook-document-notices">
+          {notices}
+        </div>
+      ) : null}
+      {children}
+    </section>
+  );
+
+  const body = hasHeader ? (
+    <div
+      className={cn("flex min-h-0 min-w-0 flex-1 overflow-hidden", bodyClassName)}
+      data-slot="notebook-document-body"
+    >
+      {rail}
+      {stage}
+    </div>
+  ) : (
+    <>
+      {rail}
+      {stage}
+    </>
+  );
 
   return (
     <Root
-      className={cn("flex min-h-0 flex-1 overflow-hidden", className)}
+      className={cn("flex min-h-0 flex-1 overflow-hidden", hasHeader && "flex-col", className)}
       data-authenticated={capabilities?.auth.canUseAuthenticatedIdentity}
       data-access-level={capabilities?.access.level}
       data-access-source={capabilities?.access.source}
@@ -48,28 +96,16 @@ export function NotebookDocumentShell({
       data-can-share={capabilities?.canManageSharing}
       data-slot="notebook-document-shell"
     >
-      {rail}
-      <section
-        className={cn("flex min-w-0 flex-1 flex-col", stageClassName)}
-        aria-label={stageLabel}
-        data-slot="notebook-document-stage"
-      >
-        {toolbar ? (
-          <div
-            className={toolbarClassName}
-            aria-label={toolbarLabel}
-            data-slot="notebook-document-toolbar"
-          >
-            {toolbar}
-          </div>
-        ) : null}
-        {notices ? (
-          <div className={noticesClassName} data-slot="notebook-document-notices">
-            {notices}
-          </div>
-        ) : null}
-        {children}
-      </section>
+      {header ? (
+        <div
+          className={headerClassName}
+          aria-label={headerLabel}
+          data-slot="notebook-document-header-frame"
+        >
+          {header}
+        </div>
+      ) : null}
+      {body}
     </Root>
   );
 }

--- a/src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx
@@ -37,6 +37,29 @@ describe("NotebookDocumentShell", () => {
     expect(screen.getByLabelText("Hosted notebook")).toBeVisible();
   });
 
+  it("can render a fixed host header above the rail and document stage", () => {
+    const { container } = render(
+      <NotebookDocumentShell
+        header={<button type="button">Sign in</button>}
+        headerLabel="Notebook controls"
+        rail={<nav aria-label="Rail">rail</nav>}
+        stageLabel="Hosted notebook"
+      >
+        <section aria-label="Notebook cells">cells</section>
+      </NotebookDocumentShell>,
+    );
+
+    const header = container.querySelector("[data-slot='notebook-document-header-frame']");
+    const body = container.querySelector("[data-slot='notebook-document-body']");
+    expect(header).not.toBeNull();
+    expect(header).toHaveAttribute("aria-label", "Notebook controls");
+    expect(body).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeVisible();
+    expect(screen.getByLabelText("Rail")).toBeVisible();
+    expect(screen.getByLabelText("Hosted notebook")).toBeVisible();
+    expect(screen.getByLabelText("Notebook cells")).toBeVisible();
+  });
+
   it("exposes host capabilities for adapters and smoke tests", () => {
     const capabilities: NotebookShellCapabilities = {
       canRead: true,


### PR DESCRIPTION
## Summary

- add a shared `NotebookDocumentShell` header/body frame for hosted notebook surfaces
- move notebook-cloud controls into that shared header frame, above the rail + document stage body
- keep cloud surface tests checking that hosted layout goes through the shared shell instead of a cloud-only toolbar lane

## Stack

- Depends on #3225 (`quod/notebook-shared-editable-view`)
- Merge order: #3223, #3224, #3225, then this PR

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
