### PR TITLE
chore(elements): run dev server through portless

### DIFF
--- a/apps/elements/next.config.mjs
+++ b/apps/elements/next.config.mjs
@@ -12,7 +12,7 @@ const frameConfigAdapterImport = "./components/isolated/frame-config-adapter.ts"
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
-  allowedDevOrigins: ["127.0.0.1"],
+  allowedDevOrigins: ["127.0.0.1", "**.nteract-elements.localhost"],
   output: "export",
   images: {
     unoptimized: true,

--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -3,8 +3,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --port 5176",
+    "dev": "portless run",
+    "dev:local": "next dev --port 5176",
+    "dev:next": "next dev",
+    "url": "portless get nteract-elements",
     "build": "next build"
+  },
+  "portless": {
+    "name": "nteract-elements",
+    "script": "dev:next"
   },
   "dependencies": {
     "@nteract/sift": "workspace:*",
@@ -34,6 +41,7 @@
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "@nteract/notebook-host": "workspace:*",
+    "portless": "^0.13.0",
     "runtimed": "workspace:*",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.3"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:e2e": "wdio run e2e/wdio.conf.js",
     "test:e2e:native": "wdio run e2e/wdio.conf.js",
     "elements:dev": "pnpm --dir apps/elements dev",
+    "elements:dev:local": "pnpm --dir apps/elements dev:local",
+    "elements:url": "pnpm --dir apps/elements url",
     "elements:build": "pnpm --dir apps/elements build",
     "prototype:sidebar-toc": "RUNTIMED_VITE_PORT=5175 RUNT_NOTEBOOK_PROTOTYPE_ROUTE=/prototypes/sidebar-toc/ pnpm --dir apps/notebook dev -- --host 127.0.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.15)
+      portless:
+        specifier: ^0.13.0
+        version: 0.13.0
       runtimed:
         specifier: workspace:*
         version: link:../../packages/runtimed


### PR DESCRIPTION
## Summary

- run the Elements dev server through Portless by default
- preserve the old fixed-port Next dev server as `dev:local` / `pnpm elements:dev:local`
- add `pnpm elements:url` to print the worktree-scoped Elements URL

## Verification

- `PORTLESS_PORT=1355 pnpm --dir apps/elements dev`
- `curl -k -I https://elements-portless.nteract-elements.localhost:1355/`
- `pnpm elements:url`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
