### PR TITLE
fix(notebook-cloud): use shared identity badge

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -60,6 +60,20 @@ test("cloud package rail renders package metadata through the shared shell panel
   assert.doesNotMatch(sourceText, /Package details are not surfaced/);
 });
 
+test("cloud identity chrome renders through the shared actor projection surface", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /NotebookIdentityBadge/);
+  assert.match(sourceText, /notebookActorIdentityFromAccess/);
+  assert.match(sourceText, /capabilities=\{shellCapabilities\}/);
+  assert.match(
+    sourceText,
+    /const actor = notebookActorIdentityFromAccess\(capabilities\.access, capabilities\.auth\)/,
+  );
+  assert.match(sourceText, /<NotebookIdentityBadge[\s\S]*actor=\{actor\}/);
+});
+
 test("cloud rail binds through the shared document rail adapter", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -276,6 +276,22 @@ body {
   display: none;
 }
 
+.cloud-auth-menu summary.cloud-auth-identity-summary {
+  height: auto;
+  max-width: min(14rem, 42vw);
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.cloud-auth-identity-summary [data-slot="notebook-identity-badge"] {
+  height: 2rem;
+  max-width: 100%;
+}
+
 .cloud-share-menu summary::-webkit-details-marker {
   display: none;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -33,7 +33,10 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookIdentityBadge,
   NotebookPackageSummaryPanel,
+  notebookActorIdentityFromAccess,
+  type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
@@ -1173,6 +1176,7 @@ function NotebookViewer({
           <CloudAuthControls
             authConfig={authConfig}
             authState={authState}
+            capabilities={shellCapabilities}
             connectionActorLabel={connectionActorLabel}
             connectionError={connectionError}
             connectionScope={connectionScope}
@@ -1712,6 +1716,7 @@ function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
 function CloudAuthControls({
   authConfig,
   authState,
+  capabilities,
   connectionActorLabel,
   connectionError,
   connectionScope,
@@ -1719,6 +1724,7 @@ function CloudAuthControls({
 }: {
   authConfig: CloudViewerAuthConfig;
   authState: CloudPrototypeAuthState;
+  capabilities: NotebookShellCapabilities;
   connectionActorLabel: string | null;
   connectionError: string | null;
   connectionScope: string | null;
@@ -1750,6 +1756,7 @@ function CloudAuthControls({
     connectionError,
     connectionScope,
   });
+  const actor = notebookActorIdentityFromAccess(capabilities.access, capabilities.auth);
   useEffect(() => {
     setCopyState("idle");
   }, [authState, connectionActorLabel, connectionError, connectionScope]);
@@ -1805,9 +1812,17 @@ function CloudAuthControls({
 
   return (
     <details className="cloud-auth-menu">
-      <summary title="Prototype collaborator identity">
-        <KeyRound aria-hidden="true" />
-        <span>{summary}</span>
+      <summary
+        className="cloud-auth-identity-summary"
+        title={`${summary}: ${prototypeAuthSummary(authState)}`}
+        aria-label={`Identity: ${actor.label}`}
+      >
+        <NotebookIdentityBadge
+          actor={actor}
+          size="sm"
+          showDetail={false}
+          className="cloud-auth-identity-badge"
+        />
       </summary>
       <form onSubmit={applyDevAuth}>
         <p>{prototypeAuthSummary(authState)}</p>


### PR DESCRIPTION
## Summary

- route the visible notebook-cloud auth identity pill through the shared `NotebookIdentityBadge`
- derive the displayed actor from `NotebookShellCapabilities` instead of bespoke cloud chrome state
- keep cloud-only diagnostics and dev-token controls behind the existing details menu

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- Deployed branch to `preview.runt.run`
- Browser checked `lets-edit` and `topic-viz` identity chrome
- `NOTEBOOK_CLOUD_HOSTED_URL=https://preview.runt.run/n/topic-viz/topic-viz pnpm --dir apps/notebook-cloud smoke:hosted`
- `env NOTEBOOK_CLOUD_HOSTED_URL='https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit' NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT='' NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS="Let's edit|Notes|Scratch space" NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0 NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER=0 NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL='user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0' NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL='user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0/agent:publish-live' pnpm --dir apps/notebook-cloud smoke:hosted`

## Review

- `uv run pr-review https://github.com/nteract/nteract/pull/3260 --max-turns 120 --out .context/reviews/pr-3260.json`
- Verdict: clear, no findings

## Notes

This is a small shell-convergence slice after #3259. It reduces cloud-only identity chrome without changing the hosted auth/debug adapter behavior.
