### PR TITLE
fix(notebook): gate structure callbacks by capabilities

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -57,7 +57,7 @@ interface CodeCellProps {
   onOutputFocusChange?: (focused: boolean) => void;
   onExecute: () => void;
   onInterrupt: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onNavigateToCell?: (cellId: string) => void;

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -57,7 +57,7 @@ function formatPluginLoadError(error: unknown): string {
 interface MarkdownCellProps {
   cell: MarkdownCellType;
   onFocus: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -807,11 +807,11 @@ function NotebookViewContent({
             onOutputFocusChange={(focused) => handleOutputFocusChange(cell.id, focused)}
             onExecute={() => onExecuteCell(cell.id)}
             onInterrupt={onInterruptKernel}
-            onDelete={() => onDeleteCell(cell.id)}
+            onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onNavigateToCell={onNavigateToCell}
-            onInsertCellAfter={() => onAddCell("code", cell.id)}
+            onInsertCellAfter={canMutateCells ? () => onAddCell("code", cell.id) : undefined}
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
@@ -820,12 +820,12 @@ function NotebookViewContent({
             canExecute={canExecuteCells}
             outputHostContext={outputHostContext}
             onToggleSourceHidden={
-              onSetCellSourceHidden
+              canMutateCells && onSetCellSourceHidden
                 ? (hidden: boolean) => onSetCellSourceHidden(cell.id, hidden)
                 : undefined
             }
             onToggleOutputsHidden={
-              onSetCellOutputsHidden
+              canMutateCells && onSetCellOutputsHidden
                 ? (hidden: boolean) => onSetCellOutputsHidden(cell.id, hidden)
                 : undefined
             }
@@ -834,6 +834,7 @@ function NotebookViewContent({
             hiddenGroupCellIds={hiddenGroupsRef.current.get(cell.id)?.groupCellIds}
             onExpandHiddenGroup={
               hiddenGroupsRef.current.has(cell.id) &&
+              canMutateCells &&
               onSetCellSourceHidden &&
               onSetCellOutputsHidden
                 ? () => {
@@ -860,10 +861,10 @@ function NotebookViewContent({
               onFocusCell(cell.id);
               presence?.setFocus(cell.id);
             }}
-            onDelete={() => onDeleteCell(cell.id)}
+            onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
-            onInsertCellAfter={() => onAddCell("markdown", cell.id)}
+            onInsertCellAfter={canMutateCells ? () => onAddCell("markdown", cell.id) : undefined}
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
@@ -884,10 +885,10 @@ function NotebookViewContent({
             onFocusCell(cell.id);
             presence?.setFocus(cell.id);
           }}
-          onDelete={() => onDeleteCell(cell.id)}
+          onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
           onFocusPrevious={onFocusPrevious}
           onFocusNext={onFocusNext}
-          onInsertCellAfter={() => onAddCell("code", cell.id)}
+          onInsertCellAfter={canMutateCells ? () => onAddCell("code", cell.id) : undefined}
           isLastCell={index === cellIdsRef.current.length - 1}
           dragHandleProps={dragHandleProps}
           isDragging={isDragging}

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -24,7 +24,7 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 interface RawCellProps {
   cell: RawCellType;
   onFocus: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -18,6 +18,14 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/capabilities\?\.canExecute \?\? !readOnly/);
     expect(sourceText).toMatch(/<CodeCell[\s\S]*canExecute=\{canExecuteCells\}/);
     expect(sourceText).toMatch(/<MarkdownCell[\s\S]*readOnly=\{!canEditMarkdownSources\}/);
+    expect(sourceText).toMatch(
+      /onDelete=\{canMutateCells \? \(\) => onDeleteCell\(cell\.id\) : undefined\}/,
+    );
+    expect(sourceText).toMatch(
+      /onInsertCellAfter=\{canMutateCells \? \(\) => onAddCell\("markdown", cell\.id\) : undefined\}/,
+    );
+    expect(sourceText).toMatch(/canMutateCells && onSetCellSourceHidden/);
+    expect(sourceText).toMatch(/canMutateCells && onSetCellOutputsHidden/);
   });
 
   it("does not install code execution keybindings when execution is unavailable", () => {


### PR DESCRIPTION
## Summary

- Gate shared `NotebookView` structure callbacks by `NotebookShellCapabilities` before they reach code, markdown, or raw cells.
- Keep markdown/source editing separate from cell structure mutation so editor-like modes can write allowed source without enabling delete/insert/visibility actions.
- Add a regression source check for capability-gated delete, insert, and visibility wiring.

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

This moves mutation safety into the shared desktop/cloud NotebookView surface. Cloud remains a host adapter: it passes capabilities, and the shared cells only receive structure mutation callbacks when those capabilities permit it.
