### PR TITLE
docs(elements): explore cell insertion affordances

### DIFF
--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -32,7 +32,7 @@ const variants: Array<{
   {
     variant: "production",
     label: "Production line",
-    body: "The current shape uses an explicit sentence plus a rule. It is clear, but the sentence can become louder than the source.",
+    body: "The current shape lets active states lead with the signal, while completed metadata stays available but visually quiet.",
   },
   {
     variant: "quiet",

--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { Check, Clock3, Play, Sparkles, X } from "lucide-react";
+import type { CSSProperties, ReactNode } from "react";
+import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
+import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
+import { notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { cn } from "@/lib/utils";
+
+type ExecutionState = "ready" | "queued" | "running" | "completed" | "failed";
+type Variant = "production" | "quiet" | "sentence" | "signal";
+
+const states: Array<{
+  state: ExecutionState;
+  label: string;
+  detail: string;
+  count: number | null;
+  elapsedMs?: number | null;
+}> = [
+  { state: "ready", label: "Ready", detail: "waiting for first run", count: null },
+  { state: "queued", label: "Queued", detail: "next in line", count: null },
+  { state: "running", label: "Running", detail: "building signal", count: null },
+  { state: "completed", label: "Completed", detail: "Run 12 in 180ms", count: 12, elapsedMs: 180 },
+  { state: "failed", label: "Failed", detail: "Run 13 stopped", count: 13 },
+];
+
+const variants: Array<{
+  variant: Variant;
+  label: string;
+  body: string;
+}> = [
+  {
+    variant: "production",
+    label: "Production line",
+    body: "The current shape uses an explicit sentence plus a rule. It is clear, but the sentence can become louder than the source.",
+  },
+  {
+    variant: "quiet",
+    label: "Quiet unless focused",
+    body: "Keep only the run affordance and language at rest. The run count and duration bloom on focus or hover.",
+  },
+  {
+    variant: "sentence",
+    label: "Short sentence",
+    body: "Treat the metadata as one compact phrase after the signal: Python, run 12 in 180ms.",
+  },
+  {
+    variant: "signal",
+    label: "Signal-led",
+    body: "Let the rule own state. Text becomes a soft caption instead of the primary visual event.",
+  },
+];
+
+export function CellExecutionLanguageExample() {
+  return (
+    <div className="not-prose space-y-6">
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Run line direction set</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The target is a cell boundary that can speak when needed, but usually reads as
+            punctuation in the notebook rhythm.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background">
+          {variants.map((variant) => (
+            <div key={variant.label} className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+              <div>
+                <h3 className="text-sm font-semibold">{variant.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{variant.body}</p>
+              </div>
+              <NotebookPreview variant={variant.variant} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">State vocabulary</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The same line should carry ready, queued, running, completed, and failed states without
+            making every cell feel like a status table.
+          </p>
+        </div>
+        <div className="grid gap-3 bg-background p-4 md:grid-cols-2">
+          {states.map((state) => (
+            <StateSample key={state.state} {...state} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function NotebookPreview({ variant }: { variant: Variant }) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background",
+        notebookCellLayoutVars,
+      )}
+    >
+      <PreviewCell
+        variant={variant}
+        state="completed"
+        count={12}
+        elapsedMs={180}
+        source={<CodeSample tokens={["total", " = ", "sum", "(", "values", ")"]} />}
+        output="42"
+      />
+      <PreviewCell
+        variant={variant}
+        state="running"
+        count={null}
+        source={<CodeSample tokens={["fit", "(", "model", ", ", "frame", ")"]} />}
+      />
+    </div>
+  );
+}
+
+function PreviewCell({
+  variant,
+  state,
+  count,
+  elapsedMs,
+  source,
+  output,
+}: {
+  variant: Variant;
+  state: ExecutionState;
+  count: number | null;
+  elapsedMs?: number | null;
+  source: ReactNode;
+  output?: string;
+}) {
+  const isRunning = state === "running";
+  const isQueued = state === "queued";
+  const isFailed = state === "failed";
+
+  return (
+    <div data-preview-state={state} className="cell-container group flex bg-background/95">
+      <div
+        className={cn(
+          "w-1 shrink-0 transition-colors",
+          state === "failed" ? "bg-red-400" : state === "running" ? "bg-emerald-400" : "bg-sky-400",
+        )}
+      />
+      <div className="min-w-0 flex-1 py-3 pl-[var(--cell-content-column-inset,3.25rem)] pr-5">
+        <div className="relative min-h-10">
+          <div className="absolute left-[calc(-1*var(--cell-content-column-inset,3.25rem)+0.4rem)] top-1">
+            <CompactExecutionButton
+              count={count}
+              isExecuting={isRunning}
+              isQueued={isQueued}
+              isErrored={isFailed}
+              isCellFocused
+            />
+          </div>
+          <div className="font-mono text-[15px] leading-7 tracking-normal text-foreground">
+            {source}
+          </div>
+          {variant === "production" ? (
+            <CodeCellCurrentLine
+              languageLabel="Python"
+              count={count}
+              elapsedMs={elapsedMs}
+              isExecuting={isRunning}
+              isQueued={isQueued}
+              isErrored={isFailed}
+              isFocused
+            />
+          ) : (
+            <ExecutionLanguageLine
+              variant={variant}
+              state={state}
+              count={count}
+              elapsedMs={elapsedMs}
+            />
+          )}
+        </div>
+        {output ? (
+          <div className="mt-5 font-mono text-[15px] leading-6 text-foreground">{output}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ExecutionLanguageLine({
+  variant,
+  state,
+  count,
+  elapsedMs,
+}: {
+  variant: Exclude<Variant, "production">;
+  state: ExecutionState;
+  count: number | null;
+  elapsedMs?: number | null;
+}) {
+  const copy = executionCopy(state, count, elapsedMs);
+
+  if (variant === "quiet") {
+    return (
+      <div className="mt-1.5 flex min-h-4 items-center gap-1.5 text-[11px] font-medium leading-none text-muted-foreground/55">
+        <LanguagePill state={state} />
+        <div className="h-px w-8 rounded-full bg-border/20 transition-all group-hover:w-12 group-hover:bg-border/35" />
+        <span className="max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-[max-width,opacity] duration-150 group-hover:max-w-48 group-hover:opacity-100 group-focus-within:max-w-48 group-focus-within:opacity-100">
+          {copy.short}
+        </span>
+        <SignalRule state={state} quiet />
+      </div>
+    );
+  }
+
+  if (variant === "sentence") {
+    return (
+      <div className="mt-1.5 flex min-h-4 items-center gap-1.5 text-[11px] font-medium leading-none text-muted-foreground/60">
+        <StateGlyph state={state} />
+        <span className="whitespace-nowrap">
+          <span className="text-foreground/65">Python</span>
+          <span className="px-1 text-muted-foreground/35">/</span>
+          <span className={stateTone(state)}>{copy.short}</span>
+        </span>
+        <SignalRule state={state} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-1.5 grid min-h-4 grid-cols-[auto_minmax(3rem,1fr)_auto] items-center gap-2 text-[11px] font-medium leading-none text-muted-foreground/55">
+      <StateGlyph state={state} />
+      <SignalRule state={state} strong />
+      <span className="whitespace-nowrap">
+        <span className="text-foreground/65">Python</span>
+        <span className="px-1 text-muted-foreground/35">/</span>
+        <span className={stateTone(state)}>{copy.tiny}</span>
+      </span>
+    </div>
+  );
+}
+
+function StateSample({
+  state,
+  label,
+  detail,
+  count,
+  elapsedMs,
+}: {
+  state: ExecutionState;
+  label: string;
+  detail: string;
+  count: number | null;
+  elapsedMs?: number | null;
+}) {
+  return (
+    <div className="rounded-md border border-fd-border bg-fd-background p-3">
+      <div className="flex items-center gap-2 text-xs font-semibold">
+        <StateGlyph state={state} />
+        <span>{label}</span>
+      </div>
+      <div className="mt-4">
+        <ExecutionLanguageLine variant="signal" state={state} count={count} elapsedMs={elapsedMs} />
+      </div>
+      <p className="mt-3 text-xs leading-5 text-fd-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function LanguagePill({ state }: { state: ExecutionState }) {
+  return (
+    <span
+      className={cn(
+        "rounded-sm px-1 py-0.5 transition-colors",
+        state === "running" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+        state === "queued" && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+        state === "failed" && "bg-red-500/10 text-red-700 dark:text-red-300",
+        (state === "ready" || state === "completed") && "bg-muted/45 text-foreground/65",
+      )}
+    >
+      Python
+    </span>
+  );
+}
+
+function StateGlyph({ state }: { state: ExecutionState }) {
+  const className = cn(
+    "size-3 shrink-0",
+    state === "running" && "text-emerald-600 dark:text-emerald-300",
+    state === "queued" && "text-sky-600 dark:text-sky-300",
+    state === "failed" && "text-red-600 dark:text-red-300",
+    state === "completed" && "text-muted-foreground/55",
+    state === "ready" && "text-muted-foreground/35",
+  );
+
+  if (state === "running") return <Sparkles className={className} aria-hidden="true" />;
+  if (state === "queued") return <Clock3 className={className} aria-hidden="true" />;
+  if (state === "failed") return <X className={className} aria-hidden="true" />;
+  if (state === "completed") return <Check className={className} aria-hidden="true" />;
+  return <Play className={cn(className, "fill-current")} aria-hidden="true" />;
+}
+
+function SignalRule({
+  state,
+  quiet = false,
+  strong = false,
+}: {
+  state: ExecutionState;
+  quiet?: boolean;
+  strong?: boolean;
+}) {
+  if (state === "running") {
+    return (
+      <span className="relative h-3 min-w-12 flex-1 overflow-hidden text-emerald-500/65 [mask-image:linear-gradient(to_right,transparent,black_0.5rem,black_calc(100%-0.5rem),transparent)]">
+        <svg
+          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
+          viewBox="0 0 240 12"
+          preserveAspectRatio="none"
+        >
+          <path
+            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
+            fill="none"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeWidth={strong ? "1.5" : "1.2"}
+            vectorEffect="non-scaling-stroke"
+          />
+        </svg>
+      </span>
+    );
+  }
+
+  if (state === "queued") {
+    return (
+      <span
+        className={cn(
+          "h-px min-w-12 flex-1 rounded-full bg-sky-400/45 animate-queue-boundary-pulse",
+          strong && "bg-sky-400/60",
+        )}
+        style={{ "--queue-pulse-duration": "2s" } as CSSProperties}
+      />
+    );
+  }
+
+  if (state === "failed") {
+    return (
+      <span className="h-px min-w-12 flex-1 bg-[repeating-linear-gradient(to_right,rgb(248_113_113/.7)_0_0.35rem,transparent_0.35rem_0.6rem)]" />
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "h-px min-w-8 flex-1 rounded-full",
+        quiet ? "bg-border/15" : "bg-border/25",
+        strong && "bg-border/35",
+      )}
+    />
+  );
+}
+
+function executionCopy(state: ExecutionState, count: number | null, elapsedMs?: number | null) {
+  if (state === "running") return { short: "running", tiny: "running" };
+  if (state === "queued") return { short: "queued", tiny: "queued" };
+  if (state === "failed")
+    return { short: count === null ? "failed" : `run ${count} failed`, tiny: "failed" };
+  if (state === "completed") {
+    const run = count === null ? "run" : `run ${count}`;
+    const elapsed = typeof elapsedMs === "number" ? ` in ${formatElapsed(elapsedMs)}` : "";
+    return { short: `${run}${elapsed}`, tiny: count === null ? "done" : `run ${count}` };
+  }
+  return { short: "ready", tiny: "ready" };
+}
+
+function stateTone(state: ExecutionState) {
+  if (state === "running") return "text-emerald-700 dark:text-emerald-300";
+  if (state === "queued") return "text-sky-700 dark:text-sky-300";
+  if (state === "failed") return "text-red-700 dark:text-red-300";
+  return "text-muted-foreground/70";
+}
+
+function formatElapsed(ms: number) {
+  if (ms < 1_000) return `${Math.max(1, Math.round(ms))}ms`;
+  const seconds = ms / 1_000;
+  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
+}
+
+function CodeSample({ tokens }: { tokens: string[] }) {
+  return (
+    <>
+      <span className="text-blue-600">{tokens[0]}</span>
+      <span className="text-muted-foreground">{tokens[1]}</span>
+      <span className="text-purple-600">{tokens[2]}</span>
+      <span className="text-muted-foreground">{tokens[3]}</span>
+      <span className="text-blue-600">{tokens[4]}</span>
+      <span className="text-muted-foreground">{tokens[5]}</span>
+    </>
+  );
+}

--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -32,7 +32,7 @@ const variants: Array<{
   {
     variant: "production",
     label: "Production line",
-    body: "The current shape lets active states lead with the signal, while completed metadata stays available but visually quiet.",
+    body: "The current shape keeps the signal lane flexible and pins the language/state readout to the right, so running, queued, failed, and completed states share one grammar.",
   },
   {
     variant: "quiet",

--- a/apps/elements/components/cell-insertion-affordances-example.tsx
+++ b/apps/elements/components/cell-insertion-affordances-example.tsx
@@ -10,7 +10,7 @@ type Intent = "code" | "markdown";
 const concepts = [
   {
     label: "Production row",
-    body: "A compact action palette appears over a continuous neutral spine.",
+    body: "The row wakes in a neutral insertion state; color appears only when code or markdown is targeted.",
     render: <ProductionInsertionPreview />,
   },
   {
@@ -77,9 +77,7 @@ export function CellInsertionAffordancesExample() {
 }
 
 function ProductionInsertionPreview() {
-  return (
-    <CellInsertionRibbon activeType="markdown" forceActionsVisible onInsert={() => undefined} />
-  );
+  return <CellInsertionRibbon forceActionsVisible onInsert={() => undefined} />;
 }
 
 function ThreadedLinePreview() {

--- a/apps/elements/components/cell-insertion-affordances-example.tsx
+++ b/apps/elements/components/cell-insertion-affordances-example.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { Code, LetterText, Plus } from "lucide-react";
+import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
+import { notebookCellLayoutVars } from "@/components/cell/cell-layout";
+import { cn } from "@/lib/utils";
+
+type Intent = "code" | "markdown";
+
+const concepts = [
+  {
+    label: "Production row",
+    body: "A compact action palette appears over a continuous neutral spine.",
+    render: <ProductionInsertionPreview />,
+  },
+  {
+    label: "Threaded line",
+    body: "Actions attach directly to the document rule, reducing the floating-button feeling.",
+    render: <ThreadedLinePreview />,
+  },
+  {
+    label: "Split landing zone",
+    body: "The left channel stays a broad insert target while the explicit choices sit in the document column.",
+    render: <SplitLandingPreview />,
+  },
+];
+
+export function CellInsertionAffordancesExample() {
+  return (
+    <div className="not-prose space-y-6">
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Between-cell direction set</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            These sketches keep the same rail-gripped ribbon and document column, but change how
+            much chrome the code and markdown choices carry.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border bg-background">
+          {concepts.map((concept) => (
+            <div key={concept.label} className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+              <div>
+                <h3 className="text-sm font-semibold">{concept.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{concept.body}</p>
+              </div>
+              <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+                {concept.render}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <h2 className="text-sm font-semibold">Document tail</h2>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            The final add row needs a softer ending than an ordinary between-cell row.
+          </p>
+        </div>
+        <div className="grid gap-4 bg-background p-4 lg:grid-cols-2">
+          <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+            <CellInsertionRibbon
+              activeType="code"
+              terminal
+              forceActionsVisible
+              onInsert={() => undefined}
+            />
+          </div>
+          <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
+            <TailFadePreview />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ProductionInsertionPreview() {
+  return (
+    <CellInsertionRibbon activeType="markdown" forceActionsVisible onInsert={() => undefined} />
+  );
+}
+
+function ThreadedLinePreview() {
+  return (
+    <div className={cn("flex h-9 w-full items-center", notebookCellLayoutVars)}>
+      <Ribbon intent="markdown" />
+      <div className="h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 bg-emerald-500/5" />
+      <div className="flex min-w-0 flex-1 items-center">
+        <div className="h-px w-6 bg-border/70" />
+        <ThreadedAction intent="code" muted />
+        <ThreadedAction intent="markdown" />
+        <div className="h-px min-w-8 flex-1 bg-border/70" />
+      </div>
+    </div>
+  );
+}
+
+function SplitLandingPreview() {
+  return (
+    <div className={cn("flex h-9 w-full items-center", notebookCellLayoutVars)}>
+      <Ribbon intent="code" />
+      <div className="flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center bg-sky-500/6">
+        <Plus className="size-3 text-sky-600/70" aria-hidden="true" />
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <SplitAction intent="code" />
+        <span className="h-px min-w-4 flex-1 bg-border/65" />
+        <SplitAction intent="markdown" muted />
+      </div>
+    </div>
+  );
+}
+
+function TailFadePreview() {
+  return (
+    <div
+      className={cn("flex h-[clamp(3.5rem,9vh,5.5rem)] w-full items-start", notebookCellLayoutVars)}
+    >
+      <div className="relative h-full w-1 shrink-0 overflow-hidden [mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]">
+        <div className="absolute inset-0 bg-gray-200/70 dark:bg-gray-700/55" />
+        <div className="absolute left-0 top-0 h-7 w-full bg-gradient-to-b from-emerald-400 via-emerald-400/50 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/50 dark:to-emerald-600/0" />
+      </div>
+      <div className="h-7 w-[var(--cell-content-column-inset,3.25rem)] shrink-0 bg-emerald-500/5" />
+      <div className="flex h-7 min-w-0 flex-1 items-center">
+        <div className="h-px w-5 bg-border/55" />
+        <SplitAction intent="code" muted />
+        <SplitAction intent="markdown" />
+        <div className="h-px min-w-8 flex-1 bg-gradient-to-r from-border/55 to-transparent" />
+      </div>
+    </div>
+  );
+}
+
+function Ribbon({ intent }: { intent: Intent }) {
+  return (
+    <div className="relative h-full w-1 shrink-0 overflow-hidden">
+      <div className="absolute inset-0 bg-gray-200/55 dark:bg-gray-700/55" />
+      <div
+        className={cn(
+          "absolute inset-0",
+          intent === "code" ? "bg-sky-400 dark:bg-sky-600" : "bg-emerald-400 dark:bg-emerald-600",
+        )}
+      />
+    </div>
+  );
+}
+
+function ThreadedAction({ intent, muted = false }: { intent: Intent; muted?: boolean }) {
+  const Icon = intent === "code" ? Code : LetterText;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex h-7 shrink-0 items-center gap-1.5 border-y border-border/70 px-2.5 text-xs font-medium transition-colors first:border-l first:rounded-l-full last:border-r last:rounded-r-full",
+        muted
+          ? "bg-background text-muted-foreground/50"
+          : intent === "code"
+            ? "bg-sky-500/10 text-sky-700 dark:text-sky-300"
+            : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+      )}
+    >
+      <Plus className="size-3" aria-hidden="true" />
+      <Icon className="size-3" aria-hidden="true" />
+      <span>{intent === "code" ? "Code" : "Markdown"}</span>
+    </button>
+  );
+}
+
+function SplitAction({ intent, muted = false }: { intent: Intent; muted?: boolean }) {
+  const Icon = intent === "code" ? Code : LetterText;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors",
+        muted
+          ? "text-muted-foreground/50 hover:bg-muted/50 hover:text-foreground"
+          : intent === "code"
+            ? "bg-sky-500/10 text-sky-700 ring-1 ring-sky-500/15 dark:text-sky-300"
+            : "bg-emerald-500/10 text-emerald-700 ring-1 ring-emerald-500/15 dark:text-emerald-300",
+      )}
+    >
+      <Plus className="size-3" aria-hidden="true" />
+      <Icon className="size-3" aria-hidden="true" />
+      <span>{intent === "code" ? "Code" : "Markdown"}</span>
+    </button>
+  );
+}

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -163,7 +163,7 @@ const scenarioFacts = [
     value:
       scenarioCodeCell.executionCount === null
         ? "not run"
-        : `In [${scenarioCodeCell.executionCount}]`,
+        : `run ${scenarioCodeCell.executionCount}`,
   },
 ];
 

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -68,6 +68,11 @@ const outlineBoundaryRows = [
     production: "NotebookView focus state + shared outline selection",
   },
   {
+    label: "Header chrome",
+    catalog: "outline title without item count",
+    production: "packages may summarize state; outline stays reading-first",
+  },
+  {
     label: "Heading anchors",
     catalog: "viewModel.markdownHeadingAnchorsByCellId",
     production: "MarkdownCell receives anchors from the shell view model",
@@ -76,6 +81,11 @@ const outlineBoundaryRows = [
     label: "Heading navigation",
     catalog: "inert outline callback updates fixture focus",
     production: "navigateMarkdownHeading, scrollIntoView, and history.replaceState",
+  },
+  {
+    label: "Drag policy",
+    catalog: "outline rows cancel native drag previews",
+    production: "navigation-only until the app owns true outline reordering",
   },
   {
     label: "DOM order",
@@ -302,14 +312,14 @@ function ScenarioNotebookCell({
 function ScenarioCellBadge({ cell }: { cell: NotebookViewCell }) {
   const label =
     cell.id === executingCellId
-      ? "Running"
+      ? "running"
       : queuedCellIds.has(cell.id)
-        ? "Queued"
+        ? "queued"
         : cell.cellType === "code"
           ? cell.executionCount === null
-            ? "Ready"
-            : `Run ${cell.executionCount}`
-          : "Markdown";
+            ? "ready"
+            : `run ${cell.executionCount}`
+          : "markdown";
 
   return (
     <span

--- a/apps/elements/content/docs/cell-execution-language.mdx
+++ b/apps/elements/content/docs/cell-execution-language.mdx
@@ -1,0 +1,13 @@
+---
+title: Cell execution language
+description: Visual language sketches for the code cell run line and execution signal.
+---
+
+import { CellExecutionLanguageExample } from "@/components/cell-execution-language-example";
+
+The code cell run line should feel like notebook punctuation first and status
+copy second. This studio compares the current production line against quieter
+directions where the execution signal carries more of the meaning and text
+appears only when it earns the space.
+
+<CellExecutionLanguageExample />

--- a/apps/elements/content/docs/cell-insertion-affordances.mdx
+++ b/apps/elements/content/docs/cell-insertion-affordances.mdx
@@ -1,0 +1,13 @@
+---
+title: Cell insertion affordances
+description: Fixture-backed sketches for making add-cell rows feel connected to the notebook spine.
+---
+
+import { CellInsertionAffordancesExample } from "@/components/cell-insertion-affordances-example";
+
+The current add-cell row has the right structural idea: the ribbon remains part
+of the document spine, while the actions appear only when the reader is near an
+insertion point. This studio keeps the production row visible and compares it
+against lighter, more line-driven directions.
+
+<CellInsertionAffordancesExample />

--- a/apps/elements/content/docs/cell-insertion-affordances.mdx
+++ b/apps/elements/content/docs/cell-insertion-affordances.mdx
@@ -10,4 +10,8 @@ of the document spine, while the actions appear only when the reader is near an
 insertion point. This studio keeps the production row visible and compares it
 against lighter, more line-driven directions.
 
+The production row now treats proximity as neutral document intent. Code and
+markdown color arrive only when a concrete target is hovered or focused, which
+keeps the spine from declaring a cell type before the reader does.
+
 <CellInsertionAffordancesExample />

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -34,6 +34,7 @@ The catalog should make it obvious which surfaces are nteract-owned notebook
 concepts and which boundaries still need a notebook-semantic wrapper.
 
 - [Cell anatomy](/docs/cell-anatomy)
+- [Cell insertion affordances](/docs/cell-insertion-affordances)
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Package manager surfaces](/docs/package-manager-surfaces)

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -34,6 +34,7 @@ The catalog should make it obvious which surfaces are nteract-owned notebook
 concepts and which boundaries still need a notebook-semantic wrapper.
 
 - [Cell anatomy](/docs/cell-anatomy)
+- [Cell execution language](/docs/cell-execution-language)
 - [Cell insertion affordances](/docs/cell-insertion-affordances)
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -11,6 +11,12 @@ slots for packages, variables, renderers, and future notebook tools.
 The rail owns notebook-level navigation and tools; the ribbon and code-cell
 chrome remain inside the notebook surface for per-cell focus and execution
 state.
+Outline rows are navigation, not drag handles. The active row now uses a quiet
+spine marker instead of a full-color selected block, and native drag previews
+are cancelled until notebook reordering through the outline is a real workflow.
+The outline header stays label-only; package panels can use the summary chip for
+runtime state, but an outline item count adds bookkeeping noise without helping
+reading flow.
 
 This fixture now renders the current notebook app toolbar and shared
 `NotebookRail` directly. The outline is projected with the same
@@ -39,12 +45,17 @@ states stay aligned with the app shell.
   the production projection path from materialized markdown headings.
 - Contextual selection depends on `outlineCellIds`: a focused code cell inside a
   section highlights the nearest preceding markdown heading.
+- Outline panel chrome is intentionally sparse. The panel title names the mode,
+  and the rows carry the useful context without an extra item-count badge.
 - Production active-section tracking still belongs to the app shell through
   viewport observation and `resolveNotebookOutlineSelection`; this page only
   fixtures the active item.
 - Heading navigation remains app-owned. Production routes heading anchors
   through `navigateMarkdownHeading`, `scrollIntoView`, and history replacement;
   the catalog keeps the callback inert.
+- Outline rows use a navigation-only drag policy. If outline-driven cell
+  reordering ships later, it should have explicit drop targets instead of a
+  browser drag ghost.
 - Keep the rail icon-led. The current shared rail exposes outline and packages;
   variables, renderers, and future side panels are tracked as planned sibling
   panels until the app has current components for them.

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -751,10 +751,10 @@ function AppContent() {
 
     return createNotebookViewModel(getNotebookCellsSnapshot().map(notebookCellToViewCell), {
       getOutlineStatusLabel: (cell) => {
-        if (cell.id === executingCellId) return "Running";
-        if (queuedOutlineCellIds.has(cell.id)) return "Queued";
+        if (cell.id === executingCellId) return "running";
+        if (queuedOutlineCellIds.has(cell.id)) return "queued";
         if (cell.cellType === "code" && cell.executionCount !== null) {
-          return `In [${cell.executionCount}]`;
+          return `run ${cell.executionCount}`;
         }
         return null;
       },

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -230,7 +230,7 @@ describe("CodeCell output focus", () => {
     expect(getByTestId("output").getAttribute("data-focused")).toBe("true");
   });
 
-  it("keeps completed execution state readable but visually quiet", () => {
+  it("keeps completed execution state in the stable right readout slot", () => {
     mockOutputs = [];
     mockExecution = { execution_count: 12, submitted_by_actor_label: null };
 
@@ -246,13 +246,15 @@ describe("CodeCell output focus", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run12");
     expect(footer?.textContent).not.toContain("In [12]");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
+    expect(rule).toHaveClass("flex-1");
   });
 
   it("keeps running status active while the stop control carries danger", () => {
@@ -272,12 +274,13 @@ describe("CodeCell output focus", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
     const stopButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("running");
     expect(status?.textContent).toBe("Python/running");
-    expect(status).toHaveClass("text-emerald-700");
+    expect(detail).toHaveClass("text-emerald-700");
     expect(status).not.toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("text-emerald-500/65");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
@@ -306,7 +309,7 @@ describe("CodeCell output focus", () => {
     const runButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("error");
-    expect(status?.textContent).toBe("Python/run 14 failed");
+    expect(status?.textContent).toBe("Python/failed");
     expect(rule).toHaveClass("text-destructive/60");
     expect(runButton).toHaveAttribute("data-execution-state", "error");
     expect(runButton).toHaveAttribute("aria-label", "Run cell again; last execution 14 failed");
@@ -331,11 +334,11 @@ describe("CodeCell output focus", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer?.getAttribute("data-execution-state")).toBe("error");
-    expect(status?.textContent).toBe("Python/error");
+    expect(status?.textContent).toBe("Python/failed");
     expect(rule).toHaveClass("text-destructive/60");
   });
 
-  it("keeps idle footer language quiet until the cell is engaged", () => {
+  it("keeps idle footer language in the stable right readout slot", () => {
     mockOutputs = [];
     mockExecution = null;
 
@@ -355,10 +358,10 @@ describe("CodeCell output focus", () => {
 
     expect(footer?.getAttribute("data-execution-state")).toBe("idle");
     expect(status?.textContent).toBe("Python/ready");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
-    expect(status).toHaveClass("group-hover:max-w-64");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
     expect(rule).toHaveClass("bg-border/15");
+    expect(rule).toHaveClass("flex-1");
   });
 
   it("uses compact current-line chrome for empty idle code cells", () => {
@@ -406,7 +409,7 @@ describe("CodeCell output focus", () => {
     expect(rule).not.toBeNull();
   });
 
-  it("keeps focused idle footer language collapsed into the boundary", () => {
+  it("keeps focused idle footer language pinned to the same readout slot", () => {
     mockOutputs = [];
     mockExecution = null;
     mockIsFocused = true;
@@ -424,9 +427,8 @@ describe("CodeCell output focus", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(status?.textContent).toBe("Python/ready");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
-    expect(status).toHaveClass("group-focus-within:max-w-64");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
   });
 
   it("keeps the current line visible when source is hidden but output remains visible", () => {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -248,7 +248,7 @@ describe("CodeCell output focus", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer?.getAttribute("data-execution-label")).toBe("Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run12");
     expect(footer?.textContent).not.toContain("In [12]");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
@@ -276,10 +276,11 @@ describe("CodeCell output focus", () => {
     const stopButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("running");
-    expect(status?.textContent).toBe("Python·Running");
-    expect(status).toHaveClass("text-primary");
+    expect(status?.textContent).toBe("Python/running");
+    expect(status).toHaveClass("text-emerald-700");
     expect(status).not.toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("text-emerald-500/65");
+    expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(rule).toHaveAttribute("data-execution-signal", "building");
     expect(rule?.querySelector("svg")).toBeNull();
     expect(stopButton).toHaveClass("text-destructive");
@@ -305,7 +306,7 @@ describe("CodeCell output focus", () => {
     const runButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("error");
-    expect(status?.textContent).toBe("Python·Run 14 failed");
+    expect(status?.textContent).toBe("Python/run 14 failed");
     expect(rule).toHaveClass("text-destructive/60");
     expect(runButton).toHaveAttribute("data-execution-state", "error");
     expect(runButton).toHaveAttribute("aria-label", "Run cell again; last execution 14 failed");
@@ -330,7 +331,7 @@ describe("CodeCell output focus", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer?.getAttribute("data-execution-state")).toBe("error");
-    expect(status?.textContent).toBe("Python·Error");
+    expect(status?.textContent).toBe("Python/error");
     expect(rule).toHaveClass("text-destructive/60");
   });
 
@@ -353,7 +354,7 @@ describe("CodeCell output focus", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer?.getAttribute("data-execution-state")).toBe("idle");
-    expect(status?.textContent).toBe("Python·Ready");
+    expect(status?.textContent).toBe("Python/ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveClass("group-hover:max-w-64");
@@ -422,7 +423,7 @@ describe("CodeCell output focus", () => {
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
-    expect(status?.textContent).toBe("Python·Ready");
+    expect(status?.textContent).toBe("Python/ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveClass("group-focus-within:max-w-64");
@@ -452,7 +453,7 @@ describe("CodeCell output focus", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     expect(queryByTestId("editor")).toBeNull();
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run4");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run4");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -44,8 +44,8 @@ export function CellInsertionRibbon({
   );
   const [interactionActive, setInteractionActive] = useState(false);
   const resolvedActiveType = activeType === undefined ? uncontrolledActiveType : activeType;
-  const visualActiveType =
-    resolvedActiveType ?? (interactionActive || forceActionsVisible ? "code" : null);
+  const visualActiveType = resolvedActiveType ?? null;
+  const isOpen = interactionActive || forceActionsVisible;
   const ribbonClass = visualActiveType
     ? terminal
       ? terminalInsertionRibbonClasses[visualActiveType]
@@ -72,6 +72,8 @@ export function CellInsertionRibbon({
     <div
       data-slot="cell-adder"
       data-terminal={terminal || undefined}
+      data-active-type={visualActiveType ?? undefined}
+      data-interaction-active={isOpen || undefined}
       className={cn(
         "group/adder flex w-full select-none",
         terminal ? "h-[clamp(3.5rem,9vh,5.5rem)] items-start" : "h-7 items-center",
@@ -103,8 +105,9 @@ export function CellInsertionRibbon({
         <div
           data-slot="cell-adder-ribbon-continuation"
           className={cn(
-            "absolute inset-0 dark:bg-gray-700/55",
+            "absolute inset-0 transition-colors duration-150 dark:bg-gray-700/55",
             terminal ? "bg-gray-200/70" : "bg-gray-200/55",
+            isOpen && !visualActiveType && "bg-gray-300/70 dark:bg-gray-600/60",
           )}
         />
         {ribbonClass ? (
@@ -127,12 +130,24 @@ export function CellInsertionRibbon({
         onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
         className={cn(
-          "h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 rounded-none transition-colors duration-150",
+          "flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
-          visualActiveType === "code" ? "bg-sky-500/5" : "hover:bg-muted/20",
+          visualActiveType === "code"
+            ? "bg-sky-500/6 text-sky-700 dark:text-sky-300"
+            : isOpen
+              ? "bg-muted/20 text-muted-foreground/45 hover:bg-muted/30 hover:text-muted-foreground/70"
+              : "text-muted-foreground/0 hover:bg-muted/20",
           terminal && "h-7",
         )}
       >
+        <Plus
+          data-slot="cell-adder-primary-glyph"
+          className={cn(
+            "size-3 transition-opacity duration-150",
+            isOpen || visualActiveType === "code" ? "opacity-100" : "opacity-0",
+          )}
+          aria-hidden="true"
+        />
         <span className="sr-only">Add code cell</span>
       </button>
       <div

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -52,7 +52,7 @@ function visualExecutionDetail({
 }): string {
   if (isExecuting) return "running";
   if (isQueued) return "queued";
-  if (isErrored) return count === null ? "error" : `run ${formatExecutionCount(count)} failed`;
+  if (isErrored) return "failed";
   if (count !== null) {
     const runPrefix = `run ${formatExecutionCount(count)}`;
     return elapsedMs === null ? runPrefix : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
@@ -156,13 +156,11 @@ function useRunningSignalPhase(isExecuting: boolean): RunningSignalPhase {
 function ExecutionBoundaryRule({
   state,
   runningSignalPhase,
-  isQuietResting,
   queuePriority,
   isFocused,
 }: {
   state: ExecutionBoundaryState;
   runningSignalPhase: RunningSignalPhase;
-  isQuietResting: boolean;
   queuePriority: number;
   isFocused: boolean;
 }) {
@@ -247,8 +245,7 @@ function ExecutionBoundaryRule({
     <div
       data-slot="code-cell-current-line-rule"
       className={cn(
-        "h-px min-w-4 rounded-full transition-[background-color,width,flex-basis] duration-150",
-        isQuietResting ? "w-10 flex-none group-hover:w-14 group-focus-within:w-14" : "flex-1",
+        "h-px min-w-8 flex-1 rounded-full transition-colors duration-150",
         executionLineClass({ isFocused }),
       )}
     />
@@ -280,7 +277,6 @@ export function CodeCellCurrentLine({
           : "idle";
   const isCompactIdle = compactIdle && state === "idle";
   const isQuietResting = state === "idle" || state === "ran";
-  const isSignalLed = state === "running" || state === "queued" || state === "error";
   const detailLabel = visualExecutionDetail({
     count,
     elapsedMs,
@@ -308,14 +304,26 @@ export function CodeCellCurrentLine({
         className,
       )}
     >
-      {!isCompactIdle && isSignalLed ? (
+      {!isCompactIdle ? (
         <ExecutionBoundaryRule
           state={state}
           runningSignalPhase={runningSignalPhase}
-          isQuietResting={isQuietResting}
           queuePriority={queuePriority}
           isFocused={isFocused}
         />
+      ) : null}
+      {!isCompactIdle && activityContent ? (
+        <div
+          data-slot="code-cell-current-line-activity"
+          className={cn(
+            "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
+            isQuietResting
+              ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
+              : "max-w-24 opacity-100",
+          )}
+        >
+          {activityContent}
+        </div>
       ) : null}
       <span
         data-slot="code-cell-current-line-status"
@@ -323,28 +331,15 @@ export function CodeCellCurrentLine({
         aria-live={isExecuting || isQueued || isErrored ? "polite" : undefined}
         className={cn(
           "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
-          isQuietResting
-            ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-64 group-hover:opacity-100 group-focus-within:max-w-64 group-focus-within:opacity-100"
-            : "max-w-64 opacity-100",
+          isCompactIdle ? "max-w-0 overflow-hidden opacity-0" : "max-w-64 opacity-100",
           isFocused && "text-foreground/70",
-          isExecuting && "text-emerald-700 dark:text-emerald-300",
-          isQueued && "text-sky-700 dark:text-sky-300",
-          isErrored && "text-destructive/80",
         )}
       >
         <span
           data-slot="code-cell-current-line-language"
           className={cn(
             "text-foreground/60 transition-colors duration-150",
-            isSignalLed
-              ? "px-0 py-0"
-              : "rounded-sm px-0.5 py-0.5 group-hover:bg-muted/50 group-hover:text-foreground/70 group-focus-within:bg-muted/50 group-focus-within:text-foreground/70",
-            !isSignalLed && isFocused && "bg-muted/45 text-foreground/70",
-            !isSignalLed &&
-              isExecuting &&
-              "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-            !isSignalLed && isQueued && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
-            !isSignalLed && isErrored && "bg-destructive/10 text-destructive/90",
+            isFocused && "text-foreground/70",
           )}
         >
           {languageLabel}
@@ -357,37 +352,18 @@ export function CodeCellCurrentLine({
         </span>
         <span
           data-slot="code-cell-current-line-detail"
-          className={cn("tabular-nums", isCompactIdle && "sr-only", isSignalLed && "font-semibold")}
+          className={cn(
+            "tabular-nums",
+            isCompactIdle && "sr-only",
+            isExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
+            isQueued && "font-semibold text-sky-700 dark:text-sky-300",
+            isErrored && "font-semibold text-destructive/80",
+            !isExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
+          )}
         >
           {detailLabel}
         </span>
       </span>
-      {!isCompactIdle && (
-        <>
-          {activityContent ? (
-            <div
-              data-slot="code-cell-current-line-activity"
-              className={cn(
-                "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
-                isQuietResting
-                  ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
-                  : "max-w-24 opacity-100",
-              )}
-            >
-              {activityContent}
-            </div>
-          ) : null}
-          {!isSignalLed ? (
-            <ExecutionBoundaryRule
-              state={state}
-              runningSignalPhase={runningSignalPhase}
-              isQuietResting={isQuietResting}
-              queuePriority={queuePriority}
-              isFocused={isFocused}
-            />
-          ) : null}
-        </>
-      )}
     </div>
   );
 }

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -50,16 +50,15 @@ function visualExecutionDetail({
   isQueued: boolean;
   isErrored: boolean;
 }): string {
-  const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
-
-  if (isExecuting) return "Running";
-  if (isQueued) return "Queued";
-  if (isErrored) return runPrefix === null ? "Error" : `${runPrefix} failed`;
+  if (isExecuting) return "running";
+  if (isQueued) return "queued";
+  if (isErrored) return count === null ? "error" : `run ${formatExecutionCount(count)} failed`;
   if (count !== null) {
-    return elapsedMs === null ? `${runPrefix}` : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
+    const runPrefix = `run ${formatExecutionCount(count)}`;
+    return elapsedMs === null ? runPrefix : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
   }
 
-  return "Ready";
+  return "ready";
 }
 
 function accessibleExecutionDetail({
@@ -281,6 +280,7 @@ export function CodeCellCurrentLine({
           : "idle";
   const isCompactIdle = compactIdle && state === "idle";
   const isQuietResting = state === "idle" || state === "ran";
+  const isSignalLed = state === "running" || state === "queued" || state === "error";
   const detailLabel = visualExecutionDetail({
     count,
     elapsedMs,
@@ -308,6 +308,15 @@ export function CodeCellCurrentLine({
         className,
       )}
     >
+      {!isCompactIdle && isSignalLed ? (
+        <ExecutionBoundaryRule
+          state={state}
+          runningSignalPhase={runningSignalPhase}
+          isQuietResting={isQuietResting}
+          queuePriority={queuePriority}
+          isFocused={isFocused}
+        />
+      ) : null}
       <span
         data-slot="code-cell-current-line-status"
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
@@ -318,7 +327,7 @@ export function CodeCellCurrentLine({
             ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-64 group-hover:opacity-100 group-focus-within:max-w-64 group-focus-within:opacity-100"
             : "max-w-64 opacity-100",
           isFocused && "text-foreground/70",
-          isExecuting && "text-primary",
+          isExecuting && "text-emerald-700 dark:text-emerald-300",
           isQueued && "text-sky-700 dark:text-sky-300",
           isErrored && "text-destructive/80",
         )}
@@ -326,12 +335,16 @@ export function CodeCellCurrentLine({
         <span
           data-slot="code-cell-current-line-language"
           className={cn(
-            "rounded-sm px-0.5 py-0.5 text-foreground/60 transition-colors duration-150",
-            "group-hover:bg-muted/50 group-hover:text-foreground/70 group-focus-within:bg-muted/50 group-focus-within:text-foreground/70",
-            isFocused && "bg-muted/45 text-foreground/70",
-            isExecuting && "bg-primary/10 text-primary",
-            isQueued && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
-            isErrored && "bg-destructive/10 text-destructive/90",
+            "text-foreground/60 transition-colors duration-150",
+            isSignalLed
+              ? "px-0 py-0"
+              : "rounded-sm px-0.5 py-0.5 group-hover:bg-muted/50 group-hover:text-foreground/70 group-focus-within:bg-muted/50 group-focus-within:text-foreground/70",
+            !isSignalLed && isFocused && "bg-muted/45 text-foreground/70",
+            !isSignalLed &&
+              isExecuting &&
+              "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+            !isSignalLed && isQueued && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+            !isSignalLed && isErrored && "bg-destructive/10 text-destructive/90",
           )}
         >
           {languageLabel}
@@ -340,11 +353,11 @@ export function CodeCellCurrentLine({
           className={cn("text-muted-foreground/35", isCompactIdle && "sr-only")}
           aria-hidden="true"
         >
-          ·
+          /
         </span>
         <span
           data-slot="code-cell-current-line-detail"
-          className={cn("tabular-nums", isCompactIdle && "sr-only")}
+          className={cn("tabular-nums", isCompactIdle && "sr-only", isSignalLed && "font-semibold")}
         >
           {detailLabel}
         </span>
@@ -364,13 +377,15 @@ export function CodeCellCurrentLine({
               {activityContent}
             </div>
           ) : null}
-          <ExecutionBoundaryRule
-            state={state}
-            runningSignalPhase={runningSignalPhase}
-            isQuietResting={isQuietResting}
-            queuePriority={queuePriority}
-            isFocused={isFocused}
-          />
+          {!isSignalLed ? (
+            <ExecutionBoundaryRule
+              state={state}
+              runningSignalPhase={runningSignalPhase}
+              isQuietResting={isQuietResting}
+              queuePriority={queuePriority}
+              isFocused={isFocused}
+            />
+          ) : null}
         </>
       )}
     </div>

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -30,10 +30,29 @@ describe("CellInsertionRibbon", () => {
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toHaveClass(
       "bg-sky-400",
     );
+    expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toHaveClass(
+      "opacity-100",
+    );
 
     fireEvent.click(hitTarget!);
 
     expect(onInsert).toHaveBeenCalledWith("code");
+  });
+
+  it("keeps the row neutral until a concrete cell type is targeted", () => {
+    const { container } = render(<CellInsertionRibbon onInsert={() => undefined} />);
+
+    const adder = container.querySelector('[data-slot="cell-adder"]');
+    const continuation = container.querySelector('[data-slot="cell-adder-ribbon-continuation"]');
+    const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+
+    fireEvent.pointerEnter(adder!);
+
+    expect(adder).toHaveAttribute("data-interaction-active", "true");
+    expect(adder).not.toHaveAttribute("data-active-type");
+    expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
+    expect(continuation).toHaveClass("bg-gray-300/70");
+    expect(hitTarget).toHaveClass("bg-muted/20");
   });
 
   it("uses the controlled active type for catalog fixtures", () => {

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -12,7 +12,7 @@ describe("CodeCellCurrentLine", () => {
 
     expect(footer).toHaveAttribute("data-execution-state", "idle");
     expect(footer).toHaveClass("min-h-4");
-    expect(status).toHaveTextContent("Python·Ready");
+    expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(rule).toHaveClass("bg-border/15");
@@ -39,7 +39,7 @@ describe("CodeCellCurrentLine", () => {
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
-    expect(status).toHaveTextContent("Python·Ready");
+    expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveClass("group-focus-within:max-w-64");
@@ -55,11 +55,12 @@ describe("CodeCellCurrentLine", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "running");
-    expect(status).toHaveTextContent("Python·Running");
+    expect(status).toHaveTextContent("Python/running");
     expect(status).toHaveAttribute("aria-label", "Python: Running");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(status).toHaveClass("text-primary");
+    expect(status).toHaveClass("text-emerald-700");
     expect(rule).toHaveClass("text-emerald-500/65");
+    expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(rule).toHaveAttribute("data-execution-signal", "building");
     expect(
       rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
@@ -146,7 +147,7 @@ describe("CodeCellCurrentLine", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "queued");
-    expect(status).toHaveTextContent("Python·Queued");
+    expect(status).toHaveTextContent("Python/queued");
     expect(status).toHaveAttribute("aria-live", "polite");
     expect(rule).toHaveClass("bg-sky-400/45");
     expect(rule).toHaveAttribute("data-queue-priority", "0.35");
@@ -179,7 +180,7 @@ describe("CodeCellCurrentLine", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "error");
-    expect(status).toHaveTextContent("Python·Run 12 failed");
+    expect(status).toHaveTextContent("Python/run 12 failed");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 failed");
     expect(status).toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("text-destructive/60");
@@ -194,7 +195,7 @@ describe("CodeCellCurrentLine", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
-    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python·Run12·1.5s");
+    expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run12·1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
     expect(status).toHaveClass("max-w-0");
   });
@@ -204,7 +205,7 @@ describe("CodeCellCurrentLine", () => {
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
-    expect(status).toHaveTextContent("Python·Run 12");
+    expect(status).toHaveTextContent("Python/run 12");
     expect(status).toHaveClass("max-w-0");
     expect(status).toHaveClass("opacity-0");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { CodeCellCurrentLine } from "../CodeCellCurrentLine";
 
 describe("CodeCellCurrentLine", () => {
-  it("keeps idle language quiet until the cell is engaged", () => {
+  it("keeps idle language in the stable right readout slot", () => {
     const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={null} />);
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
@@ -13,9 +13,11 @@ describe("CodeCellCurrentLine", () => {
     expect(footer).toHaveAttribute("data-execution-state", "idle");
     expect(footer).toHaveClass("min-h-4");
     expect(status).toHaveTextContent("Python/ready");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
     expect(rule).toHaveClass("bg-border/15");
+    expect(rule).toHaveClass("flex-1");
+    expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it("keeps blank idle cells slim without separator chrome", () => {
@@ -32,7 +34,7 @@ describe("CodeCellCurrentLine", () => {
     expect(rule).toBeNull();
   });
 
-  it("keeps focused idle language collapsed into the boundary", () => {
+  it("keeps focused idle language pinned to the same readout slot", () => {
     const { container } = render(
       <CodeCellCurrentLine languageLabel="Python" count={null} isFocused />,
     );
@@ -40,9 +42,8 @@ describe("CodeCellCurrentLine", () => {
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(status).toHaveTextContent("Python/ready");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
-    expect(status).toHaveClass("group-focus-within:max-w-64");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
   });
 
   it("separates active running status from the execution control lane", () => {
@@ -52,13 +53,14 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "running");
     expect(status).toHaveTextContent("Python/running");
     expect(status).toHaveAttribute("aria-label", "Python: Running");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(status).toHaveClass("text-emerald-700");
+    expect(detail).toHaveClass("text-emerald-700");
     expect(rule).toHaveClass("text-emerald-500/65");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(rule).toHaveAttribute("data-execution-signal", "building");
@@ -144,11 +146,13 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "queued");
     expect(status).toHaveTextContent("Python/queued");
     expect(status).toHaveAttribute("aria-live", "polite");
+    expect(detail).toHaveClass("text-sky-700");
     expect(rule).toHaveClass("bg-sky-400/45");
     expect(rule).toHaveAttribute("data-queue-priority", "0.35");
     expect(rule).toHaveClass("animate-queue-boundary-pulse");
@@ -177,12 +181,13 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "error");
-    expect(status).toHaveTextContent("Python/run 12 failed");
+    expect(status).toHaveTextContent("Python/failed");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 failed");
-    expect(status).toHaveClass("text-destructive/80");
+    expect(detail).toHaveClass("text-destructive/80");
     expect(rule).toHaveClass("text-destructive/60");
   });
 
@@ -197,18 +202,21 @@ describe("CodeCellCurrentLine", () => {
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run12·1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
-    expect(status).toHaveClass("max-w-0");
+    expect(status).toHaveClass("max-w-64");
   });
 
-  it("keeps completed metadata quiet until the cell is engaged", () => {
+  it("keeps completed metadata in the same right readout slot", () => {
     const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={12} />);
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(status).toHaveTextContent("Python/run 12");
-    expect(status).toHaveClass("max-w-0");
-    expect(status).toHaveClass("opacity-0");
+    expect(status).toHaveClass("max-w-64");
+    expect(status).toHaveClass("opacity-100");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
+    expect(rule).toHaveClass("flex-1");
+    expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it("can carry activity context after the run state", () => {
@@ -223,9 +231,13 @@ describe("CodeCellCurrentLine", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     const activity = container.querySelector('[data-slot="code-cell-current-line-activity"]');
+    const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer).toHaveTextContent("Kyle");
     expect(activity).toHaveClass("max-w-0");
+    expect(activity?.compareDocumentPosition(status as Element)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
     expect(screen.getByTestId("peer-activity")).toBeInTheDocument();
   });
 });

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight, ListTree, Package, type LucideIcon } from "lucide-react";
-import { useMemo, type MouseEvent, type ReactNode } from "react";
+import { useMemo, type DragEvent, type MouseEvent, type ReactNode } from "react";
 import {
   buildNotebookOutlineTree,
   resolveNotebookOutlineSelection,
@@ -55,12 +55,7 @@ export function NotebookRail({
   className,
 }: NotebookRailProps) {
   const title = activePanelId === "outline" ? "Outline" : "Packages";
-  const summary =
-    activePanelId === "outline"
-      ? outlineItems.length === 1
-        ? "1 item"
-        : `${outlineItems.length} items`
-      : packagesSummary;
+  const summary = activePanelId === "packages" ? packagesSummary : null;
 
   return (
     <aside
@@ -211,9 +206,17 @@ export function NotebookOutlinePanel({
   const activeSelectedItemId =
     activeItemId && items.some((item) => item.id === activeItemId) ? activeItemId : null;
   const currentItemId = resolvedSelectedItemId ?? activeSelectedItemId;
+  const handleDragStart = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+  };
 
   return (
-    <nav aria-label="Notebook outline" data-testid="notebook-outline-panel">
+    <nav
+      aria-label="Notebook outline"
+      data-testid="notebook-outline-panel"
+      data-drag-policy="navigation-only"
+      onDragStartCapture={handleDragStart}
+    >
       <ol className="space-y-0.5">
         {tree.map((node) => (
           <NotebookOutlineNode
@@ -247,29 +250,34 @@ function NotebookOutlineNode({
   const selected = selectedItemId === item.id;
   const itemHref = getItemHref?.(item) ?? item.href ?? null;
   const className = cn(
-    "flex min-h-8 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-    "select-none [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+    "relative flex min-h-8 w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors",
+    "cursor-pointer select-none touch-manipulation [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+    "before:absolute before:bottom-1.5 before:left-0 before:top-1.5 before:w-0.5 before:rounded-full before:bg-transparent before:transition-colors",
     selected
-      ? "bg-primary text-primary-foreground"
-      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      ? "bg-primary/8 text-foreground before:bg-primary"
+      : "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
   );
   const content = (
     <>
-      <span className="min-w-0 flex-1 truncate">{item.title}</span>
+      <span data-slot="notebook-outline-item-title" className="min-w-0 flex-1 truncate">
+        {item.title}
+      </span>
       {item.statusLabel ? (
         <span
+          data-slot="notebook-outline-item-meta"
           className={cn(
-            "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
-            selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
+            selected ? "bg-primary/10 text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
           {item.statusLabel}
         </span>
       ) : item.detail ? (
         <span
+          data-slot="notebook-outline-item-meta"
           className={cn(
-            "shrink-0 rounded px-1.5 py-0.5 text-[10px]",
-            selected ? "bg-primary-foreground/15" : "bg-muted text-muted-foreground",
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
+            selected ? "bg-primary/10 text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
           {item.detail}

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -48,6 +48,9 @@ describe("NotebookRail", () => {
       "aria-current",
       "location",
     );
+    expect(screen.getByRole("link", { name: "Load data" })).toHaveClass("bg-primary/8");
+    expect(screen.queryByText("2 items")).not.toBeInTheDocument();
+    expect(screen.queryByText("1 item")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Load data" })).toHaveAttribute(
       "href",
       "#notebook-cell-cell-a",
@@ -184,7 +187,7 @@ describe("NotebookRail", () => {
   });
 
   it("prevents outline links from starting browser drag previews", () => {
-    render(
+    const { container } = render(
       <NotebookRail
         activePanelId="outline"
         collapsed={false}
@@ -195,10 +198,14 @@ describe("NotebookRail", () => {
       />,
     );
 
+    const outlinePanel = screen.getByTestId("notebook-outline-panel");
     const outlineLink = screen.getByRole("link", { name: "Load data" });
+    const outlineTitle = container.querySelector('[data-slot="notebook-outline-item-title"]');
 
+    expect(outlinePanel).toHaveAttribute("data-drag-policy", "navigation-only");
     expect(outlineLink).toHaveAttribute("draggable", "false");
     expect(fireEvent.dragStart(outlineLink)).toBe(false);
+    expect(fireEvent.dragStart(outlineTitle!)).toBe(false);
   });
 
   it("marks only the first outline item for a focused cell when no item is pinned", () => {

--- a/src/components/notebook-shell/__tests__/view-model.test.ts
+++ b/src/components/notebook-shell/__tests__/view-model.test.ts
@@ -141,11 +141,11 @@ describe("notebook shell view model", () => {
     });
     expect(viewModel.outlineItems[0]).toMatchObject({
       cellId: "code-1",
-      statusLabel: "In [7]",
+      statusLabel: "run 7",
     });
     expect(viewModel.tracebackTargetsByExecutionId.get("exec-1")).toEqual({
       cellId: "code-1",
-      label: "In [7]",
+      label: "run 7",
     });
     expect(viewModel.markdownHeadingAnchorsByCellId.get("code-1")).toBeUndefined();
     expect(viewModel.packages.sections).toEqual([]);
@@ -242,7 +242,7 @@ describe("notebook shell view model", () => {
     ]);
 
     expect([...targets.entries()]).toEqual([
-      ["exec-1", { cellId: "code-1", label: "In [4]" }],
+      ["exec-1", { cellId: "code-1", label: "run 4" }],
       ["exec-2", { cellId: "code-2" }],
     ]);
   });

--- a/src/components/notebook-shell/view-model.ts
+++ b/src/components/notebook-shell/view-model.ts
@@ -128,7 +128,7 @@ export function notebookViewCellsToTracebackTargets(
     if (!cell.executionId) continue;
     const target: NotebookTracebackCellTarget = { cellId: cell.id };
     if (typeof cell.executionCount === "number") {
-      target.label = `In [${cell.executionCount}]`;
+      target.label = `run ${cell.executionCount}`;
     }
     targets.set(cell.executionId, target);
   }
@@ -156,7 +156,7 @@ export function notebookOutlineItemsToMarkdownHeadingAnchors(
 
 function notebookViewCellOutlineStatusLabel(cell: NotebookViewCell): string | null {
   if (cell.cellType === "code" && cell.executionCount !== null) {
-    return `In [${cell.executionCount}]`;
+    return `run ${cell.executionCount}`;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- add an Elements catalog page for cell insertion affordance exploration
- compare the production add-cell ribbon with two lighter line-driven concepts
- include a terminal-row variant and link the page from the catalog index

## Verification

- `pnpm exec vp check --fix apps/elements/components/cell-insertion-affordances-example.tsx apps/elements/content/docs/cell-insertion-affordances.mdx apps/elements/content/docs/index.mdx`
- `pnpm --dir apps/elements build`
- `curl -k -I https://elements-portless.nteract-elements.localhost:1355/docs/cell-insertion-affordances`
- `pnpm --filter notebook-ui exec playwright screenshot --ignore-https-errors --viewport-size=1280,1100 https://elements-portless.nteract-elements.localhost:1355/docs/cell-insertion-affordances .context/screenshots/cell-insertion-affordances.png`
- `cargo xtask lint --fix`

## Stack

This is stacked on top of #3257 so the Elements catalog can be inspected through the new Portless dev URL.

