### PR TITLE
docs(elements): refine notebook surface language

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -76,7 +76,7 @@ export function IdentityEnvironmentSurfacesExample() {
             <h2 className="text-sm font-semibold">Notebook-semantic composites</h2>
             <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
               These examples wrap shared primitives in notebook concepts: current actor, access
-              source, agent delegation, runtime state, and package metadata. Raw Avatar, Badge,
+              source, agent delegation, runtime state, and package details. Raw Avatar, Badge,
               Select, and Button primitives stay implementation details.
             </p>
           </div>

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -102,21 +102,21 @@ const capabilityRows: {
     label: "Edit markdown",
     icon: PencilLine,
     component: "NotebookView, MarkdownCell",
-    meaning: "Markdown writes are allowed through the host bridge.",
+    meaning: "Markdown changes are allowed through the host bridge.",
   },
   {
     key: "canEditCells",
     label: "Edit code source",
     icon: Code2,
     component: "NotebookView, CodeCell",
-    meaning: "Code and raw cell source editors are writable.",
+    meaning: "Code and raw cell source editors can accept changes.",
   },
   {
     key: "canEditStructure",
     label: "Edit structure",
     icon: GitBranch,
-    component: "NotebookView mutation controls",
-    meaning: "Cell insert, delete, move, and structural document writes are available.",
+    component: "NotebookView structure controls",
+    meaning: "Cell insert, delete, move, and document structure changes are available.",
   },
   {
     key: "canRequestEdit",
@@ -130,7 +130,7 @@ const capabilityRows: {
     label: "Execute",
     icon: PlayCircle,
     component: "NotebookToolbar, CodeCell run controls",
-    meaning: "Runtime actions are available through the host execution adapter.",
+    meaning: "Run and kernel controls are available through the host execution adapter.",
   },
   {
     key: "canToggleCode",
@@ -144,14 +144,14 @@ const capabilityRows: {
     label: "View packages",
     icon: Package,
     component: "NotebookDocumentRail, NotebookPackageSummaryPanel",
-    meaning: "Dependency metadata can be inspected even when mutation is disabled.",
+    meaning: "Package details can be inspected even when management is disabled.",
   },
   {
     key: "canManagePackages",
     label: "Manage packages",
     icon: Package,
     component: "DependencyHeader, package rail controls",
-    meaning: "Dependency changes and environment sync actions are writable.",
+    meaning: "Package edits, sync actions, and rebuild decisions are available.",
   },
   {
     key: "canManageSharing",
@@ -185,12 +185,12 @@ const componentRows = [
     component: "NotebookDocumentRail",
     path: "src/components/notebook-shell/NotebookDocumentRail.tsx",
     use: "Projects outline and packages through the shared view model.",
-    hostBoundary: "Navigation and package mutations remain adapter callbacks.",
+    hostBoundary: "Navigation and package writes remain host callbacks.",
   },
   {
     component: "createNotebookViewModel",
     path: "src/components/notebook-shell/view-model.ts",
-    use: "Materializes cells, outline items, heading anchors, read-only cells, and package summaries.",
+    use: "Materializes cells, outline items, heading anchors, view-only cells, and package summaries.",
     hostBoundary: "Hosts provide source facts; the projection stays notebook-semantic.",
   },
 ];
@@ -308,7 +308,7 @@ export function NotebookShellCapabilitiesExample() {
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="flex items-center gap-2 border-b border-fd-border p-4">
           <Workflow className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Shared component boundary</h2>
+          <h2 className="text-sm font-semibold">Shared notebook surface</h2>
         </div>
         <div className="grid gap-2 p-4">
           {componentRows.map((row) => (
@@ -329,7 +329,7 @@ export function NotebookShellCapabilitiesExample() {
                   </div>
                   <div>
                     <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                      Host boundary
+                      Host keeps
                     </div>
                     <p className="mt-1 text-fd-muted-foreground">{row.hostBoundary}</p>
                   </div>
@@ -409,7 +409,7 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
         <ScenarioPill label={scenario.runtimeLabel} />
         <ScenarioPill label={scenario.packageSummary} />
         <ScenarioPill
-          label={enabledLabels.length ? `writes: ${enabledLabels.join(", ")}` : "read-only"}
+          label={enabledLabels.length ? `can change: ${enabledLabels.join(", ")}` : "view only"}
         />
       </div>
     </article>

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -94,14 +94,14 @@ function createStatusSurfaces(): ToolbarSurface[] {
       title: "Idle Python notebook",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: desktopOwner,
-      role: `${desktopOwner.runtimeLabel}; normal editing state with uv inline dependency metadata and running kernel controls.`,
+      role: `${desktopOwner.runtimeLabel}; normal editing state with uv package details and running kernel controls.`,
       props: toolbarProps(desktopOwner),
     },
     {
-      title: "Busy with dependency restart",
+      title: "Busy with package restart",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: desktopOwner,
-      role: `Execution state from ${desktopOwner.title}; restart-and-run-all is marked by ${desktopOwner.packageState.syncState.status} dependency metadata.`,
+      role: `Execution state from ${desktopOwner.title}; restart-and-run-all is marked by ${desktopOwner.packageState.syncState.status} package details.`,
       props: toolbarProps(desktopOwner, {
         kernelStatus: KERNEL_STATUS.BUSY,
         statusKey: RUNTIME_STATUS.RUNNING_BUSY,
@@ -115,7 +115,7 @@ function createStatusSurfaces(): ToolbarSurface[] {
       title: "Environment preparation",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: cloudEditor,
-      role: `${cloudEditor.title} can edit markdown, but this fixture keeps execution detached while conda solve/install progress renders.`,
+      role: `${cloudEditor.title} can edit markdown, but this preview keeps execution detached while Conda solve progress renders.`,
       props: toolbarProps(cloudEditor, {
         kernelStatus: KERNEL_STATUS.STARTING,
         statusKey: RUNTIME_STATUS.PREPARING_ENV,
@@ -142,7 +142,7 @@ function createStatusSurfaces(): ToolbarSurface[] {
       title: "Published viewer with no kernel",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: cloudViewer,
-      role: `${cloudViewer.title} uses the same fixture notebook IDs while exposing read-only, published access context.`,
+      role: `${cloudViewer.title} uses the same notebook IDs while exposing view-only, published access context.`,
       props: toolbarProps(cloudViewer, {
         kernelStatus: KERNEL_STATUS.ERROR,
         statusKey: RUNTIME_STATUS.ERROR,
@@ -171,7 +171,7 @@ function createStatusSurfaces(): ToolbarSurface[] {
       title: "Pixi missing ipykernel",
       source: "apps/notebook/src/components/NotebookToolbar.tsx",
       scenario: runtimeUnavailable,
-      role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel dependency.",
+      role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel package.",
       props: toolbarProps(runtimeUnavailable, {
         kernelStatus: KERNEL_STATUS.ERROR,
         statusKey: RUNTIME_STATUS.ERROR,
@@ -219,7 +219,7 @@ const contractItems = [
   {
     icon: PlayCircle,
     title: "Runtime-free",
-    body: "Kernel actions, dependency toggles, update clicks, and cell insertion callbacks are inert.",
+    body: "Kernel actions, package toggles, update clicks, and cell insertion callbacks are inert.",
   },
   {
     icon: TimerReset,
@@ -244,16 +244,16 @@ const toolbarBoundaryRows = [
       "Start, interrupt, restart, run-all, and restart-and-run-all buttons render here without side effects. The notebook app wires them to execution and runtime control paths.",
   },
   {
-    boundary: "Dependency drawer",
+    boundary: "Package panel",
     catalogPath: "scenario.packageState + inert toggle",
-    productionBoundary: "Package rail and notebook metadata",
+    productionBoundary: "Package rail and project writes",
     detail:
-      "The fixture reads package sync state from the shared scenario and toggles visual dependency state only. Production opens package UI, writes notebook metadata, and coordinates environment rebuild decisions.",
+      "The preview reads package sync state from the shared scenario and toggles visual package state only. The notebook opens package UI, writes project files, and coordinates environment rebuild decisions.",
   },
   {
     boundary: "Cell insertion",
     catalogPath: "scenario.viewModel.cellIds",
-    productionBoundary: "NotebookView focus and CRDT mutation",
+    productionBoundary: "NotebookView focus and document changes",
     detail:
       "The add-cell affordance receives stable IDs from the shared scenario projection. Production inserts new cells through the notebook document and restores editor focus.",
   },
@@ -330,12 +330,12 @@ export function NotebookToolbarSurfacesExample() {
       <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
         <div className="mb-3 flex items-center gap-2">
           <CircleDot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Adapter boundary</h2>
+          <h2 className="text-sm font-semibold">Live work stays with the notebook</h2>
         </div>
         <p className="text-xs leading-5 text-fd-muted-foreground">
           NotebookToolbar renders from the production component, but this page owns only static
-          status props and inert callbacks. Runtime state, kernel controls, dependency writes, cell
-          insertion, and desktop update restarts stay behind the notebook app adapters.
+          status props and inert callbacks. Runtime state, kernel controls, package writes, cell
+          insertion, and desktop update restarts stay with the notebook app.
         </p>
         <div className="mt-4 grid gap-2">
           {toolbarBoundaryRows.map((row) => (
@@ -348,7 +348,7 @@ export function NotebookToolbarSurfacesExample() {
                 <div className="grid gap-2 sm:grid-cols-2">
                   <div>
                     <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
-                      Catalog path
+                      Preview uses
                     </div>
                     <div className="mt-1 break-words font-mono text-[11px] leading-4 text-emerald-700 dark:text-emerald-300">
                       {row.catalogPath}
@@ -356,7 +356,7 @@ export function NotebookToolbarSurfacesExample() {
                   </div>
                   <div>
                     <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
-                      Production boundary
+                      Notebook owns
                     </div>
                     <div className="mt-1 break-words font-mono text-[11px] leading-4 text-amber-700 dark:text-amber-300">
                       {row.productionBoundary}

--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -46,38 +46,38 @@ const packageSurfaces = [
     name: "DependencyHeader",
     source: "apps/notebook/src/components/DependencyHeader.tsx",
     manager: "uv",
-    role: "Inline uv dependencies, project pyproject.toml state, and sync prompts.",
+    role: "Inline uv dependencies, project pyproject.toml details, and sync prompts.",
   },
   {
     name: "CondaDependencyHeader",
     source: "apps/notebook/src/components/CondaDependencyHeader.tsx",
     manager: "conda",
-    role: "Conda package specs, channels, environment.yml detection, and solve progress.",
+    role: "Conda packages, channels, environment.yml details, and solve progress.",
   },
   {
     name: "PixiDependencyHeader",
     source: "apps/notebook/src/components/PixiDependencyHeader.tsx",
     manager: "pixi",
-    role: "pixi.toml detection, conda and PyPI dependency display, and restart prompts.",
+    role: "pixi.toml details, Conda and PyPI dependency display, and restart prompts.",
   },
   {
     name: "DenoDependencyHeader",
     source: "apps/notebook/src/components/DenoDependencyHeader.tsx",
     manager: "deno",
-    role: "deno.json state, npm import behavior, and Deno import examples.",
+    role: "deno.json details, npm import behavior, and Deno import examples.",
   },
 ];
 
 const packageBoundaryRows = [
   {
-    boundary: "Notebook metadata",
-    catalogPath: "static package-manager records",
-    productionBoundary: "Automerge notebook metadata and pyproject/environment files",
+    boundary: "Package details",
+    catalogPath: "static package records",
+    productionBoundary: "Automerge package state and project files",
     detail:
-      "uv, Conda, Pixi, and Deno headers receive the same prop shapes they use in the notebook app without mutating notebook documents.",
+      "uv, Conda, Pixi, and Deno headers receive the same prop shapes they use in the notebook app without editing notebook documents.",
   },
   {
-    boundary: "Manager actions",
+    boundary: "Package actions",
     catalogPath: "inert async callbacks",
     productionBoundary: "host commands, daemon sync, and environment solves",
     detail:
@@ -123,7 +123,7 @@ export function PackageManagerSurfacesExample() {
         <SurfaceFrame
           icon={<PackageCheck className="size-4 text-fuchsia-500" aria-hidden="true" />}
           title="uv inline and project"
-          detail="Elements scenario package metadata plus detected pyproject.toml state."
+          detail="Fixture package details plus detected pyproject.toml project-env state."
         >
           <DependencyHeader
             dependencies={[...scenario.packageState.dependencies]}
@@ -147,7 +147,7 @@ export function PackageManagerSurfacesExample() {
         <SurfaceFrame
           icon={<RefreshCw className="size-4 text-emerald-500" aria-hidden="true" />}
           title="Conda environment"
-          detail="Fixture channels, environment.yml imports, and environment preparation progress."
+          detail="Fixture channels, environment.yml imports, and solve progress."
         >
           <CondaDependencyHeader
             dependencies={["python=3.13", "scikit-learn", "seaborn"]}
@@ -192,7 +192,7 @@ export function PackageManagerSurfacesExample() {
         <SurfaceFrame
           icon={<Layers3 className="size-4 text-amber-500" aria-hidden="true" />}
           title="Pixi project"
-          detail="Fixture pixi.toml state with Conda and PyPI dependencies."
+          detail="Fixture pixi.toml project details with Conda and PyPI dependencies."
         >
           <PixiDependencyHeader
             pixiInfo={{
@@ -219,7 +219,7 @@ export function PackageManagerSurfacesExample() {
         <SurfaceFrame
           icon={<TerminalSquare className="size-4 text-emerald-500" aria-hidden="true" />}
           title="Deno imports"
-          detail="Fixture deno.json state and the flexible npm imports toggle."
+          detail="Fixture deno.json imports and the flexible npm toggle."
         >
           <DenoDependencyHeader
             denoConfigInfo={{
@@ -242,12 +242,12 @@ export function PackageManagerSurfacesExample() {
       <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
         <div className="mb-3 flex items-center gap-2">
           <FileCode2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Adapter boundary</h2>
+          <h2 className="text-sm font-semibold">Live work stays with the host</h2>
         </div>
         <p className="text-xs leading-5 text-fd-muted-foreground">
-          This page owns only fixture metadata and inert callbacks. The rendered headers come from
-          the notebook app, while live notebook metadata writes, daemon sync, and environment
-          rebuilding stay outside the docs runtime.
+          This page owns fixture package details and inert callbacks. The rendered headers come from
+          the notebook app, while live package writes, daemon sync, and environment rebuilding stay
+          outside the docs runtime.
         </p>
         <div className="mt-4 overflow-hidden rounded-md border border-fd-border bg-fd-card">
           <div className="hidden grid-cols-[190px_210px_240px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Boxes, ListTree, ShieldCheck, Variable } from "lucide-react";
+import { ShieldCheck } from "lucide-react";
 import { useState } from "react";
 import {
   KERNEL_STATUS,
@@ -58,49 +58,6 @@ const scenarioIds: ElementsNotebookScenarioId[] = [
 const executingCellId = "cell-model-code";
 const queuedCellIds = new Set(["cell-shape-output"]);
 
-const outlineBoundaryRows = [
-  {
-    label: "Projection source",
-    preview: "createNotebookViewModel(fixture cells)",
-    notebook: "host materializes cells before the shared shell projection",
-  },
-  {
-    label: "Shell capabilities",
-    preview: "ElementsNotebookScenario.capabilities",
-    notebook: "desktop local state or cloud ACL/auth state",
-  },
-  {
-    label: "Context selection",
-    preview: "focusedCellId fixture + viewModel.cellIds",
-    notebook: "NotebookView focus state + shared outline selection",
-  },
-  {
-    label: "Header chrome",
-    preview: "outline title without item count",
-    notebook: "packages may summarize state; outline stays reading-first",
-  },
-  {
-    label: "Heading anchors",
-    preview: "viewModel.markdownHeadingAnchorsByCellId",
-    notebook: "MarkdownCell receives anchors from the shell view model",
-  },
-  {
-    label: "Heading navigation",
-    preview: "inert outline callback updates fixture focus",
-    notebook: "navigateNotebookOutlineItem, heading measurement, and cell-anchor fallback",
-  },
-  {
-    label: "Drag policy",
-    preview: "outline rows cancel native drag previews",
-    notebook: "navigation-only until the app owns true outline reordering",
-  },
-  {
-    label: "DOM order",
-    preview: "fixture cell order",
-    notebook: "stableDomOrder renders DOM while CSS order controls visual position",
-  },
-];
-
 export function RailOutlineExample() {
   const [scenarioId, setScenarioId] = useState<ElementsNotebookScenarioId>("desktop-local-owner");
   const scenario = getElementsNotebookScenario(scenarioId);
@@ -122,7 +79,7 @@ export function RailOutlineExample() {
 
   return (
     <NotebookDocumentShell
-      className="not-prose min-h-[700px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm"
+      className="not-prose min-h-[560px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm md:min-h-[700px] max-md:[&_[data-slot=notebook-document-stage]]:hidden max-md:[&_[data-slot=notebook-rail-panel]]:min-w-0 max-md:[&_[data-slot=notebook-rail-panel]]:max-w-none max-md:[&_[data-slot=notebook-rail-panel]]:flex-1 max-md:[&_[data-testid=notebook-rail]]:w-full"
       stageClassName="min-w-[320px] bg-fd-muted/20"
       toolbarClassName="border-b border-fd-border"
       toolbarLabel="Notebook fixture toolbar"
@@ -362,26 +319,11 @@ function ScenarioCellBadge({ cell }: { cell: NotebookViewCell }) {
 }
 
 function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario }) {
-  const plannedRailPanels = [
-    {
-      icon: Variable,
-      title: "Variables",
-      detail: `${scenario.variables.length} fixture names`,
-      body: "A future rail sibling for live namespace inspection once the app has a current variable surface.",
-    },
-    {
-      icon: Boxes,
-      title: "Renderers",
-      detail: `${scenario.renderers.length} fixture MIME lanes`,
-      body: "A future diagnostics panel for output MIME routing, plugin loading, and renderer health.",
-    },
-  ];
-
   return (
     <div className="space-y-3">
       <div className="rounded-md border border-fd-border bg-fd-muted/40 p-3 text-xs leading-5 text-fd-muted-foreground">
-        This uses the current notebook package panel in a rail-sized frame. The preview owns only
-        scenario facts and inert callbacks.
+        Current notebook package controls in a rail-sized frame. The preview owns only scenario
+        facts and inert callbacks.
       </div>
       <div className="overflow-hidden rounded-md border border-fd-border bg-fd-card">
         <DependencyHeader
@@ -404,56 +346,6 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
           justSynced={false}
         />
       </div>
-      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
-        <div className="mb-3 flex items-center gap-2">
-          <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h4 className="text-sm font-semibold">Live work stays with the notebook</h4>
-        </div>
-        <div className="space-y-2">
-          {outlineBoundaryRows.map((row) => (
-            <div
-              key={row.label}
-              className="space-y-2 rounded-md border border-fd-border p-3 text-xs leading-5"
-            >
-              <div className="font-medium text-fd-foreground">{row.label}</div>
-              <div className="min-w-0">
-                <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Preview uses
-                </span>
-                <span className="break-words text-fd-muted-foreground">{row.preview}</span>
-              </div>
-              <div className="min-w-0">
-                <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Notebook owns
-                </span>
-                <span className="break-words text-fd-muted-foreground">{row.notebook}</span>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-      <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
-        <div className="mb-3 flex items-center gap-2">
-          <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h4 className="text-sm font-semibold">Planned sibling panels</h4>
-        </div>
-        <div className="grid gap-2">
-          {plannedRailPanels.map((panel) => (
-            <div key={panel.title} className="rounded-md border border-fd-border p-3">
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex items-center gap-2">
-                  <panel.icon className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-                  <h5 className="text-sm font-medium">{panel.title}</h5>
-                </div>
-                <span className="shrink-0 rounded bg-fd-muted px-1.5 py-0.5 text-[10px] text-fd-muted-foreground">
-                  {panel.detail}
-                </span>
-              </div>
-              <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{panel.body}</p>
-            </div>
-          ))}
-        </div>
-      </section>
     </div>
   );
 }

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -61,43 +61,43 @@ const queuedCellIds = new Set(["cell-shape-output"]);
 const outlineBoundaryRows = [
   {
     label: "Projection source",
-    catalog: "createNotebookViewModel(fixture cells)",
-    production: "host adapter materializes cells before the shared shell projection",
+    preview: "createNotebookViewModel(fixture cells)",
+    notebook: "host materializes cells before the shared shell projection",
   },
   {
     label: "Shell capabilities",
-    catalog: "ElementsNotebookScenario.capabilities",
-    production: "desktop local state or cloud ACL/auth adapter",
+    preview: "ElementsNotebookScenario.capabilities",
+    notebook: "desktop local state or cloud ACL/auth state",
   },
   {
     label: "Context selection",
-    catalog: "focusedCellId fixture + viewModel.cellIds",
-    production: "NotebookView focus state + shared outline selection",
+    preview: "focusedCellId fixture + viewModel.cellIds",
+    notebook: "NotebookView focus state + shared outline selection",
   },
   {
     label: "Header chrome",
-    catalog: "outline title without item count",
-    production: "packages may summarize state; outline stays reading-first",
+    preview: "outline title without item count",
+    notebook: "packages may summarize state; outline stays reading-first",
   },
   {
     label: "Heading anchors",
-    catalog: "viewModel.markdownHeadingAnchorsByCellId",
-    production: "MarkdownCell receives anchors from the shell view model",
+    preview: "viewModel.markdownHeadingAnchorsByCellId",
+    notebook: "MarkdownCell receives anchors from the shell view model",
   },
   {
     label: "Heading navigation",
-    catalog: "inert outline callback updates fixture focus",
-    production: "navigateNotebookOutlineItem, heading measurement, and cell-anchor fallback",
+    preview: "inert outline callback updates fixture focus",
+    notebook: "navigateNotebookOutlineItem, heading measurement, and cell-anchor fallback",
   },
   {
     label: "Drag policy",
-    catalog: "outline rows cancel native drag previews",
-    production: "navigation-only until the app owns true outline reordering",
+    preview: "outline rows cancel native drag previews",
+    notebook: "navigation-only until the app owns true outline reordering",
   },
   {
     label: "DOM order",
-    catalog: "fixture cell order",
-    production: "stableDomOrder renders DOM while CSS order controls visual position",
+    preview: "fixture cell order",
+    notebook: "stableDomOrder renders DOM while CSS order controls visual position",
   },
 ];
 
@@ -253,7 +253,7 @@ function ScenarioNotice({
           from current sources.
         </div>
         <p>
-          The docs app owns only scenario facts: capabilities, fixture cells, package metadata,
+          The docs app owns only scenario facts: capabilities, fixture cells, package details,
           focused cell, active panel, and inert navigation callbacks.
         </p>
       </div>
@@ -380,8 +380,8 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
   return (
     <div className="space-y-3">
       <div className="rounded-md border border-fd-border bg-fd-muted/40 p-3 text-xs leading-5 text-fd-muted-foreground">
-        This uses the current notebook dependency panel in a rail-sized frame. The catalog owns only
-        scenario metadata and inert callbacks.
+        This uses the current notebook package panel in a rail-sized frame. The preview owns only
+        scenario facts and inert callbacks.
       </div>
       <div className="overflow-hidden rounded-md border border-fd-border bg-fd-card">
         <DependencyHeader
@@ -407,7 +407,7 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
       <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
         <div className="mb-3 flex items-center gap-2">
           <ListTree className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h4 className="text-sm font-semibold">Adapter boundary</h4>
+          <h4 className="text-sm font-semibold">Live work stays with the notebook</h4>
         </div>
         <div className="space-y-2">
           {outlineBoundaryRows.map((row) => (
@@ -418,15 +418,15 @@ function PackagePanelContent({ scenario }: { scenario: ElementsNotebookScenario 
               <div className="font-medium text-fd-foreground">{row.label}</div>
               <div className="min-w-0">
                 <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Catalog
+                  Preview uses
                 </span>
-                <span className="break-words text-fd-muted-foreground">{row.catalog}</span>
+                <span className="break-words text-fd-muted-foreground">{row.preview}</span>
               </div>
               <div className="min-w-0">
                 <span className="mb-1 block text-[10px] uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Production
+                  Notebook owns
                 </span>
-                <span className="break-words text-fd-muted-foreground">{row.production}</span>
+                <span className="break-words text-fd-muted-foreground">{row.notebook}</span>
               </div>
             </div>
           ))}

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -42,7 +42,7 @@ const runtimePieces = [
   {
     name: "TrustDialog",
     source: "apps/notebook/src/components/TrustDialog.tsx",
-    role: "Dependency review gate with approved packages, typosquat warnings, and trust actions.",
+    role: "Package trust gate with approved packages, typosquat warnings, and trust actions.",
     status: "rendered",
   },
   {
@@ -54,7 +54,7 @@ const runtimePieces = [
   {
     name: "DependencyHeader",
     source: "apps/notebook/src/components/DependencyHeader.tsx",
-    role: "Notebook dependency panel for uv metadata, pyproject state, and sync prompts.",
+    role: "Notebook package panel for uv package details, pyproject state, and sync prompts.",
     status: "rendered",
   },
   {
@@ -78,7 +78,7 @@ const runtimePieces = [
   {
     name: "UntrustedBanner",
     source: "apps/notebook/src/components/UntrustedBanner.tsx",
-    role: "Inline dependency approval gate that opens TrustDialog before kernel start.",
+    role: "Inline package approval gate that opens TrustDialog before kernel start.",
     status: "rendered",
   },
   {
@@ -92,24 +92,24 @@ const runtimePieces = [
 const runtimeAdapterRows = [
   {
     boundary: "Desktop host actions",
-    catalogPath: "NotebookHostProvider fixture",
-    productionBoundary: "notebook shell host commands",
+    previewPath: "NotebookHostProvider fixture",
+    notebookOwner: "notebook shell host commands",
     detail:
-      "Pool settings, clipboard, and command callbacks stay inert in the catalog while the production app routes them through the host bridge.",
+      "Pool settings, clipboard, and command callbacks stay inert in the preview while the notebook routes them through the host bridge.",
   },
   {
     boundary: "Runtime side effects",
-    catalogPath: "static decisions with async no-ops",
-    productionBoundary: "daemon and kernel lifecycle",
+    previewPath: "static decisions with async no-ops",
+    notebookOwner: "daemon and kernel lifecycle",
     detail:
-      "Trust, environment build, retry, dismiss, and sync actions render with the current components but do not start kernels or mutate runtime state.",
+      "Trust, environment build, retry, dismiss, and sync actions render with the current components but do not start kernels or change runtime state.",
   },
   {
-    boundary: "Dependency and trust state",
-    catalogPath: "typed fixture records",
-    productionBoundary: "settings, pyproject, and RuntimeStateDoc updates",
+    boundary: "Package and trust state",
+    previewPath: "typed fixture records",
+    notebookOwner: "settings, pyproject, and RuntimeStateDoc updates",
     detail:
-      "The catalog owns deterministic package, typosquat, and pyproject data; live settings and runtime documents remain outside the docs app.",
+      "The preview owns deterministic package, typosquat, and pyproject facts; live settings and runtime documents stay outside the docs app.",
   },
 ];
 
@@ -139,7 +139,7 @@ function RuntimeDialogs({ scenario }: { scenario: ElementsNotebookScenario }) {
         <ShieldAlert className="mb-3 size-4 text-amber-500" aria-hidden="true" />
         <h3 className="text-sm font-semibold">Trust review</h3>
         <p className="mt-2 min-h-[3rem] text-xs leading-5 text-fd-muted-foreground">
-          Opens the current dependency trust dialog with approved and suspicious package fixtures.
+          Opens the current package trust dialog with approved and suspicious package fixtures.
         </p>
         <Button className="mt-4" size="sm" onClick={() => setTrustOpen(true)}>
           Open TrustDialog
@@ -178,7 +178,7 @@ function RuntimeDialogs({ scenario }: { scenario: ElementsNotebookScenario }) {
         <PackageCheck className="mb-3 size-4 text-emerald-600" aria-hidden="true" />
         <h3 className="text-sm font-semibold">Decision shell</h3>
         <p className="mt-2 min-h-[3rem] text-xs leading-5 text-fd-muted-foreground">
-          Opens the shared runtime decision shell with catalog-owned fixture content.
+          Opens the shared runtime decision shell with preview-owned fixture content.
         </p>
         <Button className="mt-4" size="sm" onClick={() => setDecisionShellOpen(true)}>
           Open RuntimeDecisionDialog
@@ -219,25 +219,31 @@ function DependencyHeaderFixture({ scenario }: { scenario: ElementsNotebookScena
       <div className="border-b border-fd-border p-4">
         <h2 className="text-sm font-semibold">DependencyHeader</h2>
         <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-          Rendered from the notebook app with fixture dependency state and inert async handlers.
+          Rendered from the notebook app in the same rail-sized package surface used by the notebook
+          shell.
         </p>
       </div>
-      <DependencyHeader
-        dependencies={[...scenario.packageState.dependencies]}
-        requiresPython={scenario.packageState.requiresPython}
-        loading={false}
-        onAdd={asyncNoop}
-        onRemove={asyncNoop}
-        onSetRequiresPython={asyncNoop}
-        syncState={scenario.packageState.syncState}
-        onSyncNow={asyncTrue}
-        pyprojectInfo={scenario.packageState.pyprojectInfo}
-        pyprojectDeps={scenario.packageState.pyprojectDeps}
-        onImportFromPyproject={asyncNoop}
-        onUseProjectEnv={asyncNoop}
-        isUsingProjectEnv={false}
-        justSynced={false}
-      />
+      <div className="bg-fd-muted/20 p-4">
+        <div className="mx-auto w-full max-w-[22rem]">
+          <DependencyHeader
+            dependencies={[...scenario.packageState.dependencies]}
+            requiresPython={scenario.packageState.requiresPython}
+            loading={false}
+            variant="rail"
+            onAdd={asyncNoop}
+            onRemove={asyncNoop}
+            onSetRequiresPython={asyncNoop}
+            syncState={scenario.packageState.syncState}
+            onSyncNow={asyncTrue}
+            pyprojectInfo={scenario.packageState.pyprojectInfo}
+            pyprojectDeps={scenario.packageState.pyprojectDeps}
+            onImportFromPyproject={asyncNoop}
+            onUseProjectEnv={asyncNoop}
+            isUsingProjectEnv={false}
+            justSynced={false}
+          />
+        </div>
+      </div>
     </section>
   );
 }
@@ -325,7 +331,7 @@ function RuntimeBanners() {
         <BannerFixture
           icon={<ShieldAlert className="size-4" aria-hidden="true" />}
           name="UntrustedBanner"
-          description="Inline trust gate before dependency-backed kernel start."
+          description="Inline trust gate before package-backed kernel start."
         >
           <UntrustedBanner onReviewClick={noop} />
         </BannerFixture>
@@ -443,18 +449,18 @@ export function RuntimeSurfacesExample() {
         <div className="rounded-lg border border-fd-border bg-fd-card p-4">
           <div className="mb-3 flex items-center gap-2">
             <CircleDot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-            <h2 className="text-sm font-semibold">Adapter Boundary</h2>
+            <h2 className="text-sm font-semibold">Live work stays with the notebook</h2>
           </div>
           <p className="text-xs leading-5 text-fd-muted-foreground">
             Components that need runtime values, daemon actions, or host-backed hooks should name
-            the boundary first, then move through a small fixture adapter before joining the
-            rendered catalog.
+            the notebook-owned work first, then move through a small preview fixture before joining
+            the rendered catalog.
           </p>
           <div className="mt-4 overflow-hidden rounded-md border border-fd-border">
             <div className="hidden grid-cols-[190px_210px_230px_minmax(0,1fr)] gap-3 border-b border-fd-border bg-fd-muted/40 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
               <span>Boundary</span>
-              <span>Catalog path</span>
-              <span>Production boundary</span>
+              <span>Preview uses</span>
+              <span>Notebook owns</span>
               <span>Notes</span>
             </div>
             {runtimeAdapterRows.map((row) => (
@@ -470,18 +476,18 @@ export function RuntimeSurfacesExample() {
                 </div>
                 <div>
                   <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                    Catalog path
+                    Preview uses
                   </div>
                   <div className="font-mono text-[11px] text-emerald-700 dark:text-emerald-300">
-                    {row.catalogPath}
+                    {row.previewPath}
                   </div>
                 </div>
                 <div>
                   <div className="text-[11px] font-medium uppercase text-fd-muted-foreground xl:hidden">
-                    Production boundary
+                    Notebook owns
                   </div>
                   <div className="font-mono text-[11px] text-amber-700 dark:text-amber-300">
-                    {row.productionBoundary}
+                    {row.notebookOwner}
                   </div>
                 </div>
                 <p className="leading-5 text-fd-muted-foreground">{row.detail}</p>

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -27,6 +27,7 @@ import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget
 import { WidgetUpdateManager, type ContentRef } from "@/components/widgets/widget-update-manager";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
+import { cn } from "@/lib/utils";
 
 type FixtureModel = {
   id: string;
@@ -1008,6 +1009,63 @@ const adapterBoundaries = [
   },
 ];
 
+const widgetSurfaceLanguage = [
+  {
+    label: "Live surface",
+    state: "interactive fixture",
+    icon: SlidersHorizontal,
+    tone: "emerald",
+    body: "Controls render through WidgetView and update the same WidgetStore contract used by live comm state.",
+  },
+  {
+    label: "Saved surface",
+    state: "snapshot",
+    icon: PackageOpen,
+    tone: "sky",
+    body: "Static widget state keeps notebooks readable when a comm is gone, stale, or intentionally unavailable.",
+  },
+  {
+    label: "Adapter seam",
+    state: "host owned",
+    icon: Cable,
+    tone: "amber",
+    body: "Sync, iframe transport, blob signing, and kernel-originated assets stay named instead of leaking into the catalog.",
+  },
+  {
+    label: "Runtime gap",
+    state: "next fixture",
+    icon: CircleDotDashed,
+    tone: "neutral",
+    body: "Unmodeled behavior gets a fixture target before it becomes production UI language.",
+  },
+] as const;
+
+const widgetSurfaceToneClasses: Record<
+  (typeof widgetSurfaceLanguage)[number]["tone"],
+  { bar: string; badge: string; icon: string }
+> = {
+  emerald: {
+    bar: "bg-emerald-400",
+    badge: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    icon: "text-emerald-600 dark:text-emerald-300",
+  },
+  sky: {
+    bar: "bg-sky-400",
+    badge: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+    icon: "text-sky-600 dark:text-sky-300",
+  },
+  amber: {
+    bar: "bg-amber-400",
+    badge: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    icon: "text-amber-600 dark:text-amber-300",
+  },
+  neutral: {
+    bar: "bg-fd-muted-foreground/35",
+    badge: "bg-fd-muted text-fd-muted-foreground",
+    icon: "text-fd-muted-foreground",
+  },
+};
+
 const widgetBoundaryRows = [
   {
     surface: "Saved widget state",
@@ -1637,22 +1695,58 @@ function WidgetInventory() {
   );
 }
 
+function WidgetSurfaceGrammar() {
+  return (
+    <section
+      className="overflow-hidden rounded-lg border border-fd-border bg-fd-card"
+      data-testid="widget-surface-grammar"
+    >
+      <div className="border-b border-fd-border p-4">
+        <div className="flex items-center gap-2">
+          <Boxes className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Widget surface grammar</h2>
+        </div>
+        <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+          The catalog should read like a notebook boundary: live where fixtures can honestly behave,
+          quiet when state is only saved, and explicit where the host still owns the seam.
+        </p>
+      </div>
+      <div className="divide-y divide-fd-border bg-background">
+        {widgetSurfaceLanguage.map((item) => {
+          const tone = widgetSurfaceToneClasses[item.tone];
+          return (
+            <div key={item.label} className="grid gap-3 p-4 sm:grid-cols-[8px_160px_1fr]">
+              <div
+                className={cn("hidden h-full min-h-12 rounded-full sm:block", tone.bar)}
+                aria-hidden="true"
+              />
+              <div className="flex items-start gap-2">
+                <item.icon className={cn("mt-0.5 size-4 shrink-0", tone.icon)} aria-hidden="true" />
+                <div>
+                  <h3 className="text-sm font-semibold">{item.label}</h3>
+                  <div
+                    className={cn(
+                      "mt-2 inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium leading-none",
+                      tone.badge,
+                    )}
+                  >
+                    {item.state}
+                  </div>
+                </div>
+              </div>
+              <p className="text-xs leading-5 text-fd-muted-foreground">{item.body}</p>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function WidgetSurfacesExample() {
   return (
     <div className="not-prose space-y-6" data-testid="widget-surfaces-example">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
-        <div className="flex items-start gap-3">
-          <SlidersHorizontal className="mt-0.5 size-4 flex-none" aria-hidden="true" />
-          <div>
-            <h2 className="text-sm font-semibold">Widget fixtures use the real widget path</h2>
-            <p className="mt-1 text-xs leading-5">
-              This page imports current widget store, registry, WidgetView, and selected built-in
-              controls. Runtime sync, iframe transport, generated WASM, and kernel comms stay behind
-              explicit adapters.
-            </p>
-          </div>
-        </div>
-      </section>
+      <WidgetSurfaceGrammar />
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">

--- a/apps/elements/content/docs/cell-insertion-affordances.mdx
+++ b/apps/elements/content/docs/cell-insertion-affordances.mdx
@@ -13,5 +13,7 @@ type.
 The production row now treats proximity as neutral document intent. Code and
 markdown color arrive only when a concrete target is hovered or focused, then
 fade back into the document rule instead of becoming a floating control surface.
+The left channel remains clickable, but it stays visually quiet until the reader
+actually points at code or markdown.
 
 <CellInsertionAffordancesExample />

--- a/apps/elements/content/docs/identity-environment-surfaces.mdx
+++ b/apps/elements/content/docs/identity-environment-surfaces.mdx
@@ -11,8 +11,8 @@ primitive components.
 
 `NotebookIdentityBadge` and `NotebookIdentityGroup` wrap the shared Avatar
 primitive with notebook actor/access facts. `NotebookEnvironmentSummary` renders
-the shared typed environment projection for access, runtime, package, sync, and
-trust state.
+the shared typed environment projection for access, runtime, package details,
+sync, and trust state.
 
 The fixtures come from `ElementsNotebookScenario`: desktop owner/read-only/
 remote-room, public viewer, cloud editor/owner, credential-attention,

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -21,10 +21,10 @@ reading flow.
 This fixture now renders the current notebook app toolbar and shared
 `NotebookDocumentRail`, which wraps the presentational `NotebookRail` used by
 desktop and cloud. The outline is projected with the same
-`createNotebookViewModel` path production uses, then fed `outlineCellIds` so a
+`createNotebookViewModel` path the notebook uses, then fed `outlineCellIds` so a
 focused code cell resolves to the nearest preceding heading. The package panel
 is supplied through `NotebookPackagesPanel` and hosts the current
-`DependencyHeader` with static dependency state.
+`DependencyHeader` with static package state.
 Scenario selection comes from the shared [notebook shell capabilities](/docs/notebook-shell-capabilities)
 fixtures so desktop, cloud viewer, cloud editor, cloud owner, and runtime-blocked
 states stay aligned with the app shell.
@@ -42,18 +42,18 @@ states stay aligned with the app shell.
   Docs own active panel, collapsed state, outline selection, and inert
   navigation callbacks.
 - The package panel imports `DependencyHeader` from the notebook app with
-  fixture dependency and sync state.
+  fixture package and sync state.
 - The outline starts from `createNotebookViewModel` over fixture cells, matching
   the production projection path from materialized markdown headings.
 - Contextual selection depends on `outlineCellIds`: a focused code cell inside a
   section highlights the nearest preceding markdown heading.
 - Outline panel chrome is intentionally sparse. The panel title names the mode,
   and the rows carry the useful context without an extra item-count badge.
-- Production active-section tracking still belongs to the app shell through
+- Notebook active-section tracking still belongs to the app shell through
   viewport observation and `resolveNotebookOutlineSelection`; this page only
   fixtures the active item.
 - Heading navigation uses the shared `navigateNotebookOutlineItem` seam.
-  Production can measure headings inside markdown frames as an enhanced path,
+  The notebook can measure headings inside markdown frames as an enhanced path,
   then falls back to canonical cell anchors; the catalog keeps the callback
   inert and stable.
 - Outline rows use a navigation-only drag policy. If outline-driven cell

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -5,29 +5,18 @@ description: A fixture-backed preview of a left rail for notebook reading and na
 
 import { RailOutlineExample } from "@/components/rail-outline-example";
 
-The rail outline is the first production direction for a notebook table of
-contents. It keeps reading navigation available while leaving clear sibling
-slots for packages, variables, renderers, and future notebook tools.
-The rail owns notebook-level navigation and tools; the ribbon and code-cell
-chrome remain inside the notebook surface for per-cell focus and execution
-state.
-Outline rows are navigation, not drag handles. The active row now uses a quiet
-spine marker instead of a full-color selected block, and native drag previews
-are cancelled until notebook reordering through the outline is a real workflow.
-The outline header stays label-only; package panels can use the summary chip for
-runtime state, but an outline item count adds bookkeeping noise without helping
-reading flow.
+The rail is notebook-level navigation and tools. It keeps reading context beside
+the document while the ribbon and code-cell chrome stay inside the notebook
+surface for per-cell focus and execution state.
 
-This fixture now renders the current notebook app toolbar and shared
-`NotebookDocumentRail`, which wraps the presentational `NotebookRail` used by
-desktop and cloud. The outline is projected with the same
-`createNotebookViewModel` path the notebook uses, then fed `outlineCellIds` so a
-focused code cell resolves to the nearest preceding heading. The package panel
-is supplied through `NotebookPackagesPanel` and hosts the current
-`DependencyHeader` with static package state.
-Scenario selection comes from the shared [notebook shell capabilities](/docs/notebook-shell-capabilities)
-fixtures so desktop, cloud viewer, cloud editor, cloud owner, and runtime-blocked
-states stay aligned with the app shell.
+Outline rows navigate; they are not drag handles. The active row uses a quiet
+spine marker, and native drag previews are cancelled until outline-driven
+reordering becomes a real workflow.
+
+This fixture renders the shared `NotebookDocumentRail` and current notebook
+toolbar with scenario state from the [notebook shell capabilities](/docs/notebook-shell-capabilities)
+fixtures. The package panel hosts the current `DependencyHeader` in its rail
+variant instead of adding docs-only chrome inside the rail.
 
 <RailOutlineExample />
 

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -8,7 +8,7 @@ import { NotebookShellCapabilitiesExample } from "@/components/notebook-shell-ca
 The notebook shell is the shared boundary between host state and notebook UI.
 Desktop, cloud, and Elements should all answer the same capability questions
 before rendering document chrome, rails, package surfaces, editable cells, or
-read-only cells.
+view-only cells.
 
 This page tracks the current host contract after the cloud and desktop
 convergence work. Elements uses deterministic fixture scenarios here, not a

--- a/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
+++ b/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
@@ -7,7 +7,7 @@ import { NotebookToolbarSurfacesExample } from "@/components/notebook-toolbar-su
 
 The notebook toolbar is workspace chrome, not generic button inventory. This
 page renders the current `NotebookToolbar` with static runtime, environment,
-dependency, and update fixtures so the catalog can track the real desktop
+package, and update facts so the catalog can track the real desktop
 surface without importing daemon hooks or notebook state.
 The hosted scenarios are shared with the
 [notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor
@@ -15,11 +15,11 @@ and owner access do not drift from cloud ACL semantics.
 
 <NotebookToolbarSurfacesExample />
 
-## Adapter rule
+## Host rule
 
 Toolbar previews own only props and callbacks. Kernel start, interrupt, restart,
-dependency toggles, update restarts, and cell insertion stay inert in the docs
-app until a host adapter is deliberately introduced. The rendered boundary map
-keeps runtime status projection, kernel actions, dependency drawer state, cell
-insertion, and desktop update restart behavior named separately so future
-toolbar work can move one adapter at a time.
+package toggles, update restarts, and cell insertion stay inert in the docs app
+until the host deliberately wires them. The rendered boundary map keeps runtime
+status projection, kernel actions, package panel state, cell insertion, and
+desktop update restart behavior named separately so future toolbar work can move
+one host-owned action at a time.

--- a/apps/elements/content/docs/package-manager-surfaces.mdx
+++ b/apps/elements/content/docs/package-manager-surfaces.mdx
@@ -5,25 +5,26 @@ description: Fixture-backed uv, Conda, Pixi, and Deno package panels from the no
 
 import { PackageManagerSurfacesExample } from "@/components/package-manager-surfaces-example";
 
-Package management is notebook UI. These surfaces are the real dependency
-headers used by the notebook app, rendered with static fixture metadata so the
-catalog can inspect package panels without a live daemon, Automerge document, or
-environment solve.
-Package viewing and package mutation are separate shell capabilities; hosted
-viewer, editor, and owner fixtures can inspect package state while package
-management remains disabled.
+Package management is notebook UI. The rail should let people read package
+details at a glance, then manage the source only when the host grants that
+affordance. This page renders the real uv, Conda, Pixi, and Deno headers with
+fixture facts so the catalog can inspect package panels without a live daemon,
+Automerge document, or environment solve.
+Package viewing and package management are separate shell capabilities; hosted
+viewer, editor, and owner fixtures can inspect package state while write actions
+remain disabled.
 
 <PackageManagerSurfacesExample />
 
 ## Rail intent
 
-- `NotebookDocumentRail` is the notebook home for package viewing. It can render
-  the shared `NotebookPackageSummaryPanel` for host-neutral read-only state, or
-  host manager-specific panels when mutation is available.
-- Manager headers remain app-adapter surfaces because they can trigger metadata
-  writes, trust approvals, sync, and rebuild decisions.
+- `NotebookDocumentRail` is the notebook home for package details. It can render
+  the shared `NotebookPackageSummaryPanel` for host-neutral view-only state, or
+  host manager-specific panels when management is available.
+- Manager headers remain app-adapter surfaces because they can write project
+  files, approve trust, sync packages, and start rebuild decisions.
 - The catalog should keep using existing notebook components, not parallel
   package-manager replicas.
-- Live metadata mutation, trust re-signing, daemon sync, and environment rebuilds
+- Live package writes, trust re-signing, daemon sync, and environment rebuilds
   stay behind app adapters. The rendered boundary map names those splits so new
   package surfaces can enter through fixtures before runtime wiring.

--- a/apps/elements/content/docs/runtime-surfaces.mdx
+++ b/apps/elements/content/docs/runtime-surfaces.mdx
@@ -6,16 +6,16 @@ description: Fixture-backed runtime decision components from the notebook app.
 import { RuntimeSurfacesExample } from "@/components/runtime-surfaces-example";
 
 Runtime decisions are notebook UI, not generic dialogs. This page starts
-cataloging the existing dependency, daemon, pool, trust, and launch decision
-surfaces with fixtures instead of live runtime state.
+cataloging the existing package, daemon, pool, trust, and launch decision
+surfaces with preview facts instead of live runtime state.
 
 <RuntimeSurfacesExample />
 
-## Adapter notes
+## Host notes
 
-The current fixtures keep side effects inert. Components that need desktop host
-access, such as the pool settings action, render under a small fixture host
-adapter instead of importing notebook shell state into the docs app. The adapter
-boundary table names the split between deterministic catalog data, host actions,
-runtime side effects, and live dependency/trust documents before new runtime
-surfaces are marked rendered.
+The current previews keep side effects inert. Components that need desktop host
+access, such as the pool settings action, render under a small preview host
+instead of importing notebook shell state into the docs app. The boundary table
+names the split between deterministic preview data, host actions, runtime side
+effects, and live package/trust documents before new runtime surfaces are marked
+rendered.

--- a/apps/elements/content/docs/widget-surfaces.mdx
+++ b/apps/elements/content/docs/widget-surfaces.mdx
@@ -5,38 +5,9 @@ description: Fixture-backed notebook widget components from nteract/nteract.
 
 import { WidgetSurfacesExample } from "@/components/widget-surfaces-example";
 
-Widgets are notebook output components. This page catalogs the current
-`src/components/widgets` path with local comm-state fixtures, not a live kernel,
-iframe, sync engine, or generated WASM resolver. The interactive examples import
-the production controls registry and render through `WidgetView`, so the page is
-tracking nteract-owned widget surfaces instead of page-local form stand-ins.
-The catalog now includes saved-state fixtures for control widgets, media
-widgets, `FileUploadModel`, `OutputModel`, layout containers, play controls, and
-controller controls. The controller fixture installs a local Gamepad API response
-so `ControllerModel` can poll browser state and update child button/axis models
-without a real gamepad. It also renders `CanvasModel` through the ipycanvas path
-with a local binary command buffer routed by the CanvasManager adapter, and it
-restores saved `image_data` bytes through the same `CanvasWidget` effect used
-when ipycanvas snapshots restore canvas state. `AnyModel` fixtures render through
-`AnyWidgetView` with inline plus URL-backed `_esm` and `_css` assets. The media
-section includes an `ImageModel` whose `value` is a hydrated `DataView`, so the
-same `buildMediaSrc` binary path used by ipywidgets media traitlets is visible in
-the catalog. It also includes a same-origin static fixture URL listed in
-`bufferPaths`, hydrated into a `DataView` before seeding `WidgetStore`, mirroring
-the iframe bridge shape without importing that runtime. The persistence fixture
-routes `sendUpdate` through `WidgetUpdateManager`, uploads binary leaves to a
-docs-local blob uploader, and writes the resulting `ContentRef` through an inert
-CRDT writer while keeping the optimistic `DataView` in the store.
-The `OutputModel` fixture also includes a nested
-`application/vnd.jupyter.widget-view+json` output, resolved by the same
-`MediaProvider` custom renderer shape used by the notebook app. A local replay
-control updates the same `outputs` trait through the widget context, so the
-catalog covers the `OutputWidget` state-update path without opening a live comm
-channel. The widget boundary map separates the catalog's deterministic
-`WidgetStore`, `WidgetUpdateManager`, media buffer, and anywidget asset fixtures
-from the production RuntimeStateDoc, live comm bridge, daemon blob resolver, and
-kernel-originated asset paths. The remaining work is listed as named next
-adapter rows so the catalog keeps runtime gaps explicit and reviewable.
+Widgets are notebook outputs. This catalog renders production `WidgetView`
+surfaces against deterministic comm-state fixtures, then names the host
+boundaries that still belong outside the docs runtime.
 
 <WidgetSurfacesExample />
 

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -161,7 +161,7 @@ export function CellInsertionRibbon({
           visualActiveType
             ? insertionChannelIntentClasses[visualActiveType]
             : isOpen
-              ? "bg-muted/20 text-muted-foreground/45 hover:bg-muted/30 hover:text-muted-foreground/70"
+              ? "bg-transparent text-muted-foreground/35 hover:bg-muted/20 hover:text-muted-foreground/65"
               : "text-muted-foreground/0 hover:bg-muted/20",
           terminal && "h-7",
         )}
@@ -170,7 +170,7 @@ export function CellInsertionRibbon({
           data-slot="cell-adder-primary-glyph"
           className={cn(
             "size-3 transition-opacity duration-150",
-            isOpen || visualActiveType === "code" ? "opacity-100" : "opacity-0",
+            visualActiveType ? "opacity-100" : "opacity-0",
           )}
           aria-hidden="true"
         />

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -45,6 +45,7 @@ describe("CellInsertionRibbon", () => {
     const adder = container.querySelector('[data-slot="cell-adder"]');
     const continuation = container.querySelector('[data-slot="cell-adder-ribbon-continuation"]');
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    const glyph = container.querySelector('[data-slot="cell-adder-primary-glyph"]');
 
     fireEvent.pointerEnter(adder!);
 
@@ -52,7 +53,8 @@ describe("CellInsertionRibbon", () => {
     expect(adder).not.toHaveAttribute("data-active-type");
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
     expect(continuation).toHaveClass("bg-gray-300/70");
-    expect(hitTarget).toHaveClass("bg-muted/20");
+    expect(hitTarget).toHaveClass("bg-transparent");
+    expect(glyph).toHaveClass("opacity-0");
   });
 
   it("keeps explicit actions out of the tab order until the row is awake", () => {

--- a/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
+++ b/src/components/notebook-shell/NotebookEnvironmentSummary.tsx
@@ -60,7 +60,7 @@ export function NotebookEnvironmentSummary({
             <h3 className="truncate text-sm font-semibold">Notebook environment</h3>
           </div>
           <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            {surface.access.label} access through {surface.access.sourceLabel}
+            {surface.access.label} access from {surface.access.sourceLabel}.
           </p>
         </div>
         <span className="shrink-0 rounded-full border border-border bg-muted px-2 py-1 text-[11px] font-medium text-muted-foreground">
@@ -105,7 +105,7 @@ export function NotebookEnvironmentSummary({
       {showPackageDetails ? (
         <div className="border-t border-border px-4 py-3">
           {packages.sections.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No package manager metadata available.</p>
+            <p className="text-xs text-muted-foreground">No package manager details yet.</p>
           ) : (
             <div className="space-y-3">
               {packages.sections.map((section) => (
@@ -163,7 +163,7 @@ function SummaryFact({
         muted && "bg-muted/40 text-muted-foreground",
       )}
     >
-      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium uppercase text-muted-foreground">
+      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
         {muted ? <Lock className="size-3.5" aria-hidden="true" /> : icon}
         <span>{label}</span>
       </div>

--- a/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
+++ b/src/components/notebook-shell/NotebookPackageSummaryPanel.tsx
@@ -22,7 +22,7 @@ export function NotebookPackageSummaryPanel({
         {header}
         {packages.sections.length === 0 ? (
           <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
-            No package metadata in this notebook.
+            No package details yet.
           </div>
         ) : (
           packages.sections.map((section) => (
@@ -35,13 +35,13 @@ export function NotebookPackageSummaryPanel({
                   <h3 className="truncate text-sm font-semibold">{section.label}</h3>
                   <p className="text-xs text-muted-foreground">
                     {section.dependencies.length === 1
-                      ? "1 dependency"
-                      : `${section.dependencies.length} dependencies`}
+                      ? "1 declared dependency"
+                      : `${section.dependencies.length} declared dependencies`}
                   </p>
                 </div>
                 {readOnly ? (
                   <span className="shrink-0 rounded-full border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-                    Read only
+                    View only
                   </span>
                 ) : null}
               </div>
@@ -49,7 +49,7 @@ export function NotebookPackageSummaryPanel({
               {section.dependencies.length > 0 ? (
                 <PackageValueList values={section.dependencies} />
               ) : (
-                <p className="text-xs text-muted-foreground">No inline dependencies.</p>
+                <p className="text-xs text-muted-foreground">No inline dependencies yet.</p>
               )}
 
               {section.details.length > 0 ? (

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -70,7 +70,7 @@ describe("NotebookEnvironmentSummary", () => {
     expect(screen.getByText("pandas>=2")).toBeVisible();
   });
 
-  it("shows read-only environment state when package mutation is unavailable", () => {
+  it("shows view-only environment state when package management is unavailable", () => {
     render(
       <NotebookEnvironmentSummary
         capabilities={{
@@ -90,7 +90,7 @@ describe("NotebookEnvironmentSummary", () => {
 
     expect(screen.getByText("Public")).toBeVisible();
     expect(screen.getByText("No runtime")).toBeVisible();
-    expect(screen.getByText("No package metadata")).toBeVisible();
+    expect(screen.getByText("No package details")).toBeVisible();
     expect(screen.getByText("No package manager details yet.")).toBeVisible();
   });
 

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -63,7 +63,7 @@ describe("NotebookEnvironmentSummary", () => {
 
     expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
     expect(screen.getByText("Python - local runtime ready")).toBeVisible();
-    expect(screen.getByText("Runtime author: Python")).toBeVisible();
+    expect(screen.getByText("Python authors runtime state")).toBeVisible();
     expect(screen.getByText("uv + pixi - 3 packages")).toBeVisible();
     expect(screen.getByText("pyproject.toml")).toBeVisible();
     expect(screen.getByText("dirty - 1 pending change")).toBeVisible();
@@ -91,7 +91,7 @@ describe("NotebookEnvironmentSummary", () => {
     expect(screen.getByText("Public")).toBeVisible();
     expect(screen.getByText("No runtime")).toBeVisible();
     expect(screen.getByText("No package metadata")).toBeVisible();
-    expect(screen.getByText("No package manager metadata available.")).toBeVisible();
+    expect(screen.getByText("No package manager details yet.")).toBeVisible();
   });
 
   it("can render only environment facts when package details are shown elsewhere", () => {
@@ -115,7 +115,7 @@ describe("NotebookEnvironmentSummary", () => {
 
     expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
     expect(screen.getByText("Live sync connected")).toBeVisible();
-    expect(screen.getByText("Package metadata read only")).toBeVisible();
+    expect(screen.getByText("Read-only in this notebook")).toBeVisible();
     expect(screen.queryByText("pandas>=2")).toBeNull();
   });
 
@@ -142,7 +142,7 @@ describe("NotebookEnvironmentSummary", () => {
           packages: {
             summary: "uv - 2 packages",
             sourceLabel: "pyproject.toml",
-            accessLabel: "Package edits available",
+            accessLabel: "Editable in this notebook",
             muted: false,
           },
           sync: {
@@ -160,7 +160,7 @@ describe("NotebookEnvironmentSummary", () => {
       />,
     );
 
-    expect(screen.getByText("Owner access through desktop host")).toBeVisible();
+    expect(screen.getByText("Owner access from desktop host.")).toBeVisible();
     expect(screen.getByText("Runtime launching")).toBeVisible();
     expect(screen.getByText("Package metadata has pending changes")).toBeVisible();
     expect(screen.getByText("Untrusted dependencies")).toBeVisible();

--- a/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
@@ -24,7 +24,8 @@ describe("NotebookPackageSummaryPanel", () => {
     expect(screen.getByText("pandas>=2")).toBeVisible();
     expect(screen.getByText("polars")).toBeVisible();
     expect(screen.getByText(">=3.12")).toBeVisible();
-    expect(screen.getByText("Read only")).toBeVisible();
+    expect(screen.getByText("2 declared dependencies")).toBeVisible();
+    expect(screen.getByText("View only")).toBeVisible();
   });
 
   it("renders a shared host summary above package details", () => {
@@ -36,12 +37,12 @@ describe("NotebookPackageSummaryPanel", () => {
     );
 
     expect(screen.getByText("Cloud viewer environment")).toBeVisible();
-    expect(screen.getByText("No package metadata in this notebook.")).toBeVisible();
+    expect(screen.getByText("No package details yet.")).toBeVisible();
   });
 
-  it("shows an empty package metadata state", () => {
+  it("shows an empty package details state", () => {
     render(<NotebookPackageSummaryPanel packages={{ summary: null, sections: [] }} />);
 
-    expect(screen.getByText("No package metadata in this notebook.")).toBeVisible();
+    expect(screen.getByText("No package details yet.")).toBeVisible();
   });
 });

--- a/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPackageSummaryPanel.test.tsx
@@ -4,7 +4,7 @@ import { NotebookPackageSummaryPanel } from "../NotebookPackageSummaryPanel";
 import type { NotebookPackageViewModel } from "../view-model";
 
 describe("NotebookPackageSummaryPanel", () => {
-  it("renders package metadata in a read-only shared rail panel", () => {
+  it("renders package details in a view-only shared rail panel", () => {
     const packages: NotebookPackageViewModel = {
       summary: "uv · 2 packages",
       sections: [

--- a/src/components/notebook-shell/environment-surface.ts
+++ b/src/components/notebook-shell/environment-surface.ts
@@ -108,7 +108,7 @@ export function createNotebookEnvironmentSurface({
       muted: !capabilities.canExecute && !capabilities.runtime.connected,
     },
     packages: {
-      summary: packages.summary ?? "No package metadata",
+      summary: packages.summary ?? "No package details",
       sourceLabel: packageSourceLabel ?? packageAccessLabel,
       accessLabel: packageAccessLabel,
       muted: !capabilities.canViewPackages,

--- a/src/components/notebook-shell/environment-surface.ts
+++ b/src/components/notebook-shell/environment-surface.ts
@@ -73,15 +73,15 @@ export function createNotebookEnvironmentSurface({
   trustStatus = null,
 }: CreateNotebookEnvironmentSurfaceOptions): NotebookEnvironmentSurface {
   const packageAccessLabel = capabilities.canManagePackages
-    ? "Package edits available"
+    ? "Editable in this notebook"
     : capabilities.canViewPackages
-      ? "Package metadata read only"
-      : "Package metadata hidden";
+      ? "Read-only in this notebook"
+      : "Hidden for this viewer";
   const runtimeStateLabel =
     runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
   const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
   const runtimeDetail = capabilities.runtime.canWriteRuntimeState
-    ? `Runtime author: ${runtimeActor?.label ?? "connected runtime"}`
+    ? `${runtimeActor?.label ?? "Connected runtime"} authors runtime state`
     : capabilities.runtime.connected
       ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
       : null;
@@ -153,7 +153,7 @@ export function accessSourceLabel(source: NotebookShellAccessSource): string {
     case "cloud":
       return "cloud";
     case "local":
-      return "local";
+      return "local host";
     case "fixture":
       return "fixture";
     case "unknown":


### PR DESCRIPTION
## Summary

- refines Elements copy for widget, toolbar, package, runtime, outline, and shell capability surfaces around the newer notebook rail language
- keeps rail-sized package/runtime previews focused on the actual product surface instead of docs-only meta chrome
- softens notebook environment and package summary wording, plus the neutral cell insertion affordance

## Verification

- `pnpm exec vp check apps/elements/components/runtime-surfaces-example.tsx apps/elements/content/docs/runtime-surfaces.mdx apps/elements/components/rail-outline-example.tsx apps/elements/content/docs/notebook-outline.mdx src/components/notebook-shell/NotebookEnvironmentSummary.tsx src/components/notebook-shell/environment-surface.ts src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/elements build`
