### PR TITLE
refactor(notebook-shell): type environment surface scenarios

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -20,13 +20,19 @@ import {
 
 const identityScenarioIds: ElementsNotebookScenarioId[] = [
   "desktop-local-owner",
+  "desktop-read-only",
+  "desktop-remote-room",
   "cloud-public-viewer",
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "credential-attention",
+  "multi-operator",
+  "mixed-idp-room",
   "runtime-peer",
   "system-schema",
   "runtime-unavailable",
+  "untrusted-dependencies",
 ];
 
 const remainingNotebookSurfaces = [
@@ -145,10 +151,7 @@ export function IdentityEnvironmentSurfacesExample() {
         <NotebookEnvironmentSummary
           capabilities={desktopOwner.capabilities}
           packages={desktopOwner.viewModel.packages}
-          runtimeLabel={desktopOwner.runtimeLabel}
-          packageSourceLabel={desktopOwner.packageState.pyprojectInfo.relative_path}
-          syncLabel={syncLabel(desktopOwner)}
-          trustLabel="Untrusted - review package changes"
+          environment={desktopOwner.environment}
         />
       </section>
 
@@ -156,18 +159,12 @@ export function IdentityEnvironmentSurfacesExample() {
         <NotebookEnvironmentSummary
           capabilities={agentScenario.capabilities}
           packages={agentScenario.viewModel.packages}
-          runtimeLabel={agentScenario.runtimeLabel}
-          packageSourceLabel="cloud runtime snapshot"
-          syncLabel="managed by owner"
-          trustLabel="Trusted by Kyle"
+          environment={agentScenario.environment}
         />
         <NotebookEnvironmentSummary
           capabilities={getElementsNotebookScenario("runtime-unavailable").capabilities}
           packages={getElementsNotebookScenario("runtime-unavailable").viewModel.packages}
-          runtimeLabel={getElementsNotebookScenario("runtime-unavailable").runtimeLabel}
-          packageSourceLabel="pyproject.toml"
-          syncLabel="package edits disabled"
-          trustLabel="Needs attention"
+          environment={getElementsNotebookScenario("runtime-unavailable").environment}
         />
       </section>
 
@@ -261,15 +258,4 @@ function Fact({ label, value }: { label: string; value: string }) {
 
 function scenarioActor(scenario: ElementsNotebookScenario): NotebookActorIdentity {
   return notebookActorIdentityFromAccess(scenario.capabilities.access, scenario.capabilities.auth);
-}
-
-function syncLabel(scenario: ElementsNotebookScenario): string {
-  const state = scenario.packageState.syncState;
-  if (state.status === "synced") return "synced";
-  if (state.status === "dirty") {
-    const added = "added" in state && Array.isArray(state.added) ? state.added.length : 0;
-    const removed = "removed" in state && Array.isArray(state.removed) ? state.removed.length : 0;
-    return `dirty - ${added + removed} pending changes`;
-  }
-  return state.status;
 }

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -2,10 +2,14 @@ import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { SupportedLanguage } from "@/components/editor/languages";
 import {
   createNotebookViewModel,
+  createNotebookEnvironmentSurface,
   notebookActorProjectionFromAccess,
   notebookActorProjectionFromRuntime,
   type NotebookActorProjection,
+  type NotebookEnvironmentSurface,
+  type NotebookPackageSyncStatus,
   type NotebookShellCapabilities,
+  type NotebookTrustStatus,
   type NotebookViewCell,
   type NotebookViewModel,
 } from "@/components/notebook-shell";
@@ -20,13 +24,19 @@ import { WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 
 export type ElementsNotebookScenarioId =
   | "desktop-local-owner"
+  | "desktop-read-only"
+  | "desktop-remote-room"
   | "cloud-public-viewer"
   | "cloud-editor"
   | "cloud-owner"
   | "agent-on-behalf"
+  | "credential-attention"
+  | "multi-operator"
+  | "mixed-idp-room"
   | "runtime-peer"
   | "system-schema"
-  | "runtime-unavailable";
+  | "runtime-unavailable"
+  | "untrusted-dependencies";
 
 export interface ElementsNotebookScenario {
   id: ElementsNotebookScenarioId;
@@ -34,6 +44,7 @@ export interface ElementsNotebookScenario {
   eyebrow: string;
   summary: string;
   capabilities: NotebookShellCapabilities;
+  environment: NotebookEnvironmentSurface;
   cells: readonly NotebookViewCell[];
   viewModel: NotebookViewModel;
   runtimeLabel: string;
@@ -352,6 +363,30 @@ const desktopRuntimeActor = actorProjection({
   scope: "runtime_peer",
 });
 
+const desktopReadOnlyActor = actorProjection({
+  actorLabel: "local:kyle/desktop:readonly-file",
+  principalId: "local:kyle",
+  principalLabel: "Kyle",
+  provider: "local",
+  namespace: "kyle",
+  operatorId: "desktop:readonly-file",
+  operatorKind: "desktop",
+  operatorLabel: "Desktop",
+  scope: "viewer",
+});
+
+const desktopRemoteActor = actorProjection({
+  actorLabel: "user:anaconda:kyle/desktop:app",
+  principalId: "user:anaconda:kyle",
+  principalLabel: "Kyle",
+  provider: "anaconda",
+  namespace: "anaconda",
+  operatorId: "desktop:app",
+  operatorKind: "desktop",
+  operatorLabel: "Desktop",
+  scope: "editor",
+});
+
 const publicViewerActor = actorProjection({
   actorLabel: "anonymous:public/browser:viewer",
   principalId: "anonymous:public",
@@ -388,6 +423,18 @@ const cloudOwnerActor = actorProjection({
   scope: "owner",
 });
 
+const cloudExpiredActor = actorProjection({
+  actorLabel: "user:anaconda:kyle/browser:cloud",
+  principalId: "user:anaconda:kyle",
+  principalLabel: "Kyle",
+  provider: "anaconda",
+  namespace: "anaconda",
+  operatorId: "browser:cloud",
+  operatorKind: "browser",
+  operatorLabel: "Browser",
+  scope: "viewer",
+});
+
 const codexAgentActor = actorProjection({
   actorLabel: "user:anaconda:kyle/agent:codex:s1",
   principalId: "user:anaconda:kyle",
@@ -410,6 +457,30 @@ const jupyterHubRuntimeActor = actorProjection({
   operatorKind: "runtime",
   operatorLabel: "JupyterHub",
   scope: "runtime_peer",
+});
+
+const kyleDesktopOperatorActor = actorProjection({
+  actorLabel: "user:anaconda:kyle/desktop:app",
+  principalId: "user:anaconda:kyle",
+  principalLabel: "Kyle",
+  provider: "anaconda",
+  namespace: "anaconda",
+  operatorId: "desktop:app",
+  operatorKind: "desktop",
+  operatorLabel: "Desktop",
+  scope: "editor",
+});
+
+const mixedIdpActor = actorProjection({
+  actorLabel: "hub:anaconda:avery/browser:cloud",
+  principalId: "hub:anaconda:avery",
+  principalLabel: "Avery",
+  provider: "jupyterhub",
+  namespace: "anaconda",
+  operatorId: "browser:cloud",
+  operatorKind: "browser",
+  operatorLabel: "Browser",
+  scope: "editor",
 });
 
 const systemSchemaActor = actorProjection({
@@ -706,6 +777,100 @@ export const elementsNotebookScenarios: Record<
       },
     },
   }),
+  "desktop-read-only": createScenario({
+    id: "desktop-read-only",
+    title: "Desktop read-only",
+    eyebrow: "local fixture",
+    summary:
+      "A local file that can be opened and inspected while filesystem/host permissions disable writes.",
+    runtimeLabel: "Python · local runtime detached",
+    runtimeStatus: "detached",
+    packageSummary: "read-only · 4 packages",
+    syncLabel: "Local file is read only",
+    syncStatus: "unavailable",
+    trustLabel: "Trust state preserved",
+    trustStatus: "trusted",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "viewer",
+        source: "local",
+        isPublic: false,
+        actorLabel: desktopReadOnlyActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopReadOnlyActor,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+      runtime: {
+        canWriteRuntimeState: false,
+        connected: true,
+        source: "local",
+        actorLabel: desktopRuntimeActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopRuntimeActor,
+      },
+    },
+  }),
+  "desktop-remote-room": createScenario({
+    id: "desktop-remote-room",
+    title: "Desktop remote room",
+    eyebrow: "remote fixture",
+    summary:
+      "Desktop renders a hosted notebook through the same shell while a local daemon uses a remote credential.",
+    runtimeLabel: "Remote room · local daemon bridge",
+    runtimeStatus: "detached",
+    packageSummary: "visible · 4 packages",
+    syncLabel: "Remote sync connected",
+    syncStatus: "synced",
+    trustLabel: "Trust managed by room",
+    trustStatus: "trusted",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: desktopRemoteActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopRemoteActor,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+      runtime: {
+        canWriteRuntimeState: false,
+        connected: true,
+        source: "local",
+        actorLabel: desktopRuntimeActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopRuntimeActor,
+      },
+    },
+  }),
   "cloud-public-viewer": createScenario({
     id: "cloud-public-viewer",
     title: "Cloud public viewer",
@@ -870,6 +1035,153 @@ export const elementsNotebookScenarios: Record<
       },
     },
   }),
+  "credential-attention": createScenario({
+    id: "credential-attention",
+    title: "Credential attention",
+    eyebrow: "auth fixture",
+    summary:
+      "An expired hosted credential keeps the notebook readable but routes edit affordances to sign-in attention.",
+    runtimeLabel: "Cloud notebook · credential expired",
+    runtimeStatus: "unavailable",
+    packageSummary: "read-only · 4 packages",
+    syncLabel: "Reconnect required",
+    syncStatus: "unavailable",
+    trustLabel: "Trust state not required",
+    trustStatus: "not_required",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: true,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "viewer",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: cloudExpiredActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: { ...cloudExpiredActor, status: "attention" },
+      },
+      auth: {
+        canSignIn: true,
+        canUseAuthenticatedIdentity: false,
+        needsAttention: true,
+      },
+      runtime: {
+        canWriteRuntimeState: false,
+        connected: false,
+        source: "cloud",
+        actorLabel: null,
+        identityLabel: null,
+      },
+    },
+  }),
+  "multi-operator": createScenario({
+    id: "multi-operator",
+    title: "One principal, multiple operators",
+    eyebrow: "identity fixture",
+    summary:
+      "A single user appears through desktop editing and a runtime operator without collapsing their attribution.",
+    runtimeLabel: "JupyterHub runtime · connected",
+    runtimeStatus: "ready",
+    packageSummary: "visible · 4 packages",
+    syncLabel: "Remote sync connected",
+    syncStatus: "synced",
+    trustLabel: "Trusted by Kyle",
+    trustStatus: "trusted",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: kyleDesktopOperatorActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: kyleDesktopOperatorActor,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+      runtime: {
+        canWriteRuntimeState: true,
+        connected: true,
+        source: "cloud",
+        actorLabel: jupyterHubRuntimeActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: {
+          ...jupyterHubRuntimeActor,
+          principal: {
+            ...jupyterHubRuntimeActor.principal,
+            id: "user:anaconda:kyle",
+            label: "Kyle",
+          },
+          actorLabel: "user:anaconda:kyle/runtime:jupyterhub",
+        },
+      },
+    },
+  }),
+  "mixed-idp-room": createScenario({
+    id: "mixed-idp-room",
+    title: "Mixed IdP room",
+    eyebrow: "identity fixture",
+    summary:
+      "A hosted room can display a JupyterHub principal beside Anaconda users through the same projection.",
+    runtimeLabel: "Cloud notebook · runtime detached",
+    runtimeStatus: "detached",
+    packageSummary: "visible · 4 packages",
+    syncLabel: "Remote sync connected",
+    syncStatus: "synced",
+    trustLabel: "Trust state not required",
+    trustStatus: "not_required",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "editor",
+        source: "cloud",
+        isPublic: false,
+        actorLabel: mixedIdpActor.actorLabel,
+        identityLabel: "Avery",
+        actor: mixedIdpActor,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+      runtime: {
+        canWriteRuntimeState: false,
+        connected: false,
+        source: "cloud",
+        actorLabel: null,
+        identityLabel: null,
+      },
+    },
+  }),
   "runtime-peer": createScenario({
     id: "runtime-peer",
     title: "Runtime peer",
@@ -994,6 +1306,53 @@ export const elementsNotebookScenarios: Record<
       },
     },
   }),
+  "untrusted-dependencies": createScenario({
+    id: "untrusted-dependencies",
+    title: "Untrusted dependencies",
+    eyebrow: "trust fixture",
+    summary:
+      "Package metadata is visible, but dependency trust requires review before mutation or execution.",
+    runtimeLabel: "Python · blocked by trust",
+    runtimeStatus: "error",
+    packageSummary: "uv:inline · 4 packages",
+    syncLabel: "Package metadata has pending changes",
+    syncStatus: "dirty",
+    trustLabel: "Untrusted dependencies",
+    trustStatus: "untrusted",
+    capabilities: {
+      canRead: true,
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+      canRequestEdit: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: {
+        level: "owner",
+        source: "local",
+        isPublic: false,
+        actorLabel: desktopOwnerActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopOwnerActor,
+      },
+      auth: {
+        canSignIn: false,
+        canUseAuthenticatedIdentity: true,
+        needsAttention: false,
+      },
+      runtime: {
+        canWriteRuntimeState: false,
+        connected: true,
+        source: "local",
+        actorLabel: desktopRuntimeActor.actorLabel,
+        identityLabel: "Kyle",
+        actor: desktopRuntimeActor,
+      },
+    },
+  }),
 };
 
 export function getElementsNotebookScenario(id: ElementsNotebookScenarioId) {
@@ -1027,7 +1386,13 @@ function createScenario({
   eyebrow,
   summary,
   runtimeLabel,
+  runtimeStatus = null,
   packageSummary,
+  packageSourceLabel = packageState.pyprojectInfo.relative_path,
+  syncLabel = packageSyncLabel(packageState.syncState.status),
+  syncStatus = notebookPackageSyncStatus(packageState.syncState.status),
+  trustLabel = trustStatusLabel(trustState.trustInfo.status),
+  trustStatus = notebookTrustStatus(trustState.trustInfo.status),
   capabilities,
 }: {
   id: ElementsNotebookScenarioId;
@@ -1035,7 +1400,13 @@ function createScenario({
   eyebrow: string;
   summary: string;
   runtimeLabel: string;
+  runtimeStatus?: NotebookEnvironmentSurface["runtime"]["status"] | null;
   packageSummary: string;
+  packageSourceLabel?: string | null;
+  syncLabel?: string | null;
+  syncStatus?: NotebookPackageSyncStatus | null;
+  trustLabel?: string | null;
+  trustStatus?: NotebookTrustStatus | null;
   capabilities: NotebookShellCapabilities;
 }): ElementsNotebookScenario {
   const projectedCapabilities: NotebookShellCapabilities = {
@@ -1053,6 +1424,17 @@ function createScenario({
         notebookActorProjectionFromRuntime(capabilities.runtime, capabilities.auth),
     },
   };
+  const environment = createNotebookEnvironmentSurface({
+    capabilities: projectedCapabilities,
+    packages: viewModel.packages,
+    runtimeLabel,
+    runtimeStatus,
+    packageSourceLabel,
+    syncLabel,
+    syncStatus,
+    trustLabel,
+    trustStatus,
+  });
 
   return {
     id,
@@ -1060,6 +1442,7 @@ function createScenario({
     eyebrow,
     summary,
     capabilities: projectedCapabilities,
+    environment,
     cells: notebookCells,
     viewModel,
     runtimeLabel,
@@ -1107,4 +1490,47 @@ function actorProjection({
     },
     scope,
   };
+}
+
+function packageSyncLabel(status: ElementsNotebookPackageState["syncState"]["status"]) {
+  switch (status) {
+    case "dirty":
+      return "Package metadata has pending changes";
+    case "not_running":
+      return "Runtime is not running";
+    case "not_uv_managed":
+      return "Package metadata is outside uv";
+    case "synced":
+      return "Package metadata synced";
+  }
+}
+
+function notebookPackageSyncStatus(
+  status: ElementsNotebookPackageState["syncState"]["status"],
+): NotebookPackageSyncStatus {
+  return status;
+}
+
+function trustStatusLabel(status: ElementsNotebookTrustState["trustInfo"]["status"]) {
+  switch (status) {
+    case "trusted":
+      return "Trusted";
+    case "untrusted":
+      return "Untrusted dependencies";
+    case "no_dependencies":
+      return "No dependency trust review needed";
+  }
+}
+
+function notebookTrustStatus(
+  status: ElementsNotebookTrustState["trustInfo"]["status"],
+): NotebookTrustStatus {
+  switch (status) {
+    case "trusted":
+      return "trusted";
+    case "untrusted":
+      return "untrusted";
+    case "no_dependencies":
+      return "not_required";
+  }
 }

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -37,13 +37,19 @@ type BooleanCapabilityKey = {
 
 const scenarioIds: ElementsNotebookScenarioId[] = [
   "desktop-local-owner",
+  "desktop-read-only",
+  "desktop-remote-room",
   "cloud-public-viewer",
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "credential-attention",
+  "multi-operator",
+  "mixed-idp-room",
   "runtime-peer",
   "system-schema",
   "runtime-unavailable",
+  "untrusted-dependencies",
 ];
 
 const hostFlows: {

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -40,13 +40,19 @@ const runningIdleLifecycle: RuntimeLifecycle = {
 
 const scenarioIds: ElementsNotebookScenarioId[] = [
   "desktop-local-owner",
+  "desktop-read-only",
+  "desktop-remote-room",
   "cloud-public-viewer",
   "cloud-editor",
   "cloud-owner",
   "agent-on-behalf",
+  "credential-attention",
+  "multi-operator",
+  "mixed-idp-room",
   "runtime-peer",
   "system-schema",
   "runtime-unavailable",
+  "untrusted-dependencies",
 ];
 
 const executingCellId = "cell-model-code";
@@ -177,9 +183,7 @@ export function RailOutlineExample() {
                   <NotebookEnvironmentSummary
                     capabilities={scenario.capabilities}
                     packages={viewModel.packages}
-                    runtimeLabel={scenario.runtimeLabel}
-                    syncLabel={packageSyncLabel(scenario.packageState.syncState.status)}
-                    trustLabel={trustStatusLabel(scenario.trustState.trustInfo.status)}
+                    environment={scenario.environment}
                     showPackageDetails={false}
                     className="shadow-none"
                   />
@@ -227,30 +231,6 @@ export function RailOutlineExample() {
       />
     </NotebookDocumentShell>
   );
-}
-
-function trustStatusLabel(status: ElementsNotebookScenario["trustState"]["trustInfo"]["status"]) {
-  switch (status) {
-    case "trusted":
-      return "Trusted";
-    case "untrusted":
-      return "Untrusted dependencies";
-    case "no_dependencies":
-      return "No dependency trust review needed";
-  }
-}
-
-function packageSyncLabel(status: ElementsNotebookScenario["packageState"]["syncState"]["status"]) {
-  switch (status) {
-    case "dirty":
-      return "Package metadata has pending changes";
-    case "not_running":
-      return "Runtime is not running";
-    case "not_uv_managed":
-      return "Package metadata is outside uv";
-    case "synced":
-      return "Package metadata synced";
-  }
 }
 
 function ScenarioNotice({

--- a/apps/elements/content/docs/identity-environment-surfaces.mdx
+++ b/apps/elements/content/docs/identity-environment-surfaces.mdx
@@ -10,22 +10,23 @@ are acting within. This page catalogs notebook-semantic composites, not raw
 primitive components.
 
 `NotebookIdentityBadge` and `NotebookIdentityGroup` wrap the shared Avatar
-primitive with notebook actor/access facts. `NotebookEnvironmentSummary` wraps
-the shared package view model and shell capabilities into a compact runtime and
-dependency state surface.
+primitive with notebook actor/access facts. `NotebookEnvironmentSummary` renders
+the shared typed environment projection for access, runtime, package, sync, and
+trust state.
 
-The fixtures come from `ElementsNotebookScenario`: local owner, public viewer,
-cloud editor, cloud owner, agent-on-behalf-of-user, runtime peer, system actor,
-and runtime-unavailable states. Desktop and cloud should feed the same
-production components from their host adapters.
+The fixtures come from `ElementsNotebookScenario`: desktop owner/read-only/
+remote-room, public viewer, cloud editor/owner, credential-attention,
+multi-operator, mixed-IdP, agent-on-behalf-of-user, runtime peer, system actor,
+runtime-unavailable, and untrusted-dependency states. Desktop and cloud should
+feed the same production components from their host adapters.
 
 <IdentityEnvironmentSurfacesExample />
 
 ## Boundary
 
 - Raw shadcn primitives stay implementation details.
-- Actor labels, access state, auth state, runtime labels, and package summaries
-  come from notebook shell projections.
+- Actor labels, access state, auth state, runtime, package, sync, and trust
+  facts come from notebook shell projections.
 - Agent attribution is represented as notebook identity, not as a generic model
   selector.
 - Package info is notebook environment context, not an npm-style package profile.

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -14,6 +14,11 @@ This page tracks the current host contract after the cloud and desktop
 convergence work. Elements uses deterministic fixture scenarios here, not a
 runtime, room host, daemon, CRDT bridge, or generated WASM binding.
 
+The scenario set intentionally covers local writable and read-only files,
+desktop-to-remote rooms, public hosted viewing, hosted editing/ownership,
+credential attention, multi-operator attribution, mixed identity providers,
+runtime peers, unavailable runtimes, and untrusted dependencies.
+
 <NotebookShellCapabilitiesExample />
 
 ## Implementation intent

--- a/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
+++ b/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
@@ -1,13 +1,17 @@
 import { CheckCircle2, Lock, Package, RefreshCw, Server, ShieldAlert } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { notebookActorIdentityFromRuntime } from "./actor-projection";
 import type { NotebookShellCapabilities } from "./capabilities";
+import {
+  createNotebookEnvironmentSurface,
+  type NotebookEnvironmentSurface,
+} from "./environment-surface";
 import type { NotebookPackageViewModel } from "./view-model";
 
 export interface NotebookEnvironmentSummaryProps {
   capabilities: NotebookShellCapabilities;
   packages: NotebookPackageViewModel;
+  environment?: NotebookEnvironmentSurface;
   runtimeLabel?: string | null;
   packageSourceLabel?: string | null;
   syncLabel?: string | null;
@@ -18,6 +22,7 @@ export interface NotebookEnvironmentSummaryProps {
 
 export function NotebookEnvironmentSummary({
   capabilities,
+  environment,
   packages,
   runtimeLabel = null,
   packageSourceLabel = null,
@@ -26,19 +31,16 @@ export function NotebookEnvironmentSummary({
   showPackageDetails = true,
   className,
 }: NotebookEnvironmentSummaryProps) {
-  const packageAccessLabel = capabilities.canManagePackages
-    ? "Package edits available"
-    : capabilities.canViewPackages
-      ? "Package metadata read only"
-      : "Package metadata hidden";
-  const runtimeStateLabel =
-    runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
-  const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
-  const runtimeDetail = capabilities.runtime.canWriteRuntimeState
-    ? `Runtime author: ${runtimeActor?.label ?? "connected runtime"}`
-    : capabilities.runtime.connected
-      ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
-      : null;
+  const surface =
+    environment ??
+    createNotebookEnvironmentSurface({
+      capabilities,
+      packages,
+      runtimeLabel,
+      packageSourceLabel,
+      syncLabel,
+      trustLabel,
+    });
 
   return (
     <section
@@ -58,12 +60,11 @@ export function NotebookEnvironmentSummary({
             <h3 className="truncate text-sm font-semibold">Notebook environment</h3>
           </div>
           <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            {accessLevelLabel(capabilities.access.level)} access through{" "}
-            {accessSourceLabel(capabilities.access.source)}
+            {surface.access.label} access through {surface.access.sourceLabel}
           </p>
         </div>
         <span className="shrink-0 rounded-full border border-border bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground">
-          {capabilities.access.isPublic ? "Public" : "Private"}
+          {surface.access.visibilityLabel}
         </span>
       </div>
 
@@ -71,33 +72,33 @@ export function NotebookEnvironmentSummary({
         <SummaryFact
           icon={<Server className="size-3.5" aria-hidden="true" />}
           label="Runtime"
-          value={runtimeStateLabel}
-          detail={runtimeDetail}
-          muted={!capabilities.canExecute && !capabilities.runtime.connected}
+          value={surface.runtime.label}
+          detail={surface.runtime.detail}
+          muted={surface.runtime.muted}
         />
         <SummaryFact
           icon={<Package className="size-3.5" aria-hidden="true" />}
           label="Packages"
-          value={packages.summary ?? "No package metadata"}
-          detail={packageSourceLabel ?? packageAccessLabel}
-          muted={!capabilities.canViewPackages}
+          value={surface.packages.summary}
+          detail={surface.packages.sourceLabel}
+          muted={surface.packages.muted}
         />
         <SummaryFact
           icon={<RefreshCw className="size-3.5" aria-hidden="true" />}
           label="Sync"
-          value={syncLabel ?? "Sync status not reported"}
-          muted={!syncLabel}
+          value={surface.sync.label}
+          muted={surface.sync.muted}
         />
         <SummaryFact
           icon={
-            trustLabel?.toLowerCase().includes("untrusted") ? (
+            surface.trust.attention ? (
               <ShieldAlert className="size-3.5" aria-hidden="true" />
             ) : (
               <CheckCircle2 className="size-3.5" aria-hidden="true" />
             )
           }
           label="Trust"
-          value={trustLabel ?? "Trust state not required"}
+          value={surface.trust.label}
         />
       </div>
 
@@ -170,30 +171,4 @@ function SummaryFact({
       {detail ? <div className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</div> : null}
     </div>
   );
-}
-
-function accessLevelLabel(level: NotebookShellCapabilities["access"]["level"]): string {
-  switch (level) {
-    case "none":
-      return "No";
-    case "viewer":
-      return "Viewer";
-    case "editor":
-      return "Editor";
-    case "owner":
-      return "Owner";
-  }
-}
-
-function accessSourceLabel(source: NotebookShellCapabilities["access"]["source"]): string {
-  switch (source) {
-    case "cloud":
-      return "cloud";
-    case "local":
-      return "local";
-    case "fixture":
-      return "fixture";
-    case "unknown":
-      return "unknown host";
-  }
 }

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -118,4 +118,51 @@ describe("NotebookEnvironmentSummary", () => {
     expect(screen.getByText("Package metadata read only")).toBeVisible();
     expect(screen.queryByText("pandas>=2")).toBeNull();
   });
+
+  it("can render from a typed environment surface projection", () => {
+    render(
+      <NotebookEnvironmentSummary
+        capabilities={capabilities}
+        packages={packages}
+        environment={{
+          access: {
+            level: "owner",
+            source: "local",
+            label: "Owner",
+            sourceLabel: "desktop host",
+            visibilityLabel: "Private",
+            isPublic: false,
+          },
+          runtime: {
+            status: "launching",
+            label: "Runtime launching",
+            detail: "Queued by Desktop",
+            muted: false,
+          },
+          packages: {
+            summary: "uv - 2 packages",
+            sourceLabel: "pyproject.toml",
+            accessLabel: "Package edits available",
+            muted: false,
+          },
+          sync: {
+            status: "dirty",
+            label: "Package metadata has pending changes",
+            muted: false,
+          },
+          trust: {
+            status: "untrusted",
+            label: "Untrusted dependencies",
+            attention: true,
+          },
+        }}
+        showPackageDetails={false}
+      />,
+    );
+
+    expect(screen.getByText("Owner access through desktop host")).toBeVisible();
+    expect(screen.getByText("Runtime launching")).toBeVisible();
+    expect(screen.getByText("Package metadata has pending changes")).toBeVisible();
+    expect(screen.getByText("Untrusted dependencies")).toBeVisible();
+  });
 });

--- a/src/components/notebook-shell/environment-surface.ts
+++ b/src/components/notebook-shell/environment-surface.ts
@@ -1,0 +1,162 @@
+import { notebookActorIdentityFromRuntime } from "./actor-projection";
+import type {
+  NotebookShellAccessLevel,
+  NotebookShellAccessSource,
+  NotebookShellCapabilities,
+} from "./capabilities";
+import type { NotebookPackageViewModel } from "./view-model";
+
+export type NotebookRuntimeStatus = "ready" | "detached" | "unavailable" | "launching" | "error";
+export type NotebookPackageSyncStatus =
+  | "synced"
+  | "dirty"
+  | "not_running"
+  | "not_uv_managed"
+  | "unavailable"
+  | "unknown";
+export type NotebookTrustStatus = "trusted" | "untrusted" | "not_required" | "unknown";
+
+export interface NotebookEnvironmentSurface {
+  access: {
+    level: NotebookShellAccessLevel;
+    source: NotebookShellAccessSource;
+    label: string;
+    sourceLabel: string;
+    visibilityLabel: string;
+    isPublic: boolean;
+  };
+  runtime: {
+    status: NotebookRuntimeStatus;
+    label: string;
+    detail: string | null;
+    muted: boolean;
+  };
+  packages: {
+    summary: string;
+    sourceLabel: string;
+    accessLabel: string;
+    muted: boolean;
+  };
+  sync: {
+    status: NotebookPackageSyncStatus;
+    label: string;
+    muted: boolean;
+  };
+  trust: {
+    status: NotebookTrustStatus;
+    label: string;
+    attention: boolean;
+  };
+}
+
+export interface CreateNotebookEnvironmentSurfaceOptions {
+  capabilities: NotebookShellCapabilities;
+  packages: NotebookPackageViewModel;
+  runtimeLabel?: string | null;
+  runtimeStatus?: NotebookRuntimeStatus | null;
+  packageSourceLabel?: string | null;
+  syncLabel?: string | null;
+  syncStatus?: NotebookPackageSyncStatus | null;
+  trustLabel?: string | null;
+  trustStatus?: NotebookTrustStatus | null;
+}
+
+export function createNotebookEnvironmentSurface({
+  capabilities,
+  packages,
+  runtimeLabel = null,
+  runtimeStatus = null,
+  packageSourceLabel = null,
+  syncLabel = null,
+  syncStatus = null,
+  trustLabel = null,
+  trustStatus = null,
+}: CreateNotebookEnvironmentSurfaceOptions): NotebookEnvironmentSurface {
+  const packageAccessLabel = capabilities.canManagePackages
+    ? "Package edits available"
+    : capabilities.canViewPackages
+      ? "Package metadata read only"
+      : "Package metadata hidden";
+  const runtimeStateLabel =
+    runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
+  const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
+  const runtimeDetail = capabilities.runtime.canWriteRuntimeState
+    ? `Runtime author: ${runtimeActor?.label ?? "connected runtime"}`
+    : capabilities.runtime.connected
+      ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
+      : null;
+
+  return {
+    access: {
+      level: capabilities.access.level,
+      source: capabilities.access.source,
+      label: accessLevelLabel(capabilities.access.level),
+      sourceLabel: accessSourceLabel(capabilities.access.source),
+      visibilityLabel: capabilities.access.isPublic ? "Public" : "Private",
+      isPublic: capabilities.access.isPublic,
+    },
+    runtime: {
+      status:
+        runtimeStatus ??
+        (capabilities.canExecute
+          ? "ready"
+          : capabilities.runtime.connected
+            ? "detached"
+            : "unavailable"),
+      label: runtimeStateLabel,
+      detail: runtimeDetail,
+      muted: !capabilities.canExecute && !capabilities.runtime.connected,
+    },
+    packages: {
+      summary: packages.summary ?? "No package metadata",
+      sourceLabel: packageSourceLabel ?? packageAccessLabel,
+      accessLabel: packageAccessLabel,
+      muted: !capabilities.canViewPackages,
+    },
+    sync: {
+      status: syncStatus ?? (syncLabel ? "synced" : "unknown"),
+      label: syncLabel ?? "Sync status not reported",
+      muted: !syncLabel,
+    },
+    trust: {
+      status:
+        trustStatus ??
+        (trustLabel?.toLowerCase().includes("untrusted")
+          ? "untrusted"
+          : trustLabel
+            ? "trusted"
+            : "not_required"),
+      label: trustLabel ?? "Trust state not required",
+      attention:
+        trustStatus === "untrusted" ||
+        trustLabel?.toLowerCase().includes("untrusted") === true ||
+        trustLabel?.toLowerCase().includes("attention") === true,
+    },
+  };
+}
+
+export function accessLevelLabel(level: NotebookShellAccessLevel): string {
+  switch (level) {
+    case "none":
+      return "No";
+    case "viewer":
+      return "Viewer";
+    case "editor":
+      return "Editor";
+    case "owner":
+      return "Owner";
+  }
+}
+
+export function accessSourceLabel(source: NotebookShellAccessSource): string {
+  switch (source) {
+    case "cloud":
+      return "cloud";
+    case "local":
+      return "local";
+    case "fixture":
+      return "fixture";
+    case "unknown":
+      return "unknown host";
+  }
+}

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -43,6 +43,16 @@ export {
   type NotebookEnvironmentSummaryProps,
 } from "./NotebookEnvironmentSummary";
 export {
+  accessLevelLabel,
+  accessSourceLabel,
+  createNotebookEnvironmentSurface,
+  type CreateNotebookEnvironmentSurfaceOptions,
+  type NotebookEnvironmentSurface,
+  type NotebookPackageSyncStatus,
+  type NotebookRuntimeStatus,
+  type NotebookTrustStatus,
+} from "./environment-surface";
+export {
   NotebookEditModeButton,
   type NotebookEditMode,
   type NotebookEditModeButtonProps,


### PR DESCRIPTION
## Summary

- introduce a typed `NotebookEnvironmentSurface` projection for access, runtime, package, sync, and trust facts
- have `NotebookEnvironmentSummary` render from that projection while preserving the existing label props as adapter inputs
- expand Elements notebook scenarios for desktop read-only, desktop remote room, credential attention, multi-operator, mixed-IdP, and untrusted dependency states
- route Elements identity/environment and rail examples through the shared environment projection

## Validation

- `pnpm test:run src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentRail.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `uv run pr-review https://github.com/nteract/nteract/pull/3268 --max-turns 120 --out .context/reviews/pr-3268.json`

## Notes

- This follows #3267 after it merged to `main`; the PR is no longer stacked.
- The projection keeps host facts typed without making React authoritative for auth, ACL, trust, package mutation, runtime launch, or filesystem writes.
