### PR TITLE
fix(notebook-cloud): align edit capabilities with mode

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -3,13 +3,16 @@ import { test } from "node:test";
 import { cloudNotebookShellCapabilities } from "../viewer/shell-capabilities";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 
-function authState(mode: CloudPrototypeAuthState["mode"]): CloudPrototypeAuthState {
+function authState(
+  mode: CloudPrototypeAuthState["mode"],
+  requestedScope: CloudPrototypeAuthState["requestedScope"] = null,
+): CloudPrototypeAuthState {
   return {
     mode,
     token: mode === "anonymous" ? null : "token",
     user: mode === "anonymous" ? null : "user@example.test",
     oidcClaims: null,
-    requestedScope: null,
+    requestedScope,
     problem: mode === "invalid" || mode === "oidc_expired" ? "auth problem" : null,
   };
 }
@@ -34,15 +37,15 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.access.isPublic, true);
 });
 
-test("cloud shell capabilities grant editor writes without execute/package management", () => {
+test("cloud shell capabilities grant editor markdown writes without code, structure, execute, or package management", () => {
   const capabilities = cloudNotebookShellCapabilities({
-    authState: authState("oidc"),
+    authState: authState("oidc", "editor"),
     connectionScope: "editor",
     hasCodeCells: false,
   });
 
   assert.equal(capabilities.canEditMarkdown, true);
-  assert.equal(capabilities.canEditCells, true);
+  assert.equal(capabilities.canEditCells, false);
   assert.equal(capabilities.canEditStructure, false);
   assert.equal(capabilities.canRequestEdit, true);
   assert.equal(capabilities.canExecute, false);
@@ -51,6 +54,36 @@ test("cloud shell capabilities grant editor writes without execute/package manag
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.access.identityLabel, "user@example.test");
   assert.equal(capabilities.auth.canUseAuthenticatedIdentity, true);
+});
+
+test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "viewer"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.access.level, "editor");
+  assert.equal(capabilities.canToggleCode, true);
+});
+
+test("cloud shell capabilities reserve code-cell source edits for owners", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, true);
+  assert.equal(capabilities.canEditCells, true);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canExecute, false);
+  assert.equal(capabilities.canManagePackages, false);
+  assert.equal(capabilities.canManageSharing, true);
+  assert.equal(capabilities.access.level, "owner");
 });
 
 test("cloud shell capabilities reserve sharing for owners", () => {

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -14,15 +14,18 @@ export function cloudNotebookShellCapabilities({
   connectionActorLabel = null,
   hasCodeCells,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
-  const canEdit = connectionScope === "editor" || connectionScope === "owner";
+  const accessLevel = cloudConnectionAccessLevel(connectionScope);
+  const userSelectedViewMode = authState.requestedScope === "viewer";
+  const activeEditLevel = userSelectedViewMode ? "viewer" : accessLevel;
+  const canEditMarkdown = activeEditLevel === "editor" || activeEditLevel === "owner";
+  const canEditCells = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
-  const accessLevel = cloudConnectionAccessLevel(connectionScope);
 
   return {
     canRead: true,
-    canEditMarkdown: canEdit,
-    canEditCells: canEdit,
+    canEditMarkdown,
+    canEditCells,
     canEditStructure: false,
     canRequestEdit: authState.mode === "oidc",
     canExecute: false,


### PR DESCRIPTION
## Summary

- Treat cloud edit permission and selected edit mode as separate inputs to notebook shell capabilities.
- Keep explicitly selected View mode read-only even when the connected identity has editor access.
- Match current room policy by allowing editor-scoped markdown source edits while keeping code/raw source edits owner-only.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-shared-cell-surface.test.ts test/collaborator-auth.test.ts test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- Deployed to `preview.runt.run`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- Browser check against `https://preview.runt.run/n/topic-viz`: view mode reports `1 viewing · viewing`, CodeMirror content is `contenteditable="false"`, and a scripted type attempt left the cell source unchanged.

## Notes

- Local `pr-reviewer` was clear with no findings.
- GitHub CI passed.
- This is part of the reset toward cloud as a host adapter for the shared NotebookView surface.
