### PR TITLE
refactor(notebook-cloud): share shell adapter chrome

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -476,7 +476,10 @@ async function ensureEditableMarkdown(page) {
 
 async function waitForPresence(page, expectedText) {
   await page.waitForFunction(
-    (expected) => document.querySelector(".cloud-presence")?.textContent?.includes(expected),
+    (expected) =>
+      document
+        .querySelector("[data-slot='notebook-presence-status']")
+        ?.textContent?.includes(expected),
     expectedText,
     { timeout: timeoutMs },
   );

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -341,7 +341,10 @@ async function main() {
     }
     if (expectedPresenceText) {
       await page.waitForFunction(
-        (expected) => document.querySelector(".cloud-presence")?.textContent?.includes(expected),
+        (expected) =>
+          document
+            .querySelector("[data-slot='notebook-presence-status']")
+            ?.textContent?.includes(expected),
         expectedPresenceText,
         { timeout: timeoutMs },
       );
@@ -417,7 +420,7 @@ async function main() {
       .locator("[data-slot='cell-container'], [data-cell-id]")
       .count();
     const presenceText = await page
-      .locator(".cloud-presence")
+      .locator("[data-slot='notebook-presence-status']")
       .textContent({ timeout: 1_000 })
       .catch(() => null);
     viewerMilestones = summarizeViewerMilestones(await collectViewerLoadMarks(page));

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -133,3 +133,13 @@ test("cloud sync keeps routine frame logs out of the browser console", () => {
   assert.match(sourceText, /const consoleSyncLogger = \{[\s\S]*info: \(\) => \{\}/);
   assert.match(sourceText, /warn: \(message: string, \.\.\.args: unknown\[\]\) => console\.warn/);
 });
+
+test("cloud installs a host logger sink for shared notebook components", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /setLoggerHost/);
+  assert.match(sourceText, /debug: \(\) => \{\}/);
+  assert.match(sourceText, /info: \(\) => \{\}/);
+  assert.match(sourceText, /warn: \(message: string, \.\.\.args: unknown\[\]\) => console\.warn/);
+});

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -74,6 +74,29 @@ test("cloud identity chrome renders through the shared actor projection surface"
   assert.match(sourceText, /<NotebookIdentityBadge[\s\S]*actor=\{actor\}/);
 });
 
+test("cloud presence chrome renders through the shared shell component", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const sharedPresencePath = new URL(
+    "../../../src/components/notebook-shell/NotebookPresenceStatus.tsx",
+    import.meta.url,
+  );
+  const sharedPresenceText = readFileSync(sharedPresencePath, "utf8");
+  const hostedSmokePath = new URL("../scripts/hosted-render-smoke.mjs", import.meta.url);
+  const hostedSmokeText = readFileSync(hostedSmokePath, "utf8");
+  const collabSmokePath = new URL("../scripts/hosted-collab-smoke.mjs", import.meta.url);
+  const collabSmokeText = readFileSync(collabSmokePath, "utf8");
+
+  assert.match(sourceText, /NotebookPresenceStatus/);
+  assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*label=\{presenceDisplay\.label\}/);
+  assert.match(sharedPresenceText, /data-slot="notebook-presence-status"/);
+  assert.match(hostedSmokeText, /\[data-slot='notebook-presence-status'\]/);
+  assert.match(collabSmokeText, /\[data-slot='notebook-presence-status'\]/);
+  assert.doesNotMatch(sourceText, /className="cloud-presence"/);
+  assert.doesNotMatch(hostedSmokeText, /cloud-presence/);
+  assert.doesNotMatch(collabSmokeText, /cloud-presence/);
+});
+
 test("cloud rail binds through the shared document rail adapter", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -97,6 +97,22 @@ test("cloud presence chrome renders through the shared shell component", () => {
   assert.doesNotMatch(collabSmokeText, /cloud-presence/);
 });
 
+test("cloud edit mode chrome renders through the shared shell component", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const cssPath = new URL("../viewer/index.css", import.meta.url);
+  const cssText = readFileSync(cssPath, "utf8");
+
+  assert.match(sourceText, /NotebookEditModeButton/);
+  assert.match(
+    sourceText,
+    /<NotebookEditModeButton[\s\S]*mode=\{requestingEdit \? "edit" : "view"\}/,
+  );
+  assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
+  assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
+  assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);
+});
+
 test("cloud rail binds through the shared document rail adapter", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -215,7 +215,6 @@ body {
 
 .cloud-share-menu summary,
 .cloud-auth-menu summary,
-.cloud-scope-toggle-button,
 .cloud-sign-in-button {
   display: inline-flex;
   align-items: center;
@@ -260,22 +259,19 @@ body {
 }
 
 .cloud-share-menu summary:hover,
-.cloud-auth-menu summary:hover,
-.cloud-scope-toggle-button:hover {
+.cloud-auth-menu summary:hover {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
 }
 
 .cloud-share-menu summary:focus-visible,
-.cloud-auth-menu summary:focus-visible,
-.cloud-scope-toggle-button:focus-visible {
+.cloud-auth-menu summary:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
 .cloud-share-menu svg,
 .cloud-auth-menu svg,
-.cloud-scope-toggle-button svg,
 .cloud-sign-in-button svg,
 .cloud-auth-state svg {
   width: 1rem;
@@ -285,7 +281,6 @@ body {
 
 .cloud-share-menu summary span,
 .cloud-auth-menu summary span,
-.cloud-scope-toggle-button span,
 .cloud-sign-in-button span {
   min-width: 0;
   overflow: hidden;
@@ -297,15 +292,6 @@ body {
 
 .cloud-sign-in-button {
   cursor: pointer;
-}
-
-.cloud-scope-toggle-button[data-state="editing"] {
-  border-color: color-mix(in srgb, #16a34a 52%, transparent);
-  color: color-mix(in srgb, #16a34a 80%, var(--foreground) 20%);
-}
-
-.cloud-scope-toggle-button[data-state="requested"] {
-  border-color: color-mix(in srgb, var(--ring) 48%, transparent);
 }
 
 .cloud-sign-in-button:hover {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -205,43 +205,6 @@ body {
   pointer-events: none;
 }
 
-.cloud-presence {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  min-width: 0;
-  max-width: min(16rem, 52vw);
-  height: 2rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-  border-radius: 999px;
-  padding-inline: 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 90%, transparent);
-  box-shadow: 0 1px 8px color-mix(in srgb, #000 6%, transparent);
-  backdrop-filter: blur(8px);
-  pointer-events: auto;
-}
-
-.cloud-presence[data-connected="true"] {
-  border-color: color-mix(in srgb, #0f766e 28%, transparent);
-  color: color-mix(in srgb, var(--foreground) 82%, #0f766e 18%);
-}
-
-.cloud-presence svg {
-  width: 1rem;
-  height: 1rem;
-  flex: 0 0 auto;
-}
-
-.cloud-presence span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.8125rem;
-  line-height: 1;
-}
-
 .cloud-auth-menu {
   position: relative;
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import { createRoot } from "react-dom/client";
 import {
-  BookOpen,
   Copy,
   Globe2,
   KeyRound,
@@ -18,7 +17,6 @@ import {
   LogIn,
   LogOut,
   Mail,
-  Pencil,
   RotateCcw,
   Share2,
   Trash2,
@@ -29,6 +27,7 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   NotebookDocumentHeader,
+  NotebookEditModeButton,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
@@ -1636,31 +1635,20 @@ function CloudNotebookEditModeButton({
   const requestedScope = authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
   const requestingEdit = requestedScope === "editor" || requestedScope === "owner";
   const editing = connectionScope === "editor" || connectionScope === "owner";
-  const label = requestingEdit ? "View" : "Edit";
-  const title = requestingEdit
-    ? editing
-      ? "Return to read-only viewing"
-      : "Stop requesting edit access"
-    : "Request edit access";
+  const state = editing ? "editing" : requestingEdit ? "requested" : "viewing";
 
   return (
-    <button
-      type="button"
-      className="cloud-scope-toggle-button"
-      aria-pressed={requestingEdit}
-      data-state={editing ? "editing" : requestingEdit ? "requested" : "viewing"}
-      title={title}
-      onClick={() => {
+    <NotebookEditModeButton
+      mode={requestingEdit ? "edit" : "view"}
+      state={state}
+      onModeChange={(mode) => {
         storeCloudRequestedScope(
           window.localStorage,
-          requestingEdit ? NOTEBOOK_CLOUD_DEFAULT_SCOPE : "editor",
+          mode === "edit" ? "editor" : NOTEBOOK_CLOUD_DEFAULT_SCOPE,
         );
         onAuthStateChange();
       }}
-    >
-      {requestingEdit ? <BookOpen aria-hidden="true" /> : <Pencil aria-hidden="true" />}
-      <span>{label}</span>
-    </button>
+    />
   );
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -23,7 +23,6 @@ import {
   Share2,
   Trash2,
   UserRound,
-  UsersRound,
 } from "lucide-react";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
@@ -34,6 +33,7 @@ import {
   NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookIdentityBadge,
+  NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
   notebookActorIdentityFromAccess,
   type NotebookShellCapabilities,
@@ -1946,16 +1946,12 @@ function CloudPresenceStatus({
         : null;
 
   return (
-    <div
-      className="cloud-presence"
-      data-connected={String(presenceDisplay.connected)}
-      title={scopeLabel ? `${presenceDisplay.title}; ${scopeLabel}` : presenceDisplay.title}
-      aria-label={presenceDisplay.title}
-      aria-live="polite"
-    >
-      <UsersRound aria-hidden="true" />
-      <span>{scopeLabel ? `${presenceDisplay.label} · ${scopeLabel}` : presenceDisplay.label}</span>
-    </div>
+    <NotebookPresenceStatus
+      connected={presenceDisplay.connected}
+      label={presenceDisplay.label}
+      modeLabel={scopeLabel}
+      title={presenceDisplay.title}
+    />
   );
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -72,6 +72,7 @@ import {
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import { flushCellUIState, setFocusedCellId } from "../../notebook/src/lib/cell-ui-state";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
+import { setLoggerHost } from "../../notebook/src/lib/logger";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 import { useNotebookViewModel } from "../../notebook/src/lib/notebook-view-model";
 import {
@@ -125,6 +126,13 @@ import {
   projectCloudWidgetComms,
 } from "./widget-runtime";
 import "./index.css";
+
+setLoggerHost({
+  debug: () => {},
+  info: () => {},
+  warn: (message: string, ...args: unknown[]) => console.warn(message, ...args),
+  error: (message: string, ...args: unknown[]) => console.error(message, ...args),
+});
 
 interface CloudViewerConfig {
   notebookId: string;

--- a/apps/notebook/src/lib/logger.ts
+++ b/apps/notebook/src/lib/logger.ts
@@ -10,7 +10,7 @@
  * to await — the transport to the sink happens in the background.
  */
 
-import type { NotebookHost } from "@nteract/notebook-host";
+import type { HostLog, NotebookHost } from "@nteract/notebook-host";
 
 /** Serialize arguments to a single log message string. */
 function formatArgs(args: unknown[]): string {
@@ -33,17 +33,17 @@ function formatArgs(args: unknown[]): string {
 // `createTauriHost()`. Until then — and in tests, SSR, Storybook — we
 // fall back to the console. Never throw from logger; it's used at the
 // error-handling boundary.
-let _host: NotebookHost | null = null;
+let _log: HostLog | null = null;
 
 /** Install the `NotebookHost` whose `log` surface this logger writes to. */
-export function setLoggerHost(host: NotebookHost | null): void {
-  _host = host;
+export function setLoggerHost(host: NotebookHost | HostLog | null): void {
+  _log = host && "log" in host ? host.log : host;
 }
 
 function emit(level: "debug" | "info" | "warn" | "error", args: unknown[]): void {
   const message = formatArgs(args);
-  if (_host) {
-    _host.log[level](message);
+  if (_log) {
+    _log[level](message);
   } else {
     // Pre-host or non-host contexts: mirror to console with a level tag.
     // eslint-disable-next-line no-console

--- a/src/components/notebook-shell/NotebookEditModeButton.tsx
+++ b/src/components/notebook-shell/NotebookEditModeButton.tsx
@@ -1,0 +1,55 @@
+import { BookOpen, Pencil } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type NotebookEditMode = "view" | "edit";
+export type NotebookEditModeState = "viewing" | "requested" | "editing";
+
+export interface NotebookEditModeButtonProps {
+  mode: NotebookEditMode;
+  state: NotebookEditModeState;
+  onModeChange: (mode: NotebookEditMode) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function NotebookEditModeButton({
+  className,
+  disabled = false,
+  mode,
+  onModeChange,
+  state,
+}: NotebookEditModeButtonProps) {
+  const requestingEdit = mode === "edit";
+  const nextMode: NotebookEditMode = requestingEdit ? "view" : "edit";
+  const label = requestingEdit ? "View" : "Edit";
+  const title = requestingEdit
+    ? state === "editing"
+      ? "Return to read-only viewing"
+      : "Stop requesting edit access"
+    : "Request edit access";
+
+  return (
+    <button
+      type="button"
+      aria-pressed={requestingEdit}
+      className={cn(
+        "inline-flex h-8 max-w-[min(12rem,38vw)] min-w-0 items-center justify-center gap-1.5 rounded-full border border-border bg-background/90 px-3 text-sm text-muted-foreground shadow-sm backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60",
+        state === "editing" && "border-emerald-500/50 text-emerald-700 dark:text-emerald-300",
+        state === "requested" && "border-ring/50 text-foreground",
+        className,
+      )}
+      data-slot="notebook-edit-mode-button"
+      data-state={state}
+      disabled={disabled}
+      title={title}
+      onClick={() => onModeChange(nextMode)}
+    >
+      {requestingEdit ? (
+        <BookOpen className="size-4 shrink-0" aria-hidden="true" />
+      ) : (
+        <Pencil className="size-4 shrink-0" aria-hidden="true" />
+      )}
+      <span className="min-w-0 truncate leading-none">{label}</span>
+    </button>
+  );
+}

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -1,0 +1,39 @@
+import { UsersRound } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface NotebookPresenceStatusProps {
+  label: string;
+  title: string;
+  connected?: boolean;
+  modeLabel?: string | null;
+  className?: string;
+}
+
+export function NotebookPresenceStatus({
+  className,
+  connected = false,
+  label,
+  modeLabel = null,
+  title,
+}: NotebookPresenceStatusProps) {
+  const displayLabel = modeLabel ? `${label} · ${modeLabel}` : label;
+  const displayTitle = modeLabel ? `${title}; ${modeLabel}` : title;
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-auto inline-flex h-8 max-w-[min(16rem,52vw)] items-center gap-1.5 rounded-full border border-border bg-background/90 px-3 text-sm text-muted-foreground shadow-sm backdrop-blur",
+        connected && "border-teal-700/30 text-foreground",
+        className,
+      )}
+      data-slot="notebook-presence-status"
+      data-connected={String(connected)}
+      title={displayTitle}
+      aria-label={title}
+      aria-live="polite"
+    >
+      <UsersRound className="size-4 shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate">{displayLabel}</span>
+    </div>
+  );
+}

--- a/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookEditModeButton } from "../NotebookEditModeButton";
+
+describe("NotebookEditModeButton", () => {
+  it("requests edit mode from view mode", () => {
+    const onModeChange = vi.fn();
+
+    render(<NotebookEditModeButton mode="view" state="viewing" onModeChange={onModeChange} />);
+
+    const button = screen.getByRole("button", { name: "Edit" });
+    expect(button).toHaveAttribute("data-slot", "notebook-edit-mode-button");
+    expect(button).toHaveAttribute("data-state", "viewing");
+
+    fireEvent.click(button);
+
+    expect(onModeChange).toHaveBeenCalledWith("edit");
+  });
+
+  it("returns to view mode from an active edit request", () => {
+    const onModeChange = vi.fn();
+
+    render(<NotebookEditModeButton mode="edit" state="editing" onModeChange={onModeChange} />);
+
+    const button = screen.getByRole("button", { name: "View" });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveAttribute("data-state", "editing");
+
+    fireEvent.click(button);
+
+    expect(onModeChange).toHaveBeenCalledWith("view");
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookPresenceStatus } from "../NotebookPresenceStatus";
+
+describe("NotebookPresenceStatus", () => {
+  it("renders shared presence copy with mode context", () => {
+    const { container } = render(
+      <NotebookPresenceStatus
+        connected
+        label="2 viewing"
+        modeLabel="editing"
+        title="2 connected viewers"
+      />,
+    );
+
+    expect(screen.getByText("2 viewing · editing")).toBeVisible();
+    expect(screen.getByLabelText("2 connected viewers")).toHaveAttribute("data-connected", "true");
+    expect(container.querySelector("[data-slot='notebook-presence-status']")).toHaveAttribute(
+      "title",
+      "2 connected viewers; editing",
+    );
+  });
+
+  it("does not invent mode copy when the host has no mode label", () => {
+    render(<NotebookPresenceStatus label="Offline" title="No live room connection" />);
+
+    expect(screen.getByText("Offline")).toBeVisible();
+    expect(screen.getByLabelText("No live room connection")).toHaveAttribute(
+      "data-connected",
+      "false",
+    );
+  });
+});

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -42,6 +42,12 @@ export {
   NotebookEnvironmentSummary,
   type NotebookEnvironmentSummaryProps,
 } from "./NotebookEnvironmentSummary";
+export {
+  NotebookEditModeButton,
+  type NotebookEditMode,
+  type NotebookEditModeButtonProps,
+  type NotebookEditModeState,
+} from "./NotebookEditModeButton";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
 export {
   NotebookPackageSummaryPanel,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -37,6 +37,7 @@ export {
   type NotebookIdentityBadgeProps,
   type NotebookIdentityGroupProps,
 } from "./NotebookIdentity";
+export { NotebookPresenceStatus, type NotebookPresenceStatusProps } from "./NotebookPresenceStatus";
 export {
   NotebookEnvironmentSummary,
   type NotebookEnvironmentSummaryProps,


### PR DESCRIPTION
## Summary
- let shared notebook app logging accept either a full NotebookHost or a host log sink
- install a notebook-cloud logger sink so shared NotebookView/rail/editor debug logs stay out of the hosted browser console
- move the visible cloud presence pill to a shared `NotebookPresenceStatus` shell component
- move the cloud Edit/View mode button to a shared `NotebookEditModeButton` shell component
- remove the old cloud-only presence/edit-mode CSS while keeping hosted room presence and requested-scope mapping in the cloud adapter
- update hosted smoke selectors to assert against the shared presence slot

## Validation
- `pnpm test:run src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx`
- `pnpm test:run src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud test`
- local `pr-reviewer`: clear, no findings
- deployed rebased branch commit `3606d9bb` to `preview.runt.run`
  - renderer assets `424ca5f5-87c5-4e28-9330-322135a8d397`
  - output document `cac87ee7-f73a-43c4-9d08-e529982be742`
  - main worker `c07918f0-c7aa-4338-9ab8-14e1fe222611`
- hosted smoke: `lets-edit` passed; first useful render 2844ms
- hosted smoke: `topic-viz` passed; first useful render 6776ms, Sift streaming complete 10139ms

## Notes
This stays in the host-adapter lane: shared notebook components own reusable shell chrome, while cloud owns hosted logging policy, room presence state mapping, and OIDC requested-scope persistence.
