### PR TITLE
fix(notebook-cloud): hydrate demos from runtime snapshot pairs

### DIFF
--- a/apps/notebook-cloud/scripts/live-notebook-fixture.mjs
+++ b/apps/notebook-cloud/scripts/live-notebook-fixture.mjs
@@ -5,6 +5,9 @@ export async function createLiveNotebookFixture(rt, { preset = "mathnet" } = {})
   if (preset === "html-output") {
     return createHtmlOutputNotebook(rt);
   }
+  if (preset === "lets-edit") {
+    return createLetsEditNotebook(rt);
+  }
   throw new Error(`Unknown NOTEBOOK_CLOUD_LIVE_PRESET ${preset}`);
 }
 
@@ -51,6 +54,44 @@ async function createMathNetNotebook(rt) {
       ].join("\n"),
       { timeoutMs: 10 * 60 * 1000 },
     );
+    return session;
+  } catch (error) {
+    await session.shutdownNotebook().catch(() => {});
+    await session.close().catch(() => {});
+    throw error;
+  }
+}
+
+async function createLetsEditNotebook(rt) {
+  const session = await rt.createNotebook({
+    runtime: "python",
+    description: "notebook-cloud shared editing smoke",
+    packageManager: "uv",
+    environmentMode: "notebook",
+  });
+
+  try {
+    await session.createCell(
+      [
+        "# Let's edit",
+        "",
+        "This is a small shared notebook for trying the hosted editor flow on preview.runt.run.",
+      ].join("\n"),
+      { cellType: "markdown" },
+    );
+    await session.createCell(
+      [
+        "## Notes",
+        "",
+        "- Add a section below.",
+        "- Try editing together from separate accounts.",
+        "- Keep this notebook intentionally lightweight while auth and sharing are still settling.",
+      ].join("\n"),
+      { cellType: "markdown" },
+    );
+    await session.createCell(["## Scratch space", "", "Start here."].join("\n"), {
+      cellType: "markdown",
+    });
     return session;
   } catch (error) {
     await session.shutdownNotebook().catch(() => {});

--- a/apps/notebook-cloud/scripts/publish-auth.mjs
+++ b/apps/notebook-cloud/scripts/publish-auth.mjs
@@ -1,0 +1,27 @@
+export function publishIdentityHeaders({
+  scope = "owner",
+  operator,
+  user,
+  devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN,
+  bearerToken = process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN ?? process.env.ANACONDA_API_KEY,
+} = {}) {
+  if (bearerToken) {
+    return {
+      Authorization: `Bearer ${bearerToken}`,
+      "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+      "X-Scope": scope,
+      ...(operator ? { "X-Operator": operator } : {}),
+    };
+  }
+
+  return {
+    "X-User": user ?? "publisher",
+    "X-Operator": operator ?? "agent:publish",
+    "X-Scope": scope,
+    ...devAuthHeaders(devAuthToken),
+  };
+}
+
+function devAuthHeaders(devAuthToken) {
+  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
+}

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -2,8 +2,9 @@ import { createHash } from "node:crypto";
 import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
+import { publishIdentityHeaders } from "./publish-auth.mjs";
+
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
-const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? "nteract-cloud-demo";
 const actorLabel = "user:dev:demo/agent:publish-demo";
 const wasmJsUrl = new URL(
@@ -141,16 +142,13 @@ async function putBytes(pathname, body, contentType, extraHeaders = {}) {
 function publishHeaders(contentType, extraHeaders) {
   return {
     "Content-Type": contentType,
-    "X-User": "demo",
-    "X-Operator": "agent:publish-demo",
-    "X-Scope": "owner",
-    ...devAuthHeaders(),
+    ...publishIdentityHeaders({
+      user: "demo",
+      operator: "agent:publish-demo",
+      scope: "owner",
+    }),
     ...extraHeaders,
   };
-}
-
-function devAuthHeaders() {
-  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
 }
 
 async function fetchJson(pathname) {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -2,8 +2,9 @@ import { createHash } from "node:crypto";
 import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
+import { publishIdentityHeaders } from "./publish-auth.mjs";
+
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
-const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
 const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? `nteract-cloud-fixture-${fixtureName}`;
 const fixtureRoot = new URL(
@@ -159,16 +160,13 @@ async function putBytes(pathname, body, contentType, extraHeaders = {}) {
 function publishHeaders(contentType, extraHeaders) {
   return {
     "Content-Type": contentType,
-    "X-User": "fixture",
-    "X-Operator": "agent:publish-fixture",
-    "X-Scope": "owner",
-    ...devAuthHeaders(),
+    ...publishIdentityHeaders({
+      user: "fixture",
+      operator: "agent:publish-fixture",
+      scope: "owner",
+    }),
     ...extraHeaders,
   };
-}
-
-function devAuthHeaders() {
-  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
 }
 
 async function fetchJson(pathname) {

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -5,12 +5,12 @@ import { fileURLToPath } from "node:url";
 
 import { collectBlobRefs } from "../src/blob-refs.ts";
 import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
+import { publishIdentityHeaders } from "./publish-auth.mjs";
 import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
 
 const rt = loadRuntimedNode();
 
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
-const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const sourceNotebookId = process.env.NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID;
 const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
 const notebookId =
@@ -190,16 +190,13 @@ async function putBytes(pathname, body, contentType, extraHeaders = {}) {
 function publishHeaders(contentType, extraHeaders) {
   return {
     "Content-Type": contentType,
-    "X-User": "live-publish",
-    "X-Operator": "agent:publish-live",
-    "X-Scope": "owner",
-    ...devAuthHeaders(),
+    ...publishIdentityHeaders({
+      user: "live-publish",
+      operator: "agent:publish-live",
+      scope: "owner",
+    }),
     ...extraHeaders,
   };
-}
-
-function devAuthHeaders() {
-  return devAuthToken ? { "X-Notebook-Cloud-Dev-Token": devAuthToken } : {};
 }
 
 async function fetchJson(pathname) {

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -335,7 +335,7 @@ export class RoomMaterializer {
     const latest = catalog?.revisions.find(
       (revision) => revision.id === catalog.notebook.latest_revision_id,
     );
-    if (!latest?.runtime_snapshot_key) {
+    if (!latest?.runtime_state_doc_id || !latest.runtime_snapshot_key) {
       return null;
     }
 
@@ -395,14 +395,6 @@ function checkpointKeepReasonForRevisionMismatch(
 }
 
 function hasUnpublishedCheckpointChanges(metadata: RoomCheckpointMetadata): boolean {
-  if (
-    metadata.version >= CHECKPOINT_VERSION &&
-    metadata.published_revision_id === null &&
-    ((metadata.published_notebook_heads === null && metadata.notebook_heads.length > 0) ||
-      (metadata.published_runtime_state_heads === null && metadata.runtime_state_heads.length > 0))
-  ) {
-    return true;
-  }
   return (
     headsChanged(metadata.notebook_heads, metadata.published_notebook_heads) ||
     headsChanged(metadata.runtime_state_heads, metadata.published_runtime_state_heads)

--- a/apps/notebook-cloud/test/live-notebook-fixture.test.mjs
+++ b/apps/notebook-cloud/test/live-notebook-fixture.test.mjs
@@ -67,6 +67,32 @@ describe("live notebook fixture", () => {
     ]);
   });
 
+  it("creates the lets-edit notebook as a lightweight markdown fixture", async () => {
+    const calls = [];
+    const session = {
+      createCell: async (source, options) => calls.push(["createCell", source, options]),
+    };
+    const rt = {
+      createNotebook: async (options) => {
+        calls.push(["createNotebook", options]);
+        return session;
+      },
+    };
+
+    const result = await createLiveNotebookFixture(rt, { preset: "lets-edit" });
+
+    assert.equal(result, session);
+    assert.deepEqual(
+      calls.map(([name]) => name),
+      ["createNotebook", "createCell", "createCell", "createCell"],
+    );
+    assert.equal(calls[0][1].description, "notebook-cloud shared editing smoke");
+    assert.equal(calls[1][2].cellType, "markdown");
+    assert.match(calls[1][1], /# Let's edit/);
+    assert.match(calls[2][1], /## Notes/);
+    assert.match(calls[3][1], /## Scratch space/);
+  });
+
   it("rejects unknown presets before creating a notebook", async () => {
     const rt = {
       createNotebook() {

--- a/apps/notebook-cloud/test/publish-auth.test.mjs
+++ b/apps/notebook-cloud/test/publish-auth.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { publishIdentityHeaders } from "../scripts/publish-auth.mjs";
+
+describe("publishIdentityHeaders", () => {
+  it("uses Anaconda bearer auth without dev identity headers", () => {
+    const headers = publishIdentityHeaders({
+      bearerToken: "api-key",
+      devAuthToken: "dev-token",
+      operator: "agent:publish-test",
+      scope: "owner",
+      user: "demo",
+    });
+
+    assert.equal(headers.Authorization, "Bearer api-key");
+    assert.equal(headers["X-Notebook-Cloud-Auth-Provider"], "anaconda-api-key");
+    assert.equal(headers["X-Scope"], "owner");
+    assert.equal(headers["X-Operator"], "agent:publish-test");
+    assert.equal(headers["X-User"], undefined);
+    assert.equal(headers["X-Notebook-Cloud-Dev-Token"], undefined);
+  });
+
+  it("uses dev identity headers when no bearer token is present", () => {
+    const headers = publishIdentityHeaders({
+      bearerToken: "",
+      devAuthToken: "dev-token",
+      operator: "agent:publish-test",
+      scope: "owner",
+      user: "demo",
+    });
+
+    assert.equal(headers.Authorization, undefined);
+    assert.equal(headers["X-Notebook-Cloud-Auth-Provider"], undefined);
+    assert.equal(headers["X-User"], "demo");
+    assert.equal(headers["X-Operator"], "agent:publish-test");
+    assert.equal(headers["X-Scope"], "owner");
+    assert.equal(headers["X-Notebook-Cloud-Dev-Token"], "dev-token");
+  });
+});

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -664,7 +664,7 @@ describe("RoomMaterializer", () => {
     );
   });
 
-  it("keeps current checkpoints with no published baseline when a snapshot appears later", async () => {
+  it("uses the latest published snapshot instead of no-baseline checkpoints", async () => {
     const state = fakeState();
     const checkpointSnapshot = await createNotebookRoomSnapshot(
       "demo",
@@ -720,8 +720,40 @@ describe("RoomMaterializer", () => {
     const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
     assert.deepEqual(
       cells.map((cell) => [cell.id, cell.source]),
-      [["local-cell", "Local room edit before first publish\n"]],
+      [["published-cell", "Later published snapshot\n"]],
     );
+  });
+
+  it("ignores catalog revisions without RuntimeStateDoc ids", async () => {
+    const state = fakeState();
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Legacy metadata publish\n",
+    );
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-without-runtime-doc-id",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+      runtimeStateDocId: null,
+    });
+
+    const materializer = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      materializer,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
   });
 
   it("uses the latest published snapshot instead of stale revision checkpoints", async () => {
@@ -1548,6 +1580,7 @@ function fakePublishedSnapshotEnv(input: {
   actorLabel: string;
   notebookBytes: Uint8Array;
   runtimeStateBytes: Uint8Array;
+  runtimeStateDocId?: string | null;
 }): Env {
   const snapshotKey = "test:notebook-snapshot";
   const runtimeSnapshotKey = "test:runtime-state-snapshot";
@@ -1567,7 +1600,9 @@ function fakePublishedSnapshotEnv(input: {
       revision: {
         id: input.revisionId,
         notebook_id: input.notebookId,
-        runtime_state_doc_id: `runtime:${input.notebookId}`,
+        runtime_state_doc_id: Object.hasOwn(input, "runtimeStateDocId")
+          ? (input.runtimeStateDocId ?? null)
+          : `runtime:${input.notebookId}`,
         notebook_heads_hash: "heads-published",
         runtime_heads_hash: "runtime-published",
         snapshot_key: snapshotKey,
@@ -1616,7 +1651,7 @@ class FakeCatalogD1 implements D1Database {
       revision: {
         id: string;
         notebook_id: string;
-        runtime_state_doc_id: string;
+        runtime_state_doc_id: string | null;
         notebook_heads_hash: string;
         runtime_heads_hash: string;
         snapshot_key: string;


### PR DESCRIPTION
## Summary

- Require complete published snapshot metadata before notebook-cloud hydrates live rooms from catalog revisions.
- Let complete published snapshot pairs replace no-baseline room checkpoints so republished demo notebooks do not stay stuck on stale empty rooms.
- Add shared publish auth headers so publish scripts can use either deployed Anaconda API-key auth or local/dev-token auth without mixing identity credentials.
- Add a `lets-edit` live fixture preset for repeatable demo publishing.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts test/publish-auth.test.mjs test/live-notebook-fixture.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- deployed preview.runt.run:
  - renderer assets version `fa2cfa32-6f2a-4bd4-b610-728be1110ed3`
  - output document version `e9a0e48b-886e-4697-98e8-a9fbeef94a56`
  - main worker version `7f01a783-c294-4a11-aec9-20e256824a6b`
- republished `https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit` with `runtime_state_doc_id=runtime:7b9059c9-9575-4972-913c-c8715bc7bad4`
- `NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit ... pnpm --dir apps/notebook-cloud smoke:hosted`
- Playwright read-only check: 3 cells rendered, 0 `contenteditable=true` nodes in view mode.
