### PR TITLE
fix(notebook): refine fluid rail affordances

### DIFF
--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -138,8 +138,9 @@ export function PackageManagerSurfacesExample() {
             pyprojectDeps={scenario.packageState.pyprojectDeps}
             onImportFromPyproject={asyncNoop}
             onUseProjectEnv={asyncNoop}
-            isUsingProjectEnv={false}
+            isUsingProjectEnv
             justSynced={false}
+            variant="rail"
           />
         </SurfaceFrame>
 
@@ -153,6 +154,8 @@ export function PackageManagerSurfacesExample() {
             channels={["conda-forge", "nvidia"]}
             python="3.13"
             loading={false}
+            envSource="conda:env_yml"
+            variant="rail"
             syncState={{ status: "dirty" }}
             onAdd={asyncNoop}
             onRemove={asyncNoop}
@@ -206,6 +209,7 @@ export function PackageManagerSurfacesExample() {
               channels: ["conda-forge"],
             }}
             envSource="pixi:toml"
+            variant="rail"
             syncState={{ status: "dirty", added: ["plotly"], removed: [] }}
             onSyncNow={asyncTrue}
             justSynced={false}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -899,21 +899,40 @@ function AppContent() {
     }
     if (runtime !== "python") return null;
     if (envType === "conda") {
-      return `conda - ${packageCountLabel(condaDependencies?.dependencies.length ?? 0)}`;
+      if (environmentYmlInfo) {
+        const count = environmentYmlPackageCount(environmentYmlDeps, environmentYmlInfo);
+        return `${environmentYmlInfo.relative_path} · ${packageCountLabel(count)}`;
+      }
+      return `conda · ${packageCountLabel(condaDependencies?.dependencies.length ?? 0)}`;
     }
     if (envType === "pixi") {
+      if (pixiInfo) {
+        const pixiCount = pixiPackageCount(pixiInfo);
+        return `${pixiInfo.relative_path} · ${packageCountLabel(pixiCount)}`;
+      }
       const pixiCount =
         (pixiInfo?.dependencies.length ?? 0) + (pixiInfo?.pypi_dependencies.length ?? 0);
-      return `pixi - ${packageCountLabel(pixiCount)}`;
+      return `pixi · ${packageCountLabel(pixiCount)}`;
     }
-    return `uv - ${packageCountLabel(dependencies?.dependencies.length ?? 0)}`;
+    if (envSource === "uv:pyproject" || pyprojectInfo?.has_dependencies) {
+      const source = pyprojectInfo?.relative_path ?? "pyproject.toml";
+      const count = pyprojectPackageCount(pyprojectDeps, pyprojectInfo?.dependency_count);
+      return count === null ? source : `${source} · ${packageCountLabel(count)}`;
+    }
+    return `uv · ${packageCountLabel(dependencies?.dependencies.length ?? 0)}`;
   }, [
     condaDependencies?.dependencies.length,
     denoConfigInfo,
     dependencies?.dependencies.length,
     envType,
-    pixiInfo?.dependencies.length,
-    pixiInfo?.pypi_dependencies.length,
+    envSource,
+    environmentYmlDeps,
+    environmentYmlInfo,
+    pyprojectDeps,
+    pyprojectInfo?.dependency_count,
+    pyprojectInfo?.has_dependencies,
+    pyprojectInfo?.relative_path,
+    pixiInfo,
     runtime,
   ]);
 
@@ -2020,6 +2039,7 @@ function AppContent() {
                       channels={condaDependencies?.channels ?? []}
                       python={condaDependencies?.python ?? null}
                       loading={condaDepsLoading}
+                      envSource={envSource}
                       syncState={condaDerivedSyncState}
                       onAdd={addCondaDependency}
                       onRemove={removeCondaDependency}
@@ -2131,6 +2151,56 @@ function notebookCellLanguage(metadata: Record<string, unknown>): string | null 
 
 function packageCountLabel(count: number): string {
   return count === 1 ? "1 package" : `${count} packages`;
+}
+
+function pyprojectPackageCount(
+  pyprojectDeps:
+    | {
+        dependencies: readonly string[];
+        dev_dependencies: readonly string[];
+      }
+    | null
+    | undefined,
+  fallbackCount: number | null | undefined,
+): number | null {
+  if (pyprojectDeps) {
+    return pyprojectDeps.dependencies.length + pyprojectDeps.dev_dependencies.length;
+  }
+  return typeof fallbackCount === "number" ? fallbackCount : null;
+}
+
+function environmentYmlPackageCount(
+  environmentYmlDeps:
+    | {
+        dependencies: readonly string[];
+        pip_dependencies: readonly string[];
+      }
+    | null
+    | undefined,
+  environmentYmlInfo:
+    | {
+        dependency_count: number;
+        pip_dependency_count: number;
+      }
+    | null
+    | undefined,
+): number {
+  if (environmentYmlDeps) {
+    return environmentYmlDeps.dependencies.length + environmentYmlDeps.pip_dependencies.length;
+  }
+  return (
+    (environmentYmlInfo?.dependency_count ?? 0) + (environmentYmlInfo?.pip_dependency_count ?? 0)
+  );
+}
+
+function pixiPackageCount(pixiInfo: {
+  dependencies: readonly string[];
+  pypi_dependencies: readonly string[];
+  dependency_count: number;
+  pypi_dependency_count: number;
+}): number {
+  const listedCount = pixiInfo.dependencies.length + pixiInfo.pypi_dependencies.length;
+  return listedCount || pixiInfo.dependency_count + pixiInfo.pypi_dependency_count;
 }
 
 function AppErrorFallback(_error: Error, resetErrorBoundary: () => void) {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -91,7 +91,7 @@ import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
 import { getNotebookCellsSnapshot, useSourceVersion } from "./lib/notebook-cells";
 import { useNotebookQueueProjection } from "./lib/notebook-executions";
-import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
+import { useDetectRuntime, useNotebookMetadata, usePixiDeps } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
 import { startWindowFocusHandler } from "./lib/window-focus";
 import type { JupyterOutput, NotebookCell } from "./types";
@@ -494,6 +494,7 @@ function AppContent() {
 
   // Pixi project detection
   const { pixiInfo } = usePixiDetection();
+  const pixiDeps = usePixiDeps();
 
   // Deno config detection and settings
   const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } = useDenoConfig();
@@ -910,8 +911,7 @@ function AppContent() {
         const pixiCount = pixiPackageCount(pixiInfo);
         return `${pixiInfo.relative_path} · ${packageCountLabel(pixiCount)}`;
       }
-      const pixiCount =
-        (pixiInfo?.dependencies.length ?? 0) + (pixiInfo?.pypi_dependencies.length ?? 0);
+      const pixiCount = pixiInlinePackageCount(pixiDeps);
       return `pixi · ${packageCountLabel(pixiCount)}`;
     }
     if (envSource === "uv:pyproject" || pyprojectInfo?.has_dependencies) {
@@ -932,6 +932,7 @@ function AppContent() {
     pyprojectInfo?.dependency_count,
     pyprojectInfo?.has_dependencies,
     pyprojectInfo?.relative_path,
+    pixiDeps,
     pixiInfo,
     runtime,
   ]);
@@ -2201,6 +2202,18 @@ function pixiPackageCount(pixiInfo: {
 }): number {
   const listedCount = pixiInfo.dependencies.length + pixiInfo.pypi_dependencies.length;
   return listedCount || pixiInfo.dependency_count + pixiInfo.pypi_dependency_count;
+}
+
+function pixiInlinePackageCount(
+  pixiDeps:
+    | {
+        dependencies: readonly string[];
+        pypiDependencies: readonly string[];
+      }
+    | null
+    | undefined,
+): number {
+  return (pixiDeps?.dependencies.length ?? 0) + (pixiDeps?.pypiDependencies.length ?? 0);
 }
 
 function AppErrorFallback(_error: Error, resetErrorBoundary: () => void) {

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -3,6 +3,7 @@ import { type KeyboardEvent, useCallback, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Progress } from "@/components/ui/progress";
 import type { EnvProgressState } from "runtimed";
+import { PackageSpecList } from "./PackageSpecList";
 import type {
   CondaSyncState,
   EnvironmentYmlDeps,
@@ -14,6 +15,7 @@ interface CondaDependencyHeaderProps {
   channels: string[];
   python: string | null;
   loading: boolean;
+  envSource?: string | null;
   variant?: "header" | "rail";
   syncState: CondaSyncState | null;
   onAdd: (pkg: string) => Promise<void>;
@@ -39,6 +41,7 @@ export function CondaDependencyHeader({
   channels,
   python,
   loading,
+  envSource,
   variant = "header",
   syncState,
   onAdd,
@@ -57,6 +60,12 @@ export function CondaDependencyHeader({
   const [newChannel, setNewChannel] = useState("");
   const [showChannelInput, setShowChannelInput] = useState(false);
   const isRail = variant === "rail";
+  const isEnvironmentYmlMode = envSource === "conda:env_yml" || Boolean(environmentYmlInfo);
+  const environmentYmlDependencyValues = environmentYmlDeps
+    ? [...environmentYmlDeps.dependencies, ...environmentYmlDeps.pip_dependencies]
+    : [];
+  const environmentYmlChannels = environmentYmlDeps?.channels ?? environmentYmlInfo?.channels ?? [];
+  const environmentYmlPython = environmentYmlDeps?.python ?? environmentYmlInfo?.python ?? null;
 
   const handleAdd = useCallback(async () => {
     if (newDep.trim()) {
@@ -221,12 +230,12 @@ export function CondaDependencyHeader({
         )}
 
         {/* environment.yml detected banner */}
-        {environmentYmlInfo?.has_dependencies && (
+        {environmentYmlInfo && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
               <FileText className="h-3.5 w-3.5 shrink-0" />
               <span>
-                Using deps from{" "}
+                Using{" "}
                 <code className="rounded bg-muted px-1">{environmentYmlInfo.relative_path}</code>
                 {environmentYmlInfo.name && (
                   <span className="text-muted-foreground ml-1">({environmentYmlInfo.name})</span>
@@ -235,7 +244,17 @@ export function CondaDependencyHeader({
             </div>
             {environmentYmlDeps &&
               (environmentYmlDeps.dependencies.length > 0 ||
-                environmentYmlDeps.pip_dependencies.length > 0) && (
+                environmentYmlDeps.pip_dependencies.length > 0) &&
+              (isRail ? (
+                <PackageSpecList
+                  values={environmentYmlDependencyValues}
+                  tone="conda"
+                  emptyLabel="No dependencies listed in environment.yml."
+                  loading={loading}
+                  framed={false}
+                  className="mt-2"
+                />
+              ) : (
                 <div className="mt-2 text-xs text-muted-foreground">
                   {environmentYmlDeps.dependencies.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-1">
@@ -257,7 +276,26 @@ export function CondaDependencyHeader({
                     </div>
                   )}
                 </div>
-              )}
+              ))}
+            {isRail && (environmentYmlPython || environmentYmlChannels.length > 0) && (
+              <div className="mt-2 space-y-1 border-t border-border/60 pt-2 text-xs text-muted-foreground">
+                {environmentYmlPython && (
+                  <div>
+                    Python <span className="font-mono">{environmentYmlPython}</span>
+                  </div>
+                )}
+                {environmentYmlChannels.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    <span>Channels</span>
+                    {environmentYmlChannels.map((channel) => (
+                      <span key={channel} className="rounded bg-muted px-1.5 py-0.5 font-mono">
+                        {channel}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -291,149 +329,165 @@ export function CondaDependencyHeader({
           </div>
         )}
 
-        {/* Channels */}
-        <div className="mb-2">
-          <div className="mb-1 text-xs font-medium text-muted-foreground">Channels</div>
-          <div className="flex flex-wrap gap-1.5 items-center">
-            {displayChannels.map((channel) => (
-              <div
-                key={channel}
-                className="flex max-w-full items-center gap-1 rounded border border-emerald-200 bg-emerald-100 px-2 py-0.5 text-xs dark:border-emerald-800 dark:bg-emerald-900/30"
-              >
-                <span className="min-w-0 truncate font-mono">{channel}</span>
-                {isUsingDefault && (
-                  <span className="text-[10px] text-muted-foreground ml-0.5">(default)</span>
-                )}
-                {channels.length > 0 && (
+        {!isEnvironmentYmlMode && (
+          <>
+            {/* Channels */}
+            <div className="mb-2">
+              <div className="mb-1 text-xs font-medium text-muted-foreground">Channels</div>
+              <div className="flex flex-wrap gap-1.5 items-center">
+                {displayChannels.map((channel) => (
+                  <div
+                    key={channel}
+                    className="flex max-w-full items-center gap-1 rounded border border-emerald-200 bg-emerald-100 px-2 py-0.5 text-xs dark:border-emerald-800 dark:bg-emerald-900/30"
+                  >
+                    <span className="min-w-0 truncate font-mono">{channel}</span>
+                    {isUsingDefault && (
+                      <span className="text-[10px] text-muted-foreground ml-0.5">(default)</span>
+                    )}
+                    {channels.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveChannel(channel)}
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                        disabled={loading}
+                        title={`Remove ${channel}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+                {showChannelInput ? (
+                  <div className="flex gap-1">
+                    <input
+                      type="text"
+                      value={newChannel}
+                      onChange={(e) => setNewChannel(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          handleAddChannel();
+                        } else if (e.key === "Escape") {
+                          setShowChannelInput(false);
+                          setNewChannel("");
+                        }
+                      }}
+                      placeholder="channel name"
+                      className="w-32 rounded border bg-background px-1.5 py-0.5 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                      autoFocus
+                      disabled={loading}
+                      autoComplete="off"
+                      spellCheck={false}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleAddChannel}
+                      disabled={loading || !newChannel.trim()}
+                      className="rounded bg-emerald-500 px-1.5 py-0.5 text-xs text-white hover:bg-emerald-600 disabled:opacity-50"
+                    >
+                      Add
+                    </button>
+                  </div>
+                ) : (
                   <button
                     type="button"
-                    onClick={() => handleRemoveChannel(channel)}
-                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    onClick={() => setShowChannelInput(true)}
+                    className="flex items-center gap-0.5 rounded bg-background px-1.5 py-0.5 text-xs border hover:bg-muted transition-colors"
                     disabled={loading}
-                    title={`Remove ${channel}`}
                   >
-                    <X className="h-3 w-3" />
+                    <Plus className="h-3 w-3" />
+                    channel
                   </button>
                 )}
               </div>
-            ))}
-            {showChannelInput ? (
-              <div className="flex gap-1">
-                <input
-                  type="text"
-                  value={newChannel}
-                  onChange={(e) => setNewChannel(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
-                      handleAddChannel();
-                    } else if (e.key === "Escape") {
-                      setShowChannelInput(false);
-                      setNewChannel("");
-                    }
-                  }}
-                  placeholder="channel name"
-                  className="w-32 rounded border bg-background px-1.5 py-0.5 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-                  autoFocus
-                  disabled={loading}
-                  autoComplete="off"
-                  spellCheck={false}
-                />
-                <button
-                  type="button"
-                  onClick={handleAddChannel}
-                  disabled={loading || !newChannel.trim()}
-                  className="rounded bg-emerald-500 px-1.5 py-0.5 text-xs text-white hover:bg-emerald-600 disabled:opacity-50"
-                >
-                  Add
-                </button>
+            </div>
+
+            {/* Python version */}
+            <label
+              className={cn(
+                "mb-2 flex items-center gap-2",
+                isRail && "flex-col items-stretch gap-1.5",
+              )}
+            >
+              <span className="text-xs font-medium text-muted-foreground">Python</span>
+              <input
+                type="text"
+                value={python ?? ""}
+                onChange={handlePythonChange}
+                placeholder="3.11"
+                className={cn(
+                  "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
+                  isRail ? "w-full" : "w-20",
+                )}
+                disabled={loading}
+                autoComplete="off"
+                spellCheck={false}
+              />
+            </label>
+
+            {/* Dependencies list */}
+            {isRail ? (
+              <PackageSpecList
+                values={dependencies}
+                tone="conda"
+                emptyLabel="No dependencies. Add conda packages to create an isolated environment."
+                loading={loading}
+                onRemove={onRemove}
+                className="mb-3"
+              />
+            ) : dependencies.length > 0 ? (
+              <div className="mb-3 flex flex-wrap gap-1.5">
+                {dependencies.map((dep) => (
+                  <div
+                    key={dep}
+                    className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
+                  >
+                    <span className="min-w-0 truncate font-mono">{dep}</span>
+                    <button
+                      type="button"
+                      onClick={() => onRemove(dep)}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                      disabled={loading}
+                      title={`Remove ${dep}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
               </div>
             ) : (
+              <div className="mb-3 text-xs text-muted-foreground">
+                No dependencies. Add conda packages to create an isolated environment.
+              </div>
+            )}
+
+            {/* Add dependency input */}
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={newDep}
+                onChange={(e) => setNewDep(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="package or package>=version"
+                data-testid="conda-deps-add-input"
+                className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                disabled={loading}
+                autoComplete="off"
+                spellCheck={false}
+              />
               <button
                 type="button"
-                onClick={() => setShowChannelInput(true)}
-                className="flex items-center gap-0.5 rounded bg-background px-1.5 py-0.5 text-xs border hover:bg-muted transition-colors"
-                disabled={loading}
+                onClick={handleAdd}
+                disabled={loading || !newDep.trim()}
+                data-testid="conda-deps-add-button"
+                className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
               >
                 <Plus className="h-3 w-3" />
-                channel
+                Add
               </button>
-            )}
-          </div>
-        </div>
-
-        {/* Python version */}
-        <label
-          className={cn("mb-2 flex items-center gap-2", isRail && "flex-col items-stretch gap-1.5")}
-        >
-          <span className="text-xs font-medium text-muted-foreground">Python</span>
-          <input
-            type="text"
-            value={python ?? ""}
-            onChange={handlePythonChange}
-            placeholder="3.11"
-            className={cn(
-              "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
-              isRail ? "w-full" : "w-20",
-            )}
-            disabled={loading}
-            autoComplete="off"
-            spellCheck={false}
-          />
-        </label>
-
-        {/* Dependencies list */}
-        {dependencies.length > 0 ? (
-          <div className="mb-3 flex flex-wrap gap-1.5">
-            {dependencies.map((dep) => (
-              <div
-                key={dep}
-                className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
-              >
-                <span className="min-w-0 truncate font-mono">{dep}</span>
-                <button
-                  type="button"
-                  onClick={() => onRemove(dep)}
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  disabled={loading}
-                  title={`Remove ${dep}`}
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="mb-3 text-xs text-muted-foreground">
-            No dependencies. Add conda packages to create an isolated environment.
-          </div>
+            </div>
+          </>
         )}
-
-        {/* Add dependency input */}
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={newDep}
-            onChange={(e) => setNewDep(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="package or package>=version"
-            data-testid="conda-deps-add-input"
-            className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-            disabled={loading}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <button
-            type="button"
-            onClick={handleAdd}
-            disabled={loading || !newDep.trim()}
-            data-testid="conda-deps-add-button"
-            className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
-          >
-            <Plus className="h-3 w-3" />
-            Add
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -1,6 +1,7 @@
 import { Check, Download, FileText, Info, Plus, RefreshCw, X } from "lucide-react";
 import { type KeyboardEvent, useCallback, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
+import { PackageSpecList } from "./PackageSpecList";
 import type { EnvSyncState, PyProjectDeps, PyProjectInfo } from "./runtime-surface-types";
 
 type DependencyPanelVariant = "header" | "rail";
@@ -49,6 +50,14 @@ export function DependencyHeader({
   const [newDep, setNewDep] = useState("");
   const [pythonSpec, setPythonSpec] = useState(requiresPython ?? "");
   const isRail = variant === "rail";
+  const pyprojectDependencyValues = pyprojectDeps
+    ? [...pyprojectDeps.dependencies, ...pyprojectDeps.dev_dependencies]
+    : [];
+  const pyprojectDependencyCount =
+    pyprojectDependencyValues.length || pyprojectInfo?.dependency_count || 0;
+  const hasPyprojectDependencies =
+    Boolean(pyprojectInfo?.has_dependencies) || pyprojectDependencyCount > 0;
+  const pyprojectPath = pyprojectInfo?.relative_path ?? "pyproject.toml";
 
   useEffect(() => {
     setPythonSpec(requiresPython ?? "");
@@ -168,14 +177,14 @@ export function DependencyHeader({
         )}
 
         {/* pyproject.toml detected banner */}
-        {pyprojectInfo?.has_dependencies && (
+        {hasPyprojectDependencies && !isUsingProjectEnv && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className={cn("flex items-center justify-between", isRail && "items-start gap-3")}>
               <div className="flex min-w-0 items-start gap-2">
                 <FileText className="h-3.5 w-3.5 shrink-0" />
                 <span className="min-w-0">
-                  <code className="rounded bg-muted px-1">{pyprojectInfo.relative_path}</code>
-                  {pyprojectInfo.project_name && (
+                  <code className="rounded bg-muted px-1">{pyprojectPath}</code>
+                  {pyprojectInfo?.project_name && (
                     <span className="text-muted-foreground ml-1">
                       ({pyprojectInfo.project_name})
                     </span>
@@ -215,7 +224,17 @@ export function DependencyHeader({
             </div>
             {pyprojectDeps &&
               (pyprojectDeps.dependencies.length > 0 ||
-                pyprojectDeps.dev_dependencies.length > 0) && (
+                pyprojectDeps.dev_dependencies.length > 0) &&
+              (isRail ? (
+                <PackageSpecList
+                  values={pyprojectDependencyValues}
+                  tone="uv"
+                  emptyLabel="No dependencies listed in pyproject.toml."
+                  loading={loading}
+                  framed={false}
+                  className="mt-2"
+                />
+              ) : (
                 <div className="mt-2 text-xs text-muted-foreground">
                   {pyprojectDeps.dependencies.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-1">
@@ -237,7 +256,7 @@ export function DependencyHeader({
                     </div>
                   )}
                 </div>
-              )}
+              ))}
           </div>
         )}
 
@@ -245,13 +264,22 @@ export function DependencyHeader({
         {isUsingProjectEnv && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              Managed by{" "}
-              <code className="rounded bg-muted px-1">
-                {pyprojectInfo?.relative_path ?? "pyproject.toml"}
-              </code>{" "}
-              — re-initialize the environment to pick up dependency changes.
-            </span>
+            <div className="min-w-0 space-y-1 leading-5">
+              <div>
+                Using <code className="rounded bg-muted px-1">{pyprojectPath}</code>
+              </div>
+              <div>Re-initialize after dependency changes.</div>
+              {isRail && pyprojectDependencyValues.length > 0 && (
+                <PackageSpecList
+                  values={pyprojectDependencyValues}
+                  tone="uv"
+                  emptyLabel="No dependencies listed in pyproject.toml."
+                  loading={loading}
+                  framed={false}
+                  className="pt-1"
+                />
+              )}
+            </div>
           </div>
         )}
 
@@ -291,7 +319,16 @@ export function DependencyHeader({
 
         {/* Dependencies list (read-only when using project env) */}
         {!isUsingProjectEnv &&
-          (dependencies.length > 0 ? (
+          (isRail ? (
+            <PackageSpecList
+              values={dependencies}
+              tone="uv"
+              emptyLabel="No inline dependencies. Add packages to create an isolated environment."
+              loading={loading}
+              onRemove={onRemove}
+              className="mb-3"
+            />
+          ) : dependencies.length > 0 ? (
             <div className="mb-3 flex flex-wrap gap-1.5">
               {dependencies.map((dep) => (
                 <div

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -1,0 +1,97 @@
+import { Package, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type PackageSpecTone = "uv" | "conda" | "pixi" | "neutral";
+
+interface PackageSpecListProps {
+  values: readonly string[];
+  tone?: PackageSpecTone;
+  emptyLabel: string;
+  loading?: boolean;
+  onRemove?: (value: string) => void;
+  className?: string;
+  framed?: boolean;
+}
+
+const toneClasses: Record<PackageSpecTone, string> = {
+  uv: "text-uv bg-uv/10 ring-uv/15",
+  conda: "text-emerald-700 bg-emerald-500/10 ring-emerald-500/15 dark:text-emerald-300",
+  pixi: "text-amber-700 bg-amber-500/10 ring-amber-500/15 dark:text-amber-300",
+  neutral: "text-muted-foreground bg-muted/70 ring-border/60",
+};
+
+export function PackageSpecList({
+  values,
+  tone = "neutral",
+  emptyLabel,
+  loading = false,
+  onRemove,
+  className,
+  framed = true,
+}: PackageSpecListProps) {
+  if (values.length === 0) {
+    return <div className={cn("text-xs text-muted-foreground", className)}>{emptyLabel}</div>;
+  }
+
+  return (
+    <div
+      className={cn(
+        framed
+          ? "overflow-hidden rounded-md border bg-background shadow-sm shadow-black/[0.02]"
+          : "overflow-hidden rounded-md bg-transparent",
+        className,
+      )}
+    >
+      {values.map((value) => {
+        const parsed = parsePackageSpec(value);
+        return (
+          <div
+            key={value}
+            className={cn(
+              "flex min-h-9 items-center gap-2 border-b px-2.5 py-1.5 text-xs last:border-b-0",
+              !framed && "px-0",
+            )}
+          >
+            <span
+              className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full ring-1",
+                toneClasses[tone],
+              )}
+              aria-hidden="true"
+            >
+              <Package className="size-3" />
+            </span>
+            <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
+            {parsed.spec ? (
+              <span className="max-w-[8rem] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+                {parsed.spec}
+              </span>
+            ) : null}
+            {onRemove ? (
+              <button
+                type="button"
+                onClick={() => onRemove(value)}
+                className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={loading}
+                title={`Remove ${value}`}
+                aria-label={`Remove ${value}`}
+              >
+                <X className="size-3" />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function parsePackageSpec(value: string): { name: string; spec: string | null } {
+  const trimmed = value.trim();
+  const specStart = trimmed.search(/[<>=!~]/);
+  if (specStart <= 0) return { name: trimmed, spec: null };
+  return {
+    name: trimmed.slice(0, specStart).trim(),
+    spec: trimmed.slice(specStart).trim() || null,
+  };
+}

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -42,11 +42,11 @@ export function PackageSpecList({
         className,
       )}
     >
-      {values.map((value) => {
+      {values.map((value, index) => {
         const parsed = parsePackageSpec(value);
         return (
           <div
-            key={value}
+            key={`${index}-${value}`}
             className={cn(
               "flex min-h-9 items-center gap-2 border-b px-2.5 py-1.5 text-xs last:border-b-0",
               !framed && "px-0",

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -1,10 +1,11 @@
-import { Check, FileText, Info, Package, Plus, RefreshCw, Terminal, X } from "lucide-react";
+import { Check, FileText, Info, Plus, RefreshCw, Terminal, X } from "lucide-react";
 import { type KeyboardEvent, useCallback, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { EnvSyncState } from "./runtime-surface-types";
 import { addPixiDependency, removePixiDependency, usePixiDeps } from "../lib/notebook-metadata";
 import type { PixiInfo } from "../hooks/usePixiDetection";
 import { PixiIcon } from "./icons";
+import { PackageSpecList } from "./PackageSpecList";
 
 interface PixiDependencyHeaderProps {
   pixiInfo: PixiInfo | null;
@@ -28,6 +29,9 @@ export function PixiDependencyHeader({
   const [newDep, setNewDep] = useState("");
   const [loading, setLoading] = useState(false);
   const isRail = variant === "rail";
+  const pixiDependencyValues = pixiInfo
+    ? [...pixiInfo.dependencies, ...pixiInfo.pypi_dependencies]
+    : [];
 
   const handleAdd = useCallback(async () => {
     if (newDep.trim()) {
@@ -144,7 +148,16 @@ export function PixiDependencyHeader({
               </span>
             </div>
 
-            {pixiInfo.dependencies.length > 0 ? (
+            {isRail ? (
+              <PackageSpecList
+                values={pixiDependencyValues}
+                tone="pixi"
+                emptyLabel="No dependencies listed in pixi.toml."
+                loading={loading}
+                framed={false}
+                className="mt-2"
+              />
+            ) : pixiInfo.dependencies.length > 0 ? (
               <div className="mt-1.5 flex flex-wrap gap-1.5">
                 {pixiInfo.dependencies.map((dep) => (
                   <span
@@ -156,7 +169,7 @@ export function PixiDependencyHeader({
                 ))}
               </div>
             ) : null}
-            {pixiInfo.pypi_dependencies.length > 0 ? (
+            {!isRail && pixiInfo.pypi_dependencies.length > 0 ? (
               <div className="mt-1.5 flex flex-wrap gap-1.5">
                 <span className="text-muted-foreground text-[10px] uppercase tracking-wide self-center">
                   PyPI
@@ -172,19 +185,24 @@ export function PixiDependencyHeader({
               </div>
             ) : null}
 
-            {pixiInfo.channels.length > 0 && (
-              <div className="mt-1.5 flex items-center gap-1.5 text-muted-foreground">
-                <Package className="h-3 w-3 shrink-0" />
-                {pixiInfo.channels.map((ch) => (
-                  <span key={ch} className="rounded bg-muted px-1.5 py-0.5">
-                    {ch}
-                  </span>
-                ))}
+            {(pixiInfo.python || pixiInfo.channels.length > 0) && (
+              <div className="mt-2 space-y-1 border-t border-border/60 pt-2 text-xs text-muted-foreground">
+                {pixiInfo.python && (
+                  <div>
+                    Python <span className="font-mono">{pixiInfo.python}</span>
+                  </div>
+                )}
+                {pixiInfo.channels.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    <span>Channels</span>
+                    {pixiInfo.channels.map((channel) => (
+                      <span key={channel} className="rounded bg-muted px-1.5 py-0.5 font-mono">
+                        {channel}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
-
-            {pixiInfo.python && (
-              <div className="mt-1.5 text-muted-foreground">Python: {pixiInfo.python}</div>
             )}
           </div>
         )}
@@ -193,7 +211,16 @@ export function PixiDependencyHeader({
         {isInlineMode && (
           <>
             {/* Current inline deps */}
-            {pixiDeps && pixiDeps.dependencies.length > 0 && (
+            {isRail ? (
+              <PackageSpecList
+                values={pixiDeps?.dependencies ?? []}
+                tone="pixi"
+                emptyLabel="No Pixi dependencies yet."
+                loading={loading}
+                onRemove={handleRemove}
+                className="mb-2"
+              />
+            ) : pixiDeps && pixiDeps.dependencies.length > 0 ? (
               <div className="mb-2 flex flex-wrap gap-1.5">
                 {pixiDeps.dependencies.map((dep) => (
                   <div
@@ -212,7 +239,7 @@ export function PixiDependencyHeader({
                   </div>
                 ))}
               </div>
-            )}
+            ) : null}
 
             {/* Add dep input */}
             <div className="mb-3 flex gap-1.5">
@@ -249,7 +276,7 @@ export function PixiDependencyHeader({
         )}
 
         {/* Tip for pixi:toml mode */}
-        {!isInlineMode && (
+        {!isInlineMode && !isRail && (
           <div className="flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
             <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -16,6 +16,12 @@ describe("PackageSpecList", () => {
     expect(screen.getByText("polars")).toBeVisible();
   });
 
+  it("preserves duplicate package rows from separate dependency sections", () => {
+    render(<PackageSpecList values={["numpy", "numpy"]} tone="uv" emptyLabel="No dependencies" />);
+
+    expect(screen.getAllByText("numpy")).toHaveLength(2);
+  });
+
   it("exposes row remove actions when mutation is available", () => {
     const onRemove = vi.fn();
 

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { CondaDependencyHeader } from "../CondaDependencyHeader";
+import { DependencyHeader } from "../DependencyHeader";
+import { PackageSpecList, parsePackageSpec } from "../PackageSpecList";
+import { PixiDependencyHeader } from "../PixiDependencyHeader";
+
+describe("PackageSpecList", () => {
+  it("renders package specs as rail rows", () => {
+    render(
+      <PackageSpecList values={["pandas>=2", "polars"]} tone="uv" emptyLabel="No dependencies" />,
+    );
+
+    expect(screen.getByText("pandas")).toBeVisible();
+    expect(screen.getByText(">=2")).toBeVisible();
+    expect(screen.getByText("polars")).toBeVisible();
+  });
+
+  it("exposes row remove actions when mutation is available", () => {
+    const onRemove = vi.fn();
+
+    render(
+      <PackageSpecList values={["pandas>=2"]} emptyLabel="No dependencies" onRemove={onRemove} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove pandas>=2" }));
+    expect(onRemove).toHaveBeenCalledWith("pandas>=2");
+  });
+
+  it("splits package names from version constraints", () => {
+    expect(parsePackageSpec("scikit-learn>=1.5")).toEqual({
+      name: "scikit-learn",
+      spec: ">=1.5",
+    });
+    expect(parsePackageSpec("numpy")).toEqual({ name: "numpy", spec: null });
+  });
+});
+
+describe("DependencyHeader rail package copy", () => {
+  it("splits project environment copy into fact and action lines", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas"]}
+        requiresPython=">=3.12"
+        loading={false}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+        pyprojectInfo={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          has_dependencies: true,
+          has_dev_dependencies: false,
+          dependency_count: 1,
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          has_venv: false,
+        }}
+        isUsingProjectEnv
+      />,
+    );
+
+    expect(screen.getByText("Using")).toBeVisible();
+    expect(screen.getAllByText("pyproject.toml").length).toBeGreaterThan(0);
+    expect(screen.getByText("Re-initialize after dependency changes.")).toBeVisible();
+  });
+});
+
+describe("file-backed package rail variants", () => {
+  it("renders environment.yml dependencies as read-only rail rows", () => {
+    render(
+      <CondaDependencyHeader
+        variant="rail"
+        dependencies={[]}
+        channels={[]}
+        python={null}
+        loading={false}
+        envSource="conda:env_yml"
+        syncState={null}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetChannels={async () => undefined}
+        onSetPython={async () => undefined}
+        onSyncNow={async () => true}
+        environmentYmlInfo={{
+          path: "/work/environment.yaml",
+          relative_path: "environment.yaml",
+          name: "analysis",
+          has_dependencies: true,
+          dependency_count: 2,
+          has_pip_dependencies: true,
+          pip_dependency_count: 1,
+          python: "3.13",
+          channels: ["conda-forge"],
+        }}
+        environmentYmlDeps={{
+          path: "/work/environment.yaml",
+          relative_path: "environment.yaml",
+          name: "analysis",
+          dependencies: ["python=3.13", "scipy"],
+          pip_dependencies: ["datasets"],
+          python: "3.13",
+          channels: ["conda-forge"],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("environment.yaml")).toBeVisible();
+    expect(screen.getByText("python")).toBeVisible();
+    expect(screen.getByText("=3.13")).toBeVisible();
+    expect(screen.getByText("scipy")).toBeVisible();
+    expect(screen.getByText("datasets")).toBeVisible();
+    expect(screen.queryByTestId("conda-deps-add-input")).not.toBeInTheDocument();
+  });
+
+  it("renders pixi.toml dependencies as read-only rail rows", () => {
+    render(
+      <PixiDependencyHeader
+        variant="rail"
+        envSource="pixi:toml"
+        pixiInfo={{
+          path: "/work/pixi.toml",
+          relative_path: "pixi.toml",
+          workspace_name: "analysis",
+          dependencies: ["python>=3.13", "numpy"],
+          has_dependencies: true,
+          dependency_count: 2,
+          pypi_dependencies: ["altair"],
+          has_pypi_dependencies: true,
+          pypi_dependency_count: 1,
+          python: ">=3.13",
+          channels: ["conda-forge"],
+        }}
+        syncState={null}
+      />,
+    );
+
+    expect(screen.getByText("pixi.toml")).toBeVisible();
+    expect(screen.getByText("python")).toBeVisible();
+    expect(screen.getAllByText(">=3.13").length).toBeGreaterThan(0);
+    expect(screen.getByText("numpy")).toBeVisible();
+    expect(screen.getByText("altair")).toBeVisible();
+    expect(screen.getByText("Channels")).toBeVisible();
+    expect(screen.queryByText(/pixi add/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -25,6 +25,12 @@ const terminalInsertionRibbonClasses: Record<CellInsertionType, string> = {
     "bg-gradient-to-b from-emerald-400 via-emerald-400/60 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/60 dark:to-emerald-600/0",
 };
 
+const actionButtonIntentClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-500/12 text-sky-700 ring-sky-500/20 hover:bg-sky-500/16 dark:text-sky-300",
+  markdown:
+    "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
+};
+
 export function CellInsertionRibbon({
   terminal = false,
   activeType,
@@ -36,11 +42,14 @@ export function CellInsertionRibbon({
   const [uncontrolledActiveType, setUncontrolledActiveType] = useState<CellInsertionType | null>(
     null,
   );
+  const [interactionActive, setInteractionActive] = useState(false);
   const resolvedActiveType = activeType === undefined ? uncontrolledActiveType : activeType;
-  const ribbonClass = resolvedActiveType
+  const visualActiveType =
+    resolvedActiveType ?? (interactionActive || forceActionsVisible ? "code" : null);
+  const ribbonClass = visualActiveType
     ? terminal
-      ? terminalInsertionRibbonClasses[resolvedActiveType]
-      : insertionRibbonClasses[resolvedActiveType]
+      ? terminalInsertionRibbonClasses[visualActiveType]
+      : insertionRibbonClasses[visualActiveType]
     : undefined;
 
   const setActiveType = (type: CellInsertionType | null) => {
@@ -52,10 +61,10 @@ export function CellInsertionRibbon({
 
   const actionButtonClass = (type: CellInsertionType) =>
     cn(
-      "inline-flex h-6 items-center justify-center gap-1 rounded-sm px-2 text-xs text-muted-foreground/60 transition-colors",
+      "inline-flex h-6 items-center justify-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors ring-1 ring-transparent",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-      resolvedActiveType === type
-        ? "bg-muted text-foreground shadow-sm"
+      visualActiveType === type
+        ? actionButtonIntentClasses[type]
         : "hover:bg-muted/60 hover:text-foreground",
     );
 
@@ -69,10 +78,16 @@ export function CellInsertionRibbon({
         notebookCellLayoutVars,
         className,
       )}
-      onPointerLeave={() => setActiveType(null)}
+      onPointerEnter={() => setInteractionActive(true)}
+      onPointerLeave={() => {
+        setInteractionActive(false);
+        setActiveType(null);
+      }}
+      onFocusCapture={() => setInteractionActive(true)}
       onBlur={(event) => {
         const nextTarget = event.relatedTarget;
         if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          setInteractionActive(false);
           setActiveType(null);
         }
       }}
@@ -108,13 +123,13 @@ export function CellInsertionRibbon({
         data-slot="cell-adder-primary-hit-target"
         title="Add code cell from insertion margin"
         aria-label="Add code cell from insertion margin"
-        onPointerEnter={() => setActiveType(null)}
-        onFocus={() => setActiveType(null)}
+        onPointerEnter={() => setActiveType("code")}
+        onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
         className={cn(
           "h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
-          resolvedActiveType ? "bg-transparent" : "hover:bg-muted/20",
+          visualActiveType === "code" ? "bg-sky-500/5" : "hover:bg-muted/20",
           terminal && "h-7",
         )}
       >
@@ -132,7 +147,7 @@ export function CellInsertionRibbon({
       >
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 items-center gap-0.5 rounded-sm border border-border/45 bg-background/85 p-0.5 shadow-sm backdrop-blur-sm"
+          className="flex h-7 items-center gap-1 rounded-full bg-background/80 px-1 shadow-sm shadow-black/[0.04] ring-1 ring-border/45 backdrop-blur-sm"
         >
           <button
             type="button"

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -19,7 +19,7 @@ describe("CellInsertionRibbon", () => {
     expect(onInsert).toHaveBeenCalledWith("code");
   });
 
-  it("keeps the left insertion channel neutral while remaining a primary code target", () => {
+  it("uses the left insertion channel as the resting code target", () => {
     const onInsert = vi.fn();
     const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
 
@@ -27,7 +27,9 @@ describe("CellInsertionRibbon", () => {
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
 
     fireEvent.pointerEnter(hitTarget!);
-    expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
+    expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toHaveClass(
+      "bg-sky-400",
+    );
 
     fireEvent.click(hitTarget!);
 
@@ -44,9 +46,10 @@ describe("CellInsertionRibbon", () => {
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
 
     expect(actions).toHaveClass("opacity-100");
-    expect(palette).toHaveClass("bg-background/85");
+    expect(palette).toHaveClass("bg-background/80");
+    expect(palette).toHaveClass("rounded-full");
     expect(intent).toHaveClass("bg-emerald-400");
-    expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-foreground");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
   });
 
   it("softens the terminal row into a document tail", () => {

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -248,7 +248,7 @@ function NotebookOutlineNode({
   const itemHref = getItemHref?.(item) ?? item.href ?? null;
   const className = cn(
     "flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+    "select-none [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
     selected
       ? "bg-primary text-primary-foreground"
       : "text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -305,7 +305,9 @@ function NotebookOutlineNode({
       <li data-outline-level={item.level}>
         <a
           href={itemHref}
+          draggable={false}
           aria-current={selected ? "location" : undefined}
+          onDragStart={(event) => event.preventDefault()}
           onClick={handleClick}
           className={className}
         >

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -183,6 +183,24 @@ describe("NotebookRail", () => {
     expect(onNavigateOutlineItem).toHaveBeenCalledWith(outlineItems[0], "#notebook-cell-cell-a");
   });
 
+  it("prevents outline links from starting browser drag previews", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    const outlineLink = screen.getByRole("link", { name: "Load data" });
+
+    expect(outlineLink).toHaveAttribute("draggable", "false");
+    expect(fireEvent.dragStart(outlineLink)).toBe(false);
+  });
+
   it("marks only the first outline item for a focused cell when no item is pinned", () => {
     render(
       <NotebookRail


### PR DESCRIPTION
## Summary

- soften the in-between cell insertion affordance and keep code/markdown intent visually consistent with the ribbon
- prevent outline links from showing unusable drag previews
- refine the packages rail so file-backed environments summarize `pyproject.toml`, `environment.yml`, and `pixi.toml` correctly, with shared compact package rows
- update the Elements package-manager surface to render the rail variants for comparison

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/notebook/src/components/__tests__/dependency-header.test.tsx src/components/cell/__tests__/CellInsertionRibbon.test.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check --fix apps/notebook/src/App.tsx apps/notebook/src/components/PackageSpecList.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/notebook/src/components/DependencyHeader.tsx apps/notebook/src/components/CondaDependencyHeader.tsx apps/notebook/src/components/PixiDependencyHeader.tsx apps/elements/components/package-manager-surfaces-example.tsx`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Notes

- Draft because this is design work and still needs review.
- I did not rely on the currently running Elements dev server for final visual verification because it appears not to be tied to this worktree.
