### PR TITLE
refactor(notebook): quiet cell execution affordances

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -112,13 +112,18 @@ const currentLineStateFixtures = [
   },
   {
     label: "Queued",
-    detail: "Waiting uses the queue accent without becoming an error.",
+    detail: "Waiting gets a dotted signal so it feels pending rather than active.",
     line: <CodeCellCurrentLine languageLabel="Python" count={12} isQueued />,
   },
   {
     label: "Running",
-    detail: "Status reads active; the stop control carries danger.",
+    detail: "Runtime work gets a green floppy wave; the stop control lives outside this boundary.",
     line: <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
+  },
+  {
+    label: "Errored",
+    detail: "Failures keep the run context visible and break the boundary instead of pulsing.",
+    line: <CodeCellCurrentLine languageLabel="Python" count={12} isErrored />,
   },
   {
     label: "Completed",
@@ -713,8 +718,8 @@ function TimedExecutionSignalConcept() {
       </span>
       <span className="font-medium tabular-nums text-primary">Run 32</span>
       <span className="text-muted-foreground/45 tabular-nums">2.1s / ~4s</span>
-      <div className="relative h-3 min-w-24 flex-1 overflow-hidden rounded-full text-sky-500/60 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]">
-        <div className="absolute inset-y-1 left-0 w-[54%] rounded-full bg-sky-400/10 animate-exec-signal-tail" />
+      <div className="relative h-3 min-w-24 flex-1 overflow-hidden rounded-full text-emerald-500/65 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]">
+        <div className="absolute inset-y-1 left-0 w-[54%] rounded-full bg-emerald-400/10 animate-exec-signal-tail" />
         <svg
           className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
           viewBox="0 0 240 12"
@@ -731,7 +736,7 @@ function TimedExecutionSignalConcept() {
           />
         </svg>
         <span
-          className="absolute left-[54%] top-1/2 h-2 w-8 -translate-y-1/2 rounded-full bg-gradient-to-r from-transparent via-sky-500/60 to-transparent blur-[0.5px]"
+          className="absolute left-[54%] top-1/2 h-2 w-8 -translate-y-1/2 rounded-full bg-gradient-to-r from-transparent via-emerald-500/60 to-transparent blur-[0.5px]"
           aria-hidden="true"
         />
       </div>

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircle2,
   CircleDot,
   FileText,
-  Play,
   Rows3,
   Search,
   ShieldCheck,
@@ -104,55 +103,22 @@ const currentLineStateFixtures = [
   {
     label: "Idle",
     detail: "Quiet until hover, focus, or keyboard focus.",
-    line: (
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={null}
-        onExecute={() => {}}
-        onInterrupt={() => {}}
-      />
-    ),
+    line: <CodeCellCurrentLine languageLabel="Python" count={null} />,
   },
   {
     label: "Focused idle",
     detail: "Cell selection colors the rule; metadata waits for hover or keyboard focus.",
-    line: (
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={null}
-        isFocused
-        onExecute={() => {}}
-        onInterrupt={() => {}}
-      />
-    ),
+    line: <CodeCellCurrentLine languageLabel="Python" count={null} isFocused />,
   },
   {
     label: "Queued",
     detail: "Waiting uses the queue accent without becoming an error.",
-    line: (
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
-        isQueued
-        submittedByActorLabel="local:kyle"
-        onExecute={() => {}}
-        onInterrupt={() => {}}
-      />
-    ),
+    line: <CodeCellCurrentLine languageLabel="Python" count={12} isQueued />,
   },
   {
     label: "Running",
     detail: "Status reads active; the stop control carries danger.",
-    line: (
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
-        isExecuting
-        submittedByActorLabel="local:kyle"
-        onExecute={() => {}}
-        onInterrupt={() => {}}
-      />
-    ),
+    line: <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
   },
   {
     label: "Completed",
@@ -163,8 +129,6 @@ const currentLineStateFixtures = [
         count={12}
         elapsedMs={1476}
         activityContent={<StaticPresenceActivity />}
-        onExecute={() => {}}
-        onInterrupt={() => {}}
       />
     ),
   },
@@ -180,10 +144,14 @@ const currentLineConceptFixtures = [
         count={26}
         elapsedMs={1476}
         activityContent={<StaticPresenceActivity />}
-        onExecute={() => {}}
-        onInterrupt={() => {}}
       />
     ),
+  },
+  {
+    label: "Timed signal",
+    detail:
+      "Speculative: start time plus recent durations could turn the running wave into rough progress.",
+    line: <TimedExecutionSignalConcept />,
   },
   {
     label: "Run state chip",
@@ -376,8 +344,6 @@ function SourceFixture() {
         activityContent={
           <CellPresenceIndicators cellId={primaryCellId} variant="inline" prefixSeparator />
         }
-        onExecute={() => {}}
-        onInterrupt={() => {}}
       />
     </div>
   );
@@ -442,8 +408,6 @@ function BoundarySourceFixture({ sourceHidden = false }: { sourceHidden?: boolea
         count={executionCount}
         elapsedMs={1476}
         isFocused
-        onExecute={() => {}}
-        onInterrupt={() => {}}
       />
     </div>
   );
@@ -609,8 +573,8 @@ export function CellAnatomyExample() {
           <h2 className="text-sm font-semibold">Current Line Studio</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             These are low-risk composition sketches for the source/result boundary. They keep the
-            production run button and layout nearby while letting the activity and completion copy
-            move around.
+            production boundary nearby while letting activity, completion copy, and future timing
+            affordances move around.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background">
@@ -735,14 +699,42 @@ function StaticPresenceActivity() {
 function CurrentLineConcept({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-[1.125rem] min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
-      <button
-        type="button"
-        className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-full text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
-        aria-label="Run cell"
-      >
-        <Play className="size-2.5 fill-current" aria-hidden="true" />
-      </button>
       {children}
+    </div>
+  );
+}
+
+function TimedExecutionSignalConcept() {
+  return (
+    <div className="flex min-h-5 min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
+      <span className="rounded-sm bg-primary/10 px-1 py-0.5 font-medium text-primary">Python</span>
+      <span className="text-muted-foreground/35" aria-hidden="true">
+        ·
+      </span>
+      <span className="font-medium tabular-nums text-primary">Run 32</span>
+      <span className="text-muted-foreground/45 tabular-nums">2.1s / ~4s</span>
+      <div className="relative h-3 min-w-24 flex-1 overflow-hidden rounded-full text-sky-500/60 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]">
+        <div className="absolute inset-y-1 left-0 w-[54%] rounded-full bg-sky-400/10 animate-exec-signal-tail" />
+        <svg
+          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
+          viewBox="0 0 240 12"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth="1.4"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+        <span
+          className="absolute left-[54%] top-1/2 h-2 w-8 -translate-y-1/2 rounded-full bg-gradient-to-r from-transparent via-sky-500/60 to-transparent blur-[0.5px]"
+          aria-hidden="true"
+        />
+      </div>
     </div>
   );
 }

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -47,7 +47,7 @@ const layers = [
   {
     name: "CodeCellCurrentLine",
     source: "src/components/cell/CodeCellCurrentLine.tsx",
-    role: "Natural-language run state, execution count, and bottom run/stop affordance.",
+    role: "Source/result boundary with a quiet run affordance and revealable execution metadata.",
     status: "rendered",
   },
   {
@@ -115,7 +115,7 @@ const currentLineStateFixtures = [
   },
   {
     label: "Focused idle",
-    detail: "Language becomes readable when the cell owns focus.",
+    detail: "Cell selection colors the rule; metadata waits for hover or keyboard focus.",
     line: (
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -156,7 +156,7 @@ const currentLineStateFixtures = [
   },
   {
     label: "Completed",
-    detail: "Finished cells keep run metadata collapsed until hover or focus.",
+    detail: "Finished cells keep run metadata collapsed into the boundary until directly engaged.",
     line: (
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -187,7 +187,7 @@ const currentLineConceptFixtures = [
   },
   {
     label: "Run state chip",
-    detail: "Makes completion feel like metadata instead of sentence copy.",
+    detail: "Keeps completion as compact metadata instead of sentence copy.",
     line: (
       <CurrentLineConcept>
         <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
@@ -203,7 +203,7 @@ const currentLineConceptFixtures = [
   },
   {
     label: "Activity edge",
-    detail: "Keeps the run text shorter and lets peer activity sit against the rule.",
+    detail: "Lets peer activity live at the edge of the rule instead of the left lane.",
     line: (
       <CurrentLineConcept>
         <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
@@ -231,7 +231,7 @@ const contracts = [
 const insertionRibbonRows = [
   {
     label: "Between cells",
-    detail: "The neutral spine stays continuous; the active add action supplies the color.",
+    detail: "The neutral spine stays continuous; the compact palette supplies insertion intent.",
     activeType: "markdown" as const,
     terminal: false,
   },
@@ -562,7 +562,7 @@ export function CellAnatomyExample() {
           <h2 className="text-sm font-semibold">Insertion Ribbon</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             Add-cell rows are part of the same document spine. The quiet continuation stays neutral,
-            while the hovered or focused action paints the insertion intent.
+            while the hovered or focused icon palette paints the insertion intent.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background py-2">
@@ -585,7 +585,7 @@ export function CellAnatomyExample() {
           <h2 className="text-sm font-semibold">Current Line States</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             Execution state sits at the source/result boundary. The language leads as cell identity,
-            and the run state reads as compact metadata.
+            and resting run metadata stays collapsed until the boundary is engaged.
           </p>
         </div>
         <div className="grid gap-3 bg-background p-4 lg:grid-cols-2">
@@ -734,10 +734,10 @@ function StaticPresenceActivity() {
 
 function CurrentLineConcept({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-6 min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
+    <div className="flex min-h-[1.125rem] min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
       <button
         type="button"
-        className="inline-flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
+        className="inline-flex size-3.5 shrink-0 items-center justify-center rounded-full text-muted-foreground/55 transition-colors hover:bg-muted hover:text-foreground"
         aria-label="Run cell"
       >
         <Play className="size-2.5 fill-current" aria-hidden="true" />

--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -123,7 +123,6 @@ export function IdentityEnvironmentSurfacesExample() {
               count={16}
               isExecuting
               isFocused
-              submittedByActorLabel={agentScenario.capabilities.access.actorLabel}
               activityContent={
                 <NotebookIdentityBadge
                   actor={scenarioActor(agentScenario)}
@@ -132,8 +131,6 @@ export function IdentityEnvironmentSurfacesExample() {
                   className="max-w-28 border-transparent bg-transparent px-0 shadow-none"
                 />
               }
-              onExecute={() => {}}
-              onInterrupt={() => {}}
             />
             <div className="rounded-md border border-border bg-card p-3">
               <NotebookIdentityBadge actor={scenarioActor(agentScenario)} />

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -196,6 +196,7 @@ export const CodeCell = memo(function CodeCell({
   const execution = useExecution(executionId);
   const executionCount = execution?.execution_count ?? null;
   const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
+  const isExecutionErrored = execution?.success === false || execution?.status === "error";
   const languageLabel =
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
   const isSourceEmpty = cell.source.trim().length === 0;
@@ -408,6 +409,7 @@ export const CodeCell = memo(function CodeCell({
       count={executionCount}
       isExecuting={isExecuting}
       isQueued={isQueued}
+      isErrored={isExecutionErrored}
       isFocused={isFocused}
       compactIdle={isSourceEmpty}
       activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" prefixSeparator />}
@@ -431,6 +433,7 @@ export const CodeCell = memo(function CodeCell({
               count={executionCount}
               isExecuting={isExecuting}
               isQueued={isQueued}
+              isErrored={isExecutionErrored}
               submittedByActorLabel={submittedByActorLabel}
               isCellFocused={isFocused}
               canExecute={canExecute}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -402,6 +402,7 @@ export const CodeCell = memo(function CodeCell({
     executionCount !== null ||
     isExecuting ||
     isQueued ||
+    isExecutionErrored ||
     isSourceHidden;
   const currentLine = hasCurrentLine ? (
     <CodeCellCurrentLine

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, Code2, EyeOff } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
+import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
@@ -394,7 +395,14 @@ export const CodeCell = memo(function CodeCell({
     [onNavigateToCell],
   );
 
-  const currentLine = (
+  const hasCurrentLine =
+    !isSourceEmpty ||
+    outputs.length > 0 ||
+    executionCount !== null ||
+    isExecuting ||
+    isQueued ||
+    isSourceHidden;
+  const currentLine = hasCurrentLine ? (
     <CodeCellCurrentLine
       languageLabel={languageLabel}
       count={executionCount}
@@ -402,13 +410,9 @@ export const CodeCell = memo(function CodeCell({
       isQueued={isQueued}
       isFocused={isFocused}
       compactIdle={isSourceEmpty}
-      submittedByActorLabel={submittedByActorLabel}
       activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" prefixSeparator />}
-      canExecute={canExecute}
-      onExecute={handleExecute}
-      onInterrupt={onInterrupt}
     />
-  );
+  ) : null;
 
   return (
     <>
@@ -421,6 +425,20 @@ export const CodeCell = memo(function CodeCell({
         outputFocused={outputFocused}
         outputDimmed={outputDimmed}
         onFocus={onFocus}
+        gutterContent={
+          !bothHidden ? (
+            <CompactExecutionButton
+              count={executionCount}
+              isExecuting={isExecuting}
+              isQueued={isQueued}
+              submittedByActorLabel={submittedByActorLabel}
+              isCellFocused={isFocused}
+              canExecute={canExecute}
+              onExecute={handleExecute}
+              onInterrupt={onInterrupt}
+            />
+          ) : undefined
+        }
         rightGutterContent={rightGutterContent}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -307,6 +307,29 @@ describe("CodeCell output focus", () => {
     expect(runButton).toHaveAttribute("aria-label", "Run cell again; last execution 14 failed");
   });
 
+  it("keeps the error boundary visible without an execution count", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: null, submitted_by_actor_label: null, success: false };
+
+    const { container } = render(
+      <CodeCell
+        cell={makeCell({ source: "" })}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer?.getAttribute("data-execution-state")).toBe("error");
+    expect(status?.textContent).toBe("Python·Error");
+    expect(rule).toHaveClass("text-destructive/60");
+  });
+
   it("keeps idle footer language quiet until the cell is engaged", () => {
     mockOutputs = [];
     mockExecution = null;

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -17,18 +17,21 @@ const mockEditorBlur = vi.fn();
 vi.mock("@/components/cell/CellContainer", () => ({
   CellContainer: ({
     codeContent,
+    gutterContent,
     outputContent,
     outputRightGutterContent,
     outputFocused,
     outputDimmed,
   }: {
     codeContent?: React.ReactNode;
+    gutterContent?: React.ReactNode;
     outputContent?: React.ReactNode;
     outputRightGutterContent?: React.ReactNode;
     outputFocused?: boolean;
     outputDimmed?: boolean;
   }) => (
     <div data-output-dimmed={String(outputDimmed)} data-output-focused={String(outputFocused)}>
+      {gutterContent}
       {codeContent}
       {outputContent}
       {outputRightGutterContent}
@@ -271,7 +274,8 @@ describe("CodeCell output focus", () => {
     expect(status?.textContent).toBe("Python·Running");
     expect(status).toHaveClass("text-primary");
     expect(status).not.toHaveClass("text-destructive/80");
-    expect(rule).toHaveClass("bg-primary/45");
+    expect(rule).toHaveClass("text-sky-500/55");
+    expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
     expect(stopButton).toHaveClass("text-destructive");
   });
 
@@ -298,12 +302,33 @@ describe("CodeCell output focus", () => {
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveClass("group-hover:max-w-64");
-    expect(rule).toHaveClass("bg-border/25");
+    expect(rule).toHaveClass("bg-border/15");
   });
 
   it("uses compact current-line chrome for empty idle code cells", () => {
     mockOutputs = [];
     mockExecution = null;
+    mockIsFocused = true;
+
+    const { container, getByTestId } = render(
+      <CodeCell
+        cell={makeCell({ source: "" })}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+
+    expect(footer).toBeNull();
+    expect(getByTestId("execute-button")).toHaveAttribute("aria-label", "Run cell");
+  });
+
+  it("keeps current-line metadata for empty cells after execution state appears", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: 3, submitted_by_actor_label: null };
     mockIsFocused = true;
 
     const { container } = render(
@@ -321,8 +346,8 @@ describe("CodeCell output focus", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveClass("min-h-4");
-    expect(detail).toHaveClass("sr-only");
-    expect(rule).toBeNull();
+    expect(detail).not.toHaveClass("sr-only");
+    expect(rule).not.toBeNull();
   });
 
   it("keeps focused idle footer language collapsed into the boundary", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -320,12 +320,12 @@ describe("CodeCell output focus", () => {
     const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
-    expect(footer).toHaveClass("min-h-5");
+    expect(footer).toHaveClass("min-h-4");
     expect(detail).toHaveClass("sr-only");
     expect(rule).toBeNull();
   });
 
-  it("shows idle footer language when the cell is focused", () => {
+  it("keeps focused idle footer language collapsed into the boundary", () => {
     mockOutputs = [];
     mockExecution = null;
     mockIsFocused = true;
@@ -343,9 +343,9 @@ describe("CodeCell output focus", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(status?.textContent).toBe("Python·Ready");
-    expect(status).toHaveClass("max-w-64");
-    expect(status).toHaveClass("opacity-100");
-    expect(status).not.toHaveClass("max-w-0");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("group-focus-within:max-w-64");
   });
 
   it("keeps the current line visible when source is hidden but output remains visible", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -8,6 +8,8 @@ let mockOutputs: unknown[] = [];
 let mockExecution: {
   execution_count: number | null;
   submitted_by_actor_label?: string | null;
+  status?: string;
+  success?: boolean | null;
 } | null = null;
 let mockIsExecuting = false;
 let mockIsFocused = false;
@@ -274,9 +276,35 @@ describe("CodeCell output focus", () => {
     expect(status?.textContent).toBe("Python·Running");
     expect(status).toHaveClass("text-primary");
     expect(status).not.toHaveClass("text-destructive/80");
-    expect(rule).toHaveClass("text-sky-500/55");
+    expect(rule).toHaveClass("text-emerald-500/65");
     expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
     expect(stopButton).toHaveClass("text-destructive");
+  });
+
+  it("uses the error boundary when the latest execution failed", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: 14, submitted_by_actor_label: null, success: false };
+
+    const { container, getByTestId } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+    const runButton = getByTestId("execute-button");
+
+    expect(footer?.getAttribute("data-execution-state")).toBe("error");
+    expect(status?.textContent).toBe("Python·Run 14 failed");
+    expect(rule).toHaveClass("text-destructive/60");
+    expect(runButton).toHaveAttribute("data-execution-state", "error");
+    expect(runButton).toHaveAttribute("aria-label", "Run cell again; last execution 14 failed");
   });
 
   it("keeps idle footer language quiet until the cell is engaged", () => {

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -1,4 +1,4 @@
-import { Code2, Pilcrow, Plus } from "lucide-react";
+import { Code, LetterText, Plus } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { notebookCellLayoutVars } from "./cell-layout";
@@ -52,7 +52,7 @@ export function CellInsertionRibbon({
 
   const actionButtonClass = (type: CellInsertionType) =>
     cn(
-      "inline-flex h-5 w-8 items-center justify-center gap-0.5 rounded-sm text-muted-foreground/55 transition-colors",
+      "inline-flex h-6 items-center justify-center gap-1 rounded-sm px-2 text-xs text-muted-foreground/60 transition-colors",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
       resolvedActiveType === type
         ? "bg-muted text-foreground shadow-sm"
@@ -108,13 +108,13 @@ export function CellInsertionRibbon({
         data-slot="cell-adder-primary-hit-target"
         title="Add code cell from insertion margin"
         aria-label="Add code cell from insertion margin"
-        onPointerEnter={() => setActiveType("code")}
-        onFocus={() => setActiveType("code")}
+        onPointerEnter={() => setActiveType(null)}
+        onFocus={() => setActiveType(null)}
         onClick={() => onInsert("code")}
         className={cn(
           "h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
-          resolvedActiveType === "code" ? "bg-sky-400/5" : "hover:bg-muted/20",
+          resolvedActiveType ? "bg-transparent" : "hover:bg-muted/20",
           terminal && "h-7",
         )}
       >
@@ -132,7 +132,7 @@ export function CellInsertionRibbon({
       >
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-6 items-center gap-0.5 rounded-sm border border-border/45 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm"
+          className="flex h-7 items-center gap-0.5 rounded-sm border border-border/45 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm"
         >
           <button
             type="button"
@@ -144,7 +144,8 @@ export function CellInsertionRibbon({
             className={actionButtonClass("code")}
           >
             <Plus className="h-2.5 w-2.5" aria-hidden="true" />
-            <Code2 className="h-3 w-3" aria-hidden="true" />
+            <Code className="h-3 w-3" aria-hidden="true" />
+            <span>Code</span>
           </button>
           <button
             type="button"
@@ -156,7 +157,8 @@ export function CellInsertionRibbon({
             className={actionButtonClass("markdown")}
           >
             <Plus className="h-2.5 w-2.5" aria-hidden="true" />
-            <Pilcrow className="h-3 w-3" aria-hidden="true" />
+            <LetterText className="h-3 w-3" aria-hidden="true" />
+            <span>Markdown</span>
           </button>
         </div>
       </div>

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { Code2, Pilcrow, Plus } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { notebookCellLayoutVars } from "./cell-layout";
@@ -49,6 +49,15 @@ export function CellInsertionRibbon({
     }
     onActiveTypeChange?.(type);
   };
+
+  const actionButtonClass = (type: CellInsertionType) =>
+    cn(
+      "inline-flex h-5 w-8 items-center justify-center gap-0.5 rounded-sm text-muted-foreground/55 transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+      resolvedActiveType === type
+        ? "bg-muted text-foreground shadow-sm"
+        : "hover:bg-muted/60 hover:text-foreground",
+    );
 
   return (
     <div
@@ -114,50 +123,42 @@ export function CellInsertionRibbon({
       <div
         data-slot="cell-adder-actions"
         className={cn(
-          "flex items-center gap-1 transition-opacity duration-150",
+          "flex items-center transition-opacity duration-150",
           terminal && "pt-0.5",
           forceActionsVisible
             ? "opacity-100"
             : "opacity-0 group-hover/adder:opacity-100 group-hover/adder:delay-75 group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
         )}
       >
-        <button
-          type="button"
-          title="Add code cell"
-          onPointerEnter={() => setActiveType("code")}
-          onFocus={() => setActiveType("code")}
-          onClick={() => onInsert("code")}
-          className={cn(
-            "inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium transition-colors",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-            forceActionsVisible && resolvedActiveType === "code"
-              ? "text-foreground hover:text-foreground"
-              : "text-muted-foreground/55 hover:text-foreground",
-          )}
+        <div
+          data-slot="cell-adder-action-palette"
+          className="flex h-6 items-center gap-0.5 rounded-sm border border-border/45 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm"
         >
-          <Plus className="h-3 w-3" aria-hidden="true" />
-          Add code
-        </button>
-        <span className="text-muted-foreground/30" aria-hidden="true">
-          ·
-        </span>
-        <button
-          type="button"
-          title="Add markdown cell"
-          onPointerEnter={() => setActiveType("markdown")}
-          onFocus={() => setActiveType("markdown")}
-          onClick={() => onInsert("markdown")}
-          className={cn(
-            "inline-flex h-6 items-center gap-1 rounded-sm px-1.5 text-xs font-medium transition-colors",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-            forceActionsVisible && resolvedActiveType === "markdown"
-              ? "text-foreground hover:text-foreground"
-              : "text-muted-foreground/55 hover:text-foreground",
-          )}
-        >
-          <Plus className="h-3 w-3" aria-hidden="true" />
-          Add markdown
-        </button>
+          <button
+            type="button"
+            title="Add code cell"
+            aria-label="Add code cell"
+            onPointerEnter={() => setActiveType("code")}
+            onFocus={() => setActiveType("code")}
+            onClick={() => onInsert("code")}
+            className={actionButtonClass("code")}
+          >
+            <Plus className="h-2.5 w-2.5" aria-hidden="true" />
+            <Code2 className="h-3 w-3" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            title="Add markdown cell"
+            aria-label="Add markdown cell"
+            onPointerEnter={() => setActiveType("markdown")}
+            onFocus={() => setActiveType("markdown")}
+            onClick={() => onInsert("markdown")}
+            className={actionButtonClass("markdown")}
+          >
+            <Plus className="h-2.5 w-2.5" aria-hidden="true" />
+            <Pilcrow className="h-3 w-3" aria-hidden="true" />
+          </button>
+        </div>
       </div>
       <div className="flex-1" />
     </div>

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -1,4 +1,3 @@
-import { Play, Square } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -10,11 +9,7 @@ export interface CodeCellCurrentLineProps {
   isQueued?: boolean;
   isFocused?: boolean;
   compactIdle?: boolean;
-  submittedByActorLabel?: string | null;
   activityContent?: ReactNode;
-  canExecute?: boolean;
-  onExecute: () => void;
-  onInterrupt: () => void;
   className?: string;
 }
 
@@ -84,28 +79,65 @@ function executionCountLabel(count: number | null): string | null {
   return count === null ? null : `Execution ${formatExecutionCount(count)}`;
 }
 
-function executionLineClass({
-  isExecuting,
-  isQueued,
-  isFocused,
-}: {
-  isExecuting: boolean;
-  isQueued: boolean;
-  isFocused: boolean;
-}) {
-  if (isExecuting) {
-    return "bg-primary/45";
-  }
-
+function executionLineClass({ isQueued, isFocused }: { isQueued: boolean; isFocused: boolean }) {
   if (isQueued) {
-    return "bg-sky-400/35";
+    return "bg-sky-400/30";
   }
 
   if (isFocused) {
-    return "bg-border/50";
+    return "bg-border/30";
   }
 
-  return "bg-border/25 group-hover:bg-border/45";
+  return "bg-border/15 group-hover:bg-border/25 group-focus-within:bg-border/25";
+}
+
+function ExecutionBoundaryRule({
+  state,
+  isQuietResting,
+  isQueued,
+  isFocused,
+}: {
+  state: "idle" | "ran" | "queued" | "running";
+  isQuietResting: boolean;
+  isQueued: boolean;
+  isFocused: boolean;
+}) {
+  if (state === "running") {
+    return (
+      <div
+        data-slot="code-cell-current-line-rule"
+        className="relative h-3 min-w-14 flex-1 overflow-hidden text-sky-500/55 dark:text-sky-300/55 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]"
+      >
+        <svg
+          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
+          viewBox="0 0 240 12"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth="1.4"
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="code-cell-current-line-rule"
+      className={cn(
+        "h-px min-w-4 rounded-full transition-[background-color,width,flex-basis] duration-150",
+        isQuietResting ? "w-10 flex-none group-hover:w-14 group-focus-within:w-14" : "flex-1",
+        executionLineClass({ isQueued, isFocused }),
+        isQueued && "animate-queue-breathe",
+      )}
+    />
+  );
 }
 
 export function CodeCellCurrentLine({
@@ -116,11 +148,7 @@ export function CodeCellCurrentLine({
   isQueued = false,
   isFocused = false,
   compactIdle = false,
-  submittedByActorLabel = null,
   activityContent,
-  canExecute = true,
-  onExecute,
-  onInterrupt,
   className,
 }: CodeCellCurrentLineProps) {
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
@@ -134,29 +162,6 @@ export function CodeCellCurrentLine({
     isQueued,
   });
   const countLabel = executionCountLabel(count);
-  const actionTitle = isExecuting
-    ? submittedByActorLabel
-      ? `Stop execution submitted by ${submittedByActorLabel}`
-      : "Stop execution"
-    : isQueued
-      ? submittedByActorLabel
-        ? `Queued for execution by ${submittedByActorLabel}`
-        : "Queued for execution"
-      : count !== null
-        ? `Run cell again; last execution ${count}`
-        : "Run cell";
-  const scopedActionTitle = canExecute ? actionTitle : "Execution unavailable";
-
-  const handleClick = () => {
-    if (!canExecute) return;
-    if (isQueued) return;
-    if (isExecuting) {
-      onInterrupt();
-    } else {
-      onExecute();
-    }
-  };
-
   return (
     <div
       data-slot="code-cell-current-line"
@@ -164,48 +169,11 @@ export function CodeCellCurrentLine({
       data-execution-count={count ?? undefined}
       data-execution-label={countLabel ?? undefined}
       className={cn(
-        "mt-1 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
-        isCompactIdle ? "min-h-4" : isQuietResting ? "min-h-[1.125rem]" : "min-h-6",
+        "mt-1.5 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
+        isCompactIdle ? "min-h-3.5" : isQuietResting ? "min-h-4" : "min-h-5",
         className,
       )}
     >
-      <button
-        type="button"
-        onClick={handleClick}
-        disabled={isQueued || !canExecute}
-        title={scopedActionTitle}
-        aria-label={scopedActionTitle}
-        aria-busy={isExecuting || undefined}
-        data-testid="execute-button"
-        data-execution-state={state}
-        data-execution-count={count ?? undefined}
-        className={cn(
-          "inline-flex size-4 shrink-0 items-center justify-center rounded-full",
-          "transition-colors duration-150",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          isQuietResting &&
-            "size-3.5 opacity-35 group-hover:opacity-85 group-focus-within:opacity-85",
-          !isExecuting && state !== "queued" && "text-muted-foreground/55",
-          isCompactIdle && "opacity-45 hover:opacity-100",
-          state === "idle" && "hover:bg-muted hover:text-foreground",
-          state === "ran" && "hover:bg-primary/5 hover:text-primary",
-          state === "queued" && "cursor-default text-sky-600 dark:text-sky-400",
-          state === "running" && "text-destructive hover:bg-destructive/10",
-          !canExecute &&
-            "cursor-default opacity-35 hover:bg-transparent hover:text-muted-foreground/55",
-        )}
-      >
-        {isExecuting ? (
-          <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
-        ) : isQueued ? (
-          <span
-            className="block size-1.5 rounded-full bg-current animate-queue-breathe"
-            aria-hidden="true"
-          />
-        ) : (
-          <Play className="size-2.5 fill-current" aria-hidden="true" />
-        )}
-      </button>
       <span
         data-slot="code-cell-current-line-status"
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
@@ -260,12 +228,11 @@ export function CodeCellCurrentLine({
               {activityContent}
             </div>
           ) : null}
-          <div
-            data-slot="code-cell-current-line-rule"
-            className={cn(
-              "h-px min-w-8 flex-1 rounded-full transition-colors duration-150",
-              executionLineClass({ isExecuting, isQueued, isFocused }),
-            )}
+          <ExecutionBoundaryRule
+            state={state}
+            isQuietResting={isQuietResting}
+            isQueued={isQueued}
+            isFocused={isFocused}
           />
         </>
       )}

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -7,11 +7,14 @@ export interface CodeCellCurrentLineProps {
   elapsedMs?: number | null;
   isExecuting?: boolean;
   isQueued?: boolean;
+  isErrored?: boolean;
   isFocused?: boolean;
   compactIdle?: boolean;
   activityContent?: ReactNode;
   className?: string;
 }
+
+type ExecutionBoundaryState = "idle" | "ran" | "queued" | "running" | "error";
 
 function formatExecutionCount(count: number): string {
   return count > 999 ? "999+" : String(count);
@@ -34,16 +37,19 @@ function visualExecutionDetail({
   elapsedMs,
   isExecuting,
   isQueued,
+  isErrored,
 }: {
   count: number | null;
   elapsedMs: number | null;
   isExecuting: boolean;
   isQueued: boolean;
+  isErrored: boolean;
 }): string {
   const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
 
   if (isExecuting) return "Running";
   if (isQueued) return "Queued";
+  if (isErrored) return runPrefix === null ? "Error" : `${runPrefix} failed`;
   if (count !== null) {
     return elapsedMs === null ? `${runPrefix}` : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
   }
@@ -56,16 +62,19 @@ function accessibleExecutionDetail({
   elapsedMs,
   isExecuting,
   isQueued,
+  isErrored,
 }: {
   count: number | null;
   elapsedMs: number | null;
   isExecuting: boolean;
   isQueued: boolean;
+  isErrored: boolean;
 }): string {
   const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
 
   if (isExecuting) return "Running";
   if (isQueued) return "Queued";
+  if (isErrored) return runPrefix === null ? "Execution failed" : `${runPrefix} failed`;
   if (count !== null) {
     return elapsedMs === null
       ? `${runPrefix} completed`
@@ -97,7 +106,7 @@ function ExecutionBoundaryRule({
   isQueued,
   isFocused,
 }: {
-  state: "idle" | "ran" | "queued" | "running";
+  state: ExecutionBoundaryState;
   isQuietResting: boolean;
   isQueued: boolean;
   isFocused: boolean;
@@ -106,7 +115,7 @@ function ExecutionBoundaryRule({
     return (
       <div
         data-slot="code-cell-current-line-rule"
-        className="relative h-3 min-w-14 flex-1 overflow-hidden text-sky-500/55 dark:text-sky-300/55 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]"
+        className="relative h-3 min-w-14 flex-1 overflow-hidden text-emerald-500/65 dark:text-emerald-300/65 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]"
       >
         <svg
           className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
@@ -123,6 +132,43 @@ function ExecutionBoundaryRule({
             vectorEffect="non-scaling-stroke"
           />
         </svg>
+      </div>
+    );
+  }
+
+  if (state === "queued") {
+    return (
+      <div
+        data-slot="code-cell-current-line-rule"
+        className="flex h-3 min-w-12 flex-1 items-center gap-1 text-sky-500/60 dark:text-sky-300/60"
+      >
+        {[0, 120, 240].map((delay) => (
+          <span
+            key={delay}
+            className="size-1 rounded-full bg-current animate-queue-breathe"
+            style={{ animationDelay: `${delay}ms` }}
+            aria-hidden="true"
+          />
+        ))}
+        <span className="h-px min-w-4 flex-1 rounded-full bg-sky-400/20" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <div
+        data-slot="code-cell-current-line-rule"
+        className="relative h-3 min-w-12 flex-1 overflow-hidden text-destructive/60"
+      >
+        <span
+          className="absolute left-0 top-1/2 h-px w-full -translate-y-1/2 bg-[repeating-linear-gradient(to_right,currentColor_0_0.375rem,transparent_0.375rem_0.625rem)]"
+          aria-hidden="true"
+        />
+        <span
+          className="absolute left-0 top-1/2 size-1.5 -translate-y-1/2 rounded-full bg-current"
+          aria-hidden="true"
+        />
       </div>
     );
   }
@@ -146,20 +192,36 @@ export function CodeCellCurrentLine({
   elapsedMs = null,
   isExecuting = false,
   isQueued = false,
+  isErrored = false,
   isFocused = false,
   compactIdle = false,
   activityContent,
   className,
 }: CodeCellCurrentLineProps) {
-  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const state: ExecutionBoundaryState = isExecuting
+    ? "running"
+    : isQueued
+      ? "queued"
+      : isErrored
+        ? "error"
+        : count !== null
+          ? "ran"
+          : "idle";
   const isCompactIdle = compactIdle && state === "idle";
   const isQuietResting = state === "idle" || state === "ran";
-  const detailLabel = visualExecutionDetail({ count, elapsedMs, isExecuting, isQueued });
+  const detailLabel = visualExecutionDetail({
+    count,
+    elapsedMs,
+    isExecuting,
+    isQueued,
+    isErrored,
+  });
   const accessibleDetailLabel = accessibleExecutionDetail({
     count,
     elapsedMs,
     isExecuting,
     isQueued,
+    isErrored,
   });
   const countLabel = executionCountLabel(count);
   return (
@@ -177,7 +239,7 @@ export function CodeCellCurrentLine({
       <span
         data-slot="code-cell-current-line-status"
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
-        aria-live={isExecuting || isQueued ? "polite" : undefined}
+        aria-live={isExecuting || isQueued || isErrored ? "polite" : undefined}
         className={cn(
           "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
           isQuietResting
@@ -186,6 +248,7 @@ export function CodeCellCurrentLine({
           isFocused && "text-foreground/70",
           isExecuting && "text-primary",
           isQueued && "text-sky-700 dark:text-sky-300",
+          isErrored && "text-destructive/80",
         )}
       >
         <span
@@ -196,6 +259,7 @@ export function CodeCellCurrentLine({
             isFocused && "bg-muted/45 text-foreground/70",
             isExecuting && "bg-primary/10 text-primary",
             isQueued && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+            isErrored && "bg-destructive/10 text-destructive/90",
           )}
         >
           {languageLabel}

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -125,7 +125,7 @@ export function CodeCellCurrentLine({
 }: CodeCellCurrentLineProps) {
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
   const isCompactIdle = compactIdle && state === "idle";
-  const isQuietResting = (state === "idle" || state === "ran") && !isFocused;
+  const isQuietResting = state === "idle" || state === "ran";
   const detailLabel = visualExecutionDetail({ count, elapsedMs, isExecuting, isQueued });
   const accessibleDetailLabel = accessibleExecutionDetail({
     count,
@@ -164,8 +164,8 @@ export function CodeCellCurrentLine({
       data-execution-count={count ?? undefined}
       data-execution-label={countLabel ?? undefined}
       className={cn(
-        "mt-1.5 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
-        isCompactIdle ? "min-h-5" : "min-h-6",
+        "mt-1 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
+        isCompactIdle ? "min-h-4" : isQuietResting ? "min-h-[1.125rem]" : "min-h-6",
         className,
       )}
     >
@@ -183,9 +183,8 @@ export function CodeCellCurrentLine({
           "inline-flex size-4 shrink-0 items-center justify-center rounded-full",
           "transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          !isFocused &&
-            (state === "idle" || state === "ran") &&
-            "opacity-45 group-hover:opacity-100",
+          isQuietResting &&
+            "size-3.5 opacity-35 group-hover:opacity-85 group-focus-within:opacity-85",
           !isExecuting && state !== "queued" && "text-muted-foreground/55",
           isCompactIdle && "opacity-45 hover:opacity-100",
           state === "idle" && "hover:bg-muted hover:text-foreground",
@@ -264,7 +263,7 @@ export function CodeCellCurrentLine({
           <div
             data-slot="code-cell-current-line-rule"
             className={cn(
-              "h-px min-w-6 flex-1 rounded-full transition-colors duration-150",
+              "h-px min-w-8 flex-1 rounded-full transition-colors duration-150",
               executionLineClass({ isExecuting, isQueued, isFocused }),
             )}
           />

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -8,6 +8,8 @@ interface CompactExecutionButtonProps {
   isExecuting?: boolean;
   /** Whether the cell is queued for execution */
   isQueued?: boolean;
+  /** Whether the latest execution finished with an error */
+  isErrored?: boolean;
   /** Authenticated actor label for the client that submitted the active execution */
   submittedByActorLabel?: string | null;
   /** Whether the owning cell currently has notebook focus */
@@ -36,6 +38,7 @@ export function CompactExecutionButton({
   count,
   isExecuting = false,
   isQueued = false,
+  isErrored = false,
   submittedByActorLabel = null,
   isCellFocused = false,
   canExecute = true,
@@ -43,7 +46,15 @@ export function CompactExecutionButton({
   onInterrupt,
   className,
 }: CompactExecutionButtonProps) {
-  const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
+  const state = isExecuting
+    ? "running"
+    : isQueued
+      ? "queued"
+      : isErrored
+        ? "error"
+        : count !== null
+          ? "ran"
+          : "idle";
   const displayCount = count === null ? null : formatExecutionCount(count);
   const handleClick = () => {
     if (!canExecute) return;
@@ -65,7 +76,9 @@ export function CompactExecutionButton({
           ? `Queued for execution by ${submittedByActorLabel}`
           : "Queued for execution"
         : count !== null
-          ? `Run cell again; last execution ${count}`
+          ? isErrored
+            ? `Run cell again; last execution ${count} failed`
+            : `Run cell again; last execution ${count}`
           : "Run cell"
     : "Execution unavailable";
 
@@ -83,6 +96,7 @@ export function CompactExecutionButton({
         state === "ran" && "text-muted-foreground/45 hover:bg-primary/5 hover:text-primary",
         state === "queued" && "text-sky-600 dark:text-sky-400",
         state === "running" && "text-destructive hover:bg-destructive/10",
+        state === "error" && "text-destructive/70 hover:bg-destructive/10 hover:text-destructive",
         isQueued || !canExecute ? "cursor-default" : "cursor-pointer",
         !canExecute && "opacity-35 hover:bg-transparent hover:text-muted-foreground/45",
         className,

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -12,6 +12,8 @@ interface CompactExecutionButtonProps {
   submittedByActorLabel?: string | null;
   /** Whether the owning cell currently has notebook focus */
   isCellFocused?: boolean;
+  /** Whether execution controls are available in this shell */
+  canExecute?: boolean;
   /** Called when user clicks to execute */
   onExecute?: () => void;
   /** Called when user clicks to interrupt */
@@ -36,6 +38,7 @@ export function CompactExecutionButton({
   isQueued = false,
   submittedByActorLabel = null,
   isCellFocused = false,
+  canExecute = true,
   onExecute,
   onInterrupt,
   className,
@@ -43,6 +46,7 @@ export function CompactExecutionButton({
   const state = isExecuting ? "running" : isQueued ? "queued" : count !== null ? "ran" : "idle";
   const displayCount = count === null ? null : formatExecutionCount(count);
   const handleClick = () => {
+    if (!canExecute) return;
     if (isQueued) return; // already in queue — no-op
     if (isExecuting) {
       onInterrupt?.();
@@ -51,81 +55,59 @@ export function CompactExecutionButton({
     }
   };
 
-  const title = isExecuting
-    ? submittedByActorLabel
-      ? `Stop execution submitted by ${submittedByActorLabel}`
-      : "Stop execution"
-    : isQueued
+  const title = canExecute
+    ? isExecuting
       ? submittedByActorLabel
-        ? `Queued for execution by ${submittedByActorLabel}`
-        : "Queued for execution"
-      : count !== null
-        ? `Run cell again; last execution ${count}`
-        : "Run cell";
+        ? `Stop execution submitted by ${submittedByActorLabel}`
+        : "Stop execution"
+      : isQueued
+        ? submittedByActorLabel
+          ? `Queued for execution by ${submittedByActorLabel}`
+          : "Queued for execution"
+        : count !== null
+          ? `Run cell again; last execution ${count}`
+          : "Run cell"
+    : "Execution unavailable";
 
   return (
     <button
       type="button"
       onClick={handleClick}
       className={cn(
-        "group/exec inline-flex h-6 min-w-9 items-center justify-end rounded-sm",
-        "font-mono text-[11px] leading-none tabular-nums",
+        "group/exec inline-flex size-5 items-center justify-center rounded-full",
         "transition-colors duration-150",
-        "focus-visible:outline-none focus-visible:text-primary",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
         state === "idle" &&
-          "text-muted-foreground/45 opacity-0 hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
-        state === "idle" && isCellFocused && "opacity-100",
-        state === "ran" && "text-muted-foreground/70 hover:text-primary",
+          "text-muted-foreground/35 opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100",
+        state === "idle" && isCellFocused && "opacity-70",
+        state === "ran" && "text-muted-foreground/45 hover:bg-primary/5 hover:text-primary",
         state === "queued" && "text-sky-600 dark:text-sky-400",
-        state === "running" && "text-destructive",
-        isQueued ? "cursor-default" : "cursor-pointer",
+        state === "running" && "text-destructive hover:bg-destructive/10",
+        isQueued || !canExecute ? "cursor-default" : "cursor-pointer",
+        !canExecute && "opacity-35 hover:bg-transparent hover:text-muted-foreground/45",
         className,
       )}
       title={title}
       aria-label={title}
-      aria-disabled={isQueued || undefined}
+      aria-disabled={isQueued || !canExecute || undefined}
       aria-busy={isExecuting || undefined}
       data-execution-state={state}
       data-execution-count={count ?? undefined}
       data-testid="execute-button"
     >
-      <span className="relative inline-flex min-w-[5ch] items-center justify-end">
-        {state === "running" ? (
-          <span className="inline-flex items-center gap-0">
-            <span className="text-muted-foreground/50">[</span>
-            <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
-            <span className="text-muted-foreground/50">]</span>
-          </span>
-        ) : state === "queued" ? (
-          <span className="inline-flex items-center gap-0">
-            <span className="text-muted-foreground/50">[</span>
-            <span
-              className="mx-[0.2ch] block size-1.5 rounded-full bg-current animate-queue-breathe"
-              aria-hidden="true"
-            />
-            <span className="text-muted-foreground/50">]</span>
-          </span>
-        ) : state === "ran" && displayCount !== null ? (
-          <>
-            <span className="transition-opacity group-hover/exec:opacity-0">
-              <span className="text-muted-foreground/50">[</span>
-              {displayCount}
-              <span className="text-muted-foreground/50">]</span>
-            </span>
-            <span className="absolute inset-0 flex items-center justify-end opacity-0 transition-opacity group-hover/exec:opacity-100">
-              <span className="text-muted-foreground/50">[</span>
-              <Play className="size-3 fill-current" aria-hidden="true" />
-              <span className="text-muted-foreground/50">]</span>
-            </span>
-          </>
-        ) : (
-          <span className="inline-flex items-center gap-0">
-            <span className="text-muted-foreground/50">[</span>
-            <Play className="size-3 fill-current" aria-hidden="true" />
-            <span className="text-muted-foreground/50">]</span>
-          </span>
-        )}
-      </span>
+      {state === "running" ? (
+        <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
+      ) : state === "queued" ? (
+        <span
+          className="block size-1.5 rounded-full bg-current animate-queue-breathe"
+          aria-hidden="true"
+        />
+      ) : (
+        <Play className="size-2.5 fill-current" aria-hidden="true" />
+      )}
+      {state === "ran" && displayCount !== null ? (
+        <span className="sr-only">Last run {displayCount}</span>
+      ) : null}
     </button>
   );
 }

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -10,6 +10,7 @@ describe("CellInsertionRibbon", () => {
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
 
     const addCodeButton = screen.getByTitle("Add code cell");
+    expect(addCodeButton).toHaveTextContent("Code");
     fireEvent.pointerEnter(addCodeButton);
     fireEvent.click(addCodeButton);
 
@@ -18,7 +19,7 @@ describe("CellInsertionRibbon", () => {
     expect(onInsert).toHaveBeenCalledWith("code");
   });
 
-  it("uses the left insertion channel as a primary code target", () => {
+  it("keeps the left insertion channel neutral while remaining a primary code target", () => {
     const onInsert = vi.fn();
     const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
 
@@ -26,10 +27,10 @@ describe("CellInsertionRibbon", () => {
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
 
     fireEvent.pointerEnter(hitTarget!);
+    expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
+
     fireEvent.click(hitTarget!);
 
-    const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
-    expect(intent).toHaveClass("bg-sky-400");
     expect(onInsert).toHaveBeenCalledWith("code");
   });
 

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -39,9 +39,11 @@ describe("CellInsertionRibbon", () => {
     );
 
     const actions = container.querySelector('[data-slot="cell-adder-actions"]');
+    const palette = container.querySelector('[data-slot="cell-adder-action-palette"]');
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
 
     expect(actions).toHaveClass("opacity-100");
+    expect(palette).toHaveClass("bg-background/85");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-foreground");
   });

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -1,60 +1,40 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
 import { CodeCellCurrentLine } from "../CodeCellCurrentLine";
 
 describe("CodeCellCurrentLine", () => {
   it("keeps idle language quiet until the cell is engaged", () => {
-    const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={null}
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
-      />,
-    );
+    const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={null} />);
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "idle");
-    expect(footer).toHaveClass("min-h-[1.125rem]");
+    expect(footer).toHaveClass("min-h-4");
     expect(status).toHaveTextContent("Python·Ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
-    expect(rule).toHaveClass("bg-border/25");
+    expect(rule).toHaveClass("bg-border/15");
   });
 
   it("keeps blank idle cells slim without separator chrome", () => {
     const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={null}
-        compactIdle
-        isFocused
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
-      />,
+      <CodeCellCurrentLine languageLabel="Python" count={null} compactIdle isFocused />,
     );
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
-    expect(footer).toHaveClass("min-h-4");
+    expect(footer).toHaveClass("min-h-3.5");
     expect(detail).toHaveClass("sr-only");
     expect(rule).toBeNull();
   });
 
   it("keeps focused idle language collapsed into the boundary", () => {
     const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={null}
-        isFocused
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
-      />,
+      <CodeCellCurrentLine languageLabel="Python" count={null} isFocused />,
     );
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
@@ -65,49 +45,27 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveClass("group-focus-within:max-w-64");
   });
 
-  it("separates active running status from the destructive stop control", () => {
-    const onInterrupt = vi.fn();
+  it("separates active running status from the execution control lane", () => {
     const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
-        isExecuting
-        submittedByActorLabel="local:kyle"
-        onExecute={() => undefined}
-        onInterrupt={onInterrupt}
-      />,
+      <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
     );
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
-    const stopButton = screen.getByRole("button", {
-      name: "Stop execution submitted by local:kyle",
-    });
 
     expect(footer).toHaveAttribute("data-execution-state", "running");
     expect(status).toHaveTextContent("Python·Running");
     expect(status).toHaveAttribute("aria-label", "Python: Running");
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveClass("text-primary");
-    expect(rule).toHaveClass("bg-primary/45");
-    expect(stopButton).toHaveClass("text-destructive");
-
-    fireEvent.click(stopButton);
-
-    expect(onInterrupt).toHaveBeenCalledTimes(1);
+    expect(rule).toHaveClass("text-sky-500/55");
+    expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
   });
 
   it("keeps completed runs available without notebook prompt syntax", () => {
     const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
-        elapsedMs={1476}
-        isFocused
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
-      />,
+      <CodeCellCurrentLine languageLabel="Python" count={12} elapsedMs={1476} isFocused />,
     );
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
@@ -120,26 +78,14 @@ describe("CodeCellCurrentLine", () => {
   });
 
   it("keeps completed metadata quiet until the cell is engaged", () => {
-    const { container } = render(
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={12}
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
-      />,
-    );
+    const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={12} />);
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
-    const button = screen.getByRole("button", {
-      name: "Run cell again; last execution 12",
-    });
 
     expect(status).toHaveTextContent("Python·Run 12");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
-    expect(button).toHaveClass("opacity-35");
-    expect(button).toHaveClass("size-3.5");
   });
 
   it("can carry activity context after the run state", () => {
@@ -148,8 +94,6 @@ describe("CodeCellCurrentLine", () => {
         languageLabel="Python"
         count={12}
         activityContent={<span data-testid="peer-activity">Kyle</span>}
-        onExecute={() => undefined}
-        onInterrupt={() => undefined}
       />,
     );
 

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -18,6 +18,7 @@ describe("CodeCellCurrentLine", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "idle");
+    expect(footer).toHaveClass("min-h-[1.125rem]");
     expect(status).toHaveTextContent("Python·Ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
@@ -40,12 +41,12 @@ describe("CodeCellCurrentLine", () => {
     const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
-    expect(footer).toHaveClass("min-h-5");
+    expect(footer).toHaveClass("min-h-4");
     expect(detail).toHaveClass("sr-only");
     expect(rule).toBeNull();
   });
 
-  it("shows idle language when the cell is focused", () => {
+  it("keeps focused idle language collapsed into the boundary", () => {
     const { container } = render(
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -59,9 +60,9 @@ describe("CodeCellCurrentLine", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(status).toHaveTextContent("Python·Ready");
-    expect(status).toHaveClass("max-w-64");
-    expect(status).toHaveClass("opacity-100");
-    expect(status).not.toHaveClass("max-w-0");
+    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("group-focus-within:max-w-64");
   });
 
   it("separates active running status from the destructive stop control", () => {
@@ -97,7 +98,7 @@ describe("CodeCellCurrentLine", () => {
     expect(onInterrupt).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps completed runs readable without notebook prompt syntax", () => {
+  it("keeps completed runs available without notebook prompt syntax", () => {
     const { container } = render(
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -110,10 +111,12 @@ describe("CodeCellCurrentLine", () => {
     );
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
+    expect(status).toHaveClass("max-w-0");
   });
 
   it("keeps completed metadata quiet until the cell is engaged", () => {
@@ -135,7 +138,8 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
-    expect(button).toHaveClass("opacity-45");
+    expect(button).toHaveClass("opacity-35");
+    expect(button).toHaveClass("size-3.5");
   });
 
   it("can carry activity context after the run state", () => {

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -59,8 +59,40 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveAttribute("aria-label", "Python: Running");
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveClass("text-primary");
-    expect(rule).toHaveClass("text-sky-500/55");
+    expect(rule).toHaveClass("text-emerald-500/65");
     expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
+  });
+
+  it("gives queued cells a pending boundary", () => {
+    const { container } = render(
+      <CodeCellCurrentLine languageLabel="Python" count={12} isQueued />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer).toHaveAttribute("data-execution-state", "queued");
+    expect(status).toHaveTextContent("Python·Queued");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(rule).toHaveClass("text-sky-500/60");
+    expect(rule?.querySelectorAll(".animate-queue-breathe")).toHaveLength(3);
+  });
+
+  it("gives errored cells a broken boundary", () => {
+    const { container } = render(
+      <CodeCellCurrentLine languageLabel="Python" count={12} isErrored />,
+    );
+
+    const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(footer).toHaveAttribute("data-execution-state", "error");
+    expect(status).toHaveTextContent("Python·Run 12 failed");
+    expect(status).toHaveAttribute("aria-label", "Python: Run 12 failed");
+    expect(status).toHaveClass("text-destructive/80");
+    expect(rule).toHaveClass("text-destructive/60");
   });
 
   it("keeps completed runs available without notebook prompt syntax", () => {

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -125,3 +125,46 @@
   animation: exec-squish 3s cubic-bezier(0.34, 1.56, 0.64, 1) 1s infinite;
   transform-origin: center center;
 }
+
+@keyframes exec-signal-wave {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+.animate-exec-signal-wave {
+  animation: exec-signal-wave 1.6s linear infinite;
+}
+
+@keyframes exec-signal-tail {
+  0% {
+    opacity: 0;
+    transform: scaleX(0.2);
+  }
+  20% {
+    opacity: 0.6;
+  }
+  70% {
+    opacity: 0.6;
+    transform: scaleX(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1);
+  }
+}
+
+.animate-exec-signal-tail {
+  animation: exec-signal-tail 2.4s ease-out infinite;
+  transform-origin: left center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-exec-signal-wave,
+  .animate-exec-signal-tail {
+    animation: none;
+  }
+}

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -163,6 +163,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .animate-queue-breathe,
+  .animate-exec-squish,
   .animate-exec-signal-wave,
   .animate-exec-signal-tail {
     animation: none;


### PR DESCRIPTION
## Summary

- move the code-cell run affordance into the cell state lane so the in-between metadata line can stay quieter
- keep the execution boundary compact while giving running, queued, and errored cells distinct visual states
- keep the cell insertion ribbon aligned with the rail and restore icon + text affordances for add-code/add-markdown
- add Elements sketches for the current-line states, including a timing/progress concept for future backend work

## Verification

- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx src/components/cell/__tests__/CellInsertionRibbon.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
