### PR TITLE
refactor(notebook): share header control chrome

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -67,12 +67,19 @@ test("cloud viewer routes notebook header controls through the shared shell head
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookDocumentHeader,/);
+  assert.match(sourceText, /NotebookDocumentHeaderButton,/);
+  assert.match(sourceText, /NotebookDocumentHeaderMenu,/);
   assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /codeControls=\{[\s\S]*className="cloud-code-toggle"/);
+  assert.match(sourceText, /codeControls=\{[\s\S]*<NotebookDocumentHeaderButton/);
+  assert.match(sourceText, /<CloudSharingControls[\s\S]*<NotebookDocumentHeaderMenu/);
+  assert.match(sourceText, /<CloudNotebookEditModeButton[\s\S]*<NotebookDocumentHeaderButton/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);
+  assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
+  assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
+  assert.doesNotMatch(sourceText, /className="cloud-sign-in-button"/);
 });
 
 test("cloud viewer defers supplemental CSS loading until the notebook surface mounts", () => {
@@ -113,7 +120,7 @@ test("cloud notebook shell keeps the rail and toolbar outside the cell scroller"
   );
   assert.match(sourceText, /\.cloud-notebook-rail\s*\{[\s\S]*height: 100%;/);
   assert.match(sourceText, /\.cloud-report-toolbar\s*\{[\s\S]*top: 0;[\s\S]*border-bottom:/);
-  assert.match(sourceText, /\.cloud-report-notebook\s*\{[\s\S]*overflow-y: auto;/);
+  assert.doesNotMatch(sourceText, /\.cloud-report-notebook\s*\{[\s\S]*overflow-y: auto;/);
   assert.doesNotMatch(
     sourceText.match(/\.cloud-notebook-shell\s*\{[^}]*\}/)?.[0] ?? "",
     /flex-direction: column;/,

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -198,6 +198,8 @@ body {
 }
 
 .cloud-report-toolbar {
+  position: sticky;
+  top: 0;
   z-index: 20;
   display: flex;
   flex: 0 0 auto;
@@ -264,129 +266,28 @@ body {
   border-radius: 999px;
 }
 
-.cloud-auth-menu {
-  position: relative;
-}
-
-.cloud-share-menu {
-  position: relative;
-}
-
 .cloud-share-menu summary,
-.cloud-auth-menu summary,
-.cloud-scope-toggle-button,
-.cloud-sign-in-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  min-width: 0;
-  max-width: min(12rem, 38vw);
-  height: 2rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 999px;
-  padding-inline: 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 90%, transparent);
-  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
-  backdrop-filter: blur(8px);
-  cursor: pointer;
+.cloud-auth-menu summary {
   list-style: none;
 }
 
+.cloud-share-menu summary::-webkit-details-marker,
 .cloud-auth-menu summary::-webkit-details-marker {
   display: none;
 }
 
-.cloud-share-menu summary::-webkit-details-marker {
-  display: none;
-}
-
-.cloud-share-menu summary:hover,
-.cloud-auth-menu summary:hover,
-.cloud-scope-toggle-button:hover {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
-}
-
-.cloud-share-menu summary:focus-visible,
-.cloud-auth-menu summary:focus-visible,
-.cloud-scope-toggle-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
-  outline-offset: 2px;
-}
-
 .cloud-share-menu svg,
 .cloud-auth-menu svg,
-.cloud-scope-toggle-button svg,
-.cloud-sign-in-button svg,
 .cloud-auth-state svg {
   width: 1rem;
   height: 1rem;
   flex: 0 0 auto;
 }
 
-.cloud-share-menu summary span,
-.cloud-auth-menu summary span,
-.cloud-scope-toggle-button span,
-.cloud-sign-in-button span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.8125rem;
-  line-height: 1;
-}
-
-.cloud-sign-in-button {
-  cursor: pointer;
-}
-
-.cloud-scope-toggle-button[data-state="editing"] {
-  border-color: color-mix(in srgb, #16a34a 52%, transparent);
-  color: color-mix(in srgb, #16a34a 80%, var(--foreground) 20%);
-}
-
-.cloud-scope-toggle-button[data-state="requested"] {
-  border-color: color-mix(in srgb, var(--ring) 48%, transparent);
-}
-
-.cloud-sign-in-button:hover {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
-}
-
-.cloud-sign-in-button:disabled {
-  cursor: progress;
-  opacity: 0.72;
-}
-
-.cloud-sign-in-button:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
-  outline-offset: 2px;
-}
-
-.cloud-sign-in-button[data-state="error"] {
-  border-color: color-mix(in srgb, #dc2626 48%, transparent);
-  color: #dc2626;
-}
-
 .cloud-share-panel {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  z-index: 30;
   display: grid;
   gap: 0.875rem;
   width: min(28rem, calc(100vw - 1.5rem));
-  max-height: min(42rem, calc(100vh - 5rem));
-  overflow: auto;
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 8px;
-  padding: 0.875rem;
-  color: var(--foreground);
-  background: var(--background);
-  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
 }
 
 .cloud-share-panel header,
@@ -576,23 +477,16 @@ body {
   background: color-mix(in srgb, #b42318 8%, var(--background));
 }
 
-.cloud-auth-menu form {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  z-index: 30;
-  display: grid;
-  gap: 0.625rem;
+.cloud-auth-panel {
   width: min(20rem, calc(100vw - 1.5rem));
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 8px;
-  padding: 0.875rem;
-  color: var(--foreground);
-  background: var(--background);
-  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
 }
 
-.cloud-auth-menu p {
+.cloud-auth-form {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.cloud-auth-form p {
   margin: 0;
   color: color-mix(in srgb, var(--foreground) 72%, transparent);
   font-size: 0.8125rem;
@@ -640,15 +534,15 @@ body {
   color: #0f766e;
 }
 
-.cloud-auth-menu label {
+.cloud-auth-form label {
   display: grid;
   gap: 0.25rem;
   font-size: 0.8125rem;
   line-height: 1.2;
 }
 
-.cloud-auth-menu input,
-.cloud-auth-menu select {
+.cloud-auth-form input,
+.cloud-auth-form select {
   min-width: 0;
   height: 2rem;
   border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
@@ -705,37 +599,6 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-}
-
-.cloud-code-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  width: 3.25rem;
-  height: 2rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 999px;
-  color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 90%, transparent);
-  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
-  backdrop-filter: blur(8px);
-  pointer-events: auto;
-}
-
-.cloud-code-toggle:hover {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
-}
-
-.cloud-code-toggle:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
-  outline-offset: 2px;
-}
-
-.cloud-code-toggle svg {
-  width: 1rem;
-  height: 1rem;
 }
 
 @media (max-width: 640px) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -33,6 +33,8 @@ import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   createNotebookViewModel,
   NotebookDocumentHeader,
+  NotebookDocumentHeaderButton,
+  NotebookDocumentHeaderMenu,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
@@ -1194,17 +1196,19 @@ function NotebookViewer({
       }
       codeControls={
         status.kind === "ready" ? (
-          <button
-            type="button"
-            className="cloud-code-toggle"
+          <NotebookDocumentHeaderButton
             aria-pressed={showCode}
             aria-label={showCode ? "Hide code cells" : "Show code cells"}
             title={showCode ? "Hide code cells" : "Show code cells"}
+            active={showCode}
+            icon={
+              <>
+                {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
+                <Code2 aria-hidden="true" />
+              </>
+            }
             onClick={() => setShowCode((current) => !current)}
-          >
-            {showCode ? <EyeOff aria-hidden="true" /> : <Eye aria-hidden="true" />}
-            <Code2 aria-hidden="true" />
-          </button>
+          />
         ) : null
       }
     />
@@ -1527,119 +1531,121 @@ function CloudSharingControls({
   };
 
   return (
-    <details
+    <NotebookDocumentHeaderMenu
       className="cloud-share-menu"
       open={open}
       onToggle={(event) => setOpen(event.currentTarget.open)}
+      trigger={
+        <>
+          <Share2 aria-hidden="true" />
+          <span>Share</span>
+        </>
+      }
+      triggerTitle="Share notebook"
+      panelClassName="cloud-share-panel"
     >
-      <summary title="Share notebook">
-        <Share2 aria-hidden="true" />
-        <span>Share</span>
-      </summary>
-      <div className="cloud-share-panel">
-        <header>
-          <div>
-            <h2>Share notebook</h2>
-            <p>Manage public read access and collaborator invites for this cloud notebook.</p>
-          </div>
-          <button type="button" onClick={() => void copyPublicLink()}>
-            <Link2 aria-hidden="true" />
-            {copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy failed" : "Copy"}
-          </button>
-        </header>
+      <header>
+        <div>
+          <h2>Share notebook</h2>
+          <p>Manage public read access and collaborator invites for this cloud notebook.</p>
+        </div>
+        <button type="button" onClick={() => void copyPublicLink()}>
+          <Link2 aria-hidden="true" />
+          {copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy failed" : "Copy"}
+        </button>
+      </header>
 
-        <section className="cloud-share-public" aria-label="Public link access">
+      <section className="cloud-share-public" aria-label="Public link access">
+        <div>
+          <Globe2 aria-hidden="true" />
           <div>
-            <Globe2 aria-hidden="true" />
-            <div>
-              <strong>Anyone with the link</strong>
-              <span>{publicEnabled ? "Can view this notebook" : "No anonymous access"}</span>
-            </div>
+            <strong>Anyone with the link</strong>
+            <span>{publicEnabled ? "Can view this notebook" : "No anonymous access"}</span>
           </div>
-          <button
-            type="button"
-            disabled={busyAction === "public" || loadState === "loading"}
-            onClick={() => void togglePublicAccess()}
+        </div>
+        <button
+          type="button"
+          disabled={busyAction === "public" || loadState === "loading"}
+          onClick={() => void togglePublicAccess()}
+        >
+          {publicEnabled ? "Disable" : "Enable"}
+        </button>
+      </section>
+
+      <form className="cloud-share-invite" onSubmit={submitInvite}>
+        <label>
+          <span>Invite by email</span>
+          <input
+            type="email"
+            value={inviteEmail}
+            placeholder="name@example.com"
+            autoComplete="email"
+            onChange={(event) => {
+              setInviteEmail(event.target.value);
+              setFormError(null);
+            }}
+          />
+        </label>
+        <label>
+          <span>Access</span>
+          <select
+            value={inviteScope}
+            onChange={(event) => setInviteScope(event.target.value as CloudShareInviteScope)}
           >
-            {publicEnabled ? "Disable" : "Enable"}
-          </button>
-        </section>
-
-        <form className="cloud-share-invite" onSubmit={submitInvite}>
-          <label>
-            <span>Invite by email</span>
-            <input
-              type="email"
-              value={inviteEmail}
-              placeholder="name@example.com"
-              autoComplete="email"
-              onChange={(event) => {
-                setInviteEmail(event.target.value);
-                setFormError(null);
-              }}
-            />
-          </label>
-          <label>
-            <span>Access</span>
-            <select
-              value={inviteScope}
-              onChange={(event) => setInviteScope(event.target.value as CloudShareInviteScope)}
-            >
-              <option value="viewer">Can view</option>
-              <option value="editor">Can edit</option>
-            </select>
-          </label>
-          <button type="submit" disabled={!inviteReady || busyAction === "invite"}>
-            <Mail aria-hidden="true" />
-            Invite
-          </button>
-          {formError ? (
-            <div className="cloud-auth-form-error" role="alert">
-              {formError}
-            </div>
-          ) : null}
-        </form>
-
-        <section className="cloud-share-current" aria-label="Current notebook access">
-          <h3>Current access</h3>
-          {loadState === "loading" && accessRows.length === 0 ? (
-            <div className="cloud-share-empty">Loading access...</div>
-          ) : accessRows.length === 0 ? (
-            <div className="cloud-share-empty">Only the owner can access this notebook.</div>
-          ) : (
-            <ul>
-              {accessRows.map((row) => (
-                <li key={row.id}>
-                  <CloudShareRowIcon row={row} />
-                  <div>
-                    <strong>{row.label}</strong>
-                    <span>{row.detail}</span>
-                  </div>
-                  <span className="cloud-share-badge">{row.badge}</span>
-                  {row.removable ? (
-                    <button
-                      type="button"
-                      aria-label={`Remove ${row.label}`}
-                      title={`Remove ${row.label}`}
-                      disabled={busyAction === row.id}
-                      onClick={() => void removeAccessRow(row)}
-                    >
-                      <Trash2 aria-hidden="true" />
-                    </button>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-        {message ? (
-          <div className="cloud-share-message" data-kind={messageKind}>
-            {message}
+            <option value="viewer">Can view</option>
+            <option value="editor">Can edit</option>
+          </select>
+        </label>
+        <button type="submit" disabled={!inviteReady || busyAction === "invite"}>
+          <Mail aria-hidden="true" />
+          Invite
+        </button>
+        {formError ? (
+          <div className="cloud-auth-form-error" role="alert">
+            {formError}
           </div>
         ) : null}
-      </div>
-    </details>
+      </form>
+
+      <section className="cloud-share-current" aria-label="Current notebook access">
+        <h3>Current access</h3>
+        {loadState === "loading" && accessRows.length === 0 ? (
+          <div className="cloud-share-empty">Loading access...</div>
+        ) : accessRows.length === 0 ? (
+          <div className="cloud-share-empty">Only the owner can access this notebook.</div>
+        ) : (
+          <ul>
+            {accessRows.map((row) => (
+              <li key={row.id}>
+                <CloudShareRowIcon row={row} />
+                <div>
+                  <strong>{row.label}</strong>
+                  <span>{row.detail}</span>
+                </div>
+                <span className="cloud-share-badge">{row.badge}</span>
+                {row.removable ? (
+                  <button
+                    type="button"
+                    aria-label={`Remove ${row.label}`}
+                    title={`Remove ${row.label}`}
+                    disabled={busyAction === row.id}
+                    onClick={() => void removeAccessRow(row)}
+                  >
+                    <Trash2 aria-hidden="true" />
+                  </button>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {message ? (
+        <div className="cloud-share-message" data-kind={messageKind}>
+          {message}
+        </div>
+      ) : null}
+    </NotebookDocumentHeaderMenu>
   );
 }
 
@@ -1667,12 +1673,13 @@ function CloudNotebookEditModeButton({
     : "Request edit access";
 
   return (
-    <button
-      type="button"
-      className="cloud-scope-toggle-button"
+    <NotebookDocumentHeaderButton
       aria-pressed={requestingEdit}
       data-state={editing ? "editing" : requestingEdit ? "requested" : "viewing"}
       title={title}
+      active={requestingEdit}
+      tone={editing ? "positive" : requestingEdit ? "attention" : "default"}
+      icon={requestingEdit ? <BookOpen aria-hidden="true" /> : <Pencil aria-hidden="true" />}
       onClick={() => {
         storeCloudRequestedScope(
           window.localStorage,
@@ -1681,9 +1688,8 @@ function CloudNotebookEditModeButton({
         onAuthStateChange();
       }}
     >
-      {requestingEdit ? <BookOpen aria-hidden="true" /> : <Pencil aria-hidden="true" />}
-      <span>{label}</span>
-    </button>
+      {label}
+    </NotebookDocumentHeaderButton>
   );
 }
 
@@ -1720,17 +1726,16 @@ function CloudNotebookSignInButton({
   };
 
   return (
-    <button
-      type="button"
-      className="cloud-sign-in-button"
+    <NotebookDocumentHeaderButton
       data-state={error ? "error" : authAction}
       disabled={authAction === "starting"}
       title={copy.title}
+      tone={error ? "danger" : "default"}
+      icon={<LogIn aria-hidden="true" />}
       onClick={beginOidcAuth}
     >
-      <LogIn aria-hidden="true" />
-      <span>{copy.label}</span>
-    </button>
+      {copy.label}
+    </NotebookDocumentHeaderButton>
   );
 }
 
@@ -1839,12 +1844,18 @@ function CloudAuthControls({
   };
 
   return (
-    <details className="cloud-auth-menu">
-      <summary title="Prototype collaborator identity">
-        <KeyRound aria-hidden="true" />
-        <span>{summary}</span>
-      </summary>
-      <form onSubmit={applyDevAuth}>
+    <NotebookDocumentHeaderMenu
+      className="cloud-auth-menu"
+      trigger={
+        <>
+          <KeyRound aria-hidden="true" />
+          <span>{summary}</span>
+        </>
+      }
+      triggerTitle="Prototype collaborator identity"
+      panelClassName="cloud-auth-panel"
+    >
+      <form className="cloud-auth-form" onSubmit={applyDevAuth}>
         <p>{prototypeAuthSummary(authState)}</p>
         <dl className="cloud-auth-diagnostics" aria-label="Prototype auth diagnostics">
           {diagnostics.rows.map((row) => (
@@ -1932,7 +1943,7 @@ function CloudAuthControls({
           </button>
         </div>
       </form>
-    </details>
+    </NotebookDocumentHeaderMenu>
   );
 }
 

--- a/src/components/notebook-shell/NotebookDocumentHeaderControl.tsx
+++ b/src/components/notebook-shell/NotebookDocumentHeaderControl.tsx
@@ -1,0 +1,96 @@
+import type { ButtonHTMLAttributes, DetailsHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type NotebookDocumentHeaderControlTone = "default" | "positive" | "attention" | "danger";
+
+export interface NotebookDocumentHeaderButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon?: ReactNode;
+  tone?: NotebookDocumentHeaderControlTone;
+  active?: boolean;
+}
+
+export function NotebookDocumentHeaderButton({
+  icon,
+  tone = "default",
+  active = false,
+  children,
+  className,
+  ...props
+}: NotebookDocumentHeaderButtonProps) {
+  return (
+    <button
+      type="button"
+      data-active={active ? "true" : "false"}
+      data-tone={tone}
+      className={cn(notebookDocumentHeaderControlClassName({ tone, active }), className)}
+      {...props}
+    >
+      {icon}
+      {children ? <span>{children}</span> : null}
+    </button>
+  );
+}
+
+export interface NotebookDocumentHeaderMenuProps extends Omit<
+  DetailsHTMLAttributes<HTMLDetailsElement>,
+  "children"
+> {
+  trigger: ReactNode;
+  triggerTitle?: string;
+  triggerClassName?: string;
+  triggerProps?: HTMLAttributes<HTMLElement>;
+  panelClassName?: string;
+  children: ReactNode;
+}
+
+export function NotebookDocumentHeaderMenu({
+  trigger,
+  triggerTitle,
+  triggerClassName,
+  triggerProps,
+  panelClassName,
+  children,
+  className,
+  ...props
+}: NotebookDocumentHeaderMenuProps) {
+  return (
+    <details className={cn("relative", className)} {...props}>
+      <summary
+        {...triggerProps}
+        title={triggerProps?.title ?? triggerTitle}
+        className={cn(notebookDocumentHeaderControlClassName(), triggerClassName)}
+      >
+        {trigger}
+      </summary>
+      <div
+        className={cn(
+          "absolute right-0 top-[calc(100%+0.5rem)] z-30 grid max-h-[min(42rem,calc(100vh-5rem))] w-[min(20rem,calc(100vw-1.5rem))] gap-3 overflow-auto rounded-md border bg-background p-3 text-foreground shadow-xl",
+          panelClassName,
+        )}
+        data-slot="notebook-document-header-menu-panel"
+      >
+        {children}
+      </div>
+    </details>
+  );
+}
+
+export function notebookDocumentHeaderControlClassName({
+  tone = "default",
+  active = false,
+}: {
+  tone?: NotebookDocumentHeaderControlTone;
+  active?: boolean;
+} = {}) {
+  return cn(
+    "pointer-events-auto inline-flex h-8 max-w-[min(12rem,38vw)] min-w-0 cursor-pointer items-center justify-center gap-1.5 rounded-full border px-3 text-sm text-muted-foreground shadow-sm backdrop-blur transition-colors",
+    "bg-background/90 hover:bg-muted hover:text-foreground",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-2",
+    "[&_svg]:size-4 [&_svg]:shrink-0 [&_span]:min-w-0 [&_span]:overflow-hidden [&_span]:text-ellipsis [&_span]:whitespace-nowrap [&_span]:text-[0.8125rem] [&_span]:leading-none",
+    active && "border-ring text-foreground",
+    tone === "positive" && "border-emerald-500/50 text-emerald-700 dark:text-emerald-300",
+    tone === "attention" && "border-ring/50 text-foreground",
+    tone === "danger" && "border-destructive/50 text-destructive",
+    "disabled:cursor-progress disabled:opacity-70",
+  );
+}

--- a/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vite-plus/test";
 import { NotebookDocumentHeader } from "../NotebookDocumentHeader";
+import {
+  NotebookDocumentHeaderButton,
+  NotebookDocumentHeaderMenu,
+} from "../NotebookDocumentHeaderControl";
 import type { NotebookShellCapabilities } from "../capabilities";
 
 function capabilities(
@@ -104,5 +109,35 @@ describe("NotebookDocumentHeader", () => {
       "data-can-request-edit",
       "true",
     );
+  });
+
+  it("provides shared header button chrome for host controls", () => {
+    render(
+      <NotebookDocumentHeaderButton active tone="positive" icon={<span aria-hidden="true">i</span>}>
+        Edit
+      </NotebookDocumentHeaderButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Edit" });
+    expect(button).toHaveAttribute("data-active", "true");
+    expect(button).toHaveAttribute("data-tone", "positive");
+    expect(button.className).toContain("rounded-full");
+  });
+
+  it("provides a shared header menu panel for host-specific forms", async () => {
+    render(
+      <NotebookDocumentHeaderMenu trigger={<span>Identity</span>} triggerTitle="Identity menu">
+        <button type="button">Sign out</button>
+      </NotebookDocumentHeaderMenu>,
+    );
+
+    const user = userEvent.setup();
+    const summary = screen.getByTitle("Identity menu");
+    await user.click(summary);
+
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeVisible();
+    expect(
+      document.querySelector("[data-slot='notebook-document-header-menu-panel']"),
+    ).not.toBeNull();
   });
 });

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -9,6 +9,14 @@ export {
 export type { NotebookCellListItem, ReadOnlyNotebookCellData } from "./cell-data";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
+export {
+  NotebookDocumentHeaderButton,
+  NotebookDocumentHeaderMenu,
+  notebookDocumentHeaderControlClassName,
+  type NotebookDocumentHeaderButtonProps,
+  type NotebookDocumentHeaderControlTone,
+  type NotebookDocumentHeaderMenuProps,
+} from "./NotebookDocumentHeaderControl";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
 export { NotebookEditableView, type NotebookEditableViewProps } from "./NotebookEditableView";
 export {


### PR DESCRIPTION
## Summary

- add shared `NotebookDocumentHeaderButton` and `NotebookDocumentHeaderMenu` primitives for notebook shell host controls
- move notebook-cloud code, edit-scope, share, and auth header controls onto those shared primitives
- keep cloud-specific auth/share behavior in the hosted route adapter while deleting the duplicate cloud-only pill/menu chrome

## Stack

- Depends on #3228 (`quod/notebook-shared-cell-scroll`)
- Merge order: #3228, then this PR after GitHub retargets the base

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
