### PR TITLE
refactor(notebook-shell): share environment rail summaries

### DIFF
--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -14,6 +14,8 @@ import {
   NotebookDocumentHeader,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookEnvironmentSummary,
+  NotebookPackageSummaryPanel,
   type NotebookViewCell,
 } from "@/components/notebook-shell";
 import { NotebookPackagesPanel, type NotebookRailPanelId } from "@/components/notebook-rail";
@@ -42,6 +44,8 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "runtime-peer",
+  "system-schema",
   "runtime-unavailable",
 ];
 
@@ -161,9 +165,27 @@ export function RailOutlineExample() {
           selectedOutlineCellId={focusedCellId}
           packagesSummary={scenario.packageSummary}
           packagesPanel={
-            <NotebookPackagesPanel readOnly={!scenario.capabilities.canManagePackages}>
-              <PackagePanelContent scenario={scenario} />
-            </NotebookPackagesPanel>
+            scenario.capabilities.canManagePackages ? (
+              <NotebookPackagesPanel>
+                <PackagePanelContent scenario={scenario} />
+              </NotebookPackagesPanel>
+            ) : (
+              <NotebookPackageSummaryPanel
+                packages={viewModel.packages}
+                readOnly
+                header={
+                  <NotebookEnvironmentSummary
+                    capabilities={scenario.capabilities}
+                    packages={viewModel.packages}
+                    runtimeLabel={scenario.runtimeLabel}
+                    syncLabel={packageSyncLabel(scenario.packageState.syncState.status)}
+                    trustLabel={trustStatusLabel(scenario.trustState.trustInfo.status)}
+                    showPackageDetails={false}
+                    className="shadow-none"
+                  />
+                }
+              />
+            )
           }
           onActivePanelChange={setActivePanel}
           onCollapsedChange={setRailCollapsed}
@@ -205,6 +227,30 @@ export function RailOutlineExample() {
       />
     </NotebookDocumentShell>
   );
+}
+
+function trustStatusLabel(status: ElementsNotebookScenario["trustState"]["trustInfo"]["status"]) {
+  switch (status) {
+    case "trusted":
+      return "Trusted";
+    case "untrusted":
+      return "Untrusted dependencies";
+    case "no_dependencies":
+      return "No dependency trust review needed";
+  }
+}
+
+function packageSyncLabel(status: ElementsNotebookScenario["packageState"]["syncState"]["status"]) {
+  switch (status) {
+    case "dirty":
+      return "Package metadata has pending changes";
+    case "not_running":
+      return "Runtime is not running";
+    case "not_uv_managed":
+      return "Package metadata is outside uv";
+    case "synced":
+      return "Package metadata synced";
+  }
 }
 
 function ScenarioNotice({

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -31,6 +31,7 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookEnvironmentSummary,
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
@@ -1155,6 +1156,17 @@ function NotebookViewer({
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}
           readOnly={!shellCapabilities.canManagePackages}
+          header={
+            <NotebookEnvironmentSummary
+              capabilities={shellCapabilities}
+              packages={notebookViewModel.packages}
+              runtimeLabel={connectionScope === "runtime_peer" ? "Runtime peer connected" : null}
+              syncLabel={connectionScope ? "Live sync connected" : "Live sync unavailable"}
+              trustLabel="Trust state not required"
+              showPackageDetails={false}
+              className="shadow-none"
+            />
+          }
         />
       }
       onActivePanelChange={setActiveRailPanel}

--- a/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
+++ b/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
@@ -12,6 +12,7 @@ export interface NotebookEnvironmentSummaryProps {
   packageSourceLabel?: string | null;
   syncLabel?: string | null;
   trustLabel?: string | null;
+  showPackageDetails?: boolean;
   className?: string;
 }
 
@@ -22,6 +23,7 @@ export function NotebookEnvironmentSummary({
   packageSourceLabel = null,
   syncLabel = null,
   trustLabel = null,
+  showPackageDetails = true,
   className,
 }: NotebookEnvironmentSummaryProps) {
   const packageAccessLabel = capabilities.canManagePackages
@@ -83,8 +85,8 @@ export function NotebookEnvironmentSummary({
         <SummaryFact
           icon={<RefreshCw className="size-3.5" aria-hidden="true" />}
           label="Sync"
-          value={syncLabel ?? packageAccessLabel}
-          muted={!capabilities.canManagePackages}
+          value={syncLabel ?? "Sync status not reported"}
+          muted={!syncLabel}
         />
         <SummaryFact
           icon={
@@ -99,38 +101,43 @@ export function NotebookEnvironmentSummary({
         />
       </div>
 
-      <div className="border-t border-border px-4 py-3">
-        {packages.sections.length === 0 ? (
-          <p className="text-xs text-muted-foreground">No package manager metadata available.</p>
-        ) : (
-          <div className="space-y-3">
-            {packages.sections.map((section) => (
-              <div key={section.manager} className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-xs font-semibold">{section.label}</span>
-                  <span className="text-[11px] text-muted-foreground">
-                    {section.dependencies.length === 1
-                      ? "1 dependency"
-                      : `${section.dependencies.length} dependencies`}
-                  </span>
+      {showPackageDetails ? (
+        <div className="border-t border-border px-4 py-3">
+          {packages.sections.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No package manager metadata available.</p>
+          ) : (
+            <div className="space-y-3">
+              {packages.sections.map((section) => (
+                <div key={section.manager} className="space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold">{section.label}</span>
+                    <span className="text-[11px] text-muted-foreground">
+                      {section.dependencies.length === 1
+                        ? "1 dependency"
+                        : `${section.dependencies.length} dependencies`}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {[
+                      ...section.dependencies,
+                      ...section.details.flatMap((detail) => detail.values),
+                    ]
+                      .slice(0, 8)
+                      .map((value, index) => (
+                        <code
+                          key={`${section.manager}:${value}:${index}`}
+                          className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                        >
+                          {value}
+                        </code>
+                      ))}
+                  </div>
                 </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {[...section.dependencies, ...section.details.flatMap((detail) => detail.values)]
-                    .slice(0, 8)
-                    .map((value, index) => (
-                      <code
-                        key={`${section.manager}:${value}:${index}`}
-                        className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
-                      >
-                        {value}
-                      </code>
-                    ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
+++ b/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
@@ -1,21 +1,25 @@
 import { NotebookPackagesPanel } from "@/components/notebook-rail";
 import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
 import type { NotebookPackageViewModel } from "./view-model";
 
 export interface NotebookPackageSummaryPanelProps {
   packages: NotebookPackageViewModel;
   readOnly?: boolean;
+  header?: ReactNode;
   className?: string;
 }
 
 export function NotebookPackageSummaryPanel({
   packages,
   readOnly = true,
+  header = null,
   className,
 }: NotebookPackageSummaryPanelProps) {
   return (
     <NotebookPackagesPanel readOnly={readOnly}>
       <div className={cn("space-y-3", className)} data-slot="notebook-package-summary-panel">
+        {header}
         {packages.sections.length === 0 ? (
           <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
             No package metadata in this notebook.

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -93,4 +93,29 @@ describe("NotebookEnvironmentSummary", () => {
     expect(screen.getByText("No package metadata")).toBeVisible();
     expect(screen.getByText("No package manager metadata available.")).toBeVisible();
   });
+
+  it("can render only environment facts when package details are shown elsewhere", () => {
+    render(
+      <NotebookEnvironmentSummary
+        capabilities={{
+          ...capabilities,
+          canManagePackages: false,
+          access: {
+            ...capabilities.access,
+            level: "viewer",
+            source: "cloud",
+            isPublic: true,
+          },
+        }}
+        packages={packages}
+        syncLabel="Live sync connected"
+        showPackageDetails={false}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
+    expect(screen.getByText("Live sync connected")).toBeVisible();
+    expect(screen.getByText("Package metadata read only")).toBeVisible();
+    expect(screen.queryByText("pandas>=2")).toBeNull();
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
@@ -27,6 +27,18 @@ describe("NotebookPackageSummaryPanel", () => {
     expect(screen.getByText("Read only")).toBeVisible();
   });
 
+  it("renders a shared host summary above package details", () => {
+    render(
+      <NotebookPackageSummaryPanel
+        packages={{ summary: "uv - 1 package", sections: [] }}
+        header={<p>Cloud viewer environment</p>}
+      />,
+    );
+
+    expect(screen.getByText("Cloud viewer environment")).toBeVisible();
+    expect(screen.getByText("No package metadata in this notebook.")).toBeVisible();
+  });
+
   it("shows an empty package metadata state", () => {
     render(<NotebookPackageSummaryPanel packages={{ summary: null, sections: [] }} />);
 


### PR DESCRIPTION
## Summary

- let `NotebookEnvironmentSummary` render environment facts without duplicating package details
- let `NotebookPackageSummaryPanel` host shared summary chrome above read-only package details
- route notebook-cloud and Elements read-only package rails through the shared environment/package surface

## Validation

- `pnpm test:run src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- deployed branch to `preview.runt.run`
- hosted smoke: `lets-edit` on `/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit`
- hosted smoke: `topic-viz` on `/n/topic-viz/topic-viz`
- preview check: Packages rail shows the shared `NotebookEnvironmentSummary`
- `uv run pr-review https://github.com/nteract/nteract/pull/3267 --max-turns 120 --out .context/reviews/pr-3267.json`

## Notes

- This keeps package details visible in read-only cloud/Elements contexts while management controls remain capability-gated.
- Desktop’s manager-specific package controls stay behind the desktop host adapter for now.
