### PR TITLE
fix(notebook): refine fluid cell state language

### DIFF
--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -31,13 +31,13 @@ const variants: Array<{
 }> = [
   {
     variant: "production",
-    label: "Production line",
-    body: "The current shape keeps the signal lane flexible and pins the language/state readout to the right, so running, queued, failed, and completed states share one grammar.",
+    label: "Production grammar",
+    body: "Quiet cells rest as punctuation: completed cells show only the run marker, ready cells stay visually silent, and full language context returns on approach.",
   },
   {
     variant: "quiet",
     label: "Quiet unless focused",
-    body: "Keep only the run affordance and language at rest. The run count and duration bloom on focus or hover.",
+    body: "An earlier sketch kept language visible at rest and bloomed the run metadata later; useful, but louder than the production direction.",
   },
   {
     variant: "sentence",
@@ -58,8 +58,8 @@ export function CellExecutionLanguageExample() {
         <div className="border-b border-fd-border p-4">
           <h2 className="text-sm font-semibold">Run line direction set</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The target is a cell boundary that can speak when needed, but usually reads as
-            punctuation in the notebook rhythm.
+            The target is a cell boundary that usually reads as punctuation in the notebook rhythm.
+            Active states get words; quiet states keep their context available but tucked away.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background">
@@ -79,8 +79,8 @@ export function CellExecutionLanguageExample() {
         <div className="border-b border-fd-border p-4">
           <h2 className="text-sm font-semibold">State vocabulary</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The same line should carry ready, queued, running, completed, and failed states without
-            making every cell feel like a status table.
+            The same line should carry ready, queued, running, completed, and failed states while
+            making quiet cells feel like document structure, not a status table.
           </p>
         </div>
         <div className="grid gap-3 bg-background p-4 md:grid-cols-2">

--- a/apps/elements/components/cell-insertion-affordances-example.tsx
+++ b/apps/elements/components/cell-insertion-affordances-example.tsx
@@ -9,13 +9,13 @@ type Intent = "code" | "markdown";
 
 const concepts = [
   {
-    label: "Production row",
-    body: "The row wakes in a neutral insertion state; color appears only when code or markdown is targeted.",
+    label: "Threaded production row",
+    body: "Actions attach directly to the document rule; the selected intent fades back into the page instead of forming a floating palette.",
     render: <ProductionInsertionPreview />,
   },
   {
-    label: "Threaded line",
-    body: "Actions attach directly to the document rule, reducing the floating-button feeling.",
+    label: "Connected group study",
+    body: "A more bordered variation keeps the actions grouped, but adds more chrome than the production row needs.",
     render: <ThreadedLinePreview />,
   },
   {
@@ -32,8 +32,8 @@ export function CellInsertionAffordancesExample() {
         <div className="border-b border-fd-border p-4">
           <h2 className="text-sm font-semibold">Between-cell direction set</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            These sketches keep the same rail-gripped ribbon and document column, but change how
-            much chrome the code and markdown choices carry.
+            These sketches keep the same rail-gripped ribbon and document column. The production row
+            now uses the threaded direction; the remaining sketches document the tradeoffs.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background">
@@ -89,7 +89,7 @@ function ThreadedLinePreview() {
         <div className="h-px w-6 bg-border/70" />
         <ThreadedAction intent="code" muted />
         <ThreadedAction intent="markdown" />
-        <div className="h-px min-w-8 flex-1 bg-border/70" />
+        <div className="h-px min-w-8 flex-1 bg-gradient-to-r from-emerald-400/25 via-border/45 to-transparent" />
       </div>
     </div>
   );

--- a/apps/elements/content/docs/cell-execution-language.mdx
+++ b/apps/elements/content/docs/cell-execution-language.mdx
@@ -6,8 +6,11 @@ description: Visual language sketches for the code cell run line and execution s
 import { CellExecutionLanguageExample } from "@/components/cell-execution-language-example";
 
 The code cell run line should feel like notebook punctuation first and status
-copy second. This studio compares the current production line against quieter
-directions where the execution signal carries more of the meaning and text
-appears only when it earns the space.
+copy second. Quiet states should carry just enough evidence to orient the
+reader, while active states can speak with color, motion, and explicit words.
+
+The production line now follows that grammar: completed cells rest as a small
+run marker, ready cells stay visually quiet, and the full language context
+returns when the reader approaches the cell.
 
 <CellExecutionLanguageExample />

--- a/apps/elements/content/docs/cell-insertion-affordances.mdx
+++ b/apps/elements/content/docs/cell-insertion-affordances.mdx
@@ -5,13 +5,13 @@ description: Fixture-backed sketches for making add-cell rows feel connected to 
 
 import { CellInsertionAffordancesExample } from "@/components/cell-insertion-affordances-example";
 
-The current add-cell row has the right structural idea: the ribbon remains part
-of the document spine, while the actions appear only when the reader is near an
-insertion point. This studio keeps the production row visible and compares it
-against lighter, more line-driven directions.
+The add-cell row now follows the same line language as the current execution
+line: the ribbon remains part of the document spine, the choices attach to a
+quiet rule, and color appears only once the reader targets a concrete cell
+type.
 
 The production row now treats proximity as neutral document intent. Code and
-markdown color arrive only when a concrete target is hovered or focused, which
-keeps the spine from declaring a cell type before the reader does.
+markdown color arrive only when a concrete target is hovered or focused, then
+fade back into the document rule instead of becoming a floating control surface.
 
 <CellInsertionAffordancesExample />

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -257,7 +257,7 @@ describe("CodeCell output focus", () => {
     expect(rule).toHaveClass("flex-1");
   });
 
-  it("keeps running status active while the stop control carries danger", () => {
+  it("keeps fast running status visually quiet while the stop control carries danger", () => {
     mockOutputs = [];
     mockExecution = { execution_count: null, submitted_by_actor_label: null };
     mockIsExecuting = true;
@@ -279,12 +279,15 @@ describe("CodeCell output focus", () => {
     const stopButton = getByTestId("execute-button");
 
     expect(footer?.getAttribute("data-execution-state")).toBe("running");
-    expect(status?.textContent).toBe("Python/running");
-    expect(detail).toHaveClass("text-emerald-700");
+    expect(footer?.getAttribute("data-execution-visual-state")).toBe("idle");
+    expect(status?.textContent).toBe("Python/ready");
+    expect(status).toHaveAttribute("aria-label", "Python: Running");
+    expect(detail).toHaveClass("text-muted-foreground/70");
+    expect(detail).not.toHaveClass("text-emerald-700");
     expect(status).not.toHaveClass("text-destructive/80");
-    expect(rule).toHaveClass("text-emerald-500/65");
+    expect(rule).toHaveClass("bg-border/15");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(rule).toHaveAttribute("data-execution-signal", "building");
+    expect(rule).not.toHaveAttribute("data-execution-signal");
     expect(rule?.querySelector("svg")).toBeNull();
     expect(stopButton).toHaveClass("text-destructive");
   });

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -42,6 +42,11 @@ const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
     "bg-gradient-to-r from-emerald-400/35 via-border/35 to-transparent dark:from-emerald-300/30 dark:via-border/30",
 };
 
+const insertionChannelIntentClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-500/6 text-sky-700 dark:text-sky-300",
+  markdown: "bg-emerald-500/6 text-emerald-700 dark:text-emerald-300",
+};
+
 export function CellInsertionRibbon({
   terminal = false,
   activeType,
@@ -153,8 +158,8 @@ export function CellInsertionRibbon({
         className={cn(
           "flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
-          visualActiveType === "code"
-            ? "bg-sky-500/6 text-sky-700 dark:text-sky-300"
+          visualActiveType
+            ? insertionChannelIntentClasses[visualActiveType]
             : isOpen
               ? "bg-muted/20 text-muted-foreground/45 hover:bg-muted/30 hover:text-muted-foreground/70"
               : "text-muted-foreground/0 hover:bg-muted/20",
@@ -184,12 +189,12 @@ export function CellInsertionRibbon({
       >
         <span
           data-slot="cell-adder-leading-rule"
-          className={cn("w-4 shrink-0", leadingInsertionRuleClass)}
+          className={cn("w-2 shrink-0", leadingInsertionRuleClass)}
           aria-hidden="true"
         />
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 shrink-0 items-center gap-1 px-1"
+          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1"
         >
           <button
             type="button"

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -57,6 +57,7 @@ export function CellInsertionRibbon({
   const resolvedActiveType = activeType === undefined ? uncontrolledActiveType : activeType;
   const visualActiveType = resolvedActiveType ?? null;
   const isOpen = interactionActive || forceActionsVisible;
+  const actionTabIndex = isOpen ? 0 : -1;
   const ribbonClass = visualActiveType
     ? terminal
       ? terminalInsertionRibbonClasses[visualActiveType]
@@ -172,6 +173,7 @@ export function CellInsertionRibbon({
       </button>
       <div
         data-slot="cell-adder-actions"
+        aria-hidden={isOpen ? undefined : true}
         className={cn(
           "flex min-w-0 flex-1 items-center transition-opacity duration-150",
           terminal && "pt-0.5",
@@ -193,6 +195,7 @@ export function CellInsertionRibbon({
             type="button"
             title="Add code cell"
             aria-label="Add code cell"
+            tabIndex={actionTabIndex}
             onPointerEnter={() => setActiveType("code")}
             onFocus={() => setActiveType("code")}
             onClick={() => onInsert("code")}
@@ -206,6 +209,7 @@ export function CellInsertionRibbon({
             type="button"
             title="Add markdown cell"
             aria-label="Add markdown cell"
+            tabIndex={actionTabIndex}
             onPointerEnter={() => setActiveType("markdown")}
             onFocus={() => setActiveType("markdown")}
             onClick={() => onInsert("markdown")}

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -31,6 +31,17 @@ const actionButtonIntentClasses: Record<CellInsertionType, string> = {
     "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
 };
 
+const insertionRuleIntentClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-400/50 dark:bg-sky-300/40",
+  markdown: "bg-emerald-400/50 dark:bg-emerald-300/40",
+};
+
+const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
+  code: "bg-gradient-to-r from-sky-400/35 via-border/35 to-transparent dark:from-sky-300/30 dark:via-border/30",
+  markdown:
+    "bg-gradient-to-r from-emerald-400/35 via-border/35 to-transparent dark:from-emerald-300/30 dark:via-border/30",
+};
+
 export function CellInsertionRibbon({
   terminal = false,
   activeType,
@@ -65,8 +76,17 @@ export function CellInsertionRibbon({
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
       visualActiveType === type
         ? actionButtonIntentClasses[type]
-        : "hover:bg-muted/60 hover:text-foreground",
+        : "hover:bg-muted/45 hover:text-foreground",
     );
+
+  const leadingInsertionRuleClass = cn(
+    "h-px rounded-full transition-colors duration-150",
+    visualActiveType ? insertionRuleIntentClasses[visualActiveType] : "bg-border/45",
+  );
+  const trailingInsertionRuleClass = cn(
+    "h-px rounded-full transition-colors duration-150",
+    visualActiveType ? insertionTrailingRuleIntentClasses[visualActiveType] : "bg-border/45",
+  );
 
   return (
     <div
@@ -153,16 +173,21 @@ export function CellInsertionRibbon({
       <div
         data-slot="cell-adder-actions"
         className={cn(
-          "flex items-center transition-opacity duration-150",
+          "flex min-w-0 flex-1 items-center transition-opacity duration-150",
           terminal && "pt-0.5",
           forceActionsVisible
             ? "opacity-100"
             : "opacity-0 group-hover/adder:opacity-100 group-hover/adder:delay-75 group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
         )}
       >
+        <span
+          data-slot="cell-adder-leading-rule"
+          className={cn("w-4 shrink-0", leadingInsertionRuleClass)}
+          aria-hidden="true"
+        />
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 items-center gap-1 rounded-full bg-background/80 px-1 shadow-sm shadow-black/[0.04] ring-1 ring-border/45 backdrop-blur-sm"
+          className="flex h-7 shrink-0 items-center gap-1 px-1"
         >
           <button
             type="button"
@@ -191,8 +216,12 @@ export function CellInsertionRibbon({
             <span>Markdown</span>
           </button>
         </div>
+        <span
+          data-slot="cell-adder-trailing-rule"
+          className={cn("min-w-8 flex-1", trailingInsertionRuleClass)}
+          aria-hidden="true"
+        />
       </div>
-      <div className="flex-1" />
     </div>
   );
 }

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -300,6 +300,7 @@ export function CodeCellCurrentLine({
     isErrored,
   });
   const isIdleReadyDetail = boundaryState === "idle" && detailLabel === "ready";
+  const isQuietContextualState = boundaryState === "idle" || boundaryState === "ran";
   const accessibleDetailLabel = accessibleExecutionDetail({
     count,
     elapsedMs,
@@ -349,47 +350,52 @@ export function CodeCellCurrentLine({
         className={cn(
           "flex min-w-0 shrink-0 items-center whitespace-nowrap font-medium transition-[color,opacity,max-width,gap] duration-150",
           isCompactIdle ? "max-w-0 overflow-hidden opacity-0" : "max-w-64 opacity-100",
-          isIdleReadyDetail ? "gap-0 group-hover:gap-1.5 group-focus-within:gap-1.5" : "gap-1.5",
+          isQuietContextualState
+            ? "gap-0 group-hover:gap-1.5 group-focus-within:gap-1.5"
+            : "gap-1.5",
           isFocused && "text-foreground/70",
         )}
       >
         <span
-          data-slot="code-cell-current-line-language"
+          data-slot="code-cell-current-line-language-context"
           className={cn(
-            "text-foreground/60 transition-colors duration-150",
-            isFocused && "text-foreground/70",
+            "flex shrink-0 items-center gap-1.5 overflow-hidden transition-[color,opacity,max-width] duration-150",
+            isQuietContextualState
+              ? "max-w-0 opacity-0 group-hover:max-w-20 group-hover:opacity-100 group-focus-within:max-w-20 group-focus-within:opacity-100"
+              : "max-w-20 opacity-100",
           )}
         >
-          {languageLabel}
-        </span>
-        <span
-          data-slot="code-cell-current-line-detail-group"
-          className={cn(
-            "flex shrink-0 items-center gap-1.5 transition-[max-width,opacity] duration-150",
-            isIdleReadyDetail
-              ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-16 group-hover:opacity-100 group-focus-within:max-w-16 group-focus-within:opacity-100"
-              : "max-w-64 opacity-100",
-          )}
-        >
+          <span
+            data-slot="code-cell-current-line-language"
+            className={cn(
+              "text-foreground/60 transition-colors duration-150",
+              isFocused && "text-foreground/70",
+            )}
+          >
+            {languageLabel}
+          </span>
           <span
             className={cn("text-muted-foreground/35", isCompactIdle && "sr-only")}
             aria-hidden="true"
           >
             /
           </span>
-          <span
-            data-slot="code-cell-current-line-detail"
-            className={cn(
-              "tabular-nums",
-              isCompactIdle && "sr-only",
-              visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
-              isQueued && "font-semibold text-sky-700 dark:text-sky-300",
-              isErrored && "font-semibold text-destructive/80",
-              !visualIsExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
-            )}
-          >
-            {detailLabel}
-          </span>
+        </span>
+        <span
+          data-slot="code-cell-current-line-detail"
+          className={cn(
+            "shrink-0 tabular-nums transition-[max-width,opacity] duration-150",
+            isCompactIdle && "sr-only",
+            isIdleReadyDetail
+              ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-16 group-hover:opacity-100 group-focus-within:max-w-16 group-focus-within:opacity-100"
+              : "max-w-64 opacity-100",
+            visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
+            isQueued && "font-semibold text-sky-700 dark:text-sky-300",
+            isErrored && "font-semibold text-destructive/80",
+            !visualIsExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
+          )}
+        >
+          {detailLabel}
         </span>
       </span>
     </div>

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -299,6 +299,7 @@ export function CodeCellCurrentLine({
     isQueued,
     isErrored,
   });
+  const isIdleReadyDetail = boundaryState === "idle" && detailLabel === "ready";
   const accessibleDetailLabel = accessibleExecutionDetail({
     count,
     elapsedMs,
@@ -346,8 +347,9 @@ export function CodeCellCurrentLine({
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
         aria-live={isExecuting || isQueued || isErrored ? "polite" : undefined}
         className={cn(
-          "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap font-medium transition-[color,opacity,max-width] duration-150",
+          "flex min-w-0 shrink-0 items-center whitespace-nowrap font-medium transition-[color,opacity,max-width,gap] duration-150",
           isCompactIdle ? "max-w-0 overflow-hidden opacity-0" : "max-w-64 opacity-100",
+          isIdleReadyDetail ? "gap-0 group-hover:gap-1.5 group-focus-within:gap-1.5" : "gap-1.5",
           isFocused && "text-foreground/70",
         )}
       >
@@ -361,23 +363,33 @@ export function CodeCellCurrentLine({
           {languageLabel}
         </span>
         <span
-          className={cn("text-muted-foreground/35", isCompactIdle && "sr-only")}
-          aria-hidden="true"
-        >
-          /
-        </span>
-        <span
-          data-slot="code-cell-current-line-detail"
+          data-slot="code-cell-current-line-detail-group"
           className={cn(
-            "tabular-nums",
-            isCompactIdle && "sr-only",
-            visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
-            isQueued && "font-semibold text-sky-700 dark:text-sky-300",
-            isErrored && "font-semibold text-destructive/80",
-            !visualIsExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
+            "flex shrink-0 items-center gap-1.5 transition-[max-width,opacity] duration-150",
+            isIdleReadyDetail
+              ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-16 group-hover:opacity-100 group-focus-within:max-w-16 group-focus-within:opacity-100"
+              : "max-w-64 opacity-100",
           )}
         >
-          {detailLabel}
+          <span
+            className={cn("text-muted-foreground/35", isCompactIdle && "sr-only")}
+            aria-hidden="true"
+          >
+            /
+          </span>
+          <span
+            data-slot="code-cell-current-line-detail"
+            className={cn(
+              "tabular-nums",
+              isCompactIdle && "sr-only",
+              visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
+              isQueued && "font-semibold text-sky-700 dark:text-sky-300",
+              isErrored && "font-semibold text-destructive/80",
+              !visualIsExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
+            )}
+          >
+            {detailLabel}
+          </span>
         </span>
       </span>
     </div>

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -92,6 +92,10 @@ function executionCountLabel(count: number | null): string | null {
   return count === null ? null : `Execution ${formatExecutionCount(count)}`;
 }
 
+function quietBoundaryState(count: number | null): ExecutionBoundaryState {
+  return count === null ? "idle" : "ran";
+}
+
 function executionLineClass({ isFocused }: { isFocused: boolean }) {
   if (isFocused) {
     return "bg-border/30";
@@ -164,7 +168,7 @@ function ExecutionBoundaryRule({
   queuePriority: number;
   isFocused: boolean;
 }) {
-  if (state === "running" || runningSignalPhase === "settling") {
+  if (state === "running") {
     const showSignal = runningSignalPhase === "active" || runningSignalPhase === "settling";
 
     return (
@@ -275,12 +279,23 @@ export function CodeCellCurrentLine({
         : count !== null
           ? "ran"
           : "idle";
-  const isCompactIdle = compactIdle && state === "idle";
-  const isQuietResting = state === "idle" || state === "ran";
+  const hasRunningSignal =
+    !isErrored &&
+    !isQueued &&
+    ((state === "running" && runningSignalPhase === "active") || runningSignalPhase === "settling");
+  const boundaryState =
+    state === "running" && !hasRunningSignal
+      ? quietBoundaryState(count)
+      : hasRunningSignal
+        ? "running"
+        : state;
+  const visualIsExecuting = state === "running" && runningSignalPhase === "active";
+  const isCompactIdle = compactIdle && boundaryState === "idle";
+  const isQuietResting = boundaryState === "idle" || boundaryState === "ran";
   const detailLabel = visualExecutionDetail({
     count,
     elapsedMs,
-    isExecuting,
+    isExecuting: visualIsExecuting,
     isQueued,
     isErrored,
   });
@@ -296,6 +311,7 @@ export function CodeCellCurrentLine({
     <div
       data-slot="code-cell-current-line"
       data-execution-state={state}
+      data-execution-visual-state={boundaryState}
       data-execution-count={count ?? undefined}
       data-execution-label={countLabel ?? undefined}
       className={cn(
@@ -306,7 +322,7 @@ export function CodeCellCurrentLine({
     >
       {!isCompactIdle ? (
         <ExecutionBoundaryRule
-          state={state}
+          state={boundaryState}
           runningSignalPhase={runningSignalPhase}
           queuePriority={queuePriority}
           isFocused={isFocused}
@@ -355,10 +371,10 @@ export function CodeCellCurrentLine({
           className={cn(
             "tabular-nums",
             isCompactIdle && "sr-only",
-            isExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
+            visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
             isQueued && "font-semibold text-sky-700 dark:text-sky-300",
             isErrored && "font-semibold text-destructive/80",
-            !isExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
+            !visualIsExecuting && !isQueued && !isErrored && "text-muted-foreground/70",
           )}
         >
           {detailLabel}

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -63,11 +63,19 @@ describe("CellInsertionRibbon", () => {
     const actions = container.querySelector('[data-slot="cell-adder-actions"]');
     const palette = container.querySelector('[data-slot="cell-adder-action-palette"]');
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
+    const leadingRule = container.querySelector('[data-slot="cell-adder-leading-rule"]');
+    const trailingRule = container.querySelector('[data-slot="cell-adder-trailing-rule"]');
 
     expect(actions).toHaveClass("opacity-100");
-    expect(palette).toHaveClass("bg-background/80");
-    expect(palette).toHaveClass("rounded-full");
+    expect(actions).toHaveClass("flex-1");
+    expect(palette).toHaveClass("shrink-0");
+    expect(palette).not.toHaveClass("rounded-full");
+    expect(palette).not.toHaveClass("shadow-sm");
     expect(intent).toHaveClass("bg-emerald-400");
+    expect(leadingRule).toHaveClass("bg-emerald-400/50");
+    expect(trailingRule).toHaveClass("bg-gradient-to-r");
+    expect(trailingRule).toHaveClass("from-emerald-400/35");
+    expect(trailingRule).toHaveClass("flex-1");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
   });
 

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -81,6 +81,7 @@ describe("CellInsertionRibbon", () => {
 
     const actions = container.querySelector('[data-slot="cell-adder-actions"]');
     const palette = container.querySelector('[data-slot="cell-adder-action-palette"]');
+    const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
     const leadingRule = container.querySelector('[data-slot="cell-adder-leading-rule"]');
     const trailingRule = container.querySelector('[data-slot="cell-adder-trailing-rule"]');
@@ -88,9 +89,13 @@ describe("CellInsertionRibbon", () => {
     expect(actions).toHaveClass("opacity-100");
     expect(actions).toHaveClass("flex-1");
     expect(palette).toHaveClass("shrink-0");
+    expect(palette).toHaveClass("pl-0.5");
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
+    expect(hitTarget).toHaveClass("bg-emerald-500/6");
+    expect(hitTarget).toHaveClass("text-emerald-700");
     expect(intent).toHaveClass("bg-emerald-400");
+    expect(leadingRule).toHaveClass("w-2");
     expect(leadingRule).toHaveClass("bg-emerald-400/50");
     expect(trailingRule).toHaveClass("bg-gradient-to-r");
     expect(trailingRule).toHaveClass("from-emerald-400/35");

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -55,6 +55,25 @@ describe("CellInsertionRibbon", () => {
     expect(hitTarget).toHaveClass("bg-muted/20");
   });
 
+  it("keeps explicit actions out of the tab order until the row is awake", () => {
+    const { container } = render(<CellInsertionRibbon onInsert={() => undefined} />);
+
+    const adder = container.querySelector('[data-slot="cell-adder"]');
+    const actions = container.querySelector('[data-slot="cell-adder-actions"]');
+    const addCodeButton = screen.getByTitle("Add code cell");
+    const addMarkdownButton = screen.getByTitle("Add markdown cell");
+
+    expect(actions).toHaveAttribute("aria-hidden", "true");
+    expect(addCodeButton).toHaveAttribute("tabindex", "-1");
+    expect(addMarkdownButton).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.pointerEnter(adder!);
+
+    expect(actions).not.toHaveAttribute("aria-hidden");
+    expect(addCodeButton).toHaveAttribute("tabindex", "0");
+    expect(addMarkdownButton).toHaveAttribute("tabindex", "0");
+  });
+
   it("uses the controlled active type for catalog fixtures", () => {
     const { container } = render(
       <CellInsertionRibbon activeType="markdown" forceActionsVisible onInsert={() => undefined} />,

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -8,6 +8,9 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detailGroup = container.querySelector(
+      '[data-slot="code-cell-current-line-detail-group"]',
+    );
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "idle");
@@ -15,6 +18,9 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
+    expect(detailGroup).toHaveClass("max-w-0");
+    expect(detailGroup).toHaveClass("opacity-0");
+    expect(detailGroup).toHaveClass("group-hover:max-w-16");
     expect(rule).toHaveClass("bg-border/15");
     expect(rule).toHaveClass("flex-1");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
@@ -34,16 +40,22 @@ describe("CodeCellCurrentLine", () => {
     expect(rule).toBeNull();
   });
 
-  it("keeps focused idle language pinned to the same readout slot", () => {
+  it("keeps focused idle language pinned while ready stays a quiet caption", () => {
     const { container } = render(
       <CodeCellCurrentLine languageLabel="Python" count={null} isFocused />,
     );
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const detailGroup = container.querySelector(
+      '[data-slot="code-cell-current-line-detail-group"]',
+    );
 
     expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
+    expect(detailGroup).toHaveClass("max-w-0");
+    expect(detailGroup).toHaveClass("opacity-0");
+    expect(detailGroup).toHaveClass("group-focus-within:max-w-16");
   });
 
   it("keeps initial running state visually quiet while execution settles", () => {

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -46,7 +46,7 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveClass("opacity-100");
   });
 
-  it("separates active running status from the execution control lane", () => {
+  it("keeps initial running state visually quiet while execution settles", () => {
     const { container } = render(
       <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
     );
@@ -57,16 +57,16 @@ describe("CodeCellCurrentLine", () => {
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "running");
-    expect(status).toHaveTextContent("Python/running");
+    expect(footer).toHaveAttribute("data-execution-visual-state", "ran");
+    expect(footer).toHaveClass("min-h-4");
+    expect(status).toHaveTextContent("Python/run 12");
     expect(status).toHaveAttribute("aria-label", "Python: Running");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(detail).toHaveClass("text-emerald-700");
-    expect(rule).toHaveClass("text-emerald-500/65");
+    expect(detail).toHaveClass("text-muted-foreground/70");
+    expect(detail).not.toHaveClass("text-emerald-700");
+    expect(rule).toHaveClass("bg-border/15");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(rule).toHaveAttribute("data-execution-signal", "building");
-    expect(
-      rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
-    ).toBeInTheDocument();
+    expect(rule).not.toHaveAttribute("data-execution-signal");
     expect(rule?.querySelector("svg")).toBeNull();
   });
 
@@ -82,6 +82,9 @@ describe("CodeCellCurrentLine", () => {
         vi.advanceTimersByTime(119);
       });
 
+      expect(
+        container.querySelector('[data-slot="code-cell-current-line-status"]'),
+      ).toHaveTextContent("Python/run 12");
       expect(container.querySelector('[data-slot="code-cell-current-line-rule"] svg')).toBeNull();
 
       rerender(<CodeCellCurrentLine languageLabel="Python" count={13} />);
@@ -106,9 +109,13 @@ describe("CodeCellCurrentLine", () => {
         vi.advanceTimersByTime(120);
       });
 
+      const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+      const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
       let rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
       let signal = container.querySelector('[data-slot="code-cell-current-line-signal"]');
 
+      expect(footer).toHaveAttribute("data-execution-visual-state", "running");
+      expect(status).toHaveTextContent("Python/running");
       expect(rule).toHaveAttribute("data-execution-signal", "active");
       expect(signal).toHaveClass("animate-exec-signal-build");
       expect(
@@ -132,6 +139,35 @@ describe("CodeCellCurrentLine", () => {
       });
 
       rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      expect(rule).not.toHaveAttribute("data-execution-signal");
+      expect(rule?.querySelector("svg")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets failed state interrupt the running settle affordance", () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container, rerender } = render(
+        <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(120);
+      });
+
+      rerender(<CodeCellCurrentLine languageLabel="Python" count={13} isErrored />);
+
+      const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+      const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+      const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+
+      expect(footer).toHaveAttribute("data-execution-state", "error");
+      expect(footer).toHaveAttribute("data-execution-visual-state", "error");
+      expect(status).toHaveTextContent("Python/failed");
+      expect(rule).toHaveClass("text-destructive/60");
       expect(rule).not.toHaveAttribute("data-execution-signal");
       expect(rule?.querySelector("svg")).toBeNull();
     } finally {

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -8,9 +8,10 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
-    const detailGroup = container.querySelector(
-      '[data-slot="code-cell-current-line-detail-group"]',
+    const languageContext = container.querySelector(
+      '[data-slot="code-cell-current-line-language-context"]',
     );
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(footer).toHaveAttribute("data-execution-state", "idle");
@@ -18,9 +19,12 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
-    expect(detailGroup).toHaveClass("max-w-0");
-    expect(detailGroup).toHaveClass("opacity-0");
-    expect(detailGroup).toHaveClass("group-hover:max-w-16");
+    expect(languageContext).toHaveClass("max-w-0");
+    expect(languageContext).toHaveClass("opacity-0");
+    expect(languageContext).toHaveClass("group-hover:max-w-20");
+    expect(detail).toHaveClass("max-w-0");
+    expect(detail).toHaveClass("opacity-0");
+    expect(detail).toHaveClass("group-hover:max-w-16");
     expect(rule).toHaveClass("bg-border/15");
     expect(rule).toHaveClass("flex-1");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
@@ -46,16 +50,20 @@ describe("CodeCellCurrentLine", () => {
     );
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
-    const detailGroup = container.querySelector(
-      '[data-slot="code-cell-current-line-detail-group"]',
+    const languageContext = container.querySelector(
+      '[data-slot="code-cell-current-line-language-context"]',
     );
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
 
     expect(status).toHaveTextContent("Python/ready");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
-    expect(detailGroup).toHaveClass("max-w-0");
-    expect(detailGroup).toHaveClass("opacity-0");
-    expect(detailGroup).toHaveClass("group-focus-within:max-w-16");
+    expect(languageContext).toHaveClass("max-w-0");
+    expect(languageContext).toHaveClass("opacity-0");
+    expect(languageContext).toHaveClass("group-focus-within:max-w-20");
+    expect(detail).toHaveClass("max-w-0");
+    expect(detail).toHaveClass("opacity-0");
+    expect(detail).toHaveClass("group-focus-within:max-w-16");
   });
 
   it("keeps initial running state visually quiet while execution settles", () => {
@@ -246,23 +254,37 @@ describe("CodeCellCurrentLine", () => {
 
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const languageContext = container.querySelector(
+      '[data-slot="code-cell-current-line-language-context"]',
+    );
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
 
     expect(footer).toHaveAttribute("data-execution-label", "Execution 12");
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run12·1.5s");
     expect(footer).not.toHaveTextContent("In [12]");
     expect(status).toHaveClass("max-w-64");
+    expect(languageContext).toHaveClass("max-w-0");
+    expect(detail).toHaveClass("max-w-64");
   });
 
   it("keeps completed metadata in the same right readout slot", () => {
     const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={12} />);
 
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
+    const languageContext = container.querySelector(
+      '[data-slot="code-cell-current-line-language-context"]',
+    );
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
     const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
 
     expect(status).toHaveTextContent("Python/run 12");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
+    expect(languageContext).toHaveClass("max-w-0");
+    expect(languageContext).toHaveClass("group-hover:max-w-20");
+    expect(detail).toHaveClass("max-w-64");
+    expect(detail).toHaveClass("opacity-100");
     expect(rule).toHaveClass("flex-1");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });


### PR DESCRIPTION
## Summary

- Refines the code-cell execution line so quiet states read as document punctuation while active states carry the stronger runtime/status vocabulary.
- Threads insertion actions into the ribbon language with quieter tab behavior, color-matched insertion intent, and tighter cell-adder spacing.
- Updates Elements examples/docs to capture the production grammar for execution language and insertion affordances.

## Verification

- `pnpm exec vp test src/components/cell/__tests__/CellInsertionRibbon.test.tsx src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
