### PR TITLE
refactor(notebook): stage execution signal animation

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -112,12 +112,18 @@ const currentLineStateFixtures = [
   },
   {
     label: "Queued",
-    detail: "Waiting gets a dotted signal so it feels pending rather than active.",
+    detail: "Waiting keeps a simple blue boundary with only a small pulse.",
     line: <CodeCellCurrentLine languageLabel="Python" count={12} isQueued />,
   },
   {
+    label: "Next queued",
+    detail: "Queue priority can proportionally tighten the pulse without exposing queue order.",
+    line: <CodeCellCurrentLine languageLabel="Python" count={12} isQueued queuePriority={1} />,
+  },
+  {
     label: "Running",
-    detail: "Runtime work gets a green floppy wave; the stop control lives outside this boundary.",
+    detail:
+      "Runtime work starts as a line, then earns the green wave if it stays busy long enough.",
     line: <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
   },
   {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -741,7 +741,6 @@ function AppContent() {
   const executingCellIds = new Set(
     notebookQueueProjection.executing_cell_id ? [notebookQueueProjection.executing_cell_id] : [],
   );
-  const queuedCellIds = new Set(notebookQueueProjection.queued_cell_ids);
   const sourceVersion = useSourceVersion();
   const notebookViewModel = useMemo(() => {
     void cellIds;
@@ -784,7 +783,7 @@ function AppContent() {
   // notify subscribers. Discarded renders never trigger notifications.
   storeSetFocusedCellId(focusedCellId);
   storeSetExecutingCellIds(executingCellIds);
-  storeSetQueuedCellIds(queuedCellIds);
+  storeSetQueuedCellIds(notebookQueueProjection.queued_cell_ids);
   storeSetSearchQuery(globalFind.query);
   storeSetSearchCurrentMatch(globalFind.currentMatch);
 

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -17,6 +17,7 @@ import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
 import {
+  useCellQueuePriority,
   useIsCellExecuting,
   useIsCellFocused,
   useIsCellQueued,
@@ -178,6 +179,7 @@ export const CodeCell = memo(function CodeCell({
   const isFocused = useIsCellFocused(cell.id);
   const isExecuting = useIsCellExecuting(cell.id);
   const isQueued = useIsCellQueued(cell.id);
+  const queuePriority = useCellQueuePriority(cell.id);
   const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
   const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
   const searchQuery = useSearchQuery();
@@ -410,6 +412,7 @@ export const CodeCell = memo(function CodeCell({
       count={executionCount}
       isExecuting={isExecuting}
       isQueued={isQueued}
+      queuePriority={queuePriority}
       isErrored={isExecutionErrored}
       isFocused={isFocused}
       compactIdle={isSourceEmpty}

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -14,6 +14,7 @@ let mockExecution: {
 let mockIsExecuting = false;
 let mockIsFocused = false;
 let mockIsQueued = false;
+let mockQueuePriority = 0;
 const mockEditorBlur = vi.fn();
 
 vi.mock("@/components/cell/CellContainer", () => ({
@@ -109,6 +110,7 @@ vi.mock("../../hooks/useCrdtBridge", () => ({
 }));
 
 vi.mock("../../lib/cell-ui-state", () => ({
+  useCellQueuePriority: () => mockQueuePriority,
   useIsCellExecuting: () => mockIsExecuting,
   useIsCellFocused: () => mockIsFocused,
   useIsCellQueued: () => mockIsQueued,
@@ -178,6 +180,7 @@ describe("CodeCell output focus", () => {
     mockIsExecuting = false;
     mockIsFocused = false;
     mockIsQueued = false;
+    mockQueuePriority = 0;
     mockOutputs = [
       {
         output_type: "display_data",
@@ -277,7 +280,8 @@ describe("CodeCell output focus", () => {
     expect(status).toHaveClass("text-primary");
     expect(status).not.toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("text-emerald-500/65");
-    expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
+    expect(rule).toHaveAttribute("data-execution-signal", "building");
+    expect(rule?.querySelector("svg")).toBeNull();
     expect(stopButton).toHaveClass("text-destructive");
   });
 

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -17,6 +17,7 @@ import { getCellIdsSnapshot, subscribeIds } from "./notebook-cells";
 let _focusedCellId: string | null = null;
 let _executingCellIds: Set<string> = new Set();
 let _queuedCellIds: Set<string> = new Set();
+let _queuedCellPriority = new Map<string, number>();
 let _searchQuery: string | undefined; // eslint-disable-line -- intentionally uninitialized alongside siblings
 let _searchCurrentMatch: FindMatch | null = null;
 
@@ -50,6 +51,19 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
   return true;
 }
 
+function mapsEqual(a: Map<string, number>, b: Map<string, number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [key, value] of a) {
+    if (b.get(key) !== value) return false;
+  }
+  return true;
+}
+
+function queuePriorityForIndex(index: number, length: number): number {
+  if (length <= 1) return 1;
+  return Math.max(0.25, 1 - index / length);
+}
+
 // ── Setters ─────────────────────────────────────────────────────────────
 //
 // Two-phase update pattern for StrictMode safety:
@@ -72,9 +86,15 @@ export function setExecutingCellIds(ids: Set<string>): void {
   _dirtySubscribers.add(_executingSubscribers);
 }
 
-export function setQueuedCellIds(ids: Set<string>): void {
-  if (setsEqual(_queuedCellIds, ids)) return;
-  _queuedCellIds = ids;
+export function setQueuedCellIds(ids: Iterable<string>): void {
+  const orderedIds = Array.from(ids);
+  const nextIds = new Set(orderedIds);
+  const nextPriority = new Map(
+    orderedIds.map((id, index) => [id, queuePriorityForIndex(index, orderedIds.length)]),
+  );
+  if (setsEqual(_queuedCellIds, nextIds) && mapsEqual(_queuedCellPriority, nextPriority)) return;
+  _queuedCellIds = nextIds;
+  _queuedCellPriority = nextPriority;
   _dirtySubscribers.add(_queuedSubscribers);
 }
 
@@ -121,6 +141,13 @@ export function useIsCellExecuting(cellId: string): boolean {
 export function useIsCellQueued(cellId: string): boolean {
   const subscribe = useMemo(() => subscribeQueuedFor(cellId), [cellId]);
   const getSnapshot = useMemo(() => getIsQueuedSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Returns a 0..1 visual priority for a queued cell, where 1 is next to run. */
+export function useCellQueuePriority(cellId: string): number {
+  const subscribe = useMemo(() => subscribeQueuedFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getQueuePrioritySnapshot(cellId), [cellId]);
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
@@ -300,6 +327,15 @@ function getIsQueuedSnapshot(cellId: string): () => boolean {
   let prev = _queuedCellIds.has(cellId);
   return () => {
     const next = _queuedCellIds.has(cellId);
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function getQueuePrioritySnapshot(cellId: string): () => number {
+  let prev = _queuedCellPriority.get(cellId) ?? 0;
+  return () => {
+    const next = _queuedCellPriority.get(cellId) ?? 0;
     if (next !== prev) prev = next;
     return prev;
   };

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 export interface CodeCellCurrentLineProps {
@@ -7,6 +7,7 @@ export interface CodeCellCurrentLineProps {
   elapsedMs?: number | null;
   isExecuting?: boolean;
   isQueued?: boolean;
+  queuePriority?: number;
   isErrored?: boolean;
   isFocused?: boolean;
   compactIdle?: boolean;
@@ -15,6 +16,10 @@ export interface CodeCellCurrentLineProps {
 }
 
 type ExecutionBoundaryState = "idle" | "ran" | "queued" | "running" | "error";
+type RunningSignalPhase = "resting" | "building" | "active" | "settling";
+
+const RUNNING_SIGNAL_DELAY_MS = 120;
+const RUNNING_SIGNAL_SETTLE_MS = 320;
 
 function formatExecutionCount(count: number): string {
   return count > 999 ? "999+" : String(count);
@@ -88,11 +93,7 @@ function executionCountLabel(count: number | null): string | null {
   return count === null ? null : `Execution ${formatExecutionCount(count)}`;
 }
 
-function executionLineClass({ isQueued, isFocused }: { isQueued: boolean; isFocused: boolean }) {
-  if (isQueued) {
-    return "bg-sky-400/30";
-  }
-
+function executionLineClass({ isFocused }: { isFocused: boolean }) {
   if (isFocused) {
     return "bg-border/30";
   }
@@ -100,58 +101,128 @@ function executionLineClass({ isQueued, isFocused }: { isQueued: boolean; isFocu
   return "bg-border/15 group-hover:bg-border/25 group-focus-within:bg-border/25";
 }
 
+function clampQueuePriority(priority: number): number {
+  return Math.max(0, Math.min(1, priority));
+}
+
+function queueSignalStyle(priority: number): CSSProperties {
+  const durationMs = Math.round(2_900 - priority * 1_450);
+  const lowOpacity = 0.34 + priority * 0.1;
+  const highOpacity = 0.58 + priority * 0.18;
+
+  return {
+    "--queue-pulse-duration": `${durationMs}ms`,
+    "--queue-pulse-low": lowOpacity.toFixed(2),
+    "--queue-pulse-high": highOpacity.toFixed(2),
+  } as CSSProperties;
+}
+
+function useRunningSignalPhase(isExecuting: boolean): RunningSignalPhase {
+  const [phase, setPhase] = useState<RunningSignalPhase>(() =>
+    isExecuting ? "building" : "resting",
+  );
+  const phaseRef = useRef(phase);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    if (isExecuting) {
+      setPhase((current) => (current === "active" ? "active" : "building"));
+      timeoutId = setTimeout(() => {
+        setPhase("active");
+      }, RUNNING_SIGNAL_DELAY_MS);
+    } else if (phaseRef.current === "active") {
+      setPhase("settling");
+      timeoutId = setTimeout(() => {
+        setPhase("resting");
+      }, RUNNING_SIGNAL_SETTLE_MS);
+    } else {
+      setPhase("resting");
+    }
+
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [isExecuting]);
+
+  return phase;
+}
+
 function ExecutionBoundaryRule({
   state,
+  runningSignalPhase,
   isQuietResting,
-  isQueued,
+  queuePriority,
   isFocused,
 }: {
   state: ExecutionBoundaryState;
+  runningSignalPhase: RunningSignalPhase;
   isQuietResting: boolean;
-  isQueued: boolean;
+  queuePriority: number;
   isFocused: boolean;
 }) {
-  if (state === "running") {
+  if (state === "running" || runningSignalPhase === "settling") {
+    const showSignal = runningSignalPhase === "active" || runningSignalPhase === "settling";
+
     return (
       <div
         data-slot="code-cell-current-line-rule"
+        data-execution-signal={runningSignalPhase}
         className="relative h-3 min-w-14 flex-1 overflow-hidden text-emerald-500/65 dark:text-emerald-300/65 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]"
       >
-        <svg
-          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
-          viewBox="0 0 240 12"
-          preserveAspectRatio="none"
-          aria-hidden="true"
-        >
-          <path
-            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
-            fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeWidth="1.4"
-            vectorEffect="non-scaling-stroke"
+        {!showSignal ? (
+          <span
+            data-slot="code-cell-current-line-resting-rule"
+            className="absolute left-0 top-1/2 h-px w-full -translate-y-1/2 rounded-full bg-current/25"
+            aria-hidden="true"
           />
-        </svg>
+        ) : null}
+        {showSignal ? (
+          <span
+            data-slot="code-cell-current-line-signal"
+            className={cn(
+              "absolute inset-0 overflow-hidden",
+              runningSignalPhase === "active" && "animate-exec-signal-build",
+              runningSignalPhase === "settling" && "animate-exec-signal-settle",
+            )}
+            aria-hidden="true"
+          >
+            <svg
+              className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
+              viewBox="0 0 240 12"
+              preserveAspectRatio="none"
+            >
+              <path
+                d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth="1.4"
+                vectorEffect="non-scaling-stroke"
+              />
+            </svg>
+          </span>
+        ) : null}
       </div>
     );
   }
 
   if (state === "queued") {
+    const normalizedQueuePriority = clampQueuePriority(queuePriority || 0.35);
+
     return (
       <div
         data-slot="code-cell-current-line-rule"
-        className="flex h-3 min-w-12 flex-1 items-center gap-1 text-sky-500/60 dark:text-sky-300/60"
-      >
-        {[0, 120, 240].map((delay) => (
-          <span
-            key={delay}
-            className="size-1 rounded-full bg-current animate-queue-breathe"
-            style={{ animationDelay: `${delay}ms` }}
-            aria-hidden="true"
-          />
-        ))}
-        <span className="h-px min-w-4 flex-1 rounded-full bg-sky-400/20" aria-hidden="true" />
-      </div>
+        data-queue-priority={normalizedQueuePriority.toFixed(2)}
+        className="h-px min-w-12 flex-1 rounded-full bg-sky-400/45 animate-queue-boundary-pulse dark:bg-sky-300/35"
+        style={queueSignalStyle(normalizedQueuePriority)}
+      />
     );
   }
 
@@ -179,8 +250,7 @@ function ExecutionBoundaryRule({
       className={cn(
         "h-px min-w-4 rounded-full transition-[background-color,width,flex-basis] duration-150",
         isQuietResting ? "w-10 flex-none group-hover:w-14 group-focus-within:w-14" : "flex-1",
-        executionLineClass({ isQueued, isFocused }),
-        isQueued && "animate-queue-breathe",
+        executionLineClass({ isFocused }),
       )}
     />
   );
@@ -192,12 +262,14 @@ export function CodeCellCurrentLine({
   elapsedMs = null,
   isExecuting = false,
   isQueued = false,
+  queuePriority = 0,
   isErrored = false,
   isFocused = false,
   compactIdle = false,
   activityContent,
   className,
 }: CodeCellCurrentLineProps) {
+  const runningSignalPhase = useRunningSignalPhase(isExecuting);
   const state: ExecutionBoundaryState = isExecuting
     ? "running"
     : isQueued
@@ -294,8 +366,9 @@ export function CodeCellCurrentLine({
           ) : null}
           <ExecutionBoundaryRule
             state={state}
+            runningSignalPhase={runningSignalPhase}
             isQuietResting={isQuietResting}
-            isQueued={isQueued}
+            queuePriority={queuePriority}
             isFocused={isFocused}
           />
         </>

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vite-plus/test";
+import { act, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
 import { CodeCellCurrentLine } from "../CodeCellCurrentLine";
 
 describe("CodeCellCurrentLine", () => {
@@ -60,7 +60,80 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(status).toHaveClass("text-primary");
     expect(rule).toHaveClass("text-emerald-500/65");
-    expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
+    expect(rule).toHaveAttribute("data-execution-signal", "building");
+    expect(
+      rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
+    ).toBeInTheDocument();
+    expect(rule?.querySelector("svg")).toBeNull();
+  });
+
+  it("delays the running wave so fast executions do not flicker", () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container, rerender } = render(
+        <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(119);
+      });
+
+      expect(container.querySelector('[data-slot="code-cell-current-line-rule"] svg')).toBeNull();
+
+      rerender(<CodeCellCurrentLine languageLabel="Python" count={13} />);
+
+      const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      expect(rule).not.toHaveAttribute("data-execution-signal");
+      expect(rule?.querySelector("svg")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("builds up and settles the running wave after sustained execution", () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container, rerender } = render(
+        <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(120);
+      });
+
+      let rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      let signal = container.querySelector('[data-slot="code-cell-current-line-signal"]');
+
+      expect(rule).toHaveAttribute("data-execution-signal", "active");
+      expect(signal).toHaveClass("animate-exec-signal-build");
+      expect(
+        rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
+      ).not.toBeInTheDocument();
+      expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
+
+      rerender(<CodeCellCurrentLine languageLabel="Python" count={13} />);
+
+      rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      signal = container.querySelector('[data-slot="code-cell-current-line-signal"]');
+
+      expect(rule).toHaveAttribute("data-execution-signal", "settling");
+      expect(signal).toHaveClass("animate-exec-signal-settle");
+      expect(
+        rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(320);
+      });
+
+      rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      expect(rule).not.toHaveAttribute("data-execution-signal");
+      expect(rule?.querySelector("svg")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("gives queued cells a pending boundary", () => {
@@ -75,8 +148,25 @@ describe("CodeCellCurrentLine", () => {
     expect(footer).toHaveAttribute("data-execution-state", "queued");
     expect(status).toHaveTextContent("Python·Queued");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(rule).toHaveClass("text-sky-500/60");
-    expect(rule?.querySelectorAll(".animate-queue-breathe")).toHaveLength(3);
+    expect(rule).toHaveClass("bg-sky-400/45");
+    expect(rule).toHaveAttribute("data-queue-priority", "0.35");
+    expect(rule).toHaveClass("animate-queue-boundary-pulse");
+    expect(rule?.querySelectorAll(".animate-queue-breathe")).toHaveLength(0);
+  });
+
+  it("uses queue priority to tune the pending pulse", () => {
+    const { container } = render(
+      <CodeCellCurrentLine languageLabel="Python" count={12} isQueued queuePriority={1} />,
+    );
+
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+    expect(rule).toHaveAttribute("data-queue-priority", "1.00");
+    expect(rule).toHaveStyle({
+      "--queue-pulse-duration": "1450ms",
+      "--queue-pulse-low": "0.44",
+      "--queue-pulse-high": "0.76",
+    });
   });
 
   it("gives errored cells a broken boundary", () => {

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -90,6 +90,20 @@
   animation: queue-breathe 3s ease-in-out infinite;
 }
 
+@keyframes queue-boundary-pulse {
+  0%,
+  100% {
+    opacity: var(--queue-pulse-low, 0.42);
+  }
+  50% {
+    opacity: var(--queue-pulse-high, 0.72);
+  }
+}
+
+.animate-queue-boundary-pulse {
+  animation: queue-boundary-pulse var(--queue-pulse-duration, 2.8s) ease-in-out infinite;
+}
+
 @keyframes exec-squish {
   0% {
     transform: scale(1, 1) rotate(0deg);
@@ -139,6 +153,39 @@
   animation: exec-signal-wave 1.6s linear infinite;
 }
 
+@keyframes exec-signal-build {
+  0% {
+    clip-path: inset(0 100% 0 0);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.55;
+  }
+  100% {
+    clip-path: inset(0 0 0 0);
+    opacity: 1;
+  }
+}
+
+.animate-exec-signal-build {
+  animation: exec-signal-build 220ms ease-out both;
+}
+
+@keyframes exec-signal-settle {
+  0% {
+    clip-path: inset(0 0 0 0);
+    opacity: 0.85;
+  }
+  100% {
+    clip-path: inset(0 0 0 72%);
+    opacity: 0;
+  }
+}
+
+.animate-exec-signal-settle {
+  animation: exec-signal-settle 320ms ease-out both;
+}
+
 @keyframes exec-signal-tail {
   0% {
     opacity: 0;
@@ -164,7 +211,10 @@
 
 @media (prefers-reduced-motion: reduce) {
   .animate-queue-breathe,
+  .animate-queue-boundary-pulse,
   .animate-exec-squish,
+  .animate-exec-signal-build,
+  .animate-exec-signal-settle,
   .animate-exec-signal-wave,
   .animate-exec-signal-tail {
     animation: none;


### PR DESCRIPTION
## Summary

- delay the running execution signal so fast cells stay visually quiet
- let sustained executions build from a baseline into the green wave, then settle out
- replace the queued-cell dots with a simple blue pulse driven by a per-cell queue priority scalar
- document the queued/running current-line states in the Elements cell anatomy examples

## Verification

- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
