### PR TITLE
refactor(notebook): consolidate shared app chrome

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -105,12 +105,13 @@ export function IdentityEnvironmentSurfacesExample() {
           <NotebookDocumentHeader
             capabilities={cloudOwner.capabilities}
             presence={<NotebookIdentityBadge actor={scenarioActor(cloudOwner)} />}
-            utilityControls={<NotebookIdentityGroup actors={activeActors} />}
+            utilityControls={<HeaderPill icon={<Cloud className="size-3.5" />} label="Cloud" />}
             runtimeControls={
               <HeaderPill icon={<Package className="size-3.5" />} label="Packages" />
             }
             codeControls={<HeaderPill icon={<UserRound className="size-3.5" />} label="Source" />}
             sharingControls={<HeaderPill icon={<KeyRound className="size-3.5" />} label="Share" />}
+            identityControls={<NotebookIdentityGroup actors={activeActors} />}
           />
         </div>
       </section>

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/notebook-scenarios";
 
 type BooleanCapabilityKey = {
-  [Key in keyof NotebookShellCapabilities]: NotebookShellCapabilities[Key] extends boolean
+  [Key in keyof NotebookShellCapabilities]-?: NotebookShellCapabilities[Key] extends boolean
     ? Key
     : never;
 }[keyof NotebookShellCapabilities];

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -15,6 +15,7 @@ import {
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   notebookActorIdentityFromProjection,
+  type NotebookActorIdentity,
   type NotebookCommandRuntimeState,
   type NotebookCommandToolbarProps,
 } from "@/components/notebook-shell";
@@ -78,8 +79,7 @@ function toolbarProps(
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
-  const actorCount =
-    scenario.capabilities.runtime.actor && scenario.capabilities.access.actor?.actorLabel ? 2 : 1;
+  const actorCount = Math.max(1, toolbarActors(scenario).length);
   return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
 }
 
@@ -398,12 +398,7 @@ export function NotebookToolbarSurfacesExample() {
 }
 
 function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
-  const accessActor = scenario.capabilities.access.actor;
-  const runtimeActor = scenario.capabilities.runtime.actor;
-  const actors = [
-    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
-    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
-  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const actors = toolbarActors(scenario);
   const interaction = scenario.capabilities.interaction;
 
   return (
@@ -432,6 +427,25 @@ function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScena
       ) : null}
     </div>
   );
+}
+
+function toolbarActors(scenario: ElementsNotebookScenario): NotebookActorIdentity[] {
+  const accessActor = scenario.capabilities.access.actor;
+  const runtimeActor = scenario.capabilities.runtime.actor;
+  const candidates = [
+    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
+    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
+  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const actors: NotebookActorIdentity[] = [];
+  const actorIds = new Set<string>();
+
+  for (const actor of candidates) {
+    if (actorIds.has(actor.id)) continue;
+    actorIds.add(actor.id);
+    actors.push(actor);
+  }
+
+  return actors;
 }
 
 function ScenarioPill({ label }: { label: string }) {

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -53,7 +53,7 @@ function toolbarProps(
     onRunAllCells: noop,
     onRestartAndRunAll: noop,
     onTogglePackages: noop,
-    leadingControls: (
+    presenceControls: (
       <NotebookPresenceStatus
         connected={scenario.capabilities.runtime.connected || scenario.capabilities.canRead}
         label={presenceLabel(scenario)}
@@ -62,14 +62,14 @@ function toolbarProps(
         className="h-7 text-xs"
       />
     ),
-    trailingControls: <ToolbarIdentityControls scenario={scenario} />,
+    identityControls: <ToolbarIdentityControls scenario={scenario} />,
     ...overrides,
   };
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
   const actorCount = Math.max(1, notebookToolbarActors(scenario.capabilities).length);
-  return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
+  return actorCount === 1 ? "1 participant here" : `${actorCount} participants here`;
 }
 
 function runtimeStatus(

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -1,21 +1,12 @@
 "use client";
 
-import {
-  BadgeCheck,
-  CircleDot,
-  Laptop,
-  PanelTop,
-  PlayCircle,
-  TimerReset,
-  UserRound,
-} from "lucide-react";
+import { BadgeCheck, CircleDot, PanelTop, PlayCircle, TimerReset } from "lucide-react";
 import {
   NotebookCommandToolbar,
   NotebookEditModeButton,
-  NotebookIdentityBadge,
   NotebookPresenceStatus,
-  notebookActorIdentityFromProjection,
-  type NotebookActorIdentity,
+  NotebookToolbarIdentity,
+  notebookToolbarActors,
   type NotebookCommandRuntimeState,
   type NotebookCommandToolbarProps,
 } from "@/components/notebook-shell";
@@ -79,7 +70,7 @@ function toolbarProps(
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
-  const actorCount = Math.max(1, toolbarActors(scenario).length);
+  const actorCount = Math.max(1, notebookToolbarActors(scenario.capabilities).length);
   return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
 }
 
@@ -398,7 +389,6 @@ export function NotebookToolbarSurfacesExample() {
 }
 
 function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
-  const actors = toolbarActors(scenario);
   const interaction = scenario.capabilities.interaction;
 
   return (
@@ -412,40 +402,9 @@ function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScena
           className="h-7 text-xs"
         />
       ) : null}
-      {actors.slice(0, 2).map((actor) => (
-        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={false} />
-      ))}
-      {actors.length === 0 ? (
-        <span className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-background px-2 text-xs text-muted-foreground">
-          {scenario.capabilities.access.source === "local" ? (
-            <Laptop className="size-3.5" aria-hidden="true" />
-          ) : (
-            <UserRound className="size-3.5" aria-hidden="true" />
-          )}
-          anonymous
-        </span>
-      ) : null}
+      <NotebookToolbarIdentity capabilities={scenario.capabilities} />
     </div>
   );
-}
-
-function toolbarActors(scenario: ElementsNotebookScenario): NotebookActorIdentity[] {
-  const accessActor = scenario.capabilities.access.actor;
-  const runtimeActor = scenario.capabilities.runtime.actor;
-  const candidates = [
-    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
-    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
-  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
-  const actors: NotebookActorIdentity[] = [];
-  const actorIds = new Set<string>();
-
-  for (const actor of candidates) {
-    if (actorIds.has(actor.id)) continue;
-    actorIds.add(actor.id);
-    actors.push(actor);
-  }
-
-  return actors;
 }
 
 function ScenarioPill({ label }: { label: string }) {

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -39,9 +39,7 @@ function toolbarProps(
   const interaction = scenario.capabilities.interaction;
 
   return {
-    canEditStructure: scenario.capabilities.canEditStructure,
-    canExecute: scenario.capabilities.canExecute,
-    canViewPackages: scenario.capabilities.canViewPackages,
+    capabilities: scenario.capabilities,
     runtime: "python",
     environmentManager: "uv",
     environmentPanelOpen: false,

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -1,210 +1,229 @@
 "use client";
 
-import { BadgeCheck, CircleDot, PanelTop, PlayCircle, TimerReset } from "lucide-react";
-import type { ComponentProps } from "react";
 import {
-  KERNEL_ERROR_REASON,
-  KERNEL_STATUS,
-  RUNTIME_STATUS,
-  type EnvProgressState,
-} from "runtimed";
+  BadgeCheck,
+  CircleDot,
+  Laptop,
+  PanelTop,
+  PlayCircle,
+  TimerReset,
+  UserRound,
+} from "lucide-react";
+import {
+  NotebookCommandToolbar,
+  NotebookEditModeButton,
+  NotebookIdentityBadge,
+  NotebookPresenceStatus,
+  notebookActorIdentityFromProjection,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandToolbarProps,
+} from "@/components/notebook-shell";
 import {
   getElementsNotebookScenario,
   type ElementsNotebookScenario,
   type ElementsNotebookScenarioId,
 } from "@/components/notebook-scenarios";
-import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
-
-type ToolbarProps = ComponentProps<typeof NotebookToolbar>;
 
 const noop = () => {};
-
-const runningIdle = { lifecycle: "Running", activity: "Idle" } as const;
-const runningBusy = { lifecycle: "Running", activity: "Busy" } as const;
-const errorLifecycle = { lifecycle: "Error" } as const;
-
-const condaProgress: EnvProgressState = {
-  isActive: true,
-  phase: "link_progress",
-  envType: "conda",
-  error: null,
-  statusText: "Installing 17/24 scikit-learn",
-  elapsedMs: 18_400,
-  progress: { completed: 17, total: 24 },
-  bytesPerSecond: null,
-  currentPackage: "scikit-learn",
-};
-
-const condaEnvMissingDetails =
-  "environment.yml declares conda env 'analysis', which is not built on this machine. Run: conda env create -f /work/notebooks/environment.yml";
 
 interface ToolbarSurface {
   title: string;
   source: string;
   role: string;
   scenario: ElementsNotebookScenario;
-  props: ToolbarProps;
-}
-
-function toolbarProps(
-  scenario: ElementsNotebookScenario,
-  overrides: Partial<ToolbarProps> = {},
-): ToolbarProps {
-  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
-  const cellIds = scenario.viewModel.cellIds;
-
-  return {
-    kernelStatus: KERNEL_STATUS.IDLE,
-    statusKey: RUNTIME_STATUS.RUNNING_IDLE,
-    lifecycle: runningIdle,
-    errorReason: null,
-    kernelErrorMessage: null,
-    envSource: "uv:inline",
-    envTypeHint: "uv",
-    envProgress: null,
-    runtime: "python",
-    focusedCellId: firstRunnableCell?.id ?? cellIds[0] ?? null,
-    lastCellId: cellIds[cellIds.length - 1] ?? null,
-    canEditStructure: scenario.capabilities.canEditStructure,
-    canExecute: scenario.capabilities.canExecute,
-    canViewPackages: scenario.capabilities.canViewPackages,
-    onStartKernel: noop,
-    onInterruptKernel: noop,
-    onRestartKernel: noop,
-    onRunAllCells: noop,
-    onRestartAndRunAll: noop,
-    onAddCell: noop,
-    onToggleDependencies: noop,
-    ...overrides,
-  };
+  props: NotebookCommandToolbarProps;
 }
 
 function scenario(id: ElementsNotebookScenarioId) {
   return getElementsNotebookScenario(id);
 }
 
+function toolbarProps(
+  scenario: ElementsNotebookScenario,
+  overrides: Partial<NotebookCommandToolbarProps> = {},
+): NotebookCommandToolbarProps {
+  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
+  const cellIds = scenario.viewModel.cellIds;
+  const interaction = scenario.capabilities.interaction;
+
+  return {
+    canEditStructure: scenario.capabilities.canEditStructure,
+    canExecute: scenario.capabilities.canExecute,
+    canViewPackages: scenario.capabilities.canViewPackages,
+    runtime: "python",
+    environmentManager: "uv",
+    environmentPanelOpen: false,
+    environmentOutOfSync: scenario.packageState.syncState.status === "dirty",
+    runtimeStatus: runtimeStatus("idle", scenario.runtimeLabel),
+    addAfterCellId: firstRunnableCell?.id ?? cellIds[cellIds.length - 1] ?? null,
+    onAddCell: noop,
+    onStartRuntime: noop,
+    onInterruptRuntime: noop,
+    onRestartRuntime: noop,
+    onRunAllCells: noop,
+    onRestartAndRunAll: noop,
+    onTogglePackages: noop,
+    leadingControls: (
+      <NotebookPresenceStatus
+        connected={scenario.capabilities.runtime.connected || scenario.capabilities.canRead}
+        label={presenceLabel(scenario)}
+        modeLabel={interaction?.state === "editing" ? "editing" : "view only"}
+        title={`${scenario.title}: actor presence and interaction state`}
+        className="h-7 text-xs"
+      />
+    ),
+    trailingControls: <ToolbarIdentityControls scenario={scenario} />,
+    ...overrides,
+  };
+}
+
+function presenceLabel(scenario: ElementsNotebookScenario): string {
+  const actorCount =
+    scenario.capabilities.runtime.actor && scenario.capabilities.access.actor?.actorLabel ? 2 : 1;
+  return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
+}
+
+function runtimeStatus(
+  state: NotebookCommandRuntimeState,
+  label: string,
+  error?: string,
+): NotebookCommandToolbarProps["runtimeStatus"] {
+  return {
+    state,
+    label: (
+      <span className={state === "error" ? "text-red-600 dark:text-red-400" : ""}>{label}</span>
+    ),
+    ariaLabel: `Runtime: ${label}`,
+    title: label,
+    error: error ? (
+      <span className="text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
+        {error}
+      </span>
+    ) : null,
+  };
+}
+
 function createStatusSurfaces(): ToolbarSurface[] {
   const desktopOwner = scenario("desktop-local-owner");
+  const desktopReadOnly = scenario("desktop-read-only");
+  const desktopRemote = scenario("desktop-remote-room");
   const cloudViewer = scenario("cloud-public-viewer");
   const cloudEditor = scenario("cloud-editor");
+  const cloudOwner = scenario("cloud-owner");
+  const agent = scenario("agent-on-behalf");
+  const runtimePeer = scenario("runtime-peer");
   const runtimeUnavailable = scenario("runtime-unavailable");
 
   return [
     {
-      title: "Idle Python notebook",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Desktop owner",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: desktopOwner,
-      role: `${desktopOwner.runtimeLabel}; normal editing state with uv package details and running kernel controls.`,
+      role: "Local desktop host can edit structure, execute, and inspect package state through the same command toolbar contract.",
       props: toolbarProps(desktopOwner),
     },
     {
-      title: "Busy with package restart",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: desktopOwner,
-      role: `Execution state from ${desktopOwner.title}; restart-and-run-all is marked by ${desktopOwner.packageState.syncState.status} package details.`,
-      props: toolbarProps(desktopOwner, {
-        kernelStatus: KERNEL_STATUS.BUSY,
-        statusKey: RUNTIME_STATUS.RUNNING_BUSY,
-        lifecycle: runningBusy,
-        envSource: "conda:inline",
-        depsOutOfSync: desktopOwner.packageState.syncState.status === "dirty",
-        isDepsOpen: desktopOwner.capabilities.canViewPackages,
+      title: "Desktop read-only file",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: desktopReadOnly,
+      role: "Filesystem or host permissions disable mutation controls while package details remain visible.",
+      props: toolbarProps(desktopReadOnly, {
+        runtimeStatus: runtimeStatus("shutdown", desktopReadOnly.runtimeLabel),
       }),
     },
     {
-      title: "Environment preparation",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: cloudEditor,
-      role: `${cloudEditor.title} can edit markdown, but this preview keeps execution detached while Conda solve progress renders.`,
-      props: toolbarProps(cloudEditor, {
-        kernelStatus: KERNEL_STATUS.STARTING,
-        statusKey: RUNTIME_STATUS.PREPARING_ENV,
-        lifecycle: { lifecycle: "PreparingEnv" },
-        envSource: null,
-        envTypeHint: "conda",
-        envProgress: condaProgress,
+      title: "Desktop remote room",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: desktopRemote,
+      role: "Desktop can be a remote notebook host: local app and daemon identity project into the same access model as cloud.",
+      props: toolbarProps(desktopRemote, {
+        runtimeStatus: runtimeStatus("unknown", desktopRemote.runtimeLabel),
       }),
     },
     {
-      title: "Awaiting trust approval",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: `${runtimeUnavailable.title} reuses the shared trust fixture before launch instead of opening a live runtime.`,
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.STARTING,
-        statusKey: RUNTIME_STATUS.AWAITING_TRUST,
-        lifecycle: { lifecycle: "AwaitingTrust" },
-        envSource: null,
-        envTypeHint: "uv",
-      }),
-    },
-    {
-      title: "Published viewer with no kernel",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Cloud public viewer",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: cloudViewer,
-      role: `${cloudViewer.title} uses the same notebook IDs while exposing view-only, published access context.`,
+      role: "Anonymous read access keeps the notebook shell readable and package-aware without edit, execution, or sharing controls.",
       props: toolbarProps(cloudViewer, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        envSource: null,
-        envTypeHint: null,
-        kernelErrorMessage: cloudViewer.runtimeLabel,
+        runtime: null,
+        environmentManager: null,
+        runtimeStatus: runtimeStatus("unknown", cloudViewer.runtimeLabel),
       }),
     },
     {
-      title: "Deno runtime unavailable",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Cloud editor",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudEditor,
+      role: "Cloud edit permission and selected edit mode are separate from host support; active controls are their intersection.",
+      props: toolbarProps(cloudEditor, {
+        runtimeStatus: runtimeStatus("unknown", cloudEditor.runtimeLabel),
+      }),
+    },
+    {
+      title: "Cloud owner",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudOwner,
+      role: "Owner access can expose sharing identity chrome without inventing a second notebook toolbar.",
+      props: toolbarProps(cloudOwner, {
+        runtimeStatus: runtimeStatus("unknown", cloudOwner.runtimeLabel),
+      }),
+    },
+    {
+      title: "Codex or Claude operator",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: agent,
+      role: "Desktop and cloud both have non-human operators. The toolbar uses actor-neutral presence and projected identity labels.",
+      props: toolbarProps(agent, {
+        runtimeStatus: runtimeStatus("unknown", agent.runtimeLabel),
+      }),
+    },
+    {
+      title: "Runtime peer",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: runtimePeer,
+      role: "Runtime authorship is present without notebook edit access, so execution authors do not become structure editors.",
+      props: toolbarProps(runtimePeer, {
+        runtimeStatus: runtimeStatus("busy", runtimePeer.runtimeLabel),
+      }),
+    },
+    {
+      title: "Preparing environment",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudEditor,
+      role: "Hosted and desktop hosts can show environment progress while keeping the work owned by their runtime adapter.",
+      props: toolbarProps(cloudEditor, {
+        runtimeStatus: runtimeStatus("starting", "Installing 17/24 scikit-learn"),
+        environmentManager: "conda",
+        environmentOutOfSync: true,
+      }),
+    },
+    {
+      title: "Runtime unavailable",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: runtimeUnavailable,
-      role: "Deno install remediation banner driven by fixture error text and inert callbacks.",
+      role: "Runtime and trust remediation can surface through shared status while host-specific fixes stay outside the command toolbar.",
       props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
+        runtimeStatus: runtimeStatus(
+          "error",
+          "Deno runtime unavailable",
+          "deno executable not found",
+        ),
         runtime: "deno",
-        envSource: "deno:imports",
-        envTypeHint: null,
-        kernelErrorMessage: "deno executable not found on PATH",
-      }),
-    },
-    {
-      title: "Pixi missing ipykernel",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel package.",
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
-        envSource: "pixi:toml",
-        envTypeHint: "pixi",
-      }),
-    },
-    {
-      title: "Conda environment.yml missing",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: "Copyable environment creation hint surfaced by the toolbar when the declared conda env is absent.",
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
-        envSource: "conda:env_yml",
-        envTypeHint: "conda",
-        kernelErrorMessage: condaEnvMissingDetails,
+        environmentManager: null,
       }),
     },
     {
       title: "Update ready",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: desktopOwner,
-      role: "Desktop update action rendered beside runtime status while the notebook remains idle.",
+      role: "Desktop update actions remain a host slot on the shared command toolbar.",
       props: toolbarProps(desktopOwner, {
-        updateStatus: "available",
-        updateVersion: "2.5.3",
-        onRestartToUpdate: noop,
+        updateAction: {
+          label: "Update 2.5.3",
+          title: "Prepare to update to v2.5.3",
+          onClick: noop,
+        },
       }),
     },
   ];
@@ -213,56 +232,56 @@ function createStatusSurfaces(): ToolbarSurface[] {
 const contractItems = [
   {
     icon: BadgeCheck,
-    title: "Current source",
-    body: "Every preview imports NotebookToolbar from the notebook app and starts from a shared Elements scenario.",
+    title: "Shared source",
+    body: "Every preview renders NotebookCommandToolbar from the host-neutral notebook shell.",
   },
   {
     icon: PlayCircle,
-    title: "Runtime-free",
-    body: "Kernel actions, package toggles, update clicks, and cell insertion callbacks are inert.",
+    title: "Adapter-owned actions",
+    body: "Kernel, package, update, and cell insertion callbacks are inert fixtures here and host-owned in production.",
   },
   {
     icon: TimerReset,
-    title: "Status vocabulary",
-    body: "Fixtures cover idle, busy, preparing, trust, error, and update states from the real runtime labels.",
+    title: "Actor-neutral chrome",
+    body: "Presence and mode copy works for humans, agents, runtime peers, and system operators.",
   },
 ];
 
 const toolbarBoundaryRows = [
   {
-    boundary: "Runtime status projection",
-    catalogPath: "ElementsNotebookScenario -> toolbarProps(status overrides)",
-    productionBoundary: "RuntimeStateDoc + kernel lifecycle",
+    boundary: "Shared command toolbar",
+    catalogPath: "NotebookCommandToolbar + ElementsNotebookScenario",
+    productionBoundary: "Desktop NotebookToolbar wrapper and cloud host adapter",
     detail:
-      "The catalog starts with deterministic scenario facts, then applies runtime status overrides. Production derives those fields from runtime state, kernel lifecycle, environment progress, and launch errors.",
+      "The catalog renders the shared command toolbar directly. Desktop and cloud wrappers may add host-specific status projection, but not duplicate command chrome.",
   },
   {
-    boundary: "Kernel actions",
-    catalogPath: "inert callbacks",
-    productionBoundary: "Notebook action handlers",
+    boundary: "Interaction mode",
+    catalogPath: "scenario.capabilities.interaction",
+    productionBoundary: "ACL/local permission + selected host mode",
     detail:
-      "Start, interrupt, restart, run-all, and restart-and-run-all buttons render here without side effects. The notebook app wires them to execution and runtime control paths.",
+      "View/edit state is a projection of permission, selected mode, and host support. The toolbar reads that projection instead of inferring editability from auth alone.",
+  },
+  {
+    boundary: "Actor identity",
+    catalogPath: "NotebookActorProjection -> NotebookActorIdentity",
+    productionBoundary: "Host/backend structured actor projection",
+    detail:
+      "Raw durable actor labels remain attribution data. User-facing toolbar labels come from structured principal/operator projections when available.",
+  },
+  {
+    boundary: "Runtime status projection",
+    catalogPath: "static runtimeStatus fixtures",
+    productionBoundary: "RuntimeStateDoc + kernel lifecycle",
+    detail:
+      "The command toolbar accepts a small runtime status shape. Hosts own the richer lifecycle, environment progress, launch errors, and remediation details.",
   },
   {
     boundary: "Package panel",
     catalogPath: "scenario.packageState + inert toggle",
     productionBoundary: "Package rail and project writes",
     detail:
-      "The preview reads package sync state from the shared scenario and toggles visual package state only. The notebook opens package UI, writes project files, and coordinates environment rebuild decisions.",
-  },
-  {
-    boundary: "Cell insertion",
-    catalogPath: "scenario.viewModel.cellIds",
-    productionBoundary: "NotebookView focus and document changes",
-    detail:
-      "The add-cell affordance receives stable IDs from the shared scenario projection. Production inserts new cells through the notebook document and restores editor focus.",
-  },
-  {
-    boundary: "Desktop update restart",
-    catalogPath: "updateStatus + onRestartToUpdate",
-    productionBoundary: "Tauri updater host action",
-    detail:
-      "The update-ready surface renders with a no-op restart callback. Desktop builds still own update installation and app restart behavior outside the docs runtime.",
+      "Read-only scenarios still expose package details. Package management remains gated separately from package viewing.",
   },
 ];
 
@@ -306,12 +325,17 @@ export function NotebookToolbarSurfacesExample() {
                   />
                   <ScenarioPill
                     label={
-                      surface.scenario.capabilities.canExecute
-                        ? "execution available"
-                        : "execution disabled"
+                      surface.scenario.capabilities.interaction?.state ??
+                      (surface.scenario.capabilities.canEditMarkdown ? "editing" : "viewing")
                     }
                   />
-                  <ScenarioPill label={`${surface.scenario.viewModel.codeCellCount} code cells`} />
+                  <ScenarioPill
+                    label={
+                      surface.scenario.capabilities.runtime.actor
+                        ? "runtime actor"
+                        : "no runtime actor"
+                    }
+                  />
                 </div>
               </div>
               <div className="break-words font-mono text-[11px] leading-5 text-fd-muted-foreground [overflow-wrap:anywhere] md:max-w-72 md:text-right">
@@ -319,8 +343,8 @@ export function NotebookToolbarSurfacesExample() {
               </div>
             </div>
             <div className="overflow-hidden bg-fd-background">
-              <div className="min-w-[760px]">
-                <NotebookToolbar {...surface.props} />
+              <div className="min-w-[860px]">
+                <NotebookCommandToolbar {...surface.props} />
               </div>
             </div>
           </article>
@@ -330,12 +354,12 @@ export function NotebookToolbarSurfacesExample() {
       <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
         <div className="mb-3 flex items-center gap-2">
           <CircleDot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Live work stays with the notebook</h2>
+          <h2 className="text-sm font-semibold">Live work stays with the host</h2>
         </div>
         <p className="text-xs leading-5 text-fd-muted-foreground">
-          NotebookToolbar renders from the production component, but this page owns only static
-          status props and inert callbacks. Runtime state, kernel controls, package writes, cell
-          insertion, and desktop update restarts stay with the notebook app.
+          NotebookCommandToolbar is shared notebook chrome. This page owns only fixture props and
+          inert callbacks; desktop and cloud remain responsible for transport, CRDT writes,
+          execution, package mutation, credentials, and deployment-specific behavior.
         </p>
         <div className="mt-4 grid gap-2">
           {toolbarBoundaryRows.map((row) => (
@@ -356,7 +380,7 @@ export function NotebookToolbarSurfacesExample() {
                   </div>
                   <div>
                     <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
-                      Notebook owns
+                      Host owns
                     </div>
                     <div className="mt-1 break-words font-mono text-[11px] leading-4 text-amber-700 dark:text-amber-300">
                       {row.productionBoundary}
@@ -369,6 +393,43 @@ export function NotebookToolbarSurfacesExample() {
           ))}
         </div>
       </section>
+    </div>
+  );
+}
+
+function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
+  const accessActor = scenario.capabilities.access.actor;
+  const runtimeActor = scenario.capabilities.runtime.actor;
+  const actors = [
+    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
+    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
+  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const interaction = scenario.capabilities.interaction;
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {interaction ? (
+        <NotebookEditModeButton
+          mode={interaction.selectedMode}
+          state={interaction.state}
+          disabled={!interaction.canRequestEdit && interaction.activeMode !== "edit"}
+          onModeChange={noop}
+          className="h-7 text-xs"
+        />
+      ) : null}
+      {actors.slice(0, 2).map((actor) => (
+        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={false} />
+      ))}
+      {actors.length === 0 ? (
+        <span className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-background px-2 text-xs text-muted-foreground">
+          {scenario.capabilities.access.source === "local" ? (
+            <Laptop className="size-3.5" aria-hidden="true" />
+          ) : (
+            <UserRound className="size-3.5" aria-hidden="true" />
+          )}
+          anonymous
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -101,9 +101,7 @@ export function RailOutlineExample() {
               runtime="python"
               focusedCellId={focusedCellId}
               lastCellId="cell-findings"
-              canEditStructure={scenario.capabilities.canEditStructure}
-              canExecute={scenario.capabilities.canExecute}
-              canViewPackages={scenario.capabilities.canViewPackages}
+              capabilities={scenario.capabilities}
               onStartKernel={noop}
               onInterruptKernel={noop}
               onRestartKernel={noop}

--- a/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
+++ b/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
@@ -1,17 +1,18 @@
 ---
 title: Notebook toolbar surfaces
-description: Runtime-free NotebookToolbar states from the current notebook app.
+description: Runtime-free shared command toolbar states from the notebook shell.
 ---
 
 import { NotebookToolbarSurfacesExample } from "@/components/notebook-toolbar-surfaces-example";
 
 The notebook toolbar is workspace chrome, not generic button inventory. This
-page renders the current `NotebookToolbar` with static runtime, environment,
-package, and update facts so the catalog can track the real desktop
-surface without importing daemon hooks or notebook state.
+page renders the shared `NotebookCommandToolbar` with static runtime,
+environment, package, identity, and update facts so the catalog can track the
+desktop and cloud contract without importing daemon hooks or notebook state.
 The hosted scenarios are shared with the
-[notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor
-and owner access do not drift from cloud ACL semantics.
+[notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor,
+owner, runtime peer, agent, and local desktop access do not drift from the
+shared capability model.
 
 <NotebookToolbarSurfacesExample />
 
@@ -19,7 +20,7 @@ and owner access do not drift from cloud ACL semantics.
 
 Toolbar previews own only props and callbacks. Kernel start, interrupt, restart,
 package toggles, update restarts, and cell insertion stay inert in the docs app
-until the host deliberately wires them. The rendered boundary map keeps runtime
-status projection, kernel actions, package panel state, cell insertion, and
-desktop update restart behavior named separately so future toolbar work can move
-one host-owned action at a time.
+until the host deliberately wires them. The rendered boundary map keeps shared
+command chrome, interaction mode, actor identity, runtime status projection,
+package panel state, and host-owned actions named separately so future toolbar
+work can move one host-owned action at a time.

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -114,7 +114,7 @@ async function main() {
 
     await timed("alice_connected", () => waitForPresence(alice.page, "editing"));
     await timed("bob_connected", () => waitForPresence(bob.page, "editing"));
-    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "viewing"));
+    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "view only"));
     checks.push("browser_alice_connected", "browser_bob_connected", "anonymous_viewer_connected");
 
     await waitForEditableMarkdown(alice.page);
@@ -221,7 +221,7 @@ ${bobMarker}
       }),
     );
     contexts.push(charlie.context);
-    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "viewing"));
+    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "view only"));
     await assertNoEditableMarkdown(charlie.page);
     checks.push("ungranted_editor_downgraded_to_viewer");
 

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -114,7 +114,7 @@ async function main() {
 
     await timed("alice_connected", () => waitForPresence(alice.page, "editing"));
     await timed("bob_connected", () => waitForPresence(bob.page, "editing"));
-    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "view only"));
+    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "here now"));
     checks.push("browser_alice_connected", "browser_bob_connected", "anonymous_viewer_connected");
 
     await waitForEditableMarkdown(alice.page);
@@ -221,7 +221,7 @@ ${bobMarker}
       }),
     );
     contexts.push(charlie.context);
-    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "view only"));
+    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "here now"));
     await assertNoEditableMarkdown(charlie.page);
     checks.push("ungranted_editor_downgraded_to_viewer");
 

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -46,7 +46,7 @@ const expectedSourceText =
   process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
-const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "viewing";
+const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "view only";
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", []);
 const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "MathNet topic visualization",

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -46,7 +46,7 @@ const expectedSourceText =
   process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
-const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "view only";
+const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "here now";
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", []);
 const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "MathNet topic visualization",

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -35,6 +35,11 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     constructor(notebookId: string);
     static create_bootstrap(actorLabel: string): NotebookHandle;
     static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): NotebookHandle;
+    add_cell_after(
+      cellId: string,
+      cellType: "code" | "markdown" | "raw",
+      afterCellId?: string | null,
+    ): string;
     cell_count(): number;
     cancel_last_flush(): void;
     cancel_last_pool_state_flush(): void;
@@ -50,6 +55,8 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_metadata_snapshot_json(): string | undefined;
     get_runtime_state_doc_id(): string | undefined;
     get_runtime_state(): unknown;
+    move_cell(cellId: string, afterCellId?: string | null): string;
+    delete_cell(cellId: string): boolean;
     get_runtime_state_heads_hex(): string[];
     receive_frame(frameBytes: Uint8Array): unknown;
     reset_sync_state(): void;

--- a/apps/notebook-cloud/test/cloud-cell-id.test.ts
+++ b/apps/notebook-cloud/test/cloud-cell-id.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createCloudNotebookCellId } from "../viewer/cloud-cell-id";
+
+test("cloud notebook cell ids use randomUUID when available", () => {
+  const id = createCloudNotebookCellId({
+    randomUUID: () => "random-id",
+    getRandomValues: () => {
+      throw new Error("getRandomValues should not be called");
+    },
+  });
+
+  assert.equal(id, "random-id");
+});
+
+test("cloud notebook cell ids fall back to random bytes without timestamp collisions", () => {
+  const id = createCloudNotebookCellId({
+    getRandomValues: (bytes: Uint8Array) => {
+      bytes.fill(0xab);
+      return bytes;
+    },
+  });
+
+  assert.equal(id, "cell-abababababababababababababababab");
+});
+
+test("cloud notebook cell ids keep a monotonic fallback when crypto is unavailable", () => {
+  const first = createCloudNotebookCellId(null);
+  const second = createCloudNotebookCellId(null);
+
+  assert.notEqual(first, second);
+  assert.match(first, /^cell-[a-z0-9]+-[a-z0-9]+$/);
+  assert.match(second, /^cell-[a-z0-9]+-[a-z0-9]+$/);
+});

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -39,7 +39,7 @@ describe("cloud viewer presence", () => {
         roomPeerCount: 1,
       },
     );
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_joined",
@@ -50,7 +50,7 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:01.000Z",
     });
     assert.equal(state.roomPeerCount, 2);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "2 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "2 here now");
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_left",
@@ -61,7 +61,7 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:02.000Z",
     });
     assert.equal(state.roomPeerCount, 1);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
   });
 
   it("surfaces disconnected state without losing the last room count", () => {
@@ -102,8 +102,8 @@ describe("cloud viewer presence", () => {
 
     assert.equal(state.ownPeerLabel, "Alice Demo");
     assert.deepEqual(cloudViewerPresenceDisplay(state), {
-      label: "2 viewing",
-      title: "2 readers connected to this notebook room; You are Alice Demo",
+      label: "2 here now",
+      title: "2 participants are in this notebook; You are Alice Demo",
       connected: true,
     });
   });

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -68,8 +68,13 @@ test("cloud viewer routes notebook header controls through the shared command to
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookCommandToolbar,/);
+  assert.match(sourceText, /NotebookDocumentHeader,/);
   assert.match(sourceText, /NotebookToolbarFrame,/);
-  assert.match(sourceText, /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookCommandToolbar/);
+  assert.match(
+    sourceText,
+    /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookDocumentHeader[\s\S]*<NotebookCommandToolbar/,
+  );
+  assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
@@ -78,8 +83,10 @@ test("cloud viewer routes notebook header controls through the shared command to
   assert.match(sourceText, /identityControls=\{[\s\S]*<NotebookToolbarIdentity/);
   assert.match(
     sourceText,
-    /presenceControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
+    /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
   );
+  assert.doesNotMatch(sourceText, /runtimeStatus=\{cloudNotebookRuntimeStatus/);
+  assert.doesNotMatch(sourceText, /label: "live"/);
   assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -72,11 +72,13 @@ test("cloud viewer routes notebook header controls through the shared command to
   assert.match(sourceText, /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookCommandToolbar/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
-  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
-  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
+  assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
+  assert.match(sourceText, /identityControls=\{[\s\S]*<NotebookToolbarIdentity/);
   assert.match(
     sourceText,
-    /leadingControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
+    /presenceControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
   );
   assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -74,7 +74,11 @@ test("cloud viewer routes notebook header controls through the shared command to
   );
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /leadingControls=\{[\s\S]*<CloudPresenceStatus/);
+  assert.match(
+    sourceText,
+    /leadingControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
+  );
+  assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -81,13 +81,11 @@ test("cloud viewer routes notebook header controls through the shared command to
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
   assert.match(sourceText, /identityControls=\{[\s\S]*<NotebookToolbarIdentity/);
-  assert.match(
-    sourceText,
-    /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
-  );
+  assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
   assert.doesNotMatch(sourceText, /runtimeStatus=\{cloudNotebookRuntimeStatus/);
   assert.doesNotMatch(sourceText, /label: "live"/);
   assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
+  assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*interaction=\{/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -63,15 +63,18 @@ test("cloud viewer keeps theme resolution out of first-class notebook chrome", (
   assert.doesNotMatch(sourceText, /className="cloud-theme-toggle"/);
 });
 
-test("cloud viewer routes notebook header controls through the shared shell header", () => {
+test("cloud viewer routes notebook header controls through the shared command toolbar", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /NotebookDocumentHeader,/);
-  assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
-  assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /codeControls=\{null\}/);
+  assert.match(sourceText, /NotebookCommandToolbar,/);
+  assert.match(
+    sourceText,
+    /<NotebookCommandToolbar[\s\S]*canEditStructure=\{shellCapabilities\.canEditStructure\}/,
+  );
+  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
+  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /leadingControls=\{[\s\S]*<CloudPresenceStatus/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -68,7 +68,10 @@ test("cloud viewer routes notebook header controls through the shared command to
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookCommandToolbar,/);
+  assert.match(sourceText, /NotebookToolbarFrame,/);
+  assert.match(sourceText, /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookCommandToolbar/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
+  assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -68,10 +68,7 @@ test("cloud viewer routes notebook header controls through the shared command to
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookCommandToolbar,/);
-  assert.match(
-    sourceText,
-    /<NotebookCommandToolbar[\s\S]*canEditStructure=\{shellCapabilities\.canEditStructure\}/,
-  );
+  assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -60,16 +60,18 @@ test("cloud package rail renders package metadata through the shared shell panel
   assert.doesNotMatch(sourceText, /Package details are not surfaced/);
 });
 
-test("cloud environment rail header uses the shared typed environment surface", () => {
+test("cloud package rail stays package-only and leaves sync/env state to app chrome", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /createNotebookEnvironmentSurface/);
-  assert.match(sourceText, /const environmentSurface = useMemo/);
-  assert.match(sourceText, /syncStatus: connectionScope \? "synced" : "unavailable"/);
-  assert.match(sourceText, /trustStatus: "not_required"/);
-  assert.match(sourceText, /<NotebookEnvironmentSummary[\s\S]*environment=\{environmentSurface\}/);
-  assert.doesNotMatch(sourceText, /<NotebookEnvironmentSummary[\s\S]*syncLabel=/);
+  assert.match(
+    sourceText,
+    /<NotebookPackageSummaryPanel[\s\S]*readOnly=\{!shellCapabilities\.canManagePackages\}/,
+  );
+  assert.doesNotMatch(sourceText, /NotebookEnvironmentSummary/);
+  assert.doesNotMatch(sourceText, /createNotebookEnvironmentSurface/);
+  assert.doesNotMatch(sourceText, /syncLabel: connectionScope/);
+  assert.doesNotMatch(sourceText, /Live sync connected/);
 });
 
 test("cloud identity chrome renders through the shared actor projection surface", () => {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -103,6 +103,7 @@ test("cloud presence chrome renders through the shared shell component", () => {
 
   assert.match(sourceText, /NotebookPresenceStatus/);
   assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*label=\{presenceDisplay\.label\}/);
+  assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*variant="inline"/);
   assert.match(sharedPresenceText, /data-slot="notebook-presence-status"/);
   assert.match(hostedSmokeText, /\[data-slot='notebook-presence-status'\]/);
   assert.match(collabSmokeText, /\[data-slot='notebook-presence-status'\]/);
@@ -120,6 +121,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /NotebookEditModeButton/);
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*mode=\{interaction\.selectedMode\}/);
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*state=\{interaction\.state\}/);
+  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
   assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -116,10 +116,8 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   const cssText = readFileSync(cssPath, "utf8");
 
   assert.match(sourceText, /NotebookEditModeButton/);
-  assert.match(
-    sourceText,
-    /<NotebookEditModeButton[\s\S]*mode=\{requestingEdit \? "edit" : "view"\}/,
-  );
+  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*mode=\{interaction\.selectedMode\}/);
+  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*state=\{interaction\.state\}/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
   assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -32,6 +32,9 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canToggleCode, true);
   assert.equal(capabilities.canManageSharing, false);
+  assert.equal(capabilities.interaction?.selectedMode, "view");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "viewing");
   assert.equal(capabilities.access.level, "viewer");
   assert.equal(capabilities.access.source, "cloud");
   assert.equal(capabilities.access.isPublic, true);
@@ -55,6 +58,9 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canToggleCode, false);
   assert.equal(capabilities.canManagePackages, false);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "edit");
+  assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.access.identityLabel, "user@example.test");
   assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
@@ -74,9 +80,29 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.canEditMarkdown, false);
   assert.equal(capabilities.canEditCells, false);
   assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.interaction?.selectedMode, "view");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "viewing");
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.canToggleCode, true);
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
+});
+
+test("cloud shell capabilities keep requested edit pending until the room grants edit access", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "viewer",
+    hasCodeCells: true,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canRequestEdit, true);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "requested");
+  assert.equal(capabilities.access.level, "viewer");
 });
 
 test("cloud shell capabilities reserve code-cell and structure edits for owners", () => {
@@ -92,6 +118,9 @@ test("cloud shell capabilities reserve code-cell and structure edits for owners"
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canManagePackages, false);
   assert.equal(capabilities.canManageSharing, true);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "edit");
+  assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "owner");
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -79,7 +79,7 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities reserve code-cell source edits for owners", () => {
+test("cloud shell capabilities reserve code-cell and structure edits for owners", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),
     connectionScope: "owner",
@@ -88,7 +88,7 @@ test("cloud shell capabilities reserve code-cell source edits for owners", () =>
 
   assert.equal(capabilities.canEditMarkdown, true);
   assert.equal(capabilities.canEditCells, true);
-  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canEditStructure, true);
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canManagePackages, false);
   assert.equal(capabilities.canManageSharing, true);

--- a/apps/notebook-cloud/viewer/cloud-cell-id.ts
+++ b/apps/notebook-cloud/viewer/cloud-cell-id.ts
@@ -1,0 +1,23 @@
+let fallbackCellIdCounter = 0;
+
+export interface CloudNotebookCellIdRandomSource {
+  randomUUID?: () => string;
+  getRandomValues?: (bytes: Uint8Array) => Uint8Array;
+}
+
+export function createCloudNotebookCellId(
+  randomSource: CloudNotebookCellIdRandomSource | null = globalThis.crypto ?? null,
+): string {
+  if (typeof randomSource?.randomUUID === "function") {
+    return randomSource.randomUUID();
+  }
+
+  if (typeof randomSource?.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    randomSource.getRandomValues(bytes);
+    return `cell-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  fallbackCellIdCounter += 1;
+  return `cell-${Date.now().toString(36)}-${fallbackCellIdCounter.toString(36)}`;
+}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -42,6 +42,12 @@ body {
   margin-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
 }
 
+.cloud-room-toolbar {
+  min-height: 3rem;
+  border-bottom: 1px solid var(--border);
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+}
+
 .cloud-rail-panel-note {
   border: 1px dashed color-mix(in srgb, var(--foreground) 16%, transparent);
   border-radius: 8px;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -43,9 +43,18 @@ body {
 }
 
 .cloud-room-toolbar {
-  min-height: 3rem;
+  min-height: 3.75rem;
   border-bottom: 1px solid var(--border);
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+}
+
+.cloud-room-toolbar [data-slot="notebook-document-header-presence"] {
+  display: flex;
+  align-items: center;
+}
+
+.cloud-room-toolbar [data-slot="notebook-document-header-controls"] {
+  gap: clamp(0.75rem, 2vw, 1.5rem);
 }
 
 .cloud-rail-panel-note {
@@ -235,14 +244,12 @@ main.flex > .cloud-report-toolbar {
   gap: 0.375rem;
   min-width: 0;
   max-width: min(12rem, 38vw);
-  height: 2rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 999px;
-  padding-inline: 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--background) 90%, transparent);
-  box-shadow: 0 1px 8px color-mix(in srgb, #000 8%, transparent);
-  backdrop-filter: blur(8px);
+  height: 2.25rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding-inline: 0.625rem;
+  color: var(--foreground);
+  background: transparent;
   cursor: pointer;
   list-style: none;
 }
@@ -253,7 +260,7 @@ main.flex > .cloud-report-toolbar {
 
 .cloud-auth-menu summary.cloud-auth-identity-summary {
   height: auto;
-  max-width: min(14rem, 42vw);
+  max-width: min(12rem, 34vw);
   border: 0;
   padding: 0;
   color: inherit;
@@ -263,7 +270,7 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-auth-identity-summary [data-slot="notebook-identity-badge"] {
-  height: 2rem;
+  height: 2.25rem;
   max-width: 100%;
 }
 
@@ -274,7 +281,7 @@ main.flex > .cloud-report-toolbar {
 .cloud-share-menu summary:hover,
 .cloud-auth-menu summary:hover {
   color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 82%, var(--foreground) 8%);
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
 }
 
 .cloud-share-menu summary:focus-visible,
@@ -299,7 +306,7 @@ main.flex > .cloud-report-toolbar {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   line-height: 1;
 }
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -85,6 +85,16 @@ body {
   line-height: 1.2;
 }
 
+.cloud-home > .cloud-report-toolbar,
+main.flex > .cloud-report-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-block: 0.5rem;
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+}
+
 .cloud-home-panel {
   align-self: start;
   justify-self: center;
@@ -193,16 +203,13 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
   border-bottom: 1px solid var(--border);
-  padding-block: 0.5rem;
-  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
   background: color-mix(in srgb, var(--background) 94%, transparent);
   backdrop-filter: blur(12px);
-  pointer-events: none;
+}
+
+.cloud-auth-diagnostics-state {
+  margin-top: 0.5rem;
 }
 
 .cloud-auth-menu {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -35,6 +35,7 @@ import {
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
+  NotebookToolbarIdentity,
   createNotebookEnvironmentSurface,
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
@@ -1301,14 +1302,7 @@ function NotebookViewer({
             interaction={shellCapabilities.interaction ?? null}
             onAuthStateChange={refreshAuthState}
           />
-          <NotebookIdentityBadge
-            actor={notebookActorIdentityFromAccess(
-              shellCapabilities.access,
-              shellCapabilities.auth,
-            )}
-            size="sm"
-            showDetail={false}
-          />
+          <NotebookToolbarIdentity capabilities={shellCapabilities} />
         </>
       }
     />

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1277,9 +1277,7 @@ function NotebookViewer({
 
   const toolbar = (
     <NotebookCommandToolbar
-      canEditStructure={shellCapabilities.canEditStructure}
-      canExecute={shellCapabilities.canExecute}
-      canViewPackages={shellCapabilities.canViewPackages}
+      capabilities={shellCapabilities}
       runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
       environmentManager={packageEnvironmentManager}
       environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1287,28 +1287,28 @@ function NotebookViewer({
         addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
         onAddCell={handleCloudAddCell}
         onTogglePackages={handleTogglePackagesRail}
-        leadingControls={
+        presenceControls={
           <CloudPresenceStatus
             presence={presence}
             interaction={shellCapabilities.interaction ?? null}
           />
         }
-        trailingControls={
-          <>
-            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-            <CloudSharingControls
-              aclEndpoint={config.aclEndpoint}
-              invitesEndpoint={config.invitesEndpoint}
-              authState={authState}
-            />
-            <CloudNotebookEditModeButton
-              authState={authState}
-              interaction={shellCapabilities.interaction ?? null}
-              onAuthStateChange={refreshAuthState}
-            />
-            <NotebookToolbarIdentity capabilities={shellCapabilities} />
-          </>
+        authControls={<CloudNotebookSignInButton authConfig={authConfig} authState={authState} />}
+        sharingControls={
+          <CloudSharingControls
+            aclEndpoint={config.aclEndpoint}
+            invitesEndpoint={config.invitesEndpoint}
+            authState={authState}
+          />
         }
+        editControls={
+          <CloudNotebookEditModeButton
+            authState={authState}
+            interaction={shellCapabilities.interaction ?? null}
+            onAuthStateChange={refreshAuthState}
+          />
+        }
+        identityControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
       />
     </NotebookToolbarFrame>
   );

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -39,6 +39,7 @@ import {
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
+  type NotebookInteractionModeProjection,
   type NotebookPackageSection,
   type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
@@ -65,6 +66,7 @@ import {
   withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
+import { createCloudNotebookCellId } from "./cloud-cell-id";
 import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { cloudNotebookShellCapabilities } from "./shell-capabilities";
@@ -1129,7 +1131,7 @@ function NotebookViewer({
       if (!shellCapabilities.canEditStructure) return null;
       const liveRuntime = liveRuntimeRef.current;
       if (!liveRuntime) return null;
-      const cellId = crypto.randomUUID ? crypto.randomUUID() : `cell-${Date.now()}`;
+      const cellId = createCloudNotebookCellId();
       try {
         liveRuntime.handle.add_cell_after(cellId, type, afterCellId ?? null);
         liveRuntime.engine.scheduleFlush();
@@ -1296,7 +1298,7 @@ function NotebookViewer({
           />
           <CloudNotebookEditModeButton
             authState={authState}
-            connectionScope={connectionScope}
+            interaction={shellCapabilities.interaction ?? null}
             onAuthStateChange={refreshAuthState}
           />
           <NotebookIdentityBadge
@@ -1794,26 +1796,24 @@ function CloudSharingControls({
 
 function CloudNotebookEditModeButton({
   authState,
-  connectionScope,
+  interaction,
   onAuthStateChange,
 }: {
   authState: CloudPrototypeAuthState;
-  connectionScope: string | null;
+  interaction: NotebookInteractionModeProjection | null;
   onAuthStateChange: () => void;
 }) {
-  if (authState.mode !== "oidc") {
+  if (
+    authState.mode !== "oidc" ||
+    (!interaction?.canRequestEdit && interaction?.activeMode !== "edit")
+  ) {
     return null;
   }
 
-  const requestedScope = authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
-  const requestingEdit = requestedScope === "editor" || requestedScope === "owner";
-  const editing = connectionScope === "editor" || connectionScope === "owner";
-  const state = editing ? "editing" : requestingEdit ? "requested" : "viewing";
-
   return (
     <NotebookEditModeButton
-      mode={requestingEdit ? "edit" : "view"}
-      state={state}
+      mode={interaction.selectedMode}
+      state={interaction.state}
       onModeChange={(mode) => {
         storeCloudRequestedScope(
           window.localStorage,

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -27,6 +27,7 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   NotebookCommandToolbar,
+  NotebookDocumentHeader,
   NotebookEditModeButton,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -40,7 +41,6 @@ import {
   createNotebookEnvironmentSurface,
   notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
-  type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
   type NotebookInteractionModeProjection,
   type NotebookPackageSection,
@@ -1125,7 +1125,6 @@ function NotebookViewer({
   const packageEnvironmentManager = cloudNotebookEnvironmentManager(
     notebookViewModel.packages.sections,
   );
-  const runtimeStatus = cloudNotebookRuntimeStatus(connectionScope, connectionError);
   const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
     materializeLiveRuntimeRef.current?.(liveRuntime);
   }, []);
@@ -1278,16 +1277,10 @@ function NotebookViewer({
 
   const toolbar = (
     <NotebookToolbarFrame className="z-20">
-      <NotebookCommandToolbar
+      <NotebookDocumentHeader
         capabilities={shellCapabilities}
-        runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
-        environmentManager={packageEnvironmentManager}
-        environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
-        runtimeStatus={runtimeStatus}
-        addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
-        onAddCell={handleCloudAddCell}
-        onTogglePackages={handleTogglePackagesRail}
-        presenceControls={
+        className="cloud-room-toolbar"
+        presence={
           <CloudPresenceStatus
             presence={presence}
             interaction={shellCapabilities.interaction ?? null}
@@ -1309,6 +1302,15 @@ function NotebookViewer({
           />
         }
         identityControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
+      />
+      <NotebookCommandToolbar
+        capabilities={shellCapabilities}
+        runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+        environmentManager={packageEnvironmentManager}
+        environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+        addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+        onAddCell={handleCloudAddCell}
+        onTogglePackages={handleTogglePackagesRail}
       />
     </NotebookToolbarFrame>
   );
@@ -1423,39 +1425,6 @@ function cloudNotebookEnvironmentManager(
     }
   }
   return null;
-}
-
-function cloudNotebookRuntimeStatus(
-  connectionScope: string | null,
-  connectionError: string | null,
-): {
-  state: NotebookCommandRuntimeState;
-  label: ReactNode;
-  ariaLabel: string;
-  title: string;
-} {
-  if (connectionError) {
-    return {
-      state: "error",
-      label: "offline",
-      ariaLabel: "Live room: offline",
-      title: connectionError,
-    };
-  }
-  if (connectionScope) {
-    return {
-      state: "idle",
-      label: "live",
-      ariaLabel: `Live room: ${connectionScope}`,
-      title: `Connected as ${connectionScope}`,
-    };
-  }
-  return {
-    state: "starting",
-    label: "connecting",
-    ariaLabel: "Live room: connecting",
-    title: "Connecting to live room",
-  };
 }
 
 function CloudSharingControls({

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -37,6 +37,7 @@ import {
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
   createNotebookEnvironmentSurface,
+  notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
@@ -1287,7 +1288,10 @@ function NotebookViewer({
       onAddCell={handleCloudAddCell}
       onTogglePackages={handleTogglePackagesRail}
       leadingControls={
-        <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
+        <CloudPresenceStatus
+          presence={presence}
+          interaction={shellCapabilities.interaction ?? null}
+        />
       }
       trailingControls={
         <>
@@ -2087,18 +2091,13 @@ function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
 
 function CloudPresenceStatus({
   presence,
-  connectionScope,
+  interaction,
 }: {
   presence: CloudViewerPresenceState;
-  connectionScope: string | null;
+  interaction: NotebookInteractionModeProjection | null;
 }) {
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
-  const scopeLabel =
-    connectionScope === "editor" || connectionScope === "owner"
-      ? "editing is allowed"
-      : connectionScope === "viewer"
-        ? "view only"
-        : null;
+  const scopeLabel = notebookInteractionPresenceLabel(interaction);
 
   return (
     <NotebookPresenceStatus

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -36,6 +36,7 @@ import {
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
+  NotebookToolbarFrame,
   createNotebookEnvironmentSurface,
   notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
@@ -1276,38 +1277,40 @@ function NotebookViewer({
   );
 
   const toolbar = (
-    <NotebookCommandToolbar
-      capabilities={shellCapabilities}
-      runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
-      environmentManager={packageEnvironmentManager}
-      environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
-      runtimeStatus={runtimeStatus}
-      addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
-      onAddCell={handleCloudAddCell}
-      onTogglePackages={handleTogglePackagesRail}
-      leadingControls={
-        <CloudPresenceStatus
-          presence={presence}
-          interaction={shellCapabilities.interaction ?? null}
-        />
-      }
-      trailingControls={
-        <>
-          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-          <CloudSharingControls
-            aclEndpoint={config.aclEndpoint}
-            invitesEndpoint={config.invitesEndpoint}
-            authState={authState}
-          />
-          <CloudNotebookEditModeButton
-            authState={authState}
+    <NotebookToolbarFrame className="z-20">
+      <NotebookCommandToolbar
+        capabilities={shellCapabilities}
+        runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+        environmentManager={packageEnvironmentManager}
+        environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+        runtimeStatus={runtimeStatus}
+        addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+        onAddCell={handleCloudAddCell}
+        onTogglePackages={handleTogglePackagesRail}
+        leadingControls={
+          <CloudPresenceStatus
+            presence={presence}
             interaction={shellCapabilities.interaction ?? null}
-            onAuthStateChange={refreshAuthState}
           />
-          <NotebookToolbarIdentity capabilities={shellCapabilities} />
-        </>
-      }
-    />
+        }
+        trailingControls={
+          <>
+            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+            <CloudSharingControls
+              aclEndpoint={config.aclEndpoint}
+              invitesEndpoint={config.invitesEndpoint}
+              authState={authState}
+            />
+            <CloudNotebookEditModeButton
+              authState={authState}
+              interaction={shellCapabilities.interaction ?? null}
+              onAuthStateChange={refreshAuthState}
+            />
+            <NotebookToolbarIdentity capabilities={shellCapabilities} />
+          </>
+        }
+      />
+    </NotebookToolbarFrame>
   );
   const authDiagnostics = shouldShowPrototypeDevControls({
     oidcConfigured: Boolean(authConfig.oidc),
@@ -1333,7 +1336,6 @@ function NotebookViewer({
       className="cloud-notebook-shell"
       stageClassName="cloud-notebook-stage"
       toolbar={toolbar}
-      toolbarClassName="cloud-report-toolbar"
       toolbarLabel="Notebook view status and controls"
       capabilities={shellCapabilities}
       rail={rail}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -26,7 +26,7 @@ import { IsolatedRendererProvider } from "@/components/isolated/isolated-rendere
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
-  NotebookDocumentHeader,
+  NotebookCommandToolbar,
   NotebookEditModeButton,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -37,6 +37,9 @@ import {
   NotebookPackageSummaryPanel,
   createNotebookEnvironmentSurface,
   notebookActorIdentityFromAccess,
+  type NotebookCommandRuntimeState,
+  type NotebookEnvironmentManager,
+  type NotebookPackageSection,
   type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -76,6 +79,7 @@ import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { setLoggerHost } from "../../notebook/src/lib/logger";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 import { useNotebookViewModel } from "../../notebook/src/lib/notebook-view-model";
+import type { NotebookCell } from "../../notebook/src/types";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudViewStoreProjection,
@@ -620,6 +624,7 @@ function NotebookViewer({
   const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
   const notebookLanguageRef = useRef("python");
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
+  const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
   const liveMaterializedRef = useRef(false);
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
@@ -965,6 +970,7 @@ function NotebookViewer({
         console.warn("[notebook-cloud] live room materialization failed", error);
       });
     };
+    materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
 
     setPresence(initialCloudViewerPresence());
     setConnectionError(null);
@@ -1052,6 +1058,7 @@ function NotebookViewer({
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
       }
+      materializeLiveRuntimeRef.current = null;
       disposeCurrentRuntime();
       resetCloudViewStoreProjection();
       livePresenceStore = null;
@@ -1090,6 +1097,14 @@ function NotebookViewer({
     setSelectedOutlineItemId(item.id);
     return navigateNotebookOutlineItem(item, href);
   }, []);
+  const handleTogglePackagesRail = useCallback(() => {
+    if (activeRailPanel === "packages" && !railCollapsed) {
+      setActiveRailPanel("outline");
+      return;
+    }
+    setRailCollapsed(false);
+    setActiveRailPanel("packages");
+  }, [activeRailPanel, railCollapsed]);
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -1102,6 +1117,73 @@ function NotebookViewer({
   );
   const canEditMarkdown = shellCapabilities.canEditMarkdown;
   const notebookCellIds = notebookViewModel.cellIds;
+  const packageEnvironmentManager = cloudNotebookEnvironmentManager(
+    notebookViewModel.packages.sections,
+  );
+  const runtimeStatus = cloudNotebookRuntimeStatus(connectionScope, connectionError);
+  const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
+    materializeLiveRuntimeRef.current?.(liveRuntime);
+  }, []);
+  const handleCloudAddCell = useCallback(
+    (type: "code" | "markdown", afterCellId?: string | null): NotebookCell | null => {
+      if (!shellCapabilities.canEditStructure) return null;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return null;
+      const cellId = crypto.randomUUID ? crypto.randomUUID() : `cell-${Date.now()}`;
+      try {
+        liveRuntime.handle.add_cell_after(cellId, type, afterCellId ?? null);
+        liveRuntime.engine.scheduleFlush();
+        requestCloudMaterialization(liveRuntime);
+      } catch (error) {
+        console.warn("[notebook-cloud] add cell failed", error);
+        return null;
+      }
+      const fallback: NotebookCell =
+        type === "markdown"
+          ? { cell_type: "markdown", id: cellId, source: "", metadata: {} }
+          : {
+              cell_type: "code",
+              id: cellId,
+              source: "",
+              execution_count: null,
+              outputs: [],
+              metadata: {},
+            };
+      return fallback;
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
+  const handleCloudDeleteCell = useCallback(
+    (cellId: string) => {
+      if (!shellCapabilities.canEditStructure) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime || liveRuntime.handle.cell_count() <= 1) return;
+      try {
+        if (liveRuntime.handle.delete_cell(cellId)) {
+          liveRuntime.engine.scheduleFlush();
+          requestCloudMaterialization(liveRuntime);
+        }
+      } catch (error) {
+        console.warn("[notebook-cloud] delete cell failed", error);
+      }
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
+  const handleCloudMoveCell = useCallback(
+    (cellId: string, afterCellId?: string | null) => {
+      if (!shellCapabilities.canEditStructure) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return;
+      try {
+        liveRuntime.handle.move_cell(cellId, afterCellId ?? null);
+        liveRuntime.engine.scheduleFlush();
+        requestCloudMaterialization(liveRuntime);
+      } catch (error) {
+        console.warn("[notebook-cloud] move cell failed", error);
+      }
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
   const cloudPresenceContext = useMemo<PresenceContextValue | null>(
     () =>
@@ -1190,41 +1272,62 @@ function NotebookViewer({
   );
 
   const toolbar = (
-    <NotebookDocumentHeader
-      capabilities={shellCapabilities}
-      presence={<CloudPresenceStatus presence={presence} connectionScope={connectionScope} />}
-      utilityControls={null}
-      sharingControls={
-        <CloudSharingControls
-          aclEndpoint={config.aclEndpoint}
-          invitesEndpoint={config.invitesEndpoint}
-          authState={authState}
-        />
+    <NotebookCommandToolbar
+      canEditStructure={shellCapabilities.canEditStructure}
+      canExecute={shellCapabilities.canExecute}
+      canViewPackages={shellCapabilities.canViewPackages}
+      runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+      environmentManager={packageEnvironmentManager}
+      environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+      runtimeStatus={runtimeStatus}
+      addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+      onAddCell={handleCloudAddCell}
+      onTogglePackages={handleTogglePackagesRail}
+      leadingControls={
+        <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
       }
-      authControls={
+      trailingControls={
         <>
           <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-          <CloudAuthControls
-            authConfig={authConfig}
+          <CloudSharingControls
+            aclEndpoint={config.aclEndpoint}
+            invitesEndpoint={config.invitesEndpoint}
             authState={authState}
-            capabilities={shellCapabilities}
-            connectionActorLabel={connectionActorLabel}
-            connectionError={connectionError}
+          />
+          <CloudNotebookEditModeButton
+            authState={authState}
             connectionScope={connectionScope}
             onAuthStateChange={refreshAuthState}
           />
+          <NotebookIdentityBadge
+            actor={notebookActorIdentityFromAccess(
+              shellCapabilities.access,
+              shellCapabilities.auth,
+            )}
+            size="sm"
+            showDetail={false}
+          />
         </>
       }
-      editControls={
-        <CloudNotebookEditModeButton
-          authState={authState}
-          connectionScope={connectionScope}
-          onAuthStateChange={refreshAuthState}
-        />
-      }
-      codeControls={null}
     />
   );
+  const authDiagnostics = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  }) ? (
+    <div className="cloud-state cloud-auth-diagnostics-state" data-kind="loading">
+      <CloudAuthControls
+        authConfig={authConfig}
+        authState={authState}
+        capabilities={shellCapabilities}
+        connectionActorLabel={connectionActorLabel}
+        connectionError={connectionError}
+        connectionScope={connectionScope}
+        onAuthStateChange={refreshAuthState}
+      />
+    </div>
+  ) : null;
 
   return (
     <NotebookDocumentShell
@@ -1275,6 +1378,8 @@ function NotebookViewer({
         </div>
       ) : null}
 
+      {authDiagnostics}
+
       {status.kind === "ready" ? null : (
         <div className="cloud-state" data-kind={status.kind}>
           {status.message}
@@ -1297,9 +1402,9 @@ function NotebookViewer({
             onFocusCell={setFocusedCellId}
             onExecuteCell={() => {}}
             onInterruptKernel={() => {}}
-            onDeleteCell={() => {}}
-            onAddCell={() => null}
-            onMoveCell={() => {}}
+            onDeleteCell={handleCloudDeleteCell}
+            onAddCell={handleCloudAddCell}
+            onMoveCell={handleCloudMoveCell}
             markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
             outputHostContext={outputHostContext}
           />
@@ -1307,6 +1412,50 @@ function NotebookViewer({
       </PresenceValueProvider>
     </NotebookDocumentShell>
   );
+}
+
+function cloudNotebookEnvironmentManager(
+  sections: readonly NotebookPackageSection[],
+): NotebookEnvironmentManager | null {
+  for (const section of sections) {
+    if (section.manager === "uv" || section.manager === "conda" || section.manager === "pixi") {
+      return section.manager;
+    }
+  }
+  return null;
+}
+
+function cloudNotebookRuntimeStatus(
+  connectionScope: string | null,
+  connectionError: string | null,
+): {
+  state: NotebookCommandRuntimeState;
+  label: ReactNode;
+  ariaLabel: string;
+  title: string;
+} {
+  if (connectionError) {
+    return {
+      state: "error",
+      label: "offline",
+      ariaLabel: "Live room: offline",
+      title: connectionError,
+    };
+  }
+  if (connectionScope) {
+    return {
+      state: "idle",
+      label: "live",
+      ariaLabel: `Live room: ${connectionScope}`,
+      title: `Connected as ${connectionScope}`,
+    };
+  }
+  return {
+    state: "starting",
+    label: "connecting",
+    ariaLabel: "Live room: connecting",
+    title: "Connecting to live room",
+  };
 }
 
 function CloudSharingControls({
@@ -1952,9 +2101,9 @@ function CloudPresenceStatus({
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
   const scopeLabel =
     connectionScope === "editor" || connectionScope === "owner"
-      ? "editing"
+      ? "editing is allowed"
       : connectionScope === "viewer"
-        ? "viewing"
+        ? "view only"
         : null;
 
   return (

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -32,13 +32,11 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookEnvironmentSummary,
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
   NotebookToolbarFrame,
-  createNotebookEnvironmentSurface,
   notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
   type NotebookEnvironmentManager,
@@ -1232,20 +1230,6 @@ function NotebookViewer({
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
   }, [refreshAuthState]);
-  const environmentSurface = useMemo(
-    () =>
-      createNotebookEnvironmentSurface({
-        capabilities: shellCapabilities,
-        packages: notebookViewModel.packages,
-        runtimeLabel: connectionScope === "runtime_peer" ? "Runtime peer connected" : null,
-        syncLabel: connectionScope ? "Live sync connected" : "Live sync unavailable",
-        syncStatus: connectionScope ? "synced" : "unavailable",
-        trustLabel: "Trust state not required",
-        trustStatus: "not_required",
-      }),
-    [connectionScope, notebookViewModel.packages, shellCapabilities],
-  );
-
   const rail = (
     <NotebookDocumentRail
       viewModel={notebookViewModel}
@@ -1256,15 +1240,6 @@ function NotebookViewer({
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}
           readOnly={!shellCapabilities.canManagePackages}
-          header={
-            <NotebookEnvironmentSummary
-              capabilities={shellCapabilities}
-              environment={environmentSurface}
-              packages={notebookViewModel.packages}
-              showPackageDetails={false}
-              className="shadow-none"
-            />
-          }
         />
       }
       onActivePanelChange={setActiveRailPanel}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -37,7 +37,6 @@ import {
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
   NotebookToolbarFrame,
-  notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
   type NotebookEnvironmentManager,
   type NotebookInteractionModeProjection,
@@ -1255,12 +1254,7 @@ function NotebookViewer({
       <NotebookDocumentHeader
         capabilities={shellCapabilities}
         className="cloud-room-toolbar"
-        presence={
-          <CloudPresenceStatus
-            presence={presence}
-            interaction={shellCapabilities.interaction ?? null}
-          />
-        }
+        presence={<CloudPresenceStatus presence={presence} />}
         authControls={<CloudNotebookSignInButton authConfig={authConfig} authState={authState} />}
         sharingControls={
           <CloudSharingControls
@@ -1276,7 +1270,9 @@ function NotebookViewer({
             onAuthStateChange={refreshAuthState}
           />
         }
-        identityControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
+        identityControls={
+          <NotebookToolbarIdentity capabilities={shellCapabilities} variant="inline" />
+        }
       />
       <NotebookCommandToolbar
         capabilities={shellCapabilities}
@@ -1756,6 +1752,7 @@ function CloudNotebookEditModeButton({
     <NotebookEditModeButton
       mode={interaction.selectedMode}
       state={interaction.state}
+      variant="segmented"
       onModeChange={(mode) => {
         storeCloudRequestedScope(
           window.localStorage,
@@ -2033,22 +2030,15 @@ function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
   liveRuntime.handle.free();
 }
 
-function CloudPresenceStatus({
-  presence,
-  interaction,
-}: {
-  presence: CloudViewerPresenceState;
-  interaction: NotebookInteractionModeProjection | null;
-}) {
+function CloudPresenceStatus({ presence }: { presence: CloudViewerPresenceState }) {
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
-  const scopeLabel = notebookInteractionPresenceLabel(interaction);
 
   return (
     <NotebookPresenceStatus
       connected={presenceDisplay.connected}
       label={presenceDisplay.label}
-      modeLabel={scopeLabel}
       title={presenceDisplay.title}
+      variant="inline"
     />
   );
 }

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -79,7 +79,7 @@ export function cloudViewerPresenceDisplay(
 
   if (state.connection === "connecting" || state.roomPeerCount === null) {
     return {
-      label: "Connecting",
+      label: "Joining room",
       title: "Connecting to the notebook room",
       connected: false,
     };
@@ -88,11 +88,11 @@ export function cloudViewerPresenceDisplay(
   const count = Math.max(1, state.roomPeerCount);
   const readerTitle =
     count === 1
-      ? "1 reader connected to this notebook room"
-      : `${count} readers connected to this notebook room`;
+      ? "1 participant is in this notebook"
+      : `${count} participants are in this notebook`;
   const selfTitle = state.ownPeerLabel ? `You are ${state.ownPeerLabel}` : null;
   return {
-    label: `${count} viewing`,
+    label: count === 1 ? "1 here now" : `${count} here now`,
     title: selfTitle ? `${readerTitle}; ${selfTitle}` : readerTitle,
     connected: true,
   };

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -24,6 +24,7 @@ export function cloudNotebookShellCapabilities({
   const activeEditLevel = userSelectedViewMode ? "viewer" : accessLevel;
   const canEditMarkdown = activeEditLevel === "editor" || activeEditLevel === "owner";
   const canEditCells = activeEditLevel === "owner";
+  const canEditStructure = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
   const auth = {
@@ -50,7 +51,7 @@ export function cloudNotebookShellCapabilities({
     canRead: true,
     canEditMarkdown,
     canEditCells,
-    canEditStructure: false,
+    canEditStructure,
     canRequestEdit: authState.mode === "oidc",
     canExecute: false,
     canToggleCode: hasCodeCells,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -3,6 +3,7 @@ import {
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook-shell/actor-projection";
 import type { NotebookShellCapabilities } from "@/components/notebook-shell/capabilities";
+import { createNotebookInteractionModeProjection } from "@/components/notebook-shell/interaction-mode";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 export interface CloudNotebookShellCapabilityInput {
@@ -20,13 +21,25 @@ export function cloudNotebookShellCapabilities({
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
   const isRuntimePeer = connectionScope === "runtime_peer";
-  const userSelectedViewMode = authState.requestedScope === "viewer";
-  const activeEditLevel = userSelectedViewMode ? "viewer" : accessLevel;
-  const canEditMarkdown = activeEditLevel === "editor" || activeEditLevel === "owner";
-  const canEditCells = activeEditLevel === "owner";
-  const canEditStructure = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
+  const interaction = createNotebookInteractionModeProjection({
+    selectedMode:
+      authState.requestedScope === "editor" || authState.requestedScope === "owner"
+        ? "edit"
+        : "view",
+    permission: {
+      canEditMarkdown: accessLevel === "editor" || accessLevel === "owner",
+      canEditCells: accessLevel === "owner",
+      canEditStructure: accessLevel === "owner",
+    },
+    hostSupport: {
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+      canRequestEdit: authState.mode === "oidc",
+    },
+  });
   const auth = {
     canSignIn: authState.mode !== "oidc",
     canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
@@ -49,15 +62,16 @@ export function cloudNotebookShellCapabilities({
 
   return {
     canRead: true,
-    canEditMarkdown,
-    canEditCells,
-    canEditStructure,
-    canRequestEdit: authState.mode === "oidc",
+    canEditMarkdown: interaction.canEditMarkdown,
+    canEditCells: interaction.canEditCells,
+    canEditStructure: interaction.canEditStructure,
+    canRequestEdit: interaction.canRequestEdit,
     canExecute: false,
     canToggleCode: hasCodeCells,
     canViewPackages: true,
     canManagePackages: false,
     canManageSharing: connectionScope === "owner",
+    interaction,
     access: {
       ...access,
       actor: notebookActorProjectionFromAccess(access, auth),

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2088,7 +2088,7 @@ function AppContent() {
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
               packagesPanel={
-                <NotebookPackagesPanel>
+                <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (
                     <div className="rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
                       <div className="mb-2 flex items-center gap-2 font-medium">
@@ -2097,7 +2097,7 @@ function AppContent() {
                       </div>
                       <div className="flex flex-wrap gap-1.5">
                         <button
-                          disabled={clearingDeps}
+                          disabled={clearingDeps || !shellCapabilities.canManagePackages}
                           onClick={async () => {
                             setClearingDeps(true);
                             try {
@@ -2113,7 +2113,7 @@ function AppContent() {
                           )
                         </button>
                         <button
-                          disabled={clearingDeps}
+                          disabled={clearingDeps || !shellCapabilities.canManagePackages}
                           onClick={async () => {
                             setClearingDeps(true);
                             try {
@@ -2139,6 +2139,7 @@ function AppContent() {
                       denoConfigInfo={denoConfigInfo}
                       flexibleNpmImports={flexibleNpmImports}
                       onSetFlexibleNpmImports={setFlexibleNpmImports}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={denoDerivedSyncState}
                       syncing={kernelStatus === KERNEL_STATUS.STARTING}
                       onSyncNow={handleSyncDeps}
@@ -2153,6 +2154,7 @@ function AppContent() {
                       python={condaDependencies?.python ?? null}
                       loading={condaDepsLoading}
                       envSource={envSource}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={condaDerivedSyncState}
                       onAdd={addCondaDependency}
                       onRemove={removeCondaDependency}
@@ -2172,6 +2174,7 @@ function AppContent() {
                       variant="rail"
                       pixiInfo={pixiInfo}
                       envSource={envSource}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={pixiDerivedSyncState}
                       onSyncNow={handleSyncDeps}
                       justSynced={justSynced}
@@ -2183,6 +2186,7 @@ function AppContent() {
                       dependencies={dependencies?.dependencies ?? []}
                       requiresPython={dependencies?.requires_python ?? null}
                       loading={depsLoading}
+                      readOnly={!shellCapabilities.canManagePackages}
                       onAdd={addDependency}
                       onRemove={removeDependency}
                       onSetRequiresPython={setRequiresPython}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2023,9 +2023,7 @@ function AppContent() {
           onAddCell={handleAddCell}
           onToggleDependencies={handleTogglePackagesRail}
           isDepsOpen={packagesRailOpen}
-          canEditStructure={shellCapabilities.canEditStructure}
-          canExecute={shellCapabilities.canExecute}
-          canViewPackages={shellCapabilities.canViewPackages}
+          capabilities={shellCapabilities}
           depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
           updateStatus={updateStatus}
           updateVersion={updateVersion}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -43,6 +43,8 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookIdentityBadge,
+  notebookActorIdentityFromAccess,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -2029,6 +2031,16 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
+          trailingControls={
+            <NotebookIdentityBadge
+              actor={notebookActorIdentityFromAccess(
+                shellCapabilities.access,
+                shellCapabilities.auth,
+              )}
+              size="sm"
+              showDetail={false}
+            />
+          }
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -43,8 +43,7 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookIdentityBadge,
-  notebookActorIdentityFromAccess,
+  NotebookToolbarIdentity,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -2031,16 +2030,7 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
-          trailingControls={
-            <NotebookIdentityBadge
-              actor={notebookActorIdentityFromAccess(
-                shellCapabilities.access,
-                shellCapabilities.auth,
-              )}
-              size="sm"
-              showDetail={false}
-            />
-          }
+          trailingControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -17,6 +17,7 @@ interface CondaDependencyHeaderProps {
   loading: boolean;
   envSource?: string | null;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   syncState: CondaSyncState | null;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
@@ -43,6 +44,7 @@ export function CondaDependencyHeader({
   loading,
   envSource,
   variant = "header",
+  readOnly = false,
   syncState,
   onAdd,
   onRemove,
@@ -68,11 +70,11 @@ export function CondaDependencyHeader({
   const environmentYmlPython = environmentYmlDeps?.python ?? environmentYmlInfo?.python ?? null;
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       await onAdd(newDep.trim());
       setNewDep("");
     }
-  }, [newDep, onAdd]);
+  }, [newDep, onAdd, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -85,7 +87,7 @@ export function CondaDependencyHeader({
   );
 
   const handleAddChannel = useCallback(async () => {
-    if (newChannel.trim()) {
+    if (!readOnly && newChannel.trim()) {
       const trimmed = newChannel.trim();
       let updated: string[];
       if (channels.length === 0 && trimmed !== "conda-forge") {
@@ -99,23 +101,25 @@ export function CondaDependencyHeader({
       setNewChannel("");
       setShowChannelInput(false);
     }
-  }, [newChannel, channels, onSetChannels, onResetProgress]);
+  }, [newChannel, channels, onSetChannels, onResetProgress, readOnly]);
 
   const handleRemoveChannel = useCallback(
     async (channel: string) => {
+      if (readOnly) return;
       const updated = channels.filter((c) => c !== channel);
       onResetProgress?.();
       await onSetChannels(updated);
     },
-    [channels, onSetChannels, onResetProgress],
+    [channels, onSetChannels, onResetProgress, readOnly],
   );
 
   const handlePythonChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (readOnly) return;
       const value = e.target.value.trim();
       await onSetPython(value || null);
     },
-    [onSetPython],
+    [onSetPython, readOnly],
   );
 
   // Default channels if none specified
@@ -185,35 +189,39 @@ export function CondaDependencyHeader({
                 <pre className="mt-1 whitespace-pre-wrap font-mono text-[10px] opacity-80 overflow-x-auto">
                   {envProgress.error}
                 </pre>
-                <div className="mt-2 text-[11px] text-red-600/80 dark:text-red-400/80">
-                  Fix channels or dependencies above, then retry.
-                </div>
-              </div>
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  type="button"
-                  disabled={loading}
-                  onClick={() => {
-                    onResetProgress?.();
-                    (onRetryLaunch ?? onSyncNow)();
-                  }}
-                  className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Retry environment creation"
-                >
-                  <RefreshCw className="h-3 w-3" />
-                  Retry
-                </button>
-                {onResetProgress && (
-                  <button
-                    type="button"
-                    onClick={onResetProgress}
-                    className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
-                    title="Dismiss"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                {!readOnly && (
+                  <div className="mt-2 text-[11px] text-red-600/80 dark:text-red-400/80">
+                    Fix channels or dependencies above, then retry.
+                  </div>
                 )}
               </div>
+              {!readOnly && (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    disabled={loading}
+                    onClick={() => {
+                      onResetProgress?.();
+                      (onRetryLaunch ?? onSyncNow)();
+                    }}
+                    className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Retry environment creation"
+                  >
+                    <RefreshCw className="h-3 w-3" />
+                    Retry
+                  </button>
+                  {onResetProgress && (
+                    <button
+                      type="button"
+                      onClick={onResetProgress}
+                      className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
+                      title="Dismiss"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -297,7 +305,7 @@ export function CondaDependencyHeader({
         )}
 
         {/* Environment drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && (
+        {!readOnly && syncState?.status === "dirty" && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -341,7 +349,7 @@ export function CondaDependencyHeader({
                     {isUsingDefault && (
                       <span className="text-[10px] text-muted-foreground ml-0.5">(default)</span>
                     )}
-                    {channels.length > 0 && (
+                    {!readOnly && channels.length > 0 && (
                       <button
                         type="button"
                         onClick={() => handleRemoveChannel(channel)}
@@ -354,7 +362,7 @@ export function CondaDependencyHeader({
                     )}
                   </div>
                 ))}
-                {showChannelInput ? (
+                {!readOnly && showChannelInput ? (
                   <div className="flex gap-1">
                     <input
                       type="text"
@@ -385,7 +393,7 @@ export function CondaDependencyHeader({
                       Add
                     </button>
                   </div>
-                ) : (
+                ) : !readOnly ? (
                   <button
                     type="button"
                     onClick={() => setShowChannelInput(true)}
@@ -395,32 +403,40 @@ export function CondaDependencyHeader({
                     <Plus className="h-3 w-3" />
                     channel
                   </button>
-                )}
+                ) : null}
               </div>
             </div>
 
             {/* Python version */}
-            <label
-              className={cn(
-                "mb-2 flex items-center gap-2",
-                isRail && "flex-col items-stretch gap-1.5",
-              )}
-            >
-              <span className="text-xs font-medium text-muted-foreground">Python</span>
-              <input
-                type="text"
-                value={python ?? ""}
-                onChange={handlePythonChange}
-                placeholder="3.11"
+            {readOnly ? (
+              python ? (
+                <div className="mb-2 text-xs text-muted-foreground">
+                  Python: <span className="font-mono">{python}</span>
+                </div>
+              ) : null
+            ) : (
+              <label
                 className={cn(
-                  "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
-                  isRail ? "w-full" : "w-20",
+                  "mb-2 flex items-center gap-2",
+                  isRail && "flex-col items-stretch gap-1.5",
                 )}
-                disabled={loading}
-                autoComplete="off"
-                spellCheck={false}
-              />
-            </label>
+              >
+                <span className="text-xs font-medium text-muted-foreground">Python</span>
+                <input
+                  type="text"
+                  value={python ?? ""}
+                  onChange={handlePythonChange}
+                  placeholder="3.11"
+                  className={cn(
+                    "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
+                    isRail ? "w-full" : "w-20",
+                  )}
+                  disabled={loading}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </label>
+            )}
 
             {/* Dependencies list */}
             {isRail ? (
@@ -429,7 +445,7 @@ export function CondaDependencyHeader({
                 tone="conda"
                 emptyLabel="No dependencies. Add conda packages to create an isolated environment."
                 loading={loading}
-                onRemove={onRemove}
+                onRemove={readOnly ? undefined : onRemove}
                 className="mb-3"
               />
             ) : dependencies.length > 0 ? (
@@ -440,15 +456,17 @@ export function CondaDependencyHeader({
                     className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
                   >
                     <span className="min-w-0 truncate font-mono">{dep}</span>
-                    <button
-                      type="button"
-                      onClick={() => onRemove(dep)}
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                      disabled={loading}
-                      title={`Remove ${dep}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => onRemove(dep)}
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                        disabled={loading}
+                        title={`Remove ${dep}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
@@ -459,30 +477,32 @@ export function CondaDependencyHeader({
             )}
 
             {/* Add dependency input */}
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={newDep}
-                onChange={(e) => setNewDep(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="package or package>=version"
-                data-testid="conda-deps-add-input"
-                className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-                disabled={loading}
-                autoComplete="off"
-                spellCheck={false}
-              />
-              <button
-                type="button"
-                onClick={handleAdd}
-                disabled={loading || !newDep.trim()}
-                data-testid="conda-deps-add-button"
-                className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
-              >
-                <Plus className="h-3 w-3" />
-                Add
-              </button>
-            </div>
+            {!readOnly && (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={newDep}
+                  onChange={(e) => setNewDep(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="package or package>=version"
+                  data-testid="conda-deps-add-input"
+                  className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                  disabled={loading}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={loading || !newDep.trim()}
+                  data-testid="conda-deps-add-button"
+                  className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -9,6 +9,7 @@ interface DenoDependencyHeaderProps {
   flexibleNpmImports: boolean;
   onSetFlexibleNpmImports: (enabled: boolean) => void;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   // Sync state props - shows banner when config drifts from running kernel
   syncState?: { status: "synced" | "dirty" } | null;
   syncing?: boolean;
@@ -22,6 +23,7 @@ export function DenoDependencyHeader({
   flexibleNpmImports,
   onSetFlexibleNpmImports,
   variant = "header",
+  readOnly = false,
   syncState,
   syncing,
   onSyncNow,
@@ -72,7 +74,7 @@ export function DenoDependencyHeader({
         )}
 
         {/* Config drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -146,12 +148,18 @@ export function DenoDependencyHeader({
           <Checkbox
             id="flexible-npm-imports"
             checked={flexibleNpmImports}
-            onCheckedChange={(checked) => onSetFlexibleNpmImports(checked === true)}
+            onCheckedChange={(checked) => {
+              if (!readOnly) onSetFlexibleNpmImports(checked === true);
+            }}
             className="mt-0.5"
+            disabled={readOnly}
           />
           <Label
             htmlFor="flexible-npm-imports"
-            className="flex-1 flex-col items-start gap-1 cursor-pointer"
+            className={cn(
+              "flex-1 flex-col items-start gap-1",
+              readOnly ? "cursor-default" : "cursor-pointer",
+            )}
           >
             <span className="text-xs font-medium text-foreground">Auto-install npm packages</span>
             <p className="text-xs text-muted-foreground font-normal">

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -11,6 +11,7 @@ interface DependencyHeaderProps {
   requiresPython: string | null;
   loading: boolean;
   variant?: DependencyPanelVariant;
+  readOnly?: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
   onSetRequiresPython: (version: string | null) => Promise<void>;
@@ -35,6 +36,7 @@ export function DependencyHeader({
   requiresPython,
   loading,
   variant = "header",
+  readOnly = false,
   onAdd,
   onRemove,
   onSetRequiresPython,
@@ -64,11 +66,11 @@ export function DependencyHeader({
   }, [requiresPython]);
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       await onAdd(newDep.trim());
       setNewDep("");
     }
-  }, [newDep, onAdd]);
+  }, [newDep, onAdd, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -83,9 +85,10 @@ export function DependencyHeader({
   const commitPythonSpec = useCallback(async () => {
     const next = pythonSpec.trim();
     const current = requiresPython ?? "";
+    if (readOnly) return;
     if (next === current) return;
     await onSetRequiresPython(next || null);
-  }, [onSetRequiresPython, pythonSpec, requiresPython]);
+  }, [onSetRequiresPython, pythonSpec, readOnly, requiresPython]);
 
   const handlePythonKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -134,7 +137,7 @@ export function DependencyHeader({
         )}
 
         {/* Environment drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -187,7 +190,7 @@ export function DependencyHeader({
                 data-slot="deps-pyproject-actions"
                 className={cn("flex items-center gap-2", isRail && "flex-wrap justify-start pl-5")}
               >
-                {onUseProjectEnv && !isUsingProjectEnv && (
+                {!readOnly && onUseProjectEnv && !isUsingProjectEnv && (
                   <button
                     type="button"
                     onClick={onUseProjectEnv}
@@ -203,7 +206,7 @@ export function DependencyHeader({
                     Active
                   </span>
                 )}
-                {onImportFromPyproject && (
+                {!readOnly && onImportFromPyproject && (
                   <button
                     type="button"
                     onClick={onImportFromPyproject}
@@ -285,6 +288,12 @@ export function DependencyHeader({
               Python: <span className="font-mono">{requiresPython}</span>
             </div>
           )
+        ) : readOnly ? (
+          requiresPython ? (
+            <div className="mb-2 text-xs text-muted-foreground">
+              Python: <span className="font-mono">{requiresPython}</span>
+            </div>
+          ) : null
         ) : (
           <label
             className={cn(
@@ -320,7 +329,7 @@ export function DependencyHeader({
               tone="uv"
               emptyLabel="No inline dependencies. Add packages to create an isolated environment."
               loading={loading}
-              onRemove={onRemove}
+              onRemove={readOnly ? undefined : onRemove}
               className="mb-3"
             />
           ) : dependencies.length > 0 ? (
@@ -331,15 +340,17 @@ export function DependencyHeader({
                   className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
                 >
                   <span className="min-w-0 truncate font-mono">{dep}</span>
-                  <button
-                    type="button"
-                    onClick={() => onRemove(dep)}
-                    className="text-muted-foreground hover:text-foreground transition-colors"
-                    disabled={loading}
-                    title={`Remove ${dep}`}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                  {!readOnly && (
+                    <button
+                      type="button"
+                      onClick={() => onRemove(dep)}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                      disabled={loading}
+                      title={`Remove ${dep}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
                 </div>
               ))}
             </div>
@@ -350,7 +361,7 @@ export function DependencyHeader({
           ))}
 
         {/* Add dependency input (hidden when using project env) */}
-        {!isUsingProjectEnv && (
+        {!readOnly && !isUsingProjectEnv && (
           <div className="flex gap-2">
             <input
               type="text"

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -5,6 +5,7 @@ import {
   NotebookCommandToolbar,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
+  type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
@@ -45,9 +46,10 @@ interface NotebookToolbarProps {
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
-  canEditStructure?: boolean;
-  canExecute?: boolean;
-  canViewPackages?: boolean;
+  capabilities: Pick<
+    NotebookShellCapabilities,
+    "canEditStructure" | "canExecute" | "canViewPackages"
+  >;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
   updateStatus?: UpdateStatus;
@@ -79,9 +81,7 @@ export function NotebookToolbar({
   onAddCell,
   onToggleDependencies,
   isDepsOpen = false,
-  canEditStructure = true,
-  canExecute = true,
-  canViewPackages = true,
+  capabilities,
   depsOutOfSync = false,
   listKernelspecs,
   updateStatus,
@@ -184,9 +184,7 @@ export function NotebookToolbar({
   return (
     <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
       <NotebookCommandToolbar
-        canEditStructure={canEditStructure}
-        canExecute={canExecute}
-        canViewPackages={canViewPackages}
+        capabilities={capabilities}
         runtime={runtime}
         environmentManager={envManager}
         environmentPanelOpen={isDepsOpen}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -49,7 +49,12 @@ interface NotebookToolbarProps {
   isDepsOpen?: boolean;
   capabilities: Pick<
     NotebookShellCapabilities,
-    "canEditStructure" | "canExecute" | "canViewPackages"
+    | "canEditStructure"
+    | "canExecute"
+    | "canViewPackages"
+    | "canManageSharing"
+    | "canRequestEdit"
+    | "auth"
   >;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
@@ -273,7 +278,7 @@ export function NotebookToolbar({
               }
             : null
         }
-        trailingControls={trailingControls}
+        identityControls={trailingControls}
       />
     </NotebookToolbarFrame>
   );

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,17 +1,11 @@
-import {
-  ArrowDownToLine,
-  Copy,
-  ChevronsRight,
-  Code,
-  Info,
-  LetterText,
-  Play,
-  RotateCcw,
-  Square,
-} from "lucide-react";
+import { Copy, Info } from "lucide-react";
 import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { cn } from "@/lib/utils";
+import {
+  NotebookCommandToolbar,
+  type NotebookCommandRuntimeState,
+  type NotebookEnvironmentManager,
+} from "@/components/notebook-shell";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
 import {
@@ -22,11 +16,10 @@ import {
   type RuntimeStatusKey,
 } from "../lib/kernel-status";
 import type { KernelspecInfo } from "../types";
-import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "./icons";
 import { extractCondaEnvCreateCommand } from "./EnvBuildDecisionDialog";
 
 /** Badge color variant for environment sources */
-type EnvBadgeVariant = "uv" | "conda" | "pixi";
+type EnvBadgeVariant = NotebookEnvironmentManager;
 
 interface NotebookToolbarProps {
   kernelStatus: KernelStatus;
@@ -60,6 +53,7 @@ interface NotebookToolbarProps {
   updateStatus?: UpdateStatus;
   updateVersion?: string | null;
   onRestartToUpdate?: () => void;
+  trailingControls?: ReactNode;
 }
 
 export function NotebookToolbar({
@@ -93,6 +87,7 @@ export function NotebookToolbar({
   updateStatus,
   updateVersion,
   onRestartToUpdate,
+  trailingControls,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
   const [condaCommandCopied, setCondaCommandCopied] = useState(false);
@@ -120,11 +115,6 @@ export function NotebookToolbar({
       onStartKernel(spec.name);
     }
   }, [kernelspecs, onStartKernel, listKernelspecs]);
-
-  const isKernelRunning =
-    kernelStatus === KERNEL_STATUS.IDLE ||
-    kernelStatus === KERNEL_STATUS.BUSY ||
-    kernelStatus === KERNEL_STATUS.STARTING;
 
   // `statusKey` is already the throttled runtime vocabulary from
   // `useDaemonKernel` — the `RUNNING_BUSY` ↔ `RUNNING_IDLE` transition
@@ -172,244 +162,74 @@ export function NotebookToolbar({
             : "uv"
         : (envTypeHint ?? null)
       : null;
+  const runtimeStatusState = notebookCommandRuntimeState(kernelStatus, Boolean(envErrorMessage));
+  const runtimeStatusError = envErrorMessage ? (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <span className="cursor-help text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
+          {envStatusText}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align="end" className="w-80 max-w-[calc(100vw-2rem)] p-3">
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-red-600 dark:text-red-400">Environment error</p>
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
+            {envErrorMessage}
+          </pre>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  ) : null;
 
   return (
-    <header
-      data-testid="notebook-toolbar"
-      className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
-    >
-      <div className="flex h-10 items-center gap-2 px-3">
-        {/* Add cells */}
-        {canEditStructure && (
-          <>
-            <button
-              type="button"
-              onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title="Add code cell"
-              aria-label="Add code cell"
-              data-testid="add-code-cell-button"
-            >
-              <Code className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Code</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title="Add markdown cell"
-              aria-label="Add markdown cell"
-              data-testid="add-markdown-cell-button"
-            >
-              <LetterText className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Markdown</span>
-            </button>
-          </>
-        )}
-
-        {canEditStructure && canExecute ? <div className="h-4 w-px bg-border" /> : null}
-
-        {/* Kernel controls */}
-        {canExecute && !isKernelRunning && (
-          <button
-            type="button"
-            onClick={handleStartKernel}
-            disabled={listKernelspecs && kernelspecs.length === 0}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-            title="Start kernel"
-            aria-label="Start kernel"
-            data-testid="start-kernel-button"
-          >
-            <Play className="h-3 w-3" fill="currentColor" />
-            <span className="hidden @[40rem]:inline">Start kernel</span>
-          </button>
-        )}
-        {canExecute && (
-          <>
-            <button
-              type="button"
-              onClick={onRunAllCells}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-              title="Run all cells"
-              aria-label="Run all cells"
-              data-testid="run-all-button"
-            >
-              <ChevronsRight className="h-3.5 w-3.5" />
-              <span className="hidden @[40rem]:inline">Run all</span>
-            </button>
-            <button
-              type="button"
-              onClick={onRestartKernel}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-              title="Restart kernel"
-              aria-label="Restart kernel"
-              data-testid="restart-kernel-button"
-            >
-              <RotateCcw className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Restart</span>
-            </button>
-            <button
-              type="button"
-              onClick={onRestartAndRunAll}
-              className={cn(
-                "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-                depsOutOfSync
-                  ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
-                  : "text-foreground hover:bg-muted",
-              )}
-              title={
-                depsOutOfSync
-                  ? "Dependencies changed — restart kernel and run all cells"
-                  : "Restart kernel and run all cells"
+    <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
+      <NotebookCommandToolbar
+        canEditStructure={canEditStructure}
+        canExecute={canExecute}
+        canViewPackages={canViewPackages}
+        runtime={runtime}
+        environmentManager={envManager}
+        environmentPanelOpen={isDepsOpen}
+        environmentOutOfSync={depsOutOfSync}
+        runtimeStatus={{
+          state: runtimeStatusState,
+          label: envProgress?.isActive ? (
+            envStatusText
+          ) : (
+            <span
+              className={
+                kernelStatus === KERNEL_STATUS.ERROR
+                  ? "capitalize text-red-600 dark:text-red-400"
+                  : "capitalize"
               }
-              data-testid="restart-run-all-button"
             >
-              <RotateCcw className="h-3 w-3" />
-              <ChevronsRight className="h-3 w-3 -ml-1" />
-            </button>
-          </>
-        )}
-        {canExecute && isKernelRunning && (
-          <button
-            type="button"
-            onClick={onInterruptKernel}
-            className={cn(
-              "flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs transition-colors",
-              kernelStatus === KERNEL_STATUS.BUSY
-                ? "text-destructive hover:bg-destructive/10"
-                : "text-foreground hover:bg-muted",
-            )}
-            title="Interrupt kernel"
-            aria-label="Interrupt kernel"
-            data-testid="interrupt-kernel-button"
-          >
-            <Square
-              className="h-3 w-3"
-              fill={kernelStatus === KERNEL_STATUS.BUSY ? "currentColor" : "none"}
-            />
-            <span className="hidden @[40rem]:inline">Interrupt</span>
-          </button>
-        )}
-
-        <div className="flex-1" />
-
-        {/* Update available */}
-        {updateStatus === "available" && onRestartToUpdate && (
-          <button
-            type="button"
-            onClick={onRestartToUpdate}
-            data-testid="update-download-button"
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
-            title={`Prepare to update to v${updateVersion}`}
-          >
-            <ArrowDownToLine className="h-3 w-3" />
-            <span>Update {updateVersion}</span>
-          </button>
-        )}
-
-        {/* Runtime / deps toggle — hidden until runtime is known to avoid flicker */}
-        {runtime && canViewPackages && (
-          <button
-            type="button"
-            onClick={onToggleDependencies}
-            data-testid="deps-toggle"
-            data-runtime={runtime}
-            data-env-manager={envManager || undefined}
-            className={cn(
-              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
-              runtime === "deno"
-                ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
-                : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
-              isDepsOpen && "ring-1 ring-current/25",
-            )}
-            title={(() => {
-              const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
-              const mgr = envManager ? ` · ${envManager}` : "";
-              const action = isDepsOpen ? "close environment panel" : "open environment panel";
-              return `${lang}${mgr} — ${action}`;
-            })()}
-          >
-            {runtime === "deno" ? (
-              <>
-                <DenoIcon className="h-3 w-3" />
-                <span>Deno</span>
-              </>
-            ) : (
-              <>
-                <PythonIcon className="h-3 w-3" />
-                <span>Python</span>
-              </>
-            )}
-            {envManager && (
-              <>
-                <span className="opacity-40">·</span>
-                {envManager === "uv" && (
-                  <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
-                )}
-                {envManager === "conda" && (
-                  <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
-                )}
-                {envManager === "pixi" && (
-                  <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
-                )}
-              </>
-            )}
-          </button>
-        )}
-
-        {/* Kernel status */}
-        <div
-          className="flex items-center gap-1.5 whitespace-nowrap"
-          role="status"
-          aria-label={`Kernel: ${kernelStatusDescription}`}
-          title={envErrorMessage ? undefined : kernelStatusTooltip}
-          data-testid="kernel-status"
-          data-kernel-status={kernelStatus}
-        >
-          <div
-            className={cn(
-              "h-2 w-2 shrink-0 rounded-full",
-              kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
-              kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
-              kernelStatus === KERNEL_STATUS.STARTING && "bg-blue-500 animate-pulse",
-              kernelStatus === KERNEL_STATUS.NOT_STARTED && "bg-blue-500 animate-pulse",
-              kernelStatus === KERNEL_STATUS.SHUTDOWN && "bg-gray-400 dark:bg-gray-500",
-              (kernelStatus === KERNEL_STATUS.ERROR || envErrorMessage) && "bg-red-500",
-            )}
-          />
-          <span className="text-xs text-muted-foreground whitespace-nowrap">
-            {envProgress?.isActive ? (
-              envStatusText
-            ) : envErrorMessage ? (
-              <HoverCard openDelay={150} closeDelay={100}>
-                <HoverCardTrigger asChild>
-                  <span className="cursor-help text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
-                    {envStatusText}
-                  </span>
-                </HoverCardTrigger>
-                <HoverCardContent align="end" className="w-80 max-w-[calc(100vw-2rem)] p-3">
-                  <div className="space-y-1">
-                    <p className="text-xs font-medium text-red-600 dark:text-red-400">
-                      Environment error
-                    </p>
-                    <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
-                      {envErrorMessage}
-                    </pre>
-                  </div>
-                </HoverCardContent>
-              </HoverCard>
-            ) : (
-              <span
-                className={cn(
-                  kernelStatus === KERNEL_STATUS.ERROR && "text-red-600 dark:text-red-400",
-                )}
-              >
-                {kernelStatusText}
-              </span>
-            )}
-          </span>
-        </div>
-      </div>
+              {kernelStatusText}
+            </span>
+          ),
+          ariaLabel: `Kernel: ${kernelStatusDescription}`,
+          title: kernelStatusTooltip,
+          error: runtimeStatusError,
+        }}
+        startDisabled={Boolean(listKernelspecs && kernelspecs.length === 0)}
+        addAfterCellId={focusedCellId ?? lastCellId}
+        onAddCell={onAddCell}
+        onStartRuntime={handleStartKernel}
+        onInterruptRuntime={onInterruptKernel}
+        onRestartRuntime={onRestartKernel}
+        onRunAllCells={onRunAllCells}
+        onRestartAndRunAll={onRestartAndRunAll}
+        onTogglePackages={onToggleDependencies}
+        updateAction={
+          updateStatus === "available" && onRestartToUpdate
+            ? {
+                label: `Update ${updateVersion}`,
+                title: `Prepare to update to v${updateVersion}`,
+                onClick: onRestartToUpdate,
+              }
+            : null
+        }
+        trailingControls={trailingControls}
+      />
 
       {/* Deno install prompt */}
       {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
@@ -454,6 +274,31 @@ export function NotebookToolbar({
       )}
     </header>
   );
+}
+
+function notebookCommandRuntimeState(
+  kernelStatus: KernelStatus,
+  hasEnvironmentError: boolean,
+): NotebookCommandRuntimeState {
+  if (hasEnvironmentError) {
+    return "error";
+  }
+  switch (kernelStatus) {
+    case KERNEL_STATUS.NOT_STARTED:
+    case KERNEL_STATUS.AWAITING_TRUST:
+    case KERNEL_STATUS.AWAITING_ENV_BUILD:
+      return "not_started";
+    case KERNEL_STATUS.STARTING:
+      return "starting";
+    case KERNEL_STATUS.IDLE:
+      return "idle";
+    case KERNEL_STATUS.BUSY:
+      return "busy";
+    case KERNEL_STATUS.ERROR:
+      return "error";
+    case KERNEL_STATUS.SHUTDOWN:
+      return "shutdown";
+  }
 }
 
 /** Remediation copy for `KernelErrorReason::MissingIpykernel`, branched by

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState, type ReactElement, type ReactNode } f
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
   NotebookCommandToolbar,
+  NotebookToolbarFrame,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
   type NotebookShellCapabilities,
@@ -181,8 +182,54 @@ export function NotebookToolbar({
     </HoverCard>
   ) : null;
 
+  const notices = (
+    <>
+      {/* Deno install prompt */}
+      {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
+        <div className="border-t px-3 py-2">
+          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              <span className="font-medium">Deno not available.</span> Auto-install failed. Install
+              manually with{" "}
+              <code className="rounded bg-amber-500/20 px-1">
+                curl -fsSL https://deno.land/install.sh | sh
+              </code>{" "}
+              and restart.
+            </span>
+          </div>
+        </div>
+      )}
+      {/* ipykernel install prompt — only when daemon signals missing_ipykernel.
+          Pixi and uv/conda inline envs reach this state through different
+          mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
+          same shape: explain where ipykernel should go for the current env,
+          then tell the user to restart. */}
+      {runtime === "python" &&
+        lifecycle.lifecycle === "Error" &&
+        envSource &&
+        hasToolbarHandledIpykernelError &&
+        renderIpykernelErrorPrompt({
+          envSource,
+          errorReason,
+          errorDetails: kernelErrorMessage ?? null,
+          condaPython,
+          condaChannels,
+          projectContext,
+        })}
+      {showCondaEnvYmlMissingBanner && (
+        <CondaEnvYmlMissingBanner
+          details={kernelErrorMessage}
+          command={condaEnvCreateCommand}
+          copied={condaCommandCopied}
+          onCopyCommand={copyCondaEnvCommand}
+        />
+      )}
+    </>
+  );
+
   return (
-    <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
+    <NotebookToolbarFrame notices={notices}>
       <NotebookCommandToolbar
         capabilities={capabilities}
         runtime={runtime}
@@ -228,49 +275,7 @@ export function NotebookToolbar({
         }
         trailingControls={trailingControls}
       />
-
-      {/* Deno install prompt */}
-      {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
-        <div className="border-t px-3 py-2">
-          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              <span className="font-medium">Deno not available.</span> Auto-install failed. Install
-              manually with{" "}
-              <code className="rounded bg-amber-500/20 px-1">
-                curl -fsSL https://deno.land/install.sh | sh
-              </code>{" "}
-              and restart.
-            </span>
-          </div>
-        </div>
-      )}
-      {/* ipykernel install prompt — only when daemon signals missing_ipykernel.
-          Pixi and uv/conda inline envs reach this state through different
-          mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
-          same shape: explain where ipykernel should go for the current env,
-          then tell the user to restart. */}
-      {runtime === "python" &&
-        lifecycle.lifecycle === "Error" &&
-        envSource &&
-        hasToolbarHandledIpykernelError &&
-        renderIpykernelErrorPrompt({
-          envSource,
-          errorReason,
-          errorDetails: kernelErrorMessage ?? null,
-          condaPython,
-          condaChannels,
-          projectContext,
-        })}
-      {showCondaEnvYmlMissingBanner && (
-        <CondaEnvYmlMissingBanner
-          details={kernelErrorMessage}
-          command={condaEnvCreateCommand}
-          copied={condaCommandCopied}
-          onCopyCommand={copyCondaEnvCommand}
-        />
-      )}
-    </header>
+    </NotebookToolbarFrame>
   );
 }
 

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -11,6 +11,7 @@ interface PixiDependencyHeaderProps {
   pixiInfo: PixiInfo | null;
   envSource: string | null;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   syncState?: EnvSyncState | null;
   onSyncNow?: () => Promise<boolean>;
   justSynced?: boolean;
@@ -20,6 +21,7 @@ export function PixiDependencyHeader({
   pixiInfo,
   envSource,
   variant = "header",
+  readOnly = false,
   syncState,
   onSyncNow,
   justSynced,
@@ -34,7 +36,7 @@ export function PixiDependencyHeader({
     : [];
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       setLoading(true);
       try {
         await addPixiDependency(newDep.trim());
@@ -43,7 +45,7 @@ export function PixiDependencyHeader({
       }
       setNewDep("");
     }
-  }, [newDep]);
+  }, [newDep, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -55,14 +57,18 @@ export function PixiDependencyHeader({
     [handleAdd],
   );
 
-  const handleRemove = useCallback(async (pkg: string) => {
-    setLoading(true);
-    try {
-      await removePixiDependency(pkg);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const handleRemove = useCallback(
+    async (pkg: string) => {
+      if (readOnly) return;
+      setLoading(true);
+      try {
+        await removePixiDependency(pkg);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [readOnly],
+  );
 
   return (
     <div
@@ -108,7 +114,7 @@ export function PixiDependencyHeader({
         )}
 
         {/* Sync state drift banner */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -218,7 +224,7 @@ export function PixiDependencyHeader({
                 tone="pixi"
                 emptyLabel="No Pixi dependencies yet."
                 loading={loading}
-                onRemove={handleRemove}
+                onRemove={readOnly ? undefined : handleRemove}
                 className="mb-2"
               />
             ) : pixiDeps && pixiDeps.dependencies.length > 0 ? (
@@ -229,39 +235,43 @@ export function PixiDependencyHeader({
                     className="flex max-w-full items-center gap-1 rounded border border-amber-200 bg-amber-100 px-2 py-0.5 text-xs dark:border-amber-800 dark:bg-amber-900/30"
                   >
                     <span className="min-w-0 truncate">{dep}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(dep)}
-                      disabled={loading}
-                      className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(dep)}
+                        disabled={loading}
+                        className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
             ) : null}
 
             {/* Add dep input */}
-            <div className="mb-3 flex gap-1.5">
-              <input
-                type="text"
-                value={newDep}
-                onChange={(e) => setNewDep(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Add conda package..."
-                className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
-              />
-              <button
-                type="button"
-                onClick={handleAdd}
-                disabled={loading || !newDep.trim()}
-                className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
-              >
-                <Plus className="h-3 w-3" />
-                Add
-              </button>
-            </div>
+            {!readOnly && (
+              <div className="mb-3 flex gap-1.5">
+                <input
+                  type="text"
+                  value={newDep}
+                  onChange={(e) => setNewDep(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Add conda package..."
+                  className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+                <button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={loading || !newDep.trim()}
+                  className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              </div>
+            )}
           </>
         )}
 

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { CondaDependencyHeader } from "../CondaDependencyHeader";
+import { DenoDependencyHeader } from "../DenoDependencyHeader";
 import { DependencyHeader } from "../DependencyHeader";
 import { PackageSpecList, parsePackageSpec } from "../PackageSpecList";
 import { PixiDependencyHeader } from "../PixiDependencyHeader";
@@ -249,6 +250,113 @@ describe("DependencyHeader rail package copy", () => {
     expect(screen.getByText("Using")).toBeVisible();
     expect(screen.getAllByText("pyproject.toml").length).toBeGreaterThan(0);
     expect(screen.getByText("Re-initialize after dependency changes.")).toBeVisible();
+  });
+
+  it("keeps uv package details visible while read-only", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas>=2"]}
+        requiresPython=">=3.12"
+        loading={false}
+        readOnly
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+        syncState={{ status: "dirty", added: ["pandas"], removed: [] }}
+        onSyncNow={async () => true}
+        pyprojectInfo={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          has_dependencies: true,
+          has_dev_dependencies: false,
+          dependency_count: 1,
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          has_venv: false,
+        }}
+        onImportFromPyproject={async () => undefined}
+        onUseProjectEnv={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByText("pandas")).toBeVisible();
+    expect(screen.getByText(">=2")).toBeVisible();
+    expect(screen.getByText("Python:")).toBeVisible();
+    expect(screen.queryByTestId("uv-python-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-add-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-restart-button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove pandas/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /use project env/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy to notebook/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("read-only package rails", () => {
+  it("keeps conda package details visible without mutation controls", () => {
+    render(
+      <CondaDependencyHeader
+        variant="rail"
+        dependencies={["scipy"]}
+        channels={["conda-forge"]}
+        python="3.12"
+        loading={false}
+        readOnly
+        envSource="conda:inline"
+        syncState={{ status: "dirty", added: ["scipy"], removed: [] }}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetChannels={async () => undefined}
+        onSetPython={async () => undefined}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("scipy")).toBeVisible();
+    expect(screen.getByText("conda-forge")).toBeVisible();
+    expect(screen.getByText("Python:")).toBeVisible();
+    expect(screen.queryByTestId("conda-deps-add-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-restart-button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove scipy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove conda-forge/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^channel$/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps Deno package guidance visible but makes settings read-only", () => {
+    const onSetFlexibleNpmImports = vi.fn();
+    render(
+      <DenoDependencyHeader
+        variant="rail"
+        denoConfigInfo={null}
+        flexibleNpmImports
+        onSetFlexibleNpmImports={onSetFlexibleNpmImports}
+        readOnly
+        syncState={{ status: "dirty" }}
+        syncing={false}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("Import modules directly in your code:")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: /auto-install npm packages/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps inline Pixi details visible while read-only", () => {
+    render(
+      <PixiDependencyHeader
+        variant="rail"
+        envSource="pixi:inline"
+        pixiInfo={null}
+        readOnly
+        syncState={{ status: "dirty", added: ["numpy"], removed: [] }}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("No Pixi dependencies yet.")).toBeVisible();
+    expect(screen.queryByPlaceholderText("Add conda package...")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -73,6 +73,13 @@ const baseProps = {
     canEditStructure: true,
     canExecute: true,
     canViewPackages: true,
+    canManageSharing: false,
+    canRequestEdit: false,
+    auth: {
+      canSignIn: false,
+      canUseAuthenticatedIdentity: false,
+      needsAttention: false,
+    },
   },
 };
 

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -69,6 +69,11 @@ const baseProps = {
   onRestartAndRunAll: vi.fn(),
   onAddCell: vi.fn(),
   onToggleDependencies: vi.fn(),
+  capabilities: {
+    canEditStructure: true,
+    canExecute: true,
+    canViewPackages: true,
+  },
 };
 
 describe("NotebookToolbar", () => {

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -21,6 +21,15 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canExecute).toBe(true);
     expect(capabilities.canManagePackages).toBe(true);
     expect(capabilities.canManageSharing).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+      canRequestEdit: false,
+    });
     expect(capabilities.runtime).toMatchObject({
       canWriteRuntimeState: true,
       connected: true,
@@ -61,6 +70,14 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canRequestEdit).toBe(false);
     expect(capabilities.canExecute).toBe(false);
     expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
     expect(capabilities.runtime).toMatchObject({
       canWriteRuntimeState: false,
       connected: false,
@@ -91,6 +108,14 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canEditStructure).toBe(false);
     expect(capabilities.canExecute).toBe(false);
     expect(capabilities.runtime.canWriteRuntimeState).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
   });
 
   it("maps local read-only files to viewer access without cloud source", () => {
@@ -118,6 +143,14 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "local",
       actorLabel: null,
     });
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
   });
 
   it("keeps runtime peer authority separate from document editing access", () => {
@@ -143,6 +176,40 @@ describe("desktopNotebookShellCapabilities", () => {
       principal: { label: "Alice" },
       operator: { kind: "runtime", label: "JupyterHub" },
       scope: "runtime_peer",
+    });
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("projects desktop agent actors without treating desktop as a single human", () => {
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:kyle%40example.com/agent:codex:s1",
+      connectionScope: "editor",
+    });
+
+    expect(capabilities.access.level).toBe("editor");
+    expect(capabilities.canEditMarkdown).toBe(true);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+    });
+    expect(capabilities.access.actor).toMatchObject({
+      actorLabel: "user:anaconda:kyle%40example.com/agent:codex:s1",
+      principal: {
+        label: "kyle@example.com",
+        source: { provider: "anaconda", namespace: "anaconda" },
+      },
+      operator: { kind: "agent", label: "Codex" },
+      scope: "editor",
     });
   });
 });

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -2,6 +2,7 @@ import {
   notebookActorProjectionFromAccess,
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook-shell/actor-projection";
+import { createNotebookInteractionModeProjection } from "@/components/notebook-shell/interaction-mode";
 import type {
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
@@ -24,10 +25,25 @@ export function desktopNotebookShellCapabilities({
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
   const source = desktopAccessSourceFromActor(connectionScope, localActor);
   const isRuntimePeer = connectionScope === "runtime_peer";
+  const hasDocumentEditPermission = accessLevel === "editor" || accessLevel === "owner";
   const canWriteDocument =
-    canAcceptCellMutations && (accessLevel === "editor" || accessLevel === "owner");
+    canAcceptCellMutations && hasDocumentEditPermission;
   const canWriteRuntimeState =
     sessionReady && (isRuntimePeer || (source === "local" && canWriteDocument));
+  const interaction = createNotebookInteractionModeProjection({
+    selectedMode: hasDocumentEditPermission ? "edit" : "view",
+    permission: {
+      canEditMarkdown: hasDocumentEditPermission,
+      canEditCells: hasDocumentEditPermission,
+      canEditStructure: hasDocumentEditPermission,
+    },
+    hostSupport: {
+      canEditMarkdown: canAcceptCellMutations,
+      canEditCells: canAcceptCellMutations,
+      canEditStructure: canAcceptCellMutations,
+      canRequestEdit: false,
+    },
+  });
   const access = {
     level: accessLevel,
     source,
@@ -54,6 +70,7 @@ export function desktopNotebookShellCapabilities({
     canViewPackages: true,
     canManagePackages: canWriteDocument,
     canManageSharing: accessLevel === "owner" && source === "cloud",
+    interaction,
     access: {
       ...access,
       actor: notebookActorProjectionFromAccess(access),

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.css
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.css
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0cd3bb0ac1cb88ecbad3473447b984e454797ff637b9a79e3380be321ef904fc
+oid sha256:0d5224626ec9b71a40eb2f4b2a982873b44f011162417bc3f7c1c1c945d49362
 size 1524502

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -50,7 +50,7 @@ export interface NotebookCommandToolbarProps {
   environmentManager?: NotebookEnvironmentManager | null;
   environmentPanelOpen?: boolean;
   environmentOutOfSync?: boolean;
-  runtimeStatus: NotebookCommandToolbarStatus;
+  runtimeStatus?: NotebookCommandToolbarStatus | null;
   startDisabled?: boolean;
   addAfterCellId?: string | null;
   onAddCell?: (type: "code" | "markdown", afterCellId?: string | null) => unknown;
@@ -101,15 +101,20 @@ export function NotebookCommandToolbar({
 }: NotebookCommandToolbarProps) {
   const { auth, canEditStructure, canExecute, canManageSharing, canRequestEdit, canViewPackages } =
     capabilities;
+  const hasRuntimeStatus = Boolean(runtimeStatus);
   const isRuntimeRunning =
-    runtimeStatus.state === "idle" ||
-    runtimeStatus.state === "busy" ||
-    runtimeStatus.state === "starting";
+    runtimeStatus?.state === "idle" ||
+    runtimeStatus?.state === "busy" ||
+    runtimeStatus?.state === "starting";
   const showAddCellControls = canEditStructure && Boolean(onAddCell);
-  const showRuntimeStart = canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
+  const showRuntimeStart =
+    hasRuntimeStatus && canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
   const showRuntimeActions =
-    canExecute && Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
-  const showInterrupt = canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
+    hasRuntimeStatus &&
+    canExecute &&
+    Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
+  const showInterrupt =
+    hasRuntimeStatus && canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
   const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
   const showAuthControls =
     Boolean(authControls) &&
@@ -221,7 +226,7 @@ export function NotebookCommandToolbar({
           onClick={onInterruptRuntime}
           className={cn(
             "flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs transition-colors",
-            runtimeStatus.state === "busy"
+            runtimeStatus?.state === "busy"
               ? "text-destructive hover:bg-destructive/10"
               : "text-foreground hover:bg-muted",
           )}
@@ -231,7 +236,7 @@ export function NotebookCommandToolbar({
         >
           <Square
             className="h-3 w-3"
-            fill={runtimeStatus.state === "busy" ? "currentColor" : "none"}
+            fill={runtimeStatus?.state === "busy" ? "currentColor" : "none"}
           />
           <span className="hidden @[40rem]:inline">Interrupt</span>
         </button>
@@ -305,30 +310,32 @@ export function NotebookCommandToolbar({
         </button>
       ) : null}
 
-      <div
-        className="flex items-center gap-1.5 whitespace-nowrap"
-        role="status"
-        aria-label={runtimeStatus.ariaLabel}
-        title={runtimeStatus.error ? undefined : runtimeStatus.title}
-        data-testid="kernel-status"
-        data-kernel-status={runtimeStatus.state}
-      >
+      {runtimeStatus ? (
         <div
-          className={cn(
-            "h-2 w-2 shrink-0 rounded-full",
-            runtimeStatus.state === "idle" && "bg-green-500",
-            runtimeStatus.state === "busy" && "bg-amber-500",
-            (runtimeStatus.state === "starting" || runtimeStatus.state === "not_started") &&
-              "bg-blue-500 animate-pulse",
-            runtimeStatus.state === "shutdown" && "bg-gray-400 dark:bg-gray-500",
-            runtimeStatus.state === "error" && "bg-red-500",
-            runtimeStatus.state === "unknown" && "bg-muted-foreground",
-          )}
-        />
-        <span className="text-xs text-muted-foreground whitespace-nowrap">
-          {runtimeStatus.error ?? runtimeStatus.label}
-        </span>
-      </div>
+          className="flex items-center gap-1.5 whitespace-nowrap"
+          role="status"
+          aria-label={runtimeStatus.ariaLabel}
+          title={runtimeStatus.error ? undefined : runtimeStatus.title}
+          data-testid="kernel-status"
+          data-kernel-status={runtimeStatus.state}
+        >
+          <div
+            className={cn(
+              "h-2 w-2 shrink-0 rounded-full",
+              runtimeStatus.state === "idle" && "bg-green-500",
+              runtimeStatus.state === "busy" && "bg-amber-500",
+              (runtimeStatus.state === "starting" || runtimeStatus.state === "not_started") &&
+                "bg-blue-500 animate-pulse",
+              runtimeStatus.state === "shutdown" && "bg-gray-400 dark:bg-gray-500",
+              runtimeStatus.state === "error" && "bg-red-500",
+              runtimeStatus.state === "unknown" && "bg-muted-foreground",
+            )}
+          />
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {runtimeStatus.error ?? runtimeStatus.label}
+          </span>
+        </div>
+      ) : null}
 
       {canManageSharing ? sharingControls : null}
       {canRequestEdit ? editControls : null}

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -39,7 +39,12 @@ export interface NotebookCommandToolbarUpdateAction {
 export interface NotebookCommandToolbarProps {
   capabilities: Pick<
     NotebookShellCapabilities,
-    "canEditStructure" | "canExecute" | "canViewPackages"
+    | "canEditStructure"
+    | "canExecute"
+    | "canViewPackages"
+    | "canManageSharing"
+    | "canRequestEdit"
+    | "auth"
   >;
   runtime?: string | null;
   environmentManager?: NotebookEnvironmentManager | null;
@@ -56,6 +61,12 @@ export interface NotebookCommandToolbarProps {
   onRestartAndRunAll?: () => void;
   onTogglePackages?: () => void;
   updateAction?: NotebookCommandToolbarUpdateAction | null;
+  presenceControls?: ReactNode;
+  utilityControls?: ReactNode;
+  sharingControls?: ReactNode;
+  editControls?: ReactNode;
+  authControls?: ReactNode;
+  identityControls?: ReactNode;
   leadingControls?: ReactNode;
   trailingControls?: ReactNode;
   className?: string;
@@ -78,11 +89,18 @@ export function NotebookCommandToolbar({
   onRestartAndRunAll,
   onTogglePackages,
   updateAction = null,
+  presenceControls,
+  utilityControls,
+  sharingControls,
+  editControls,
+  authControls,
+  identityControls,
   leadingControls,
   trailingControls,
   className,
 }: NotebookCommandToolbarProps) {
-  const { canEditStructure, canExecute, canViewPackages } = capabilities;
+  const { auth, canEditStructure, canExecute, canManageSharing, canRequestEdit, canViewPackages } =
+    capabilities;
   const isRuntimeRunning =
     runtimeStatus.state === "idle" ||
     runtimeStatus.state === "busy" ||
@@ -93,6 +111,9 @@ export function NotebookCommandToolbar({
     canExecute && Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
   const showInterrupt = canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
   const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
+  const showAuthControls =
+    Boolean(authControls) &&
+    (auth.canSignIn || auth.canUseAuthenticatedIdentity || auth.needsAttention);
 
   return (
     <div
@@ -100,7 +121,7 @@ export function NotebookCommandToolbar({
       data-slot="notebook-command-toolbar"
       className={cn("@container flex h-10 min-w-0 items-center gap-2 px-3 select-none", className)}
     >
-      {leadingControls}
+      {presenceControls ?? leadingControls}
 
       {showAddCellControls ? (
         <>
@@ -218,6 +239,8 @@ export function NotebookCommandToolbar({
 
       <div className="flex-1" />
 
+      {utilityControls}
+
       {updateAction ? (
         <button
           type="button"
@@ -307,6 +330,10 @@ export function NotebookCommandToolbar({
         </span>
       </div>
 
+      {canManageSharing ? sharingControls : null}
+      {canRequestEdit ? editControls : null}
+      {showAuthControls ? authControls : null}
+      {identityControls}
       {trailingControls}
     </div>
   );

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import type { NotebookShellCapabilities } from "./capabilities";
 
 export type NotebookCommandRuntimeState =
   | "not_started"
@@ -36,9 +37,10 @@ export interface NotebookCommandToolbarUpdateAction {
 }
 
 export interface NotebookCommandToolbarProps {
-  canEditStructure: boolean;
-  canExecute: boolean;
-  canViewPackages: boolean;
+  capabilities: Pick<
+    NotebookShellCapabilities,
+    "canEditStructure" | "canExecute" | "canViewPackages"
+  >;
   runtime?: string | null;
   environmentManager?: NotebookEnvironmentManager | null;
   environmentPanelOpen?: boolean;
@@ -60,9 +62,7 @@ export interface NotebookCommandToolbarProps {
 }
 
 export function NotebookCommandToolbar({
-  canEditStructure,
-  canExecute,
-  canViewPackages,
+  capabilities,
   runtime = null,
   environmentManager = null,
   environmentPanelOpen = false,
@@ -82,6 +82,7 @@ export function NotebookCommandToolbar({
   trailingControls,
   className,
 }: NotebookCommandToolbarProps) {
+  const { canEditStructure, canExecute, canViewPackages } = capabilities;
   const isRuntimeRunning =
     runtimeStatus.state === "idle" ||
     runtimeStatus.state === "busy" ||

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -1,0 +1,397 @@
+import {
+  ArrowDownToLine,
+  ChevronsRight,
+  Code,
+  LetterText,
+  Play,
+  RotateCcw,
+  Square,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type NotebookCommandRuntimeState =
+  | "not_started"
+  | "starting"
+  | "idle"
+  | "busy"
+  | "error"
+  | "shutdown"
+  | "unknown";
+
+export type NotebookEnvironmentManager = "uv" | "conda" | "pixi";
+
+export interface NotebookCommandToolbarStatus {
+  state: NotebookCommandRuntimeState;
+  label: ReactNode;
+  ariaLabel: string;
+  title?: string;
+  error?: ReactNode;
+}
+
+export interface NotebookCommandToolbarUpdateAction {
+  label: string;
+  title: string;
+  onClick: () => void;
+}
+
+export interface NotebookCommandToolbarProps {
+  canEditStructure: boolean;
+  canExecute: boolean;
+  canViewPackages: boolean;
+  runtime?: string | null;
+  environmentManager?: NotebookEnvironmentManager | null;
+  environmentPanelOpen?: boolean;
+  environmentOutOfSync?: boolean;
+  runtimeStatus: NotebookCommandToolbarStatus;
+  startDisabled?: boolean;
+  addAfterCellId?: string | null;
+  onAddCell?: (type: "code" | "markdown", afterCellId?: string | null) => unknown;
+  onStartRuntime?: () => void;
+  onInterruptRuntime?: () => void;
+  onRestartRuntime?: () => void;
+  onRunAllCells?: () => void;
+  onRestartAndRunAll?: () => void;
+  onTogglePackages?: () => void;
+  updateAction?: NotebookCommandToolbarUpdateAction | null;
+  leadingControls?: ReactNode;
+  trailingControls?: ReactNode;
+  className?: string;
+}
+
+export function NotebookCommandToolbar({
+  canEditStructure,
+  canExecute,
+  canViewPackages,
+  runtime = null,
+  environmentManager = null,
+  environmentPanelOpen = false,
+  environmentOutOfSync = false,
+  runtimeStatus,
+  startDisabled = false,
+  addAfterCellId = null,
+  onAddCell,
+  onStartRuntime,
+  onInterruptRuntime,
+  onRestartRuntime,
+  onRunAllCells,
+  onRestartAndRunAll,
+  onTogglePackages,
+  updateAction = null,
+  leadingControls,
+  trailingControls,
+  className,
+}: NotebookCommandToolbarProps) {
+  const isRuntimeRunning =
+    runtimeStatus.state === "idle" ||
+    runtimeStatus.state === "busy" ||
+    runtimeStatus.state === "starting";
+  const showAddCellControls = canEditStructure && Boolean(onAddCell);
+  const showRuntimeStart = canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
+  const showRuntimeActions =
+    canExecute && Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
+  const showInterrupt = canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
+  const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
+
+  return (
+    <div
+      data-testid="notebook-toolbar"
+      data-slot="notebook-command-toolbar"
+      className={cn("@container flex h-10 min-w-0 items-center gap-2 px-3 select-none", className)}
+    >
+      {leadingControls}
+
+      {showAddCellControls ? (
+        <>
+          <button
+            type="button"
+            onClick={() => onAddCell?.("code", addAfterCellId)}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add code cell"
+            aria-label="Add code cell"
+            data-testid="add-code-cell-button"
+          >
+            <Code className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Code</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onAddCell?.("markdown", addAfterCellId)}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add markdown cell"
+            aria-label="Add markdown cell"
+            data-testid="add-markdown-cell-button"
+          >
+            <LetterText className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Markdown</span>
+          </button>
+        </>
+      ) : null}
+
+      {showAddCellControls && (showRuntimeStart || showRuntimeActions || showInterrupt) ? (
+        <div className="h-4 w-px bg-border" />
+      ) : null}
+
+      {showRuntimeStart ? (
+        <button
+          type="button"
+          onClick={onStartRuntime}
+          disabled={startDisabled}
+          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+          title="Start kernel"
+          aria-label="Start kernel"
+          data-testid="start-kernel-button"
+        >
+          <Play className="h-3 w-3" fill="currentColor" />
+          <span className="hidden @[40rem]:inline">Start kernel</span>
+        </button>
+      ) : null}
+
+      {showRuntimeActions ? (
+        <>
+          <button
+            type="button"
+            onClick={onRunAllCells}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Run all cells"
+            aria-label="Run all cells"
+            data-testid="run-all-button"
+          >
+            <ChevronsRight className="h-3.5 w-3.5" />
+            <span className="hidden @[40rem]:inline">Run all</span>
+          </button>
+          <button
+            type="button"
+            onClick={onRestartRuntime}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Restart kernel"
+            aria-label="Restart kernel"
+            data-testid="restart-kernel-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Restart</span>
+          </button>
+          <button
+            type="button"
+            onClick={onRestartAndRunAll}
+            className={cn(
+              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+              environmentOutOfSync
+                ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
+                : "text-foreground hover:bg-muted",
+            )}
+            title={
+              environmentOutOfSync
+                ? "Dependencies changed - restart kernel and run all cells"
+                : "Restart kernel and run all cells"
+            }
+            data-testid="restart-run-all-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            <ChevronsRight className="h-3 w-3 -ml-1" />
+          </button>
+        </>
+      ) : null}
+
+      {showInterrupt ? (
+        <button
+          type="button"
+          onClick={onInterruptRuntime}
+          className={cn(
+            "flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs transition-colors",
+            runtimeStatus.state === "busy"
+              ? "text-destructive hover:bg-destructive/10"
+              : "text-foreground hover:bg-muted",
+          )}
+          title="Interrupt kernel"
+          aria-label="Interrupt kernel"
+          data-testid="interrupt-kernel-button"
+        >
+          <Square
+            className="h-3 w-3"
+            fill={runtimeStatus.state === "busy" ? "currentColor" : "none"}
+          />
+          <span className="hidden @[40rem]:inline">Interrupt</span>
+        </button>
+      ) : null}
+
+      <div className="flex-1" />
+
+      {updateAction ? (
+        <button
+          type="button"
+          onClick={updateAction.onClick}
+          data-testid="update-download-button"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
+          title={updateAction.title}
+        >
+          <ArrowDownToLine className="h-3 w-3" />
+          <span>{updateAction.label}</span>
+        </button>
+      ) : null}
+
+      {showPackageToggle ? (
+        <button
+          type="button"
+          onClick={onTogglePackages}
+          data-testid="deps-toggle"
+          data-runtime={runtime ?? undefined}
+          data-env-manager={environmentManager || undefined}
+          className={cn(
+            "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+            runtime === "deno"
+              ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
+              : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
+            environmentPanelOpen && "ring-1 ring-current/25",
+          )}
+          title={(() => {
+            const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
+            const manager = environmentManager ? ` / ${environmentManager}` : "";
+            const action = environmentPanelOpen
+              ? "close environment panel"
+              : "open environment panel";
+            return `${lang}${manager} - ${action}`;
+          })()}
+        >
+          {runtime === "deno" ? (
+            <>
+              <DenoIcon className="h-3 w-3" />
+              <span>Deno</span>
+            </>
+          ) : (
+            <>
+              <PythonIcon className="h-3 w-3" />
+              <span>Python</span>
+            </>
+          )}
+          {environmentManager ? (
+            <>
+              <span className="opacity-40">/</span>
+              {environmentManager === "uv" ? (
+                <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
+              ) : null}
+              {environmentManager === "conda" ? (
+                <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
+              ) : null}
+              {environmentManager === "pixi" ? (
+                <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+              ) : null}
+            </>
+          ) : null}
+        </button>
+      ) : null}
+
+      <div
+        className="flex items-center gap-1.5 whitespace-nowrap"
+        role="status"
+        aria-label={runtimeStatus.ariaLabel}
+        title={runtimeStatus.error ? undefined : runtimeStatus.title}
+        data-testid="kernel-status"
+        data-kernel-status={runtimeStatus.state}
+      >
+        <div
+          className={cn(
+            "h-2 w-2 shrink-0 rounded-full",
+            runtimeStatus.state === "idle" && "bg-green-500",
+            runtimeStatus.state === "busy" && "bg-amber-500",
+            (runtimeStatus.state === "starting" || runtimeStatus.state === "not_started") &&
+              "bg-blue-500 animate-pulse",
+            runtimeStatus.state === "shutdown" && "bg-gray-400 dark:bg-gray-500",
+            runtimeStatus.state === "error" && "bg-red-500",
+            runtimeStatus.state === "unknown" && "bg-muted-foreground",
+          )}
+        />
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {runtimeStatus.error ?? runtimeStatus.label}
+        </span>
+      </div>
+
+      {trailingControls}
+    </div>
+  );
+}
+
+function DenoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+      <path d="M13.47 20.882l-1.47 -5.882c-2.649 -.088 -5 -1.624 -5 -3.5c0 -1.933 2.239 -3.5 5 -3.5s4 1 5 3c.024 .048 .69 2.215 2 6.5" />
+      <path d="M12 11h.01" />
+    </svg>
+  );
+}
+
+function PythonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 9h-7a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h3" />
+      <path d="M12 15h7a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-3" />
+      <path d="M8 9v-4a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v5a2 2 0 0 1 -2 2h-4a2 2 0 0 0 -2 2v5a2 2 0 0 0 2 2h4a2 2 0 0 0 2 -2v-4" />
+      <path d="M11 6l0 .01" />
+      <path d="M13 18l0 .01" />
+    </svg>
+  );
+}
+
+function UvIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 41 41"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M-5.28619e-06 0.168629L0.0843098 20.1685L0.151762 36.1683C0.161075 38.3774 1.95947 40.1607 4.16859 40.1514L20.1684 40.084L30.1684 40.0418L31.1852 40.0375C33.3877 40.0282 35.1683 38.2026 35.1683 36V36L37.0003 36L37.0003 39.9992L40.1683 39.9996L39.9996 -9.94653e-07L21.5998 0.0775689L21.6774 16.0185L21.6774 25.9998L20.0774 25.9998L18.3998 25.9998L18.4774 16.032L18.3998 0.0910593L-5.28619e-06 0.168629Z" />
+    </svg>
+  );
+}
+
+function CondaIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 23.565 27.149"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="0.25px"
+      className={className}
+    >
+      <path
+        d="M47.3 23.46c-.69-1.27-2.08-3.82-4.51-6.25-.81 3.47-.81 6.48-.69 7.99-.12 0 2.2-1.16 5.2-1.74zM36.54 28.32c-1.27-1.04-3.7-2.89-7.28-4.4.92 3.82 2.43 6.6 3.24 7.99 0 .23 1.62-1.74 4.05-3.59zM50.67 20.08c.81-2.08 2.31-5.09 4.74-8.22-1.5-2.66-3.58-5.32-6.36-7.64-2.2 2.78-3.7 5.56-4.74 8.33 3.12 2.66 5.09 5.44 6.36 7.52zM29.15 36.66c-1.22-.22-2.56-.41-4-.52a40.19 40.19 0 0 0-5.77-.06c1.01 1.29 2.24 2.71 3.73 4.14A39.43 39.43 0 0 0 26.35 43c.35-1.03.77-2.12 1.28-3.28a43.76 43.76 0 0 1 1.51-3.06zM11.92 49.15c4.16-2.66 8.09-3.82 10.75-4.17-2.08-1.74-5.09-4.51-7.52-8.33-3.47.69-7.01 2.02-10.36 4.33 1.97 3.47 4.47 6.2 7.12 8.17zM25.21 48.11c-1.62.12-5.56.34-10.19 3.12 4.28 2.66 8.22 4.06 10.19 4.52-.35-2.55-.35-5.21 0-7.64zM39.21 14.02c-2.54-1.74-5.78-3.24-9.83-4.17-.81 3.47-.92 6.71-.69 9.49 3.93 1.27 6.94 3.12 9.02 4.63 0-2.31.35-5.9 1.5-9.95z"
+        fillRule="evenodd"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+    </svg>
+  );
+}
+
+function PixiIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 27.4 40.2"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M27.116 3.67449C27.0374 1.63273 25.7268 0.270764 23.633 0.19141C16.9597-0.0609578 10.2854-0.0667476 3.61182 0.19175C1.56495 0.270764 0.211498 1.63273 0.128738 3.67449C0.0507459 5.60828 0.00647096 8.27738 0 9.98946C0 10.843 0.666168 11.488 1.56086 11.488C2.04414 11.488 2.46169 11.2956 2.74845 10.988C2.7539 10.985 2.76174 10.9846 2.76548 10.9802C3.03897 10.6791 3.2348 10.3079 3.50385 10.001C3.83217 9.62675 4.21021 9.28515 4.63219 9.0195C5.45945 8.49842 6.37151 8.20655 7.44535 8.20655C10.2694 8.20655 12.5673 10.2745 12.5673 13.3496C12.5673 16.4638 10.3297 18.5679 7.27779 18.5679C5.44514 18.5679 3.82195 17.7733 2.92351 16.2333C2.91193 16.2132 2.89695 16.1978 2.88469 16.1791C2.8789 16.1709 2.87311 16.1631 2.86732 16.1549C2.83019 16.1028 2.78932 16.0558 2.74505 16.0139C2.45862 15.7088 2.0421 15.518 1.5612 15.518C0.777537 15.518 0.169607 16.0132 0.0306519 16.7094C0.00919558 16.7714 0 16.8555 0.000340577 17.0162C0.00613038 18.7246 0.0527894 21.6614 0.129079 23.6953C0.166542 24.6952 0.572169 25.6696 1.34017 26.3269C2.21647 27.0772 3.21028 27.0776 4.28207 27.272C4.6516 27.3391 5.02215 27.4587 5.30585 27.7148C5.7159 28.0853 5.86712 28.6974 5.73531 29.2338C5.59125 29.8185 5.17268 30.2007 4.69996 30.5327C4.26232 30.8403 3.85874 31.1689 3.5168 31.5837C2.78694 32.4686 2.4089 33.5853 2.4089 34.7293C2.4089 37.8435 4.56986 40.0764 7.72326 40.0764C10.8375 40.0764 13.0836 37.9808 13.0836 35.0426C13.0836 33.8976 12.7699 32.7509 12.0912 31.8191C11.7683 31.376 11.3708 30.9935 10.9213 30.6809C10.47 30.3672 10.0136 30.1349 9.78409 29.5989C9.65433 29.2954 9.6104 28.9531 9.68362 28.6296C10.0068 27.1981 11.6052 27.3551 12.7233 27.3592C14.2909 27.365 15.8586 27.3579 17.426 27.3364C19.4956 27.3081 21.565 27.2557 23.6333 27.178C25.5899 27.1045 27.0377 25.6999 27.1164 23.695C27.3783 17.0217 27.3735 10.3474 27.1164 3.67381Z" />
+    </svg>
+  );
+}

--- a/src/components/notebook-shell/NotebookDocumentHeader.tsx
+++ b/src/components/notebook-shell/NotebookDocumentHeader.tsx
@@ -11,6 +11,7 @@ export interface NotebookDocumentHeaderProps {
   sharingControls?: ReactNode;
   editControls?: ReactNode;
   authControls?: ReactNode;
+  identityControls?: ReactNode;
   className?: string;
 }
 
@@ -23,6 +24,7 @@ export function NotebookDocumentHeader({
   sharingControls,
   editControls,
   authControls,
+  identityControls,
   className,
 }: NotebookDocumentHeaderProps) {
   const showCodeControls = capabilities.canToggleCode && Boolean(codeControls);
@@ -83,6 +85,11 @@ export function NotebookDocumentHeader({
         {showAuthControls ? (
           <div className="contents" data-slot="notebook-document-header-auth-controls">
             {authControls}
+          </div>
+        ) : null}
+        {identityControls ? (
+          <div className="contents" data-slot="notebook-document-header-identity-controls">
+            {identityControls}
           </div>
         ) : null}
       </div>

--- a/src/components/notebook-shell/NotebookEditModeButton.tsx
+++ b/src/components/notebook-shell/NotebookEditModeButton.tsx
@@ -10,6 +10,7 @@ export interface NotebookEditModeButtonProps {
   state: NotebookEditModeState;
   onModeChange: (mode: NotebookEditMode) => void;
   disabled?: boolean;
+  variant?: "button" | "segmented";
   className?: string;
 }
 
@@ -19,6 +20,7 @@ export function NotebookEditModeButton({
   mode,
   onModeChange,
   state,
+  variant = "button",
 }: NotebookEditModeButtonProps) {
   const requestingEdit = mode === "edit";
   const nextMode: NotebookEditMode = requestingEdit ? "view" : "edit";
@@ -28,6 +30,52 @@ export function NotebookEditModeButton({
       ? "Return to read-only viewing"
       : "Stop requesting edit access"
     : "Request edit access";
+
+  if (variant === "segmented") {
+    return (
+      <div
+        className={cn(
+          "inline-flex h-9 max-w-[min(18rem,58vw)] min-w-0 items-center rounded-lg border border-border bg-background p-1 text-sm text-muted-foreground",
+          disabled && "opacity-60",
+          className,
+        )}
+        role="group"
+        aria-label="Notebook interaction mode"
+        data-slot="notebook-edit-mode-button"
+        data-state={state}
+        data-variant={variant}
+      >
+        <button
+          type="button"
+          aria-pressed={mode === "view"}
+          className={cn(
+            "inline-flex h-7 min-w-0 items-center justify-center gap-1.5 rounded-md px-2.5 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed",
+            mode === "view" && "bg-background text-foreground shadow-sm",
+          )}
+          disabled={disabled}
+          title="View notebook"
+          onClick={() => onModeChange("view")}
+        >
+          <BookOpen className="size-4 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 truncate leading-none">Viewing</span>
+        </button>
+        <button
+          type="button"
+          aria-pressed={mode === "edit"}
+          className={cn(
+            "inline-flex h-7 min-w-0 items-center justify-center gap-1.5 rounded-md px-2.5 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed",
+            mode === "edit" && "bg-background text-emerald-700 shadow-sm dark:text-emerald-300",
+          )}
+          disabled={disabled}
+          title={state === "editing" ? "Editing notebook" : "Request edit access"}
+          onClick={() => onModeChange("edit")}
+        >
+          <Pencil className="size-4 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 truncate leading-none">Editing</span>
+        </button>
+      </div>
+    );
+  }
 
   return (
     <button
@@ -41,6 +89,7 @@ export function NotebookEditModeButton({
       )}
       data-slot="notebook-edit-mode-button"
       data-state={state}
+      data-variant={variant}
       disabled={disabled}
       title={title}
       onClick={() => onModeChange(nextMode)}

--- a/src/components/notebook-shell/NotebookEditModeButton.tsx
+++ b/src/components/notebook-shell/NotebookEditModeButton.tsx
@@ -1,8 +1,9 @@
 import { BookOpen, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { NotebookInteractionMode, NotebookInteractionState } from "./interaction-mode";
 
-export type NotebookEditMode = "view" | "edit";
-export type NotebookEditModeState = "viewing" | "requested" | "editing";
+export type NotebookEditMode = NotebookInteractionMode;
+export type NotebookEditModeState = NotebookInteractionState;
 
 export interface NotebookEditModeButtonProps {
   mode: NotebookEditMode;

--- a/src/components/notebook-shell/NotebookEditModeButton.tsx
+++ b/src/components/notebook-shell/NotebookEditModeButton.tsx
@@ -54,7 +54,11 @@ export function NotebookEditModeButton({
           )}
           disabled={disabled}
           title="View notebook"
-          onClick={() => onModeChange("view")}
+          onClick={() => {
+            if (mode !== "view") {
+              onModeChange("view");
+            }
+          }}
         >
           <BookOpen className="size-4 shrink-0" aria-hidden="true" />
           <span className="min-w-0 truncate leading-none">Viewing</span>
@@ -68,7 +72,11 @@ export function NotebookEditModeButton({
           )}
           disabled={disabled}
           title={state === "editing" ? "Editing notebook" : "Request edit access"}
-          onClick={() => onModeChange("edit")}
+          onClick={() => {
+            if (mode !== "edit") {
+              onModeChange("edit");
+            }
+          }}
         >
           <Pencil className="size-4 shrink-0" aria-hidden="true" />
           <span className="min-w-0 truncate leading-none">Editing</span>

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -27,6 +27,7 @@ export interface NotebookIdentityBadgeProps {
   actor: NotebookActorIdentity;
   size?: "sm" | "default";
   showDetail?: boolean;
+  variant?: "badge" | "inline";
   className?: string;
 }
 
@@ -41,29 +42,42 @@ export function NotebookIdentityBadge({
   actor,
   size = "default",
   showDetail = true,
+  variant = "badge",
   className,
 }: NotebookIdentityBadgeProps) {
   const Icon = actorIcon(actor.kind);
   const avatarSize = size === "sm" ? "sm" : "default";
+  const inline = variant === "inline";
 
   return (
     <div
       className={cn(
-        "inline-flex min-w-0 items-center gap-2 rounded-full border border-border bg-background px-2 py-1 text-foreground shadow-sm",
-        size === "sm" && "gap-1.5 px-1.5 py-0.5",
+        "inline-flex min-w-0 items-center text-foreground",
+        inline
+          ? "gap-2"
+          : "gap-2 rounded-full border border-border bg-background px-2 py-1 shadow-sm",
+        size === "sm" && !inline && "gap-1.5 px-1.5 py-0.5",
         className,
       )}
       data-slot="notebook-identity-badge"
       data-actor-kind={actor.kind}
       data-actor-status={actor.status ?? "active"}
+      data-variant={variant}
       title={actor.detail ? `${actor.label} - ${actor.detail}` : actor.label}
     >
-      <NotebookActorAvatar actor={actor} icon={Icon} size={avatarSize} />
+      {inline ? (
+        <span
+          className={cn("size-2 shrink-0 rounded-full", statusTone(actor.status ?? "active"))}
+          aria-hidden="true"
+        />
+      ) : (
+        <NotebookActorAvatar actor={actor} icon={Icon} size={avatarSize} />
+      )}
       <span className="min-w-0">
         <span
           className={cn(
             "block truncate font-medium leading-tight",
-            size === "sm" ? "text-xs" : "text-sm",
+            inline ? "text-sm" : size === "sm" ? "text-xs" : "text-sm",
           )}
         >
           {actor.label}

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -48,6 +48,7 @@ export function NotebookIdentityBadge({
   const Icon = actorIcon(actor.kind);
   const avatarSize = size === "sm" ? "sm" : "default";
   const inline = variant === "inline";
+  const label = inline ? compactPublicIdentityLabel(actor.label) : actor.label;
 
   return (
     <div
@@ -80,7 +81,7 @@ export function NotebookIdentityBadge({
             inline ? "text-sm" : size === "sm" ? "text-xs" : "text-sm",
           )}
         >
-          {actor.label}
+          {label}
         </span>
         {showDetail && actor.detail ? (
           <span className="block truncate text-[11px] leading-tight text-muted-foreground">
@@ -90,6 +91,15 @@ export function NotebookIdentityBadge({
       </span>
     </div>
   );
+}
+
+function compactPublicIdentityLabel(label: string): string {
+  const trimmed = label.trim();
+  const emailMatch = /^([^@\s]+)@([^@\s]+\.[^@\s]+)$/.exec(trimmed);
+  if (emailMatch?.[1]) {
+    return emailMatch[1];
+  }
+  return trimmed;
 }
 
 export function NotebookIdentityGroup({

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -29,7 +29,7 @@ export function NotebookPresenceStatus({
       data-slot="notebook-presence-status"
       data-connected={String(connected)}
       title={displayTitle}
-      aria-label={title}
+      aria-label={displayTitle}
       aria-live="polite"
     >
       <UsersRound className="size-4 shrink-0" aria-hidden="true" />

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -16,8 +16,8 @@ export function NotebookPresenceStatus({
   modeLabel = null,
   title,
 }: NotebookPresenceStatusProps) {
-  const displayLabel = modeLabel ? `${label} · ${modeLabel}` : label;
-  const displayTitle = modeLabel ? `${title}; ${modeLabel}` : title;
+  const displayLabel = modeLabel ? `${label}, ${modeLabel}` : label;
+  const displayTitle = modeLabel ? `${title}. ${modeLabel}` : title;
 
   return (
     <div

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -6,6 +6,7 @@ export interface NotebookPresenceStatusProps {
   title: string;
   connected?: boolean;
   modeLabel?: string | null;
+  variant?: "pill" | "inline";
   className?: string;
 }
 
@@ -15,24 +16,35 @@ export function NotebookPresenceStatus({
   label,
   modeLabel = null,
   title,
+  variant = "pill",
 }: NotebookPresenceStatusProps) {
   const displayLabel = modeLabel ? `${label}, ${modeLabel}` : label;
   const displayTitle = modeLabel ? `${title}. ${modeLabel}` : title;
+  const inline = variant === "inline";
 
   return (
     <div
       className={cn(
-        "pointer-events-auto inline-flex h-8 max-w-[min(16rem,52vw)] items-center gap-1.5 rounded-full border border-border bg-background/90 px-3 text-sm text-muted-foreground shadow-sm backdrop-blur",
-        connected && "border-teal-700/30 text-foreground",
+        "pointer-events-auto inline-flex h-8 max-w-[min(16rem,52vw)] items-center text-sm",
+        inline
+          ? "gap-2 text-foreground"
+          : "gap-1.5 rounded-full border border-border bg-background/90 px-3 text-muted-foreground shadow-sm backdrop-blur",
+        connected && !inline && "border-teal-700/30 text-foreground",
         className,
       )}
       data-slot="notebook-presence-status"
       data-connected={String(connected)}
+      data-variant={variant}
       title={displayTitle}
       aria-label={displayTitle}
       aria-live="polite"
     >
-      <UsersRound className="size-4 shrink-0" aria-hidden="true" />
+      <span className="relative inline-flex shrink-0" aria-hidden="true">
+        <UsersRound className="size-4" />
+        {inline && connected ? (
+          <span className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full bg-emerald-500 ring-1 ring-background" />
+        ) : null}
+      </span>
       <span className="min-w-0 truncate">{displayLabel}</span>
     </div>
   );

--- a/src/components/notebook-shell/NotebookToolbarFrame.tsx
+++ b/src/components/notebook-shell/NotebookToolbarFrame.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface NotebookToolbarFrameProps {
+  children: ReactNode;
+  className?: string;
+  notices?: ReactNode;
+}
+
+export function NotebookToolbarFrame({ children, className, notices }: NotebookToolbarFrameProps) {
+  return (
+    <header
+      className={cn(
+        "@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none",
+        className,
+      )}
+      data-slot="notebook-toolbar-frame"
+    >
+      {children}
+      {notices}
+    </header>
+  );
+}

--- a/src/components/notebook-shell/NotebookToolbarIdentity.tsx
+++ b/src/components/notebook-shell/NotebookToolbarIdentity.tsx
@@ -10,6 +10,7 @@ export interface NotebookToolbarIdentityProps {
   capabilities: NotebookShellCapabilities;
   maxVisible?: number;
   showDetail?: boolean;
+  variant?: "badge" | "inline";
   className?: string;
 }
 
@@ -17,6 +18,7 @@ export function NotebookToolbarIdentity({
   capabilities,
   maxVisible = 2,
   showDetail = false,
+  variant = "badge",
   className,
 }: NotebookToolbarIdentityProps) {
   const actors = notebookToolbarActors(capabilities).slice(0, maxVisible);
@@ -28,7 +30,13 @@ export function NotebookToolbarIdentity({
       aria-label="Notebook actors"
     >
       {actors.map((actor) => (
-        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={showDetail} />
+        <NotebookIdentityBadge
+          key={actor.id}
+          actor={actor}
+          size="sm"
+          showDetail={showDetail}
+          variant={variant}
+        />
       ))}
     </div>
   );

--- a/src/components/notebook-shell/NotebookToolbarIdentity.tsx
+++ b/src/components/notebook-shell/NotebookToolbarIdentity.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+import { NotebookIdentityBadge } from "./NotebookIdentity";
+import {
+  notebookActorIdentityFromAccess,
+  notebookActorIdentityFromRuntime,
+} from "./actor-projection";
+import type { NotebookActorIdentity, NotebookShellCapabilities } from "./capabilities";
+
+export interface NotebookToolbarIdentityProps {
+  capabilities: NotebookShellCapabilities;
+  maxVisible?: number;
+  showDetail?: boolean;
+  className?: string;
+}
+
+export function NotebookToolbarIdentity({
+  capabilities,
+  maxVisible = 2,
+  showDetail = false,
+  className,
+}: NotebookToolbarIdentityProps) {
+  const actors = notebookToolbarActors(capabilities).slice(0, maxVisible);
+
+  return (
+    <div
+      className={cn("flex min-w-0 items-center gap-1.5", className)}
+      data-slot="notebook-toolbar-identity"
+      aria-label="Notebook actors"
+    >
+      {actors.map((actor) => (
+        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={showDetail} />
+      ))}
+    </div>
+  );
+}
+
+export function notebookToolbarActors(
+  capabilities: NotebookShellCapabilities,
+): NotebookActorIdentity[] {
+  const candidates = [
+    notebookActorIdentityFromAccess(capabilities.access, capabilities.auth),
+    notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth),
+  ].filter((actor): actor is NotebookActorIdentity => Boolean(actor));
+  const actors: NotebookActorIdentity[] = [];
+  const actorIds = new Set<string>();
+
+  for (const actor of candidates) {
+    if (actorIds.has(actor.id)) continue;
+    actorIds.add(actor.id);
+    actors.push(actor);
+  }
+
+  return actors;
+}

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -9,6 +9,12 @@ const runtimeStatus = {
   title: "Kernel is idle",
 };
 
+const editableToolbarCapabilities = {
+  canEditStructure: true,
+  canExecute: true,
+  canViewPackages: true,
+};
+
 describe("NotebookCommandToolbar", () => {
   it("renders shared desktop command controls when host capabilities allow them", () => {
     const onAddCell = vi.fn();
@@ -16,9 +22,7 @@ describe("NotebookCommandToolbar", () => {
 
     render(
       <NotebookCommandToolbar
-        canEditStructure
-        canExecute
-        canViewPackages
+        capabilities={editableToolbarCapabilities}
         runtime="python"
         environmentManager="uv"
         runtimeStatus={runtimeStatus}
@@ -45,9 +49,11 @@ describe("NotebookCommandToolbar", () => {
   it("hides mutation and execution controls when the host does not grant them", () => {
     render(
       <NotebookCommandToolbar
-        canEditStructure={false}
-        canExecute={false}
-        canViewPackages
+        capabilities={{
+          ...editableToolbarCapabilities,
+          canEditStructure: false,
+          canExecute: false,
+        }}
         runtime="python"
         runtimeStatus={runtimeStatus}
         onAddCell={() => {}}

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -109,4 +109,21 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
   });
+
+  it("can render notebook commands without a runtime status surface", () => {
+    render(
+      <NotebookCommandToolbar
+        capabilities={{
+          ...editableToolbarCapabilities,
+          canExecute: false,
+        }}
+        runtime="python"
+        onTogglePackages={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("deps-toggle")).toBeVisible();
+    expect(screen.queryByTestId("kernel-status")).toBeNull();
+    expect(screen.queryByTestId("run-all-button")).toBeNull();
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -13,6 +13,13 @@ const editableToolbarCapabilities = {
   canEditStructure: true,
   canExecute: true,
   canViewPackages: true,
+  canManageSharing: true,
+  canRequestEdit: true,
+  auth: {
+    canSignIn: true,
+    canUseAuthenticatedIdentity: true,
+    needsAttention: false,
+  },
 };
 
 describe("NotebookCommandToolbar", () => {
@@ -33,7 +40,7 @@ describe("NotebookCommandToolbar", () => {
         onRestartAndRunAll={() => {}}
         onInterruptRuntime={() => {}}
         onTogglePackages={() => {}}
-        trailingControls={<button type="button">Kyle</button>}
+        identityControls={<button type="button">Kyle</button>}
       />,
     );
 
@@ -46,6 +53,28 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
   });
 
+  it("renders host chrome through named capability-scoped slots", () => {
+    render(
+      <NotebookCommandToolbar
+        capabilities={editableToolbarCapabilities}
+        runtimeStatus={runtimeStatus}
+        presenceControls={<div>2 here now, editing</div>}
+        utilityControls={<button type="button">Utility</button>}
+        sharingControls={<button type="button">Share</button>}
+        editControls={<button type="button">View</button>}
+        authControls={<button type="button">Sign in</button>}
+        identityControls={<button type="button">Kyle</button>}
+      />,
+    );
+
+    expect(screen.getByText("2 here now, editing")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Utility" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Share" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "View" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
+  });
+
   it("hides mutation and execution controls when the host does not grant them", () => {
     render(
       <NotebookCommandToolbar
@@ -53,6 +82,13 @@ describe("NotebookCommandToolbar", () => {
           ...editableToolbarCapabilities,
           canEditStructure: false,
           canExecute: false,
+          canManageSharing: false,
+          canRequestEdit: false,
+          auth: {
+            canSignIn: false,
+            canUseAuthenticatedIdentity: false,
+            needsAttention: false,
+          },
         }}
         runtime="python"
         runtimeStatus={runtimeStatus}
@@ -60,11 +96,17 @@ describe("NotebookCommandToolbar", () => {
         onRunAllCells={() => {}}
         onRestartRuntime={() => {}}
         onRestartAndRunAll={() => {}}
+        sharingControls={<button type="button">Share</button>}
+        editControls={<button type="button">Edit</button>}
+        authControls={<button type="button">Sign in</button>}
       />,
     );
 
     expect(screen.queryByTestId("add-code-cell-button")).toBeNull();
     expect(screen.queryByTestId("run-all-button")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
   });
 });

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookCommandToolbar } from "../NotebookCommandToolbar";
+
+const runtimeStatus = {
+  state: "idle" as const,
+  label: "idle",
+  ariaLabel: "Kernel: idle",
+  title: "Kernel is idle",
+};
+
+describe("NotebookCommandToolbar", () => {
+  it("renders shared desktop command controls when host capabilities allow them", () => {
+    const onAddCell = vi.fn();
+    const onRunAllCells = vi.fn();
+
+    render(
+      <NotebookCommandToolbar
+        canEditStructure
+        canExecute
+        canViewPackages
+        runtime="python"
+        environmentManager="uv"
+        runtimeStatus={runtimeStatus}
+        addAfterCellId="cell-1"
+        onAddCell={onAddCell}
+        onRunAllCells={onRunAllCells}
+        onRestartRuntime={() => {}}
+        onRestartAndRunAll={() => {}}
+        onInterruptRuntime={() => {}}
+        onTogglePackages={() => {}}
+        trailingControls={<button type="button">Kyle</button>}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("add-code-cell-button"));
+    fireEvent.click(screen.getByTestId("run-all-button"));
+
+    expect(onAddCell).toHaveBeenCalledWith("code", "cell-1");
+    expect(onRunAllCells).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("deps-toggle")).toHaveAttribute("data-env-manager", "uv");
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
+  });
+
+  it("hides mutation and execution controls when the host does not grant them", () => {
+    render(
+      <NotebookCommandToolbar
+        canEditStructure={false}
+        canExecute={false}
+        canViewPackages
+        runtime="python"
+        runtimeStatus={runtimeStatus}
+        onAddCell={() => {}}
+        onRunAllCells={() => {}}
+        onRestartRuntime={() => {}}
+        onRestartAndRunAll={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("add-code-cell-button")).toBeNull();
+    expect(screen.queryByTestId("run-all-button")).toBeNull();
+    expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
@@ -47,11 +47,13 @@ describe("NotebookDocumentHeader", () => {
         capabilities={capabilities()}
         presence={<span>1 viewing</span>}
         utilityControls={<button type="button">Theme</button>}
+        identityControls={<button type="button">Kyle</button>}
       />,
     );
 
     expect(screen.getByText("1 viewing")).toBeVisible();
     expect(screen.getByRole("button", { name: "Theme" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
   });
 
   it("gates document controls through shared shell capabilities", () => {
@@ -63,6 +65,7 @@ describe("NotebookDocumentHeader", () => {
         sharingControls={<button type="button">Share</button>}
         editControls={<button type="button">Edit</button>}
         authControls={<button type="button">Sign in</button>}
+        identityControls={<button type="button">Anonymous viewer</button>}
       />,
     );
 
@@ -71,6 +74,7 @@ describe("NotebookDocumentHeader", () => {
     expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(screen.getByRole("button", { name: "Sign in" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Anonymous viewer" })).toBeVisible();
   });
 
   it("exposes all controls when the host grants those capabilities", () => {
@@ -101,6 +105,7 @@ describe("NotebookDocumentHeader", () => {
         sharingControls={<button type="button">Share</button>}
         editControls={<button type="button">Edit</button>}
         authControls={<button type="button">Identity</button>}
+        identityControls={<button type="button">Alice</button>}
       />,
     );
 
@@ -109,6 +114,7 @@ describe("NotebookDocumentHeader", () => {
     expect(screen.getByRole("button", { name: "Share" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Identity" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Alice" })).toBeVisible();
     expect(container.querySelector("[data-slot='notebook-document-header']")).toHaveAttribute(
       "data-can-request-edit",
       "true",

--- a/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
@@ -52,4 +52,21 @@ describe("NotebookEditModeButton", () => {
 
     expect(onModeChange).toHaveBeenCalledWith("edit");
   });
+
+  it("does not reapply the already selected segmented mode", () => {
+    const onModeChange = vi.fn();
+
+    render(
+      <NotebookEditModeButton
+        mode="view"
+        state="viewing"
+        variant="segmented"
+        onModeChange={onModeChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Viewing" }));
+
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEditModeButton.test.tsx
@@ -30,4 +30,26 @@ describe("NotebookEditModeButton", () => {
 
     expect(onModeChange).toHaveBeenCalledWith("view");
   });
+
+  it("can render a segmented mode control", () => {
+    const onModeChange = vi.fn();
+
+    render(
+      <NotebookEditModeButton
+        mode="view"
+        state="viewing"
+        variant="segmented"
+        onModeChange={onModeChange}
+      />,
+    );
+
+    const group = screen.getByRole("group", { name: "Notebook interaction mode" });
+    expect(group).toHaveAttribute("data-slot", "notebook-edit-mode-button");
+    expect(group).toHaveAttribute("data-variant", "segmented");
+    expect(screen.getByRole("button", { name: "Viewing" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Editing" }));
+
+    expect(onModeChange).toHaveBeenCalledWith("edit");
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -63,7 +63,7 @@ describe("NotebookEnvironmentSummary", () => {
 
     expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
     expect(screen.getByText("Python - local runtime ready")).toBeVisible();
-    expect(screen.getByText("Python authors runtime state")).toBeVisible();
+    expect(screen.getByText("Python authors runtime state for Kyle")).toBeVisible();
     expect(screen.getByText("uv + pixi - 3 packages")).toBeVisible();
     expect(screen.getByText("pyproject.toml")).toBeVisible();
     expect(screen.getByText("dirty - 1 pending change")).toBeVisible();

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -36,8 +36,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for Kyle")).toBeVisible();
+    expect(screen.getByText("Codex for Kyle")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
   });
 
   it("projects durable principal/operator labels for delegated agents", () => {
@@ -53,8 +53,26 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for kyle@example.com")).toBeVisible();
+    expect(screen.getByText("Codex for kyle@example.com")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
+  });
+
+  it("keeps delegated agent attribution when access scope is absent", () => {
+    const actor = notebookActorIdentityFromAccess({
+      level: "none",
+      source: "local",
+      isPublic: false,
+      actorLabel: "user:local:kyle/agent:claude:s1",
+      identityLabel: "Kyle",
+    });
+
+    expect(actor.kind).toBe("agent");
+    expect(actor.detail).toBeNull();
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Claude for Kyle")).toBeVisible();
+    expect(screen.getByTitle("Claude for Kyle")).toBeVisible();
   });
 
   it("prefers structured actor projections over durable label fallback", () => {
@@ -114,8 +132,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for Alice Appleseed")).toBeVisible();
+    expect(screen.getByText("Codex for Alice Appleseed")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
     expect(screen.queryByText("Legacy")).toBeNull();
     expect(screen.queryByText("for Someone Else")).toBeNull();
   });
@@ -133,8 +151,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("JupyterHub")).toBeVisible();
-    expect(screen.getByText("for Alice")).toBeVisible();
+    expect(screen.getByText("JupyterHub for Alice")).toBeVisible();
+    expect(screen.getByText("Viewer")).toBeVisible();
   });
 
   it("projects durable system operators separately from human identity", () => {

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -14,7 +14,7 @@ describe("NotebookPresenceStatus", () => {
     );
 
     expect(screen.getByText("2 here now, editing")).toBeVisible();
-    expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
+    expect(screen.getByLabelText("2 participants are in this notebook. editing")).toHaveAttribute(
       "data-connected",
       "true",
     );

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -8,19 +8,19 @@ describe("NotebookPresenceStatus", () => {
       <NotebookPresenceStatus
         connected
         label="2 here now"
-        modeLabel="editing is allowed"
+        modeLabel="editing"
         title="2 participants are in this notebook"
       />,
     );
 
-    expect(screen.getByText("2 here now, editing is allowed")).toBeVisible();
+    expect(screen.getByText("2 here now, editing")).toBeVisible();
     expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
       "data-connected",
       "true",
     );
     expect(container.querySelector("[data-slot='notebook-presence-status']")).toHaveAttribute(
       "title",
-      "2 participants are in this notebook. editing is allowed",
+      "2 participants are in this notebook. editing",
     );
   });
 

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -7,17 +7,20 @@ describe("NotebookPresenceStatus", () => {
     const { container } = render(
       <NotebookPresenceStatus
         connected
-        label="2 viewing"
-        modeLabel="editing"
-        title="2 connected viewers"
+        label="2 here now"
+        modeLabel="editing is allowed"
+        title="2 participants are in this notebook"
       />,
     );
 
-    expect(screen.getByText("2 viewing · editing")).toBeVisible();
-    expect(screen.getByLabelText("2 connected viewers")).toHaveAttribute("data-connected", "true");
+    expect(screen.getByText("2 here now, editing is allowed")).toBeVisible();
+    expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
+      "data-connected",
+      "true",
+    );
     expect(container.querySelector("[data-slot='notebook-presence-status']")).toHaveAttribute(
       "title",
-      "2 connected viewers; editing",
+      "2 participants are in this notebook. editing is allowed",
     );
   });
 

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -33,4 +33,19 @@ describe("NotebookPresenceStatus", () => {
       "false",
     );
   });
+
+  it("can render as inline app chrome", () => {
+    render(
+      <NotebookPresenceStatus
+        connected
+        label="2 here now"
+        title="2 participants are in this notebook"
+        variant="inline"
+      />,
+    );
+
+    const status = screen.getByLabelText("2 participants are in this notebook");
+    expect(status).toHaveAttribute("data-variant", "inline");
+    expect(screen.getByText("2 here now")).toBeVisible();
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookToolbarFrame } from "../NotebookToolbarFrame";
+
+describe("NotebookToolbarFrame", () => {
+  it("provides the shared sticky notebook toolbar frame", () => {
+    const { container } = render(
+      <NotebookToolbarFrame notices={<p>Syncing</p>}>
+        <button type="button">Run</button>
+      </NotebookToolbarFrame>,
+    );
+
+    const frame = container.querySelector("[data-slot='notebook-toolbar-frame']");
+    expect(frame).toHaveClass("sticky");
+    expect(frame).toHaveClass("top-0");
+    expect(screen.getByRole("button", { name: "Run" })).toBeVisible();
+    expect(screen.getByText("Syncing")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -118,4 +118,27 @@ describe("NotebookToolbarIdentity", () => {
     expect(screen.getByText("Kyle")).toBeVisible();
     expect(screen.getByText("JupyterHub for Kyle")).toBeVisible();
   });
+
+  it("can render actors as inline app chrome", () => {
+    render(
+      <NotebookToolbarIdentity
+        variant="inline"
+        capabilities={capabilities({
+          access: {
+            level: "owner",
+            source: "cloud",
+            isPublic: false,
+            actorLabel: "user:anaconda:kyle/browser:tab",
+            identityLabel: "Kyle",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(document.querySelector("[data-slot='notebook-identity-badge']")).toHaveAttribute(
+      "data-variant",
+      "inline",
+    );
+  });
 });

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { readOnlyNotebookShellCapabilities } from "../capabilities";
+import { NotebookToolbarIdentity, notebookToolbarActors } from "../NotebookToolbarIdentity";
+import type { NotebookShellCapabilities } from "../capabilities";
+
+function capabilities(
+  overrides: Partial<NotebookShellCapabilities> = {},
+): NotebookShellCapabilities {
+  return {
+    ...readOnlyNotebookShellCapabilities,
+    ...overrides,
+    access: {
+      ...readOnlyNotebookShellCapabilities.access,
+      ...overrides.access,
+    },
+    auth: {
+      ...readOnlyNotebookShellCapabilities.auth,
+      ...overrides.auth,
+    },
+    runtime: {
+      ...readOnlyNotebookShellCapabilities.runtime,
+      ...overrides.runtime,
+    },
+  };
+}
+
+describe("NotebookToolbarIdentity", () => {
+  it("dedupes the same actor when document access and runtime authorship match", () => {
+    const actor = {
+      actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+      principal: {
+        id: "user:anaconda:alice",
+        label: "Alice",
+        source: { provider: "anaconda", namespace: "anaconda" },
+      },
+      operator: {
+        id: "runtime:jupyterhub",
+        kind: "runtime",
+        label: "JupyterHub",
+      },
+      scope: "runtime_peer",
+    } satisfies NonNullable<NotebookShellCapabilities["access"]["actor"]>;
+    const actors = notebookToolbarActors(
+      capabilities({
+        access: {
+          level: "editor",
+          source: "cloud",
+          isPublic: false,
+          actorLabel: actor.actorLabel,
+          identityLabel: "Alice",
+          actor,
+        },
+        runtime: {
+          connected: true,
+          canWriteRuntimeState: true,
+          source: "cloud",
+          actorLabel: actor.actorLabel,
+          identityLabel: "Alice",
+          actor,
+        },
+      }),
+    );
+
+    expect(actors).toHaveLength(1);
+    expect(actors[0]?.label).toBe("JupyterHub");
+  });
+
+  it("keeps desktop access, agent, and runtime actors distinct", () => {
+    const actors = notebookToolbarActors(
+      capabilities({
+        access: {
+          level: "editor",
+          source: "local",
+          isPublic: false,
+          actorLabel: "user:local:kyle/agent:codex:s1",
+          identityLabel: "Kyle",
+        },
+        runtime: {
+          connected: true,
+          canWriteRuntimeState: true,
+          source: "local",
+          actorLabel: "user:local:kyle/runtime:python",
+          identityLabel: "Kyle",
+        },
+      }),
+    );
+
+    expect(actors.map((actor) => actor.kind)).toEqual(["agent", "runtime"]);
+    expect(actors.map((actor) => actor.label)).toEqual(["Codex", "Python"]);
+  });
+
+  it("renders the shared toolbar actor badges", () => {
+    render(
+      <NotebookToolbarIdentity
+        capabilities={capabilities({
+          access: {
+            level: "owner",
+            source: "cloud",
+            isPublic: false,
+            actorLabel: "user:anaconda:kyle/browser:tab",
+            identityLabel: "Kyle",
+          },
+          runtime: {
+            connected: true,
+            canWriteRuntimeState: true,
+            source: "cloud",
+            actorLabel: "user:anaconda:kyle/runtime:jupyterhub",
+            identityLabel: "Kyle",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Notebook actors")).toBeVisible();
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(screen.getByText("JupyterHub")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -63,7 +63,8 @@ describe("NotebookToolbarIdentity", () => {
     );
 
     expect(actors).toHaveLength(1);
-    expect(actors[0]?.label).toBe("JupyterHub");
+    expect(actors[0]?.label).toBe("JupyterHub for Alice");
+    expect(actors[0]?.detail).toBe("Runtime peer");
   });
 
   it("keeps desktop access, agent, and runtime actors distinct", () => {
@@ -87,7 +88,8 @@ describe("NotebookToolbarIdentity", () => {
     );
 
     expect(actors.map((actor) => actor.kind)).toEqual(["agent", "runtime"]);
-    expect(actors.map((actor) => actor.label)).toEqual(["Codex", "Python"]);
+    expect(actors.map((actor) => actor.label)).toEqual(["Codex for Kyle", "Python for Kyle"]);
+    expect(actors.map((actor) => actor.detail)).toEqual(["Editor", "Runtime peer"]);
   });
 
   it("renders the shared toolbar actor badges", () => {
@@ -114,6 +116,6 @@ describe("NotebookToolbarIdentity", () => {
 
     expect(screen.getByLabelText("Notebook actors")).toBeVisible();
     expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getByText("JupyterHub")).toBeVisible();
+    expect(screen.getByText("JupyterHub for Kyle")).toBeVisible();
   });
 });

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -141,4 +141,28 @@ describe("NotebookToolbarIdentity", () => {
       "inline",
     );
   });
+
+  it("uses a compact label for inline email identities", () => {
+    render(
+      <NotebookToolbarIdentity
+        variant="inline"
+        capabilities={capabilities({
+          access: {
+            level: "owner",
+            source: "cloud",
+            isPublic: false,
+            actorLabel: "user:anaconda:alice/browser:tab",
+            identityLabel: "alice@example.com",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("alice")).toBeVisible();
+    expect(screen.queryByText("alice@example.com")).not.toBeInTheDocument();
+    expect(document.querySelector("[data-slot='notebook-identity-badge']")).toHaveAttribute(
+      "title",
+      "alice@example.com - Owner",
+    );
+  });
 });

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import {
-  createNotebookInteractionModeProjection,
-  notebookInteractionPresenceLabel,
-} from "../interaction-mode";
+import { createNotebookInteractionModeProjection } from "../interaction-mode";
 
 describe("createNotebookInteractionModeProjection", () => {
   it("keeps a user-selected view mode read-only even when edit permission exists", () => {
@@ -108,70 +105,5 @@ describe("createNotebookInteractionModeProjection", () => {
       canEditCells: false,
       canEditStructure: false,
     });
-  });
-
-  it("uses selected mode, permission, and host support for shared presence copy", () => {
-    const editableView = createNotebookInteractionModeProjection({
-      selectedMode: "view",
-      permission: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: false,
-      },
-      hostSupport: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: false,
-        canRequestEdit: true,
-      },
-    });
-    const activeEdit = createNotebookInteractionModeProjection({
-      selectedMode: "edit",
-      permission: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: false,
-      },
-      hostSupport: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: false,
-        canRequestEdit: true,
-      },
-    });
-    const requestedEdit = createNotebookInteractionModeProjection({
-      selectedMode: "edit",
-      permission: {
-        canEditMarkdown: false,
-        canEditCells: false,
-        canEditStructure: false,
-      },
-      hostSupport: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: true,
-        canRequestEdit: true,
-      },
-    });
-    const readOnlyView = createNotebookInteractionModeProjection({
-      selectedMode: "view",
-      permission: {
-        canEditMarkdown: false,
-        canEditCells: false,
-        canEditStructure: false,
-      },
-      hostSupport: {
-        canEditMarkdown: true,
-        canEditCells: true,
-        canEditStructure: true,
-        canRequestEdit: false,
-      },
-    });
-
-    expect(notebookInteractionPresenceLabel(editableView)).toBe("viewing");
-    expect(notebookInteractionPresenceLabel(activeEdit)).toBe("editing");
-    expect(notebookInteractionPresenceLabel(requestedEdit)).toBe("waiting for edit access");
-    expect(notebookInteractionPresenceLabel(readOnlyView)).toBe("view only");
-    expect(notebookInteractionPresenceLabel(null)).toBeNull();
   });
 });

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -84,6 +84,32 @@ describe("createNotebookInteractionModeProjection", () => {
     });
   });
 
+  it("treats edit as requested when the host cannot accept edits yet", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
   it("uses selected mode, permission, and host support for shared presence copy", () => {
     const editableView = createNotebookInteractionModeProjection({
       selectedMode: "view",

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createNotebookInteractionModeProjection } from "../interaction-mode";
+import {
+  createNotebookInteractionModeProjection,
+  notebookInteractionPresenceLabel,
+} from "../interaction-mode";
 
 describe("createNotebookInteractionModeProjection", () => {
   it("keeps a user-selected view mode read-only even when edit permission exists", () => {
@@ -79,5 +82,70 @@ describe("createNotebookInteractionModeProjection", () => {
       canEditCells: false,
       canEditStructure: false,
     });
+  });
+
+  it("uses selected mode, permission, and host support for shared presence copy", () => {
+    const editableView = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+        canRequestEdit: true,
+      },
+    });
+    const activeEdit = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+        canRequestEdit: true,
+      },
+    });
+    const requestedEdit = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+    const readOnlyView = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(notebookInteractionPresenceLabel(editableView)).toBe("viewing");
+    expect(notebookInteractionPresenceLabel(activeEdit)).toBe("editing");
+    expect(notebookInteractionPresenceLabel(requestedEdit)).toBe("waiting for edit access");
+    expect(notebookInteractionPresenceLabel(readOnlyView)).toBe("view only");
+    expect(notebookInteractionPresenceLabel(null)).toBeNull();
   });
 });

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createNotebookInteractionModeProjection } from "../interaction-mode";
+
+describe("createNotebookInteractionModeProjection", () => {
+  it("keeps a user-selected view mode read-only even when edit permission exists", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("treats edit as requested when permission has not been granted", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("intersects granted permission with host support for active edits", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: false,
+        canEditStructure: false,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canRequestEdit: false,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+});

--- a/src/components/notebook-shell/actor-projection.ts
+++ b/src/components/notebook-shell/actor-projection.ts
@@ -88,7 +88,7 @@ export function notebookActorIdentityFromProjection(
   actor: NotebookActorProjection,
 ): NotebookActorIdentity {
   const kind = actorKindFromProjection(actor);
-  const detail = actorDetailFromProjection(actor, kind);
+  const detail = actorDetailFromProjection(actor);
 
   return {
     id: actor.actorLabel,
@@ -218,22 +218,35 @@ function actorKindFromProjection(actor: NotebookActorProjection): NotebookActorK
 
 function actorLabelFromProjection(actor: NotebookActorProjection, kind: NotebookActorKind): string {
   if (kind === "agent" || kind === "runtime" || kind === "system") {
-    return actor.operator.label;
+    return operatorActorLabel(actor);
   }
   return actor.principal.label;
 }
 
-function actorDetailFromProjection(
-  actor: NotebookActorProjection,
-  kind: NotebookActorKind,
-): string | null {
-  if (kind === "agent" || kind === "runtime" || kind === "system") {
-    const principalLabel = actor.principal.label;
-    return kind === "system" && actor.principal.id === "system"
-      ? accessScopeLabel(actor.scope)
-      : `for ${principalLabel}`;
-  }
+function actorDetailFromProjection(actor: NotebookActorProjection): string | null {
   return accessScopeLabel(actor.scope);
+}
+
+function operatorActorLabel(actor: NotebookActorProjection): string {
+  const principalLabel = actor.principal.label.trim();
+  if (
+    principalLabel &&
+    principalLabel !== actor.operator.label &&
+    !isGenericPrincipalLabel(principalLabel)
+  ) {
+    return `${actor.operator.label} for ${principalLabel}`;
+  }
+  return actor.operator.label;
+}
+
+function isGenericPrincipalLabel(label: string): boolean {
+  return (
+    label === "Runtime principal" ||
+    label === "Unknown viewer" ||
+    label === "Public viewer" ||
+    label === "System" ||
+    label === "Peer"
+  );
 }
 
 function accessScopeLabel(scope: NotebookActorProjection["scope"]): string | null {

--- a/src/components/notebook-shell/capabilities.ts
+++ b/src/components/notebook-shell/capabilities.ts
@@ -1,3 +1,5 @@
+import type { NotebookInteractionModeProjection } from "./interaction-mode";
+
 export type NotebookShellAccessLevel = "none" | "viewer" | "editor" | "owner";
 
 export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown";
@@ -103,6 +105,7 @@ export interface NotebookShellCapabilities {
   canViewPackages: boolean;
   canManagePackages: boolean;
   canManageSharing: boolean;
+  interaction?: NotebookInteractionModeProjection | null;
   access: NotebookShellAccessCapabilities;
   auth: NotebookShellAuthCapabilities;
   runtime: NotebookShellRuntimeCapabilities;
@@ -119,6 +122,15 @@ export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
   canViewPackages: true,
   canManagePackages: false,
   canManageSharing: false,
+  interaction: {
+    selectedMode: "view",
+    activeMode: "view",
+    state: "viewing",
+    canRequestEdit: false,
+    canEditMarkdown: false,
+    canEditCells: false,
+    canEditStructure: false,
+  },
   access: {
     level: "viewer",
     source: "unknown",

--- a/src/components/notebook-shell/environment-surface.ts
+++ b/src/components/notebook-shell/environment-surface.ts
@@ -1,5 +1,6 @@
 import { notebookActorIdentityFromRuntime } from "./actor-projection";
 import type {
+  NotebookActorIdentity,
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
   NotebookShellCapabilities,
@@ -81,7 +82,7 @@ export function createNotebookEnvironmentSurface({
     runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
   const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
   const runtimeDetail = capabilities.runtime.canWriteRuntimeState
-    ? `${runtimeActor?.label ?? "Connected runtime"} authors runtime state`
+    ? runtimeAuthorshipDetail(runtimeActor)
     : capabilities.runtime.connected
       ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
       : null;
@@ -159,4 +160,12 @@ export function accessSourceLabel(source: NotebookShellAccessSource): string {
     case "unknown":
       return "unknown host";
   }
+}
+
+function runtimeAuthorshipDetail(actor: NotebookActorIdentity | null): string {
+  if (!actor) return "Connected runtime authors runtime state";
+  if (actor.operatorLabel && actor.principalLabel && actor.operatorLabel !== actor.principalLabel) {
+    return `${actor.operatorLabel} authors runtime state for ${actor.principalLabel}`;
+  }
+  return `${actor.label} authors runtime state`;
 }

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -74,7 +74,6 @@ export {
 } from "./NotebookEditModeButton";
 export {
   createNotebookInteractionModeProjection,
-  notebookInteractionPresenceLabel,
   type CreateNotebookInteractionModeProjectionOptions,
   type NotebookInteractionHostSupport,
   type NotebookInteractionMode,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -39,6 +39,7 @@ export {
   type NotebookCommandToolbarUpdateAction,
   type NotebookEnvironmentManager,
 } from "./NotebookCommandToolbar";
+export { NotebookToolbarFrame, type NotebookToolbarFrameProps } from "./NotebookToolbarFrame";
 export {
   NotebookIdentityBadge,
   NotebookIdentityGroup,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -47,6 +47,11 @@ export {
 } from "./NotebookIdentity";
 export { NotebookPresenceStatus, type NotebookPresenceStatusProps } from "./NotebookPresenceStatus";
 export {
+  NotebookToolbarIdentity,
+  notebookToolbarActors,
+  type NotebookToolbarIdentityProps,
+} from "./NotebookToolbarIdentity";
+export {
   NotebookEnvironmentSummary,
   type NotebookEnvironmentSummaryProps,
 } from "./NotebookEnvironmentSummary";

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -66,6 +66,15 @@ export {
   type NotebookEditModeButtonProps,
   type NotebookEditModeState,
 } from "./NotebookEditModeButton";
+export {
+  createNotebookInteractionModeProjection,
+  type CreateNotebookInteractionModeProjectionOptions,
+  type NotebookInteractionHostSupport,
+  type NotebookInteractionMode,
+  type NotebookInteractionModeProjection,
+  type NotebookInteractionPermission,
+  type NotebookInteractionState,
+} from "./interaction-mode";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
 export {
   NotebookPackageSummaryPanel,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -32,6 +32,14 @@ export {
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export {
+  NotebookCommandToolbar,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandToolbarProps,
+  type NotebookCommandToolbarStatus,
+  type NotebookCommandToolbarUpdateAction,
+  type NotebookEnvironmentManager,
+} from "./NotebookCommandToolbar";
+export {
   NotebookIdentityBadge,
   NotebookIdentityGroup,
   type NotebookIdentityBadgeProps,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -73,6 +73,7 @@ export {
 } from "./NotebookEditModeButton";
 export {
   createNotebookInteractionModeProjection,
+  notebookInteractionPresenceLabel,
   type CreateNotebookInteractionModeProjectionOptions,
   type NotebookInteractionHostSupport,
   type NotebookInteractionMode,

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -1,0 +1,57 @@
+export type NotebookInteractionMode = "view" | "edit";
+export type NotebookInteractionState = "viewing" | "requested" | "editing";
+
+export interface NotebookInteractionPermission {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+}
+
+export interface NotebookInteractionHostSupport {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+  canRequestEdit: boolean;
+}
+
+export interface NotebookInteractionModeProjection extends NotebookInteractionPermission {
+  selectedMode: NotebookInteractionMode;
+  activeMode: NotebookInteractionMode;
+  state: NotebookInteractionState;
+  canRequestEdit: boolean;
+}
+
+export interface CreateNotebookInteractionModeProjectionOptions {
+  selectedMode: NotebookInteractionMode;
+  permission: NotebookInteractionPermission;
+  hostSupport: NotebookInteractionHostSupport;
+}
+
+export function createNotebookInteractionModeProjection({
+  hostSupport,
+  permission,
+  selectedMode,
+}: CreateNotebookInteractionModeProjectionOptions): NotebookInteractionModeProjection {
+  const wantsEdit = selectedMode === "edit";
+  const hasAnyEditPermission =
+    permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
+  const canActivateEdit = wantsEdit && hasAnyEditPermission;
+  const activeMode: NotebookInteractionMode = canActivateEdit ? "edit" : "view";
+  const state: NotebookInteractionState = !wantsEdit
+    ? "viewing"
+    : canActivateEdit
+      ? "editing"
+      : "requested";
+
+  return {
+    selectedMode,
+    activeMode,
+    state,
+    canRequestEdit: hostSupport.canRequestEdit,
+    canEditMarkdown:
+      activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown,
+    canEditCells: activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells,
+    canEditStructure:
+      activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
+  };
+}

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -59,18 +59,3 @@ export function createNotebookInteractionModeProjection({
       activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
   };
 }
-
-export function notebookInteractionPresenceLabel(
-  interaction: NotebookInteractionModeProjection | null | undefined,
-): string | null {
-  if (!interaction) return null;
-
-  switch (interaction.state) {
-    case "editing":
-      return "editing";
-    case "requested":
-      return "waiting for edit access";
-    case "viewing":
-      return interaction.canRequestEdit ? "viewing" : "view only";
-  }
-}

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -55,3 +55,18 @@ export function createNotebookInteractionModeProjection({
       activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
   };
 }
+
+export function notebookInteractionPresenceLabel(
+  interaction: NotebookInteractionModeProjection | null | undefined,
+): string | null {
+  if (!interaction) return null;
+
+  switch (interaction.state) {
+    case "editing":
+      return "editing";
+    case "requested":
+      return "waiting for edit access";
+    case "viewing":
+      return interaction.canRequestEdit ? "viewing" : "view only";
+  }
+}

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -35,7 +35,11 @@ export function createNotebookInteractionModeProjection({
   const wantsEdit = selectedMode === "edit";
   const hasAnyEditPermission =
     permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
-  const canActivateEdit = wantsEdit && hasAnyEditPermission;
+  const hasAnyHostEditSupport =
+    (permission.canEditMarkdown && hostSupport.canEditMarkdown) ||
+    (permission.canEditCells && hostSupport.canEditCells) ||
+    (permission.canEditStructure && hostSupport.canEditStructure);
+  const canActivateEdit = wantsEdit && hasAnyEditPermission && hasAnyHostEditSupport;
   const activeMode: NotebookInteractionMode = canActivateEdit ? "edit" : "view";
   const state: NotebookInteractionState = !wantsEdit
     ? "viewing"


### PR DESCRIPTION
## Summary

Consolidates the shared notebook chrome stack onto one PR after rebasing on the fluid rail work from #3279.

- moves cloud onto shared notebook shell chrome instead of cloud-only toolbar/body paths
- extracts and reuses the shared command toolbar, toolbar frame, identity slot, presence copy, and interaction mode projection
- keeps the hosted room header above the notebook command toolbar so browser/cloud auth, sharing, presence, and identity chrome stay separate from notebook commands
- removes cloud's fake kernel/runtime labels for live room sync (`live`, `offline`, `connecting`)
- gates command toolbar actions by capabilities, including read-only package and execution affordances
- keeps cloud using the shared NotebookView path and adds regression coverage for that convergence

## Stack cleanup

This PR supersedes the old stacked PRs:

- #3274
- #3275
- #3276
- #3277
- #3278
- #3280
- #3281
- #3282
- #3283
- #3284

Those should close once this consolidated PR is accepted.

## Validation

- `pnpm --workspace-root exec tsc --noEmit --pretty false --project apps/notebook-cloud/tsconfig.json`
- `pnpm --workspace-root exec tsc --noEmit --pretty false --project apps/notebook/tsconfig.json`
- `pnpm --workspace-root exec tsc --noEmit --pretty false --project apps/elements/tsconfig.json`
- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx`
- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts test/viewer-presence.test.ts test/viewer-shared-cell-surface.test.ts test/cloud-cell-id.test.ts`
- `cargo xtask lint --fix`
