### PR TITLE
feat(notebook): structure actor projections

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -8,7 +8,7 @@ import {
   NotebookIdentityBadge,
   NotebookIdentityGroup,
   NotebookDocumentHeader,
-  notebookActorFromAccess,
+  notebookActorIdentityFromAccess,
   type NotebookActorIdentity,
 } from "@/components/notebook-shell";
 import { cn } from "@/lib/utils";
@@ -260,7 +260,7 @@ function Fact({ label, value }: { label: string; value: string }) {
 }
 
 function scenarioActor(scenario: ElementsNotebookScenario): NotebookActorIdentity {
-  return notebookActorFromAccess(scenario.capabilities.access, scenario.capabilities.auth);
+  return notebookActorIdentityFromAccess(scenario.capabilities.access, scenario.capabilities.auth);
 }
 
 function syncLabel(scenario: ElementsNotebookScenario): string {

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -2,6 +2,8 @@ import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import {
   createNotebookViewModel,
+  notebookActorProjectionFromAccess,
+  notebookActorProjectionFromRuntime,
   type NotebookShellCapabilities,
   type NotebookViewCell,
   type NotebookViewModel,
@@ -919,12 +921,28 @@ function createScenario({
   packageSummary: string;
   capabilities: NotebookShellCapabilities;
 }): ElementsNotebookScenario {
+  const projectedCapabilities: NotebookShellCapabilities = {
+    ...capabilities,
+    access: {
+      ...capabilities.access,
+      actor:
+        capabilities.access.actor ??
+        notebookActorProjectionFromAccess(capabilities.access, capabilities.auth),
+    },
+    runtime: {
+      ...capabilities.runtime,
+      actor:
+        capabilities.runtime.actor ??
+        notebookActorProjectionFromRuntime(capabilities.runtime, capabilities.auth),
+    },
+  };
+
   return {
     id,
     title,
     eyebrow,
     summary,
-    capabilities,
+    capabilities: projectedCapabilities,
     cells: notebookCells,
     viewModel,
     runtimeLabel,

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -35,6 +35,9 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.access.level, "viewer");
   assert.equal(capabilities.access.source, "cloud");
   assert.equal(capabilities.access.isPublic, true);
+  assert.equal(capabilities.access.actor?.principal.label, "Public viewer");
+  assert.equal(capabilities.access.actor?.principal.source?.provider, "anonymous");
+  assert.equal(capabilities.access.actor?.operator.kind, "browser");
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
@@ -54,6 +57,9 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
   assert.equal(capabilities.canManagePackages, false);
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.access.identityLabel, "user@example.test");
+  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.access.actor?.principal.source?.provider, "oidc");
+  assert.equal(capabilities.access.actor?.operator.kind, "browser");
   assert.equal(capabilities.auth.canUseAuthenticatedIdentity, true);
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
@@ -134,6 +140,8 @@ test("cloud shell capabilities preserve room actor labels for shared access UI",
   assert.equal(capabilities.access.level, "owner");
   assert.equal(capabilities.access.actorLabel, "user:anaconda:alice/browser:tab");
   assert.equal(capabilities.access.identityLabel, "user@example.test");
+  assert.equal(capabilities.access.actor?.actorLabel, "user:anaconda:alice/browser:tab");
+  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
 });
 
 test("cloud shell capabilities keep runtime peer authority separate from document access", () => {
@@ -154,4 +162,8 @@ test("cloud shell capabilities keep runtime peer authority separate from documen
   assert.equal(capabilities.runtime.source, "cloud");
   assert.equal(capabilities.runtime.actorLabel, "user:anaconda:alice/runtime:jupyterhub");
   assert.equal(capabilities.runtime.identityLabel, "user@example.test");
+  assert.equal(capabilities.runtime.actor?.scope, "runtime_peer");
+  assert.equal(capabilities.runtime.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.runtime.actor?.operator.kind, "runtime");
+  assert.equal(capabilities.runtime.actor?.operator.label, "JupyterHub");
 });

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -1,4 +1,8 @@
-import type { NotebookShellCapabilities } from "@/components/notebook-shell";
+import {
+  notebookActorProjectionFromAccess,
+  notebookActorProjectionFromRuntime,
+} from "@/components/notebook-shell/actor-projection";
+import type { NotebookShellCapabilities } from "@/components/notebook-shell/capabilities";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 export interface CloudNotebookShellCapabilityInput {
@@ -22,6 +26,25 @@ export function cloudNotebookShellCapabilities({
   const canEditCells = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
+  const auth = {
+    canSignIn: authState.mode !== "oidc",
+    canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
+    needsAttention: authNeedsAttention,
+  };
+  const access = {
+    level: accessLevel,
+    source: "cloud" as const,
+    isPublic: !authenticated && accessLevel === "viewer",
+    actorLabel: connectionActorLabel,
+    identityLabel: authState.user,
+  };
+  const runtime = {
+    canWriteRuntimeState: isRuntimePeer,
+    connected: isRuntimePeer,
+    source: "cloud" as const,
+    actorLabel: isRuntimePeer ? connectionActorLabel : null,
+    identityLabel: isRuntimePeer ? authState.user : null,
+  };
 
   return {
     canRead: true,
@@ -35,23 +58,13 @@ export function cloudNotebookShellCapabilities({
     canManagePackages: false,
     canManageSharing: connectionScope === "owner",
     access: {
-      level: accessLevel,
-      source: "cloud",
-      isPublic: !authenticated && accessLevel === "viewer",
-      actorLabel: connectionActorLabel,
-      identityLabel: authState.user,
+      ...access,
+      actor: notebookActorProjectionFromAccess(access, auth),
     },
-    auth: {
-      canSignIn: authState.mode !== "oidc",
-      canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
-      needsAttention: authNeedsAttention,
-    },
+    auth,
     runtime: {
-      canWriteRuntimeState: isRuntimePeer,
-      connected: isRuntimePeer,
-      source: "cloud",
-      actorLabel: isRuntimePeer ? connectionActorLabel : null,
-      identityLabel: isRuntimePeer ? authState.user : null,
+      ...runtime,
+      actor: notebookActorProjectionFromRuntime(runtime, auth),
     },
   };
 }

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -27,6 +27,19 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "local",
       actorLabel: "local:kyle/desktop:window",
     });
+    expect(capabilities.access.actor).toMatchObject({
+      principal: {
+        label: "Kyle",
+        source: { provider: "local", namespace: "kyle" },
+      },
+      operator: { kind: "desktop" },
+      scope: "owner",
+    });
+    expect(capabilities.runtime.actor).toMatchObject({
+      principal: { label: "Kyle" },
+      operator: { kind: "desktop" },
+      scope: "runtime_peer",
+    });
   });
 
   it("maps cloud viewer scope in desktop to read-only shell access", () => {
@@ -54,6 +67,15 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "cloud",
       actorLabel: null,
     });
+    expect(capabilities.access.actor).toMatchObject({
+      principal: {
+        label: "Alice",
+        source: { provider: "oidc", namespace: "anaconda" },
+      },
+      operator: { kind: "desktop" },
+      scope: "viewer",
+    });
+    expect(capabilities.runtime.actor).toBeNull();
   });
 
   it("keeps desktop editing disabled until local Automerge mutations are accepted", () => {
@@ -89,6 +111,11 @@ describe("desktopNotebookShellCapabilities", () => {
       connected: true,
       source: "cloud",
       actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+    });
+    expect(capabilities.runtime.actor).toMatchObject({
+      principal: { label: "Alice" },
+      operator: { kind: "runtime", label: "JupyterHub" },
+      scope: "runtime_peer",
     });
   });
 });

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -1,8 +1,12 @@
+import {
+  notebookActorProjectionFromAccess,
+  notebookActorProjectionFromRuntime,
+} from "@/components/notebook-shell/actor-projection";
 import type {
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
   NotebookShellCapabilities,
-} from "@/components/notebook-shell";
+} from "@/components/notebook-shell/capabilities";
 
 export interface DesktopNotebookShellCapabilityInput {
   canAcceptCellMutations: boolean;
@@ -24,6 +28,20 @@ export function desktopNotebookShellCapabilities({
     canAcceptCellMutations && (accessLevel === "editor" || accessLevel === "owner");
   const canWriteRuntimeState =
     sessionReady && (isRuntimePeer || (source === "local" && canWriteDocument));
+  const access = {
+    level: accessLevel,
+    source,
+    isPublic: false,
+    actorLabel: localActor,
+    identityLabel: null,
+  };
+  const runtime = {
+    canWriteRuntimeState,
+    connected: sessionReady && (source === "local" || isRuntimePeer),
+    source,
+    actorLabel: canWriteRuntimeState ? localActor : null,
+    identityLabel: null,
+  };
 
   return {
     canRead: accessLevel !== "none",
@@ -37,11 +55,8 @@ export function desktopNotebookShellCapabilities({
     canManagePackages: canWriteDocument,
     canManageSharing: accessLevel === "owner" && source === "cloud",
     access: {
-      level: accessLevel,
-      source,
-      isPublic: false,
-      actorLabel: localActor,
-      identityLabel: localActor,
+      ...access,
+      actor: notebookActorProjectionFromAccess(access),
     },
     auth: {
       canSignIn: false,
@@ -49,11 +64,8 @@ export function desktopNotebookShellCapabilities({
       needsAttention: false,
     },
     runtime: {
-      canWriteRuntimeState,
-      connected: sessionReady && (source === "local" || isRuntimePeer),
-      source,
-      actorLabel: canWriteRuntimeState ? localActor : null,
-      identityLabel: canWriteRuntimeState ? localActor : null,
+      ...runtime,
+      actor: notebookActorProjectionFromRuntime(runtime),
     },
   };
 }

--- a/docs/architecture/notebook-identity-environment-surfaces.md
+++ b/docs/architecture/notebook-identity-environment-surfaces.md
@@ -125,6 +125,10 @@ Elements and production host adapters should cover these states first:
 2. Raw actor-label parsing is transitional compatibility input for current
    adapters only. The target projection carries the verified principal,
    accepted operator, and display metadata as structured host-owned facts.
+   `NotebookShellCapabilities.access.actor` and
+   `NotebookShellCapabilities.runtime.actor` carry this projection today;
+   fallback helpers may parse durable labels while hosts grow richer profile
+   data.
 3. The actor projection must let UI derive human, local, public, agent,
    runtime, system, and unknown actor presentations from principal source plus
    operator kind.

--- a/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
+++ b/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle2, Lock, Package, RefreshCw, Server, ShieldAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { friendlyNotebookActorLabel, parseNotebookActorLabel } from "./actor-labels";
+import { notebookActorIdentityFromRuntime } from "./actor-projection";
 import type { NotebookShellCapabilities } from "./capabilities";
 import type { NotebookPackageViewModel } from "./view-model";
 
@@ -31,11 +31,9 @@ export function NotebookEnvironmentSummary({
       : "Package metadata hidden";
   const runtimeStateLabel =
     runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
-  const runtimeActorLabel =
-    parseNotebookActorLabel(capabilities.runtime.actorLabel)?.label ??
-    friendlyNotebookActorLabel(capabilities.runtime.actorLabel);
+  const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
   const runtimeDetail = capabilities.runtime.canWriteRuntimeState
-    ? `Runtime author: ${runtimeActorLabel ?? "connected runtime"}`
+    ? `Runtime author: ${runtimeActor?.label ?? "connected runtime"}`
     : capabilities.runtime.connected
       ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
       : null;

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -16,33 +16,12 @@ import {
   AvatarGroup,
   AvatarImage,
 } from "@/components/ui/avatar";
-import type {
-  NotebookShellAccessCapabilities,
-  NotebookShellAuthCapabilities,
-} from "./capabilities";
-import {
-  friendlyNotebookActorLabel,
-  parseNotebookActorLabel,
-  type ParsedNotebookActorKind,
-} from "./actor-labels";
-
-export type NotebookActorKind =
-  | "agent"
-  | "human"
-  | "local"
-  | "public"
-  | "runtime"
-  | "system"
-  | "unknown";
-
-export interface NotebookActorIdentity {
-  id: string;
-  label: string;
-  detail: string | null;
-  kind: NotebookActorKind;
-  imageUrl?: string | null;
-  status?: "active" | "attention" | "idle" | "offline";
-}
+import type { NotebookActorIdentity, NotebookActorKind } from "./capabilities";
+export {
+  notebookActorIdentityFromAccess,
+  notebookActorIdentityFromProjection,
+  notebookActorIdentityFromRuntime,
+} from "./actor-projection";
 
 export interface NotebookIdentityBadgeProps {
   actor: NotebookActorIdentity;
@@ -56,70 +35,6 @@ export interface NotebookIdentityGroupProps {
   maxVisible?: number;
   label?: string;
   className?: string;
-}
-
-export function notebookActorFromAccess(
-  access: NotebookShellAccessCapabilities,
-  auth?: NotebookShellAuthCapabilities,
-): NotebookActorIdentity {
-  const parsedLabel = parseNotebookActorLabel(access.actorLabel);
-  const kind = actorKindFromAccess(access, parsedLabel?.kind ?? null);
-  const accessLabel = accessLevelLabel(access.level);
-  const sourceLabel = accessSourceLabel(access.source);
-
-  if (parsedLabel?.kind === "agent") {
-    const behalfLabel = access.identityLabel ?? parsedLabel.onBehalfOf;
-    return {
-      id: access.actorLabel ?? parsedLabel.label,
-      label: parsedLabel.label,
-      detail: behalfLabel ? `on behalf of ${behalfLabel}` : accessLabel,
-      kind: "agent",
-      status: auth?.needsAttention ? "attention" : "active",
-    };
-  }
-
-  if (parsedLabel?.kind === "runtime") {
-    return {
-      id: access.actorLabel ?? parsedLabel.label,
-      label: parsedLabel.label,
-      detail: access.identityLabel ? `for ${access.identityLabel}` : accessLabel,
-      kind: "runtime",
-      status: auth?.needsAttention ? "attention" : "active",
-    };
-  }
-
-  if (parsedLabel?.kind === "system") {
-    return {
-      id: access.actorLabel ?? parsedLabel.label,
-      label: parsedLabel.label,
-      detail: access.identityLabel ? `for ${access.identityLabel}` : accessLabel,
-      kind: "system",
-      status: auth?.needsAttention ? "attention" : "active",
-    };
-  }
-
-  if (access.isPublic) {
-    return {
-      id: access.actorLabel ?? "public-viewer",
-      label: access.identityLabel ?? "Public viewer",
-      detail: accessLabel,
-      kind: "public",
-      status: auth?.needsAttention ? "attention" : "active",
-    };
-  }
-
-  const label =
-    access.identityLabel ?? friendlyNotebookActorLabel(access.actorLabel) ?? "Unknown viewer";
-  const detail =
-    sourceLabel === null ? accessLabel : `${accessLabel.toLowerCase()} through ${sourceLabel}`;
-
-  return {
-    id: access.actorLabel ?? label,
-    label,
-    detail,
-    kind,
-    status: auth?.needsAttention ? "attention" : "active",
-  };
 }
 
 export function NotebookIdentityBadge({
@@ -230,17 +145,6 @@ function NotebookActorAvatar({
   );
 }
 
-function actorKindFromAccess(
-  access: NotebookShellAccessCapabilities,
-  parsedKind: ParsedNotebookActorKind | null,
-): NotebookActorKind {
-  if (parsedKind) return parsedKind;
-  if (access.isPublic) return "public";
-  if (access.source === "local") return "local";
-  if (access.identityLabel || access.actorLabel) return "human";
-  return "unknown";
-}
-
 function actorIcon(kind: NotebookActorKind): LucideIcon {
   switch (kind) {
     case "agent":
@@ -289,32 +193,6 @@ function statusTone(status: NonNullable<NotebookActorIdentity["status"]>): strin
       return "bg-muted-foreground";
     case "offline":
       return "bg-muted";
-  }
-}
-
-function accessLevelLabel(level: NotebookShellAccessCapabilities["level"]): string {
-  switch (level) {
-    case "none":
-      return "No access";
-    case "viewer":
-      return "Viewer";
-    case "editor":
-      return "Editor";
-    case "owner":
-      return "Owner";
-  }
-}
-
-function accessSourceLabel(source: NotebookShellAccessCapabilities["source"]): string | null {
-  switch (source) {
-    case "cloud":
-      return "cloud";
-    case "local":
-      return "local";
-    case "fixture":
-      return "fixture";
-    case "unknown":
-      return null;
   }
 }
 

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   NotebookIdentityBadge,
   NotebookIdentityGroup,
-  notebookActorFromAccess,
+  notebookActorIdentityFromAccess,
 } from "../NotebookIdentity";
 import type { NotebookShellCapabilities } from "../capabilities";
 
@@ -17,16 +17,16 @@ const cloudOwnerAccess: NotebookShellCapabilities["access"] = {
 
 describe("NotebookIdentity", () => {
   it("projects cloud access into a human identity badge", () => {
-    const actor = notebookActorFromAccess(cloudOwnerAccess);
+    const actor = notebookActorIdentityFromAccess(cloudOwnerAccess);
 
     render(<NotebookIdentityBadge actor={actor} />);
 
     expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getByText("owner through cloud")).toBeVisible();
+    expect(screen.getByText("Owner")).toBeVisible();
   });
 
-  it("projects agent access as acting on behalf of an identity", () => {
-    const actor = notebookActorFromAccess({
+  it("projects agent access as acting for an identity", () => {
+    const actor = notebookActorIdentityFromAccess({
       level: "editor",
       source: "cloud",
       isPublic: false,
@@ -37,11 +37,11 @@ describe("NotebookIdentity", () => {
     render(<NotebookIdentityBadge actor={actor} />);
 
     expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("on behalf of Kyle")).toBeVisible();
+    expect(screen.getByText("for Kyle")).toBeVisible();
   });
 
   it("projects durable principal/operator labels for delegated agents", () => {
-    const actor = notebookActorFromAccess({
+    const actor = notebookActorIdentityFromAccess({
       level: "editor",
       source: "cloud",
       isPublic: false,
@@ -54,11 +54,43 @@ describe("NotebookIdentity", () => {
     render(<NotebookIdentityBadge actor={actor} />);
 
     expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("on behalf of kyle@example.com")).toBeVisible();
+    expect(screen.getByText("for kyle@example.com")).toBeVisible();
+  });
+
+  it("prefers structured actor projections over durable label fallback", () => {
+    const actor = notebookActorIdentityFromAccess({
+      level: "editor",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "user:anaconda:opaque/browser:tab",
+      identityLabel: null,
+      actor: {
+        actorLabel: "user:anaconda:opaque/browser:tab",
+        principal: {
+          id: "user:anaconda:opaque",
+          label: "Alice Appleseed",
+          source: { provider: "oidc", namespace: "anaconda" },
+        },
+        operator: {
+          id: "browser:tab",
+          kind: "browser",
+          label: "Browser",
+        },
+        scope: "editor",
+      },
+    });
+
+    expect(actor.id).toBe("user:anaconda:opaque/browser:tab");
+    expect(actor.principalLabel).toBe("Alice Appleseed");
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Alice Appleseed")).toBeVisible();
+    expect(screen.queryByText("Anaconda user")).toBeNull();
   });
 
   it("projects durable runtime operators separately from document access", () => {
-    const actor = notebookActorFromAccess({
+    const actor = notebookActorIdentityFromAccess({
       level: "viewer",
       source: "cloud",
       isPublic: false,
@@ -75,7 +107,7 @@ describe("NotebookIdentity", () => {
   });
 
   it("projects durable system operators separately from human identity", () => {
-    const actor = notebookActorFromAccess({
+    const actor = notebookActorIdentityFromAccess({
       level: "viewer",
       source: "fixture",
       isPublic: false,
@@ -93,15 +125,15 @@ describe("NotebookIdentity", () => {
 
   it("renders grouped notebook actors with overflow", () => {
     const actors = [
-      notebookActorFromAccess(cloudOwnerAccess),
-      notebookActorFromAccess({
+      notebookActorIdentityFromAccess(cloudOwnerAccess),
+      notebookActorIdentityFromAccess({
         level: "viewer",
         source: "cloud",
         isPublic: true,
         actorLabel: "public viewer",
         identityLabel: null,
       }),
-      notebookActorFromAccess({
+      notebookActorIdentityFromAccess({
         level: "editor",
         source: "local",
         isPublic: false,

--- a/src/components/notebook-shell/actor-projection.ts
+++ b/src/components/notebook-shell/actor-projection.ts
@@ -1,0 +1,264 @@
+import {
+  friendlyNotebookActorLabel,
+  friendlyNotebookOperatorLabel,
+  parseNotebookActorLabel,
+  parseNotebookOperatorLabel,
+  splitNotebookActorPrincipalOperator,
+} from "./actor-labels";
+import type {
+  NotebookActorIdentity,
+  NotebookActorKind,
+  NotebookActorOperator,
+  NotebookActorPrincipal,
+  NotebookActorProjection,
+  NotebookShellAccessCapabilities,
+  NotebookShellAuthCapabilities,
+  NotebookShellRuntimeCapabilities,
+} from "./capabilities";
+
+export function notebookActorProjectionFromAccess(
+  access: NotebookShellAccessCapabilities,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorProjection {
+  if (access.actor) {
+    return withAuthStatus(access.actor, auth);
+  }
+
+  const actorLabel = access.actorLabel ?? fallbackActorLabelForAccess(access);
+  const [principalId, operatorId] = splitNotebookActorPrincipalOperator(actorLabel);
+  const legacyProjection = parseNotebookActorLabel(access.actorLabel);
+  const operator = operatorFromLabel(operatorId, access.source);
+  const principalLabel =
+    access.identityLabel ??
+    legacyProjection?.onBehalfOf ??
+    friendlyNotebookActorLabel(principalId) ??
+    (access.isPublic ? "Public viewer" : "Unknown viewer");
+
+  return withAuthStatus(
+    {
+      actorLabel,
+      principal: {
+        id: principalId,
+        label: access.isPublic ? "Public viewer" : principalLabel,
+        source: principalSource(principalId, access.source, access.isPublic),
+      },
+      operator:
+        legacyProjection && (isLegacyAgentLabel(actorLabel) || !operatorId)
+          ? legacyOperatorFromProjection(actorLabel, legacyProjection)
+          : operator,
+      scope: access.level === "none" ? undefined : access.level,
+    },
+    auth,
+  );
+}
+
+export function notebookActorProjectionFromRuntime(
+  runtime: NotebookShellRuntimeCapabilities,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorProjection | null {
+  if (runtime.actor) {
+    return withAuthStatus(runtime.actor, auth);
+  }
+
+  if (!runtime.connected && !runtime.actorLabel) {
+    return null;
+  }
+
+  const actorLabel = runtime.actorLabel ?? fallbackActorLabelForRuntime(runtime);
+  const [principalId, operatorId] = splitNotebookActorPrincipalOperator(actorLabel);
+  const principalLabel =
+    runtime.identityLabel ?? friendlyNotebookActorLabel(principalId) ?? "Runtime principal";
+
+  return withAuthStatus(
+    {
+      actorLabel,
+      principal: {
+        id: principalId,
+        label: principalLabel,
+        source: principalSource(principalId, runtime.source, false),
+      },
+      operator: operatorFromLabel(operatorId, runtime.source, "runtime"),
+      scope: runtime.canWriteRuntimeState ? "runtime_peer" : undefined,
+    },
+    auth,
+  );
+}
+
+export function notebookActorIdentityFromProjection(
+  actor: NotebookActorProjection,
+): NotebookActorIdentity {
+  const kind = actorKindFromProjection(actor);
+  const detail = actorDetailFromProjection(actor, kind);
+
+  return {
+    id: actor.actorLabel,
+    label: actorLabelFromProjection(actor, kind),
+    detail,
+    kind,
+    imageUrl: actor.principal.imageUrl,
+    status: actor.status ?? "active",
+    principalLabel: actor.principal.label,
+    operatorLabel: actor.operator.label,
+  };
+}
+
+export function notebookActorIdentityFromAccess(
+  access: NotebookShellAccessCapabilities,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorIdentity {
+  return notebookActorIdentityFromProjection(notebookActorProjectionFromAccess(access, auth));
+}
+
+export function notebookActorIdentityFromRuntime(
+  runtime: NotebookShellRuntimeCapabilities,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorIdentity | null {
+  const projection = notebookActorProjectionFromRuntime(runtime, auth);
+  return projection ? notebookActorIdentityFromProjection(projection) : null;
+}
+
+function withAuthStatus(
+  actor: NotebookActorProjection,
+  auth?: NotebookShellAuthCapabilities,
+): NotebookActorProjection {
+  return {
+    ...actor,
+    status: auth?.needsAttention ? "attention" : (actor.status ?? "active"),
+  };
+}
+
+function fallbackActorLabelForAccess(access: NotebookShellAccessCapabilities): string {
+  if (access.isPublic) return "anonymous:public/browser:viewer";
+  if (access.source === "local") return "local:desktop/desktop:app";
+  return "unknown:viewer/browser:viewer";
+}
+
+function fallbackActorLabelForRuntime(runtime: NotebookShellRuntimeCapabilities): string {
+  if (runtime.source === "local") return "local:desktop/runtime:local";
+  return "unknown:runtime/runtime:unknown";
+}
+
+function operatorFromLabel(
+  operatorId: string | null,
+  source: NotebookShellAccessCapabilities["source"],
+  fallbackKind?: string,
+): NotebookActorOperator {
+  const id = operatorId ?? fallbackOperatorId(source, fallbackKind);
+  const kind = id.split(":").find(Boolean) ?? fallbackKind ?? "unknown";
+  const parsedOperator = parseNotebookOperatorLabel(id, null);
+
+  return {
+    id,
+    kind,
+    label:
+      parsedOperator?.label ?? friendlyNotebookOperatorLabel(id) ?? friendlyOperatorKindLabel(kind),
+  };
+}
+
+function legacyOperatorFromProjection(
+  actorLabel: string,
+  projection: NonNullable<ReturnType<typeof parseNotebookActorLabel>>,
+): NotebookActorOperator {
+  return {
+    id: actorLabel,
+    kind: projection.kind,
+    label: projection.label,
+  };
+}
+
+function isLegacyAgentLabel(actorLabel: string): boolean {
+  return actorLabel.startsWith("agent:");
+}
+
+function fallbackOperatorId(
+  source: NotebookShellAccessCapabilities["source"],
+  fallbackKind?: string,
+): string {
+  if (fallbackKind) return `${fallbackKind}:unknown`;
+  if (source === "local") return "desktop:app";
+  if (source === "cloud") return "browser:viewer";
+  return "unknown:viewer";
+}
+
+function principalSource(
+  principalId: string,
+  source: NotebookShellAccessCapabilities["source"],
+  isPublic: boolean,
+): NotebookActorPrincipal["source"] {
+  if (isPublic || principalId.startsWith("anonymous:")) {
+    return { provider: "anonymous", namespace: "public" };
+  }
+  if (principalId.startsWith("local:")) {
+    return { provider: "local", namespace: principalId.split(":")[1] ?? "desktop" };
+  }
+  if (principalId.startsWith("user:anaconda:")) {
+    return { provider: "oidc", namespace: "anaconda" };
+  }
+  if (principalId.startsWith("hub:")) {
+    return { provider: "jupyterhub", namespace: principalId.split(":")[1] ?? "hub" };
+  }
+  if (source === "cloud") {
+    return { provider: "oidc", namespace: "cloud" };
+  }
+  if (source === "local") {
+    return { provider: "local", namespace: "desktop" };
+  }
+  return undefined;
+}
+
+function actorKindFromProjection(actor: NotebookActorProjection): NotebookActorKind {
+  if (actor.operator.kind === "agent") return "agent";
+  if (actor.operator.kind === "runtime") return "runtime";
+  if (actor.operator.kind === "system" || actor.principal.id === "system") return "system";
+  if (actor.principal.source?.provider === "anonymous") return "public";
+  if (actor.principal.source?.provider === "local") return "local";
+  if (actor.principal.id || actor.principal.label) return "human";
+  return "unknown";
+}
+
+function actorLabelFromProjection(actor: NotebookActorProjection, kind: NotebookActorKind): string {
+  const parsed = parseNotebookActorLabel(actor.actorLabel);
+  if (parsed && (kind === "agent" || kind === "runtime" || kind === "system")) {
+    return parsed.label;
+  }
+  if (kind === "agent" || kind === "runtime" || kind === "system") {
+    return actor.operator.label;
+  }
+  return actor.principal.label;
+}
+
+function actorDetailFromProjection(
+  actor: NotebookActorProjection,
+  kind: NotebookActorKind,
+): string | null {
+  const parsed = parseNotebookActorLabel(actor.actorLabel);
+  if (kind === "agent" || kind === "runtime" || kind === "system") {
+    const principalLabel = parsed?.onBehalfOf ?? actor.principal.label;
+    return kind === "system" && !parsed?.onBehalfOf
+      ? accessScopeLabel(actor.scope)
+      : `for ${principalLabel}`;
+  }
+  return accessScopeLabel(actor.scope);
+}
+
+function accessScopeLabel(scope: NotebookActorProjection["scope"]): string | null {
+  switch (scope) {
+    case "viewer":
+      return "Viewer";
+    case "editor":
+      return "Editor";
+    case "owner":
+      return "Owner";
+    case "runtime_peer":
+      return "Runtime peer";
+    case undefined:
+      return null;
+  }
+}
+
+function friendlyOperatorKindLabel(kind: string): string {
+  const parsed = parseNotebookActorLabel(`${kind}:unknown`);
+  return (
+    parsed?.label ?? kind.replace(/[-_]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
+  );
+}

--- a/src/components/notebook-shell/capabilities.ts
+++ b/src/components/notebook-shell/capabilities.ts
@@ -2,6 +2,58 @@ export type NotebookShellAccessLevel = "none" | "viewer" | "editor" | "owner";
 
 export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown";
 
+export type NotebookActorSourceProvider =
+  | "anonymous"
+  | "anaconda-api-key"
+  | "dev"
+  | "jupyterhub"
+  | "local"
+  | "oidc";
+
+export interface NotebookActorPrincipal {
+  id: string;
+  label: string;
+  imageUrl?: string | null;
+  source?: {
+    provider: NotebookActorSourceProvider;
+    namespace: string;
+  };
+}
+
+export interface NotebookActorOperator {
+  id: string;
+  kind: string;
+  label: string;
+}
+
+export interface NotebookActorProjection {
+  actorLabel: string;
+  principal: NotebookActorPrincipal;
+  operator: NotebookActorOperator;
+  scope?: "viewer" | "editor" | "runtime_peer" | "owner";
+  status?: "active" | "attention" | "idle" | "offline";
+}
+
+export type NotebookActorKind =
+  | "agent"
+  | "human"
+  | "local"
+  | "public"
+  | "runtime"
+  | "system"
+  | "unknown";
+
+export interface NotebookActorIdentity {
+  id: string;
+  label: string;
+  detail: string | null;
+  kind: NotebookActorKind;
+  imageUrl?: string | null;
+  status?: "active" | "attention" | "idle" | "offline";
+  principalLabel?: string | null;
+  operatorLabel?: string | null;
+}
+
 export interface NotebookShellAccessCapabilities {
   /**
    * The document-level access granted to the current identity. Hosts derive
@@ -12,6 +64,12 @@ export interface NotebookShellAccessCapabilities {
   isPublic: boolean;
   actorLabel: string | null;
   identityLabel: string | null;
+  /**
+   * Structured host-owned actor projection. Durable actor labels remain the
+   * backend/CRDT attribution source; React falls back to parsing them only
+   * while hosts are still adopting this source-shaped projection.
+   */
+  actor?: NotebookActorProjection | null;
 }
 
 export interface NotebookShellAuthCapabilities {
@@ -31,6 +89,7 @@ export interface NotebookShellRuntimeCapabilities {
   source: NotebookShellAccessSource;
   actorLabel: string | null;
   identityLabel: string | null;
+  actor?: NotebookActorProjection | null;
 }
 
 export interface NotebookShellCapabilities {

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -8,7 +8,20 @@ export {
   type ParsedNotebookActorLabel,
 } from "./actor-labels";
 export {
+  notebookActorIdentityFromAccess,
+  notebookActorIdentityFromProjection,
+  notebookActorIdentityFromRuntime,
+  notebookActorProjectionFromAccess,
+  notebookActorProjectionFromRuntime,
+} from "./actor-projection";
+export {
   readOnlyNotebookShellCapabilities,
+  type NotebookActorIdentity,
+  type NotebookActorKind,
+  type NotebookActorOperator,
+  type NotebookActorPrincipal,
+  type NotebookActorProjection,
+  type NotebookActorSourceProvider,
   type NotebookShellAccessCapabilities,
   type NotebookShellAccessLevel,
   type NotebookShellAccessSource,
@@ -21,9 +34,6 @@ export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./Note
 export {
   NotebookIdentityBadge,
   NotebookIdentityGroup,
-  notebookActorFromAccess,
-  type NotebookActorIdentity,
-  type NotebookActorKind,
   type NotebookIdentityBadgeProps,
   type NotebookIdentityGroupProps,
 } from "./NotebookIdentity";


### PR DESCRIPTION
## Summary

- add structured `NotebookActorIdentity` projections to shared notebook shell capabilities
- move durable actor-label parsing out of React components into shared `actor-projection` helpers
- wire desktop, cloud, and Elements scenario adapters to provide access/runtime actor projections
- keep raw durable actor labels available for backend/CRDT attribution while UI reads structured labels first

## Notes

This follows #3249 by keeping runtime peer authorship separate from document access, then making the UI-facing actor projection explicit in `NotebookShellCapabilities`.

## Verification

- `pnpm test:run src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
