### PR TITLE
docs(identity): align presence and provider projection

### DIFF
--- a/apps/notebook/src/lib/__tests__/cursor-registry.test.ts
+++ b/apps/notebook/src/lib/__tests__/cursor-registry.test.ts
@@ -232,12 +232,12 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
 
-      const color = findPeerColorByActorLabel("agent:claude:abc123");
+      const color = findPeerColorByActorLabel("user:anaconda:alice/agent:claude:s1");
       expect(color).toBeDefined();
       // peerColor mock returns `#${peerId.slice(0, 6)}`
       expect(color).toBe("#peer-1");
@@ -248,17 +248,17 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
 
-      const color = findPeerColorByActorLabel("agent:other:xyz789");
+      const color = findPeerColorByActorLabel("user:anaconda:bob/agent:other:s2");
       expect(color).toBeUndefined();
     });
 
     it("returns undefined when no peers are connected", () => {
-      const color = findPeerColorByActorLabel("agent:claude:abc123");
+      const color = findPeerColorByActorLabel("user:anaconda:alice/agent:claude:s1");
       expect(color).toBeUndefined();
     });
 
@@ -268,12 +268,12 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "local-peer",
         peer_label: "Me",
-        actor_label: "human:local-session",
+        actor_label: "local:kyle/desktop:window",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
 
-      const color = findPeerColorByActorLabel("human:local-session");
+      const color = findPeerColorByActorLabel("local:kyle/desktop:window");
       expect(color).toBeUndefined();
     });
 
@@ -285,7 +285,7 @@ describe("cursor-registry cell-level functions", () => {
           {
             peer_id: "agent-peer",
             peer_label: "Claude",
-            actor_label: "agent:claude:snap123",
+            actor_label: "user:anaconda:alice/agent:claude:snap123",
             channels: [
               {
                 channel: "cursor",
@@ -296,7 +296,7 @@ describe("cursor-registry cell-level functions", () => {
         ],
       });
 
-      const color = findPeerColorByActorLabel("agent:claude:snap123");
+      const color = findPeerColorByActorLabel("user:anaconda:alice/agent:claude:snap123");
       expect(color).toBeDefined();
       expect(color).toBe("#agent-");
     });
@@ -306,13 +306,13 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
 
       // Verify it's there
-      expect(findPeerColorByActorLabel("agent:claude:abc123")).toBeDefined();
+      expect(findPeerColorByActorLabel("user:anaconda:alice/agent:claude:s1")).toBeDefined();
 
       // Peer disconnects
       presenceHandler?.({
@@ -321,7 +321,7 @@ describe("cursor-registry cell-level functions", () => {
       });
 
       // Actor label lookup should no longer match
-      expect(findPeerColorByActorLabel("agent:claude:abc123")).toBeUndefined();
+      expect(findPeerColorByActorLabel("user:anaconda:alice/agent:claude:s1")).toBeUndefined();
     });
 
     it("does not match by substring (exact only)", () => {
@@ -329,7 +329,7 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
@@ -338,7 +338,7 @@ describe("cursor-registry cell-level functions", () => {
       // the old fuzzy findPeerColorByLabel
       expect(findPeerColorByActorLabel("agent:claude")).toBeUndefined();
       expect(findPeerColorByActorLabel("claude")).toBeUndefined();
-      expect(findPeerColorByActorLabel("abc123")).toBeUndefined();
+      expect(findPeerColorByActorLabel("alice")).toBeUndefined();
     });
   });
 
@@ -348,14 +348,14 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
 
       const peers = getPeersForCell("cell-1");
       expect(peers).toHaveLength(1);
-      expect(peers[0].actorLabel).toBe("agent:claude:abc123");
+      expect(peers[0].actorLabel).toBe("user:anaconda:alice/agent:claude:s1");
     });
 
     it("stores actor_label from snapshot", () => {
@@ -366,7 +366,7 @@ describe("cursor-registry cell-level functions", () => {
           {
             peer_id: "peer-1",
             peer_label: "Human",
-            actor_label: "human:session-abc",
+            actor_label: "local:kyle/desktop:session-abc",
             channels: [
               {
                 channel: "cursor",
@@ -379,7 +379,7 @@ describe("cursor-registry cell-level functions", () => {
 
       const peers = getPeersForCell("cell-1");
       expect(peers).toHaveLength(1);
-      expect(peers[0].actorLabel).toBe("human:session-abc");
+      expect(peers[0].actorLabel).toBe("local:kyle/desktop:session-abc");
     });
 
     it("preserves actor_label when absent from subsequent updates", () => {
@@ -388,7 +388,7 @@ describe("cursor-registry cell-level functions", () => {
         type: "update",
         peer_id: "peer-1",
         peer_label: "Claude",
-        actor_label: "agent:claude:abc123",
+        actor_label: "user:anaconda:alice/agent:claude:s1",
         channel: "cursor",
         data: { cell_id: "cell-1", line: 0, column: 0 },
       });
@@ -404,7 +404,7 @@ describe("cursor-registry cell-level functions", () => {
 
       const peers = getPeersForCell("cell-1");
       expect(peers).toHaveLength(1);
-      expect(peers[0].actorLabel).toBe("agent:claude:abc123");
+      expect(peers[0].actorLabel).toBe("user:anaconda:alice/agent:claude:s1");
     });
 
     it("handles peer with no actor_label gracefully", () => {

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -70,7 +70,7 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.access.actor).toMatchObject({
       principal: {
         label: "Alice",
-        source: { provider: "oidc", namespace: "anaconda" },
+        source: { provider: "anaconda", namespace: "anaconda" },
       },
       operator: { kind: "desktop" },
       scope: "viewer",

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -5540,8 +5540,8 @@ mod tests {
 
     #[test]
     fn test_new_with_actor() {
-        let doc = NotebookDoc::new_with_actor("test", "agent:claude:abc123");
-        assert_eq!(doc.get_actor_id(), "agent:claude:abc123");
+        let doc = NotebookDoc::new_with_actor("test", "user:anaconda:alice/agent:claude:s1");
+        assert_eq!(doc.get_actor_id(), "user:anaconda:alice/agent:claude:s1");
     }
 
     #[test]

--- a/crates/notebook-doc/src/presence.rs
+++ b/crates/notebook-doc/src/presence.rs
@@ -167,7 +167,8 @@ pub enum PresenceMessage {
         peer_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         peer_label: Option<String>,
-        /// Automerge actor label (e.g. "human:abc123", "agent:claude:def456").
+        /// Automerge actor label (e.g. "local:kyle/desktop:window",
+        /// "user:anaconda:alice/agent:claude:s1").
         /// Bridges presence identity to CRDT attribution identity so
         /// attribution highlights can use the same color as the peer's cursor.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -198,7 +199,7 @@ pub enum PresenceMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerSnapshot {
     pub peer_id: String,
-    /// Free-form label identifying the peer (e.g. "human", "agent", "daemon").
+    /// Free-form display label identifying the peer (e.g. "Kyle", "Codex", "daemon").
     pub peer_label: String,
     /// Automerge actor label for CRDT attribution color matching.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1295,7 +1296,7 @@ mod tests {
         let encoded = encode_cursor_update_labeled(
             "peer-1",
             Some("Claude"),
-            Some("agent:claude:abc123"),
+            Some("user:anaconda:alice/agent:claude:s1"),
             &CursorPosition {
                 cell_id: "c1".into(),
                 line: 5,
@@ -1314,7 +1315,10 @@ mod tests {
             } => {
                 assert_eq!(peer_id, "peer-1");
                 assert_eq!(peer_label, Some("Claude".to_string()));
-                assert_eq!(actor_label, Some("agent:claude:abc123".to_string()));
+                assert_eq!(
+                    actor_label,
+                    Some("user:anaconda:alice/agent:claude:s1".to_string())
+                );
                 assert!(matches!(data, ChannelData::Cursor(_)));
             }
             _ => panic!("expected Update"),
@@ -1355,14 +1359,17 @@ mod tests {
         state1.update_peer(
             "agent-peer",
             "Claude",
-            Some("agent:claude:abc123"),
+            Some("user:anaconda:alice/agent:claude:s1"),
             cursor,
             1000,
         );
 
         // Verify actor_label is stored in state
         let peer = state1.get_peer("agent-peer").unwrap();
-        assert_eq!(peer.actor_label, Some("agent:claude:abc123".to_string()));
+        assert_eq!(
+            peer.actor_label,
+            Some("user:anaconda:alice/agent:claude:s1".to_string())
+        );
 
         // Encode snapshot and decode into fresh state
         let snapshot_bytes = state1.encode_snapshot("daemon").unwrap();
@@ -1372,7 +1379,7 @@ mod tests {
             // Verify actor_label is in the snapshot wire data
             assert_eq!(
                 peers[0].actor_label,
-                Some("agent:claude:abc123".to_string())
+                Some("user:anaconda:alice/agent:claude:s1".to_string())
             );
             state2.apply_snapshot(&peers, 2000);
         } else {
@@ -1381,7 +1388,10 @@ mod tests {
 
         // Verify actor_label survived into the new state
         let peer2 = state2.get_peer("agent-peer").unwrap();
-        assert_eq!(peer2.actor_label, Some("agent:claude:abc123".to_string()));
+        assert_eq!(
+            peer2.actor_label,
+            Some("user:anaconda:alice/agent:claude:s1".to_string())
+        );
     }
 
     #[test]

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -156,7 +156,8 @@ macro_rules! connect_stream {
 ///
 /// `actor_label` sets the Automerge actor identity **before** initial sync
 /// so that even the bootstrap operations are attributed to the caller
-/// (e.g., `"agent:claude:abc123"`, `"human:kyle:session42"`).
+/// (e.g., `"local:kyle/desktop:window"`,
+/// `"user:anaconda:alice/agent:claude:s1"`).
 pub async fn connect(
     socket_path: PathBuf,
     notebook_id: String,

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -706,8 +706,13 @@ mod tests {
     #[test]
     fn test_set_actor_and_get_actor_id() {
         let (handle, _changed_rx, _cmd_rx) = test_handle();
-        handle.set_actor("agent:claude:abc123").unwrap();
-        assert_eq!(handle.get_actor_id().unwrap(), "agent:claude:abc123");
+        handle
+            .set_actor("user:anaconda:alice/agent:claude:s1")
+            .unwrap();
+        assert_eq!(
+            handle.get_actor_id().unwrap(),
+            "user:anaconda:alice/agent:claude:s1"
+        );
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1347,7 +1347,8 @@ impl NotebookHandle {
     /// contributed changes to this document's history.
     ///
     /// Useful for debugging provenance — call after sync to see which
-    /// peers (e.g., `"runtimed"`, `"human:abc123"`) have touched the notebook.
+    /// peers (e.g., `"local:kyle/desktop:window"`,
+    /// `"user:anaconda:alice/agent:codex:s1"`) have touched the notebook.
     pub fn contributing_actors(&mut self) -> Vec<String> {
         self.doc.contributing_actors()
     }

--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -173,6 +173,11 @@ Presence frames carry `peer_id`, `peer_label`, and `actor_label` (the last two o
 
 The principal prefix is always server-controlled; no presence ingress path lets a client choose what principal it appears as. Operator and display name are client-declared unless the host replaces them with connection-derived defaults.
 
+The current presence protocol carries only `peer_id`, optional `peer_label`,
+and optional `actor_label`. The room host still stamps or rewrites those fields
+on ingress, and shared UI can derive a temporary projection from the durable
+label while the wire shape catches up.
+
 The target presence protocol keeps `actor_label` as the stable attribution key
 and adds a compact, host-stamped actor projection to presence `Update` and
 `Snapshot` messages so shared UI does not parse raw labels as its primary
@@ -206,10 +211,17 @@ such as "Codex for Kyle Kelley" is derived from `operator` plus `principal`; it
 does not require a separate `on_behalf_of` field unless a future feature models
 delegation chains between multiple principals.
 
+Projection scope does not make a viewer less of a sync participant. A `viewer`
+or read-only peer still receives room changes, sends empty sync negotiation
+frames, publishes presence, and consumes the same structured actor projection as
+editors and owners. Scope only constrains writes and mutating requests at the
+server boundary.
+
 `principal.source.provider` names the principal authority used for federation
-and display. It is not the credential transport. For example, an API key that
-authenticates an Anaconda user still projects as provider `anaconda`; the API
-key detail belongs to the credential layer described below.
+and display. It is not the credential transport. For example, a browser OAuth
+session, OIDC bearer token, or API key that authenticates an Anaconda user all
+project as provider `anaconda`; the OAuth/API-key detail belongs to the
+credential layer described below.
 
 ## Decision 4: Credentials and identity providers are separate concerns
 
@@ -352,7 +364,14 @@ Every new request variant or frame type must specify its required scope at the d
 
 ### What does and does not appear on the wire
 
-Scope is **not** sent on the wire today. The server is the only authority. A future protocol extension may add a `connection_scope` field to the handshake response so UIs can render "read-only" badges without inferring scope from request failures. That field would be advisory; the server still enforces.
+The post-handshake capability payload includes `actor_label` and
+`connection_scope` so UIs can render current-actor and read-only/runtime-peer
+state without inferring scope from request failures. The client may consume this
+payload to choose UI capabilities, but it is informational from the server's
+trust perspective. The server remains the only authority and still enforces
+scope at frame ingress, request dispatch, and ACL mutation boundaries. A
+`viewer` connection remains a full sync, presence, and projection peer; only its
+changes and mutating requests are denied.
 
 ## Decision 6: Publish is a fresh document in the destination space
 
@@ -404,16 +423,15 @@ These follow-up ADRs and design decisions are tracked but not decided here:
 
 1. **Room-host crate extraction.** Pulling `runtimed::notebook_sync_server::room` into `nteract-room-host` with pluggable `Listener` and `SnapshotStore` traits. Tracked in a separate ADR.
 2. **Identity provider selection for Anaconda hosted v1.** Direct OIDC against Anaconda's existing SSO is the first browser session layer for the hosted Worker. The staging target is the retired `preview.runt.run` lane from `runtimed/intheloop`, using Anaconda stage OIDC and a `/oidc` callback. `docs/architecture/hosted-credential-transport.md` tracks the exact credential transport and principal-namespace decision.
-3. **Anonymous viewer scope.** Whether read-only public publish URLs require a session or run un-authenticated under a synthetic `system:anonymous` principal.
+3. **Public viewer presence visibility.** Public-read URLs use explicit ACL-backed anonymous viewer access under an `anonymous:<session>/browser:<session>` actor. Still open: whether public viewers should see each other in presence, only see aggregate counts, or remain fully local-only.
 4. **Revocation signal and historical-change subduction.** Two parts. First, the wire signal: the exact `SESSION_CONTROL` close frame and the channel for admin revokes / plan downgrades. Second, what happens to changes a revoked principal already authored. The Automerge `filters` work (`origin/filters` branch, `rust/automerge/src/filter.rs`) is the natural primitive: install a `Filter::with_author(revoked, Rule::AllowUpTo { heads: validated })` to subduct edits authored after revocation while keeping causal integrity intact. Wait for `filters` to land in main before depending on it; until then, revocation is a hard connection close with no post-hoc audit hiding.
-5. **Connection-scope field on the wire.** Optional handshake response field so UIs can render "read-only" badges without inferring from request failures.
-6. **Federation.** A notebook host trusting another notebook host's identity claims (e.g., JupyterHub Anaconda interop). Not v1.
-7. **`runtime_peer` connection topology.** The hosted prototype now supports direct `runtime_peer` `RuntimeStateDoc` ingress into the room. Still open: whether the production kernel sidecar connects to the room directly with its own `runtime_peer` scope credential, or whether a separate runtime-coordination protocol relays writes. Tied to the future remote-runtime work.
-8. **Deployment topology.** How clients reach rooms (browser-direct WebSocket, local-daemon proxy, native client), where kernels run, TLS/CORS, credential keyring placement. Drafted in `docs/architecture/deployment-topology.md`.
-9. **ACL mechanics beyond the Cloudflare v1 shape.** The hosted prototype covers flat D1 rows, public-read rows, and owner-only row mutation. Still open: owner transfer UX, group/org expansion, inherited ACLs, audit event retention, Zanzibar/Authzed-style evaluation, and product policy for anonymous public presence.
-10. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. Until then, publish produces a fresh document in the destination space (see Decision 6).
-11. **Bearer-token replay mitigation.** DPoP / proof-of-possession tokens, mTLS for system-to-system, short token lifetimes. v1 inherits the bearer-token threat model; tightening it is future work.
-12. **Lower-cost actor-label validator.** Replace the v1 clone-preview validator with parsing of `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/architecture/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.
+5. **Federation.** A notebook host trusting another notebook host's identity claims (e.g., JupyterHub Anaconda interop). Not v1.
+6. **`runtime_peer` connection topology.** The hosted prototype now supports direct `runtime_peer` `RuntimeStateDoc` ingress into the room. Still open: whether the production kernel sidecar connects to the room directly with its own `runtime_peer` scope credential, or whether a separate runtime-coordination protocol relays writes. Tied to the future remote-runtime work.
+7. **Deployment topology.** How clients reach rooms (browser-direct WebSocket, local-daemon proxy, native client), where kernels run, TLS/CORS, credential keyring placement. Drafted in `docs/architecture/deployment-topology.md`.
+8. **ACL mechanics beyond the Cloudflare v1 shape.** The hosted prototype covers flat D1 rows, public-read rows, and owner-only row mutation. Still open: owner transfer UX, group/org expansion, inherited ACLs, audit event retention, Zanzibar/Authzed-style evaluation, and product policy for anonymous public presence.
+9. **Signed-change authorship across publish.** When Automerge gains signed changes (keyhive direction), publish flows could carry historical authorship across identity spaces with cryptographic verification. Until then, publish produces a fresh document in the destination space (see Decision 6).
+10. **Bearer-token replay mitigation.** DPoP / proof-of-possession tokens, mTLS for system-to-system, short token lifetimes. v1 inherits the bearer-token threat model; tightening it is future work.
+11. **Lower-cost actor-label validator.** Replace the v1 clone-preview validator with parsing of `automerge::sync::Message.changes` chunks (V1 and V2) before merge to reject changes whose actor's principal doesn't match the connection's authenticated principal. Deferred until we land a patch on our Automerge fork as part of the room-host crate extraction. Drafted in `docs/architecture/automerge-fork-patches.md`. Pairs with the filters work above for full attribution integrity once both are in.
 
 ## Worked examples
 

--- a/docs/architecture/notebook-identity-environment-surfaces.md
+++ b/docs/architecture/notebook-identity-environment-surfaces.md
@@ -251,8 +251,9 @@ derived from `operator` plus `principal`; they do not need a separate
 `onBehalfOf` field unless the product later models delegation chains between
 multiple principals.
 `source.provider` names the principal authority, not the credential transport:
-an Anaconda API key still projects an Anaconda principal, while the API key
-itself remains credential-layer metadata.
+browser OAuth, an OIDC bearer token, and an Anaconda API key can all project the
+same Anaconda principal. The credential path stays in host/auth metadata; shared
+notebook UI sees provider `anaconda`.
 
 ## Placement
 

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -69,7 +69,7 @@ describe("NotebookIdentity", () => {
         principal: {
           id: "user:anaconda:opaque",
           label: "Alice Appleseed",
-          source: { provider: "oidc", namespace: "anaconda" },
+          source: { provider: "anaconda", namespace: "anaconda" },
         },
         operator: {
           id: "browser:tab",
@@ -87,6 +87,37 @@ describe("NotebookIdentity", () => {
 
     expect(screen.getByText("Alice Appleseed")).toBeVisible();
     expect(screen.queryByText("Anaconda user")).toBeNull();
+  });
+
+  it("does not reparse raw labels over structured agent projections", () => {
+    const actor = notebookActorIdentityFromAccess({
+      level: "editor",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "agent:legacy/on-behalf-of:someone-else",
+      identityLabel: null,
+      actor: {
+        actorLabel: "agent:legacy/on-behalf-of:someone-else",
+        principal: {
+          id: "user:anaconda:opaque",
+          label: "Alice Appleseed",
+          source: { provider: "anaconda", namespace: "anaconda" },
+        },
+        operator: {
+          id: "agent:codex:s1",
+          kind: "agent",
+          label: "Codex",
+        },
+        scope: "editor",
+      },
+    });
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Codex")).toBeVisible();
+    expect(screen.getByText("for Alice Appleseed")).toBeVisible();
+    expect(screen.queryByText("Legacy")).toBeNull();
+    expect(screen.queryByText("for Someone Else")).toBeNull();
   });
 
   it("projects durable runtime operators separately from document access", () => {

--- a/src/components/notebook-shell/actor-projection.ts
+++ b/src/components/notebook-shell/actor-projection.ts
@@ -192,7 +192,7 @@ function principalSource(
     return { provider: "local", namespace: principalId.split(":")[1] ?? "desktop" };
   }
   if (principalId.startsWith("user:anaconda:")) {
-    return { provider: "oidc", namespace: "anaconda" };
+    return { provider: "anaconda", namespace: "anaconda" };
   }
   if (principalId.startsWith("hub:")) {
     return { provider: "jupyterhub", namespace: principalId.split(":")[1] ?? "hub" };
@@ -217,10 +217,6 @@ function actorKindFromProjection(actor: NotebookActorProjection): NotebookActorK
 }
 
 function actorLabelFromProjection(actor: NotebookActorProjection, kind: NotebookActorKind): string {
-  const parsed = parseNotebookActorLabel(actor.actorLabel);
-  if (parsed && (kind === "agent" || kind === "runtime" || kind === "system")) {
-    return parsed.label;
-  }
   if (kind === "agent" || kind === "runtime" || kind === "system") {
     return actor.operator.label;
   }
@@ -231,10 +227,9 @@ function actorDetailFromProjection(
   actor: NotebookActorProjection,
   kind: NotebookActorKind,
 ): string | null {
-  const parsed = parseNotebookActorLabel(actor.actorLabel);
   if (kind === "agent" || kind === "runtime" || kind === "system") {
-    const principalLabel = parsed?.onBehalfOf ?? actor.principal.label;
-    return kind === "system" && !parsed?.onBehalfOf
+    const principalLabel = actor.principal.label;
+    return kind === "system" && actor.principal.id === "system"
       ? accessScopeLabel(actor.scope)
       : `for ${principalLabel}`;
   }

--- a/src/components/notebook-shell/capabilities.ts
+++ b/src/components/notebook-shell/capabilities.ts
@@ -4,7 +4,7 @@ export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown
 
 export type NotebookActorSourceProvider =
   | "anonymous"
-  | "anaconda-api-key"
+  | "anaconda"
   | "dev"
   | "jupyterhub"
   | "local"


### PR DESCRIPTION
## Summary

- clarify that `connection_scope` already ships as advisory post-handshake capability data
- mark structured presence actor projections as target-state while current presence still carries `actor_label` and `peer_label`
- align shared notebook identity projection so Anaconda is the principal authority and credential path stays outside `source.provider`
- refresh stale actor-label examples toward `<principal>/<operator>` labels

## Verification

- `pnpm test:run src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts apps/notebook/src/lib/__tests__/cursor-registry.test.ts`
- `cargo test -p notebook-doc test_actor_label`
- `cargo test -p notebook-doc tests::test_new_with_actor`
- `cargo test -p notebook-sync tests::test_set_actor_and_get_actor_id`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
