### PR TITLE
feat(notebook): converge shell identity and cloud chrome

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -24,6 +24,8 @@ const identityScenarioIds: ElementsNotebookScenarioId[] = [
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "runtime-peer",
+  "system-schema",
   "runtime-unavailable",
 ];
 
@@ -48,10 +50,12 @@ export function IdentityEnvironmentSurfacesExample() {
   const cloudOwner = getElementsNotebookScenario("cloud-owner");
   const cloudEditor = getElementsNotebookScenario("cloud-editor");
   const agentScenario = getElementsNotebookScenario("agent-on-behalf");
+  const runtimePeer = getElementsNotebookScenario("runtime-peer");
   const activeActors = [
     scenarioActor(cloudOwner),
     scenarioActor(cloudEditor),
     scenarioActor(agentScenario),
+    scenarioActor(runtimePeer),
   ];
 
   return (

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -21,6 +21,8 @@ export type ElementsNotebookScenarioId =
   | "cloud-editor"
   | "cloud-owner"
   | "agent-on-behalf"
+  | "runtime-peer"
+  | "system-schema"
   | "runtime-unavailable";
 
 export interface ElementsNotebookScenario {
@@ -714,6 +716,72 @@ export const elementsNotebookScenarios: Record<
       auth: {
         canSignIn: false,
         canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+    },
+  }),
+  "runtime-peer": createScenario({
+    id: "runtime-peer",
+    title: "Runtime peer",
+    eyebrow: "runtime fixture",
+    summary:
+      "A runtime operator authors execution and output state without becoming a notebook editor.",
+    runtimeLabel: "JupyterHub runtime · connected",
+    packageSummary: "visible · 4 packages",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "viewer",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+        identityLabel: "Alice",
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+    },
+  }),
+  "system-schema": createScenario({
+    id: "system-schema",
+    title: "System schema actor",
+    eyebrow: "system fixture",
+    summary:
+      "Schema and system-authored changes remain attributable without appearing as human collaborators.",
+    runtimeLabel: "System · schema seed",
+    packageSummary: "not applicable",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: false,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "viewer",
+        source: "fixture",
+        isPublic: false,
+        actorLabel: "system/schema:notebook:v5",
+        identityLabel: null,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: false,
         needsAttention: false,
       },
     },

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -41,6 +41,8 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "runtime-peer",
+  "system-schema",
   "runtime-unavailable",
 ];
 

--- a/apps/elements/content/docs/identity-environment-surfaces.mdx
+++ b/apps/elements/content/docs/identity-environment-surfaces.mdx
@@ -15,9 +15,9 @@ the shared package view model and shell capabilities into a compact runtime and
 dependency state surface.
 
 The fixtures come from `ElementsNotebookScenario`: local owner, public viewer,
-cloud editor, cloud owner, agent-on-behalf-of-user, and runtime-unavailable
-states. Desktop and cloud should feed the same production components from their
-host adapters.
+cloud editor, cloud owner, agent-on-behalf-of-user, runtime peer, system actor,
+and runtime-unavailable states. Desktop and cloud should feed the same
+production components from their host adapters.
 
 <IdentityEnvironmentSurfacesExample />
 

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -88,7 +88,7 @@ function CloudRendererParityHarness() {
           <h1>Renderer parity fixture</h1>
         </div>
         <div className="cloud-render-parity-actions" aria-label="Theme controls">
-          <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
+          <ThemeToggle theme={theme} onThemeChange={setTheme} />
         </div>
       </header>
       <div data-testid="fixture-markers" hidden>

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -49,14 +49,18 @@ test("cloud notebook rendering uses shared cell chrome instead of report-mode ce
   );
 });
 
-test("cloud viewer exposes the shared theme toggle and shared theme hook", () => {
+test("cloud viewer keeps theme resolution out of first-class notebook chrome", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /import \{ ThemeToggle \} from "@\/components\/ui\/theme-toggle";/);
   assert.match(sourceText, /useTheme\(CLOUD_VIEWER_THEME_STORAGE_KEY\)/);
-  assert.match(sourceText, /<ThemeToggle/);
-  assert.match(sourceText, /className="cloud-theme-toggle"/);
+  assert.match(sourceText, /applyDocumentTheme\(resolvedTheme\)/);
+  assert.doesNotMatch(
+    sourceText,
+    /import \{ ThemeToggle \} from "@\/components\/ui\/theme-toggle";/,
+  );
+  assert.doesNotMatch(sourceText, /<ThemeToggle/);
+  assert.doesNotMatch(sourceText, /className="cloud-theme-toggle"/);
 });
 
 test("cloud viewer routes notebook header controls through the shared shell header", () => {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -242,21 +242,6 @@ body {
   line-height: 1;
 }
 
-.cloud-theme-toggle {
-  height: 2rem;
-  border-color: color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--background) 90%, transparent);
-  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
-  backdrop-filter: blur(8px);
-}
-
-.cloud-theme-toggle button {
-  width: 1.625rem;
-  height: 1.625rem;
-  border-radius: 999px;
-}
-
 .cloud-auth-menu {
   position: relative;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -37,7 +37,6 @@ import {
   NotebookPackageSummaryPanel,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
-import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -406,7 +405,7 @@ function CloudNotebookProviders({
 }
 
 function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
-  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const [scope, setScope] = useState<ConnectionScope>(
     authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
@@ -455,7 +454,6 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
     <main className="cloud-home">
       <div className="cloud-report-toolbar" aria-label="Notebook cloud entry controls">
         <h1>nteract cloud notebooks</h1>
-        <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
       </div>
 
       <section className="cloud-home-panel" aria-label="Notebook cloud sign-in">
@@ -528,7 +526,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
 }
 
 function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
-  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
     message: "Completing sign-in...",
@@ -578,7 +576,6 @@ function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig })
     <main className="flex min-h-screen w-full flex-col px-8 py-4 pr-4">
       <div className="cloud-report-toolbar" aria-label="Sign-in status and controls">
         <h1 className="text-xl font-semibold tracking-normal">nteract cloud notebook</h1>
-        <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
       </div>
       <div className="cloud-state" data-kind={status.kind}>
         {status.message}
@@ -596,7 +593,7 @@ function NotebookViewer({
 }) {
   const { config } = runtime;
   const loadingPolicy = cloudViewerLoadingPolicy(config);
-  const { theme, setTheme, resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
   const [status, setStatus] = useState<ViewerStatus>({
     kind: "loading",
@@ -1166,9 +1163,7 @@ function NotebookViewer({
     <NotebookDocumentHeader
       capabilities={shellCapabilities}
       presence={<CloudPresenceStatus presence={presence} connectionScope={connectionScope} />}
-      utilityControls={
-        <ThemeToggle theme={theme} onThemeChange={setTheme} className="cloud-theme-toggle" />
-      }
+      utilityControls={null}
       sharingControls={
         <CloudSharingControls
           aclEndpoint={config.aclEndpoint}

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,4 +1,5 @@
 import type { SessionControlMessage } from "../src/protocol";
+import { friendlyNotebookActorLabel } from "@/components/notebook-shell/actor-labels";
 
 export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
 
@@ -130,56 +131,13 @@ export function cloudFriendlyPeerLabel({
     return trimmedEmail;
   }
 
-  return friendlyActorLabel(actorLabel) ?? "Peer";
+  return friendlyNotebookActorLabel(actorLabel) ?? "Peer";
 }
 
 function safeRoomPeerCount(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
 }
 
-function friendlyActorLabel(actorLabel: string | null | undefined): string | null {
-  const trimmedActorLabel = actorLabel?.trim();
-  if (!trimmedActorLabel) return null;
-
-  const principal = trimmedActorLabel.split("/", 1)[0];
-  if (principal.startsWith("anonymous:")) {
-    return "Anonymous";
-  }
-
-  if (!principal.startsWith("user:")) {
-    return null;
-  }
-
-  const parts = principal.split(":");
-  const namespace = parts.slice(0, 2).join(":");
-  const encodedSubject = parts.slice(2).join(":");
-  const subject = decodeActorLabelSubject(encodedSubject);
-  if (!subject) {
-    return namespace === "user:anaconda" ? "Anaconda user" : "User";
-  }
-  if (subject.includes("@")) {
-    return subject;
-  }
-  if (namespace === "user:anaconda" && looksOpaqueSubject(subject)) {
-    return "Anaconda user";
-  }
-
-  return subject;
-}
-
-function decodeActorLabelSubject(value: string): string {
-  if (!value) return "";
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-}
-
 function looksLikeRawIdentityLabel(value: string): boolean {
   return /^(anonymous|user):/.test(value);
-}
-
-function looksOpaqueSubject(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
 }

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -20,6 +20,11 @@ import type {
   NotebookShellAccessCapabilities,
   NotebookShellAuthCapabilities,
 } from "./capabilities";
+import {
+  friendlyNotebookActorLabel,
+  parseNotebookActorLabel,
+  type ParsedNotebookActorKind,
+} from "./actor-labels";
 
 export type NotebookActorKind =
   | "agent"
@@ -103,7 +108,8 @@ export function notebookActorFromAccess(
     };
   }
 
-  const label = access.identityLabel ?? friendlyActorLabel(access.actorLabel) ?? "Unknown viewer";
+  const label =
+    access.identityLabel ?? friendlyNotebookActorLabel(access.actorLabel) ?? "Unknown viewer";
   const detail =
     sourceLabel === null ? accessLabel : `${accessLabel.toLowerCase()} through ${sourceLabel}`;
 
@@ -283,128 +289,6 @@ function statusTone(status: NonNullable<NotebookActorIdentity["status"]>): strin
       return "bg-muted-foreground";
     case "offline":
       return "bg-muted";
-  }
-}
-
-type ParsedNotebookActorKind = "agent" | "runtime" | "system";
-
-function parseNotebookActorLabel(actorLabel: string | null): {
-  kind: ParsedNotebookActorKind;
-  label: string;
-  onBehalfOf: string | null;
-} | null {
-  if (!actorLabel) return null;
-
-  const [principal, operator] = splitActorPrincipalOperator(actorLabel);
-  const operatorProjection = operator ? parseOperatorLabel(operator, principal) : null;
-  if (operatorProjection) return operatorProjection;
-
-  if (principal === "system" && operator) {
-    return {
-      kind: "system",
-      label: friendlyOperatorLabel(operator) ?? "System",
-      onBehalfOf: null,
-    };
-  }
-
-  if (actorLabel.startsWith("agent:")) {
-    const agentValue = actorLabel.slice("agent:".length);
-    const [rawAgent, rawBehalf] = agentValue.split("/on-behalf-of:");
-    return {
-      kind: "agent",
-      label: friendlyActorLabel(rawAgent) ?? "Agent",
-      onBehalfOf: friendlyActorLabel(rawBehalf ?? null),
-    };
-  }
-
-  return parseOperatorLabel(actorLabel, null);
-}
-
-function parseOperatorLabel(
-  operatorLabel: string,
-  principalLabel: string | null,
-): {
-  kind: ParsedNotebookActorKind;
-  label: string;
-  onBehalfOf: string | null;
-} | null {
-  if (operatorLabel.startsWith("agent:")) {
-    return {
-      kind: "agent",
-      label: friendlyOperatorLabel(operatorLabel.slice("agent:".length)) ?? "Agent",
-      onBehalfOf: friendlyActorLabel(principalLabel),
-    };
-  }
-
-  if (operatorLabel.startsWith("runtime:")) {
-    return {
-      kind: "runtime",
-      label: friendlyOperatorLabel(operatorLabel.slice("runtime:".length)) ?? "Runtime",
-      onBehalfOf: friendlyActorLabel(principalLabel),
-    };
-  }
-
-  if (operatorLabel.startsWith("system:")) {
-    return {
-      kind: "system",
-      label: friendlyOperatorLabel(operatorLabel.slice("system:".length)) ?? "System",
-      onBehalfOf: friendlyActorLabel(principalLabel),
-    };
-  }
-
-  return null;
-}
-
-function splitActorPrincipalOperator(actorLabel: string): [string, string | null] {
-  const separatorIndex = actorLabel.indexOf("/");
-  if (separatorIndex === -1) {
-    return [actorLabel, null];
-  }
-  return [actorLabel.slice(0, separatorIndex), actorLabel.slice(separatorIndex + 1)];
-}
-
-function friendlyActorLabel(actorLabel: string | null | undefined): string | null {
-  const trimmed = actorLabel?.trim();
-  if (!trimmed) return null;
-
-  const lastSegment = trimmed.split(/[/:]/).filter(Boolean).at(-1) ?? trimmed;
-  const decoded = safeDecodeActorSegment(lastSegment);
-  if (decoded.includes("@")) {
-    return decoded;
-  }
-  const knownLabel = knownActorLabel(decoded);
-  if (knownLabel) return knownLabel;
-  return decoded.replace(/[-_]+/g, " ").replace(/\b\w/g, titleCaseChar).trim();
-}
-
-function friendlyOperatorLabel(operatorLabel: string | null | undefined): string | null {
-  const trimmed = operatorLabel?.trim();
-  if (!trimmed) return null;
-
-  const firstSegment = trimmed.split(":").find(Boolean) ?? trimmed;
-  return friendlyActorLabel(firstSegment);
-}
-
-function safeDecodeActorSegment(segment: string): string {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    return segment;
-  }
-}
-
-function titleCaseChar(char: string): string {
-  return char.toUpperCase();
-}
-
-function knownActorLabel(label: string): string | null {
-  switch (label.toLowerCase()) {
-    case "codex":
-      return "Codex";
-    case "jupyterhub":
-      return "JupyterHub";
-    default:
-      return null;
   }
 }
 

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -1,4 +1,13 @@
-import { Bot, Globe2, Laptop, UserRound, UsersRound, type LucideIcon } from "lucide-react";
+import {
+  Bot,
+  Cog,
+  Cpu,
+  Globe2,
+  Laptop,
+  UserRound,
+  UsersRound,
+  type LucideIcon,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Avatar,
@@ -12,7 +21,14 @@ import type {
   NotebookShellAuthCapabilities,
 } from "./capabilities";
 
-export type NotebookActorKind = "agent" | "human" | "local" | "public" | "unknown";
+export type NotebookActorKind =
+  | "agent"
+  | "human"
+  | "local"
+  | "public"
+  | "runtime"
+  | "system"
+  | "unknown";
 
 export interface NotebookActorIdentity {
   id: string;
@@ -41,18 +57,38 @@ export function notebookActorFromAccess(
   access: NotebookShellAccessCapabilities,
   auth?: NotebookShellAuthCapabilities,
 ): NotebookActorIdentity {
-  const agent = parseAgentActorLabel(access.actorLabel);
-  const kind = actorKindFromAccess(access, agent !== null);
+  const parsedLabel = parseNotebookActorLabel(access.actorLabel);
+  const kind = actorKindFromAccess(access, parsedLabel?.kind ?? null);
   const accessLabel = accessLevelLabel(access.level);
   const sourceLabel = accessSourceLabel(access.source);
 
-  if (agent) {
-    const behalfLabel = access.identityLabel ?? agent.onBehalfOf;
+  if (parsedLabel?.kind === "agent") {
+    const behalfLabel = access.identityLabel ?? parsedLabel.onBehalfOf;
     return {
-      id: access.actorLabel ?? agent.agentLabel,
-      label: agent.agentLabel,
+      id: access.actorLabel ?? parsedLabel.label,
+      label: parsedLabel.label,
       detail: behalfLabel ? `on behalf of ${behalfLabel}` : accessLabel,
       kind: "agent",
+      status: auth?.needsAttention ? "attention" : "active",
+    };
+  }
+
+  if (parsedLabel?.kind === "runtime") {
+    return {
+      id: access.actorLabel ?? parsedLabel.label,
+      label: parsedLabel.label,
+      detail: access.identityLabel ? `for ${access.identityLabel}` : accessLabel,
+      kind: "runtime",
+      status: auth?.needsAttention ? "attention" : "active",
+    };
+  }
+
+  if (parsedLabel?.kind === "system") {
+    return {
+      id: access.actorLabel ?? parsedLabel.label,
+      label: parsedLabel.label,
+      detail: access.identityLabel ? `for ${access.identityLabel}` : accessLabel,
+      kind: "system",
       status: auth?.needsAttention ? "attention" : "active",
     };
   }
@@ -190,9 +226,9 @@ function NotebookActorAvatar({
 
 function actorKindFromAccess(
   access: NotebookShellAccessCapabilities,
-  isAgent: boolean,
+  parsedKind: ParsedNotebookActorKind | null,
 ): NotebookActorKind {
-  if (isAgent) return "agent";
+  if (parsedKind) return parsedKind;
   if (access.isPublic) return "public";
   if (access.source === "local") return "local";
   if (access.identityLabel || access.actorLabel) return "human";
@@ -203,6 +239,10 @@ function actorIcon(kind: NotebookActorKind): LucideIcon {
   switch (kind) {
     case "agent":
       return Bot;
+    case "runtime":
+      return Cpu;
+    case "system":
+      return Cog;
     case "local":
       return Laptop;
     case "public":
@@ -218,6 +258,10 @@ function actorTone(kind: NotebookActorKind): string {
   switch (kind) {
     case "agent":
       return "bg-purple-500/10 text-purple-700 dark:text-purple-300";
+    case "runtime":
+      return "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300";
+    case "system":
+      return "bg-zinc-500/10 text-zinc-700 dark:text-zinc-300";
     case "local":
       return "bg-sky-500/10 text-sky-700 dark:text-sky-300";
     case "public":
@@ -242,20 +286,81 @@ function statusTone(status: NonNullable<NotebookActorIdentity["status"]>): strin
   }
 }
 
-function parseAgentActorLabel(actorLabel: string | null): {
-  agentLabel: string;
+type ParsedNotebookActorKind = "agent" | "runtime" | "system";
+
+function parseNotebookActorLabel(actorLabel: string | null): {
+  kind: ParsedNotebookActorKind;
+  label: string;
   onBehalfOf: string | null;
 } | null {
-  if (!actorLabel?.startsWith("agent:")) return null;
+  if (!actorLabel) return null;
 
-  const agentValue = actorLabel.slice("agent:".length);
-  const [rawAgent, rawBehalf] = agentValue.split("/on-behalf-of:");
-  const agentLabel = friendlyActorLabel(rawAgent) ?? "Agent";
+  const [principal, operator] = splitActorPrincipalOperator(actorLabel);
+  const operatorProjection = operator ? parseOperatorLabel(operator, principal) : null;
+  if (operatorProjection) return operatorProjection;
 
-  return {
-    agentLabel,
-    onBehalfOf: friendlyActorLabel(rawBehalf ?? null),
-  };
+  if (principal === "system" && operator) {
+    return {
+      kind: "system",
+      label: friendlyOperatorLabel(operator) ?? "System",
+      onBehalfOf: null,
+    };
+  }
+
+  if (actorLabel.startsWith("agent:")) {
+    const agentValue = actorLabel.slice("agent:".length);
+    const [rawAgent, rawBehalf] = agentValue.split("/on-behalf-of:");
+    return {
+      kind: "agent",
+      label: friendlyActorLabel(rawAgent) ?? "Agent",
+      onBehalfOf: friendlyActorLabel(rawBehalf ?? null),
+    };
+  }
+
+  return parseOperatorLabel(actorLabel, null);
+}
+
+function parseOperatorLabel(
+  operatorLabel: string,
+  principalLabel: string | null,
+): {
+  kind: ParsedNotebookActorKind;
+  label: string;
+  onBehalfOf: string | null;
+} | null {
+  if (operatorLabel.startsWith("agent:")) {
+    return {
+      kind: "agent",
+      label: friendlyOperatorLabel(operatorLabel.slice("agent:".length)) ?? "Agent",
+      onBehalfOf: friendlyActorLabel(principalLabel),
+    };
+  }
+
+  if (operatorLabel.startsWith("runtime:")) {
+    return {
+      kind: "runtime",
+      label: friendlyOperatorLabel(operatorLabel.slice("runtime:".length)) ?? "Runtime",
+      onBehalfOf: friendlyActorLabel(principalLabel),
+    };
+  }
+
+  if (operatorLabel.startsWith("system:")) {
+    return {
+      kind: "system",
+      label: friendlyOperatorLabel(operatorLabel.slice("system:".length)) ?? "System",
+      onBehalfOf: friendlyActorLabel(principalLabel),
+    };
+  }
+
+  return null;
+}
+
+function splitActorPrincipalOperator(actorLabel: string): [string, string | null] {
+  const separatorIndex = actorLabel.indexOf("/");
+  if (separatorIndex === -1) {
+    return [actorLabel, null];
+  }
+  return [actorLabel.slice(0, separatorIndex), actorLabel.slice(separatorIndex + 1)];
 }
 
 function friendlyActorLabel(actorLabel: string | null | undefined): string | null {
@@ -263,10 +368,44 @@ function friendlyActorLabel(actorLabel: string | null | undefined): string | nul
   if (!trimmed) return null;
 
   const lastSegment = trimmed.split(/[/:]/).filter(Boolean).at(-1) ?? trimmed;
-  return lastSegment
-    .replace(/[-_]+/g, " ")
-    .replace(/\b\w/g, (char) => char.toUpperCase())
-    .trim();
+  const decoded = safeDecodeActorSegment(lastSegment);
+  if (decoded.includes("@")) {
+    return decoded;
+  }
+  const knownLabel = knownActorLabel(decoded);
+  if (knownLabel) return knownLabel;
+  return decoded.replace(/[-_]+/g, " ").replace(/\b\w/g, titleCaseChar).trim();
+}
+
+function friendlyOperatorLabel(operatorLabel: string | null | undefined): string | null {
+  const trimmed = operatorLabel?.trim();
+  if (!trimmed) return null;
+
+  const firstSegment = trimmed.split(":").find(Boolean) ?? trimmed;
+  return friendlyActorLabel(firstSegment);
+}
+
+function safeDecodeActorSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function titleCaseChar(char: string): string {
+  return char.toUpperCase();
+}
+
+function knownActorLabel(label: string): string | null {
+  switch (label.toLowerCase()) {
+    case "codex":
+      return "Codex";
+    case "jupyterhub":
+      return "JupyterHub";
+    default:
+      return null;
+  }
 }
 
 function accessLevelLabel(level: NotebookShellAccessCapabilities["level"]): string {

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -40,6 +40,57 @@ describe("NotebookIdentity", () => {
     expect(screen.getByText("on behalf of Kyle")).toBeVisible();
   });
 
+  it("projects durable principal/operator labels for delegated agents", () => {
+    const actor = notebookActorFromAccess({
+      level: "editor",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "user:dev:kyle%40example.com/agent:codex:s1",
+      identityLabel: null,
+    });
+
+    expect(actor.kind).toBe("agent");
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Codex")).toBeVisible();
+    expect(screen.getByText("on behalf of kyle@example.com")).toBeVisible();
+  });
+
+  it("projects durable runtime operators separately from document access", () => {
+    const actor = notebookActorFromAccess({
+      level: "viewer",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+      identityLabel: "Alice",
+    });
+
+    expect(actor.kind).toBe("runtime");
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("JupyterHub")).toBeVisible();
+    expect(screen.getByText("for Alice")).toBeVisible();
+  });
+
+  it("projects durable system operators separately from human identity", () => {
+    const actor = notebookActorFromAccess({
+      level: "viewer",
+      source: "fixture",
+      isPublic: false,
+      actorLabel: "system/schema:notebook:v5",
+      identityLabel: null,
+    });
+
+    expect(actor.kind).toBe("system");
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Schema")).toBeVisible();
+    expect(screen.getByText("Viewer")).toBeVisible();
+  });
+
   it("renders grouped notebook actors with overflow", () => {
     const actors = [
       notebookActorFromAccess(cloudOwnerAccess),

--- a/src/components/notebook-shell/__tests__/actor-labels.test.ts
+++ b/src/components/notebook-shell/__tests__/actor-labels.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  friendlyNotebookActorLabel,
+  parseNotebookActorLabel,
+  splitNotebookActorPrincipalOperator,
+} from "../actor-labels";
+
+describe("notebook actor labels", () => {
+  it("splits durable principal/operator labels without changing either side", () => {
+    expect(
+      splitNotebookActorPrincipalOperator("user:dev:kyle%40example.com/agent:codex:s1"),
+    ).toEqual(["user:dev:kyle%40example.com", "agent:codex:s1"]);
+  });
+
+  it("projects delegated agents with a friendly principal label", () => {
+    expect(parseNotebookActorLabel("user:dev:kyle%40example.com/agent:codex:s1")).toEqual({
+      kind: "agent",
+      label: "Codex",
+      onBehalfOf: "kyle@example.com",
+    });
+  });
+
+  it("projects runtime and system operators independently from document access", () => {
+    expect(parseNotebookActorLabel("user:anaconda:alice/runtime:jupyterhub")).toEqual({
+      kind: "runtime",
+      label: "JupyterHub",
+      onBehalfOf: "Alice",
+    });
+    expect(parseNotebookActorLabel("system/schema:notebook:v5")).toEqual({
+      kind: "system",
+      label: "Schema",
+      onBehalfOf: null,
+    });
+  });
+
+  it("turns raw principals into human-scale labels for presence fallbacks", () => {
+    expect(friendlyNotebookActorLabel("anonymous:viewer:session-a/browser:tab")).toBe("Anonymous");
+    expect(
+      friendlyNotebookActorLabel("user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab"),
+    ).toBe("Anaconda user");
+    expect(friendlyNotebookActorLabel("user:anaconda:alice/browser:tab")).toBe("Alice");
+  });
+});

--- a/src/components/notebook-shell/actor-labels.ts
+++ b/src/components/notebook-shell/actor-labels.ts
@@ -1,0 +1,165 @@
+export type ParsedNotebookActorKind = "agent" | "runtime" | "system";
+
+export interface ParsedNotebookActorLabel {
+  kind: ParsedNotebookActorKind;
+  label: string;
+  onBehalfOf: string | null;
+}
+
+export function parseNotebookActorLabel(
+  actorLabel: string | null | undefined,
+): ParsedNotebookActorLabel | null {
+  if (!actorLabel) return null;
+
+  const [principal, operator] = splitNotebookActorPrincipalOperator(actorLabel);
+  const operatorProjection = operator ? parseNotebookOperatorLabel(operator, principal) : null;
+  if (operatorProjection) return operatorProjection;
+
+  if (principal === "system" && operator) {
+    return {
+      kind: "system",
+      label: friendlyNotebookOperatorLabel(operator) ?? "System",
+      onBehalfOf: null,
+    };
+  }
+
+  if (actorLabel.startsWith("agent:")) {
+    const agentValue = actorLabel.slice("agent:".length);
+    const [rawAgent, rawBehalf] = agentValue.split("/on-behalf-of:");
+    return {
+      kind: "agent",
+      label: friendlyNotebookActorLabel(rawAgent) ?? "Agent",
+      onBehalfOf: friendlyNotebookActorLabel(rawBehalf ?? null),
+    };
+  }
+
+  return parseNotebookOperatorLabel(actorLabel, null);
+}
+
+export function parseNotebookOperatorLabel(
+  operatorLabel: string,
+  principalLabel: string | null,
+): ParsedNotebookActorLabel | null {
+  if (operatorLabel.startsWith("agent:")) {
+    return {
+      kind: "agent",
+      label: friendlyNotebookOperatorLabel(operatorLabel.slice("agent:".length)) ?? "Agent",
+      onBehalfOf: friendlyNotebookActorLabel(principalLabel),
+    };
+  }
+
+  if (operatorLabel.startsWith("runtime:")) {
+    return {
+      kind: "runtime",
+      label: friendlyNotebookOperatorLabel(operatorLabel.slice("runtime:".length)) ?? "Runtime",
+      onBehalfOf: friendlyNotebookActorLabel(principalLabel),
+    };
+  }
+
+  if (operatorLabel.startsWith("system:")) {
+    return {
+      kind: "system",
+      label: friendlyNotebookOperatorLabel(operatorLabel.slice("system:".length)) ?? "System",
+      onBehalfOf: friendlyNotebookActorLabel(principalLabel),
+    };
+  }
+
+  return null;
+}
+
+export function splitNotebookActorPrincipalOperator(
+  actorLabel: string,
+): [principal: string, operator: string | null] {
+  const separatorIndex = actorLabel.indexOf("/");
+  if (separatorIndex === -1) {
+    return [actorLabel, null];
+  }
+  return [actorLabel.slice(0, separatorIndex), actorLabel.slice(separatorIndex + 1)];
+}
+
+export function friendlyNotebookActorLabel(actorLabel: string | null | undefined): string | null {
+  const trimmed = actorLabel?.trim();
+  if (!trimmed) return null;
+
+  const [principal] = splitNotebookActorPrincipalOperator(trimmed);
+
+  if (principal.startsWith("anonymous:")) {
+    return "Anonymous";
+  }
+
+  if (principal.startsWith("user:")) {
+    return friendlyUserPrincipalLabel(principal);
+  }
+
+  if (principal === "system") {
+    return "System";
+  }
+
+  const lastSegment = principal.split(/[/:]/).filter(Boolean).at(-1) ?? principal;
+  return humanizeActorSegment(lastSegment);
+}
+
+export function friendlyNotebookOperatorLabel(
+  operatorLabel: string | null | undefined,
+): string | null {
+  const trimmed = operatorLabel?.trim();
+  if (!trimmed) return null;
+
+  const firstSegment = trimmed.split(":").find(Boolean) ?? trimmed;
+  return friendlyNotebookActorLabel(firstSegment);
+}
+
+function friendlyUserPrincipalLabel(principal: string): string {
+  const parts = principal.split(":");
+  const namespace = parts.slice(0, 2).join(":");
+  const encodedSubject = parts.slice(2).join(":");
+  const subject = safeDecodeActorSegment(encodedSubject);
+  if (!subject) {
+    return namespace === "user:anaconda" ? "Anaconda user" : "User";
+  }
+  if (subject.includes("@")) {
+    return subject;
+  }
+  if (namespace === "user:anaconda" && looksOpaqueSubject(subject)) {
+    return "Anaconda user";
+  }
+
+  return humanizeActorSegment(subject);
+}
+
+function humanizeActorSegment(segment: string): string {
+  const decoded = safeDecodeActorSegment(segment);
+  if (decoded.includes("@")) {
+    return decoded;
+  }
+  const knownLabel = knownActorLabel(decoded);
+  if (knownLabel) return knownLabel;
+  return decoded.replace(/[-_]+/g, " ").replace(/\b\w/g, titleCaseChar).trim();
+}
+
+function safeDecodeActorSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function titleCaseChar(char: string): string {
+  return char.toUpperCase();
+}
+
+function looksOpaqueSubject(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+function knownActorLabel(label: string): string | null {
+  switch (label.toLowerCase()) {
+    case "codex":
+      return "Codex";
+    case "jupyterhub":
+      return "JupyterHub";
+    default:
+      return null;
+  }
+}

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -1,4 +1,13 @@
 export {
+  friendlyNotebookActorLabel,
+  friendlyNotebookOperatorLabel,
+  parseNotebookActorLabel,
+  parseNotebookOperatorLabel,
+  splitNotebookActorPrincipalOperator,
+  type ParsedNotebookActorKind,
+  type ParsedNotebookActorLabel,
+} from "./actor-labels";
+export {
   readOnlyNotebookShellCapabilities,
   type NotebookShellAccessCapabilities,
   type NotebookShellAccessLevel,


### PR DESCRIPTION
## Summary

- add shared durable actor-label projection for principal/operator labels, including runtime, system, and delegated agent operators
- route cloud presence fallbacks and shared identity badges through that shared projection
- add Elements scenarios that pressure-test runtime peer and system schema actors through shared shell examples
- remove the production cloud viewer's prototype theme toggle chrome while keeping resolved theme application intact

## Validation

- `pnpm test:run src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx`
- `pnpm test:run src/components/notebook-shell/__tests__`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

- This keeps cloud moving toward a host adapter for the shared NotebookView shell instead of adding more cloud-specific notebook chrome.
- The theme preference plumbing remains available; this only removes the first-class cloud toggle until the shared settings/header placement is designed.
