### PR TITLE
fix(notebook-cloud): generate vanity publish ids

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -66,7 +66,7 @@ http://127.0.0.1:8787/n/demo/debug
 The notebook viewer is available at:
 
 ```text
-http://127.0.0.1:8787/n/nteract-cloud-demo/demo
+http://127.0.0.1:8787/n/{generated-ulid}/demo
 ```
 
 `/` serves the sign-in shell; open notebooks through `/n/{id}/{vanityName}`.
@@ -75,11 +75,15 @@ http://127.0.0.1:8787/n/nteract-cloud-demo/demo
 and publishes a notebook revision with real `RuntimeStateDoc` output manifests:
 
 ```text
-http://127.0.0.1:8787/n/nteract-cloud-fixture-output_streaming/output_streaming
+http://127.0.0.1:8787/n/{generated-ulid}/output_streaming
 ```
 
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
-`NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair.
+`NOTEBOOK_CLOUD_NOTEBOOK_ID=<id>` to publish another fixture pair. If no
+notebook id is provided, `publish:demo`, `publish:fixture`, and `publish:live`
+generate a fresh ULID-shaped `NotebookDoc` id. The readable path segment is a
+vanity name derived from the notebook title or filename stem when available,
+and can be overridden with `NOTEBOOK_CLOUD_VANITY_NAME`.
 
 `smoke:hosted` runs a headless Chromium check against the deployed
 `preview.runt.run` topic-viz notebook by default:

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -2,13 +2,18 @@ import { createHash } from "node:crypto";
 import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
+import {
+  canonicalViewerUrl,
+  notebookIdFromEnvOrGenerated,
+  runtimeStateDocIdFromEnvOrDefault,
+  vanityNameFromEnvOrNotebookName,
+} from "./publish-notebook-id.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
-const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? "nteract-cloud-demo";
-const vanityName = process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? "demo";
-const runtimeStateDocIdOverride =
-  process.env.NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID ?? `${notebookId}:runtime-state`;
+const notebookId = notebookIdFromEnvOrGenerated();
+const vanityName = vanityNameFromEnvOrNotebookName("demo.ipynb");
+const runtimeStateDocIdOverride = runtimeStateDocIdFromEnvOrDefault(notebookId);
 const actorLabel = "user:dev:demo/agent:publish-demo";
 const wasmJsUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
@@ -112,11 +117,6 @@ console.log(
 function headsDigest(heads) {
   const input = heads.length > 0 ? heads.slice().sort().join("\n") : "empty";
   return `heads-${createHash("sha256").update(input).digest("hex").slice(0, 24)}`;
-}
-
-function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
-  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
-    .href;
 }
 
 function requiredRuntimeStateDocId(handle) {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -2,14 +2,19 @@ import { createHash } from "node:crypto";
 import { access, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
+import {
+  canonicalViewerUrl,
+  notebookIdFromEnvOrGenerated,
+  runtimeStateDocIdFromEnvOrDefault,
+  vanityNameFromEnvOrNotebookName,
+} from "./publish-notebook-id.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
 const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
-const notebookId = process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? `nteract-cloud-fixture-${fixtureName}`;
-const vanityName = process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? fixtureName;
-const runtimeStateDocIdOverride =
-  process.env.NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID ?? `${notebookId}:runtime-state`;
+const notebookId = notebookIdFromEnvOrGenerated();
+const vanityName = vanityNameFromEnvOrNotebookName(fixtureName);
+const runtimeStateDocIdOverride = runtimeStateDocIdFromEnvOrDefault(notebookId);
 const fixtureRoot = new URL(
   `../../../packages/runtimed/tests/fixtures/${fixtureName}/`,
   import.meta.url,
@@ -135,11 +140,6 @@ async function uploadFixtureBlob(blob) {
     bytes,
     typeof blob.content_type === "string" ? blob.content_type : "application/octet-stream",
   );
-}
-
-function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
-  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
-    .href;
 }
 
 function headsDigest(heads) {

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -5,6 +5,11 @@ import { fileURLToPath } from "node:url";
 
 import { collectBlobRefs } from "../src/blob-refs.ts";
 import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
+import {
+  canonicalViewerUrl,
+  notebookIdFromEnvOrGenerated,
+  vanityNameFromEnvOrNotebookName,
+} from "./publish-notebook-id.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
 
@@ -13,11 +18,10 @@ const rt = loadRuntimedNode();
 const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
 const sourceNotebookId = process.env.NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID;
 const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
-const notebookId =
-  process.env.NOTEBOOK_CLOUD_NOTEBOOK_ID ??
-  (sourceNotebookId ? `live-${sourceNotebookId}` : `nteract-cloud-live-${preset}`);
-const vanityName =
-  process.env.NOTEBOOK_CLOUD_VANITY_NAME ?? defaultLiveVanityName({ preset, sourceNotebookId });
+const notebookId = notebookIdFromEnvOrGenerated();
+const vanityName = vanityNameFromEnvOrNotebookName(
+  defaultLiveNotebookName({ preset, sourceNotebookId }),
+);
 const wasmJsUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
   import.meta.url,
@@ -135,19 +139,14 @@ function requiredRuntimeStateDocId(handle) {
   return runtimeStateDocId;
 }
 
-function defaultLiveVanityName({ preset, sourceNotebookId }) {
+function defaultLiveNotebookName({ preset, sourceNotebookId }) {
   if (sourceNotebookId) {
-    return "source";
+    return "notebook";
   }
   if (preset === "mathnet") {
-    return "topic-viz";
+    return "topic-viz.ipynb";
   }
   return preset;
-}
-
-function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
-  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
-    .href;
 }
 
 async function uploadLiveBlob(ref, snapshot) {

--- a/apps/notebook-cloud/scripts/publish-notebook-id.mjs
+++ b/apps/notebook-cloud/scripts/publish-notebook-id.mjs
@@ -1,0 +1,82 @@
+import { randomBytes } from "node:crypto";
+
+const CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const ULID_LENGTH = 26;
+
+export function notebookIdFromEnvOrGenerated(env = process.env) {
+  return env.NOTEBOOK_CLOUD_NOTEBOOK_ID ?? createUlid();
+}
+
+export function runtimeStateDocIdFromEnvOrDefault(notebookId, env = process.env) {
+  return env.NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID ?? `runtime:${notebookId}`;
+}
+
+export function vanityNameFromEnvOrNotebookName(name, env = process.env) {
+  return env.NOTEBOOK_CLOUD_VANITY_NAME ?? slugifyVanityName(notebookNameStem(name));
+}
+
+export function canonicalViewerUrl(baseUrl, notebookId, vanityName) {
+  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanityName)}`, baseUrl)
+    .href;
+}
+
+export function createUlid(now = Date.now(), random = randomBytes(10)) {
+  if (!Number.isInteger(now) || now < 0 || now > 0xffffffffffff) {
+    throw new RangeError(`ULID timestamp must fit in 48 bits, got ${now}`);
+  }
+  if (!(random instanceof Uint8Array) || random.byteLength !== 10) {
+    throw new RangeError("ULID random bytes must be a 10-byte Uint8Array");
+  }
+
+  return `${encodeTime(now)}${encodeRandom(random)}`;
+}
+
+export function isCanonicalUlid(value) {
+  return (
+    typeof value === "string" &&
+    value.length === ULID_LENGTH &&
+    /^[0-9A-HJKMNP-TV-Z]{26}$/.test(value)
+  );
+}
+
+function encodeTime(now) {
+  let value = now;
+  let encoded = "";
+  for (let index = 0; index < 10; index += 1) {
+    encoded = CROCKFORD_BASE32[value % 32] + encoded;
+    value = Math.floor(value / 32);
+  }
+  return encoded;
+}
+
+function encodeRandom(bytes) {
+  let value = 0n;
+  for (const byte of bytes) {
+    value = (value << 8n) | BigInt(byte);
+  }
+
+  let encoded = "";
+  for (let index = 0; index < 16; index += 1) {
+    encoded = CROCKFORD_BASE32[Number(value & 31n)] + encoded;
+    value >>= 5n;
+  }
+  return encoded;
+}
+
+function slugifyVanityName(title) {
+  return (
+    String(title ?? "notebook")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "notebook"
+  );
+}
+
+function notebookNameStem(name) {
+  const basename =
+    String(name ?? "notebook")
+      .split(/[\\/]/)
+      .pop() ?? "notebook";
+  return basename.replace(/\.ipynb$/i, "");
+}

--- a/apps/notebook-cloud/test/publish-notebook-id.test.mjs
+++ b/apps/notebook-cloud/test/publish-notebook-id.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  canonicalViewerUrl,
+  createUlid,
+  isCanonicalUlid,
+  notebookIdFromEnvOrGenerated,
+  runtimeStateDocIdFromEnvOrDefault,
+  vanityNameFromEnvOrNotebookName,
+} from "../scripts/publish-notebook-id.mjs";
+
+describe("publish notebook ids", () => {
+  it("generates canonical ULID-shaped notebook ids by default", () => {
+    const id = notebookIdFromEnvOrGenerated({});
+
+    assert.equal(isCanonicalUlid(id), true);
+  });
+
+  it("preserves explicit notebook id overrides", () => {
+    assert.equal(
+      notebookIdFromEnvOrGenerated({ NOTEBOOK_CLOUD_NOTEBOOK_ID: "topic-viz" }),
+      "topic-viz",
+    );
+  });
+
+  it("keeps runtime state document ids paired to generated notebook ids", () => {
+    assert.equal(
+      runtimeStateDocIdFromEnvOrDefault("01KSQKEPFJVHV4T4ZDYS9V7T80"),
+      "runtime:01KSQKEPFJVHV4T4ZDYS9V7T80",
+    );
+    assert.equal(
+      runtimeStateDocIdFromEnvOrDefault("doc", {
+        NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID: "runtime:explicit",
+      }),
+      "runtime:explicit",
+    );
+  });
+
+  it("builds canonical vanity viewer URLs", () => {
+    assert.equal(
+      canonicalViewerUrl("https://preview.runt.run", "01KSQKEPFJVHV4T4ZDYS9V7T80", "lets-edit"),
+      "https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit",
+    );
+  });
+
+  it("uses semantic notebook titles for vanity names", () => {
+    assert.equal(vanityNameFromEnvOrNotebookName("Let's edit"), "let-s-edit");
+    assert.equal(vanityNameFromEnvOrNotebookName("~/notebooks/topic viz.ipynb"), "topic-viz");
+    assert.equal(
+      vanityNameFromEnvOrNotebookName("ignored.ipynb", { NOTEBOOK_CLOUD_VANITY_NAME: "topic-viz" }),
+      "topic-viz",
+    );
+  });
+
+  it("encodes ULID timestamp and random bytes predictably", () => {
+    const id = createUlid(0x0198387e6c00, new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+    assert.equal(id, "01K0W7WV00000G40R40M30E209");
+  });
+});


### PR DESCRIPTION
## Summary

- generate ULID-shaped notebook ids by default for `publish:demo`, `publish:fixture`, and `publish:live`
- keep the readable `/n/{id}/{vanityName}` segment as a semantic vanity name instead of reusing slug-like ids
- derive generated vanity names from notebook title/filename-shaped inputs by slugging the stem, with env overrides for real filenames not yet surfaced by the API
- centralize publish-time viewer URL and default RuntimeStateDoc id construction

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/publish-notebook-id.test.mjs test/hosted-live-smoke-env.test.mjs test/hosted-smoke-routes.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

- `NOTEBOOK_CLOUD_NOTEBOOK_ID` and `NOTEBOOK_CLOUD_RUNTIME_STATE_DOC_ID` still override the generated defaults for deterministic republish or migration work.
- This follows #3239, which made `/n/{id}/{vanityName}` the required hosted viewer route.
