### PR TITLE
fix(notebook-cloud): gate source writes by capabilities

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -4,7 +4,7 @@ This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It 
 
 The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document pair in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and stores bounded frame metadata for sync frames that actually change a materialized document. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes are deliberately limited to existing markdown-cell source edits in this prototype; code cells and structural document changes remain read-only unless the connection has owner scope. Runtime peers use a separate `RuntimeStatePeerHandle` authoring surface: they can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
 
-`/n/:notebookId` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` is an immutable pinned viewer that loads the persisted `NotebookDoc` + `RuntimeStateDoc` Automerge snapshot pair directly through `/api/n/:id/snapshots/:headsHash`, `/api/n/:id/runtime-snapshots/:runtimeHeadsHash`, and catalog revision metadata. Snapshot-pair publishes validate that the pair can be loaded and that referenced output blobs exist before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
+`/n/:notebookId/:vanityName` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` is an immutable pinned viewer that loads the persisted `NotebookDoc` + `RuntimeStateDoc` Automerge snapshot pair directly through `/api/n/:id/snapshots/:headsHash`, `/api/n/:id/runtime-snapshots/:runtimeHeadsHash`, and catalog revision metadata. Snapshot-pair publishes validate that the pair can be loaded and that referenced output blobs exist before recording the catalog revision, so missing runtime snapshots, corrupt snapshot bytes, or missing output blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
 ## Local dev
 
@@ -66,16 +66,16 @@ http://127.0.0.1:8787/n/demo/debug
 The notebook viewer is available at:
 
 ```text
-http://127.0.0.1:8787/n/nteract-cloud-demo
+http://127.0.0.1:8787/n/nteract-cloud-demo/demo
 ```
 
-`/` redirects to that demo notebook id.
+`/` serves the sign-in shell; open notebooks through `/n/{id}/{vanityName}`.
 
 `publish:fixture` defaults to `packages/runtimed/tests/fixtures/output_streaming`
 and publishes a notebook revision with real `RuntimeStateDoc` output manifests:
 
 ```text
-http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming
+http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming/output_streaming
 ```
 
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
@@ -85,7 +85,7 @@ Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
 `preview.runt.run` topic-viz notebook by default:
 
 ```text
-https://preview.runt.run/n/topic-viz
+https://preview.runt.run/n/topic-viz/topic-viz
 ```
 
 Install the Chromium browser once before running the hosted smoke from a fresh
@@ -157,7 +157,7 @@ sends the token as a subprotocol instead of a URL parameter. The smoke verifies
 that Alice edits reach Bob and anonymous without reload, Bob edits reach Alice
 and anonymous without reload, Charlie is denied editor access, and no request
 URL contains the dev token. Pass
-`NOTEBOOK_CLOUD_COLLAB_VIEWER_URL=https://.../n/<id>` to reuse an existing room
+`NOTEBOOK_CLOUD_COLLAB_VIEWER_URL=https://.../n/<id>/<vanity-name>` to reuse an existing room
 instead of seeding a new one.
 
 ## Dev auth

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke-env.mjs
@@ -25,8 +25,9 @@ export function browserDevTokenForSmoke({ baseUrl, devAuthToken }) {
   throw new Error("NOTEBOOK_CLOUD_DEV_TOKEN is required for deployed browser collaboration smoke");
 }
 
-export function viewerUrlForRoom(baseUrl, roomId) {
-  return new URL(`/n/${encodeURIComponent(roomId)}`, baseUrl).href;
+export function viewerUrlForRoom(baseUrl, roomId, vanityName = "collab") {
+  return new URL(`/n/${encodeURIComponent(roomId)}/${encodeURIComponent(vanityName)}`, baseUrl)
+    .href;
 }
 
 export function storageStateForDevIdentity({ origin, token, user, scope }) {

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -587,9 +587,11 @@ function parseJson(stdout, label) {
 
 function roomFromViewerUrl(viewerUrl) {
   const parsed = new URL(viewerUrl);
-  const [, prefix, encodedRoomId] = parsed.pathname.split("/");
-  if (prefix !== "n" || !encodedRoomId) {
-    throw new Error(`NOTEBOOK_CLOUD_COLLAB_VIEWER_URL must point at /n/:id, got ${viewerUrl}`);
+  const [, prefix, encodedRoomId, vanityName] = parsed.pathname.split("/");
+  if (prefix !== "n" || !encodedRoomId || !vanityName) {
+    throw new Error(
+      `NOTEBOOK_CLOUD_COLLAB_VIEWER_URL must point at /n/:id/:vanityName, got ${viewerUrl}`,
+    );
   }
   return {
     roomId: decodeURIComponent(encodedRoomId),

--- a/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
@@ -17,6 +17,12 @@ export function smokeEnvForPublishResult(env, publishResult) {
     publishResult.runtimeHeadsHash,
     "runtimeHeadsHash",
   );
+  setRequiredDefaultEnv(
+    smokeEnv,
+    "NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID",
+    publishResult.runtimeStateDocId,
+    "runtimeStateDocId",
+  );
 
   if (!hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN")) {
     const origin = new URL(publishResult.viewerUrl).origin;

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -19,15 +19,15 @@ export function isRenderCacheApiUrl(requestUrl) {
 
 export function notebookViewerUrl(viewerUrl) {
   const parsed = new URL(viewerUrl);
-  const match = parsed.pathname.match(/^\/n\/([^/]+)(?:\/([^/]+))?\/?$/);
+  const match = parsed.pathname.match(/^\/n\/([^/]+)\/([^/]+)\/?$/);
   if (!match) {
     return null;
   }
   const [, notebookId, vanityName] = match;
-  if (vanityName && ["debug", "r", "sync"].includes(vanityName)) {
+  if (["debug", "r", "sync"].includes(vanityName)) {
     return null;
   }
-  return { origin: parsed.origin, notebookId, vanityName: vanityName ?? null };
+  return { origin: parsed.origin, notebookId, vanityName };
 }
 
 export function pinnedNotebookViewerUrl(viewerUrl) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -30,7 +30,7 @@ import {
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
 import { catalogApiUrlForViewer, isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 
-const DEFAULT_URL = "https://preview.runt.run/n/topic-viz";
+const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
 const DEFAULT_OUTPUT_DOCUMENT_ORIGIN = "https://preview.runtusercontent.com";
 const DEFAULT_CATALOG_OWNER_PRINCIPAL = "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375";

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -6,6 +6,9 @@ import { publishIdentityHeaders } from "./publish-auth.mjs";
 
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
 const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? "nteract-cloud-demo";
+const vanityName = process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? "demo";
+const runtimeStateDocIdOverride =
+  process.env.NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID ?? `${notebookId}:runtime-state`;
 const actorLabel = "user:dev:demo/agent:publish-demo";
 const wasmJsUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
@@ -24,6 +27,7 @@ initSync({ module: wasmBytes });
 
 const handle = new NotebookHandle(notebookId);
 handle.set_actor(actorLabel);
+handle.set_runtime_state_doc_id(runtimeStateDocIdOverride);
 handle.add_cell_after("intro", "markdown", null);
 handle.update_source(
   "intro",
@@ -87,7 +91,8 @@ console.log(
       ok: true,
       baseUrl,
       notebookId,
-      viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      vanityName,
+      viewerUrl: canonicalViewerUrl(baseUrl, notebookId, vanityName),
       runtimeStateDocId,
       headsHash,
       runtimeHeadsHash,
@@ -107,6 +112,11 @@ console.log(
 function headsDigest(heads) {
   const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
   return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
+}
+
+function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
+  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
+    .href;
 }
 
 function requiredRuntimeStateDocId(handle) {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -7,6 +7,9 @@ import { publishIdentityHeaders } from "./publish-auth.mjs";
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
 const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
 const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? `nteract-cloud-fixture-${fixtureName}`;
+const vanityName = process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? fixtureName;
+const runtimeStateDocIdOverride =
+  process.env.NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID ?? `${notebookId}:runtime-state`;
 const fixtureRoot = new URL(
   `../../../packages/runtimed/tests/fixtures/${fixtureName}/`,
   import.meta.url,
@@ -37,7 +40,7 @@ const [snapshotBytes, runtimeSnapshotBytes] = await Promise.all([
 const fixtureManifest = JSON.parse(await readFile(new URL("manifest.json", fixtureRoot), "utf8"));
 const fixtureBlobs = Array.isArray(fixtureManifest.blobs) ? fixtureManifest.blobs : [];
 const handle = NotebookHandle.load_snapshot(snapshotBytes, runtimeSnapshotBytes);
-handle.set_runtime_state_doc_id(`runtime:${notebookId}`);
+handle.set_runtime_state_doc_id(runtimeStateDocIdOverride);
 const headsHash = headsDigest(handle.get_heads_hex());
 const runtimeHeadsHash = headsDigest(handle.get_runtime_state_heads_hex());
 const runtimeStateDocId = requiredRuntimeStateDocId(handle);
@@ -85,7 +88,8 @@ console.log(
       baseUrl,
       fixtureName,
       notebookId,
-      viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+      vanityName,
+      viewerUrl: canonicalViewerUrl(baseUrl, notebookId, vanityName),
       runtimeStateDocId,
       headsHash,
       runtimeHeadsHash,
@@ -131,6 +135,11 @@ async function uploadFixtureBlob(blob) {
     bytes,
     typeof blob.content_type === "string" ? blob.content_type : "application/octet-stream",
   );
+}
+
+function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
+  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
+    .href;
 }
 
 function headsDigest(heads) {

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -16,6 +16,8 @@ const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
 const notebookId =
   process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ??
   (sourceNotebookId ? `live-${sourceNotebookId}` : `nteract-cloud-live-${preset}`);
+const vanityName =
+  process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? defaultLiveVanityName({ preset, sourceNotebookId });
 const wasmJsUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
   import.meta.url,
@@ -84,7 +86,8 @@ try {
         preset: sourceNotebookId ? "source-notebook" : preset,
         sourceNotebookId: sourceNotebookId ?? session.notebookId,
         notebookId,
-        viewerUrl: new URL(`/n/${encodeURIComponent(notebookId)}`, baseUrl).href,
+        vanityName,
+        viewerUrl: canonicalViewerUrl(baseUrl, notebookId, vanityName),
         runtimeStateDocId,
         headsHash,
         runtimeHeadsHash,
@@ -130,6 +133,21 @@ function requiredRuntimeStateDocId(handle) {
     "NotebookDoc live snapshot is missing runtime_state_doc_id",
   );
   return runtimeStateDocId;
+}
+
+function defaultLiveVanityName({ preset, sourceNotebookId }) {
+  if (sourceNotebookId) {
+    return "source";
+  }
+  if (preset === "mathnet") {
+    return "topic-viz";
+  }
+  return preset;
+}
+
+function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
+  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
+    .href;
 }
 
 async function uploadLiveBlob(ref, snapshot) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -146,11 +146,6 @@ const worker: ExportedHandler<Env> = {
       );
     }
 
-    const viewerMatch = url.pathname.match(/^\/n\/([^/]+)\/?$/);
-    if (viewerMatch && request.method === "GET") {
-      return viewer(decodeURIComponent(viewerMatch[1]), request, env);
-    }
-
     const vanityViewerMatch = url.pathname.match(/^\/n\/([^/]+)\/([^/]+)\/?$/);
     if (vanityViewerMatch && request.method === "GET") {
       return viewer(decodeURIComponent(vanityViewerMatch[1]), request, env);

--- a/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-collab-smoke-env.test.mjs
@@ -51,7 +51,10 @@ describe("hosted browser collaboration smoke environment", () => {
     );
     const parsed = new URL(url);
 
-    assert.equal(url, "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/room%2Fwith%2Fslashes");
+    assert.equal(
+      url,
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/room%2Fwith%2Fslashes/collab",
+    );
     assert.equal(parsed.search, "");
     assert.equal(parsed.hash, "");
   });

--- a/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
@@ -11,15 +11,16 @@ describe("hosted live smoke environment", () => {
     const smokeEnv = smokeEnvForPublishResult(
       {},
       {
-        viewerUrl: "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source",
+        viewerUrl: "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source/source",
         headsHash: "heads-notebook",
         runtimeHeadsHash: "heads-runtime",
+        runtimeStateDocId: "runtime-state-doc",
       },
     );
 
     assert.equal(
       smokeEnv.NOTEBOOK_CLOUD_HOSTED_URL,
-      "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source",
+      "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/live-source/source",
     );
     assert.equal(
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH,
@@ -28,6 +29,10 @@ describe("hosted live smoke environment", () => {
     assert.equal(
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH,
       "heads-runtime",
+    );
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID,
+      "runtime-state-doc",
     );
     assert.equal(
       Object.hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE"),
@@ -44,9 +49,10 @@ describe("hosted live smoke environment", () => {
         NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN: "https://assets.example.test",
       },
       {
-        viewerUrl: "http://127.0.0.1:8787/n/live-source",
+        viewerUrl: "http://127.0.0.1:8787/n/live-source/source",
         headsHash: "heads-notebook",
         runtimeHeadsHash: "heads-runtime",
+        runtimeStateDocId: "runtime-state-doc",
       },
     );
 
@@ -65,9 +71,10 @@ describe("hosted live smoke environment", () => {
     const smokeEnv = smokeEnvForPublishResult(
       {},
       {
-        viewerUrl: "http://127.0.0.1:8787/n/live-source",
+        viewerUrl: "http://127.0.0.1:8787/n/live-source/source",
         headsHash: "heads-notebook",
         runtimeHeadsHash: "heads-runtime",
+        runtimeStateDocId: "runtime-state-doc",
       },
     );
 
@@ -80,7 +87,7 @@ describe("hosted live smoke environment", () => {
         smokeEnvForPublishResult(
           {},
           {
-            viewerUrl: "http://127.0.0.1:8787/n/live-source",
+            viewerUrl: "http://127.0.0.1:8787/n/live-source/source",
           },
         ),
       /did not provide headsHash/,
@@ -90,9 +97,10 @@ describe("hosted live smoke environment", () => {
         {
           NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH: "",
           NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH: "",
+          NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID: "",
         },
         {
-          viewerUrl: "http://127.0.0.1:8787/n/live-source",
+          viewerUrl: "http://127.0.0.1:8787/n/live-source/source",
         },
       ),
     );

--- a/apps/notebook-cloud/test/hosted-smoke-assets.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-assets.test.mjs
@@ -62,7 +62,7 @@ describe("hosted render smoke viewer CSS assets", () => {
       ],
     ]);
 
-    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz", {
+    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz/topic-viz", {
       fetchImpl: fakeFetch(responses),
       maxPrimaryBytes: 250_000,
     });
@@ -96,7 +96,7 @@ describe("hosted render smoke viewer CSS assets", () => {
       ],
     ]);
 
-    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz", {
+    const check = await checkViewerCssSplit("https://preview.runt.run/n/topic-viz/topic-viz", {
       fetchImpl: fakeFetch(responses),
       maxPrimaryBytes: 250_000,
     });

--- a/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-performance.test.mjs
@@ -46,7 +46,7 @@ describe("hosted smoke performance diagnostics", () => {
       "notebook_blob",
     );
     assert.equal(
-      classifyPerformanceResource("https://preview.runt.run/n/topic-viz", origins),
+      classifyPerformanceResource("https://preview.runt.run/n/topic-viz/topic-viz", origins),
       "viewer_document",
     );
     assert.equal(

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -12,14 +12,11 @@ describe("hosted render smoke routes", () => {
   it("derives the catalog API URL from a hosted notebook viewer URL", () => {
     assert.equal(
       catalogApiUrlForViewer(
-        "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet",
+        "https://nteract-notebook-cloud.rgbkrk.workers.dev/n/nteract-cloud-live-mathnet/topic-viz",
       ),
       "https://nteract-notebook-cloud.rgbkrk.workers.dev/api/n/nteract-cloud-live-mathnet",
     );
-    assert.equal(
-      catalogApiUrlForViewer("https://example.com/n/foo/"),
-      "https://example.com/api/n/foo",
-    );
+    assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/"), null);
     assert.equal(
       catalogApiUrlForViewer("https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit"),
       "https://preview.runt.run/api/n/01KSQKEPFJVHV4T4ZDYS9V7T80",
@@ -31,11 +28,7 @@ describe("hosted render smoke routes", () => {
   });
 
   it("summarizes plain and vanity viewer URLs", () => {
-    assert.deepEqual(notebookViewerUrl("https://example.com/n/foo"), {
-      origin: "https://example.com",
-      notebookId: "foo",
-      vanityName: null,
-    });
+    assert.equal(notebookViewerUrl("https://example.com/n/foo"), null);
     assert.deepEqual(notebookViewerUrl("https://example.com/n/foo/lets-edit"), {
       origin: "https://example.com",
       notebookId: "foo",
@@ -54,6 +47,7 @@ describe("hosted render smoke routes", () => {
 
   it("returns null for non-viewer URLs", () => {
     assert.equal(catalogApiUrlForViewer("https://example.com/"), null);
+    assert.equal(catalogApiUrlForViewer("https://example.com/n/foo"), null);
     assert.equal(catalogApiUrlForViewer("https://example.com/n/foo/sync"), null);
   });
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -103,9 +103,19 @@ describe("HTML script serialization", () => {
     assert.doesNotMatch(html, /id="notebook"/);
   });
 
-  it("serves latest notebook viewers as live-sync shells without a latest render endpoint", async () => {
+  it("does not serve legacy one-segment notebook viewer URLs", async () => {
     const response = await worker.fetch(
       new Request("https://cloud.test/n/demo"),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+  });
+
+  it("serves vanity notebook viewers as live-sync shells without a latest render endpoint", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/example"),
       fakeEnv(),
       fakeContext(),
     );
@@ -159,7 +169,7 @@ describe("HTML script serialization", () => {
 
   it("injects OIDC runtime config without exposing it through health", async () => {
     const response = await worker.fetch(
-      new Request("https://preview.runt.run/n/demo"),
+      new Request("https://preview.runt.run/n/demo/example"),
       fakeEnv({
         NOTEBOOK_CLOUD_OIDC_CLIENT_ID: "client-id",
         NOTEBOOK_CLOUD_OIDC_ISSUER: "https://auth.stage.anaconda.com/api/auth",
@@ -200,7 +210,7 @@ describe("HTML script serialization", () => {
 
   it("allows the host to place renderer assets on a separate origin", async () => {
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/demo"),
+      new Request("https://cloud.test/n/demo/example"),
       fakeEnv({
         RENDERER_ASSETS_BASE_URL: "https://outputs.example/plugins",
       }),
@@ -219,7 +229,7 @@ describe("HTML script serialization", () => {
 
   it("allows the host to place runtimed WASM assets on a separate origin", async () => {
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/demo"),
+      new Request("https://cloud.test/n/demo/example"),
       fakeEnv({
         RUNTIMED_WASM_BASE_URL: "https://wasm.example/runtime",
       }),
@@ -253,7 +263,7 @@ describe("HTML script serialization", () => {
 
   it("allows the host to place output documents on a separate origin", async () => {
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/demo"),
+      new Request("https://cloud.test/n/demo/example"),
       fakeEnv({
         OUTPUT_DOCUMENT_BASE_URL: "https://outputs.example/frame",
       }),
@@ -272,7 +282,7 @@ describe("HTML script serialization", () => {
 
   it("deduplicates hosted sidecar preconnect hints by origin", async () => {
     const response = await worker.fetch(
-      new Request("https://cloud.test/n/demo"),
+      new Request("https://cloud.test/n/demo/example"),
       fakeEnv({
         OUTPUT_DOCUMENT_BASE_URL: "https://outputs.example/frame",
         RENDERER_ASSETS_BASE_URL: "https://outputs.example/renderer-assets",

--- a/apps/notebook-cloud/test/oidc-auth.test.ts
+++ b/apps/notebook-cloud/test/oidc-auth.test.ts
@@ -52,7 +52,7 @@ describe("cloud OIDC browser auth", () => {
       challenge: "challenge",
       verifier: "verifier",
       state: "state-123",
-      returnUrl: "https://preview.runt.run/n/demo",
+      returnUrl: "https://preview.runt.run/n/demo/example",
     };
 
     const url = buildOidcAuthorizationUrl(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -26,6 +26,10 @@ test("cloud projects live cells into the NotebookView stores", () => {
     /useLayoutEffect\(\(\) => \{\s+cellsRef\.current = cells;\s+projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
+  assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*canWriteSource=\{canWriteCellSource\}/);
+  assert.match(sourceText, /cell\.cellType === "markdown"/);
+  assert.match(sourceText, /return shellCapabilities\.canEditMarkdown/);
+  assert.match(sourceText, /return shellCapabilities\.canEditCells/);
   assert.doesNotMatch(sourceText, /onSourceChanged=/);
 });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -23,7 +23,7 @@ test("cloud projects live cells into the NotebookView stores", () => {
 
   assert.match(
     sourceText,
-    /useLayoutEffect\(\(\) => \{\s+cellsRef\.current = cells;\s+projectCloudCellsIntoNotebookViewStores\(cells\);/,
+    /useLayoutEffect\(\(\) => \{[\s\S]*cellsRef\.current = cells;[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*canWriteSource=\{canWriteCellSource\}/);

--- a/apps/notebook-cloud/test/viewer-sift-preload.test.ts
+++ b/apps/notebook-cloud/test/viewer-sift-preload.test.ts
@@ -141,7 +141,7 @@ function preloadOptions(overrides: Partial<Parameters<typeof siftWasmPreloadUrlF
   return {
     blobBasePath: "/api/n/demo/blobs/",
     rendererAssetsBasePath: "/renderer-assets/",
-    pageUrl: "https://cloud.test/n/demo",
+    pageUrl: "https://cloud.test/n/demo/example",
     ...overrides,
   };
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -515,7 +515,6 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
               {authAction === "starting" ? "Starting sign-in" : "Sign in with Anaconda"}
             </button>
           )}
-          <a href="/n/topic-viz">Open topic-viz</a>
           {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
             <button type="button" onClick={resetAuth}>
               <RotateCcw aria-hidden="true" />
@@ -609,6 +608,7 @@ function NotebookViewer({
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const cellsRef = useRef<ResolvedCell[]>([]);
+  const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
   const notebookLanguageRef = useRef("python");
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
   const liveMaterializedRef = useRef(false);
@@ -663,6 +663,7 @@ function NotebookViewer({
 
   useLayoutEffect(() => {
     cellsRef.current = cells;
+    cellsByIdRef.current = new Map(cells.map((cell) => [cell.id, cell]));
     projectCloudCellsIntoNotebookViewStores(cells);
   }, [cells]);
 
@@ -1125,7 +1126,7 @@ function NotebookViewer({
   }, [canEditMarkdown]);
   const canWriteCellSource = useCallback(
     (cellId: string) => {
-      const cell = cellsRef.current.find((candidate) => candidate.id === cellId);
+      const cell = cellsByIdRef.current.get(cellId);
       if (!cell) {
         return false;
       }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1123,6 +1123,19 @@ function NotebookViewer({
     if (!canEditMarkdown) return;
     liveRuntimeRef.current?.engine.scheduleFlush();
   }, [canEditMarkdown]);
+  const canWriteCellSource = useCallback(
+    (cellId: string) => {
+      const cell = cellsRef.current.find((candidate) => candidate.id === cellId);
+      if (!cell) {
+        return false;
+      }
+      if (cell.cellType === "markdown") {
+        return shellCapabilities.canEditMarkdown;
+      }
+      return shellCapabilities.canEditCells;
+    },
+    [shellCapabilities],
+  );
   const resetPrototypeAuth = useCallback(() => {
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
@@ -1244,6 +1257,7 @@ function NotebookViewer({
       <PresenceValueProvider value={cloudPresenceContext}>
         <CrdtBridgeProvider
           getHandle={getLiveNotebookHandle}
+          canWriteSource={canWriteCellSource}
           onSyncNeeded={handleMarkdownSyncNeeded}
           localActor={connectionActorLabel ?? ""}
         >

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -86,8 +86,9 @@ test.describe("notebook rail outline", () => {
     await expect
       .poll(async () => (await childHeading.boundingBox())?.y ?? Infinity)
       .toBeLessThan(beforeClickY - 400);
+    const viewportHeight = page.viewportSize()?.height ?? 720;
     await expect
       .poll(async () => (await childHeading.boundingBox())?.y ?? Infinity)
-      .toBeLessThan(480);
+      .toBeLessThan(viewportHeight - 32);
   });
 });

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -33,6 +33,8 @@ import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 interface CrdtBridgeContextValue {
   /** Read the current WASM NotebookHandle (null during bootstrap). */
   getHandle: () => NotebookHandle | null;
+  /** Host capability gate for outbound source mutations for a specific cell. */
+  canWriteSource?: (cellId: string) => boolean;
   /** Signal that the CRDT was mutated and needs syncing to daemon. */
   onSyncNeeded: () => void;
   /** Local actor label (e.g. "local:kyle/desktop:abcd1234") for filtering self-echo attributions. */
@@ -45,6 +47,7 @@ const CrdtBridgeContext = createContext<CrdtBridgeContextValue | null>(null);
 
 interface CrdtBridgeProviderProps {
   getHandle: () => NotebookHandle | null;
+  canWriteSource?: (cellId: string) => boolean;
   onSyncNeeded: () => void;
   localActor: string;
   children: ReactNode;
@@ -52,6 +55,7 @@ interface CrdtBridgeProviderProps {
 
 export function CrdtBridgeProvider({
   getHandle,
+  canWriteSource,
   onSyncNeeded,
   localActor,
   children,
@@ -59,10 +63,12 @@ export function CrdtBridgeProvider({
   // Stable ref so the context value doesn't change on every render.
   const valueRef = useRef<CrdtBridgeContextValue>({
     getHandle,
+    canWriteSource,
     onSyncNeeded,
     localActor,
   });
   valueRef.current.getHandle = getHandle;
+  valueRef.current.canWriteSource = canWriteSource;
   valueRef.current.onSyncNeeded = onSyncNeeded;
   valueRef.current.localActor = localActor;
 
@@ -101,6 +107,7 @@ export function useCrdtBridge(cellId: string): {
     return createCrdtBridge({
       getHandle: () => ctxRef.current.getHandle(),
       cellId,
+      canWriteSource: () => ctxRef.current.canWriteSource?.(cellId) ?? true,
       onSourceChanged: (source: string) => {
         updateCellById(cellId, (c) => ({ ...c, source }));
       },

--- a/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vite-plus/test";
+// @vitest-environment jsdom
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 import { createCrdtBridge, remoteChangesFromTextAttributions } from "../crdt-editor-bridge";
+
+let views: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of views) {
+    view.destroy();
+  }
+  views = [];
+});
 
 describe("remoteChangesFromTextAttributions", () => {
   it("filters attributions to the requested cell", () => {
@@ -72,6 +84,36 @@ describe("remoteChangesFromTextAttributions", () => {
 });
 
 describe("createCrdtBridge capability gating", () => {
+  it("blocks outbound editor transactions when the host cannot write", () => {
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          splice_source: (_cellId: string, _index: number, _deleteCount: number, text: string) => {
+            calls.push(text);
+            return true;
+          },
+          get_cell_source: () => "unchanged",
+        }) as never,
+      cellId: "cell-a",
+      canWriteSource: () => false,
+      onSourceChanged: (source) => calls.push(`store:${source}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridge.extension],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+
+    expect(view.state.doc.toString()).toBe("hello!");
+    expect(calls).toEqual([]);
+  });
+
   it("blocks imperative source replacement when the host cannot write", () => {
     const calls: string[] = [];
     const bridge = createCrdtBridge({

--- a/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { remoteChangesFromTextAttributions } from "../crdt-editor-bridge";
+import { createCrdtBridge, remoteChangesFromTextAttributions } from "../crdt-editor-bridge";
 
 describe("remoteChangesFromTextAttributions", () => {
   it("filters attributions to the requested cell", () => {
@@ -68,5 +68,28 @@ describe("remoteChangesFromTextAttributions", () => {
     );
 
     expect(changes).toEqual([{ index: 1, text: "merged", deleted: 2 }]);
+  });
+});
+
+describe("createCrdtBridge capability gating", () => {
+  it("blocks imperative source replacement when the host cannot write", () => {
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          update_source: (_cellId: string, source: string) => {
+            calls.push(source);
+            return true;
+          },
+          get_cell_source: () => "updated",
+        }) as never,
+      cellId: "cell-a",
+      canWriteSource: () => false,
+      onSourceChanged: (source) => calls.push(`store:${source}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+
+    expect(bridge.replaceSource("blocked")).toBe(false);
+    expect(calls).toEqual([]);
   });
 });

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -66,6 +66,14 @@ export interface CrdtBridgeConfig {
   /** The cell ID this editor is bound to. */
   cellId: string;
   /**
+   * Host capability gate for outbound source mutations.
+   *
+   * Desktop normally allows source writes. Cloud can return false for viewer
+   * mode or ACL-denied cells so stale editors cannot mutate the CRDT even if
+   * CodeMirror produces a transaction.
+   */
+  canWriteSource?: () => boolean;
+  /**
    * Called after outbound splices are applied to the CRDT.
    * The bridge passes the full source string so the cell store can be updated.
    */
@@ -152,7 +160,7 @@ export function remoteChangesFromTextAttributions(
  * via the ViewPlugin.
  */
 export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
-  const { getHandle, cellId, onSourceChanged, onSyncNeeded } = config;
+  const { getHandle, cellId, canWriteSource = () => true, onSourceChanged, onSyncNeeded } = config;
 
   // Shared mutable state between the plugin instance and the bridge handle.
   // The plugin sets `currentView` on create; the bridge reads it for inbound.
@@ -174,6 +182,8 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
       );
 
       if (outboundTxs.length === 0) return;
+
+      if (!canWriteSource()) return;
 
       const handle = getHandle();
       if (!handle) return;
@@ -394,6 +404,8 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
   }
 
   function replaceSource(source: string): boolean {
+    if (!canWriteSource()) return false;
+
     const handle = getHandle();
     if (!handle) return false;
 


### PR DESCRIPTION
## Summary

- add a shared CRDT bridge source-write gate so hosts can deny outbound cell source mutations at the store/Automerge boundary
- wire notebook-cloud's gate from shared shell capabilities and current cell type, including the real CodeMirror transaction path
- keep cloud cell lookup O(1) while projecting live cells into the shared NotebookView stores
- require hosted notebook viewer routes to use `/n/{id}/{vanityName}` and stop serving the legacy one-segment `/n/{id}` path
- thread RuntimeStateDoc ids through publish/live smoke fixtures so hosted validation checks the paired notebook/runtime snapshots
- stabilize the shared outline-heading E2E assertion against the current shell/header geometry

## Validation

- `pnpm --dir apps/notebook exec vp test run src/lib/__tests__/crdt-editor-bridge.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/hosted-smoke-routes.test.mjs test/hosted-live-smoke-env.test.mjs test/hosted-collab-smoke-env.test.mjs test/hosted-smoke-assets.test.mjs test/hosted-smoke-performance.test.mjs test/oidc-auth.test.ts test/viewer-sift-preload.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1 e2e/notebook-rail-outline.spec.ts`
