### PR TITLE
test(notebook): cover local read-only capabilities

### DIFF
--- a/apps/notebook/e2e/fixtures/basic-permissions.ipynb
+++ b/apps/notebook/e2e/fixtures/basic-permissions.ipynb
@@ -1,0 +1,31 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "readonly-heading",
+      "metadata": {},
+      "source": ["# Read-only fixture\n", "\n", "This notebook is copied and chmodded by E2E tests."]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "readonly-code",
+      "metadata": {},
+      "outputs": [],
+      "source": ["print(\"read only fixture\")"]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/apps/notebook/e2e/local-file-permissions.spec.ts
+++ b/apps/notebook/e2e/local-file-permissions.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { waitForNotebookReady } from "./helpers";
+
+const fixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures/basic-permissions.ipynb",
+);
+
+function copyFixture(mode: number) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nteract-permissions-"));
+  const notebookPath = path.join(dir, "permissions.ipynb");
+  fs.copyFileSync(fixturePath, notebookPath);
+  fs.chmodSync(notebookPath, mode);
+  return { dir, notebookPath };
+}
+
+function cleanupFixture(dir: string) {
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      fs.chmodSync(path.join(dir, entry), 0o600);
+    }
+  } catch {
+    // Best effort: the assertion failure should stay focused on notebook behavior.
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test.describe("local file permissions", () => {
+  test.skip(process.platform === "win32", "chmod-based file permission checks are POSIX-only");
+  test.skip(process.getuid?.() === 0, "root bypasses POSIX file permission checks");
+
+  test("opens a read-only ipynb through viewer capabilities", async ({ page }) => {
+    const { dir, notebookPath } = copyFixture(0o444);
+    try {
+      await waitForNotebookReady(
+        page,
+        `/?path=${encodeURIComponent(notebookPath)}&environment_mode=notebook`,
+      );
+
+      const shell = page.locator('[data-slot="notebook-document-shell"]');
+      await expect(shell).toHaveAttribute("data-access-level", "viewer");
+      await expect(shell).toHaveAttribute("data-access-source", "local");
+      await expect(shell).toHaveAttribute("data-can-edit", "false");
+      await expect(shell).toHaveAttribute("data-can-edit-structure", "false");
+
+      await expect(page.getByTestId("add-code-cell-button")).toHaveCount(0);
+      await expect(page.getByTestId("add-markdown-cell-button")).toHaveCount(0);
+      await expect(page.getByTestId("run-all-button")).toHaveCount(0);
+      await expect(page.getByTestId("restart-kernel-button")).toHaveCount(0);
+
+      await expect(page.locator('[data-cell-type="markdown"]')).toContainText("Read-only fixture");
+      await expect(page.locator('[data-cell-type="code"] .cm-content')).toHaveAttribute(
+        "contenteditable",
+        "false",
+      );
+    } finally {
+      cleanupFixture(dir);
+    }
+  });
+
+  test("reports an inaccessible ipynb without showing writable controls", async ({ page }) => {
+    const { dir, notebookPath } = copyFixture(0o000);
+    try {
+      await page.goto(`/?path=${encodeURIComponent(notebookPath)}&environment_mode=notebook`);
+      await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
+
+      const shell = page.locator('[data-slot="notebook-document-shell"]');
+      await expect(shell).toHaveAttribute("data-access-level", "viewer");
+      await expect(shell).toHaveAttribute("data-access-source", "local");
+      await expect(shell).toHaveAttribute("data-can-edit", "false");
+      await expect(page.getByText("Notebook load failed")).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByTestId("add-code-cell-button")).toHaveCount(0);
+      await expect(page.getByTestId("run-all-button")).toHaveCount(0);
+    } finally {
+      cleanupFixture(dir);
+    }
+  });
+});

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -954,13 +954,17 @@ function AppContent() {
   }, []);
 
   const handleTogglePackagesRail = useCallback(() => {
+    if (!shellCapabilities.canViewPackages) {
+      logger.debug("[App] handleTogglePackagesRail: package view capability unavailable, skipping");
+      return;
+    }
     if (activeRailPanel === "packages" && !railCollapsed) {
       setRailCollapsed(true);
       return;
     }
     setActiveRailPanel("packages");
     setRailCollapsed(false);
-  }, [activeRailPanel, railCollapsed]);
+  }, [activeRailPanel, railCollapsed, shellCapabilities.canViewPackages]);
 
   const handleSelectOutlineItem = useCallback(
     (item: NotebookOutlineItem) => {
@@ -1024,6 +1028,10 @@ function AppContent() {
   // Returns true if kernel was started, false if trust dialog opened or error.
   const tryStartKernel = useCallback(
     async (blockedAction: PendingTrustAction | null = null): Promise<boolean> => {
+      if (!shellCapabilities.canExecute) {
+        logger.debug("[App] tryStartKernel: execute capability unavailable, skipping");
+        return false;
+      }
       // Fail-closed until the daemon has confirmed first RuntimeStateSync.
       // Before that, `runtimeState.trust.status` is the default and cannot
       // gate an install. Buttons are disabled in this state, but keyboard
@@ -1061,6 +1069,7 @@ function AppContent() {
     },
     [
       sessionReady,
+      shellCapabilities.canExecute,
       checkTrust,
       launchKernel,
       envProgress,
@@ -1378,6 +1387,12 @@ function AppContent() {
 
   // Start kernel explicitly with pyproject.toml (user action from DependencyHeader)
   const handleStartKernelWithPyproject = useCallback(async () => {
+    if (!shellCapabilities.canExecute) {
+      logger.debug(
+        "[App] handleStartKernelWithPyproject: execute capability unavailable, skipping",
+      );
+      return;
+    }
     if (!sessionReady) {
       logger.debug("[App] handleStartKernelWithPyproject: session not ready, skipping");
       return;
@@ -1388,10 +1403,14 @@ function AppContent() {
     } else if (response.result === "guard_rejected") {
       setTrustActionNotice(response.reason);
     }
-  }, [sessionReady, launchKernel, setTrustActionNotice]);
+  }, [sessionReady, shellCapabilities.canExecute, launchKernel, setTrustActionNotice]);
 
   const handleExecuteCell = useCallback(
     async (cellId: string) => {
+      if (!shellCapabilities.canExecute) {
+        logger.debug("[App] handleExecuteCell: execute capability unavailable, skipping");
+        return;
+      }
       // Fail-closed until the daemon has confirmed first RuntimeStateSync.
       // If a runtime agent is already alive from a prior session,
       // `execute_cell` would otherwise queue into RuntimeStateDoc before
@@ -1451,14 +1470,25 @@ function AppContent() {
         }, 150);
       }
     },
-    [sessionReady, kernelStatus, tryStartKernel, captureExecuteTrustAction, executeCell],
+    [
+      sessionReady,
+      shellCapabilities.canExecute,
+      kernelStatus,
+      tryStartKernel,
+      captureExecuteTrustAction,
+      executeCell,
+    ],
   );
 
   const handleAddCell = useCallback(
     (type: "code" | "markdown" | "raw", afterCellId?: string | null) => {
+      if (!shellCapabilities.canEditStructure) {
+        logger.debug("[App] handleAddCell: structure edit capability unavailable, skipping");
+        return null;
+      }
       return addCell(type, afterCellId);
     },
-    [addCell],
+    [addCell, shellCapabilities.canEditStructure],
   );
 
   // Wrapper for toolbar's start kernel - uses trust check before starting
@@ -1471,6 +1501,10 @@ function AppContent() {
 
   // Restart kernel (shutdown then start)
   const handleRestartKernel = useCallback(async () => {
+    if (!shellCapabilities.canExecute) {
+      logger.debug("[App] handleRestartKernel: execute capability unavailable, skipping");
+      return;
+    }
     // Fail-closed until first RuntimeStateSync. Shutdown writes
     // RuntimeLifecycle::Shutdown via the runtime-agent request path, so
     // firing it against a still-syncing session would mutate kernel
@@ -1483,9 +1517,13 @@ function AppContent() {
     }
     await shutdownKernel();
     await tryStartKernel();
-  }, [sessionReady, shutdownKernel, tryStartKernel]);
+  }, [sessionReady, shellCapabilities.canExecute, shutdownKernel, tryStartKernel]);
 
   const handleRunAllCells = useCallback(async () => {
+    if (!shellCapabilities.canExecute) {
+      logger.debug("[App] handleRunAllCells: execute capability unavailable, skipping");
+      return;
+    }
     // Fail-closed until first RuntimeStateSync. Same reasoning as
     // handleExecuteCell: if a runtime agent is already alive, the daemon
     // would queue into RuntimeStateDoc before we've verified trust.
@@ -1528,13 +1566,24 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [sessionReady, kernelStatus, tryStartKernel, captureRunAllTrustAction, daemonRunAllCells]);
+  }, [
+    sessionReady,
+    shellCapabilities.canExecute,
+    kernelStatus,
+    tryStartKernel,
+    captureRunAllTrustAction,
+    daemonRunAllCells,
+  ]);
 
   const handleRestartAndRunAll = useCallback(async () => {
+    if (!shellCapabilities.canExecute) {
+      logger.debug("[App] handleRestartAndRunAll: execute capability unavailable, skipping");
+      return;
+    }
     // The daemon clears visible outputs by moving cells to fresh execution
     // pointers before queuing, then ensureKernelStarted restarts the kernel.
     await restartAndRunAll();
-  }, [restartAndRunAll]);
+  }, [restartAndRunAll, shellCapabilities.canExecute]);
 
   // Cmd+S keyboard shortcut. The native menu item is routed through
   // host.commands.run("notebook.save") by the Tauri menu bridge.
@@ -1918,6 +1967,9 @@ function AppContent() {
           onAddCell={handleAddCell}
           onToggleDependencies={handleTogglePackagesRail}
           isDepsOpen={packagesRailOpen}
+          canEditStructure={shellCapabilities.canEditStructure}
+          canExecute={shellCapabilities.canExecute}
+          canViewPackages={shellCapabilities.canViewPackages}
           depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
           updateStatus={updateStatus}
           updateVersion={updateVersion}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -52,6 +52,9 @@ interface NotebookToolbarProps {
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
+  canEditStructure?: boolean;
+  canExecute?: boolean;
+  canViewPackages?: boolean;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
   updateStatus?: UpdateStatus;
@@ -82,6 +85,9 @@ export function NotebookToolbar({
   onAddCell,
   onToggleDependencies,
   isDepsOpen = false,
+  canEditStructure = true,
+  canExecute = true,
+  canViewPackages = true,
   depsOutOfSync = false,
   listKernelspecs,
   updateStatus,
@@ -174,33 +180,37 @@ export function NotebookToolbar({
     >
       <div className="flex h-10 items-center gap-2 px-3">
         {/* Add cells */}
-        <button
-          type="button"
-          onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
-          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Add code cell"
-          aria-label="Add code cell"
-          data-testid="add-code-cell-button"
-        >
-          <Code className="h-3 w-3" />
-          <span className="hidden @[40rem]:inline">Code</span>
-        </button>
-        <button
-          type="button"
-          onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
-          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Add markdown cell"
-          aria-label="Add markdown cell"
-          data-testid="add-markdown-cell-button"
-        >
-          <LetterText className="h-3 w-3" />
-          <span className="hidden @[40rem]:inline">Markdown</span>
-        </button>
+        {canEditStructure && (
+          <>
+            <button
+              type="button"
+              onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
+              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title="Add code cell"
+              aria-label="Add code cell"
+              data-testid="add-code-cell-button"
+            >
+              <Code className="h-3 w-3" />
+              <span className="hidden @[40rem]:inline">Code</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
+              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title="Add markdown cell"
+              aria-label="Add markdown cell"
+              data-testid="add-markdown-cell-button"
+            >
+              <LetterText className="h-3 w-3" />
+              <span className="hidden @[40rem]:inline">Markdown</span>
+            </button>
+          </>
+        )}
 
-        <div className="h-4 w-px bg-border" />
+        {canEditStructure && canExecute ? <div className="h-4 w-px bg-border" /> : null}
 
         {/* Kernel controls */}
-        {!isKernelRunning && (
+        {canExecute && !isKernelRunning && (
           <button
             type="button"
             onClick={handleStartKernel}
@@ -214,48 +224,52 @@ export function NotebookToolbar({
             <span className="hidden @[40rem]:inline">Start Kernel</span>
           </button>
         )}
-        <button
-          type="button"
-          onClick={onRunAllCells}
-          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-          title="Run all cells"
-          aria-label="Run all cells"
-          data-testid="run-all-button"
-        >
-          <ChevronsRight className="h-3.5 w-3.5" />
-          <span className="hidden @[40rem]:inline">Run All</span>
-        </button>
-        <button
-          type="button"
-          onClick={onRestartKernel}
-          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-          title="Restart kernel"
-          aria-label="Restart kernel"
-          data-testid="restart-kernel-button"
-        >
-          <RotateCcw className="h-3 w-3" />
-          <span className="hidden @[40rem]:inline">Restart</span>
-        </button>
-        <button
-          type="button"
-          onClick={onRestartAndRunAll}
-          className={cn(
-            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-            depsOutOfSync
-              ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
-              : "text-foreground hover:bg-muted",
-          )}
-          title={
-            depsOutOfSync
-              ? "Dependencies changed — restart kernel and run all cells"
-              : "Restart kernel and run all cells"
-          }
-          data-testid="restart-run-all-button"
-        >
-          <RotateCcw className="h-3 w-3" />
-          <ChevronsRight className="h-3 w-3 -ml-1" />
-        </button>
-        {isKernelRunning && (
+        {canExecute && (
+          <>
+            <button
+              type="button"
+              onClick={onRunAllCells}
+              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+              title="Run all cells"
+              aria-label="Run all cells"
+              data-testid="run-all-button"
+            >
+              <ChevronsRight className="h-3.5 w-3.5" />
+              <span className="hidden @[40rem]:inline">Run All</span>
+            </button>
+            <button
+              type="button"
+              onClick={onRestartKernel}
+              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+              title="Restart kernel"
+              aria-label="Restart kernel"
+              data-testid="restart-kernel-button"
+            >
+              <RotateCcw className="h-3 w-3" />
+              <span className="hidden @[40rem]:inline">Restart</span>
+            </button>
+            <button
+              type="button"
+              onClick={onRestartAndRunAll}
+              className={cn(
+                "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+                depsOutOfSync
+                  ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
+                  : "text-foreground hover:bg-muted",
+              )}
+              title={
+                depsOutOfSync
+                  ? "Dependencies changed — restart kernel and run all cells"
+                  : "Restart kernel and run all cells"
+              }
+              data-testid="restart-run-all-button"
+            >
+              <RotateCcw className="h-3 w-3" />
+              <ChevronsRight className="h-3 w-3 -ml-1" />
+            </button>
+          </>
+        )}
+        {canExecute && isKernelRunning && (
           <button
             type="button"
             onClick={onInterruptKernel}
@@ -294,7 +308,7 @@ export function NotebookToolbar({
         )}
 
         {/* Runtime / deps toggle — hidden until runtime is known to avoid flicker */}
-        {runtime && (
+        {runtime && canViewPackages && (
           <button
             type="button"
             onClick={onToggleDependencies}

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -49,6 +49,10 @@ const wasmReady: Promise<void> = init().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
 });
 
+function scopeAllowsNotebookWrite(scope: string | null): boolean {
+  return scope === null || scope === "editor" || scope === "owner";
+}
+
 let warnedMissingExecutionViewProjector = false;
 
 function projectExecutionViewChangeset(handle: NotebookHandle) {
@@ -91,6 +95,7 @@ export function useAutomergeNotebook() {
   const actorLabelRef = useRef(`desktop:${sessionIdRef.current}`);
   const [localActor, setLocalActor] = useState(actorLabelRef.current);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
+  const canWriteNotebookRef = useRef(true);
 
   const [handleHost] = useState(
     () =>
@@ -185,7 +190,7 @@ export function useAutomergeNotebook() {
 
   const refreshCanAcceptCellMutations = useCallback(
     (handle = handleHost.current) => {
-      const canAccept = handle?.has_cells_map() ?? false;
+      const canAccept = canWriteNotebookRef.current && (handle?.has_cells_map() ?? false);
       setCanAcceptCellMutations(canAccept);
       return canAccept;
     },
@@ -202,6 +207,10 @@ export function useAutomergeNotebook() {
       const engine = engineRef.current;
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] commitMutation skipped: no handle/engine");
+        return false;
+      }
+      if (!canWriteNotebookRef.current) {
+        logger.debug("[automerge-notebook] commitMutation skipped: connection is read-only");
         return false;
       }
       if (!mutate(handle)) return false;
@@ -292,7 +301,9 @@ export function useAutomergeNotebook() {
           actorLabelRef.current = trigger.payload.actor_label;
           setLocalActor(trigger.payload.actor_label);
         }
-        setConnectionScope(trigger.payload.connection_scope ?? null);
+        const connectionScope = trigger.payload.connection_scope ?? null;
+        setConnectionScope(connectionScope);
+        canWriteNotebookRef.current = scopeAllowsNotebookWrite(connectionScope);
         storeBridge.resetReadiness();
         refreshBlobPort();
         resetNotebookCells();
@@ -346,6 +357,7 @@ export function useAutomergeNotebook() {
       resetRuntimeState();
       resetRuntimeStoresProjection();
       resetPoolState();
+      canWriteNotebookRef.current = false;
       setCanAcceptCellMutations(false);
       handleHost.clear();
     };
@@ -364,6 +376,10 @@ export function useAutomergeNotebook() {
     const handle = handleHost.current;
     const engine = engineRef.current;
     if (!handle || !engine) return;
+    if (!canWriteNotebookRef.current) {
+      logger.debug("[automerge-notebook] updateCellSource skipped: connection is read-only");
+      return;
+    }
 
     const updated = handle.update_source(cellId, source);
     if (!updated) return;
@@ -379,6 +395,10 @@ export function useAutomergeNotebook() {
 
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] addCell skipped: no handle/engine");
+        return null;
+      }
+      if (!canWriteNotebookRef.current) {
+        logger.debug("[automerge-notebook] addCell skipped: connection is read-only");
         return null;
       }
 
@@ -450,6 +470,10 @@ export function useAutomergeNotebook() {
       const engine = engineRef.current;
       if (!handle || !engine) {
         logger.debug("[automerge-notebook] clearOutputs skipped: no handle/engine");
+        return false;
+      }
+      if (!canWriteNotebookRef.current) {
+        logger.debug("[automerge-notebook] clearOutputs skipped: connection is read-only");
         return false;
       }
 

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -93,6 +93,33 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.runtime.canWriteRuntimeState).toBe(false);
   });
 
+  it("maps local read-only files to viewer access without cloud source", () => {
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: false,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: "viewer",
+    });
+
+    expect(capabilities.access).toMatchObject({
+      level: "viewer",
+      source: "local",
+      actorLabel: "local:kyle/desktop:window",
+    });
+    expect(capabilities.canRead).toBe(true);
+    expect(capabilities.canEditMarkdown).toBe(false);
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canEditStructure).toBe(false);
+    expect(capabilities.canExecute).toBe(false);
+    expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.runtime).toMatchObject({
+      canWriteRuntimeState: false,
+      connected: true,
+      source: "local",
+      actorLabel: null,
+    });
+  });
+
   it("keeps runtime peer authority separate from document editing access", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: false,

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -22,7 +22,7 @@ export function desktopNotebookShellCapabilities({
   connectionScope,
 }: DesktopNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
-  const source = desktopAccessSourceFromConnectionScope(connectionScope);
+  const source = desktopAccessSourceFromActor(connectionScope, localActor);
   const isRuntimePeer = connectionScope === "runtime_peer";
   const canWriteDocument =
     canAcceptCellMutations && (accessLevel === "editor" || accessLevel === "owner");
@@ -82,8 +82,10 @@ function desktopAccessLevelFromConnectionScope(
   return "owner";
 }
 
-function desktopAccessSourceFromConnectionScope(
+function desktopAccessSourceFromActor(
   connectionScope: string | null,
+  localActor: string | null,
 ): NotebookShellAccessSource {
+  if (localActor?.startsWith("local:")) return "local";
   return connectionScope ? "cloud" : "local";
 }

--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -275,9 +275,17 @@ async function handleRelayConnection(
       ephemeral?: boolean;
       notebook_path?: string | null;
       runtime?: string;
+      actor_label?: string;
+      connection_scope?: string;
+      capabilities?: {
+        actor_label?: string;
+        connection_scope?: string;
+      };
     };
 
     if (info.error) throw new Error(info.error);
+    const actorLabel = info.actor_label ?? info.capabilities?.actor_label;
+    const connectionScope = info.connection_scope ?? info.capabilities?.connection_scope;
 
     const daemonInfoJson = readDaemonInfo(socketPath);
     control(ws, {
@@ -289,6 +297,8 @@ async function handleRelayConnection(
         ephemeral: info.ephemeral ?? true,
         notebook_path: info.notebook_path ?? null,
         runtime: info.runtime,
+        actor_label: actorLabel,
+        connection_scope: connectionScope,
       },
       blob_port: daemonInfoJson?.blob_port ?? null,
       daemon: daemonInfoJson

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2706,8 +2706,6 @@ impl Daemon {
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
-        let connection_identity =
-            crate::notebook_sync_server::RoomConnectionIdentity::local(operator.clone()).await?;
 
         // Diagnostic: flag suspicious path shapes. UUID-shaped paths (no slash,
         // no extension, parses as a UUID) almost certainly indicate a bug
@@ -2839,6 +2837,30 @@ impl Daemon {
             }
         };
 
+        fn existing_file_allows_write(path: &std::path::Path) -> bool {
+            match std::fs::metadata(path) {
+                Ok(metadata) if metadata.permissions().readonly() => return false,
+                Ok(_) => {}
+                Err(_) => return false,
+            }
+            #[cfg(unix)]
+            {
+                use std::ffi::CString;
+                use std::os::unix::ffi::OsStrExt;
+
+                let Ok(path) = CString::new(path.as_os_str().as_bytes()) else {
+                    return false;
+                };
+                // SAFETY: `path` is a valid NUL-terminated C string created
+                // from the OS path bytes above. `access` does not retain it.
+                unsafe { libc::access(path.as_ptr(), libc::W_OK) == 0 }
+            }
+            #[cfg(not(unix))]
+            {
+                true
+            }
+        }
+
         // Derive notebook_id from path
         // For existing files: canonicalize for stable cross-process identity
         // For new files: use absolute path (canonicalize would fail)
@@ -2862,6 +2884,19 @@ impl Daemon {
                 .to_string_lossy()
                 .to_string()
         };
+
+        let connection_scope =
+            if file_exists && !existing_file_allows_write(&PathBuf::from(&notebook_id)) {
+                nteract_identity::ConnectionScope::Viewer
+            } else {
+                nteract_identity::ConnectionScope::Owner
+            };
+        let connection_identity =
+            crate::notebook_sync_server::RoomConnectionIdentity::local_with_scope(
+                operator.clone(),
+                connection_scope,
+            )
+            .await?;
 
         // Get or create room for this notebook.
         // First check if an existing room already owns this canonical path.

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -16,11 +16,23 @@ pub(crate) struct RoomConnectionIdentity {
 impl RoomConnectionIdentity {
     /// Authenticate a local same-UID daemon connection.
     pub(crate) async fn local(presented_operator: Option<String>) -> anyhow::Result<Self> {
+        Self::local_with_scope(presented_operator, ConnectionScope::Owner).await
+    }
+
+    /// Authenticate a local same-UID daemon connection with an explicit scope.
+    ///
+    /// Local file-backed rooms use this to downgrade a connection to viewer
+    /// when the host can read a notebook but cannot write it. The principal is
+    /// still the local user; only the room-enforced document capabilities differ.
+    pub(crate) async fn local_with_scope(
+        presented_operator: Option<String>,
+        scope: ConnectionScope,
+    ) -> anyhow::Result<Self> {
         let username = local_username();
         let provider = IdentityProvider::local();
         let credential = Credential::LocalPeer(LocalPeerCredential::new(username)?);
         let user = provider.authenticate(credential).await?;
-        let auth = AuthenticatedConnection::from_user(user);
+        let auth = AuthenticatedConnection::new(user.principal().clone(), scope);
         let fallback_operator = fallback_operator("desktop");
         let operator = presented_operator
             .as_deref()
@@ -173,6 +185,24 @@ mod tests {
         assert_eq!(identity.scope(), ConnectionScope::Owner);
         assert!(identity.allows_notebook_write());
         assert!(identity.allows_runtime_state_write());
+    }
+
+    #[tokio::test]
+    async fn local_identity_can_be_downgraded_to_viewer() {
+        let identity = RoomConnectionIdentity::local_with_scope(
+            Some("desktop:window-1".to_string()),
+            ConnectionScope::Viewer,
+        )
+        .await
+        .expect("local viewer identity");
+
+        assert_eq!(identity.scope(), ConnectionScope::Viewer);
+        assert!(!identity.allows_notebook_write());
+        assert!(!identity.allows_runtime_state_write());
+        assert!(identity
+            .actor_label()
+            .as_str()
+            .contains("/desktop:window-1"));
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -1,7 +1,7 @@
 use super::blob_upload::{enqueue_put_blob, spawn_put_blob_worker, MultipartUploadState};
 use super::peer_notebook_sync::{
     finish_notebook_doc_frame, forward_notebook_doc_broadcast, handle_notebook_doc_frame,
-    queue_doc_sync, NotebookDocFrameOutcome,
+    queue_doc_sync,
 };
 use super::peer_pool_sync::{
     forward_pool_state_broadcast, handle_pool_state_frame, send_initial_pool_sync,
@@ -243,17 +243,7 @@ where
                 }
                 match frame.frame_type {
                             NotebookFrameType::AutomergeSync => {
-                                if !connection_identity.allows_notebook_write() {
-                                    warn!(
-                                        "[notebook-sync] Rejecting NotebookDoc frame for {} from peer {} with scope {}",
-                                        notebook_id,
-                                        peer_id,
-                                        connection_identity.scope()
-                                    );
-                                    continue;
-                                }
-                                let NotebookDocFrameOutcome::Applied(notebook_doc_effects) =
-                                    handle_notebook_doc_frame(
+                                let notebook_doc_effects = handle_notebook_doc_frame(
                                     room,
                                     &mut peer_state,
                                     connection_identity,
@@ -289,6 +279,7 @@ where
                                     &frame.payload,
                                     &notebook_id,
                                     peer_id,
+                                    connection_identity.scope(),
                                 )?;
                             }
 
@@ -304,15 +295,6 @@ where
                             }
 
                             NotebookFrameType::RuntimeStateSync => {
-                                if !connection_identity.allows_runtime_state_write() {
-                                    warn!(
-                                        "[notebook-sync] Rejecting RuntimeStateDoc frame for {} from peer {} with scope {}",
-                                        notebook_id,
-                                        peer_id,
-                                        connection_identity.scope()
-                                    );
-                                    continue;
-                                }
                                 if !handle_runtime_state_frame(
                                     room,
                                     &mut state_peer_state,

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -16,16 +16,25 @@ pub(super) async fn handle_notebook_doc_frame(
     connection_identity: &RoomConnectionIdentity,
     writer: &PeerWriter,
     payload: &[u8],
-) -> anyhow::Result<NotebookDocFrameOutcome> {
-    let message =
+) -> anyhow::Result<NotebookDocSideEffects> {
+    let mut message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
+    let has_client_changes = !message.changes.is_empty();
+    if has_client_changes && !connection_identity.allows_notebook_write() {
+        warn!(
+            "[notebook-sync] Stripping unauthorized NotebookDoc changes for scope {}",
+            connection_identity.scope()
+        );
+        message.changes = sync::ChunkList::empty();
+    }
+    let has_client_changes = !message.changes.is_empty();
 
     // Complete all document mutations inside the lock, encode the reply, then
     // release the lock before performing async I/O.
     let (persist_bytes, reply_encoded, metadata_changed) = {
         let mut doc = room.doc.write().await;
 
-        if !message.changes.is_empty() {
+        if has_client_changes {
             // v1: clone-preview validator. Replace with sync_message_new_changes
             // once nteract/automerge ships Patch 1.
             let heads_before = doc.get_heads();
@@ -58,12 +67,15 @@ pub(super) async fn handle_notebook_doc_frame(
         }
 
         let heads_after = doc.get_heads();
-        let metadata_changed = diff_metadata_touched(doc.doc_mut(), &heads_before, &heads_after);
+        let changed = heads_before != heads_after;
+        let metadata_changed =
+            changed && diff_metadata_touched(doc.doc_mut(), &heads_before, &heads_after);
 
-        let bytes = doc.save();
-
-        // Notify other peers in this room.
-        let _ = room.broadcasts.changed_tx.send(());
+        let bytes = if changed { Some(doc.save()) } else { None };
+        if changed {
+            // Notify other peers in this room.
+            let _ = room.broadcasts.changed_tx.send(());
+        }
 
         let encoded = match doc.generate_sync_message_recovering(peer_state, "doc-sync-reply") {
             Ok(message) => message.map(|reply| reply.encode()),
@@ -82,18 +94,14 @@ pub(super) async fn handle_notebook_doc_frame(
         writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
     }
 
-    Ok(NotebookDocFrameOutcome::Applied(NotebookDocSideEffects {
+    Ok(NotebookDocSideEffects {
         persist_bytes,
         metadata_changed,
-    }))
-}
-
-pub(super) enum NotebookDocFrameOutcome {
-    Applied(NotebookDocSideEffects),
+    })
 }
 
 pub(super) struct NotebookDocSideEffects {
-    persist_bytes: Vec<u8>,
+    persist_bytes: Option<Vec<u8>>,
     metadata_changed: bool,
 }
 
@@ -101,8 +109,11 @@ pub(super) async fn finish_notebook_doc_frame(
     room: &NotebookRoom,
     effects: NotebookDocSideEffects,
 ) {
-    room.persistence
-        .enqueue_persist_bytes(effects.persist_bytes);
+    let Some(persist_bytes) = effects.persist_bytes else {
+        return;
+    };
+
+    room.persistence.enqueue_persist_bytes(persist_bytes);
 
     if effects.metadata_changed {
         check_and_broadcast_sync_state(room).await;

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_sync.rs
@@ -77,13 +77,22 @@ pub(super) async fn handle_runtime_state_frame(
     persisted_records: &mut PersistedExecutionRecords,
     connection_identity: &RoomConnectionIdentity,
 ) -> anyhow::Result<bool> {
-    let message =
+    let mut message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode state sync: {}", e))?;
+    let has_client_changes = !message.changes.is_empty();
+    if has_client_changes && !connection_identity.allows_runtime_state_write() {
+        warn!(
+            "[notebook-sync] Stripping unauthorized RuntimeStateDoc changes for scope {}",
+            connection_identity.scope()
+        );
+        message.changes = sync::ChunkList::empty();
+    }
+    let has_client_changes = !message.changes.is_empty();
     let mut runtime_file_dirty = false;
 
     let reply_encoded = room.state.with_doc(|state_doc| {
         let before = runtime_file_save_fingerprint(state_doc);
-        if !message.changes.is_empty() {
+        if has_client_changes {
             // v1: clone-preview validator. Replace with sync_message_new_changes
             // once nteract/automerge ships Patch 1.
             let heads_before = state_doc.get_heads();

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use notebook_protocol::connection::{self, NotebookFrameType};
+use nteract_identity::ConnectionScope;
 
 use super::blob_upload::{maybe_handle_blob_upload_request, MultipartUploadState};
 use super::NotebookRoom;
@@ -384,9 +385,30 @@ pub(super) fn enqueue_notebook_request(
     payload: &[u8],
     notebook_id: &str,
     peer_id: &str,
+    connection_scope: ConnectionScope,
 ) -> anyhow::Result<()> {
     let envelope: notebook_protocol::protocol::NotebookRequestEnvelope =
         serde_json::from_slice(payload)?;
+    if !request_allowed_for_scope(&envelope.request, connection_scope) {
+        warn!(
+            "[notebook-sync] Rejecting {} request for {} from peer {} with scope {}",
+            request_label(&envelope.request),
+            notebook_id,
+            peer_id,
+            connection_scope.as_str()
+        );
+        queue_request_error(
+            writer,
+            envelope.id.clone(),
+            format!(
+                "{} is not allowed for {} connections",
+                request_label(&envelope.request),
+                connection_scope.as_str()
+            ),
+        )?;
+        return Ok(());
+    }
+
     debug!(
         "[notebook-sync] Enqueuing {} id={} peer={} notebook={}",
         request_label(&envelope.request),
@@ -415,6 +437,17 @@ pub(super) fn enqueue_notebook_request(
         }
     }
     Ok(())
+}
+
+fn request_allowed_for_scope(
+    request: &notebook_protocol::protocol::NotebookRequest,
+    connection_scope: ConnectionScope,
+) -> bool {
+    connection_scope.allows_notebook_write()
+        || matches!(
+            request,
+            notebook_protocol::protocol::NotebookRequest::GetDocBytes {}
+        )
 }
 
 pub(super) fn queue_request_error(
@@ -868,9 +901,15 @@ mod tests {
         };
         let (writer, mut reliable_rx, _ephemeral_rx) = test_peer_writer_with_capacities(1, 1);
 
-        let err =
-            enqueue_notebook_request(&request_worker, &writer, b"not json", "notebook", "peer")
-                .expect_err("malformed request payload should fail");
+        let err = enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            b"not json",
+            "notebook",
+            "peer",
+            ConnectionScope::Owner,
+        )
+        .expect_err("malformed request payload should fail");
         assert!(err.to_string().contains("expected ident"));
         assert!(
             reliable_rx.try_recv().is_err(),
@@ -901,8 +940,15 @@ mod tests {
             request: NotebookRequest::GetDocBytes {},
         })
         .unwrap();
-        enqueue_notebook_request(&request_worker, &writer, &payload, "notebook", "peer")
-            .expect("full queue should be reported to the peer without failing the loop");
+        enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            &payload,
+            "notebook",
+            "peer",
+            ConnectionScope::Owner,
+        )
+        .expect("full queue should be reported to the peer without failing the loop");
 
         let frame = reliable_rx
             .try_recv()
@@ -935,8 +981,15 @@ mod tests {
             request: NotebookRequest::GetDocBytes {},
         })
         .unwrap();
-        let err = enqueue_notebook_request(&request_worker, &writer, &payload, "notebook", "peer")
-            .expect_err("closed worker should stop the peer loop");
+        let err = enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            &payload,
+            "notebook",
+            "peer",
+            ConnectionScope::Owner,
+        )
+        .expect_err("closed worker should stop the peer loop");
         assert_eq!(err.to_string(), "peer request worker stopped for notebook");
 
         let frame = reliable_rx
@@ -950,6 +1003,53 @@ mod tests {
             reply.response,
             notebook_protocol::protocol::NotebookResponse::Error { ref error }
                 if error == "Peer request worker stopped"
+        ));
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_rejects_viewer_mutations_without_failing_loop() {
+        let (request_tx, mut request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer, mut reliable_rx, _ephemeral_rx) = test_peer_writer_with_capacities(1, 1);
+
+        let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
+            id: Some("execute".to_string()),
+            required_heads: Vec::new(),
+            request: NotebookRequest::ExecuteCell {
+                cell_id: "cell-1".to_string(),
+                execution_id: None,
+            },
+        })
+        .unwrap();
+        enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            &payload,
+            "notebook",
+            "peer",
+            ConnectionScope::Viewer,
+        )
+        .expect("unauthorized requests should be reported without failing the peer loop");
+
+        assert!(
+            request_rx.try_recv().is_err(),
+            "viewer mutation should not reach the request worker"
+        );
+        let frame = reliable_rx
+            .try_recv()
+            .expect("unauthorized request should enqueue an error response");
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let reply: notebook_protocol::protocol::NotebookResponseEnvelope =
+            serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(reply.id.as_deref(), Some("execute"));
+        assert!(matches!(
+            reply.response,
+            notebook_protocol::protocol::NotebookResponse::Error { ref error }
+                if error.contains("ExecuteCell is not allowed")
         ));
     }
 }


### PR DESCRIPTION
## Summary

- map local read-only notebook files to viewer-level `NotebookShellCapabilities`
- gate desktop toolbar and mutation entry points by structure/package/execute capabilities
- keep read-only Automerge peers synced by rejecting only actual document/runtime-state changes, not no-change sync acknowledgements
- add browser E2E coverage that copies a committed fixture to temp files and chmods it to read-only or inaccessible modes

## Validation

- `pnpm test:run -- apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --filter notebook-ui exec tsc --noEmit`
- `cargo test -p runtimed notebook_sync_server::identity::tests::local_identity_can_be_downgraded_to_viewer`
- `cargo test -p runtimed enqueue_notebook_request_rejects_viewer_mutations_without_failing_loop`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1 e2e/local-file-permissions.spec.ts`
- `cargo xtask lint --fix`

## Notes

- Git cannot preserve arbitrary no-read/no-write fixture permissions, so the committed `.ipynb` stays normal and the E2E test applies POSIX modes to a temp copy at runtime.
- Runtime connection can still be present for local read-only notebooks; write and execute capabilities are disabled.
