### PR TITLE
docs(elements): surface ANSI palette previews

### DIFF
--- a/apps/elements/components/notebook-palette-toggle.tsx
+++ b/apps/elements/components/notebook-palette-toggle.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { ChevronDown, Palette } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { cn } from "@/lib/utils";
 
 type NotebookPalette = "classic" | "cream";
 
 const storageKey = "notebook-color-theme";
+const paletteChangeEvent = "notebook-color-theme-change";
 
 const options: Array<{
   value: NotebookPalette;
@@ -40,12 +41,37 @@ function applyPalette(value: NotebookPalette) {
 }
 
 export function NotebookPaletteToggle({ className }: { className?: string }) {
+  const selectId = useId();
   const [palette, setPalette] = useState<NotebookPalette>("classic");
 
   useEffect(() => {
     const stored = readStoredPalette();
     setPalette(stored);
     applyPalette(stored);
+
+    const syncPalette = (value: string | null) => {
+      if (!isNotebookPalette(value)) return;
+      setPalette(value);
+      applyPalette(value);
+    };
+
+    const handlePaletteChange = (event: Event) => {
+      syncPalette((event as CustomEvent<string>).detail);
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === storageKey) {
+        syncPalette(event.newValue);
+      }
+    };
+
+    window.addEventListener(paletteChangeEvent, handlePaletteChange);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener(paletteChangeEvent, handlePaletteChange);
+      window.removeEventListener("storage", handleStorage);
+    };
   }, []);
 
   const selectPalette = (value: NotebookPalette) => {
@@ -56,6 +82,7 @@ export function NotebookPaletteToggle({ className }: { className?: string }) {
     } catch {
       // localStorage can be unavailable in private or locked-down contexts.
     }
+    window.dispatchEvent(new CustomEvent(paletteChangeEvent, { detail: value }));
   };
 
   return (
@@ -67,12 +94,12 @@ export function NotebookPaletteToggle({ className }: { className?: string }) {
       aria-label="Notebook flavor"
     >
       <Palette className="size-4 flex-none" aria-hidden="true" />
-      <label className="sr-only" htmlFor="notebook-flavor-select">
+      <label className="sr-only" htmlFor={selectId}>
         Notebook flavor
       </label>
       <div className="relative min-w-0 flex-1">
         <select
-          id="notebook-flavor-select"
+          id={selectId}
           value={palette}
           onChange={(event) => selectPalette(event.target.value as NotebookPalette)}
           className="h-8 w-full appearance-none rounded-md bg-fd-background py-0 pe-8 ps-3 text-sm font-medium text-fd-foreground shadow-sm outline-none transition-colors hover:bg-fd-accent focus-visible:ring-2 focus-visible:ring-fd-ring"

--- a/apps/elements/components/theme-surfaces-example.tsx
+++ b/apps/elements/components/theme-surfaces-example.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { AnsiOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { NotebookPaletteToggle } from "@/components/notebook-palette-toggle";
 
 const surfaces = [
@@ -31,9 +34,44 @@ const accents = [
   { label: "error", className: "bg-red-500" },
 ];
 
+const ansiSwatches = [
+  { label: "black", fg: "ansi-black-fg", bg: "ansi-black-bg", code: "30" },
+  { label: "red", fg: "ansi-red-fg", bg: "ansi-red-bg", code: "31" },
+  { label: "green", fg: "ansi-green-fg", bg: "ansi-green-bg", code: "32" },
+  { label: "yellow", fg: "ansi-yellow-fg", bg: "ansi-yellow-bg", code: "33" },
+  { label: "blue", fg: "ansi-blue-fg", bg: "ansi-blue-bg", code: "34" },
+  { label: "magenta", fg: "ansi-magenta-fg", bg: "ansi-magenta-bg", code: "35" },
+  { label: "cyan", fg: "ansi-cyan-fg", bg: "ansi-cyan-bg", code: "36" },
+  { label: "white", fg: "ansi-white-fg", bg: "ansi-white-bg", code: "37" },
+];
+
+const brightAnsiSwatches = [
+  { label: "bright black", fg: "ansi-bright-black-fg", code: "90" },
+  { label: "bright red", fg: "ansi-bright-red-fg", code: "91" },
+  { label: "bright green", fg: "ansi-bright-green-fg", code: "92" },
+  { label: "bright yellow", fg: "ansi-bright-yellow-fg", code: "93" },
+  { label: "bright blue", fg: "ansi-bright-blue-fg", code: "94" },
+  { label: "bright magenta", fg: "ansi-bright-magenta-fg", code: "95" },
+  { label: "bright cyan", fg: "ansi-bright-cyan-fg", code: "96" },
+  { label: "bright white", fg: "ansi-bright-white-fg", code: "97" },
+];
+
+const notebookOutputPreview = [
+  "\u001b[33m0.79131883437586\u001b[0m",
+  "\u001b[90m[\u001b[0m \u001b[33m1\u001b[0m, \u001b[33m2\u001b[0m, \u001b[33m3\u001b[0m \u001b[90m]\u001b[0m",
+  '\u001b[32m"hey"\u001b[0m',
+  "\u001b[31mNameError\u001b[0m: name 'wasdfasdf' is not defined",
+].join("\n");
+
+const terminalPreview = [
+  "\u001b[32mtraining\u001b[0m fold=01 mae=\u001b[33m8.91\u001b[0m",
+  "\u001b[33mvalidating\u001b[0m fold=02 mae=\u001b[33m8.42\u001b[0m",
+  "\u001b[34mexported\u001b[0m forecast.parquet",
+].join("\n");
+
 export function ThemeSurfacesExample() {
   return (
-    <div className="not-prose space-y-4 rounded-lg border border-fd-border bg-fd-card p-4">
+    <div className="not-prose space-y-5 rounded-lg border border-fd-border bg-fd-card p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <h2 className="text-sm font-semibold text-fd-foreground">Notebook palette</h2>
@@ -77,6 +115,69 @@ export function ThemeSurfacesExample() {
           </div>
         </div>
         <div className="h-2 rounded-full bg-gradient-to-r from-sky-500 via-emerald-500 to-purple-500" />
+      </div>
+
+      <div className="space-y-4 border-t border-border pt-4 text-foreground">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h3 className="text-sm font-semibold">ANSI output palette</h3>
+            <div className="mt-1 text-xs leading-5 text-muted-foreground">
+              Output renderers use the shared ANSI variables for classic, cream, light, and dark.
+            </div>
+          </div>
+          <div className="font-mono text-[11px] text-muted-foreground">src/styles/ansi.css</div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="min-w-0 rounded-lg border border-border bg-background p-4">
+            <div className="mb-3 text-xs font-semibold text-muted-foreground">
+              Notebook output values
+            </div>
+            <AnsiOutput className="text-[13px] leading-7">{notebookOutputPreview}</AnsiOutput>
+          </div>
+
+          <div className="min-w-0 rounded-lg border border-border bg-background p-4">
+            <div className="mb-3 text-xs font-semibold text-muted-foreground">Stream output</div>
+            <AnsiStreamOutput className="py-0" streamName="stdout" text={terminalPreview} />
+          </div>
+        </div>
+
+        <div className="grid gap-2 md:grid-cols-2">
+          <div className="rounded-lg border border-border bg-background p-3">
+            <div className="mb-3 text-xs font-semibold text-muted-foreground">Standard colors</div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {ansiSwatches.map((swatch) => (
+                <div
+                  key={swatch.label}
+                  className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-muted/50 px-2 py-1.5"
+                >
+                  <span className={["size-3 rounded-sm", swatch.bg].join(" ")} />
+                  <span className={["truncate text-sm font-medium", swatch.fg].join(" ")}>
+                    {swatch.label}
+                  </span>
+                  <span className="font-mono text-[11px] text-muted-foreground">{swatch.code}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-border bg-background p-3">
+            <div className="mb-3 text-xs font-semibold text-muted-foreground">Bright colors</div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {brightAnsiSwatches.map((swatch) => (
+                <div
+                  key={swatch.label}
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md bg-muted/50 px-2 py-1.5"
+                >
+                  <span className={["truncate text-sm font-medium", swatch.fg].join(" ")}>
+                    {swatch.label}
+                  </span>
+                  <span className="font-mono text-[11px] text-muted-foreground">{swatch.code}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/styles/ansi.css
+++ b/src/styles/ansi.css
@@ -9,28 +9,28 @@
 @layer base {
   :root {
     --ansi-black: #4b5563;
-    --ansi-red: #dc2626;
-    --ansi-green: #15803d;
-    --ansi-yellow: #a16207;
-    --ansi-blue: #1d4ed8;
-    --ansi-magenta: #9333ea;
-    --ansi-cyan: #0e7490;
+    --ansi-red: #cf222e;
+    --ansi-green: #1a7f37;
+    --ansi-yellow: #b45309;
+    --ansi-blue: #0969da;
+    --ansi-magenta: #8250df;
+    --ansi-cyan: #087990;
     --ansi-white: #6b7280;
     --ansi-bright-black: #6b7280;
-    --ansi-bright-red: #dc2626;
-    --ansi-bright-green: #15803d;
-    --ansi-bright-yellow: #a16207;
+    --ansi-bright-red: #cf222e;
+    --ansi-bright-green: #1a7f37;
+    --ansi-bright-yellow: #b45309;
     --ansi-bright-blue: #2563eb;
-    --ansi-bright-magenta: #9333ea;
-    --ansi-bright-cyan: #0e7490;
+    --ansi-bright-magenta: #8250df;
+    --ansi-bright-cyan: #087990;
     --ansi-bright-white: #111827;
     --ansi-black-bg: #4b5563;
-    --ansi-red-bg: #dc2626;
-    --ansi-green-bg: #15803d;
-    --ansi-yellow-bg: #a16207;
-    --ansi-blue-bg: #1d4ed8;
-    --ansi-magenta-bg: #9333ea;
-    --ansi-cyan-bg: #0e7490;
+    --ansi-red-bg: #cf222e;
+    --ansi-green-bg: #1a7f37;
+    --ansi-yellow-bg: #b45309;
+    --ansi-blue-bg: #0969da;
+    --ansi-magenta-bg: #8250df;
+    --ansi-cyan-bg: #087990;
     --ansi-white-bg: #6b7280;
   }
 


### PR DESCRIPTION
## Summary

- adds an ANSI output palette preview to the Elements theme surfaces page using the production ANSI renderer
- shows notebook-like values, stream output, standard ANSI colors, and bright ANSI colors against the active notebook palette
- brightens the classic light ANSI palette while keeping foreground contrast checks passing
- keeps multiple Elements palette selectors synchronized and gives each select a stable unique id

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- `pnpm test:run src/components/outputs/__tests__/ansi-theme-css.test.ts src/components/outputs/__tests__/ansi-output.test.tsx`
- launched `pnpm --dir apps/elements dev:local` and checked `/docs/theme-surfaces` with local Playwright in classic, cream, and cream dark
