### PR TITLE
refactor(notebook): share cell-list scrolling

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -97,6 +97,7 @@ test("cloud live notebook passes renderer policy into editable markdown cells", 
 
   assert.match(sourceText, /NotebookEditableView/);
   assert.match(sourceText, /slot="cloud-live-notebook"/);
+  assert.match(sourceText, /scrollable/);
   assert.match(sourceText, /viewModel: NotebookViewModel<ResolvedCell>/);
   assert.match(sourceText, /<NotebookEditableView[\s\S]*viewModel=\{viewModel\}/);
   assert.match(sourceText, /<EditableMarkdownCell[\s\S]*priority=\{priority\}/);
@@ -134,6 +135,7 @@ test("cloud read-only notebook renders from the shared notebook view model", () 
 
   assert.match(sourceText, /NotebookReadOnlyView/);
   assert.match(sourceText, /<NotebookReadOnlyView[\s\S]*viewModel=\{notebookViewModel\}/);
+  assert.match(sourceText, /<NotebookReadOnlyView[\s\S]*scrollable/);
   assert.doesNotMatch(sourceText, /cells=\{readOnlyCells\}/);
 });
 

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -55,6 +55,7 @@ export function CloudLiveNotebook({
       viewModel={viewModel}
       className="cloud-report-notebook"
       slot="cloud-live-notebook"
+      scrollable
       renderCellError={(error, _cell, index) => (
         <div className="cloud-state" data-kind="error">
           Unable to render cell {index + 1}: {error.message}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -758,9 +758,6 @@ body {
 
 .cloud-report-notebook {
   min-height: 0;
-  overflow-y: auto;
-  scroll-behavior: smooth;
-  overscroll-behavior: contain;
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 0.75rem);
   padding-block: 1rem 2rem;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1290,6 +1290,7 @@ function NotebookViewer({
           hostContext={outputHostContext}
           showCode={showCode}
           className="cloud-report-notebook"
+          scrollable
           cellClassName="cloud-cell"
           sourceClassName="cloud-source-block"
           outputClassName="cloud-output-block"

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -23,6 +23,7 @@ export interface ReadOnlyNotebookProps {
   outputClassName?: string;
   lineWrapping?: boolean;
   label?: string;
+  scrollable?: boolean;
   emptyContent?: ReactNode;
   renderCellError?: (error: Error, cell: ReadOnlyNotebookCellData, index: number) => ReactNode;
   resolveTracebackExecutionTarget?: TracebackExecutionResolver;
@@ -44,6 +45,7 @@ export function ReadOnlyNotebook({
   outputClassName,
   lineWrapping = true,
   label = "Notebook cells",
+  scrollable = false,
   emptyContent = null,
   renderCellError,
   resolveTracebackExecutionTarget,
@@ -55,6 +57,7 @@ export function ReadOnlyNotebook({
       label={label}
       className={className}
       slot="read-only-notebook"
+      scrollable={scrollable}
       emptyContent={emptyContent}
       keyForCell={(cell, index) => `${cell.id}:${index}`}
       renderCellError={(error, cell, index) =>

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -103,6 +103,7 @@ describe("ReadOnlyNotebook", () => {
           },
         }}
         className="notebook-shell"
+        scrollable
         cellClassName="cell-shell"
         sourceClassName="source-shell"
         outputClassName="output-shell"
@@ -113,6 +114,7 @@ describe("ReadOnlyNotebook", () => {
     expect(notebook).toHaveAttribute("aria-label", "Notebook cells");
     expect(notebook).toHaveAttribute("data-cell-count", "2");
     expect(notebook).toHaveClass("notebook-shell");
+    expect(notebook).toHaveClass("overflow-y-auto");
 
     const cells = screen.getAllByTestId("read-only-cell");
     expect(cells).toHaveLength(2);

--- a/src/components/notebook-shell/NotebookCellList.tsx
+++ b/src/components/notebook-shell/NotebookCellList.tsx
@@ -8,6 +8,7 @@ export interface NotebookCellListProps<TCell extends NotebookCellListItem = Note
   label?: string;
   className?: string;
   slot?: string;
+  scrollable?: boolean;
   emptyContent?: ReactNode;
   keyForCell?: (cell: TCell, index: number) => string;
   resetKeysForCell?: (cell: TCell, index: number) => readonly unknown[];
@@ -20,6 +21,7 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
   label = "Notebook cells",
   className,
   slot = "notebook-cell-list",
+  scrollable = false,
   emptyContent = null,
   keyForCell = defaultKeyForCell,
   resetKeysForCell = defaultResetKeysForCell,
@@ -29,7 +31,11 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
   return (
     <section
       aria-label={label}
-      className={cn("flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain", className)}
+      className={cn(
+        "flex min-h-0 flex-1 flex-col overflow-x-clip overscroll-x-contain",
+        scrollable && "overflow-y-auto overscroll-contain scroll-smooth",
+        className,
+      )}
       data-cell-count={cells.length}
       data-slot={slot}
     >

--- a/src/components/notebook-shell/NotebookEditableView.tsx
+++ b/src/components/notebook-shell/NotebookEditableView.tsx
@@ -6,6 +6,7 @@ export interface NotebookEditableViewProps<TCell extends NotebookViewCell = Note
   viewModel: Pick<NotebookViewModel<TCell>, "cells">;
   className?: string;
   slot?: string;
+  scrollable?: boolean;
   renderMarkdownCell: (cell: TCell, index: number) => ReactNode;
   renderCodeCell: (cell: TCell, index: number) => ReactNode;
   renderFallbackCell: (cell: TCell, index: number) => ReactNode;
@@ -16,6 +17,7 @@ export function NotebookEditableView<TCell extends NotebookViewCell = NotebookVi
   viewModel,
   className,
   slot = "notebook-editable-view",
+  scrollable,
   renderMarkdownCell,
   renderCodeCell,
   renderFallbackCell,
@@ -26,6 +28,7 @@ export function NotebookEditableView<TCell extends NotebookViewCell = NotebookVi
       cells={viewModel.cells}
       className={className}
       slot={slot}
+      scrollable={scrollable}
       renderCellError={renderCellError}
       renderCell={(cell, index) => {
         if (cell.cellType === "markdown") {

--- a/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
@@ -60,6 +60,20 @@ describe("NotebookCellList", () => {
     expect(screen.getByText("No cells")).toBeVisible();
   });
 
+  it("can own notebook cell scrolling for document-shell hosts", () => {
+    render(
+      <NotebookCellList
+        cells={cells}
+        scrollable
+        renderCell={(cell) => <article>{cell.source}</article>}
+      />,
+    );
+
+    expect(screen.getByLabelText("Notebook cells")).toHaveClass("overflow-y-auto");
+    expect(screen.getByLabelText("Notebook cells")).toHaveClass("scroll-smooth");
+    expect(screen.getByLabelText("Notebook cells")).toHaveClass("overscroll-contain");
+  });
+
   it("lets read-only hosts keep duplicate cell ids renderable for malformed imported notebooks", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {

--- a/src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx
@@ -44,6 +44,7 @@ describe("NotebookEditableView", () => {
       <NotebookEditableView
         viewModel={viewModel}
         slot="host-editable-cells"
+        scrollable
         renderMarkdownCell={(cell) => <article>markdown:{cell.source}</article>}
         renderCodeCell={(cell) => <article>code:{cell.source}</article>}
         renderFallbackCell={(cell) => <article>fallback:{cell.source}</article>}
@@ -54,6 +55,7 @@ describe("NotebookEditableView", () => {
       "data-slot",
       "host-editable-cells",
     );
+    expect(screen.getByLabelText("Notebook cells")).toHaveClass("overflow-y-auto");
     expect(screen.getByText("markdown:# Intro")).toBeVisible();
     expect(screen.getByText("code:print('ok')")).toBeVisible();
     expect(screen.getByText("fallback:raw body")).toBeVisible();


### PR DESCRIPTION
## Summary

- let the shared `NotebookCellList` own scrollable notebook-cell viewport behavior
- expose the scrollable option through shared editable and read-only notebook surfaces
- switch notebook-cloud read-only/live notebook views to the shared scroll path and remove the cloud-local scroll CSS

## Stack

- Depends on #3227 (`quod/notebook-cloud-frame-smoke`)
- Merge order: #3223, #3224, #3225, #3226, #3227, then this PR

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookCellList.test.tsx src/components/notebook-shell/__tests__/NotebookEditableView.test.tsx src/components/cell/__tests__/ReadOnlyNotebook.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
