### PR TITLE
fix(notebook): share NotebookView projection

### DIFF
--- a/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { updateCellById } from "../../notebook/src/lib/notebook-cells.ts";
+import { createNotebookViewModelFromNotebookCells } from "../../notebook/src/lib/notebook-view-model.ts";
+import {
+  projectCloudCellsIntoNotebookViewStores,
+  resetCloudViewStoreProjection,
+} from "../viewer/notebook-view-store-bridge.ts";
+
+describe("cloud NotebookView store bridge", () => {
+  afterEach(() => {
+    resetCloudViewStoreProjection();
+  });
+
+  it("keeps outline projection tied to the shared NotebookView store after local source edits", () => {
+    projectCloudCellsIntoNotebookViewStores([
+      {
+        id: "intro",
+        cellType: "markdown",
+        source: "# Original title",
+        language: null,
+        executionId: null,
+        executionCount: null,
+        outputs: [],
+        metadata: {},
+      },
+    ]);
+
+    assert.deepEqual(outlineTitlesFromStore(), ["Original title"]);
+
+    updateCellById("intro", (cell) => ({
+      ...cell,
+      source: "# Updated title\n\nBody",
+    }));
+
+    assert.deepEqual(outlineTitlesFromStore(), ["Updated title"]);
+  });
+});
+
+function outlineTitlesFromStore(): string[] {
+  return createNotebookViewModelFromNotebookCells().outlineItems.map((item) => item.title);
+}

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -74,7 +74,9 @@ test("cloud viewer shell uses the shared notebook rail as an adapter surface", (
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookDocumentRail/);
-  assert.match(sourceText, /createNotebookViewModel\(cells/);
+  assert.match(sourceText, /useNotebookViewModel\(/);
+  assert.doesNotMatch(sourceText, /createNotebookViewModel\(\s+cells/);
+  assert.doesNotMatch(sourceText, /useSourceVersion\(\)/);
   assert.match(sourceText, /<NotebookDocumentRail[\s\S]*viewModel=\{notebookViewModel\}/);
   assert.match(sourceText, /onNavigateOutlineItem=\{handleNavigateOutlineItem\}/);
   assert.match(sourceText, /navigateNotebookOutlineItem\(item, href/);
@@ -107,4 +109,13 @@ test("hosted smoke waits for shared NotebookView cell markers", () => {
 
   assert.match(sourceText, /\[data-slot='cell-container'\], \[data-cell-id\]/);
   assert.doesNotMatch(sourceText, /read-only-report-cell/);
+});
+
+test("cloud sync keeps routine frame logs out of the browser console", () => {
+  const sourcePath = new URL("../viewer/live-sync.ts", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /const consoleSyncLogger = \{[\s\S]*debug: \(\) => \{\}/);
+  assert.match(sourceText, /const consoleSyncLogger = \{[\s\S]*info: \(\) => \{\}/);
+  assert.match(sourceText, /warn: \(message: string, \.\.\.args: unknown\[\]\) => console\.warn/);
 });

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -29,7 +29,6 @@ import { IsolatedRendererProvider } from "@/components/isolated/isolated-rendere
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
-  createNotebookViewModel,
   NotebookDocumentHeader,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -71,6 +70,7 @@ import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import { flushCellUIState, setFocusedCellId } from "../../notebook/src/lib/cell-ui-state";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
+import { useNotebookViewModel } from "../../notebook/src/lib/notebook-view-model";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudViewStoreProjection,
@@ -1060,14 +1060,10 @@ function NotebookViewer({
     widgetStore,
   ]);
 
-  const notebookViewModel = useMemo(
-    () =>
-      createNotebookViewModel(cells, {
-        metadata: notebookMetadata,
-        resolveLanguage: cloudSourceLanguage,
-      }),
-    [cells, notebookMetadata],
-  );
+  const notebookViewModel = useNotebookViewModel({
+    metadata: notebookMetadata,
+    resolveLanguage: cloudSourceLanguage,
+  });
   const { codeCellCount, outlineItems } = notebookViewModel;
   useEffect(() => {
     if (!selectedOutlineItemId) return;
@@ -1093,7 +1089,7 @@ function NotebookViewer({
     [authState, codeCellCount, connectionActorLabel, connectionScope],
   );
   const canEditMarkdown = shellCapabilities.canEditMarkdown;
-  const notebookCellIds = useMemo(() => cells.map((cell) => cell.id), [cells]);
+  const notebookCellIds = notebookViewModel.cellIds;
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
   const cloudPresenceContext = useMemo<PresenceContextValue | null>(
     () =>

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -418,8 +418,8 @@ export function cloudRoomReadyPeerLabel(
 }
 
 const consoleSyncLogger = {
-  debug: (message: string, ...args: unknown[]) => console.debug(message, ...args),
-  info: (message: string, ...args: unknown[]) => console.info(message, ...args),
+  debug: () => {},
+  info: () => {},
   warn: (message: string, ...args: unknown[]) => console.warn(message, ...args),
   error: (message: string, ...args: unknown[]) => console.error(message, ...args),
 };

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -34,11 +34,9 @@ import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { NotebookPackagesPanel, type NotebookRailPanelId } from "@/components/notebook-rail";
 import {
-  createNotebookViewModel,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  type NotebookViewCell,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -89,12 +87,13 @@ import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kerne
 import { type PendingTrustAction } from "./lib/trust-actions";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
-import { getNotebookCellsSnapshot, useSourceVersion } from "./lib/notebook-cells";
+import { getNotebookCellsSnapshot } from "./lib/notebook-cells";
 import { useNotebookQueueProjection } from "./lib/notebook-executions";
+import { useNotebookViewModel } from "./lib/notebook-view-model";
 import { useDetectRuntime, useNotebookMetadata, usePixiDeps } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
 import { startWindowFocusHandler } from "./lib/window-focus";
-import type { JupyterOutput, NotebookCell } from "./types";
+import type { JupyterOutput } from "./types";
 
 /** MIME bundle type for output data */
 export type MimeBundle = Record<string, unknown>;
@@ -742,29 +741,18 @@ function AppContent() {
   const executingCellIds = new Set(
     notebookQueueProjection.executing_cell_id ? [notebookQueueProjection.executing_cell_id] : [],
   );
-  const sourceVersion = useSourceVersion();
-  const notebookViewModel = useMemo(() => {
-    void cellIds;
-    void sourceVersion;
-    const executingCellId = notebookQueueProjection.executing_cell_id;
-    const queuedOutlineCellIds = new Set(notebookQueueProjection.queued_cell_ids);
-
-    return createNotebookViewModel(getNotebookCellsSnapshot().map(notebookCellToViewCell), {
-      getOutlineStatusLabel: (cell) => {
-        if (cell.id === executingCellId) return "running";
-        if (queuedOutlineCellIds.has(cell.id)) return "queued";
-        if (cell.cellType === "code" && cell.executionCount !== null) {
-          return `run ${cell.executionCount}`;
-        }
-        return null;
-      },
-    });
-  }, [
-    cellIds,
-    sourceVersion,
-    notebookQueueProjection.executing_cell_id,
-    notebookQueueProjection.queued_cell_ids,
-  ]);
+  const getOutlineStatusLabel = useCallback(
+    (cell: { id: string; cellType: string; executionCount: number | null }) => {
+      if (cell.id === notebookQueueProjection.executing_cell_id) return "running";
+      if (notebookQueueProjection.queued_cell_ids.includes(cell.id)) return "queued";
+      if (cell.cellType === "code" && cell.executionCount !== null) {
+        return `run ${cell.executionCount}`;
+      }
+      return null;
+    },
+    [notebookQueueProjection.executing_cell_id, notebookQueueProjection.queued_cell_ids],
+  );
+  const notebookViewModel = useNotebookViewModel({ getOutlineStatusLabel });
   const outlineItems = notebookViewModel.outlineItems;
   const markdownHeadingAnchorsByCellId = notebookViewModel.markdownHeadingAnchorsByCellId;
   const activeOutlineItemId = useActiveOutlineItemId(
@@ -2182,24 +2170,6 @@ function AppContent() {
       </div>
     </PresenceProvider>
   );
-}
-
-function notebookCellToViewCell(cell: NotebookCell): NotebookViewCell {
-  return {
-    id: cell.id,
-    cellType: cell.cell_type,
-    source: cell.source,
-    language: cell.cell_type === "code" ? notebookCellLanguage(cell.metadata) : null,
-    executionId: null,
-    executionCount: cell.cell_type === "code" ? cell.execution_count : null,
-    outputs: cell.cell_type === "code" ? cell.outputs : [],
-    metadata: cell.metadata,
-  };
-}
-
-function notebookCellLanguage(metadata: Record<string, unknown>): string | null {
-  const language = metadata.language;
-  return typeof language === "string" ? language : null;
 }
 
 function packageCountLabel(count: number): string {

--- a/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
@@ -174,7 +174,7 @@ describe("subscriber notifications", () => {
   });
 });
 
-describe("materialization version", () => {
+describe("cell chrome version", () => {
   it("does not bump for output-only replacements", () => {
     const firstOutput = {
       output_type: "stream" as const,
@@ -226,6 +226,47 @@ describe("materialization version", () => {
 
     expect(result.current).toBe(initialVersion + 1);
     expect(renderCount.current).toBe(2);
+  });
+
+  it("bumps when updateCellById changes cell chrome", () => {
+    replaceNotebookCells([codeCell("a", "old")]);
+
+    const { result } = renderHook(() => useMaterializeVersion());
+    const initialVersion = result.current;
+
+    act(() => {
+      updateCellById("a", (cell) =>
+        cell.cell_type === "code" ? { ...cell, execution_count: 1 } : cell,
+      );
+    });
+
+    expect(result.current).toBe(initialVersion + 1);
+  });
+
+  it("does not bump when updateCellById changes only legacy outputs", () => {
+    replaceNotebookCells([codeCell("a", "print('hello')")]);
+
+    const { result } = renderHook(() => useMaterializeVersion());
+    const initialVersion = result.current;
+
+    act(() => {
+      updateCellById("a", (cell) =>
+        cell.cell_type === "code"
+          ? {
+              ...cell,
+              outputs: [
+                {
+                  output_type: "stream" as const,
+                  name: "stdout" as const,
+                  text: "hello",
+                },
+              ],
+            }
+          : cell,
+      );
+    });
+
+    expect(result.current).toBe(initialVersion);
   });
 });
 

--- a/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { replaceNotebookCells, resetNotebookCells, updateCellById } from "../notebook-cells";
+import { createNotebookViewModelFromNotebookCells } from "../notebook-view-model";
+import type { NotebookCell } from "../../types";
+
+const codeCell = (id: string, source = "", executionCount: number | null = null): NotebookCell => ({
+  cell_type: "code",
+  id,
+  source,
+  execution_count: executionCount,
+  outputs: [],
+  metadata: {},
+});
+
+const markdownCell = (id: string, source = ""): NotebookCell => ({
+  cell_type: "markdown",
+  id,
+  source,
+  metadata: {},
+});
+
+afterEach(() => {
+  resetNotebookCells();
+});
+
+describe("createNotebookViewModelFromNotebookCells", () => {
+  it("projects outline headings from the shared NotebookView cell store", () => {
+    replaceNotebookCells([markdownCell("intro", "# Original title")]);
+
+    expect(outlineTitles()).toEqual(["Original title"]);
+
+    updateCellById("intro", (cell) => ({
+      ...cell,
+      source: "# Updated title\n\nBody",
+    }));
+
+    expect(outlineTitles()).toEqual(["Updated title"]);
+  });
+
+  it("projects outline status labels from shared cell chrome", () => {
+    replaceNotebookCells([codeCell("code-1", "print('hi')")]);
+
+    expect(createNotebookViewModelFromNotebookCells().outlineItems[0].statusLabel).toBeNull();
+
+    updateCellById("code-1", (cell) =>
+      cell.cell_type === "code" ? { ...cell, execution_count: 7 } : cell,
+    );
+
+    expect(createNotebookViewModelFromNotebookCells().outlineItems[0].statusLabel).toBe("run 7");
+  });
+});
+
+function outlineTitles(): string[] {
+  return createNotebookViewModelFromNotebookCells().outlineItems.map((item) => item.title);
+}

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -237,13 +237,16 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
             const { fromA, toA, inserted } = changes[i];
             const deleteCount = toA - fromA;
 
-            // Diagnostic: log splices near non-BMP characters (surrogate pairs)
+            // Diagnostic: log splices near non-BMP characters (surrogate pairs).
+            // Do not compare against the WASM source length here: the handle
+            // has not applied this splice yet, so ordinary edits are expected
+            // to differ from the post-transaction CodeMirror document.
             const docText = vu.state.doc.toString();
-            const wasmSource = handle.get_cell_source(cellId) ?? "";
             const hasNonBMP = /[\uD800-\uDBFF]/.test(
               docText.slice(Math.max(0, fromA - 4), fromA + deleteCount + 4),
             );
-            if (hasNonBMP || wasmSource.length !== docText.length) {
+            if (hasNonBMP) {
+              const wasmSource = handle.get_cell_source(cellId) ?? "";
               logger.debug("[crdt-bridge] SPLICE", {
                 cellId: cellId.slice(0, 8),
                 fromA,

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -27,10 +27,10 @@ const _idsSubscribers = new Set<() => void>();
 // Per-cell subscribers (keyed by cell ID)
 const _cellSubscribers = new Map<string, Set<() => void>>();
 
-// Materialization version — bumps when full-array ops change the ordered
-// cell list or cell chrome (source / metadata / type / execution count),
-// but not when they only refresh legacy `cell.outputs`. Used by components
-// that derive cross-cell state (e.g., hiddenGroups).
+// Cell chrome version — bumps when ops change the ordered cell list or cell
+// chrome (source / metadata / type / execution count), but not when they only
+// refresh legacy `cell.outputs`. Used by components that derive cross-cell
+// state (e.g., hiddenGroups, NotebookViewModel/outline).
 let _materializeVersion = 0;
 const _materializeSubscribers = new Set<() => void>();
 
@@ -82,9 +82,9 @@ export function useCell(id: string): NotebookCell | undefined {
 }
 
 /**
- * Subscribe to the materialization version counter. Re-renders on
- * replaceNotebookCells / updateNotebookCells (full-array ops) but NOT
- * on per-cell updateCellById. Useful for cross-cell derived state.
+ * Subscribe to the cell chrome version counter. Re-renders on
+ * replaceNotebookCells / updateNotebookCells and on per-cell updateCellById
+ * when the update changes cell chrome. Useful for cross-cell derived state.
  */
 export function useMaterializeVersion(): number {
   return useSyncExternalStore(subscribeMaterialize, getMaterializeSnapshot);
@@ -234,8 +234,12 @@ export function updateCellById(
   if (!cell) return;
   const updated = updater(cell);
   if (cellsEqual(cell, updated)) return;
+  const chromeChanged = !cellChromeEqual(cell, updated);
   _cellMap.set(id, updated);
   emitCellChange(id);
+  if (chromeChanged) {
+    emitMaterializeChange();
+  }
   if (updated.source !== cell.source) {
     emitSourceChange();
   }

--- a/apps/notebook/src/lib/notebook-view-model.ts
+++ b/apps/notebook/src/lib/notebook-view-model.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import {
+  createNotebookViewModel,
+  type CreateNotebookViewModelOptions,
+  type NotebookViewCell,
+  type NotebookViewModel,
+} from "../../../../src/components/notebook-shell/view-model";
+import {
+  getNotebookCellsSnapshot,
+  useCellIds,
+  useMaterializeVersion,
+} from "./notebook-cells";
+import type { NotebookCell } from "../types";
+
+export function useNotebookViewModel<TCell extends NotebookViewCell = NotebookViewCell>(
+  options: CreateNotebookViewModelOptions = {},
+): NotebookViewModel<TCell> {
+  const cellIds = useCellIds();
+  const materializeVersion = useMaterializeVersion();
+  const { getOutlineStatusLabel, metadata, resolveLanguage } = options;
+
+  return useMemo(() => {
+    void cellIds;
+    void materializeVersion;
+    return createNotebookViewModelFromNotebookCells({
+      getOutlineStatusLabel,
+      metadata,
+      resolveLanguage,
+    }) as NotebookViewModel<TCell>;
+  }, [cellIds, getOutlineStatusLabel, materializeVersion, metadata, resolveLanguage]);
+}
+
+export function createNotebookViewModelFromNotebookCells(
+  options: CreateNotebookViewModelOptions = {},
+): NotebookViewModel {
+  return createNotebookViewModel(getNotebookCellsSnapshot().map(notebookCellToViewCell), options);
+}
+
+export function notebookCellToViewCell(cell: NotebookCell): NotebookViewCell {
+  return {
+    id: cell.id,
+    cellType: cell.cell_type,
+    source: cell.source,
+    language: cell.cell_type === "code" ? notebookCellLanguage(cell.metadata) : null,
+    executionId: null,
+    executionCount: cell.cell_type === "code" ? cell.execution_count : null,
+    outputs: cell.cell_type === "code" ? cell.outputs : [],
+    metadata: cell.metadata,
+  };
+}
+
+function notebookCellLanguage(metadata: Record<string, unknown>): string | null {
+  const language = metadata.language;
+  return typeof language === "string" ? language : null;
+}


### PR DESCRIPTION
## Summary

- route desktop and cloud through one shared `useNotebookViewModel` projection over the NotebookView cell store
- make the cell-store chrome revision update for local `updateCellById` chrome changes, so outline/status projections stay fresh for local and remote edits
- quiet routine hosted sync debug/info logs and keep CRDT splice diagnostics focused on non-BMP edge cases

## Why

This fixes a live preview issue where notebook content updated through the shared NotebookView store while the cloud rail outline could stay stale. The durable direction is shared projection semantics for desktop and cloud, not cloud-specific outline repair.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-cells.test.ts apps/notebook/src/lib/__tests__/notebook-view-model.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-view-store-bridge.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --workspace-root exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Preview

Deployed this branch to `preview.runt.run`:

- renderer assets Worker version: `063c7677-f9b1-4102-bce5-352f496a29ec`
- output document Worker version: `14e5216d-9506-4340-b8ae-8acc7444973d`
- notebook-cloud Worker version: `331dc3c0-fd61-46aa-aec6-3488a7783e83`

Hosted smokes passed:

- `NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/topic-viz/topic-viz pnpm --dir apps/notebook-cloud smoke:hosted`
- `NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit ... pnpm --dir apps/notebook-cloud smoke:hosted`

Keeping the PR draft until rerun review and GitHub CI are clear after the amended commit.
