### PR TITLE
fix(notebook): reconcile denied source edits

### DIFF
--- a/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
@@ -84,7 +84,7 @@ describe("remoteChangesFromTextAttributions", () => {
 });
 
 describe("createCrdtBridge capability gating", () => {
-  it("blocks outbound editor transactions when the host cannot write", () => {
+  it("reconciles outbound editor transactions when the host cannot write", () => {
     const calls: string[] = [];
     const bridge = createCrdtBridge({
       getHandle: () =>
@@ -93,7 +93,7 @@ describe("createCrdtBridge capability gating", () => {
             calls.push(text);
             return true;
           },
-          get_cell_source: () => "unchanged",
+          get_cell_source: () => "hello",
         }) as never,
       cellId: "cell-a",
       canWriteSource: () => false,
@@ -110,8 +110,57 @@ describe("createCrdtBridge capability gating", () => {
 
     view.dispatch({ changes: { from: 5, insert: "!" } });
 
-    expect(view.state.doc.toString()).toBe("hello!");
+    expect(view.state.doc.toString()).toBe("hello");
     expect(calls).toEqual([]);
+  });
+
+  it("reconciles outbound editor transactions when the handle is unavailable", () => {
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () => null,
+      cellId: "cell-a",
+      onSourceChanged: (source) => calls.push(`store:${source}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridge.extension],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+
+    expect(view.state.doc.toString()).toBe("hello");
+    expect(calls).toEqual([]);
+  });
+
+  it("reconciles to the handle source when a splice is rejected", async () => {
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          splice_source: () => false,
+          get_cell_source: () => "authoritative",
+        }) as never,
+      cellId: "cell-a",
+      onSourceChanged: (source) => calls.push(`store:${source}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridge.extension],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe("authoritative");
+    expect(calls).toEqual(["store:authoritative", "sync"]);
   });
 
   it("blocks imperative source replacement when the host cannot write", () => {

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -27,7 +27,7 @@
  *   // call bridge.destroy() on unmount
  */
 
-import type { ChangeSpec, Extension, Transaction } from "@codemirror/state";
+import { EditorState, type ChangeSpec, type Extension, type Transaction } from "@codemirror/state";
 import {
   type EditorView,
   type PluginValue,
@@ -284,6 +284,14 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
           }
         }
 
+        if (aborted) {
+          const source = handle.get_cell_source(cellId) ?? "";
+          scheduleEditorReconcile(vu.view, source);
+          onSourceChanged(source);
+          onSyncNeeded();
+          return;
+        }
+
         // Read the full source back from WASM for the cell store.
         // This is cheap — single O(n) text read — and keeps the store
         // in sync for non-CM consumers (cell list, find, etc.).
@@ -300,7 +308,31 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
     }
   }
 
-  const plugin = ViewPlugin.fromClass(CrdtBridgePlugin);
+  const outboundGuard = EditorState.transactionFilter.of((tr) => {
+    if (!tr.docChanged || isReconcileTx(tr)) return tr;
+    if (!canWriteSource()) return [];
+    if (!getHandle()) return [];
+    return tr;
+  });
+
+  const plugin = [outboundGuard, ViewPlugin.fromClass(CrdtBridgePlugin)];
+
+  function scheduleEditorReconcile(view: EditorView, source: string): void {
+    queueMicrotask(() => reconcileEditorToSource(view, source));
+  }
+
+  function reconcileEditorToSource(view: EditorView, source: string): void {
+    const currentSource = view.state.doc.toString();
+    if (currentSource === source) return;
+    view.dispatch({
+      changes: {
+        from: 0,
+        to: view.state.doc.length,
+        insert: source,
+      },
+      annotations: externalChangeAnnotation.of(true),
+    });
+  }
 
   // ── Inbound methods ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- blocks local CodeMirror source transactions before they apply when the host capability gate denies writes or the Automerge handle is unavailable
- reconciles the editor back to the WASM source if an accepted splice is rejected by the handle
- expands CRDT bridge tests around read-only/viewer mutation safety

## Stack

Depends on #3247. Merge #3247 first, then retarget this PR to `main`.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts`
- `pnpm test:run apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/collaborator-auth.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
