### PR TITLE
fix(notebook-cloud): use shared environment surface

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -60,6 +60,18 @@ test("cloud package rail renders package metadata through the shared shell panel
   assert.doesNotMatch(sourceText, /Package details are not surfaced/);
 });
 
+test("cloud environment rail header uses the shared typed environment surface", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /createNotebookEnvironmentSurface/);
+  assert.match(sourceText, /const environmentSurface = useMemo/);
+  assert.match(sourceText, /syncStatus: connectionScope \? "synced" : "unavailable"/);
+  assert.match(sourceText, /trustStatus: "not_required"/);
+  assert.match(sourceText, /<NotebookEnvironmentSummary[\s\S]*environment=\{environmentSurface\}/);
+  assert.doesNotMatch(sourceText, /<NotebookEnvironmentSummary[\s\S]*syncLabel=/);
+});
+
 test("cloud identity chrome renders through the shared actor projection surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -35,6 +35,7 @@ import {
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
+  createNotebookEnvironmentSurface,
   notebookActorIdentityFromAccess,
   type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
@@ -1145,6 +1146,19 @@ function NotebookViewer({
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
   }, [refreshAuthState]);
+  const environmentSurface = useMemo(
+    () =>
+      createNotebookEnvironmentSurface({
+        capabilities: shellCapabilities,
+        packages: notebookViewModel.packages,
+        runtimeLabel: connectionScope === "runtime_peer" ? "Runtime peer connected" : null,
+        syncLabel: connectionScope ? "Live sync connected" : "Live sync unavailable",
+        syncStatus: connectionScope ? "synced" : "unavailable",
+        trustLabel: "Trust state not required",
+        trustStatus: "not_required",
+      }),
+    [connectionScope, notebookViewModel.packages, shellCapabilities],
+  );
 
   const rail = (
     <NotebookDocumentRail
@@ -1159,10 +1173,8 @@ function NotebookViewer({
           header={
             <NotebookEnvironmentSummary
               capabilities={shellCapabilities}
+              environment={environmentSurface}
               packages={notebookViewModel.packages}
-              runtimeLabel={connectionScope === "runtime_peer" ? "Runtime peer connected" : null}
-              syncLabel={connectionScope ? "Live sync connected" : "Live sync unavailable"}
-              trustLabel="Trust state not required"
               showPackageDetails={false}
               className="shadow-none"
             />


### PR DESCRIPTION
## Summary

- route notebook-cloud's environment rail header through the shared typed `NotebookEnvironmentSurface`
- keep package, sync, runtime, trust, and capability projections behind the shared notebook-shell contract
- add a focused guard so cloud does not regress to ad hoc environment summary props

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm test:run src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
