### PR TITLE
refactor(notebook): share shell capability derivation

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -214,6 +214,14 @@ test("cloud viewer shell uses the shared notebook rail as an adapter surface", (
   assert.doesNotMatch(sourceText, /findCellElement: \(outlineItem\)/);
 });
 
+test("cloud editable notebook opts into the shared stable cell-list DOM order", () => {
+  const sourcePath = new URL("../viewer/cloud-live-notebook.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /<NotebookEditableView[\s\S]*stableDomOrder/);
+  assert.doesNotMatch(sourceText, /\.map\(\(cell/);
+});
+
 test("cloud live materialization skips empty room handles before resolving outputs", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
+++ b/apps/notebook-cloud/viewer/cloud-live-notebook.tsx
@@ -56,6 +56,7 @@ export function CloudLiveNotebook({
       className="cloud-report-notebook"
       slot="cloud-live-notebook"
       scrollable
+      stableDomOrder
       renderCellError={(error, _cell, index) => (
         <div className="cloud-state" data-kind="error">
           Unable to render cell {index + 1}: {error.message}

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -1,4 +1,7 @@
-import type { NotebookShellCapabilities } from "@/components/notebook-shell";
+import {
+  createNotebookShellCapabilities,
+  type NotebookShellCapabilities,
+} from "@/components/notebook-shell/capabilities";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 export interface CloudNotebookShellCapabilityInput {
@@ -14,21 +17,18 @@ export function cloudNotebookShellCapabilities({
   connectionActorLabel = null,
   hasCodeCells,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
-  const canEdit = connectionScope === "editor" || connectionScope === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
 
-  return {
-    canRead: true,
-    canEditMarkdown: canEdit,
-    canEditCells: canEdit,
+  return createNotebookShellCapabilities({
+    canMutateDocument: true,
     canRequestEdit: authState.mode === "oidc",
     canExecute: false,
     canToggleCode: hasCodeCells,
     canViewPackages: true,
     canManagePackages: false,
-    canManageSharing: connectionScope === "owner",
+    canManageSharing: true,
     access: {
       level: accessLevel,
       source: "cloud",
@@ -41,7 +41,7 @@ export function cloudNotebookShellCapabilities({
       canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
       needsAttention: authNeedsAttention,
     },
-  };
+  });
 }
 
 function cloudConnectionAccessLevel(

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -2,7 +2,8 @@ import type {
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
   NotebookShellCapabilities,
-} from "@/components/notebook-shell";
+} from "@/components/notebook-shell/capabilities";
+import { createNotebookShellCapabilities } from "@/components/notebook-shell/capabilities";
 
 export interface DesktopNotebookShellCapabilityInput {
   canAcceptCellMutations: boolean;
@@ -19,19 +20,15 @@ export function desktopNotebookShellCapabilities({
 }: DesktopNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
   const source = desktopAccessSourceFromConnectionScope(connectionScope);
-  const canWriteDocument =
-    canAcceptCellMutations && (accessLevel === "editor" || accessLevel === "owner");
 
-  return {
-    canRead: accessLevel !== "none",
-    canEditMarkdown: canWriteDocument,
-    canEditCells: canWriteDocument,
+  return createNotebookShellCapabilities({
+    canMutateDocument: canAcceptCellMutations,
     canRequestEdit: false,
-    canExecute: sessionReady && canWriteDocument,
+    canExecute: sessionReady,
     canToggleCode: true,
     canViewPackages: true,
-    canManagePackages: canWriteDocument,
-    canManageSharing: accessLevel === "owner" && source === "cloud",
+    canManagePackages: true,
+    canManageSharing: source === "cloud",
     access: {
       level: accessLevel,
       source,
@@ -44,7 +41,7 @@ export function desktopNotebookShellCapabilities({
       canUseAuthenticatedIdentity: Boolean(localActor),
       needsAttention: false,
     },
-  };
+  });
 }
 
 function desktopAccessLevelFromConnectionScope(

--- a/src/components/notebook-shell/NotebookCellList.tsx
+++ b/src/components/notebook-shell/NotebookCellList.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import type { NotebookCellListItem } from "./cell-data";
@@ -10,6 +10,7 @@ export interface NotebookCellListProps<TCell extends NotebookCellListItem = Note
   slot?: string;
   scrollable?: boolean;
   emptyContent?: ReactNode;
+  stableDomOrder?: boolean;
   keyForCell?: (cell: TCell, index: number) => string;
   resetKeysForCell?: (cell: TCell, index: number) => readonly unknown[];
   renderCell: (cell: TCell, index: number) => ReactNode;
@@ -23,6 +24,7 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
   slot = "notebook-cell-list",
   scrollable = false,
   emptyContent = null,
+  stableDomOrder = false,
   keyForCell = defaultKeyForCell,
   resetKeysForCell = defaultResetKeysForCell,
   renderCell,
@@ -41,21 +43,66 @@ export function NotebookCellList<TCell extends NotebookCellListItem = NotebookCe
     >
       {cells.length === 0
         ? emptyContent
-        : cells.map((cell, index) => (
-            <ErrorBoundary
-              key={keyForCell(cell, index)}
-              resetKeys={resetKeysForCell(cell, index)}
-              fallback={(error) =>
-                renderCellError
-                  ? renderCellError(error, cell, index)
-                  : defaultCellError(error, index)
-              }
-            >
-              {renderCell(cell, index)}
-            </ErrorBoundary>
-          ))}
+        : notebookCellListEntries(cells, keyForCell, stableDomOrder).map(({ cell, index, key }) =>
+            stableDomOrder ? (
+              <div
+                key={key}
+                data-slot="notebook-cell-list-item"
+                style={cellListItemOrderStyle(index)}
+              >
+                <ErrorBoundary
+                  resetKeys={resetKeysForCell(cell, index)}
+                  fallback={(error) =>
+                    renderCellError
+                      ? renderCellError(error, cell, index)
+                      : defaultCellError(error, index)
+                  }
+                >
+                  {renderCell(cell, index)}
+                </ErrorBoundary>
+              </div>
+            ) : (
+              <ErrorBoundary
+                key={key}
+                resetKeys={resetKeysForCell(cell, index)}
+                fallback={(error) =>
+                  renderCellError
+                    ? renderCellError(error, cell, index)
+                    : defaultCellError(error, index)
+                }
+              >
+                {renderCell(cell, index)}
+              </ErrorBoundary>
+            ),
+          )}
     </section>
   );
+}
+
+interface NotebookCellListEntry<TCell extends NotebookCellListItem> {
+  cell: TCell;
+  index: number;
+  key: string;
+}
+
+function notebookCellListEntries<TCell extends NotebookCellListItem>(
+  cells: readonly TCell[],
+  keyForCell: (cell: TCell, index: number) => string,
+  stableDomOrder: boolean,
+): Array<NotebookCellListEntry<TCell>> {
+  const entries = cells.map((cell, index) => ({
+    cell,
+    index,
+    key: keyForCell(cell, index),
+  }));
+  if (!stableDomOrder) {
+    return entries;
+  }
+  return [...entries].sort((a, b) => a.cell.id.localeCompare(b.cell.id) || a.index - b.index);
+}
+
+function cellListItemOrderStyle(index: number): CSSProperties {
+  return { order: index };
 }
 
 function defaultKeyForCell(cell: NotebookCellListItem): string {

--- a/src/components/notebook-shell/NotebookEditableView.tsx
+++ b/src/components/notebook-shell/NotebookEditableView.tsx
@@ -7,6 +7,7 @@ export interface NotebookEditableViewProps<TCell extends NotebookViewCell = Note
   className?: string;
   slot?: string;
   scrollable?: boolean;
+  stableDomOrder?: boolean;
   renderMarkdownCell: (cell: TCell, index: number) => ReactNode;
   renderCodeCell: (cell: TCell, index: number) => ReactNode;
   renderFallbackCell: (cell: TCell, index: number) => ReactNode;
@@ -18,6 +19,7 @@ export function NotebookEditableView<TCell extends NotebookViewCell = NotebookVi
   className,
   slot = "notebook-editable-view",
   scrollable,
+  stableDomOrder,
   renderMarkdownCell,
   renderCodeCell,
   renderFallbackCell,
@@ -29,6 +31,7 @@ export function NotebookEditableView<TCell extends NotebookViewCell = NotebookVi
       className={className}
       slot={slot}
       scrollable={scrollable}
+      stableDomOrder={stableDomOrder}
       renderCellError={renderCellError}
       renderCell={(cell, index) => {
         if (cell.cellType === "markdown") {

--- a/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCellList.test.tsx
@@ -74,6 +74,40 @@ describe("NotebookCellList", () => {
     expect(screen.getByLabelText("Notebook cells")).toHaveClass("overscroll-contain");
   });
 
+  it("can keep stable DOM order while preserving the visual cell order", () => {
+    const reorderedCells: NotebookViewCell[] = [
+      { ...cells[0], id: "z-cell", source: "# Visual first" },
+      { ...cells[1], id: "a-cell", source: "print('dom first')" },
+    ];
+    const { container } = render(
+      <NotebookCellList
+        cells={reorderedCells}
+        stableDomOrder
+        renderCell={(cell, index) => (
+          <article data-testid="cell" data-cell-id={cell.id} data-visual-index={index}>
+            {cell.source}
+          </article>
+        )}
+      />,
+    );
+
+    const renderedCells = screen.getAllByTestId("cell");
+    expect(renderedCells.map((cell) => cell.getAttribute("data-cell-id"))).toEqual([
+      "a-cell",
+      "z-cell",
+    ]);
+    expect(renderedCells.map((cell) => cell.getAttribute("data-visual-index"))).toEqual(["1", "0"]);
+
+    const listItems = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-slot="notebook-cell-list-item"]'),
+    );
+    expect(listItems.map((item) => item.textContent)).toEqual([
+      "print('dom first')",
+      "# Visual first",
+    ]);
+    expect(listItems.map((item) => item.style.order)).toEqual(["1", "0"]);
+  });
+
   it("lets read-only hosts keep duplicate cell ids renderable for malformed imported notebooks", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     try {

--- a/src/components/notebook-shell/__tests__/capabilities.test.ts
+++ b/src/components/notebook-shell/__tests__/capabilities.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createNotebookShellCapabilities } from "../capabilities";
+import type {
+  NotebookShellAccessCapabilities,
+  NotebookShellAuthCapabilities,
+} from "../capabilities";
+
+const auth: NotebookShellAuthCapabilities = {
+  canSignIn: false,
+  canUseAuthenticatedIdentity: true,
+  needsAttention: false,
+};
+
+function access(
+  overrides: Partial<NotebookShellAccessCapabilities> = {},
+): NotebookShellAccessCapabilities {
+  return {
+    level: "owner",
+    source: "local",
+    isPublic: false,
+    actorLabel: "local:kyle/desktop:window",
+    identityLabel: "Kyle",
+    ...overrides,
+  };
+}
+
+describe("createNotebookShellCapabilities", () => {
+  it("derives edit, execute, package, and sharing capability from writable owner access", () => {
+    const capabilities = createNotebookShellCapabilities({
+      access: access(),
+      auth,
+      canMutateDocument: true,
+      canExecute: true,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: true,
+      canManageSharing: true,
+    });
+
+    expect(capabilities.canRead).toBe(true);
+    expect(capabilities.canEditMarkdown).toBe(true);
+    expect(capabilities.canEditCells).toBe(true);
+    expect(capabilities.canExecute).toBe(true);
+    expect(capabilities.canToggleCode).toBe(true);
+    expect(capabilities.canViewPackages).toBe(true);
+    expect(capabilities.canManagePackages).toBe(true);
+    expect(capabilities.canManageSharing).toBe(true);
+  });
+
+  it("keeps viewer access read-only even when a host supports write affordances", () => {
+    const capabilities = createNotebookShellCapabilities({
+      access: access({ level: "viewer", source: "cloud" }),
+      auth,
+      canMutateDocument: true,
+      canExecute: true,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: true,
+      canManageSharing: true,
+    });
+
+    expect(capabilities.canRead).toBe(true);
+    expect(capabilities.canEditMarkdown).toBe(false);
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canExecute).toBe(false);
+    expect(capabilities.canToggleCode).toBe(true);
+    expect(capabilities.canViewPackages).toBe(true);
+    expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.canManageSharing).toBe(false);
+  });
+
+  it("lets hosts expose request-edit affordances independently of current write access", () => {
+    const capabilities = createNotebookShellCapabilities({
+      access: access({ level: "viewer", source: "cloud" }),
+      auth,
+      canRequestEdit: true,
+    });
+
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canRequestEdit).toBe(true);
+  });
+
+  it("treats no access as fully non-readable regardless of host affordances", () => {
+    const capabilities = createNotebookShellCapabilities({
+      access: access({ level: "none", source: "cloud" }),
+      auth,
+      canMutateDocument: true,
+      canExecute: true,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: true,
+      canManageSharing: true,
+    });
+
+    expect(capabilities.canRead).toBe(false);
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canExecute).toBe(false);
+    expect(capabilities.canToggleCode).toBe(false);
+    expect(capabilities.canViewPackages).toBe(false);
+    expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.canManageSharing).toBe(false);
+  });
+});

--- a/src/components/notebook-shell/capabilities.ts
+++ b/src/components/notebook-shell/capabilities.ts
@@ -34,6 +34,53 @@ export interface NotebookShellCapabilities {
   auth: NotebookShellAuthCapabilities;
 }
 
+export interface CreateNotebookShellCapabilitiesOptions {
+  access: NotebookShellAccessCapabilities;
+  auth: NotebookShellAuthCapabilities;
+  /**
+   * Whether this host can currently accept notebook document mutations.
+   * Local read-only files and cloud viewer rooms can grant document access
+   * while still rejecting writes.
+   */
+  canMutateDocument?: boolean;
+  canRequestEdit?: boolean;
+  canExecute?: boolean;
+  canToggleCode?: boolean;
+  canViewPackages?: boolean;
+  canManagePackages?: boolean;
+  canManageSharing?: boolean;
+}
+
+export function createNotebookShellCapabilities({
+  access,
+  auth,
+  canMutateDocument = false,
+  canRequestEdit = false,
+  canExecute = false,
+  canToggleCode = false,
+  canViewPackages = false,
+  canManagePackages = false,
+  canManageSharing = false,
+}: CreateNotebookShellCapabilitiesOptions): NotebookShellCapabilities {
+  const canRead = access.level !== "none";
+  const hasWriteAccess = access.level === "editor" || access.level === "owner";
+  const canEditCells = canRead && hasWriteAccess && canMutateDocument;
+
+  return {
+    canRead,
+    canEditMarkdown: canEditCells,
+    canEditCells,
+    canRequestEdit,
+    canExecute: canEditCells && canExecute,
+    canToggleCode: canRead && canToggleCode,
+    canViewPackages: canRead && canViewPackages,
+    canManagePackages: canEditCells && canManagePackages,
+    canManageSharing: access.level === "owner" && canManageSharing,
+    access,
+    auth,
+  };
+}
+
 export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
   canRead: true,
   canEditMarkdown: false,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -1,5 +1,7 @@
 export {
+  createNotebookShellCapabilities,
   readOnlyNotebookShellCapabilities,
+  type CreateNotebookShellCapabilitiesOptions,
   type NotebookShellAccessCapabilities,
   type NotebookShellAccessLevel,
   type NotebookShellAccessSource,


### PR DESCRIPTION
## Summary

- adds `createNotebookShellCapabilities` as the shared derivation point for notebook shell capability booleans
- rewires notebook-cloud and desktop adapters to pass host/access/auth facts into that shared helper
- moves the stable DOM-order cell-list invariant into the shared notebook shell frame
- opts notebook-cloud editable rendering into that shared cell-list ordering so output iframes keep stable DOM positions while visual order changes
- covers the shared helper plus existing desktop/cloud adapter behavior

## Stack order

This PR is stacked on #3230.

Merge order:

1. #3229
2. #3230
3. this PR, after GitHub retargets it to `main`

## Validation

- `pnpm exec vp test run src/components/notebook-shell/__tests__/capabilities.test.ts apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm exec vp test run src/components/notebook-shell/__tests__/NotebookCellList.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
