### PR TITLE
docs(elements): remove catalog-only cell sketches

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -145,58 +145,6 @@ const currentLineStateFixtures = [
   },
 ];
 
-const currentLineConceptFixtures = [
-  {
-    label: "Production",
-    detail: "Default reading mode keeps completed metadata collapsed into the boundary line.",
-    line: (
-      <CodeCellCurrentLine
-        languageLabel="Python"
-        count={26}
-        elapsedMs={1476}
-        activityContent={<StaticPresenceActivity />}
-      />
-    ),
-  },
-  {
-    label: "Timed signal",
-    detail:
-      "Speculative: start time plus recent durations could turn the running wave into rough progress.",
-    line: <TimedExecutionSignalConcept />,
-  },
-  {
-    label: "Run state chip",
-    detail: "Keeps completion as compact metadata instead of sentence copy.",
-    line: (
-      <CurrentLineConcept>
-        <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
-          Python
-        </span>
-        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-medium tabular-nums text-foreground/65">
-          Run 26
-        </span>
-        <span className="text-muted-foreground/55">1.5s</span>
-        <StaticPresenceDots />
-      </CurrentLineConcept>
-    ),
-  },
-  {
-    label: "Activity edge",
-    detail: "Lets peer activity live at the edge of the rule instead of the left lane.",
-    line: (
-      <CurrentLineConcept>
-        <span className="rounded-sm bg-muted/60 px-1.5 py-0.5 font-medium text-foreground/70">
-          Python
-        </span>
-        <span className="font-medium tabular-nums text-foreground/65">Run 26</span>
-        <span className="text-muted-foreground/45">1.5s</span>
-        <div className="h-px min-w-8 flex-1 rounded-full bg-border/45" />
-        <StaticPresenceDots />
-      </CurrentLineConcept>
-    ),
-  },
-];
-
 const contracts = [
   "Catalog examples import current components before adding fixture-only wrappers.",
   "Fixture content may stand in for runtime/editor/output systems until an adapter exists.",
@@ -581,30 +529,6 @@ export function CellAnatomyExample() {
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Current Line Studio</h2>
-          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            These are low-risk composition sketches for the source/result boundary. They keep the
-            production boundary nearby while letting activity, completion copy, and future timing
-            affordances move around.
-          </p>
-        </div>
-        <div className="divide-y divide-fd-border bg-background">
-          {currentLineConceptFixtures.map((concept) => (
-            <div key={concept.label} className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
-              <div>
-                <h3 className="text-sm font-semibold">{concept.label}</h3>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{concept.detail}</p>
-              </div>
-              <div className="group min-w-0 rounded-md border border-fd-border bg-fd-card px-3 py-4">
-                {concept.line}
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="border-b border-fd-border p-4">
           <h2 className="text-sm font-semibold">Hidden Boundaries</h2>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             The current line belongs to the source/result boundary. It remains when either side is
@@ -704,48 +628,5 @@ function StaticPresenceActivity() {
       </span>
       <StaticPresenceDots />
     </>
-  );
-}
-
-function CurrentLineConcept({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex min-h-[1.125rem] min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
-      {children}
-    </div>
-  );
-}
-
-function TimedExecutionSignalConcept() {
-  return (
-    <div className="flex min-h-5 min-w-0 items-center gap-1.5 text-[11px] leading-none text-muted-foreground/70">
-      <span className="rounded-sm bg-primary/10 px-1 py-0.5 font-medium text-primary">Python</span>
-      <span className="text-muted-foreground/35" aria-hidden="true">
-        ·
-      </span>
-      <span className="font-medium tabular-nums text-primary">Run 32</span>
-      <span className="text-muted-foreground/45 tabular-nums">2.1s / ~4s</span>
-      <div className="relative h-3 min-w-24 flex-1 overflow-hidden rounded-full text-emerald-500/65 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]">
-        <div className="absolute inset-y-1 left-0 w-[54%] rounded-full bg-emerald-400/10 animate-exec-signal-tail" />
-        <svg
-          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
-          viewBox="0 0 240 12"
-          preserveAspectRatio="none"
-          aria-hidden="true"
-        >
-          <path
-            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
-            fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeWidth="1.4"
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
-        <span
-          className="absolute left-[54%] top-1/2 h-2 w-8 -translate-y-1/2 rounded-full bg-gradient-to-r from-transparent via-emerald-500/60 to-transparent blur-[0.5px]"
-          aria-hidden="true"
-        />
-      </div>
-    </div>
   );
 }

--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -2,8 +2,6 @@
 
 import {
   Braces,
-  ChevronRight,
-  Code2,
   CheckCircle2,
   CircleDot,
   FileText,
@@ -171,33 +169,6 @@ const insertionRibbonRows = [
   },
 ];
 
-const hiddenBoundaryRows = [
-  {
-    id: "source-hidden-output-visible",
-    label: "Input hidden",
-    detail: "The source reveal sits above the current line; output still follows the boundary.",
-    codeContent: <BoundarySourceFixture sourceHidden />,
-    outputContent: <BoundaryOutputFixture />,
-    hideOutput: false,
-  },
-  {
-    id: "output-hidden-source-visible",
-    label: "Output hidden",
-    detail: "The current line stays with the source; the hidden output reveal owns the output row.",
-    codeContent: <BoundarySourceFixture />,
-    outputContent: <HiddenOutputFixture />,
-    hideOutput: false,
-  },
-  {
-    id: "both-hidden",
-    label: "Input and output hidden",
-    detail: "When both sides disappear, the cell collapses to one reveal affordance.",
-    codeContent: <HiddenCellFixture />,
-    outputContent: <HiddenOutputFixture />,
-    hideOutput: true,
-  },
-];
-
 const presenceSnapshot = {
   type: "snapshot",
   peer_id: "local-docs-peer",
@@ -345,67 +316,6 @@ function InsertionRibbonFixture({
   );
 }
 
-function BoundarySourceFixture({ sourceHidden = false }: { sourceHidden?: boolean }) {
-  return (
-    <div className="group min-w-0">
-      {sourceHidden ? (
-        <button
-          type="button"
-          className="inline-flex max-w-full items-center gap-1 rounded bg-muted/50 px-2 py-0.5 font-mono text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <Code2 className="size-3 flex-none" aria-hidden="true" />
-          <span className="truncate">{sourceFixture.split("\n")[0]}</span>
-          <ChevronRight className="size-3 flex-none" aria-hidden="true" />
-        </button>
-      ) : (
-        <pre className="m-0 overflow-hidden rounded border border-border bg-background px-3 py-2 font-mono text-xs leading-5 text-foreground">
-          {sourceFixture.split("\n").slice(0, 2).join("\n")}
-        </pre>
-      )}
-      <CodeCellCurrentLine
-        languageLabel={languageLabel}
-        count={executionCount}
-        elapsedMs={1476}
-        isFocused
-      />
-    </div>
-  );
-}
-
-function BoundaryOutputFixture() {
-  return (
-    <div className="px-3 py-2 text-xs leading-5 text-fd-muted-foreground">
-      MAE=8.42&nbsp;&nbsp;MAPE=6.8%&nbsp;&nbsp;Backtest=16 weeks
-    </div>
-  );
-}
-
-function HiddenOutputFixture() {
-  return (
-    <div className="px-3 py-2">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1 rounded bg-muted/50 px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        <span>2 outputs</span>
-        <ChevronRight className="size-3" aria-hidden="true" />
-      </button>
-    </div>
-  );
-}
-
-function HiddenCellFixture() {
-  return (
-    <button
-      type="button"
-      className="inline-flex items-center gap-1 rounded bg-muted/50 px-2 py-0.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-    >
-      <span>Cell hidden</span>
-      <ChevronRight className="size-3" aria-hidden="true" />
-    </button>
-  );
-}
-
 export function CellAnatomyExample() {
   return (
     <div className="not-prose space-y-6">
@@ -522,35 +432,6 @@ export function CellAnatomyExample() {
                 <div className="mt-1 text-xs text-fd-muted-foreground">{state.detail}</div>
               </div>
               <div className="mt-3 min-w-0">{state.line}</div>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Hidden Boundaries</h2>
-          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The current line belongs to the source/result boundary. It remains when either side is
-            still visible and disappears only when the whole cell is intentionally collapsed.
-          </p>
-        </div>
-        <div className="divide-y divide-fd-border bg-background py-2">
-          {hiddenBoundaryRows.map((row) => (
-            <div key={row.id} className="grid gap-3 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
-              <div>
-                <h3 className="text-sm font-semibold">{row.label}</h3>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
-              </div>
-              <CellContainer
-                id={row.id}
-                cellType="code"
-                isFocused
-                className="mx-0 px-0"
-                codeContent={row.codeContent}
-                outputContent={row.outputContent}
-                hideOutput={row.hideOutput}
-              />
             </div>
           ))}
         </div>

--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -1,399 +1,230 @@
 "use client";
 
-import { Check, Clock3, Play, Sparkles, X } from "lucide-react";
-import type { CSSProperties, ReactNode } from "react";
+import { CheckCircle2, FileCode2, Rows3 } from "lucide-react";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { notebookCellLayoutVars } from "@/components/cell/cell-layout";
 import { cn } from "@/lib/utils";
 
-type ExecutionState = "ready" | "queued" | "running" | "completed" | "failed";
-type Variant = "production" | "quiet" | "sentence" | "signal";
-
-const states: Array<{
-  state: ExecutionState;
+type ExecutionState = {
+  id: string;
   label: string;
   detail: string;
   count: number | null;
   elapsedMs?: number | null;
-}> = [
-  { state: "ready", label: "Ready", detail: "waiting for first run", count: null },
-  { state: "queued", label: "Queued", detail: "next in line", count: null },
-  { state: "running", label: "Running", detail: "building signal", count: null },
-  { state: "completed", label: "Completed", detail: "Run 12 in 180ms", count: 12, elapsedMs: 180 },
-  { state: "failed", label: "Failed", detail: "Run 13 stopped", count: 13 },
+  isExecuting?: boolean;
+  isQueued?: boolean;
+  queuePriority?: number;
+  isErrored?: boolean;
+  submittedByActorLabel?: string | null;
+};
+
+const executionStates: ExecutionState[] = [
+  {
+    id: "ready",
+    label: "Ready",
+    detail: "Never-run cells keep the state lane quiet until hover, focus, or keyboard access.",
+    count: null,
+  },
+  {
+    id: "focused-ready",
+    label: "Focused ready",
+    detail: "Notebook focus makes the run affordance available without adding status copy.",
+    count: null,
+  },
+  {
+    id: "queued",
+    label: "Queued",
+    detail: "Queued cells use the production queue pulse and keep the interrupt action disabled.",
+    count: 12,
+    isQueued: true,
+    queuePriority: 0.7,
+    submittedByActorLabel: "Kyle Kelley",
+  },
+  {
+    id: "running",
+    label: "Running",
+    detail: "Active execution moves through the compact stop button and current-line signal.",
+    count: 12,
+    isExecuting: true,
+    submittedByActorLabel: "Kyle Kelley",
+  },
+  {
+    id: "completed",
+    label: "Completed",
+    detail: "Finished runs collapse to the production run count and elapsed-time boundary.",
+    count: 12,
+    elapsedMs: 180,
+  },
+  {
+    id: "failed",
+    label: "Failed",
+    detail: "Errors keep the retry affordance in the state lane and mark the boundary as failed.",
+    count: 13,
+    isErrored: true,
+  },
 ];
 
-const variants: Array<{
-  variant: Variant;
-  label: string;
-  body: string;
-}> = [
+const componentRows = [
   {
-    variant: "production",
-    label: "Production grammar",
-    body: "Quiet cells rest as punctuation: completed cells show only the run marker, ready cells stay visually silent, and full language context returns on approach.",
+    component: "CompactExecutionButton",
+    path: "src/components/cell/CompactExecutionButton.tsx",
+    role: "Run, queued, running, error, and disabled execution affordance in the cell state lane.",
   },
   {
-    variant: "quiet",
-    label: "Quiet unless focused",
-    body: "An earlier sketch kept language visible at rest and bloomed the run metadata later; useful, but louder than the production direction.",
+    component: "CodeCellCurrentLine",
+    path: "src/components/cell/CodeCellCurrentLine.tsx",
+    role: "Source/result boundary with language context, count, elapsed time, queue pulse, and running signal.",
   },
   {
-    variant: "sentence",
-    label: "Short sentence",
-    body: "Treat the metadata as one compact phrase after the signal: Python, run 12 in 180ms.",
-  },
-  {
-    variant: "signal",
-    label: "Signal-led",
-    body: "Let the rule own state. Text becomes a soft caption instead of the primary visual event.",
+    component: "notebookCellLayoutVars",
+    path: "src/components/cell/cell-layout.ts",
+    role: "Shared cell column geometry so catalog previews line up with the notebook app.",
   },
 ];
 
 export function CellExecutionLanguageExample() {
   return (
     <div className="not-prose space-y-6">
-      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Run line direction set</h2>
-          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The target is a cell boundary that usually reads as punctuation in the notebook rhythm.
-            Active states get words; quiet states keep their context available but tucked away.
-          </p>
-        </div>
-        <div className="divide-y divide-fd-border bg-background">
-          {variants.map((variant) => (
-            <div key={variant.label} className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
-              <div>
-                <h3 className="text-sm font-semibold">{variant.label}</h3>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{variant.body}</p>
-              </div>
-              <NotebookPreview variant={variant.variant} />
-            </div>
-          ))}
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Production execution language only</h2>
+            <p className="mt-1 text-xs leading-5">
+              This page renders the current cell execution components directly. It no longer keeps
+              alternate execution-line variants beside the production line, so catalog review stays
+              focused on the UI the notebook app actually ships.
+            </p>
+          </div>
         </div>
       </section>
 
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">State vocabulary</h2>
+          <div className="flex items-center gap-2">
+            <FileCode2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Run lane in context</h2>
+          </div>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The same line should carry ready, queued, running, completed, and failed states while
-            making quiet cells feel like document structure, not a status table.
+            The preview below is fixture code around production execution controls. The buttons,
+            boundary lines, labels, animation hooks, and accessibility text come from shared
+            components.
+          </p>
+        </div>
+        <div className={cn("divide-y divide-border bg-background", notebookCellLayoutVars)}>
+          <PreviewCell
+            state={executionStates[4]}
+            source="features = orders.assign(month=orders.date.dt.month)"
+          />
+          <PreviewCell state={executionStates[3]} source="model.fit(features[columns], target)" />
+          <PreviewCell
+            state={executionStates[2]}
+            source="predictions = model.predict(features_holdout)"
+          />
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Execution state matrix</h2>
+          </div>
+          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+            Each state is a production `CompactExecutionButton` paired with a production
+            `CodeCellCurrentLine`.
           </p>
         </div>
         <div className="grid gap-3 bg-background p-4 md:grid-cols-2">
-          {states.map((state) => (
-            <StateSample key={state.state} {...state} />
+          {executionStates.map((state) => (
+            <StateSample key={state.id} state={state} />
           ))}
         </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {componentRows.map((row) => (
+          <article
+            key={row.component}
+            className="rounded-lg border border-fd-border bg-fd-card p-4"
+          >
+            <h3 className="text-sm font-semibold">{row.component}</h3>
+            <p className="mt-2 break-words font-mono text-[11px] leading-5 text-fd-muted-foreground">
+              {row.path}
+            </p>
+            <p className="mt-3 text-xs leading-5 text-fd-muted-foreground">{row.role}</p>
+          </article>
+        ))}
       </section>
     </div>
   );
 }
 
-function NotebookPreview({ variant }: { variant: Variant }) {
+function PreviewCell({ state, source }: { state: ExecutionState; source: string }) {
   return (
-    <div
-      className={cn(
-        "min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background",
-        notebookCellLayoutVars,
-      )}
-    >
-      <PreviewCell
-        variant={variant}
-        state="completed"
-        count={12}
-        elapsedMs={180}
-        source={<CodeSample tokens={["total", " = ", "sum", "(", "values", ")"]} />}
-        output="42"
-      />
-      <PreviewCell
-        variant={variant}
-        state="running"
-        count={null}
-        source={<CodeSample tokens={["fit", "(", "model", ", ", "frame", ")"]} />}
-      />
-    </div>
-  );
-}
-
-function PreviewCell({
-  variant,
-  state,
-  count,
-  elapsedMs,
-  source,
-  output,
-}: {
-  variant: Variant;
-  state: ExecutionState;
-  count: number | null;
-  elapsedMs?: number | null;
-  source: ReactNode;
-  output?: string;
-}) {
-  const isRunning = state === "running";
-  const isQueued = state === "queued";
-  const isFailed = state === "failed";
-
-  return (
-    <div data-preview-state={state} className="cell-container group flex bg-background/95">
-      <div
-        className={cn(
-          "w-1 shrink-0 transition-colors",
-          state === "failed" ? "bg-red-400" : state === "running" ? "bg-emerald-400" : "bg-sky-400",
-        )}
-      />
-      <div className="min-w-0 flex-1 py-3 pl-[var(--cell-content-column-inset,3.25rem)] pr-5">
-        <div className="relative min-h-10">
-          <div className="absolute left-[calc(-1*var(--cell-content-column-inset,3.25rem)+0.4rem)] top-1">
-            <CompactExecutionButton
-              count={count}
-              isExecuting={isRunning}
-              isQueued={isQueued}
-              isErrored={isFailed}
-              isCellFocused
-            />
-          </div>
-          <div className="font-mono text-[15px] leading-7 tracking-normal text-foreground">
-            {source}
-          </div>
-          {variant === "production" ? (
-            <CodeCellCurrentLine
-              languageLabel="Python"
-              count={count}
-              elapsedMs={elapsedMs}
-              isExecuting={isRunning}
-              isQueued={isQueued}
-              isErrored={isFailed}
-              isFocused
-            />
-          ) : (
-            <ExecutionLanguageLine
-              variant={variant}
-              state={state}
-              count={count}
-              elapsedMs={elapsedMs}
-            />
-          )}
+    <div className="cell-container group flex bg-background/95">
+      <div className="w-1 shrink-0 bg-sky-400 transition-colors dark:bg-sky-600" />
+      <div className="relative min-w-0 flex-1 py-3 pl-[var(--cell-content-column-inset,3.25rem)] pr-5">
+        <div className="absolute left-2 top-3.5">
+          <CompactExecutionButton
+            count={state.count}
+            isExecuting={state.isExecuting}
+            isQueued={state.isQueued}
+            isErrored={state.isErrored}
+            submittedByActorLabel={state.submittedByActorLabel}
+            isCellFocused
+          />
         </div>
-        {output ? (
-          <div className="mt-5 font-mono text-[15px] leading-6 text-foreground">{output}</div>
-        ) : null}
+        <pre className="m-0 overflow-x-auto whitespace-pre font-mono text-[13px] leading-6 text-foreground">
+          {source}
+        </pre>
+        <CodeCellCurrentLine
+          languageLabel="Python"
+          count={state.count}
+          elapsedMs={state.elapsedMs}
+          isExecuting={state.isExecuting}
+          isQueued={state.isQueued}
+          queuePriority={state.queuePriority}
+          isErrored={state.isErrored}
+          isFocused
+        />
       </div>
     </div>
   );
 }
 
-function ExecutionLanguageLine({
-  variant,
-  state,
-  count,
-  elapsedMs,
-}: {
-  variant: Exclude<Variant, "production">;
-  state: ExecutionState;
-  count: number | null;
-  elapsedMs?: number | null;
-}) {
-  const copy = executionCopy(state, count, elapsedMs);
-
-  if (variant === "quiet") {
-    return (
-      <div className="mt-1.5 flex min-h-4 items-center gap-1.5 text-[11px] font-medium leading-none text-muted-foreground/55">
-        <LanguagePill state={state} />
-        <div className="h-px w-8 rounded-full bg-border/20 transition-all group-hover:w-12 group-hover:bg-border/35" />
-        <span className="max-w-0 overflow-hidden whitespace-nowrap opacity-0 transition-[max-width,opacity] duration-150 group-hover:max-w-48 group-hover:opacity-100 group-focus-within:max-w-48 group-focus-within:opacity-100">
-          {copy.short}
-        </span>
-        <SignalRule state={state} quiet />
-      </div>
-    );
-  }
-
-  if (variant === "sentence") {
-    return (
-      <div className="mt-1.5 flex min-h-4 items-center gap-1.5 text-[11px] font-medium leading-none text-muted-foreground/60">
-        <StateGlyph state={state} />
-        <span className="whitespace-nowrap">
-          <span className="text-foreground/65">Python</span>
-          <span className="px-1 text-muted-foreground/35">/</span>
-          <span className={stateTone(state)}>{copy.short}</span>
-        </span>
-        <SignalRule state={state} />
-      </div>
-    );
-  }
+function StateSample({ state }: { state: ExecutionState }) {
+  const focused = state.id === "focused-ready" || state.isExecuting || state.isQueued;
 
   return (
-    <div className="mt-1.5 grid min-h-4 grid-cols-[auto_minmax(3rem,1fr)_auto] items-center gap-2 text-[11px] font-medium leading-none text-muted-foreground/55">
-      <StateGlyph state={state} />
-      <SignalRule state={state} strong />
-      <span className="whitespace-nowrap">
-        <span className="text-foreground/65">Python</span>
-        <span className="px-1 text-muted-foreground/35">/</span>
-        <span className={stateTone(state)}>{copy.tiny}</span>
-      </span>
-    </div>
-  );
-}
-
-function StateSample({
-  state,
-  label,
-  detail,
-  count,
-  elapsedMs,
-}: {
-  state: ExecutionState;
-  label: string;
-  detail: string;
-  count: number | null;
-  elapsedMs?: number | null;
-}) {
-  return (
-    <div className="rounded-md border border-fd-border bg-fd-background p-3">
-      <div className="flex items-center gap-2 text-xs font-semibold">
-        <StateGlyph state={state} />
-        <span>{label}</span>
+    <article className="group rounded-md border border-fd-border bg-fd-background p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">{state.label}</h3>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">{state.detail}</p>
+        </div>
+        <CompactExecutionButton
+          count={state.count}
+          isExecuting={state.isExecuting}
+          isQueued={state.isQueued}
+          isErrored={state.isErrored}
+          submittedByActorLabel={state.submittedByActorLabel}
+          isCellFocused={focused}
+        />
       </div>
       <div className="mt-4">
-        <ExecutionLanguageLine variant="signal" state={state} count={count} elapsedMs={elapsedMs} />
+        <CodeCellCurrentLine
+          languageLabel="Python"
+          count={state.count}
+          elapsedMs={state.elapsedMs}
+          isExecuting={state.isExecuting}
+          isQueued={state.isQueued}
+          queuePriority={state.queuePriority}
+          isErrored={state.isErrored}
+          isFocused={focused}
+        />
       </div>
-      <p className="mt-3 text-xs leading-5 text-fd-muted-foreground">{detail}</p>
-    </div>
-  );
-}
-
-function LanguagePill({ state }: { state: ExecutionState }) {
-  return (
-    <span
-      className={cn(
-        "rounded-sm px-1 py-0.5 transition-colors",
-        state === "running" && "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-        state === "queued" && "bg-sky-500/10 text-sky-700 dark:text-sky-300",
-        state === "failed" && "bg-red-500/10 text-red-700 dark:text-red-300",
-        (state === "ready" || state === "completed") && "bg-muted/45 text-foreground/65",
-      )}
-    >
-      Python
-    </span>
-  );
-}
-
-function StateGlyph({ state }: { state: ExecutionState }) {
-  const className = cn(
-    "size-3 shrink-0",
-    state === "running" && "text-emerald-600 dark:text-emerald-300",
-    state === "queued" && "text-sky-600 dark:text-sky-300",
-    state === "failed" && "text-red-600 dark:text-red-300",
-    state === "completed" && "text-muted-foreground/55",
-    state === "ready" && "text-muted-foreground/35",
-  );
-
-  if (state === "running") return <Sparkles className={className} aria-hidden="true" />;
-  if (state === "queued") return <Clock3 className={className} aria-hidden="true" />;
-  if (state === "failed") return <X className={className} aria-hidden="true" />;
-  if (state === "completed") return <Check className={className} aria-hidden="true" />;
-  return <Play className={cn(className, "fill-current")} aria-hidden="true" />;
-}
-
-function SignalRule({
-  state,
-  quiet = false,
-  strong = false,
-}: {
-  state: ExecutionState;
-  quiet?: boolean;
-  strong?: boolean;
-}) {
-  if (state === "running") {
-    return (
-      <span className="relative h-3 min-w-12 flex-1 overflow-hidden text-emerald-500/65 [mask-image:linear-gradient(to_right,transparent,black_0.5rem,black_calc(100%-0.5rem),transparent)]">
-        <svg
-          className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
-          viewBox="0 0 240 12"
-          preserveAspectRatio="none"
-        >
-          <path
-            d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
-            fill="none"
-            stroke="currentColor"
-            strokeLinecap="round"
-            strokeWidth={strong ? "1.5" : "1.2"}
-            vectorEffect="non-scaling-stroke"
-          />
-        </svg>
-      </span>
-    );
-  }
-
-  if (state === "queued") {
-    return (
-      <span
-        className={cn(
-          "h-px min-w-12 flex-1 rounded-full bg-sky-400/45 animate-queue-boundary-pulse",
-          strong && "bg-sky-400/60",
-        )}
-        style={{ "--queue-pulse-duration": "2s" } as CSSProperties}
-      />
-    );
-  }
-
-  if (state === "failed") {
-    return (
-      <span className="h-px min-w-12 flex-1 bg-[repeating-linear-gradient(to_right,rgb(248_113_113/.7)_0_0.35rem,transparent_0.35rem_0.6rem)]" />
-    );
-  }
-
-  return (
-    <span
-      className={cn(
-        "h-px min-w-8 flex-1 rounded-full",
-        quiet ? "bg-border/15" : "bg-border/25",
-        strong && "bg-border/35",
-      )}
-    />
-  );
-}
-
-function executionCopy(state: ExecutionState, count: number | null, elapsedMs?: number | null) {
-  if (state === "running") return { short: "running", tiny: "running" };
-  if (state === "queued") return { short: "queued", tiny: "queued" };
-  if (state === "failed")
-    return { short: count === null ? "failed" : `run ${count} failed`, tiny: "failed" };
-  if (state === "completed") {
-    const run = count === null ? "run" : `run ${count}`;
-    const elapsed = typeof elapsedMs === "number" ? ` in ${formatElapsed(elapsedMs)}` : "";
-    return { short: `${run}${elapsed}`, tiny: count === null ? "done" : `run ${count}` };
-  }
-  return { short: "ready", tiny: "ready" };
-}
-
-function stateTone(state: ExecutionState) {
-  if (state === "running") return "text-emerald-700 dark:text-emerald-300";
-  if (state === "queued") return "text-sky-700 dark:text-sky-300";
-  if (state === "failed") return "text-red-700 dark:text-red-300";
-  return "text-muted-foreground/70";
-}
-
-function formatElapsed(ms: number) {
-  if (ms < 1_000) return `${Math.max(1, Math.round(ms))}ms`;
-  const seconds = ms / 1_000;
-  return seconds < 10 ? `${seconds.toFixed(1)}s` : `${Math.round(seconds)}s`;
-}
-
-function CodeSample({ tokens }: { tokens: string[] }) {
-  return (
-    <>
-      <span className="text-blue-600">{tokens[0]}</span>
-      <span className="text-muted-foreground">{tokens[1]}</span>
-      <span className="text-purple-600">{tokens[2]}</span>
-      <span className="text-muted-foreground">{tokens[3]}</span>
-      <span className="text-blue-600">{tokens[4]}</span>
-      <span className="text-muted-foreground">{tokens[5]}</span>
-    </>
+    </article>
   );
 }

--- a/apps/elements/components/cell-insertion-affordances-example.tsx
+++ b/apps/elements/components/cell-insertion-affordances-example.tsx
@@ -1,190 +1,105 @@
 "use client";
 
-import { Code, LetterText, Plus } from "lucide-react";
+import { CheckCircle2, Rows3 } from "lucide-react";
 import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
-import { notebookCellLayoutVars } from "@/components/cell/cell-layout";
-import { cn } from "@/lib/utils";
 
-type Intent = "code" | "markdown";
-
-const concepts = [
+const insertionRows = [
   {
-    label: "Threaded production row",
-    body: "Actions attach directly to the document rule; the selected intent fades back into the page instead of forming a floating palette.",
-    render: <ProductionInsertionPreview />,
+    label: "Between cells",
+    detail:
+      "Default row between existing notebook cells. Hover and focus reveal production actions.",
+    props: {},
   },
   {
-    label: "Connected group study",
-    body: "A more bordered variation keeps the actions grouped, but adds more chrome than the production row needs.",
-    render: <ThreadedLinePreview />,
+    label: "Code target",
+    detail:
+      "The controlled code state shows the same color and action grammar used in NotebookView.",
+    props: { activeType: "code" as const, forceActionsVisible: true },
   },
   {
-    label: "Split landing zone",
-    body: "The left channel stays a broad insert target while the explicit choices sit in the document column.",
-    render: <SplitLandingPreview />,
+    label: "Markdown target",
+    detail: "The controlled markdown state uses the production markdown ribbon and insertion rule.",
+    props: { activeType: "markdown" as const, forceActionsVisible: true },
+  },
+  {
+    label: "Document tail",
+    detail:
+      "The terminal row fades the spine while keeping the production add-cell actions attached.",
+    props: { activeType: "code" as const, terminal: true, forceActionsVisible: true },
   },
 ];
+
+const componentRows = [
+  {
+    component: "CellInsertionRibbon",
+    path: "src/components/cell/CellInsertionRibbon.tsx",
+    role: "Between-cell and terminal add-cell row used by the notebook workspace.",
+  },
+  {
+    component: "notebookCellLayoutVars",
+    path: "src/components/cell/cell-layout.ts",
+    role: "Shared content column and ribbon geometry for cells and add-cell rows.",
+  },
+];
+
+const noopInsert = () => undefined;
 
 export function CellInsertionAffordancesExample() {
   return (
     <div className="not-prose space-y-6">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold">Production add-cell rows only</h2>
+            <p className="mt-1 text-xs leading-5">
+              This page renders `CellInsertionRibbon` states directly. Earlier alternative row
+              studies have been removed so the catalog does not imply a second add-cell component.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
         <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Between-cell direction set</h2>
+          <div className="flex items-center gap-2">
+            <Rows3 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">Insertion row states</h2>
+          </div>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            These sketches keep the same rail-gripped ribbon and document column. The production row
-            now uses the threaded direction; the remaining sketches document the tradeoffs.
+            The catalog controls only the fixture state and inert insert callback. Layout, hover
+            behavior, labels, icons, and terminal fading are all owned by the shared component.
           </p>
         </div>
         <div className="divide-y divide-fd-border bg-background">
-          {concepts.map((concept) => (
-            <div key={concept.label} className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
+          {insertionRows.map((row) => (
+            <div key={row.label} className="grid gap-4 p-4 lg:grid-cols-[220px_minmax(0,1fr)]">
               <div>
-                <h3 className="text-sm font-semibold">{concept.label}</h3>
-                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{concept.body}</p>
+                <h3 className="text-sm font-semibold">{row.label}</h3>
+                <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
               </div>
               <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
-                {concept.render}
+                <CellInsertionRibbon {...row.props} onInsert={noopInsert} />
               </div>
             </div>
           ))}
         </div>
       </section>
 
-      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <div className="border-b border-fd-border p-4">
-          <h2 className="text-sm font-semibold">Document tail</h2>
-          <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-            The final add row needs a softer ending than an ordinary between-cell row.
-          </p>
-        </div>
-        <div className="grid gap-4 bg-background p-4 lg:grid-cols-2">
-          <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
-            <CellInsertionRibbon
-              activeType="code"
-              terminal
-              forceActionsVisible
-              onInsert={() => undefined}
-            />
-          </div>
-          <div className="min-w-0 overflow-hidden rounded-md border border-fd-border bg-fd-background">
-            <TailFadePreview />
-          </div>
-        </div>
+      <section className="grid gap-3 md:grid-cols-2">
+        {componentRows.map((row) => (
+          <article
+            key={row.component}
+            className="rounded-lg border border-fd-border bg-fd-card p-4"
+          >
+            <h3 className="text-sm font-semibold">{row.component}</h3>
+            <p className="mt-2 break-words font-mono text-[11px] leading-5 text-fd-muted-foreground">
+              {row.path}
+            </p>
+            <p className="mt-3 text-xs leading-5 text-fd-muted-foreground">{row.role}</p>
+          </article>
+        ))}
       </section>
     </div>
-  );
-}
-
-function ProductionInsertionPreview() {
-  return <CellInsertionRibbon forceActionsVisible onInsert={() => undefined} />;
-}
-
-function ThreadedLinePreview() {
-  return (
-    <div className={cn("flex h-9 w-full items-center", notebookCellLayoutVars)}>
-      <Ribbon intent="markdown" />
-      <div className="h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 bg-emerald-500/5" />
-      <div className="flex min-w-0 flex-1 items-center">
-        <div className="h-px w-6 bg-border/70" />
-        <ThreadedAction intent="code" muted />
-        <ThreadedAction intent="markdown" />
-        <div className="h-px min-w-8 flex-1 bg-gradient-to-r from-emerald-400/25 via-border/45 to-transparent" />
-      </div>
-    </div>
-  );
-}
-
-function SplitLandingPreview() {
-  return (
-    <div className={cn("flex h-9 w-full items-center", notebookCellLayoutVars)}>
-      <Ribbon intent="code" />
-      <div className="flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center bg-sky-500/6">
-        <Plus className="size-3 text-sky-600/70" aria-hidden="true" />
-      </div>
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <SplitAction intent="code" />
-        <span className="h-px min-w-4 flex-1 bg-border/65" />
-        <SplitAction intent="markdown" muted />
-      </div>
-    </div>
-  );
-}
-
-function TailFadePreview() {
-  return (
-    <div
-      className={cn("flex h-[clamp(3.5rem,9vh,5.5rem)] w-full items-start", notebookCellLayoutVars)}
-    >
-      <div className="relative h-full w-1 shrink-0 overflow-hidden [mask-image:linear-gradient(to_bottom,black_0,black_calc(100%-1.5rem),transparent_100%)]">
-        <div className="absolute inset-0 bg-gray-200/70 dark:bg-gray-700/55" />
-        <div className="absolute left-0 top-0 h-7 w-full bg-gradient-to-b from-emerald-400 via-emerald-400/50 to-emerald-400/0 dark:from-emerald-600 dark:via-emerald-600/50 dark:to-emerald-600/0" />
-      </div>
-      <div className="h-7 w-[var(--cell-content-column-inset,3.25rem)] shrink-0 bg-emerald-500/5" />
-      <div className="flex h-7 min-w-0 flex-1 items-center">
-        <div className="h-px w-5 bg-border/55" />
-        <SplitAction intent="code" muted />
-        <SplitAction intent="markdown" />
-        <div className="h-px min-w-8 flex-1 bg-gradient-to-r from-border/55 to-transparent" />
-      </div>
-    </div>
-  );
-}
-
-function Ribbon({ intent }: { intent: Intent }) {
-  return (
-    <div className="relative h-full w-1 shrink-0 overflow-hidden">
-      <div className="absolute inset-0 bg-gray-200/55 dark:bg-gray-700/55" />
-      <div
-        className={cn(
-          "absolute inset-0",
-          intent === "code" ? "bg-sky-400 dark:bg-sky-600" : "bg-emerald-400 dark:bg-emerald-600",
-        )}
-      />
-    </div>
-  );
-}
-
-function ThreadedAction({ intent, muted = false }: { intent: Intent; muted?: boolean }) {
-  const Icon = intent === "code" ? Code : LetterText;
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        "inline-flex h-7 shrink-0 items-center gap-1.5 border-y border-border/70 px-2.5 text-xs font-medium transition-colors first:border-l first:rounded-l-full last:border-r last:rounded-r-full",
-        muted
-          ? "bg-background text-muted-foreground/50"
-          : intent === "code"
-            ? "bg-sky-500/10 text-sky-700 dark:text-sky-300"
-            : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-      )}
-    >
-      <Plus className="size-3" aria-hidden="true" />
-      <Icon className="size-3" aria-hidden="true" />
-      <span>{intent === "code" ? "Code" : "Markdown"}</span>
-    </button>
-  );
-}
-
-function SplitAction({ intent, muted = false }: { intent: Intent; muted?: boolean }) {
-  const Icon = intent === "code" ? Code : LetterText;
-
-  return (
-    <button
-      type="button"
-      className={cn(
-        "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors",
-        muted
-          ? "text-muted-foreground/50 hover:bg-muted/50 hover:text-foreground"
-          : intent === "code"
-            ? "bg-sky-500/10 text-sky-700 ring-1 ring-sky-500/15 dark:text-sky-300"
-            : "bg-emerald-500/10 text-emerald-700 ring-1 ring-emerald-500/15 dark:text-emerald-300",
-      )}
-    >
-      <Plus className="size-3" aria-hidden="true" />
-      <Icon className="size-3" aria-hidden="true" />
-      <span>{intent === "code" ? "Code" : "Markdown"}</span>
-    </button>
   );
 }

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -53,6 +53,32 @@ const codeCell: CodeCellType = scenarioCodeCellToStandaloneCodeCell(
   standaloneCodeCellOutputs,
 );
 
+const hiddenCodeCellRows = [
+  hiddenCodeCellFixture({
+    id: "elements-hidden-source-cell",
+    label: "Source hidden",
+    detail: "Production CodeCell renders the source reveal while outputs remain visible.",
+    sourceHidden: true,
+    outputsHidden: false,
+  }),
+  hiddenCodeCellFixture({
+    id: "elements-hidden-output-cell",
+    label: "Outputs hidden",
+    detail:
+      "Production CodeCell keeps the source and current line visible while output reveal owns the output row.",
+    sourceHidden: false,
+    outputsHidden: true,
+  }),
+  hiddenCodeCellFixture({
+    id: "elements-hidden-both-cell",
+    label: "Source and outputs hidden",
+    detail: "Production CodeCell collapses to the shared hidden-cell reveal affordance.",
+    sourceHidden: true,
+    outputsHidden: true,
+    hiddenGroupCount: 1,
+  }),
+];
+
 const markdownFixtureSource = [
   "## Forecast review",
   "",
@@ -86,7 +112,7 @@ const fullCellRows = [
     label: "CodeCell",
     source: "apps/notebook/src/components/CodeCell.tsx",
     detail:
-      "Rendered with seeded execution and output stores, ribbon-first CellContainer, code-cell current line, and OutputArea.",
+      "Rendered with seeded execution and output stores, ribbon-first CellContainer, code-cell current line, OutputArea, and hidden source/output states.",
   },
   {
     label: "MarkdownCell",
@@ -116,6 +142,13 @@ const fullCellBoundaryRows = [
     productionBoundary: "runtimed execution pipeline",
     detail:
       "Scenario code cells seed the same execution pointer and output ID stores as production, but queueing, kernel lifecycle, and output mutation still stay outside the docs runtime.",
+  },
+  {
+    surface: "Hidden source/output state",
+    catalogPath: "fixture metadata.jupyter flags",
+    productionBoundary: "NotebookView source/output visibility mutations",
+    detail:
+      "The catalog renders production CodeCell hidden affordances from static metadata. Production writes those flags back through notebook document mutations.",
   },
   {
     surface: "Transient cell UI state",
@@ -168,6 +201,49 @@ function scenarioCodeCellToStandaloneCodeCell(
   };
 }
 
+function hiddenCodeCellFixture({
+  id,
+  label,
+  detail,
+  sourceHidden,
+  outputsHidden,
+  hiddenGroupCount,
+}: {
+  id: string;
+  label: string;
+  detail: string;
+  sourceHidden: boolean;
+  outputsHidden: boolean;
+  hiddenGroupCount?: number;
+}) {
+  const outputs = primaryScenarioCodeCell.outputs.map((output, index) => ({
+    ...output,
+    output_id: `${id}:output:${output.output_id ?? index}`,
+  })) as JupyterOutput[];
+  const cell = scenarioCodeCellToStandaloneCodeCell(primaryScenarioCodeCell, id, outputs);
+
+  cell.metadata = {
+    ...cell.metadata,
+    jupyter: {
+      ...(cell.metadata?.jupyter as Record<string, unknown> | undefined),
+      source_hidden: sourceHidden,
+      outputs_hidden: outputsHidden,
+    },
+  };
+
+  return {
+    id,
+    label,
+    detail,
+    sourceHidden,
+    outputsHidden,
+    hiddenGroupCount,
+    executionId: `${id}:execution`,
+    outputs,
+    cell,
+  };
+}
+
 function scenarioCellToNotebookCell(cell: NotebookViewCell): NotebookCell {
   if (cell.cellType === "code") {
     return {
@@ -216,6 +292,26 @@ function seedFullCellFixtures() {
     submitted_by_actor_label: fullCellScenario.capabilities.access.actorLabel,
   });
   setCellExecutionPointer(codeCell.id, standaloneCodeCellExecutionId);
+
+  for (const row of hiddenCodeCellRows) {
+    const outputIds = row.outputs
+      .map((output) => output.output_id)
+      .filter((outputId): outputId is string => Boolean(outputId));
+
+    for (const output of row.outputs) {
+      if (!output.output_id) continue;
+      setOutput(output.output_id, output);
+    }
+
+    setExecution(row.executionId, {
+      execution_count: primaryScenarioCodeCell.executionCount,
+      status: "done",
+      success: true,
+      output_ids: outputIds,
+      submitted_by_actor_label: fullCellScenario.capabilities.access.actorLabel,
+    });
+    setCellExecutionPointer(row.cell.id, row.executionId);
+  }
 
   for (const cell of fullCellScenario.cells) {
     if (cell.cellType !== "code" || !cell.executionId) continue;
@@ -331,6 +427,47 @@ export function FullCellSurfacesExample() {
                 </span>
               }
             />
+          </div>
+        </section>
+
+        <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+          <div className="border-b border-fd-border p-4">
+            <div className="flex items-center gap-2">
+              <FileCode2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <h2 className="text-sm font-semibold">CodeCell hidden states</h2>
+            </div>
+            <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
+              Source-hidden, output-hidden, and fully-hidden affordances are owned by the production
+              `CodeCell`. The catalog seeds metadata and output stores, then supplies inert toggle
+              callbacks.
+            </p>
+          </div>
+          <div className="divide-y divide-border bg-background">
+            {hiddenCodeCellRows.map((row) => (
+              <div key={row.id} className="grid gap-4 p-4 xl:grid-cols-[220px_minmax(0,1fr)]">
+                <div>
+                  <h3 className="text-sm font-semibold">{row.label}</h3>
+                  <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">{row.detail}</p>
+                </div>
+                <div className="min-w-0 rounded-md border border-border bg-background py-3 pl-3 pr-2">
+                  <CodeCell
+                    cell={row.cell}
+                    language={codeCellLanguage}
+                    onFocus={() => focusFixtureCell(row.cell.id)}
+                    onExecute={noop}
+                    onInterrupt={noop}
+                    onDelete={noop}
+                    onFocusPrevious={noop}
+                    onFocusNext={noop}
+                    onInsertCellAfter={noop}
+                    onToggleSourceHidden={noop}
+                    onToggleOutputsHidden={noop}
+                    hiddenGroupCount={row.hiddenGroupCount}
+                    onExpandHiddenGroup={noop}
+                  />
+                </div>
+              </div>
+            ))}
           </div>
         </section>
 

--- a/apps/elements/content/docs/cell-execution-language.mdx
+++ b/apps/elements/content/docs/cell-execution-language.mdx
@@ -1,16 +1,17 @@
 ---
 title: Cell execution language
-description: Visual language sketches for the code cell run line and execution signal.
+description: Production CodeCellCurrentLine and CompactExecutionButton states.
 ---
 
 import { CellExecutionLanguageExample } from "@/components/cell-execution-language-example";
 
 The code cell run line should feel like notebook punctuation first and status
-copy second. Quiet states should carry just enough evidence to orient the
-reader, while active states can speak with color, motion, and explicit words.
+copy second. This page renders the current production execution components
+directly: `CompactExecutionButton` for the state lane and
+`CodeCellCurrentLine` for the source/result boundary.
 
-The production line now follows that grammar: completed cells rest as a small
-run marker, ready cells stay visually quiet, and the full language context
-returns when the reader approaches the cell.
+Fixture state drives the examples, but there are no alternate catalog-only
+execution-line components here. If the visual language changes, it should
+change in `src/components/cell` first.
 
 <CellExecutionLanguageExample />

--- a/apps/elements/content/docs/cell-insertion-affordances.mdx
+++ b/apps/elements/content/docs/cell-insertion-affordances.mdx
@@ -1,19 +1,16 @@
 ---
 title: Cell insertion affordances
-description: Fixture-backed sketches for making add-cell rows feel connected to the notebook spine.
+description: Production CellInsertionRibbon states for notebook add-cell rows.
 ---
 
 import { CellInsertionAffordancesExample } from "@/components/cell-insertion-affordances-example";
 
-The add-cell row now follows the same line language as the current execution
-line: the ribbon remains part of the document spine, the choices attach to a
-quiet rule, and color appears only once the reader targets a concrete cell
-type.
+The add-cell row follows the same line language as the current execution line:
+the ribbon remains part of the document spine, the choices attach to a quiet
+rule, and color appears only once the reader targets a concrete cell type.
 
-The production row now treats proximity as neutral document intent. Code and
-markdown color arrive only when a concrete target is hovered or focused, then
-fade back into the document rule instead of becoming a floating control surface.
-The left channel remains clickable, but it stays visually quiet until the reader
-actually points at code or markdown.
+This page renders `CellInsertionRibbon` directly with fixture state. There are
+no alternate docs-local insertion controls here; changes should land in
+`src/components/cell/CellInsertionRibbon.tsx` first.
 
 <CellInsertionAffordancesExample />

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -22,12 +22,11 @@ repo-level `docs/` tree.
 
 ## Current direction
 
-Keep the production-backed notebook surfaces ahead of design-only exploration.
-The catalog should render shared shell, rail, toolbar, identity, package, cell,
-output, and widget components from deterministic fixtures without importing the
-desktop runtime, sync engine, Cloudflare host, or generated runtimed WASM
-bindings. Renderer-specific assets like Sift WASM should stay explicit,
-docs-served adapters.
+Keep the catalog production-backed. It should render shared shell, rail,
+toolbar, identity, package, cell, output, and widget components from
+deterministic fixtures without importing the desktop runtime, sync engine,
+Cloudflare host, or generated runtimed WASM bindings. Renderer-specific assets
+like Sift WASM should stay explicit, docs-served adapters.
 
 ## Production-backed catalog
 
@@ -40,6 +39,8 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Notebook outline rail](/docs/notebook-outline)
 - [Package manager surfaces](/docs/package-manager-surfaces)
 - [Cell anatomy](/docs/cell-anatomy)
+- [Cell execution language](/docs/cell-execution-language)
+- [Cell insertion affordances](/docs/cell-insertion-affordances)
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Search surfaces](/docs/search-surfaces)
@@ -48,11 +49,3 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)
 - [Theme surfaces](/docs/theme-surfaces)
 - [Widget surfaces](/docs/widget-surfaces)
-
-## Design explorations
-
-These pages are still useful, but they are product-language studios until the
-corresponding shared component surface is ready:
-
-- [Cell execution language](/docs/cell-execution-language)
-- [Cell insertion affordances](/docs/cell-insertion-affordances)


### PR DESCRIPTION
## Summary

- remove the remaining catalog-only execution-line and insertion-row sketches from Elements
- make the cell execution and insertion pages render only production `src/components/cell` surfaces
- move those pages out of the design exploration bucket and into the production-backed catalog
- drop the speculative current-line studio from the cell anatomy page
- move hidden source/output examples onto production `CodeCell` instead of hand-rolled anatomy fixtures

## Notes

This PR keeps fixture data and wrapper layout in `apps/elements`, but the notebook UI under review now comes from current nteract-owned components. Follow-up cleanup can continue auditing shell-level pages for places where a matrix or boundary map should be paired with a production rendered surface.

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
