### PR TITLE
Pin Automerge to current nteract patch branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "automerge"
 version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=345f172285641cd52a1f9227569d33d60d68d76a#345f172285641cd52a1f9227569d33d60d68d76a"
+source = "git+https://github.com/nteract/automerge?rev=f22752bd5bf7b7df0a0ad30b4618049644249237#f22752bd5bf7b7df0a0ad30b4618049644249237"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=345f172285641cd52a1f9227569d33d60d68d76a#345f172285641cd52a1f9227569d33d60d68d76a"
+source = "git+https://github.com/nteract/automerge?rev=f22752bd5bf7b7df0a0ad30b4618049644249237#f22752bd5bf7b7df0a0ad30b4618049644249237"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -5094,7 +5094,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5674,7 +5674,7 @@ checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
  "clap",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -9522,7 +9522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "345f172285641cd52a1f9227569d33d60d68d76a" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "f22752bd5bf7b7df0a0ad30b4618049644249237" }
 thiserror = "2"
 schemars = "1"
 notify = "8"

--- a/crates/automerge-recovery/src/lib.rs
+++ b/crates/automerge-recovery/src/lib.rs
@@ -157,7 +157,7 @@ pub fn catch_automerge_result<T, E>(
 /// Returns true when a sync-path Automerge error is safe to contain by
 /// rebuilding the local document and resetting the peer's `sync::State`.
 pub fn is_recoverable_sync_error(source: &automerge::AutomergeError) -> bool {
-    matches!(source, automerge::AutomergeError::PatchLogMismatch)
+    matches!(source, automerge::AutomergeError::PatchLogMismatch(_))
 }
 
 /// Run an Automerge operation and, when it returns a caller-marked recoverable
@@ -313,7 +313,7 @@ mod tests {
             |calls| {
                 *calls += 1;
                 if *calls == 1 {
-                    Err(automerge::AutomergeError::PatchLogMismatch)
+                    Err(automerge::PatchLogMismatch.into())
                 } else {
                     Ok("retried")
                 }
@@ -332,9 +332,8 @@ mod tests {
 
     #[test]
     fn only_patch_log_mismatch_is_recoverable_sync_error() {
-        assert!(is_recoverable_sync_error(
-            &automerge::AutomergeError::PatchLogMismatch
-        ));
+        let mismatch: automerge::AutomergeError = automerge::PatchLogMismatch.into();
+        assert!(is_recoverable_sync_error(&mismatch));
 
         let actor = ActorId::from(b"policy-actor" as &[u8]);
         let sources = [

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -425,7 +425,7 @@ impl RuntimeStateDoc {
                 return Ok(());
             }
             calls.set(count - 1);
-            Err(AutomergeError::PatchLogMismatch)
+            Err(automerge::PatchLogMismatch.into())
         })
     }
 

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -1517,7 +1517,7 @@ impl SettingsDoc {
             })
             .is_ok()
         {
-            return Err(AutomergeError::PatchLogMismatch);
+            return Err(automerge::PatchLogMismatch.into());
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Pins nteract to the new nteract Automerge draft patch branch:

- nteract/automerge#5
- `f22752bd5bf7b7df0a0ad30b4618049644249237`

This keeps nteract pointed at the nteract Automerge fork and replaces the old `desktop-patches` pin at `345f172285641cd52a1f9227569d33d60d68d76a`.

## Details

The new Automerge branch is based on current Automerge `main` and intentionally leaves out the broader downstream patch-log transaction behavior from the old branch. It carries the `fork_at` missing-ops root-cause fix plus the malformed-change/load hardening we still want to test with nteract.

Because upstream Automerge now has `automerge/automerge#1388`, `AutomergeError::PatchLogMismatch` is no longer a unit variant. This PR updates nteract's construction and matching sites to use the tuple-variant shape:

- `AutomergeError::PatchLogMismatch(_)`
- `automerge::PatchLogMismatch.into()`

## Verification

```text
cargo fmt --all -- --check
cargo test --locked -p automerge-recovery
cargo test --locked -p runtime-doc
cargo test --locked -p runtimed-client
cargo test --locked -p notebook-doc
```

All passed locally after rebasing onto current `origin/main`.

## Notes

This PR pins an explicit commit from the nteract fork. It does not require `nteract/automerge`'s `main` branch to diverge from upstream Automerge `main`; `nteract/automerge#5` is the documented downstream patch delta for now.
