### PR TITLE
fix(notebook): align compact code cell placeholder

### DIFF
--- a/apps/notebook/e2e/code-cell-placeholder-layout.spec.ts
+++ b/apps/notebook/e2e/code-cell-placeholder-layout.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { openNotebookRoom, waitForCellCount } from "./helpers";
+
+test.describe("code cell placeholder layout", () => {
+  test("keeps the empty placeholder aligned in a compact viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 624, height: 540 });
+    await openNotebookRoom(page, crypto.randomUUID());
+    await waitForCellCount(page, 1);
+
+    const cell = page.locator('[data-cell-type="code"]').first();
+    const metrics = await cell.evaluate((cellElement) => {
+      const rectFor = (selector: string) => {
+        const element = cellElement.querySelector(selector);
+        if (!element) throw new Error(`Missing ${selector}`);
+
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return {
+          centerY: (rect.top + rect.bottom) / 2,
+          height: rect.height,
+          marginTop: style.marginTop,
+        };
+      };
+
+      const row = rectFor('[data-slot="cell-code-row"]');
+      const placeholder = rectFor(".cm-placeholder");
+      const executeButton = rectFor('[data-testid="execute-button"]');
+      const editor = rectFor(".cm-editor");
+
+      return {
+        editorMarginTop: editor.marginTop,
+        placeholderToRowCenter: placeholder.centerY - row.centerY,
+        placeholderToExecuteCenter: placeholder.centerY - executeButton.centerY,
+        rowHeight: row.height,
+      };
+    });
+
+    expect(metrics.editorMarginTop).toBe("0px");
+    expect(Math.abs(metrics.placeholderToRowCenter)).toBeLessThanOrEqual(4);
+    expect(Math.abs(metrics.placeholderToExecuteCenter)).toBeLessThanOrEqual(2);
+    expect(metrics.rowHeight).toBeGreaterThan(50);
+  });
+});

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -138,7 +138,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {/* Optional state lane - lives inside the source inset so clipped scroll containers do not hide it. */}
         <div
           data-slot="cell-state-lane"
-          className="absolute left-1 top-0 z-10 flex w-[var(--cell-content-column-inset,3.25rem)] flex-col items-center justify-start gap-0.5 pt-3.5 select-none"
+          className="absolute left-1 top-0 z-10 flex w-[var(--cell-content-column-inset,3.25rem)] flex-col items-center justify-start gap-0.5 pt-[1.125rem] select-none sm:pt-3.5"
           onMouseDown={onFocus}
         >
           {gutterContent}
@@ -148,7 +148,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {useSegmentedRibbon ? (
           <div className="flex min-w-0 flex-1 flex-col">
             {/* Code row - ribbon + content + right gutter */}
-            <div className="relative flex" onMouseDown={onFocus}>
+            <div data-slot="cell-code-row" className="relative flex" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
                 data-slot="cell-ribbon"
@@ -177,7 +177,11 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             {/* Output row - ribbon + content + right gutter
                 onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
-              <div className={cn("relative flex", hideOutput && "hidden")} onMouseDown={onFocus}>
+              <div
+                data-slot="cell-output-row"
+                className={cn("relative flex", hideOutput && "hidden")}
+                onMouseDown={onFocus}
+              >
                 <div
                   data-slot="cell-output-ribbon"
                   className={cn("w-1 transition-colors duration-150", outputRibbonColor)}

--- a/src/styles/notebook-base.css
+++ b/src/styles/notebook-base.css
@@ -35,6 +35,12 @@ code {
   font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
 }
 
+@media (max-width: 640px) {
+  [data-slot="cell-code-content"] .cm-editor.cm-editor {
+    margin-top: 0;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary

- Align the compact-width empty code cell placeholder with the play affordance.
- Reset the CodeMirror negative top margin in compact cell layouts where the peer-cursor padding no longer needs the desktop compensation.
- Add a browser E2E layout regression that measures the compact placeholder, play button, and code row centers.

## Verification

- `RUNTIMED_VITE_PORT=9866 NTERACT_BROWSER_E2E_BASE_URL=http://localhost:9866 pnpm --filter notebook-ui exec playwright test -c playwright.config.ts e2e/code-cell-placeholder-layout.spec.ts --project=chromium`
- `pnpm test:run src/components/cell/__tests__/CellContainer.test.tsx src/components/editor/__tests__/codemirror-editor.test.tsx`
- `cargo xtask lint --fix`
