### PR TITLE
fix(notebook): collapse active rail panel buttons

### DIFF
--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -82,6 +82,10 @@ export function NotebookRail({
             icon={item.icon}
             active={!collapsed && activePanelId === item.id}
             onClick={() => {
+              if (!collapsed && activePanelId === item.id) {
+                onCollapsedChange(true);
+                return;
+              }
               onActivePanelChange(item.id);
               onCollapsedChange(false);
             }}

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -59,6 +59,7 @@ describe("NotebookRail", () => {
 
   it("switches to packages without owning package-management state", () => {
     const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
 
     render(
       <NotebookRail
@@ -72,12 +73,73 @@ describe("NotebookRail", () => {
           </NotebookPackagesPanel>
         }
         onActivePanelChange={onActivePanelChange}
-        onCollapsedChange={vi.fn()}
+        onCollapsedChange={onCollapsedChange}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Packages" }));
     expect(onActivePanelChange).toHaveBeenCalledWith("packages");
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("collapses the rail when clicking the active expanded panel button", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Outline" }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+    expect(onActivePanelChange).not.toHaveBeenCalled();
+  });
+
+  it("collapses the expanded packages panel from its rail button", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <NotebookRail
+        activePanelId="packages"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Packages" }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+    expect(onActivePanelChange).not.toHaveBeenCalled();
+  });
+
+  it("expands the selected panel when clicking a panel button while collapsed", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <NotebookRail
+        activePanelId="packages"
+        collapsed
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Packages" }));
+    expect(onActivePanelChange).toHaveBeenCalledWith("packages");
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 
   it("exposes a stable panel slot for host shell layout adapters", () => {


### PR DESCRIPTION
## Summary

- Makes active notebook rail panel buttons toggle the rail closed when the panel is already expanded.
- Preserves existing behavior for switching panels or opening a selected panel from the collapsed rail.
- Adds focused tests for Outline, Packages, and collapsed-to-expanded panel button behavior.

## Verification

- `pnpm test:run src/components/notebook-rail/__tests__/NotebookRail.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3236 --max-turns 120 --out .context/reviews/pr-3236.json`: clear
