### PR TITLE
docs(elements): add identity environment surfaces

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -10,6 +10,8 @@
 @source "../../../src/components/cell/**/*.{ts,tsx}";
 @source "../../../src/components/editor/**/*.{ts,tsx}";
 @source "../../../src/components/isolated/**/*.{ts,tsx}";
+@source "../../../src/components/notebook-rail/**/*.{ts,tsx}";
+@source "../../../src/components/notebook-shell/**/*.{ts,tsx}";
 @source "../../../src/components/outputs/**/*.{ts,tsx}";
 @source "../../../src/components/ui/**/*.{ts,tsx}";
 @source "../../../src/components/widgets/**/*.{ts,tsx}";

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -5,6 +5,7 @@ import {
   Cloud,
   FileCode2,
   Frame,
+  IdCard,
   PackageCheck,
   Palette,
   PanelLeft,
@@ -34,6 +35,12 @@ const entries = [
     description: "Dependency headers and package-state controls from the notebook app.",
     href: "/docs/package-manager-surfaces",
     icon: PackageCheck,
+  },
+  {
+    title: "Identity and environment",
+    description: "Notebook actors, access state, runtime, and package context.",
+    href: "/docs/identity-environment-surfaces",
+    icon: IdCard,
   },
   {
     title: "Cell anatomy",

--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { Bot, CheckCircle2, Cloud, KeyRound, Package, UserRound } from "lucide-react";
+import type { ReactNode } from "react";
+import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
+import {
+  NotebookEnvironmentSummary,
+  NotebookIdentityBadge,
+  NotebookIdentityGroup,
+  NotebookDocumentHeader,
+  notebookActorFromAccess,
+  type NotebookActorIdentity,
+} from "@/components/notebook-shell";
+import { cn } from "@/lib/utils";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+  type ElementsNotebookScenarioId,
+} from "@/components/notebook-scenarios";
+
+const identityScenarioIds: ElementsNotebookScenarioId[] = [
+  "desktop-local-owner",
+  "cloud-public-viewer",
+  "cloud-editor",
+  "cloud-owner",
+  "agent-on-behalf",
+  "runtime-unavailable",
+];
+
+const remainingNotebookSurfaces = [
+  {
+    surface: "Notebook activity feed",
+    why: "The shell knows access and current execution actors, but we do not yet have a reusable timeline for runs, saves, trust, and sharing events.",
+  },
+  {
+    surface: "Variable rail panel",
+    why: "Elements scenarios carry variable facts, but the production rail currently exposes outline and packages only.",
+  },
+  {
+    surface: "Sharing controls",
+    why: "Cloud has ACL actor labels, but the shared shell only reserves the slot; the notebook-semantic invite/list surface is still host-local.",
+  },
+];
+
+export function IdentityEnvironmentSurfacesExample() {
+  const scenarios = identityScenarioIds.map((id) => getElementsNotebookScenario(id));
+  const desktopOwner = getElementsNotebookScenario("desktop-local-owner");
+  const cloudOwner = getElementsNotebookScenario("cloud-owner");
+  const cloudEditor = getElementsNotebookScenario("cloud-editor");
+  const agentScenario = getElementsNotebookScenario("agent-on-behalf");
+  const activeActors = [
+    scenarioActor(cloudOwner),
+    scenarioActor(cloudEditor),
+    scenarioActor(agentScenario),
+  ];
+
+  return (
+    <div className="not-prose space-y-6" data-elements-slot="identity-environment-surfaces">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-fd-foreground">
+        <div className="flex items-start gap-3">
+          <CheckCircle2
+            className="mt-0.5 size-4 flex-none text-emerald-700 dark:text-emerald-300"
+            aria-hidden="true"
+          />
+          <div>
+            <h2 className="text-sm font-semibold">Notebook-semantic composites</h2>
+            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+              These examples wrap shared primitives in notebook concepts: current actor, access
+              source, agent delegation, runtime state, and package metadata. Raw Avatar, Badge,
+              Select, and Button primitives stay implementation details.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-3">
+        {scenarios.map((scenario) => (
+          <IdentityScenarioCard key={scenario.id} scenario={scenario} />
+        ))}
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Cloud className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Header composition</h2>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            `NotebookDocumentHeader` owns the shared slot policy. The identity and active actor
+            group can be supplied by desktop, cloud, or Elements fixtures without changing the
+            shell.
+          </p>
+        </div>
+        <div className="bg-background p-4 text-foreground">
+          <NotebookDocumentHeader
+            capabilities={cloudOwner.capabilities}
+            presence={<NotebookIdentityBadge actor={scenarioActor(cloudOwner)} />}
+            utilityControls={<NotebookIdentityGroup actors={activeActors} />}
+            runtimeControls={
+              <HeaderPill icon={<Package className="size-3.5" />} label="Packages" />
+            }
+            codeControls={<HeaderPill icon={<UserRound className="size-3.5" />} label="Source" />}
+            sharingControls={<HeaderPill icon={<KeyRound className="size-3.5" />} label="Share" />}
+          />
+        </div>
+      </section>
+
+      <section className="grid items-start gap-4 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
+        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <Bot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">Execution attribution</h2>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+              Code cells already receive `submitted_by_actor_label`. The shared identity badge makes
+              the agent/user relationship visible without teaching cells about cloud auth.
+            </p>
+          </div>
+          <div className="space-y-3 bg-background p-4 text-foreground">
+            <CodeCellCurrentLine
+              languageLabel="Python"
+              count={16}
+              isExecuting
+              isFocused
+              submittedByActorLabel={agentScenario.capabilities.access.actorLabel}
+              activityContent={
+                <NotebookIdentityBadge
+                  actor={scenarioActor(agentScenario)}
+                  size="sm"
+                  showDetail={false}
+                  className="max-w-28 border-transparent bg-transparent px-0 shadow-none"
+                />
+              }
+              onExecute={() => {}}
+              onInterrupt={() => {}}
+            />
+            <div className="rounded-md border border-border bg-card p-3">
+              <NotebookIdentityBadge actor={scenarioActor(agentScenario)} />
+            </div>
+          </div>
+        </div>
+
+        <NotebookEnvironmentSummary
+          capabilities={desktopOwner.capabilities}
+          packages={desktopOwner.viewModel.packages}
+          runtimeLabel={desktopOwner.runtimeLabel}
+          packageSourceLabel={desktopOwner.packageState.pyprojectInfo.relative_path}
+          syncLabel={syncLabel(desktopOwner)}
+          trustLabel="Untrusted - review package changes"
+        />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <NotebookEnvironmentSummary
+          capabilities={agentScenario.capabilities}
+          packages={agentScenario.viewModel.packages}
+          runtimeLabel={agentScenario.runtimeLabel}
+          packageSourceLabel="cloud runtime snapshot"
+          syncLabel="managed by owner"
+          trustLabel="Trusted by Kyle"
+        />
+        <NotebookEnvironmentSummary
+          capabilities={getElementsNotebookScenario("runtime-unavailable").capabilities}
+          packages={getElementsNotebookScenario("runtime-unavailable").viewModel.packages}
+          runtimeLabel={getElementsNotebookScenario("runtime-unavailable").runtimeLabel}
+          packageSourceLabel="pyproject.toml"
+          syncLabel="package edits disabled"
+          trustLabel="Needs attention"
+        />
+      </section>
+
+      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
+        <h2 className="text-sm font-semibold">Remaining notebook-specific surfaces</h2>
+        <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+          The catalog should keep moving toward notebook semantics, not raw primitives. These are
+          the next gaps after identity and environment summary.
+        </p>
+        <div className="mt-4 grid gap-3 md:grid-cols-3">
+          {remainingNotebookSurfaces.map((item) => (
+            <article
+              key={item.surface}
+              className="rounded-md border border-fd-border bg-fd-card p-3"
+            >
+              <h3 className="text-sm font-semibold">{item.surface}</h3>
+              <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{item.why}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function IdentityScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
+  const actor = scenarioActor(scenario);
+
+  return (
+    <article className="rounded-lg border border-fd-border bg-fd-card p-4">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+            {scenario.eyebrow}
+          </div>
+          <h2 className="mt-1 truncate text-sm font-semibold">{scenario.title}</h2>
+        </div>
+        <AccessPill scenario={scenario} />
+      </div>
+      <NotebookIdentityBadge actor={actor} className="max-w-full" />
+      <dl className="mt-4 grid gap-2 text-xs">
+        <Fact
+          label="Access"
+          value={`${scenario.capabilities.access.level} / ${scenario.capabilities.access.source}`}
+        />
+        <Fact label="Runtime" value={scenario.runtimeLabel} />
+        <Fact
+          label="Packages"
+          value={scenario.viewModel.packages.summary ?? scenario.packageSummary}
+        />
+      </dl>
+    </article>
+  );
+}
+
+function HeaderPill({ icon, label }: { icon: ReactNode; label: string }) {
+  return (
+    <button
+      type="button"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-xs font-medium text-foreground shadow-sm"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function AccessPill({ scenario }: { scenario: ElementsNotebookScenario }) {
+  return (
+    <span
+      className={cn(
+        "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        scenario.capabilities.access.isPublic
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+          : "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+      )}
+    >
+      {scenario.capabilities.access.isPublic ? "public" : scenario.capabilities.access.level}
+    </span>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="grid grid-cols-[80px_minmax(0,1fr)] gap-2">
+      <dt className="text-fd-muted-foreground">{label}</dt>
+      <dd className="truncate font-medium">{value}</dd>
+    </div>
+  );
+}
+
+function scenarioActor(scenario: ElementsNotebookScenario): NotebookActorIdentity {
+  return notebookActorFromAccess(scenario.capabilities.access, scenario.capabilities.auth);
+}
+
+function syncLabel(scenario: ElementsNotebookScenario): string {
+  const state = scenario.packageState.syncState;
+  if (state.status === "synced") return "synced";
+  if (state.status === "dirty") {
+    const added = "added" in state && Array.isArray(state.added) ? state.added.length : 0;
+    const removed = "removed" in state && Array.isArray(state.removed) ? state.removed.length : 0;
+    return `dirty - ${added + removed} pending changes`;
+  }
+  return state.status;
+}

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -20,6 +20,7 @@ export type ElementsNotebookScenarioId =
   | "cloud-public-viewer"
   | "cloud-editor"
   | "cloud-owner"
+  | "agent-on-behalf"
   | "runtime-unavailable";
 
 export interface ElementsNotebookScenario {
@@ -231,13 +232,36 @@ const notebookCells: readonly NotebookViewCell[] = [
   },
 ];
 
+const packageDependencies = ["pandas>=2", "polars", "plotly", "scikit-learn"];
+const packageRequiresPython = ">=3.13";
+
+const notebookMetadata = {
+  runt: {
+    uv: {
+      dependencies: packageDependencies,
+      "requires-python": packageRequiresPython,
+    },
+    pixi: {
+      dependencies: ["numpy", "pandas"],
+      pypi_dependencies: ["altair", "great-tables"],
+      channels: ["conda-forge"],
+      python: packageRequiresPython,
+    },
+    deno: {
+      permissions: ["net", "read"],
+      flexible_npm_imports: true,
+    },
+  },
+};
+
 const viewModel = createNotebookViewModel(notebookCells, {
   resolveLanguage: resolveElementsNotebookLanguage,
+  metadata: notebookMetadata,
 });
 
 const packageState: ElementsNotebookPackageState = {
-  dependencies: ["pandas>=2", "polars", "plotly", "scikit-learn"],
-  requiresPython: ">=3.13",
+  dependencies: packageDependencies,
+  requiresPython: packageRequiresPython,
   syncState: { status: "dirty", added: ["altair"], removed: [] },
   pyprojectInfo: {
     path: "/Users/kyle/notebooks/pyproject.toml",
@@ -652,6 +676,39 @@ export const elementsNotebookScenarios: Record<
         source: "cloud",
         isPublic: false,
         actorLabel: "cloud:kyle",
+        identityLabel: "Kyle",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+    },
+  }),
+  "agent-on-behalf": createScenario({
+    id: "agent-on-behalf",
+    title: "Agent on behalf",
+    eyebrow: "agency fixture",
+    summary:
+      "An authenticated agent actor working through the cloud shell on behalf of a notebook owner.",
+    runtimeLabel: "Cloud notebook - agent session active",
+    packageSummary: "visible - 8 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: true,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: "agent:codex/on-behalf-of:kyle",
         identityLabel: "Kyle",
       },
       auth: {

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -40,6 +40,7 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
   "cloud-public-viewer",
   "cloud-editor",
   "cloud-owner",
+  "agent-on-behalf",
   "runtime-unavailable",
 ];
 

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -44,6 +44,7 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
   "cloud-public-viewer",
   "cloud-editor",
   "cloud-owner",
+  "agent-on-behalf",
   "runtime-unavailable",
 ];
 

--- a/apps/elements/content/docs/identity-environment-surfaces.mdx
+++ b/apps/elements/content/docs/identity-environment-surfaces.mdx
@@ -1,0 +1,31 @@
+---
+title: Identity and environment surfaces
+description: Notebook identity, agency, access, runtime, and package summary composites.
+---
+
+import { IdentityEnvironmentSurfacesExample } from "@/components/identity-environment-surfaces-example";
+
+Notebook UI needs product language for who is acting and what environment they
+are acting within. This page catalogs notebook-semantic composites, not raw
+primitive components.
+
+`NotebookIdentityBadge` and `NotebookIdentityGroup` wrap the shared Avatar
+primitive with notebook actor/access facts. `NotebookEnvironmentSummary` wraps
+the shared package view model and shell capabilities into a compact runtime and
+dependency state surface.
+
+The fixtures come from `ElementsNotebookScenario`: local owner, public viewer,
+cloud editor, cloud owner, agent-on-behalf-of-user, and runtime-unavailable
+states. Desktop and cloud should feed the same production components from their
+host adapters.
+
+<IdentityEnvironmentSurfacesExample />
+
+## Boundary
+
+- Raw shadcn primitives stay implementation details.
+- Actor labels, access state, auth state, runtime labels, and package summaries
+  come from notebook shell projections.
+- Agent attribution is represented as notebook identity, not as a generic model
+  selector.
+- Package info is notebook environment context, not an npm-style package profile.

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -37,6 +37,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Package manager surfaces](/docs/package-manager-surfaces)
+- [Identity and environment surfaces](/docs/identity-environment-surfaces)
 - [Search surfaces](/docs/search-surfaces)
 - [Output renderers](/docs/output-renderers)
 - [Output isolation surfaces](/docs/isolated-output-surfaces)

--- a/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
+++ b/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
@@ -1,0 +1,184 @@
+import { CheckCircle2, Lock, Package, RefreshCw, Server, ShieldAlert } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import type { NotebookShellCapabilities } from "./capabilities";
+import type { NotebookPackageViewModel } from "./view-model";
+
+export interface NotebookEnvironmentSummaryProps {
+  capabilities: NotebookShellCapabilities;
+  packages: NotebookPackageViewModel;
+  runtimeLabel?: string | null;
+  packageSourceLabel?: string | null;
+  syncLabel?: string | null;
+  trustLabel?: string | null;
+  className?: string;
+}
+
+export function NotebookEnvironmentSummary({
+  capabilities,
+  packages,
+  runtimeLabel = null,
+  packageSourceLabel = null,
+  syncLabel = null,
+  trustLabel = null,
+  className,
+}: NotebookEnvironmentSummaryProps) {
+  const packageAccessLabel = capabilities.canManagePackages
+    ? "Package edits available"
+    : capabilities.canViewPackages
+      ? "Package metadata read only"
+      : "Package metadata hidden";
+  const runtimeStateLabel =
+    runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
+
+  return (
+    <section
+      className={cn(
+        "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+        className,
+      )}
+      data-slot="notebook-environment-summary"
+      data-can-execute={capabilities.canExecute}
+      data-can-manage-packages={capabilities.canManagePackages}
+      data-access-level={capabilities.access.level}
+    >
+      <div className="flex items-start justify-between gap-3 border-b border-border p-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Server className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+            <h3 className="truncate text-sm font-semibold">Notebook environment</h3>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {accessLevelLabel(capabilities.access.level)} access through{" "}
+            {accessSourceLabel(capabilities.access.source)}
+          </p>
+        </div>
+        <span className="shrink-0 rounded-full border border-border bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground">
+          {capabilities.access.isPublic ? "Public" : "Private"}
+        </span>
+      </div>
+
+      <div className="grid gap-2 p-4 sm:grid-cols-2">
+        <SummaryFact
+          icon={<Server className="size-3.5" aria-hidden="true" />}
+          label="Runtime"
+          value={runtimeStateLabel}
+          muted={!capabilities.canExecute}
+        />
+        <SummaryFact
+          icon={<Package className="size-3.5" aria-hidden="true" />}
+          label="Packages"
+          value={packages.summary ?? "No package metadata"}
+          detail={packageSourceLabel ?? packageAccessLabel}
+          muted={!capabilities.canViewPackages}
+        />
+        <SummaryFact
+          icon={<RefreshCw className="size-3.5" aria-hidden="true" />}
+          label="Sync"
+          value={syncLabel ?? packageAccessLabel}
+          muted={!capabilities.canManagePackages}
+        />
+        <SummaryFact
+          icon={
+            trustLabel?.toLowerCase().includes("untrusted") ? (
+              <ShieldAlert className="size-3.5" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="size-3.5" aria-hidden="true" />
+            )
+          }
+          label="Trust"
+          value={trustLabel ?? "Trust state not required"}
+        />
+      </div>
+
+      <div className="border-t border-border px-4 py-3">
+        {packages.sections.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No package manager metadata available.</p>
+        ) : (
+          <div className="space-y-3">
+            {packages.sections.map((section) => (
+              <div key={section.manager} className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-semibold">{section.label}</span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {section.dependencies.length === 1
+                      ? "1 dependency"
+                      : `${section.dependencies.length} dependencies`}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {[...section.dependencies, ...section.details.flatMap((detail) => detail.values)]
+                    .slice(0, 8)
+                    .map((value, index) => (
+                      <code
+                        key={`${section.manager}:${value}:${index}`}
+                        className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                      >
+                        {value}
+                      </code>
+                    ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function SummaryFact({
+  detail,
+  icon,
+  label,
+  muted = false,
+  value,
+}: {
+  detail?: string | null;
+  icon: ReactNode;
+  label: string;
+  muted?: boolean;
+  value: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border bg-background p-3",
+        muted && "bg-muted/40 text-muted-foreground",
+      )}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase text-muted-foreground">
+        {muted ? <Lock className="size-3.5" aria-hidden="true" /> : icon}
+        <span>{label}</span>
+      </div>
+      <div className="text-sm font-semibold">{value}</div>
+      {detail ? <div className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</div> : null}
+    </div>
+  );
+}
+
+function accessLevelLabel(level: NotebookShellCapabilities["access"]["level"]): string {
+  switch (level) {
+    case "none":
+      return "No";
+    case "viewer":
+      return "Viewer";
+    case "editor":
+      return "Editor";
+    case "owner":
+      return "Owner";
+  }
+}
+
+function accessSourceLabel(source: NotebookShellCapabilities["access"]["source"]): string {
+  switch (source) {
+    case "cloud":
+      return "cloud";
+    case "local":
+      return "local";
+    case "fixture":
+      return "fixture";
+    case "unknown":
+      return "unknown host";
+  }
+}

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -1,0 +1,303 @@
+import { Bot, Globe2, Laptop, UserRound, UsersRound, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarImage,
+} from "@/components/ui/avatar";
+import type {
+  NotebookShellAccessCapabilities,
+  NotebookShellAuthCapabilities,
+} from "./capabilities";
+
+export type NotebookActorKind = "agent" | "human" | "local" | "public" | "unknown";
+
+export interface NotebookActorIdentity {
+  id: string;
+  label: string;
+  detail: string | null;
+  kind: NotebookActorKind;
+  imageUrl?: string | null;
+  status?: "active" | "attention" | "idle" | "offline";
+}
+
+export interface NotebookIdentityBadgeProps {
+  actor: NotebookActorIdentity;
+  size?: "sm" | "default";
+  showDetail?: boolean;
+  className?: string;
+}
+
+export interface NotebookIdentityGroupProps {
+  actors: readonly NotebookActorIdentity[];
+  maxVisible?: number;
+  label?: string;
+  className?: string;
+}
+
+export function notebookActorFromAccess(
+  access: NotebookShellAccessCapabilities,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorIdentity {
+  const agent = parseAgentActorLabel(access.actorLabel);
+  const kind = actorKindFromAccess(access, agent !== null);
+  const accessLabel = accessLevelLabel(access.level);
+  const sourceLabel = accessSourceLabel(access.source);
+
+  if (agent) {
+    const behalfLabel = access.identityLabel ?? agent.onBehalfOf;
+    return {
+      id: access.actorLabel ?? agent.agentLabel,
+      label: agent.agentLabel,
+      detail: behalfLabel ? `on behalf of ${behalfLabel}` : accessLabel,
+      kind: "agent",
+      status: auth?.needsAttention ? "attention" : "active",
+    };
+  }
+
+  if (access.isPublic) {
+    return {
+      id: access.actorLabel ?? "public-viewer",
+      label: access.identityLabel ?? "Public viewer",
+      detail: accessLabel,
+      kind: "public",
+      status: auth?.needsAttention ? "attention" : "active",
+    };
+  }
+
+  const label = access.identityLabel ?? friendlyActorLabel(access.actorLabel) ?? "Unknown viewer";
+  const detail =
+    sourceLabel === null ? accessLabel : `${accessLabel.toLowerCase()} through ${sourceLabel}`;
+
+  return {
+    id: access.actorLabel ?? label,
+    label,
+    detail,
+    kind,
+    status: auth?.needsAttention ? "attention" : "active",
+  };
+}
+
+export function NotebookIdentityBadge({
+  actor,
+  size = "default",
+  showDetail = true,
+  className,
+}: NotebookIdentityBadgeProps) {
+  const Icon = actorIcon(actor.kind);
+  const avatarSize = size === "sm" ? "sm" : "default";
+
+  return (
+    <div
+      className={cn(
+        "inline-flex min-w-0 items-center gap-2 rounded-full border border-border bg-background px-2 py-1 text-foreground shadow-sm",
+        size === "sm" && "gap-1.5 px-1.5 py-0.5",
+        className,
+      )}
+      data-slot="notebook-identity-badge"
+      data-actor-kind={actor.kind}
+      data-actor-status={actor.status ?? "active"}
+      title={actor.detail ? `${actor.label} - ${actor.detail}` : actor.label}
+    >
+      <NotebookActorAvatar actor={actor} icon={Icon} size={avatarSize} />
+      <span className="min-w-0">
+        <span
+          className={cn(
+            "block truncate font-medium leading-tight",
+            size === "sm" ? "text-xs" : "text-sm",
+          )}
+        >
+          {actor.label}
+        </span>
+        {showDetail && actor.detail ? (
+          <span className="block truncate text-[11px] leading-tight text-muted-foreground">
+            {actor.detail}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+export function NotebookIdentityGroup({
+  actors,
+  maxVisible = 3,
+  label = "Notebook actors",
+  className,
+}: NotebookIdentityGroupProps) {
+  const visibleActors = actors.slice(0, maxVisible);
+  const hiddenCount = Math.max(0, actors.length - visibleActors.length);
+  const title = actors
+    .map((actor) => (actor.detail ? `${actor.label} - ${actor.detail}` : actor.label))
+    .join(", ");
+
+  if (actors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn("inline-flex items-center gap-2", className)}
+      data-slot="notebook-identity-group"
+      aria-label={label}
+      title={title}
+    >
+      <AvatarGroup>
+        {visibleActors.map((actor) => (
+          <NotebookActorAvatar key={actor.id} actor={actor} icon={actorIcon(actor.kind)} />
+        ))}
+        {hiddenCount > 0 ? (
+          <div className="relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-muted-foreground ring-2 ring-background">
+            +{hiddenCount}
+          </div>
+        ) : null}
+      </AvatarGroup>
+      <span className="sr-only">{title}</span>
+    </div>
+  );
+}
+
+function NotebookActorAvatar({
+  actor,
+  icon: Icon,
+  size = "default",
+}: {
+  actor: NotebookActorIdentity;
+  icon: LucideIcon;
+  size?: "sm" | "default";
+}) {
+  return (
+    <Avatar
+      size={size}
+      className={cn("border border-border bg-muted text-muted-foreground", actorTone(actor.kind))}
+      data-slot="notebook-actor-avatar"
+      data-actor-kind={actor.kind}
+    >
+      {actor.imageUrl ? <AvatarImage src={actor.imageUrl} alt="" /> : null}
+      <AvatarFallback>
+        {actor.kind === "human" || actor.kind === "local" ? (
+          initials(actor.label)
+        ) : (
+          <Icon className="size-3.5" aria-hidden="true" />
+        )}
+      </AvatarFallback>
+      <AvatarBadge className={statusTone(actor.status ?? "active")} />
+    </Avatar>
+  );
+}
+
+function actorKindFromAccess(
+  access: NotebookShellAccessCapabilities,
+  isAgent: boolean,
+): NotebookActorKind {
+  if (isAgent) return "agent";
+  if (access.isPublic) return "public";
+  if (access.source === "local") return "local";
+  if (access.identityLabel || access.actorLabel) return "human";
+  return "unknown";
+}
+
+function actorIcon(kind: NotebookActorKind): LucideIcon {
+  switch (kind) {
+    case "agent":
+      return Bot;
+    case "local":
+      return Laptop;
+    case "public":
+      return Globe2;
+    case "human":
+      return UserRound;
+    case "unknown":
+      return UsersRound;
+  }
+}
+
+function actorTone(kind: NotebookActorKind): string {
+  switch (kind) {
+    case "agent":
+      return "bg-purple-500/10 text-purple-700 dark:text-purple-300";
+    case "local":
+      return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
+    case "public":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+    case "human":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+    case "unknown":
+      return "bg-muted text-muted-foreground";
+  }
+}
+
+function statusTone(status: NonNullable<NotebookActorIdentity["status"]>): string {
+  switch (status) {
+    case "active":
+      return "bg-emerald-500";
+    case "attention":
+      return "bg-amber-500";
+    case "idle":
+      return "bg-muted-foreground";
+    case "offline":
+      return "bg-muted";
+  }
+}
+
+function parseAgentActorLabel(actorLabel: string | null): {
+  agentLabel: string;
+  onBehalfOf: string | null;
+} | null {
+  if (!actorLabel?.startsWith("agent:")) return null;
+
+  const agentValue = actorLabel.slice("agent:".length);
+  const [rawAgent, rawBehalf] = agentValue.split("/on-behalf-of:");
+  const agentLabel = friendlyActorLabel(rawAgent) ?? "Agent";
+
+  return {
+    agentLabel,
+    onBehalfOf: friendlyActorLabel(rawBehalf ?? null),
+  };
+}
+
+function friendlyActorLabel(actorLabel: string | null | undefined): string | null {
+  const trimmed = actorLabel?.trim();
+  if (!trimmed) return null;
+
+  const lastSegment = trimmed.split(/[/:]/).filter(Boolean).at(-1) ?? trimmed;
+  return lastSegment
+    .replace(/[-_]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .trim();
+}
+
+function accessLevelLabel(level: NotebookShellAccessCapabilities["level"]): string {
+  switch (level) {
+    case "none":
+      return "No access";
+    case "viewer":
+      return "Viewer";
+    case "editor":
+      return "Editor";
+    case "owner":
+      return "Owner";
+  }
+}
+
+function accessSourceLabel(source: NotebookShellAccessCapabilities["source"]): string | null {
+  switch (source) {
+    case "cloud":
+      return "cloud";
+    case "local":
+      return "local";
+    case "fixture":
+      return "fixture";
+    case "unknown":
+      return null;
+  }
+}
+
+function initials(label: string): string {
+  const parts = label.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
+}

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookEnvironmentSummary } from "../NotebookEnvironmentSummary";
+import type { NotebookShellCapabilities } from "../capabilities";
+import type { NotebookPackageViewModel } from "../view-model";
+
+const capabilities: NotebookShellCapabilities = {
+  canRead: true,
+  canEditMarkdown: true,
+  canEditCells: true,
+  canEditStructure: true,
+  canRequestEdit: false,
+  canExecute: true,
+  canToggleCode: true,
+  canViewPackages: true,
+  canManagePackages: true,
+  canManageSharing: false,
+  access: {
+    level: "owner",
+    source: "local",
+    isPublic: false,
+    actorLabel: "local:kyle",
+    identityLabel: "Kyle",
+  },
+  auth: {
+    canSignIn: false,
+    canUseAuthenticatedIdentity: true,
+    needsAttention: false,
+  },
+};
+
+const packages: NotebookPackageViewModel = {
+  summary: "uv + pixi - 3 packages",
+  sections: [
+    {
+      manager: "uv",
+      label: "uv",
+      dependencies: ["pandas>=2", "polars"],
+      details: [{ label: "Python", values: [">=3.13"] }],
+    },
+  ],
+};
+
+describe("NotebookEnvironmentSummary", () => {
+  it("renders runtime, package, sync, and trust facts", () => {
+    render(
+      <NotebookEnvironmentSummary
+        capabilities={capabilities}
+        packages={packages}
+        runtimeLabel="Python - local runtime ready"
+        packageSourceLabel="pyproject.toml"
+        syncLabel="dirty - 1 pending change"
+        trustLabel="Trusted"
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
+    expect(screen.getByText("Python - local runtime ready")).toBeVisible();
+    expect(screen.getByText("uv + pixi - 3 packages")).toBeVisible();
+    expect(screen.getByText("pyproject.toml")).toBeVisible();
+    expect(screen.getByText("dirty - 1 pending change")).toBeVisible();
+    expect(screen.getByText("pandas>=2")).toBeVisible();
+  });
+
+  it("shows read-only environment state when package mutation is unavailable", () => {
+    render(
+      <NotebookEnvironmentSummary
+        capabilities={{
+          ...capabilities,
+          canExecute: false,
+          canManagePackages: false,
+          access: {
+            ...capabilities.access,
+            level: "viewer",
+            source: "cloud",
+            isPublic: true,
+          },
+        }}
+        packages={{ summary: null, sections: [] }}
+      />,
+    );
+
+    expect(screen.getByText("Public")).toBeVisible();
+    expect(screen.getByText("No runtime")).toBeVisible();
+    expect(screen.getByText("No package metadata")).toBeVisible();
+    expect(screen.getByText("No package manager metadata available.")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NotebookIdentityBadge,
+  NotebookIdentityGroup,
+  notebookActorFromAccess,
+} from "../NotebookIdentity";
+import type { NotebookShellCapabilities } from "../capabilities";
+
+const cloudOwnerAccess: NotebookShellCapabilities["access"] = {
+  level: "owner",
+  source: "cloud",
+  isPublic: false,
+  actorLabel: "cloud:kyle",
+  identityLabel: "Kyle",
+};
+
+describe("NotebookIdentity", () => {
+  it("projects cloud access into a human identity badge", () => {
+    const actor = notebookActorFromAccess(cloudOwnerAccess);
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(screen.getByText("owner through cloud")).toBeVisible();
+  });
+
+  it("projects agent access as acting on behalf of an identity", () => {
+    const actor = notebookActorFromAccess({
+      level: "editor",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "agent:codex/on-behalf-of:kyle",
+      identityLabel: "Kyle",
+    });
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Codex")).toBeVisible();
+    expect(screen.getByText("on behalf of Kyle")).toBeVisible();
+  });
+
+  it("renders grouped notebook actors with overflow", () => {
+    const actors = [
+      notebookActorFromAccess(cloudOwnerAccess),
+      notebookActorFromAccess({
+        level: "viewer",
+        source: "cloud",
+        isPublic: true,
+        actorLabel: "public viewer",
+        identityLabel: null,
+      }),
+      notebookActorFromAccess({
+        level: "editor",
+        source: "local",
+        isPublic: false,
+        actorLabel: "local:morgan",
+        identityLabel: "Morgan",
+      }),
+    ];
+
+    render(<NotebookIdentityGroup actors={actors} maxVisible={2} />);
+
+    expect(screen.getByLabelText("Notebook actors")).toBeVisible();
+    expect(screen.getByText("+1")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -8,6 +8,19 @@ export {
 } from "./capabilities";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
+export {
+  NotebookIdentityBadge,
+  NotebookIdentityGroup,
+  notebookActorFromAccess,
+  type NotebookActorIdentity,
+  type NotebookActorKind,
+  type NotebookIdentityBadgeProps,
+  type NotebookIdentityGroupProps,
+} from "./NotebookIdentity";
+export {
+  NotebookEnvironmentSummary,
+  type NotebookEnvironmentSummaryProps,
+} from "./NotebookEnvironmentSummary";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
 export {
   NotebookPackageSummaryPanel,


### PR DESCRIPTION
## Summary

- add shared notebook identity components for actor/access display, including agent-on-behalf attribution
- add a shared notebook environment summary component for runtime, package, sync, and trust context
- add an Elements page backed by `ElementsNotebookScenario` fixtures for local, cloud, public, agent, and runtime-unavailable states

## Verification

- `pnpm elements:build`
- `pnpm test:run src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx`
- `cargo xtask lint --fix`
- Browser spot check: `/docs/identity-environment-surfaces` in light/cream and dark/cream
