### PR TITLE
docs(elements): document shell capabilities

### DIFF
--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -19,6 +19,7 @@ export type ElementsNotebookScenarioId =
   | "desktop-local-owner"
   | "cloud-public-viewer"
   | "cloud-editor"
+  | "cloud-owner"
   | "runtime-unavailable";
 
 export interface ElementsNotebookScenario {
@@ -574,9 +575,9 @@ export const elementsNotebookScenarios: Record<
       canEditMarkdown: false,
       canEditCells: false,
       canEditStructure: false,
-      canRequestEdit: true,
+      canRequestEdit: false,
       canExecute: false,
-      canToggleCode: false,
+      canToggleCode: true,
       canViewPackages: true,
       canManagePackages: false,
       canManageSharing: false,
@@ -599,9 +600,42 @@ export const elementsNotebookScenarios: Record<
     title: "Cloud editor",
     eyebrow: "hosted fixture",
     summary:
-      "Authenticated cloud editing where the shell can edit cells and share, while execution still waits for a runtime.",
+      "Authenticated cloud editor access where markdown can change but code cells, structure, packages, sharing, and execution stay gated.",
     runtimeLabel: "Cloud notebook · runtime detached",
-    packageSummary: "managed · 4 packages",
+    packageSummary: "visible · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: true,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: "cloud:morgan",
+        identityLabel: "Morgan",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+    },
+  }),
+  "cloud-owner": createScenario({
+    id: "cloud-owner",
+    title: "Cloud owner",
+    eyebrow: "hosted fixture",
+    summary:
+      "Authenticated cloud owner access with markdown and code-cell source edits plus sharing, while structure, packages, and execution remain host-gated.",
+    runtimeLabel: "Cloud notebook · runtime detached",
+    packageSummary: "visible · 4 packages",
     capabilities: {
       canRead: true,
       canEditMarkdown: true,
@@ -611,7 +645,7 @@ export const elementsNotebookScenarios: Record<
       canExecute: false,
       canToggleCode: true,
       canViewPackages: true,
-      canManagePackages: true,
+      canManagePackages: false,
       canManageSharing: true,
       access: {
         level: "owner",

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import {
+  Check,
+  CircleSlash2,
+  Cloud,
+  Code2,
+  Eye,
+  FileCode2,
+  GitBranch,
+  KeyRound,
+  ListTree,
+  Monitor,
+  Package,
+  PencilLine,
+  PlayCircle,
+  Rows3,
+  Share2,
+  ShieldCheck,
+  TestTube2,
+  Workflow,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { NotebookShellCapabilities } from "@/components/notebook-shell";
+import { cn } from "@/lib/utils";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+  type ElementsNotebookScenarioId,
+} from "@/components/notebook-scenarios";
+
+type BooleanCapabilityKey = {
+  [Key in keyof NotebookShellCapabilities]: NotebookShellCapabilities[Key] extends boolean
+    ? Key
+    : never;
+}[keyof NotebookShellCapabilities];
+
+const scenarioIds: ElementsNotebookScenarioId[] = [
+  "desktop-local-owner",
+  "cloud-public-viewer",
+  "cloud-editor",
+  "cloud-owner",
+  "runtime-unavailable",
+];
+
+const hostFlows: {
+  title: string;
+  icon: LucideIcon;
+  facts: string;
+  adapter: string;
+  sharedSurface: string;
+}[] = [
+  {
+    title: "Desktop host",
+    icon: Monitor,
+    facts:
+      "local file mutability, daemon session readiness, local actor, hosted scope when attached",
+    adapter: "desktopNotebookShellCapabilities",
+    sharedSurface: "NotebookDocumentShell + NotebookView + NotebookDocumentRail",
+  },
+  {
+    title: "Cloud host",
+    icon: Cloud,
+    facts: "OIDC/auth mode, room ACL, requested viewer/editor mode, code-cell presence",
+    adapter: "cloudNotebookShellCapabilities",
+    sharedSurface: "NotebookDocumentShell + NotebookView + NotebookDocumentHeader",
+  },
+  {
+    title: "Elements host",
+    icon: TestTube2,
+    facts: "deterministic scenarios, fixture cells, package facts, inert callbacks",
+    adapter: "ElementsNotebookScenario.capabilities",
+    sharedSurface: "the same shared shell components, without daemon or room side effects",
+  },
+];
+
+const capabilityRows: {
+  key: BooleanCapabilityKey;
+  label: string;
+  icon: LucideIcon;
+  component: string;
+  meaning: string;
+}[] = [
+  {
+    key: "canRead",
+    label: "Read notebook",
+    icon: Eye,
+    component: "NotebookDocumentShell, NotebookCellList",
+    meaning: "The host can show the document and projected cell list.",
+  },
+  {
+    key: "canEditMarkdown",
+    label: "Edit markdown",
+    icon: PencilLine,
+    component: "NotebookView, MarkdownCell",
+    meaning: "Markdown writes are allowed through the host bridge.",
+  },
+  {
+    key: "canEditCells",
+    label: "Edit code source",
+    icon: Code2,
+    component: "NotebookView, CodeCell",
+    meaning: "Code and raw cell source editors are writable.",
+  },
+  {
+    key: "canEditStructure",
+    label: "Edit structure",
+    icon: GitBranch,
+    component: "NotebookView mutation controls",
+    meaning: "Cell insert, delete, move, and structural document writes are available.",
+  },
+  {
+    key: "canRequestEdit",
+    label: "Request edit",
+    icon: KeyRound,
+    component: "NotebookDocumentHeader edit slot",
+    meaning: "The host can render a sign-in or edit-mode affordance separate from write access.",
+  },
+  {
+    key: "canExecute",
+    label: "Execute",
+    icon: PlayCircle,
+    component: "NotebookToolbar, CodeCell run controls",
+    meaning: "Runtime actions are available through the host execution adapter.",
+  },
+  {
+    key: "canToggleCode",
+    label: "Toggle source",
+    icon: FileCode2,
+    component: "NotebookDocumentHeader code slot",
+    meaning: "The host can expose source visibility controls for notebooks with code cells.",
+  },
+  {
+    key: "canViewPackages",
+    label: "View packages",
+    icon: Package,
+    component: "NotebookDocumentRail, NotebookPackageSummaryPanel",
+    meaning: "Dependency metadata can be inspected even when mutation is disabled.",
+  },
+  {
+    key: "canManagePackages",
+    label: "Manage packages",
+    icon: Package,
+    component: "DependencyHeader, package rail controls",
+    meaning: "Dependency changes and environment sync actions are writable.",
+  },
+  {
+    key: "canManageSharing",
+    label: "Manage sharing",
+    icon: Share2,
+    component: "NotebookDocumentHeader sharing slot",
+    meaning: "Host-specific ACL or invite controls can render.",
+  },
+];
+
+const componentRows = [
+  {
+    component: "NotebookDocumentShell",
+    path: "src/components/notebook-shell/NotebookDocumentShell.tsx",
+    use: "Hosts the document stage, header, rail, notice slots, and capability data attributes.",
+    hostBoundary: "No Tauri, OIDC, room host, daemon, or catalog router imports.",
+  },
+  {
+    component: "NotebookDocumentHeader",
+    path: "src/components/notebook-shell/NotebookDocumentHeader.tsx",
+    use: "Gates utility, runtime, code, sharing, edit, and auth slots from capabilities.",
+    hostBoundary: "Controls stay host-specific; visibility policy stays shared.",
+  },
+  {
+    component: "NotebookView",
+    path: "apps/notebook/src/components/NotebookView.tsx",
+    use: "Renders editable markdown, code cells, raw cells, outputs, and stable DOM order.",
+    hostBoundary: "Receives capabilities and callbacks instead of reading cloud or desktop state.",
+  },
+  {
+    component: "NotebookDocumentRail",
+    path: "src/components/notebook-shell/NotebookDocumentRail.tsx",
+    use: "Projects outline and packages through the shared view model.",
+    hostBoundary: "Navigation and package mutations remain adapter callbacks.",
+  },
+  {
+    component: "createNotebookViewModel",
+    path: "src/components/notebook-shell/view-model.ts",
+    use: "Materializes cells, outline items, heading anchors, read-only cells, and package summaries.",
+    hostBoundary: "Hosts provide source facts; the projection stays notebook-semantic.",
+  },
+];
+
+export function NotebookShellCapabilitiesExample() {
+  const scenarios = scenarioIds.map((id) => getElementsNotebookScenario(id));
+
+  return (
+    <div className="not-prose space-y-6" data-elements-slot="notebook-shell-capabilities">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-200">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Shared host contract</h2>
+            <p className="mt-1 text-xs leading-5">
+              Desktop, cloud, and Elements should feed the same shell facts into the same notebook
+              components. The catalog fixtures are only a host adapter: they provide capabilities,
+              projected cells, package state, and inert callbacks.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {hostFlows.map((flow) => (
+          <article key={flow.title} className="rounded-lg border border-fd-border bg-fd-card p-4">
+            <flow.icon className="mb-3 size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">{flow.title}</h2>
+            <dl className="mt-3 space-y-3 text-xs leading-5">
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  Source facts
+                </dt>
+                <dd className="mt-1 text-fd-muted-foreground">{flow.facts}</dd>
+              </div>
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  Adapter
+                </dt>
+                <dd className="mt-1 break-words font-mono text-[11px] text-fd-foreground">
+                  {flow.adapter}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  Shared surface
+                </dt>
+                <dd className="mt-1 text-fd-muted-foreground">{flow.sharedSurface}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="flex items-center gap-2 border-b border-fd-border p-4">
+            <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Scenario capability matrix</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[860px] border-separate border-spacing-0 text-left text-xs">
+              <thead>
+                <tr className="text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
+                  <th className="w-64 border-b border-fd-border p-3 font-medium">Capability</th>
+                  {scenarios.map((scenario) => (
+                    <th key={scenario.id} className="border-b border-fd-border p-3 font-medium">
+                      {scenario.title}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {capabilityRows.map((row) => (
+                  <tr key={row.key} className="align-top">
+                    <th className="border-b border-fd-border p-3 font-normal">
+                      <div className="flex items-start gap-2">
+                        <row.icon
+                          className="mt-0.5 size-4 flex-none text-fd-muted-foreground"
+                          aria-hidden="true"
+                        />
+                        <div>
+                          <div className="font-semibold text-fd-foreground">{row.label}</div>
+                          <div className="mt-1 text-[11px] leading-4 text-fd-muted-foreground">
+                            {row.meaning}
+                          </div>
+                          <div className="mt-1 break-words font-mono text-[10px] leading-4 text-fd-muted-foreground">
+                            {row.component}
+                          </div>
+                        </div>
+                      </div>
+                    </th>
+                    {scenarios.map((scenario) => (
+                      <td
+                        key={`${scenario.id}-${row.key}`}
+                        className="border-b border-fd-border p-3"
+                      >
+                        <CapabilityState enabled={scenario.capabilities[row.key]} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {scenarios.map((scenario) => (
+            <ScenarioCard key={scenario.id} scenario={scenario} />
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="flex items-center gap-2 border-b border-fd-border p-4">
+          <Workflow className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Shared component boundary</h2>
+        </div>
+        <div className="grid gap-2 p-4">
+          {componentRows.map((row) => (
+            <article key={row.component} className="rounded-md border border-fd-border p-3">
+              <div className="grid gap-3 md:grid-cols-[240px_minmax(0,1fr)]">
+                <div className="min-w-0">
+                  <div className="font-semibold">{row.component}</div>
+                  <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                    {row.path}
+                  </div>
+                </div>
+                <div className="grid gap-3 text-xs leading-5 md:grid-cols-2">
+                  <div>
+                    <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                      Shared use
+                    </div>
+                    <p className="mt-1 text-fd-muted-foreground">{row.use}</p>
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+                      Host boundary
+                    </div>
+                    <p className="mt-1 text-fd-muted-foreground">{row.hostBoundary}</p>
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Catalog rule</h2>
+        </div>
+        <p className="text-xs leading-5 text-fd-muted-foreground">
+          New Elements pages should start from these scenarios when they need document context.
+          Lower-level fixtures are still fine for isolated renderers, but shell-level pages should
+          not invent their own desktop/cloud permission vocabulary.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function CapabilityState({ enabled }: { enabled: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium",
+        enabled
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          : "border-fd-border bg-fd-muted text-fd-muted-foreground",
+      )}
+    >
+      {enabled ? (
+        <Check className="size-3" aria-hidden="true" />
+      ) : (
+        <CircleSlash2 className="size-3" aria-hidden="true" />
+      )}
+      {enabled ? "yes" : "no"}
+    </span>
+  );
+}
+
+function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
+  const enabledLabels = [
+    scenario.capabilities.canEditMarkdown ? "markdown" : null,
+    scenario.capabilities.canEditCells ? "code source" : null,
+    scenario.capabilities.canExecute ? "execute" : null,
+    scenario.capabilities.canManagePackages ? "packages" : null,
+    scenario.capabilities.canManageSharing ? "sharing" : null,
+  ].filter(Boolean);
+  const authLabel = scenario.capabilities.auth.needsAttention
+    ? "auth attention"
+    : scenario.capabilities.auth.canUseAuthenticatedIdentity
+      ? "authenticated"
+      : scenario.capabilities.auth.canSignIn
+        ? "sign-in available"
+        : "local fixture";
+
+  return (
+    <article className="rounded-lg border border-fd-border bg-fd-card p-3 text-xs leading-5">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="font-semibold text-fd-foreground">{scenario.title}</div>
+          <div className="mt-1 text-[11px] text-fd-muted-foreground">{scenario.eyebrow}</div>
+        </div>
+        <span className="shrink-0 rounded-full border border-fd-border bg-fd-background px-2 py-0.5 text-[10px] text-fd-muted-foreground">
+          {scenario.capabilities.access.source}:{scenario.capabilities.access.level}
+        </span>
+      </div>
+      <p className="mt-2 text-fd-muted-foreground">{scenario.summary}</p>
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <ScenarioPill label={authLabel} />
+        <ScenarioPill label={scenario.runtimeLabel} />
+        <ScenarioPill label={scenario.packageSummary} />
+        <ScenarioPill
+          label={enabledLabels.length ? `writes: ${enabledLabels.join(", ")}` : "read-only"}
+        />
+      </div>
+    </article>
+  );
+}
+
+function ScenarioPill({ label }: { label: string }) {
+  return (
+    <span className="rounded-full border border-fd-border bg-fd-background px-2 py-0.5 text-[10px] text-fd-muted-foreground">
+      {label}
+    </span>
+  );
+}

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -112,7 +112,7 @@ function createStatusSurfaces(): ToolbarSurface[] {
       title: "Environment preparation",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: cloudEditor,
-      role: `${cloudEditor.title} can edit cells, but this fixture keeps execution detached while conda solve/install progress renders.`,
+      role: `${cloudEditor.title} can edit markdown, but this fixture keeps execution detached while conda solve/install progress renders.`,
       props: toolbarProps(cloudEditor, {
         kernelStatus: KERNEL_STATUS.STARTING,
         statusKey: RUNTIME_STATUS.PREPARING_ENV,

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -43,6 +43,7 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
   "desktop-local-owner",
   "cloud-public-viewer",
   "cloud-editor",
+  "cloud-owner",
   "runtime-unavailable",
 ];
 

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -41,6 +41,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Output renderers](/docs/output-renderers)
 - [Output isolation surfaces](/docs/isolated-output-surfaces)
 - [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)
+- [Notebook shell capabilities](/docs/notebook-shell-capabilities)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)
 - [Theme surfaces](/docs/theme-surfaces)

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -18,6 +18,9 @@ This fixture now renders the current notebook app toolbar and shared
 focused code cell resolves to the nearest preceding heading. The package panel
 is supplied through `NotebookPackagesPanel` and hosts the current
 `DependencyHeader` with static dependency state.
+Scenario selection comes from the shared [notebook shell capabilities](/docs/notebook-shell-capabilities)
+fixtures so desktop, cloud viewer, cloud editor, cloud owner, and runtime-blocked
+states stay aligned with the app shell.
 
 <RailOutlineExample />
 

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -1,0 +1,29 @@
+---
+title: Notebook shell capabilities
+description: Desktop, cloud, and Elements host facts mapped into the shared notebook shell.
+---
+
+import { NotebookShellCapabilitiesExample } from "@/components/notebook-shell-capabilities-example";
+
+The notebook shell is the shared boundary between host state and notebook UI.
+Desktop, cloud, and Elements should all answer the same capability questions
+before rendering document chrome, rails, package surfaces, editable cells, or
+read-only cells.
+
+This page tracks the current host contract after the cloud and desktop
+convergence work. Elements uses deterministic fixture scenarios here, not a
+runtime, room host, daemon, CRDT bridge, or generated WASM binding.
+
+<NotebookShellCapabilitiesExample />
+
+## Implementation intent
+
+- Hosts derive `NotebookShellCapabilities` from local state, cloud ACL/auth
+  state, or Elements fixtures.
+- Shared surfaces consume the capability object and view model instead of
+  importing desktop or cloud state directly.
+- Cloud editor access can edit markdown, but code-cell source edits and sharing
+  are owner-only; execution and package management remain disabled in hosted
+  previews for now.
+- The catalog should reuse these scenarios whenever a page needs notebook-level
+  context so component examples do not drift from the desktop/cloud shells.

--- a/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
+++ b/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
@@ -9,6 +9,9 @@ The notebook toolbar is workspace chrome, not generic button inventory. This
 page renders the current `NotebookToolbar` with static runtime, environment,
 dependency, and update fixtures so the catalog can track the real desktop
 surface without importing daemon hooks or notebook state.
+The hosted scenarios are shared with the
+[notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor
+and owner access do not drift from cloud ACL semantics.
 
 <NotebookToolbarSurfacesExample />
 

--- a/apps/elements/content/docs/package-manager-surfaces.mdx
+++ b/apps/elements/content/docs/package-manager-surfaces.mdx
@@ -9,6 +9,9 @@ Package management is notebook UI. These surfaces are the real dependency
 headers used by the notebook app, rendered with static fixture metadata so the
 catalog can inspect package panels without a live daemon, Automerge document, or
 environment solve.
+Package viewing and package mutation are separate shell capabilities; hosted
+viewer, editor, and owner fixtures can inspect package state while package
+management remains disabled.
 
 <PackageManagerSurfacesExample />
 

--- a/apps/elements/content/docs/read-only-notebook-surfaces.mdx
+++ b/apps/elements/content/docs/read-only-notebook-surfaces.mdx
@@ -8,6 +8,10 @@ import { ReadOnlyNotebookSurfacesExample } from "@/components/read-only-notebook
 Hosted notebooks and cloud previews should not fork the notebook cell stack.
 This page renders the shared read-only path from current nteract components
 with static nbformat-style fixtures.
+The cloud viewer fixture follows the shared
+[notebook shell capabilities](/docs/notebook-shell-capabilities) contract:
+public readers can inspect notebook and package state but cannot request edit
+until a host-authenticated flow is active.
 
 <ReadOnlyNotebookSurfacesExample />
 


### PR DESCRIPTION
## Summary

- add a Notebook shell capabilities page to the Elements catalog
- align Elements cloud viewer/editor/owner fixtures with the merged cloud shell capability semantics
- point outline, toolbar, read-only notebook, and package pages at the shared capability scenarios

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- `curl -I http://127.0.0.1:5176/docs/notebook-shell-capabilities`
- `curl -I http://127.0.0.1:5176/docs/notebook-outline`

## Notes

- scoped to `apps/elements`
- runtime-free: no daemon, room host, CRDT bridge, or generated WASM bindings
- one Elements PR for this batch
