### PR TITLE
fix(notebook): refine fluid rail surfaces

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -105,7 +105,7 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
-const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 40rem)";
+const RAIL_TAKEOVER_MEDIA_QUERY = "(width < 600px)";
 
 function focusRailCollapseButtonWhenStageIsHidden(railCollapsed: boolean): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
@@ -2036,7 +2036,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[40rem]:hidden")}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[600px]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2001,7 +2001,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[600px]:hidden")}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[44rem]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -105,7 +105,7 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
-const RAIL_TAKEOVER_MEDIA_QUERY = "(width < 600px)";
+const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599px)";
 
 function focusRailCollapseButtonWhenStageIsHidden(railCollapsed: boolean): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2001,11 +2001,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn(
-            "flex-row min-w-0 flex-1",
-            !railCollapsed &&
-              (activeRailPanel === "packages" ? "max-[1400px]:hidden" : "max-sm:hidden"),
-          )}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[600px]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -105,6 +105,26 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
+const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 40rem)";
+
+function focusRailCollapseButtonWhenStageIsHidden(railCollapsed: boolean): void {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
+  if (!takeoverQuery?.matches || railCollapsed) return;
+
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement)) return;
+
+  const stage = document.querySelector('[data-slot="notebook-document-stage"]');
+  if (!stage?.contains(activeElement)) return;
+
+  const collapseButton = document.querySelector<HTMLButtonElement>(
+    '[data-slot="notebook-rail-collapse-button"]',
+  );
+  requestAnimationFrame(() => collapseButton?.focus());
+}
+
 function isLaunchErrorHandledByRuntimeBanner(error: string): boolean {
   return (
     error.includes("ipykernel not found in pixi.toml") ||
@@ -403,6 +423,23 @@ function AppContent() {
   // whenever the kernel transitions out of Error (so the next failure
   // shows the banner fresh) or a different details string arrives.
   const [dismissedLaunchError, setDismissedLaunchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
+    if (!takeoverQuery) return;
+
+    const handleTakeoverChange = () => {
+      focusRailCollapseButtonWhenStageIsHidden(railCollapsed);
+    };
+
+    handleTakeoverChange();
+    takeoverQuery.addEventListener("change", handleTakeoverChange);
+    return () => {
+      takeoverQuery.removeEventListener("change", handleTakeoverChange);
+    };
+  }, [railCollapsed]);
 
   // Daemon startup status (installing, starting, failed, etc.)
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -919,7 +919,6 @@ function AppContent() {
     pyprojectDeps,
     pyprojectInfo?.dependency_count,
     pyprojectInfo?.has_dependencies,
-    pyprojectInfo?.relative_path,
     pixiDeps,
     pixiInfo,
     runtime,

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -32,6 +32,7 @@ import { type BlobUploader, WidgetUpdateManager } from "@/components/widgets/wid
 import { WidgetView } from "@/components/widgets/widget-view";
 import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
+import { cn } from "@/lib/utils";
 import { NotebookPackagesPanel, type NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   navigateNotebookOutlineItem,
@@ -2000,7 +2001,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName="flex-row min-w-0 flex-1"
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-sm:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -105,9 +105,12 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
-const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599px)";
+const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
 
-function focusRailCollapseButtonWhenStageIsHidden(railCollapsed: boolean): void {
+function focusRailCollapseButtonWhenStageIsHidden(
+  railCollapsed: boolean,
+  stageHadFocusBeforeTakeover: boolean,
+): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
@@ -117,7 +120,10 @@ function focusRailCollapseButtonWhenStageIsHidden(railCollapsed: boolean): void 
   if (!(activeElement instanceof HTMLElement)) return;
 
   const stage = document.querySelector('[data-slot="notebook-document-stage"]');
-  if (!stage?.contains(activeElement)) return;
+  const focusWasInStage = stage?.contains(activeElement);
+  const focusWasClearedFromHiddenStage =
+    stageHadFocusBeforeTakeover && activeElement === document.body;
+  if (!focusWasInStage && !focusWasClearedFromHiddenStage) return;
 
   const collapseButton = document.querySelector<HTMLButtonElement>(
     '[data-slot="notebook-rail-collapse-button"]',
@@ -405,6 +411,7 @@ function AppContent() {
 
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(true);
+  const stageHadFocusBeforeRailTakeoverRef = useRef(false);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
@@ -425,19 +432,40 @@ function AppContent() {
   const [dismissedLaunchError, setDismissedLaunchError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const stage = document.querySelector('[data-slot="notebook-document-stage"]');
+      stageHadFocusBeforeRailTakeoverRef.current = Boolean(
+        event.target instanceof Node && stage?.contains(event.target),
+      );
+    };
+
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, []);
+
+  useEffect(() => {
     if (typeof window === "undefined") return;
 
     const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
     if (!takeoverQuery) return;
 
     const handleTakeoverChange = () => {
-      focusRailCollapseButtonWhenStageIsHidden(railCollapsed);
+      focusRailCollapseButtonWhenStageIsHidden(
+        railCollapsed,
+        stageHadFocusBeforeRailTakeoverRef.current,
+      );
     };
 
     handleTakeoverChange();
     takeoverQuery.addEventListener("change", handleTakeoverChange);
+    window.addEventListener("resize", handleTakeoverChange);
     return () => {
       takeoverQuery.removeEventListener("change", handleTakeoverChange);
+      window.removeEventListener("resize", handleTakeoverChange);
     };
   }, [railCollapsed]);
 
@@ -2036,7 +2064,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[600px]:hidden")}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[599.98px]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -891,22 +891,21 @@ function AppContent() {
     if (envType === "conda") {
       if (environmentYmlInfo) {
         const count = environmentYmlPackageCount(environmentYmlDeps, environmentYmlInfo);
-        return `${environmentYmlInfo.relative_path} · ${packageCountLabel(count)}`;
+        return packageCountLabel(count);
       }
       return `conda · ${packageCountLabel(condaDependencies?.dependencies.length ?? 0)}`;
     }
     if (envType === "pixi") {
       if (pixiInfo) {
         const pixiCount = pixiPackageCount(pixiInfo);
-        return `${pixiInfo.relative_path} · ${packageCountLabel(pixiCount)}`;
+        return packageCountLabel(pixiCount);
       }
       const pixiCount = pixiInlinePackageCount(pixiDeps);
       return `pixi · ${packageCountLabel(pixiCount)}`;
     }
     if (envSource === "uv:pyproject" || pyprojectInfo?.has_dependencies) {
-      const source = pyprojectInfo?.relative_path ?? "pyproject.toml";
       const count = pyprojectPackageCount(pyprojectDeps, pyprojectInfo?.dependency_count);
-      return count === null ? source : `${source} · ${packageCountLabel(count)}`;
+      return count === null ? "Project env" : packageCountLabel(count);
     }
     return `uv · ${packageCountLabel(dependencies?.dependencies.length ?? 0)}`;
   }, [

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2001,7 +2001,11 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-sm:hidden")}
+          stageClassName={cn(
+            "flex-row min-w-0 flex-1",
+            !railCollapsed &&
+              (activeRailPanel === "packages" ? "max-[1400px]:hidden" : "max-sm:hidden"),
+          )}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1999,7 +1999,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[37.5rem]:hidden")}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[40rem]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1999,7 +1999,7 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[44rem]:hidden")}
+          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[37.5rem]:hidden")}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -264,7 +264,7 @@ export function DependencyHeader({
         {isUsingProjectEnv && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <div className="min-w-0 space-y-1 leading-5">
+            <div className="min-w-0 flex-1 space-y-1 leading-5">
               <div>
                 Using <code className="rounded bg-muted px-1">{pyprojectPath}</code>
               </div>

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -37,8 +37,8 @@ export function PackageSpecList({
     <div
       className={cn(
         framed
-          ? "overflow-hidden rounded-md border bg-background shadow-sm shadow-black/[0.02]"
-          : "overflow-hidden rounded-md bg-transparent",
+          ? "w-full overflow-hidden rounded-md border bg-background shadow-sm shadow-black/[0.02]"
+          : "w-full overflow-hidden rounded-md bg-transparent",
         className,
       )}
     >

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -27,6 +27,9 @@ const toneDotClasses: Record<PackageSpecTone, string> = {
   neutral: "bg-muted-foreground/50",
 };
 
+const markerStartPattern =
+  /^(?:python_version|python_full_version|os_name|sys_platform|platform_release|platform_system|platform_version|platform_machine|platform_python_implementation|implementation_name|implementation_version|extra)\b/;
+
 export function PackageSpecList({
   values,
   tone = "neutral",
@@ -118,7 +121,7 @@ export function PackageSpecList({
 
 export function parsePackageSpec(value: string): { name: string; spec: string | null } {
   const trimmed = value.trim();
-  const markerStart = trimmed.indexOf(";");
+  const markerStart = findEnvironmentMarkerStart(trimmed);
   if (markerStart > 0) {
     const packagePart = trimmed.slice(0, markerStart).trim();
     const markerPart = trimmed.slice(markerStart + 1).trim();
@@ -129,10 +132,34 @@ export function parsePackageSpec(value: string): { name: string; spec: string | 
     };
   }
 
+  const urlDependencyStart = trimmed.indexOf(" @ ");
+  if (urlDependencyStart > 0) {
+    return {
+      name: trimmed.slice(0, urlDependencyStart).trim(),
+      spec: trimmed.slice(urlDependencyStart).trim() || null,
+    };
+  }
+
   const specStart = trimmed.search(/[<>=!~]/);
   if (specStart <= 0) return { name: trimmed, spec: null };
   return {
     name: trimmed.slice(0, specStart).trim(),
     spec: trimmed.slice(specStart).trim() || null,
   };
+}
+
+function findEnvironmentMarkerStart(value: string): number {
+  let searchStart = 0;
+
+  while (searchStart < value.length) {
+    const markerStart = value.indexOf(";", searchStart);
+    if (markerStart === -1) return -1;
+
+    const markerCandidate = value.slice(markerStart + 1).trimStart();
+    if (markerStartPattern.test(markerCandidate)) return markerStart;
+
+    searchStart = markerStart + 1;
+  }
+
+  return -1;
 }

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -44,17 +44,19 @@ export function PackageSpecList({
     >
       {values.map((value, index) => {
         const parsed = parsePackageSpec(value);
+        const hasEnvironmentMarker = value.includes(";");
         return (
           <div
             key={`${index}-${value}`}
             className={cn(
-              "flex min-h-9 items-center gap-2 border-b px-2.5 py-1.5 text-xs last:border-b-0",
+              "grid min-h-9 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-x-2 gap-y-0.5 border-b px-2.5 py-1.5 text-xs last:border-b-0",
               !framed && "px-0",
             )}
           >
             <span
               className={cn(
                 "flex size-5 shrink-0 items-center justify-center rounded-full ring-1",
+                hasEnvironmentMarker && parsed.spec && "row-span-2 self-start",
                 toneClasses[tone],
               )}
               aria-hidden="true"
@@ -62,7 +64,11 @@ export function PackageSpecList({
               <Package className="size-3" />
             </span>
             <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
-            {parsed.spec ? (
+            {parsed.spec && hasEnvironmentMarker ? (
+              <span className="col-span-3 col-start-2 min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+                {parsed.spec}
+              </span>
+            ) : parsed.spec ? (
               <span className="max-w-[8rem] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
                 {parsed.spec}
               </span>
@@ -88,6 +94,17 @@ export function PackageSpecList({
 
 export function parsePackageSpec(value: string): { name: string; spec: string | null } {
   const trimmed = value.trim();
+  const markerStart = trimmed.indexOf(";");
+  if (markerStart > 0) {
+    const packagePart = trimmed.slice(0, markerStart).trim();
+    const markerPart = trimmed.slice(markerStart + 1).trim();
+    const parsedPackage = parsePackageSpec(packagePart);
+    return {
+      name: parsedPackage.name,
+      spec: [parsedPackage.spec, markerPart].filter(Boolean).join(" · ") || null,
+    };
+  }
+
   const specStart = trimmed.search(/[<>=!~]/);
   if (specStart <= 0) return { name: trimmed, spec: null };
   return {

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -20,6 +20,13 @@ const toneClasses: Record<PackageSpecTone, string> = {
   neutral: "text-muted-foreground bg-muted/70 ring-border/60",
 };
 
+const toneDotClasses: Record<PackageSpecTone, string> = {
+  uv: "bg-uv/60",
+  conda: "bg-emerald-500/60",
+  pixi: "bg-amber-500/60",
+  neutral: "bg-muted-foreground/50",
+};
+
 export function PackageSpecList({
   values,
   tone = "neutral",
@@ -45,27 +52,49 @@ export function PackageSpecList({
       {values.map((value, index) => {
         const parsed = parsePackageSpec(value);
         const hasEnvironmentMarker = value.includes(";");
+        const showIcon = framed || Boolean(onRemove);
+        const showDot = !showIcon;
         return (
           <div
             key={`${index}-${value}`}
             className={cn(
-              "grid min-h-9 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-x-2 gap-y-0.5 border-b px-2.5 py-1.5 text-xs last:border-b-0",
+              "grid items-center gap-x-2 gap-y-0.5 border-b px-2.5 py-1.5 text-xs last:border-b-0",
+              showIcon
+                ? "min-h-9 grid-cols-[auto_minmax(0,1fr)_auto_auto]"
+                : "min-h-8 grid-cols-[auto_minmax(0,1fr)_auto_auto]",
               !framed && "px-0",
             )}
           >
-            <span
-              className={cn(
-                "flex size-5 shrink-0 items-center justify-center rounded-full ring-1",
-                hasEnvironmentMarker && parsed.spec && "row-span-2 self-start",
-                toneClasses[tone],
-              )}
-              aria-hidden="true"
-            >
-              <Package className="size-3" />
-            </span>
+            {showIcon && (
+              <span
+                className={cn(
+                  "flex size-5 shrink-0 items-center justify-center rounded-full ring-1",
+                  hasEnvironmentMarker && parsed.spec && "row-span-2 self-start",
+                  toneClasses[tone],
+                )}
+                aria-hidden="true"
+              >
+                <Package className="size-3" />
+              </span>
+            )}
+            {showDot && (
+              <span
+                className={cn(
+                  "mt-1.5 size-1.5 self-start rounded-full",
+                  hasEnvironmentMarker && parsed.spec && "row-span-2",
+                  toneDotClasses[tone],
+                )}
+                aria-hidden="true"
+              />
+            )}
             <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
             {parsed.spec && hasEnvironmentMarker ? (
-              <span className="col-span-3 col-start-2 min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+              <span
+                className={cn(
+                  "min-w-0 truncate font-mono text-[11px] text-muted-foreground",
+                  showIcon || showDot ? "col-span-3 col-start-2" : "col-span-3 col-start-1",
+                )}
+              >
                 {parsed.spec}
               </span>
             ) : parsed.spec ? (

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -89,12 +89,7 @@ export function PackageSpecList({
             )}
             <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
             {parsed.spec && hasEnvironmentMarker ? (
-              <span
-                className={cn(
-                  "min-w-0 truncate font-mono text-[11px] text-muted-foreground",
-                  showIcon || showDot ? "col-span-3 col-start-2" : "col-span-3 col-start-1",
-                )}
-              >
+              <span className="col-span-3 col-start-2 min-w-0 truncate font-mono text-[11px] text-muted-foreground">
                 {parsed.spec}
               </span>
             ) : parsed.spec ? (

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -60,6 +60,7 @@ export function PackageSpecList({
         return (
           <div
             key={`${index}-${value}`}
+            title={value}
             className={cn(
               "grid items-center gap-x-2 gap-y-0.5 border-b px-2.5 py-1.5 text-xs last:border-b-0",
               showIcon
@@ -90,13 +91,21 @@ export function PackageSpecList({
                 aria-hidden="true"
               />
             )}
-            <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
+            <span className="min-w-0 flex-1 truncate font-mono text-foreground" title={parsed.name}>
+              {parsed.name}
+            </span>
             {parsed.spec && hasEnvironmentMarker ? (
-              <span className="col-span-3 col-start-2 min-w-0 whitespace-normal break-words text-[11px] leading-snug text-muted-foreground">
+              <span
+                className="col-span-3 col-start-2 min-w-0 whitespace-normal break-words text-[11px] leading-snug text-muted-foreground"
+                title={parsed.spec}
+              >
                 {parsed.spec}
               </span>
             ) : parsed.spec ? (
-              <span className="max-w-[8rem] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+              <span
+                className="max-w-[8rem] truncate rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+                title={parsed.spec}
+              >
                 {parsed.spec}
               </span>
             ) : null}

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -54,7 +54,7 @@ export function PackageSpecList({
     >
       {values.map((value, index) => {
         const parsed = parsePackageSpec(value);
-        const hasEnvironmentMarker = value.includes(";");
+        const hasEnvironmentMarker = findEnvironmentMarkerStart(value.trim()) > 0;
         const showIcon = framed || Boolean(onRemove);
         const showDot = !showIcon;
         return (
@@ -92,7 +92,7 @@ export function PackageSpecList({
             )}
             <span className="min-w-0 flex-1 truncate font-mono text-foreground">{parsed.name}</span>
             {parsed.spec && hasEnvironmentMarker ? (
-              <span className="col-span-3 col-start-2 min-w-0 truncate font-mono text-[11px] text-muted-foreground">
+              <span className="col-span-3 col-start-2 min-w-0 whitespace-normal break-words text-[11px] leading-snug text-muted-foreground">
                 {parsed.spec}
               </span>
             ) : parsed.spec ? (

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -36,6 +36,8 @@ describe("PackageSpecList", () => {
     expect(container.querySelector(".bg-uv\\/60")).toBeInTheDocument();
     expect(screen.getByText("nteract")).toBeVisible();
     expect(screen.getByText("sys_platform == 'darwin'")).toBeVisible();
+    expect(screen.getByText("sys_platform == 'darwin'")).not.toHaveClass("truncate");
+    expect(screen.getByText("sys_platform == 'darwin'")).toHaveClass("whitespace-normal");
   });
 
   it("exposes row remove actions when mutation is available", () => {
@@ -70,7 +72,27 @@ describe("PackageSpecList", () => {
       name: "example",
       spec: "@ https://packages.example.test/example;download=1 · python_version >= '3.11'",
     });
+    expect(parsePackageSpec("example @ https://packages.example.test/example;download=1")).toEqual({
+      name: "example",
+      spec: "@ https://packages.example.test/example;download=1",
+    });
     expect(parsePackageSpec("numpy")).toEqual({ name: "numpy", spec: null });
+  });
+
+  it("does not render URL semicolons as environment-marker rows", () => {
+    render(
+      <PackageSpecList
+        values={["example @ https://packages.example.test/example;download=1"]}
+        tone="uv"
+        emptyLabel="No dependencies"
+        framed={false}
+      />,
+    );
+
+    const urlSpec = screen.getByText("@ https://packages.example.test/example;download=1");
+    expect(urlSpec).toBeVisible();
+    expect(urlSpec).not.toHaveClass("whitespace-normal");
+    expect(urlSpec).toHaveClass("font-mono");
   });
 });
 

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -35,9 +35,31 @@ describe("PackageSpecList", () => {
     expect(container.querySelector("svg")).not.toBeInTheDocument();
     expect(container.querySelector(".bg-uv\\/60")).toBeInTheDocument();
     expect(screen.getByText("nteract")).toBeVisible();
+    expect(screen.getByText("gremlin")).toHaveAttribute("title", "gremlin");
     expect(screen.getByText("sys_platform == 'darwin'")).toBeVisible();
+    expect(screen.getByText("sys_platform == 'darwin'")).toHaveAttribute(
+      "title",
+      "sys_platform == 'darwin'",
+    );
     expect(screen.getByText("sys_platform == 'darwin'")).not.toHaveClass("truncate");
     expect(screen.getByText("sys_platform == 'darwin'")).toHaveClass("whitespace-normal");
+  });
+
+  it("keeps full package specs available when rail text truncates", () => {
+    render(
+      <PackageSpecList
+        values={["nteract-kernel-launcher>=1.2.3"]}
+        tone="uv"
+        emptyLabel="No dependencies"
+        framed={false}
+      />,
+    );
+
+    expect(screen.getByText("nteract-kernel-launcher")).toHaveAttribute(
+      "title",
+      "nteract-kernel-launcher",
+    );
+    expect(screen.getByText(">=1.2.3")).toHaveAttribute("title", ">=1.2.3");
   });
 
   it("exposes row remove actions when mutation is available", () => {

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -22,6 +22,22 @@ describe("PackageSpecList", () => {
     expect(screen.getAllByText("numpy")).toHaveLength(2);
   });
 
+  it("quiets read-only package rows without dropping tone", () => {
+    const { container } = render(
+      <PackageSpecList
+        values={["nteract", "gremlin ; sys_platform == 'darwin'"]}
+        tone="uv"
+        emptyLabel="No dependencies"
+        framed={false}
+      />,
+    );
+
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+    expect(container.querySelector(".bg-uv\\/60")).toBeInTheDocument();
+    expect(screen.getByText("nteract")).toBeVisible();
+    expect(screen.getByText("sys_platform == 'darwin'")).toBeVisible();
+  });
+
   it("exposes row remove actions when mutation is available", () => {
     const onRemove = vi.fn();
 

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -38,6 +38,14 @@ describe("PackageSpecList", () => {
       name: "scikit-learn",
       spec: ">=1.5",
     });
+    expect(parsePackageSpec("gremlin ; sys_platform == 'darwin'")).toEqual({
+      name: "gremlin",
+      spec: "sys_platform == 'darwin'",
+    });
+    expect(parsePackageSpec("pyzmq>=26 ; python_version >= '3.11'")).toEqual({
+      name: "pyzmq",
+      spec: ">=26 · python_version >= '3.11'",
+    });
     expect(parsePackageSpec("numpy")).toEqual({ name: "numpy", spec: null });
   });
 });

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -62,6 +62,14 @@ describe("PackageSpecList", () => {
       name: "pyzmq",
       spec: ">=26 · python_version >= '3.11'",
     });
+    expect(
+      parsePackageSpec(
+        "example @ https://packages.example.test/example;download=1 ; python_version >= '3.11'",
+      ),
+    ).toEqual({
+      name: "example",
+      spec: "@ https://packages.example.test/example;download=1 · python_version >= '3.11'",
+    });
     expect(parsePackageSpec("numpy")).toEqual({ name: "numpy", spec: null });
   });
 });

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -253,6 +253,9 @@ describe("CodeCell output focus", () => {
     expect(footer?.textContent).not.toContain("In [12]");
     expect(status).toHaveClass("max-w-64");
     expect(status).toHaveClass("opacity-100");
+    expect(container.querySelector('[data-slot="code-cell-current-line-detail"]')).toHaveClass(
+      "max-w-0",
+    );
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
     expect(rule).toHaveClass("flex-1");
   });

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -392,7 +392,9 @@ export function CodeCellCurrentLine({
               : "max-w-64 opacity-100",
             isCompletedRunDetail &&
               "max-w-0 overflow-hidden opacity-0 group-hover:max-w-40 group-hover:opacity-100 group-focus-within:max-w-40 group-focus-within:opacity-100",
-            isCompletedRunDetail && isFocused && "max-w-64 opacity-100",
+            isCompletedRunDetail &&
+              isFocused &&
+              "max-w-64 opacity-100 group-hover:max-w-64 group-focus-within:max-w-64",
             visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
             isQueued && "font-semibold text-sky-700 dark:text-sky-300",
             isErrored && "font-semibold text-destructive/80",

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -300,6 +300,7 @@ export function CodeCellCurrentLine({
     isErrored,
   });
   const isIdleReadyDetail = boundaryState === "idle" && detailLabel === "ready";
+  const isCompletedRunDetail = boundaryState === "ran" && count !== null;
   const isQuietContextualState = boundaryState === "idle" || boundaryState === "ran";
   const accessibleDetailLabel = accessibleExecutionDetail({
     count,
@@ -389,6 +390,9 @@ export function CodeCellCurrentLine({
             isIdleReadyDetail
               ? "max-w-0 overflow-hidden opacity-0 group-hover:max-w-16 group-hover:opacity-100 group-focus-within:max-w-16 group-focus-within:opacity-100"
               : "max-w-64 opacity-100",
+            isCompletedRunDetail &&
+              "max-w-0 overflow-hidden opacity-0 group-hover:max-w-40 group-hover:opacity-100 group-focus-within:max-w-40 group-focus-within:opacity-100",
+            isCompletedRunDetail && isFocused && "max-w-64 opacity-100",
             visualIsExecuting && "font-semibold text-emerald-700 dark:text-emerald-300",
             isQueued && "font-semibold text-sky-700 dark:text-sky-300",
             isErrored && "font-semibold text-destructive/80",

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -299,6 +299,8 @@ describe("CodeCellCurrentLine", () => {
     const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
 
     expect(detail).toHaveClass("max-w-64");
+    expect(detail).toHaveClass("group-hover:max-w-64");
+    expect(detail).not.toHaveClass("group-hover:max-w-40");
     expect(detail).toHaveClass("opacity-100");
   });
 

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -264,6 +264,7 @@ describe("CodeCellCurrentLine", () => {
     expect(footer).not.toHaveTextContent("In [12]");
     expect(status).toHaveClass("max-w-64");
     expect(languageContext).toHaveClass("max-w-0");
+    expect(languageContext).toHaveClass("group-hover:max-w-20");
     expect(detail).toHaveClass("max-w-64");
   });
 
@@ -283,10 +284,22 @@ describe("CodeCellCurrentLine", () => {
     expect(status).toHaveAttribute("aria-label", "Python: Run 12 completed");
     expect(languageContext).toHaveClass("max-w-0");
     expect(languageContext).toHaveClass("group-hover:max-w-20");
-    expect(detail).toHaveClass("max-w-64");
-    expect(detail).toHaveClass("opacity-100");
+    expect(detail).toHaveClass("max-w-0");
+    expect(detail).toHaveClass("opacity-0");
+    expect(detail).toHaveClass("group-hover:max-w-40");
     expect(rule).toHaveClass("flex-1");
     expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("shows completed metadata immediately for the focused cell", () => {
+    const { container } = render(
+      <CodeCellCurrentLine languageLabel="Python" count={12} isFocused />,
+    );
+
+    const detail = container.querySelector('[data-slot="code-cell-current-line-detail"]');
+
+    expect(detail).toHaveClass("max-w-64");
+    expect(detail).toHaveClass("opacity-100");
   });
 
   it("can carry activity context after the run state", () => {

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -91,7 +91,10 @@ export function NotebookRail({
       {!collapsed && (
         <div
           className={cn(
-            "flex min-h-0 w-[clamp(18rem,24vw,22rem)] min-w-72 max-w-[calc(100vw-3rem)] flex-col bg-background",
+            "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
+            activePanelId === "packages"
+              ? "w-[clamp(18rem,24vw,22rem)] min-w-72"
+              : "w-[clamp(16rem,20vw,18rem)] min-w-64",
             "max-[44rem]:w-[calc(100vw-3rem)] max-[44rem]:min-w-0 max-[44rem]:max-w-none",
           )}
           data-slot="notebook-rail-panel"

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -90,7 +90,12 @@ export function NotebookRail({
 
       {!collapsed && (
         <div
-          className="flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background max-sm:w-[calc(100vw-3rem)] max-sm:min-w-0 max-sm:max-w-none"
+          className={cn(
+            "flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background",
+            "max-sm:w-[calc(100vw-3rem)] max-sm:min-w-0 max-sm:max-w-none",
+            activePanelId === "packages" &&
+              "max-[1400px]:w-[calc(100vw-3rem)] max-[1400px]:min-w-0 max-[1400px]:max-w-none",
+          )}
           data-slot="notebook-rail-panel"
         >
           <div className="border-b px-4 py-3">

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -93,9 +93,9 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(18rem,24vw,22rem)] min-w-72"
+              ? "w-[clamp(17rem,21vw,19rem)] min-w-[17rem]"
               : "w-[clamp(16rem,20vw,18rem)] min-w-64",
-            "max-[44rem]:w-[calc(100vw-3rem)] max-[44rem]:min-w-0 max-[44rem]:max-w-none",
+            "max-[37.5rem]:w-[calc(100vw-3rem)] max-[37.5rem]:min-w-0 max-[37.5rem]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -93,8 +93,8 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(17rem,21vw,19rem)] min-w-[17rem]"
-              : "w-[clamp(16rem,20vw,18rem)] min-w-64",
+              ? "w-[clamp(14rem,21vw,18rem)] min-w-56"
+              : "w-[clamp(14rem,20vw,17rem)] min-w-56",
             "max-[37.5rem]:w-[calc(100vw-3rem)] max-[37.5rem]:min-w-0 max-[37.5rem]:max-w-none",
           )}
           data-slot="notebook-rail-panel"

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -260,7 +260,7 @@ function NotebookOutlineNode({
     "cursor-pointer select-none touch-manipulation [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
     "before:absolute before:bottom-1.5 before:left-0 before:top-1.5 before:w-0.5 before:rounded-full before:bg-transparent before:transition-colors",
     selected
-      ? "bg-primary/8 text-foreground before:bg-primary"
+      ? "font-medium text-foreground before:bg-primary"
       : "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
   );
   const content = (
@@ -273,7 +273,7 @@ function NotebookOutlineNode({
           data-slot="notebook-outline-item-meta"
           className={cn(
             "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
-            selected ? "bg-primary/10 text-foreground/70" : "bg-muted text-muted-foreground",
+            selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
           {item.statusLabel}
@@ -283,7 +283,7 @@ function NotebookOutlineNode({
           data-slot="notebook-outline-item-meta"
           className={cn(
             "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
-            selected ? "bg-primary/10 text-foreground/70" : "bg-muted text-muted-foreground",
+            selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
           {item.detail}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -256,7 +256,7 @@ function NotebookOutlineNode({
   const selected = selectedItemId === item.id;
   const itemHref = getItemHref?.(item) ?? item.href ?? null;
   const className = cn(
-    "relative flex min-h-8 w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors",
+    "relative flex min-h-8 w-full items-start gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors",
     "cursor-pointer select-none touch-manipulation [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
     "before:absolute before:bottom-1.5 before:left-0 before:top-1.5 before:w-0.5 before:rounded-full before:bg-transparent before:transition-colors",
     selected
@@ -265,14 +265,17 @@ function NotebookOutlineNode({
   );
   const content = (
     <>
-      <span data-slot="notebook-outline-item-title" className="min-w-0 flex-1 truncate">
+      <span
+        data-slot="notebook-outline-item-title"
+        className="line-clamp-2 min-w-0 flex-1 break-words leading-snug [overflow-wrap:anywhere]"
+      >
         {item.title}
       </span>
       {item.statusLabel ? (
         <span
           data-slot="notebook-outline-item-meta"
           className={cn(
-            "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
+            "mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
             selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
@@ -282,7 +285,7 @@ function NotebookOutlineNode({
         <span
           data-slot="notebook-outline-item-meta"
           className={cn(
-            "shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
+            "mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
             selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -91,10 +91,8 @@ export function NotebookRail({
       {!collapsed && (
         <div
           className={cn(
-            "flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background",
-            "max-sm:w-[calc(100vw-3rem)] max-sm:min-w-0 max-sm:max-w-none",
-            activePanelId === "packages" &&
-              "max-[1400px]:w-[calc(100vw-3rem)] max-[1400px]:min-w-0 max-[1400px]:max-w-none",
+            "flex min-h-0 w-[clamp(20rem,26vw,24rem)] min-w-64 max-w-[calc(100vw-3rem)] flex-col bg-background",
+            "max-[600px]:w-[calc(100vw-3rem)] max-[600px]:min-w-0 max-[600px]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -96,7 +96,7 @@ export function NotebookRail({
             activePanelId === "packages"
               ? "w-[clamp(14rem,21vw,18rem)] min-w-56"
               : "w-[clamp(14rem,20vw,17rem)] min-w-56",
-            "max-[40rem]:w-[calc(100vw-3rem)] max-[40rem]:min-w-0 max-[40rem]:max-w-none",
+            "max-[600px]:w-[calc(100vw-3rem)] max-[600px]:min-w-0 max-[600px]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -96,7 +96,7 @@ export function NotebookRail({
             activePanelId === "packages"
               ? "w-[clamp(14rem,21vw,18rem)] min-w-56"
               : "w-[clamp(14rem,20vw,17rem)] min-w-56",
-            "max-[600px]:w-[calc(100vw-3rem)] max-[600px]:min-w-0 max-[600px]:max-w-none",
+            "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -91,8 +91,8 @@ export function NotebookRail({
       {!collapsed && (
         <div
           className={cn(
-            "flex min-h-0 w-[clamp(20rem,26vw,24rem)] min-w-64 max-w-[calc(100vw-3rem)] flex-col bg-background",
-            "max-[600px]:w-[calc(100vw-3rem)] max-[600px]:min-w-0 max-[600px]:max-w-none",
+            "flex min-h-0 w-[clamp(18rem,24vw,22rem)] min-w-72 max-w-[calc(100vw-3rem)] flex-col bg-background",
+            "max-[44rem]:w-[calc(100vw-3rem)] max-[44rem]:min-w-0 max-[44rem]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -97,15 +97,15 @@ export function NotebookRail({
           data-slot="notebook-rail-panel"
         >
           <div className="border-b px-4 py-3">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+            <div className="flex flex-col gap-2">
               <div className="min-w-0">
                 <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
                   Notebook
                 </p>
-                <h2 className="mt-1 truncate text-sm font-semibold text-foreground">{title}</h2>
+                <h2 className="mt-1 text-sm font-semibold text-foreground">{title}</h2>
               </div>
               {summary && (
-                <span className="max-w-full self-start truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground sm:shrink-0">
+                <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
                   {summary}
                 </span>
               )}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -68,6 +68,7 @@ export function NotebookRail({
           label={collapsed ? "Expand rail" : "Collapse rail"}
           icon={collapsed ? ChevronRight : ChevronLeft}
           active={false}
+          dataSlot="notebook-rail-collapse-button"
           onClick={() => onCollapsedChange(!collapsed)}
         />
         {railButtons.map((item) => (
@@ -139,6 +140,7 @@ export function NotebookRail({
 export interface NotebookRailButtonProps {
   label: string;
   icon: LucideIcon;
+  dataSlot?: string;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
@@ -147,6 +149,7 @@ export interface NotebookRailButtonProps {
 export function NotebookRailButton({
   label,
   icon: Icon,
+  dataSlot,
   active = false,
   disabled = false,
   onClick,
@@ -159,6 +162,7 @@ export function NotebookRailButton({
       title={label}
       disabled={disabled}
       onClick={onClick}
+      data-slot={dataSlot}
       className={cn(
         "flex size-8 items-center justify-center rounded-md border text-xs transition-colors",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -90,11 +90,11 @@ export function NotebookRail({
 
       {!collapsed && (
         <div
-          className="flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background"
+          className="flex min-h-0 w-80 max-w-[34vw] min-w-64 flex-col bg-background max-sm:w-[calc(100vw-3rem)] max-sm:min-w-0 max-sm:max-w-none"
           data-slot="notebook-rail-panel"
         >
           <div className="border-b px-4 py-3">
-            <div className="flex items-start justify-between gap-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
               <div className="min-w-0">
                 <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
                   Notebook
@@ -102,7 +102,7 @@ export function NotebookRail({
                 <h2 className="mt-1 truncate text-sm font-semibold text-foreground">{title}</h2>
               </div>
               {summary && (
-                <span className="shrink-0 rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+                <span className="max-w-full self-start truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground sm:shrink-0">
                   {summary}
                 </span>
               )}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -95,7 +95,7 @@ export function NotebookRail({
             activePanelId === "packages"
               ? "w-[clamp(14rem,21vw,18rem)] min-w-56"
               : "w-[clamp(14rem,20vw,17rem)] min-w-56",
-            "max-[37.5rem]:w-[calc(100vw-3rem)] max-[37.5rem]:min-w-0 max-[37.5rem]:max-w-none",
+            "max-[40rem]:w-[calc(100vw-3rem)] max-[40rem]:min-w-0 max-[40rem]:max-w-none",
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -48,7 +48,10 @@ describe("NotebookRail", () => {
       "aria-current",
       "location",
     );
-    expect(screen.getByRole("link", { name: "Load data" })).toHaveClass("bg-primary/8");
+    expect(screen.getByRole("link", { name: "Load data" })).toHaveClass(
+      "font-medium",
+      "before:bg-primary",
+    );
     expect(screen.queryByText("2 items")).not.toBeInTheDocument();
     expect(screen.queryByText("1 item")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Load data" })).toHaveAttribute(

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -125,6 +125,23 @@ describe("NotebookRail", () => {
     expect(onActivePanelChange).not.toHaveBeenCalled();
   });
 
+  it("exposes the collapse control for narrow takeover focus recovery", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-slot="notebook-rail-collapse-button"]'),
+    ).toHaveAccessibleName("Collapse rail");
+  });
+
   it("collapses the expanded packages panel from its rail button", () => {
     const onActivePanelChange = vi.fn();
     const onCollapsedChange = vi.fn();

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -179,7 +179,7 @@ describe("NotebookRail", () => {
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(16rem,20vw,18rem)]",
-      "max-[44rem]:w-[calc(100vw-3rem)]",
+      "max-[37.5rem]:w-[calc(100vw-3rem)]",
     );
   });
 
@@ -196,8 +196,8 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(18rem,24vw,22rem)]",
-      "min-w-72",
+      "w-[clamp(17rem,21vw,19rem)]",
+      "min-w-[17rem]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -85,6 +85,23 @@ describe("NotebookRail", () => {
     expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 
+  it("keeps the active panel title primary when package metadata is present", () => {
+    render(
+      <NotebookRail
+        activePanelId="packages"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesSummary="../pyproject.toml · 25 packages"
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
+    expect(screen.getByText("../pyproject.toml · 25 packages")).toHaveClass("w-fit", "max-w-full");
+  });
+
   it("collapses the rail when clicking the active expanded panel button", () => {
     const onActivePanelChange = vi.fn();
     const onCollapsedChange = vi.fn();

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -178,8 +178,26 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(18rem,24vw,22rem)]",
+      "w-[clamp(16rem,20vw,18rem)]",
       "max-[44rem]:w-[calc(100vw-3rem)]",
+    );
+  });
+
+  it("gives package details a wider rail than outline navigation", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="packages"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
+      "w-[clamp(18rem,24vw,22rem)]",
+      "min-w-72",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -199,7 +199,7 @@ describe("NotebookRail", () => {
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(14rem,20vw,17rem)]",
-      "max-[600px]:w-[calc(100vw-3rem)]",
+      "max-[599.98px]:w-[calc(100vw-3rem)]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -181,7 +181,7 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(16rem,20vw,18rem)]",
+      "w-[clamp(14rem,20vw,17rem)]",
       "max-[37.5rem]:w-[calc(100vw-3rem)]",
     );
   });
@@ -199,8 +199,8 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(17rem,21vw,19rem)]",
-      "min-w-[17rem]",
+      "w-[clamp(14rem,21vw,18rem)]",
+      "min-w-56",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -199,7 +199,7 @@ describe("NotebookRail", () => {
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(14rem,20vw,17rem)]",
-      "max-[40rem]:w-[calc(100vw-3rem)]",
+      "max-[600px]:w-[calc(100vw-3rem)]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -146,7 +146,7 @@ describe("NotebookRail", () => {
   });
 
   it("exposes a stable panel slot for host shell layout adapters", () => {
-    render(
+    const { container } = render(
       <NotebookRail
         activePanelId="outline"
         collapsed={false}
@@ -160,6 +160,10 @@ describe("NotebookRail", () => {
     expect(
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
+      "w-[clamp(20rem,26vw,24rem)]",
+      "max-[600px]:w-[calc(100vw-3rem)]",
+    );
   });
 
   it("lets the host handle anchor navigation without browser default navigation", () => {

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -182,7 +182,7 @@ describe("NotebookRail", () => {
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(14rem,20vw,17rem)]",
-      "max-[37.5rem]:w-[calc(100vw-3rem)]",
+      "max-[40rem]:w-[calc(100vw-3rem)]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -161,8 +161,8 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(20rem,26vw,24rem)]",
-      "max-[600px]:w-[calc(100vw-3rem)]",
+      "w-[clamp(18rem,24vw,22rem)]",
+      "max-[44rem]:w-[calc(100vw-3rem)]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -250,6 +250,35 @@ describe("NotebookRail", () => {
     expect(fireEvent.dragStart(outlineTitle!)).toBe(false);
   });
 
+  it("lets outline titles wrap as document language in the rail", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[
+          {
+            id: "cell-a:heading:0",
+            cellId: "cell-a",
+            title: "Recent Download Activity Across the Last Thirty Days",
+            level: 1,
+            kind: "heading" as const,
+            cellAnchorId: "notebook-cell-cell-a",
+            headingAnchorId: "notebook-cell-cell-a-heading-recent-download-activity",
+            href: "#notebook-cell-cell-a",
+            anchor: "recent-download-activity",
+          },
+        ]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    const outlineTitle = container.querySelector('[data-slot="notebook-outline-item-title"]');
+    expect(outlineTitle).toHaveClass("line-clamp-2");
+    expect(outlineTitle).not.toHaveClass("truncate");
+  });
+
   it("marks only the first outline item for a focused cell when no item is pinned", () => {
     render(
       <NotebookRail


### PR DESCRIPTION
## Summary

- keeps the rail slimmer at normal and near-compact widths so package details do not crowd the notebook stage
- lets the rail become the primary surface below 600px, where the split view stops giving the notebook useful reading width
- sizes outline and package panels from the shared rail shell instead of making package-list internals fight the layout
- moves focus to the rail collapse control when responsive takeover hides a focused notebook stage
- softens outline selection so the current heading reads from the guide line instead of a filled pill
- keeps package summaries count-first and moves source-path context into the package detail card
- lets file-backed package rows use small tone dots, with markers wrapping into a quieter secondary line
- treats file-backed environment markers as secondary prose so compact rails can show the full condition without clipped code
- keeps full package names and specs available on compact rows even when visible text truncates
- keeps URL-style package specs from being split on URL semicolons while still surfacing environment markers
- quiets completed run captions so resting notebooks show the boundary line first and reveal run metadata on hover/focus

## Screenshots

Package rail still shares the stage at 680px:

![Package rail and notebook at 680px](https://img.runt.run/2026/06/01/0b2ddaf3d790.png)

Package rail still shares the stage at 601px:

![Package rail and notebook at 601px](https://img.runt.run/2026/06/01/ab42edd77198.png)

Package rail takeover below the compact breakpoint at 599px:

![Package rail takeover at 599px](https://img.runt.run/2026/06/01/20d83be02577.png)

Package rows keep color with quiet file-backed tone dots:

![Package rows with tone dots](https://img.runt.run/2026/06/01/2e1e99fa983d.png)

Package markers wrap as secondary prose in the slim rail:

![Package marker prose at 680px](https://img.runt.run/2026/06/01/b3737e8bfe5a.png)

Outline selection reads from the rail guide:

![Outline rail selection](https://img.runt.run/2026/06/01/c57f60670b5f.png)

Slimmer outline rail with wrapped heading language:

![Wrapped outline heading at 700px](https://img.runt.run/2026/06/01/a7916a868480.png)

Quiet completed run captions:

![Quiet completed run captions](https://img.runt.run/2026/06/01/aa78ec2cafb7.png)

Completed run captions on hover:

![Completed run captions on hover](https://img.runt.run/2026/06/01/120912306171.png)

## Verification

- `pnpm exec vp check src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/PackageSpecList.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx src/components/cell/CodeCellCurrentLine.tsx src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/PackageSpecList.test.tsx src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm exec vp check apps/notebook/src/App.tsx apps/notebook/src/components/PackageSpecList.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/PackageSpecList.test.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/PackageSpecList.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- Playwright package rail check: compact package rows expose full long names and marker text in `title` attributes
- Playwright responsive rail check: packages stay split at 600px and take over at 599px
- Playwright focus check: focused notebook stage at 601px, resized to 599px, focus moved to `notebook-rail-collapse-button`
- `cargo xtask lint --fix`
