### PR TITLE
fix(notebook): keep read-only markdown navigation

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -402,9 +402,6 @@ export const MarkdownCell = memo(function MarkdownCell({
   // Handle keyboard navigation in view mode (when not editing)
   const handleViewKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (readOnly) {
-        return;
-      }
       if (e.key === "ArrowDown") {
         onFocusNext?.("start");
         e.preventDefault();
@@ -419,6 +416,9 @@ export const MarkdownCell = memo(function MarkdownCell({
         onFocusNext?.("start");
         e.preventDefault();
       } else if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (readOnly) {
+          return;
+        }
         // Enter: enter edit mode
         setEditing(true);
         e.preventDefault();

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -341,4 +341,35 @@ describe("MarkdownCell theme sync", () => {
 
     expect(preview.className).not.toContain("hidden");
   });
+
+  it("keeps view-mode keyboard navigation active for read-only markdown cells", () => {
+    const onFocusNext = vi.fn();
+    const onFocusPrevious = vi.fn();
+
+    const { getByLabelText } = render(
+      <MarkdownCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onDelete={() => {}}
+        onFocusNext={onFocusNext}
+        onFocusPrevious={onFocusPrevious}
+        readOnly
+      />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+
+    fireEvent.keyDown(preview, { key: "ArrowDown" });
+    expect(onFocusNext).toHaveBeenCalledWith("start");
+
+    fireEvent.keyDown(preview, { key: "ArrowUp" });
+    expect(onFocusPrevious).toHaveBeenCalledWith("end");
+
+    fireEvent.keyDown(preview, { key: "Enter", shiftKey: true });
+    expect(onFocusNext).toHaveBeenCalledTimes(2);
+    expect(onFocusNext).toHaveBeenLastCalledWith("start");
+
+    fireEvent.keyDown(preview, { key: "Enter" });
+    expect(preview.className).not.toContain("hidden");
+  });
 });


### PR DESCRIPTION
## Summary

- keep read-only markdown preview cells in the shared keyboard navigation path
- leave edit entry disabled when markdown cells are read-only
- add coverage for ArrowUp/ArrowDown/Shift+Enter navigation in read-only markdown view mode

## Convergence lens

This is a follow-up to #3232. Cloud now renders through the shared desktop `NotebookView`, so read-only cloud behavior should be fixed in the shared markdown cell rather than patched in notebook-cloud. The change increases desktop/cloud convergence by making read-only a capability on the shared cell surface.

## Verification

- `pnpm --workspace-root test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3233 --max-turns 120 --out .context/reviews/pr-3233.json` (clear)
- deployed to `preview.runt.run` and smoke-checked read-only markdown key handling with Playwright: ArrowDown/ArrowUp/Shift+Enter handled, plain Enter does not enter edit mode
