### PR TITLE
test(elements): exercise shared notebook toolbar

### DIFF
--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/notebook-scenarios";
 
 type BooleanCapabilityKey = {
-  [Key in keyof NotebookShellCapabilities]: NotebookShellCapabilities[Key] extends boolean
+  [Key in keyof NotebookShellCapabilities]-?: NotebookShellCapabilities[Key] extends boolean
     ? Key
     : never;
 }[keyof NotebookShellCapabilities];

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -15,6 +15,7 @@ import {
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   notebookActorIdentityFromProjection,
+  type NotebookActorIdentity,
   type NotebookCommandRuntimeState,
   type NotebookCommandToolbarProps,
 } from "@/components/notebook-shell";
@@ -78,8 +79,7 @@ function toolbarProps(
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
-  const actorCount =
-    scenario.capabilities.runtime.actor && scenario.capabilities.access.actor?.actorLabel ? 2 : 1;
+  const actorCount = Math.max(1, toolbarActors(scenario).length);
   return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
 }
 
@@ -398,12 +398,7 @@ export function NotebookToolbarSurfacesExample() {
 }
 
 function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
-  const accessActor = scenario.capabilities.access.actor;
-  const runtimeActor = scenario.capabilities.runtime.actor;
-  const actors = [
-    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
-    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
-  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const actors = toolbarActors(scenario);
   const interaction = scenario.capabilities.interaction;
 
   return (
@@ -432,6 +427,25 @@ function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScena
       ) : null}
     </div>
   );
+}
+
+function toolbarActors(scenario: ElementsNotebookScenario): NotebookActorIdentity[] {
+  const accessActor = scenario.capabilities.access.actor;
+  const runtimeActor = scenario.capabilities.runtime.actor;
+  const candidates = [
+    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
+    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
+  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const actors: NotebookActorIdentity[] = [];
+  const actorIds = new Set<string>();
+
+  for (const actor of candidates) {
+    if (actorIds.has(actor.id)) continue;
+    actorIds.add(actor.id);
+    actors.push(actor);
+  }
+
+  return actors;
 }
 
 function ScenarioPill({ label }: { label: string }) {

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -1,210 +1,229 @@
 "use client";
 
-import { BadgeCheck, CircleDot, PanelTop, PlayCircle, TimerReset } from "lucide-react";
-import type { ComponentProps } from "react";
 import {
-  KERNEL_ERROR_REASON,
-  KERNEL_STATUS,
-  RUNTIME_STATUS,
-  type EnvProgressState,
-} from "runtimed";
+  BadgeCheck,
+  CircleDot,
+  Laptop,
+  PanelTop,
+  PlayCircle,
+  TimerReset,
+  UserRound,
+} from "lucide-react";
+import {
+  NotebookCommandToolbar,
+  NotebookEditModeButton,
+  NotebookIdentityBadge,
+  NotebookPresenceStatus,
+  notebookActorIdentityFromProjection,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandToolbarProps,
+} from "@/components/notebook-shell";
 import {
   getElementsNotebookScenario,
   type ElementsNotebookScenario,
   type ElementsNotebookScenarioId,
 } from "@/components/notebook-scenarios";
-import { NotebookToolbar } from "@/notebook-components/NotebookToolbar";
-
-type ToolbarProps = ComponentProps<typeof NotebookToolbar>;
 
 const noop = () => {};
-
-const runningIdle = { lifecycle: "Running", activity: "Idle" } as const;
-const runningBusy = { lifecycle: "Running", activity: "Busy" } as const;
-const errorLifecycle = { lifecycle: "Error" } as const;
-
-const condaProgress: EnvProgressState = {
-  isActive: true,
-  phase: "link_progress",
-  envType: "conda",
-  error: null,
-  statusText: "Installing 17/24 scikit-learn",
-  elapsedMs: 18_400,
-  progress: { completed: 17, total: 24 },
-  bytesPerSecond: null,
-  currentPackage: "scikit-learn",
-};
-
-const condaEnvMissingDetails =
-  "environment.yml declares conda env 'analysis', which is not built on this machine. Run: conda env create -f /work/notebooks/environment.yml";
 
 interface ToolbarSurface {
   title: string;
   source: string;
   role: string;
   scenario: ElementsNotebookScenario;
-  props: ToolbarProps;
-}
-
-function toolbarProps(
-  scenario: ElementsNotebookScenario,
-  overrides: Partial<ToolbarProps> = {},
-): ToolbarProps {
-  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
-  const cellIds = scenario.viewModel.cellIds;
-
-  return {
-    kernelStatus: KERNEL_STATUS.IDLE,
-    statusKey: RUNTIME_STATUS.RUNNING_IDLE,
-    lifecycle: runningIdle,
-    errorReason: null,
-    kernelErrorMessage: null,
-    envSource: "uv:inline",
-    envTypeHint: "uv",
-    envProgress: null,
-    runtime: "python",
-    focusedCellId: firstRunnableCell?.id ?? cellIds[0] ?? null,
-    lastCellId: cellIds[cellIds.length - 1] ?? null,
-    canEditStructure: scenario.capabilities.canEditStructure,
-    canExecute: scenario.capabilities.canExecute,
-    canViewPackages: scenario.capabilities.canViewPackages,
-    onStartKernel: noop,
-    onInterruptKernel: noop,
-    onRestartKernel: noop,
-    onRunAllCells: noop,
-    onRestartAndRunAll: noop,
-    onAddCell: noop,
-    onToggleDependencies: noop,
-    ...overrides,
-  };
+  props: NotebookCommandToolbarProps;
 }
 
 function scenario(id: ElementsNotebookScenarioId) {
   return getElementsNotebookScenario(id);
 }
 
+function toolbarProps(
+  scenario: ElementsNotebookScenario,
+  overrides: Partial<NotebookCommandToolbarProps> = {},
+): NotebookCommandToolbarProps {
+  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
+  const cellIds = scenario.viewModel.cellIds;
+  const interaction = scenario.capabilities.interaction;
+
+  return {
+    canEditStructure: scenario.capabilities.canEditStructure,
+    canExecute: scenario.capabilities.canExecute,
+    canViewPackages: scenario.capabilities.canViewPackages,
+    runtime: "python",
+    environmentManager: "uv",
+    environmentPanelOpen: false,
+    environmentOutOfSync: scenario.packageState.syncState.status === "dirty",
+    runtimeStatus: runtimeStatus("idle", scenario.runtimeLabel),
+    addAfterCellId: firstRunnableCell?.id ?? cellIds[cellIds.length - 1] ?? null,
+    onAddCell: noop,
+    onStartRuntime: noop,
+    onInterruptRuntime: noop,
+    onRestartRuntime: noop,
+    onRunAllCells: noop,
+    onRestartAndRunAll: noop,
+    onTogglePackages: noop,
+    leadingControls: (
+      <NotebookPresenceStatus
+        connected={scenario.capabilities.runtime.connected || scenario.capabilities.canRead}
+        label={presenceLabel(scenario)}
+        modeLabel={interaction?.state === "editing" ? "editing" : "view only"}
+        title={`${scenario.title}: actor presence and interaction state`}
+        className="h-7 text-xs"
+      />
+    ),
+    trailingControls: <ToolbarIdentityControls scenario={scenario} />,
+    ...overrides,
+  };
+}
+
+function presenceLabel(scenario: ElementsNotebookScenario): string {
+  const actorCount =
+    scenario.capabilities.runtime.actor && scenario.capabilities.access.actor?.actorLabel ? 2 : 1;
+  return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
+}
+
+function runtimeStatus(
+  state: NotebookCommandRuntimeState,
+  label: string,
+  error?: string,
+): NotebookCommandToolbarProps["runtimeStatus"] {
+  return {
+    state,
+    label: (
+      <span className={state === "error" ? "text-red-600 dark:text-red-400" : ""}>{label}</span>
+    ),
+    ariaLabel: `Runtime: ${label}`,
+    title: label,
+    error: error ? (
+      <span className="text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
+        {error}
+      </span>
+    ) : null,
+  };
+}
+
 function createStatusSurfaces(): ToolbarSurface[] {
   const desktopOwner = scenario("desktop-local-owner");
+  const desktopReadOnly = scenario("desktop-read-only");
+  const desktopRemote = scenario("desktop-remote-room");
   const cloudViewer = scenario("cloud-public-viewer");
   const cloudEditor = scenario("cloud-editor");
+  const cloudOwner = scenario("cloud-owner");
+  const agent = scenario("agent-on-behalf");
+  const runtimePeer = scenario("runtime-peer");
   const runtimeUnavailable = scenario("runtime-unavailable");
 
   return [
     {
-      title: "Idle Python notebook",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Desktop owner",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: desktopOwner,
-      role: `${desktopOwner.runtimeLabel}; normal editing state with uv package details and running kernel controls.`,
+      role: "Local desktop host can edit structure, execute, and inspect package state through the same command toolbar contract.",
       props: toolbarProps(desktopOwner),
     },
     {
-      title: "Busy with package restart",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: desktopOwner,
-      role: `Execution state from ${desktopOwner.title}; restart-and-run-all is marked by ${desktopOwner.packageState.syncState.status} package details.`,
-      props: toolbarProps(desktopOwner, {
-        kernelStatus: KERNEL_STATUS.BUSY,
-        statusKey: RUNTIME_STATUS.RUNNING_BUSY,
-        lifecycle: runningBusy,
-        envSource: "conda:inline",
-        depsOutOfSync: desktopOwner.packageState.syncState.status === "dirty",
-        isDepsOpen: desktopOwner.capabilities.canViewPackages,
+      title: "Desktop read-only file",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: desktopReadOnly,
+      role: "Filesystem or host permissions disable mutation controls while package details remain visible.",
+      props: toolbarProps(desktopReadOnly, {
+        runtimeStatus: runtimeStatus("shutdown", desktopReadOnly.runtimeLabel),
       }),
     },
     {
-      title: "Environment preparation",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: cloudEditor,
-      role: `${cloudEditor.title} can edit markdown, but this preview keeps execution detached while Conda solve progress renders.`,
-      props: toolbarProps(cloudEditor, {
-        kernelStatus: KERNEL_STATUS.STARTING,
-        statusKey: RUNTIME_STATUS.PREPARING_ENV,
-        lifecycle: { lifecycle: "PreparingEnv" },
-        envSource: null,
-        envTypeHint: "conda",
-        envProgress: condaProgress,
+      title: "Desktop remote room",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: desktopRemote,
+      role: "Desktop can be a remote notebook host: local app and daemon identity project into the same access model as cloud.",
+      props: toolbarProps(desktopRemote, {
+        runtimeStatus: runtimeStatus("unknown", desktopRemote.runtimeLabel),
       }),
     },
     {
-      title: "Awaiting trust approval",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: `${runtimeUnavailable.title} reuses the shared trust fixture before launch instead of opening a live runtime.`,
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.STARTING,
-        statusKey: RUNTIME_STATUS.AWAITING_TRUST,
-        lifecycle: { lifecycle: "AwaitingTrust" },
-        envSource: null,
-        envTypeHint: "uv",
-      }),
-    },
-    {
-      title: "Published viewer with no kernel",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Cloud public viewer",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: cloudViewer,
-      role: `${cloudViewer.title} uses the same notebook IDs while exposing view-only, published access context.`,
+      role: "Anonymous read access keeps the notebook shell readable and package-aware without edit, execution, or sharing controls.",
       props: toolbarProps(cloudViewer, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        envSource: null,
-        envTypeHint: null,
-        kernelErrorMessage: cloudViewer.runtimeLabel,
+        runtime: null,
+        environmentManager: null,
+        runtimeStatus: runtimeStatus("unknown", cloudViewer.runtimeLabel),
       }),
     },
     {
-      title: "Deno runtime unavailable",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      title: "Cloud editor",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudEditor,
+      role: "Cloud edit permission and selected edit mode are separate from host support; active controls are their intersection.",
+      props: toolbarProps(cloudEditor, {
+        runtimeStatus: runtimeStatus("unknown", cloudEditor.runtimeLabel),
+      }),
+    },
+    {
+      title: "Cloud owner",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudOwner,
+      role: "Owner access can expose sharing identity chrome without inventing a second notebook toolbar.",
+      props: toolbarProps(cloudOwner, {
+        runtimeStatus: runtimeStatus("unknown", cloudOwner.runtimeLabel),
+      }),
+    },
+    {
+      title: "Codex or Claude operator",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: agent,
+      role: "Desktop and cloud both have non-human operators. The toolbar uses actor-neutral presence and projected identity labels.",
+      props: toolbarProps(agent, {
+        runtimeStatus: runtimeStatus("unknown", agent.runtimeLabel),
+      }),
+    },
+    {
+      title: "Runtime peer",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: runtimePeer,
+      role: "Runtime authorship is present without notebook edit access, so execution authors do not become structure editors.",
+      props: toolbarProps(runtimePeer, {
+        runtimeStatus: runtimeStatus("busy", runtimePeer.runtimeLabel),
+      }),
+    },
+    {
+      title: "Preparing environment",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
+      scenario: cloudEditor,
+      role: "Hosted and desktop hosts can show environment progress while keeping the work owned by their runtime adapter.",
+      props: toolbarProps(cloudEditor, {
+        runtimeStatus: runtimeStatus("starting", "Installing 17/24 scikit-learn"),
+        environmentManager: "conda",
+        environmentOutOfSync: true,
+      }),
+    },
+    {
+      title: "Runtime unavailable",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: runtimeUnavailable,
-      role: "Deno install remediation banner driven by fixture error text and inert callbacks.",
+      role: "Runtime and trust remediation can surface through shared status while host-specific fixes stay outside the command toolbar.",
       props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
+        runtimeStatus: runtimeStatus(
+          "error",
+          "Deno runtime unavailable",
+          "deno executable not found",
+        ),
         runtime: "deno",
-        envSource: "deno:imports",
-        envTypeHint: null,
-        kernelErrorMessage: "deno executable not found on PATH",
-      }),
-    },
-    {
-      title: "Pixi missing ipykernel",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: "Python runtime error branch for pixi.toml notebooks that need an explicit ipykernel package.",
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        errorReason: KERNEL_ERROR_REASON.MISSING_IPYKERNEL,
-        envSource: "pixi:toml",
-        envTypeHint: "pixi",
-      }),
-    },
-    {
-      title: "Conda environment.yml missing",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
-      scenario: runtimeUnavailable,
-      role: "Copyable environment creation hint surfaced by the toolbar when the declared conda env is absent.",
-      props: toolbarProps(runtimeUnavailable, {
-        kernelStatus: KERNEL_STATUS.ERROR,
-        statusKey: RUNTIME_STATUS.ERROR,
-        lifecycle: errorLifecycle,
-        errorReason: KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING,
-        envSource: "conda:env_yml",
-        envTypeHint: "conda",
-        kernelErrorMessage: condaEnvMissingDetails,
+        environmentManager: null,
       }),
     },
     {
       title: "Update ready",
-      source: "apps/notebook/src/components/NotebookToolbar.tsx",
+      source: "src/components/notebook-shell/NotebookCommandToolbar.tsx",
       scenario: desktopOwner,
-      role: "Desktop update action rendered beside runtime status while the notebook remains idle.",
+      role: "Desktop update actions remain a host slot on the shared command toolbar.",
       props: toolbarProps(desktopOwner, {
-        updateStatus: "available",
-        updateVersion: "2.5.3",
-        onRestartToUpdate: noop,
+        updateAction: {
+          label: "Update 2.5.3",
+          title: "Prepare to update to v2.5.3",
+          onClick: noop,
+        },
       }),
     },
   ];
@@ -213,56 +232,56 @@ function createStatusSurfaces(): ToolbarSurface[] {
 const contractItems = [
   {
     icon: BadgeCheck,
-    title: "Current source",
-    body: "Every preview imports NotebookToolbar from the notebook app and starts from a shared Elements scenario.",
+    title: "Shared source",
+    body: "Every preview renders NotebookCommandToolbar from the host-neutral notebook shell.",
   },
   {
     icon: PlayCircle,
-    title: "Runtime-free",
-    body: "Kernel actions, package toggles, update clicks, and cell insertion callbacks are inert.",
+    title: "Adapter-owned actions",
+    body: "Kernel, package, update, and cell insertion callbacks are inert fixtures here and host-owned in production.",
   },
   {
     icon: TimerReset,
-    title: "Status vocabulary",
-    body: "Fixtures cover idle, busy, preparing, trust, error, and update states from the real runtime labels.",
+    title: "Actor-neutral chrome",
+    body: "Presence and mode copy works for humans, agents, runtime peers, and system operators.",
   },
 ];
 
 const toolbarBoundaryRows = [
   {
-    boundary: "Runtime status projection",
-    catalogPath: "ElementsNotebookScenario -> toolbarProps(status overrides)",
-    productionBoundary: "RuntimeStateDoc + kernel lifecycle",
+    boundary: "Shared command toolbar",
+    catalogPath: "NotebookCommandToolbar + ElementsNotebookScenario",
+    productionBoundary: "Desktop NotebookToolbar wrapper and cloud host adapter",
     detail:
-      "The catalog starts with deterministic scenario facts, then applies runtime status overrides. Production derives those fields from runtime state, kernel lifecycle, environment progress, and launch errors.",
+      "The catalog renders the shared command toolbar directly. Desktop and cloud wrappers may add host-specific status projection, but not duplicate command chrome.",
   },
   {
-    boundary: "Kernel actions",
-    catalogPath: "inert callbacks",
-    productionBoundary: "Notebook action handlers",
+    boundary: "Interaction mode",
+    catalogPath: "scenario.capabilities.interaction",
+    productionBoundary: "ACL/local permission + selected host mode",
     detail:
-      "Start, interrupt, restart, run-all, and restart-and-run-all buttons render here without side effects. The notebook app wires them to execution and runtime control paths.",
+      "View/edit state is a projection of permission, selected mode, and host support. The toolbar reads that projection instead of inferring editability from auth alone.",
+  },
+  {
+    boundary: "Actor identity",
+    catalogPath: "NotebookActorProjection -> NotebookActorIdentity",
+    productionBoundary: "Host/backend structured actor projection",
+    detail:
+      "Raw durable actor labels remain attribution data. User-facing toolbar labels come from structured principal/operator projections when available.",
+  },
+  {
+    boundary: "Runtime status projection",
+    catalogPath: "static runtimeStatus fixtures",
+    productionBoundary: "RuntimeStateDoc + kernel lifecycle",
+    detail:
+      "The command toolbar accepts a small runtime status shape. Hosts own the richer lifecycle, environment progress, launch errors, and remediation details.",
   },
   {
     boundary: "Package panel",
     catalogPath: "scenario.packageState + inert toggle",
     productionBoundary: "Package rail and project writes",
     detail:
-      "The preview reads package sync state from the shared scenario and toggles visual package state only. The notebook opens package UI, writes project files, and coordinates environment rebuild decisions.",
-  },
-  {
-    boundary: "Cell insertion",
-    catalogPath: "scenario.viewModel.cellIds",
-    productionBoundary: "NotebookView focus and document changes",
-    detail:
-      "The add-cell affordance receives stable IDs from the shared scenario projection. Production inserts new cells through the notebook document and restores editor focus.",
-  },
-  {
-    boundary: "Desktop update restart",
-    catalogPath: "updateStatus + onRestartToUpdate",
-    productionBoundary: "Tauri updater host action",
-    detail:
-      "The update-ready surface renders with a no-op restart callback. Desktop builds still own update installation and app restart behavior outside the docs runtime.",
+      "Read-only scenarios still expose package details. Package management remains gated separately from package viewing.",
   },
 ];
 
@@ -306,12 +325,17 @@ export function NotebookToolbarSurfacesExample() {
                   />
                   <ScenarioPill
                     label={
-                      surface.scenario.capabilities.canExecute
-                        ? "execution available"
-                        : "execution disabled"
+                      surface.scenario.capabilities.interaction?.state ??
+                      (surface.scenario.capabilities.canEditMarkdown ? "editing" : "viewing")
                     }
                   />
-                  <ScenarioPill label={`${surface.scenario.viewModel.codeCellCount} code cells`} />
+                  <ScenarioPill
+                    label={
+                      surface.scenario.capabilities.runtime.actor
+                        ? "runtime actor"
+                        : "no runtime actor"
+                    }
+                  />
                 </div>
               </div>
               <div className="break-words font-mono text-[11px] leading-5 text-fd-muted-foreground [overflow-wrap:anywhere] md:max-w-72 md:text-right">
@@ -319,8 +343,8 @@ export function NotebookToolbarSurfacesExample() {
               </div>
             </div>
             <div className="overflow-hidden bg-fd-background">
-              <div className="min-w-[760px]">
-                <NotebookToolbar {...surface.props} />
+              <div className="min-w-[860px]">
+                <NotebookCommandToolbar {...surface.props} />
               </div>
             </div>
           </article>
@@ -330,12 +354,12 @@ export function NotebookToolbarSurfacesExample() {
       <section className="rounded-lg border border-dashed border-fd-border bg-fd-background p-4">
         <div className="mb-3 flex items-center gap-2">
           <CircleDot className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Live work stays with the notebook</h2>
+          <h2 className="text-sm font-semibold">Live work stays with the host</h2>
         </div>
         <p className="text-xs leading-5 text-fd-muted-foreground">
-          NotebookToolbar renders from the production component, but this page owns only static
-          status props and inert callbacks. Runtime state, kernel controls, package writes, cell
-          insertion, and desktop update restarts stay with the notebook app.
+          NotebookCommandToolbar is shared notebook chrome. This page owns only fixture props and
+          inert callbacks; desktop and cloud remain responsible for transport, CRDT writes,
+          execution, package mutation, credentials, and deployment-specific behavior.
         </p>
         <div className="mt-4 grid gap-2">
           {toolbarBoundaryRows.map((row) => (
@@ -356,7 +380,7 @@ export function NotebookToolbarSurfacesExample() {
                   </div>
                   <div>
                     <div className="text-[11px] font-medium uppercase text-fd-muted-foreground">
-                      Notebook owns
+                      Host owns
                     </div>
                     <div className="mt-1 break-words font-mono text-[11px] leading-4 text-amber-700 dark:text-amber-300">
                       {row.productionBoundary}
@@ -369,6 +393,43 @@ export function NotebookToolbarSurfacesExample() {
           ))}
         </div>
       </section>
+    </div>
+  );
+}
+
+function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
+  const accessActor = scenario.capabilities.access.actor;
+  const runtimeActor = scenario.capabilities.runtime.actor;
+  const actors = [
+    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
+    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
+  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
+  const interaction = scenario.capabilities.interaction;
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {interaction ? (
+        <NotebookEditModeButton
+          mode={interaction.selectedMode}
+          state={interaction.state}
+          disabled={!interaction.canRequestEdit && interaction.activeMode !== "edit"}
+          onModeChange={noop}
+          className="h-7 text-xs"
+        />
+      ) : null}
+      {actors.slice(0, 2).map((actor) => (
+        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={false} />
+      ))}
+      {actors.length === 0 ? (
+        <span className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-background px-2 text-xs text-muted-foreground">
+          {scenario.capabilities.access.source === "local" ? (
+            <Laptop className="size-3.5" aria-hidden="true" />
+          ) : (
+            <UserRound className="size-3.5" aria-hidden="true" />
+          )}
+          anonymous
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
+++ b/apps/elements/content/docs/notebook-toolbar-surfaces.mdx
@@ -1,17 +1,18 @@
 ---
 title: Notebook toolbar surfaces
-description: Runtime-free NotebookToolbar states from the current notebook app.
+description: Runtime-free shared command toolbar states from the notebook shell.
 ---
 
 import { NotebookToolbarSurfacesExample } from "@/components/notebook-toolbar-surfaces-example";
 
 The notebook toolbar is workspace chrome, not generic button inventory. This
-page renders the current `NotebookToolbar` with static runtime, environment,
-package, and update facts so the catalog can track the real desktop
-surface without importing daemon hooks or notebook state.
+page renders the shared `NotebookCommandToolbar` with static runtime,
+environment, package, identity, and update facts so the catalog can track the
+desktop and cloud contract without importing daemon hooks or notebook state.
 The hosted scenarios are shared with the
-[notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor
-and owner access do not drift from cloud ACL semantics.
+[notebook shell capabilities](/docs/notebook-shell-capabilities) page so editor,
+owner, runtime peer, agent, and local desktop access do not drift from the
+shared capability model.
 
 <NotebookToolbarSurfacesExample />
 
@@ -19,7 +20,7 @@ and owner access do not drift from cloud ACL semantics.
 
 Toolbar previews own only props and callbacks. Kernel start, interrupt, restart,
 package toggles, update restarts, and cell insertion stay inert in the docs app
-until the host deliberately wires them. The rendered boundary map keeps runtime
-status projection, kernel actions, package panel state, cell insertion, and
-desktop update restart behavior named separately so future toolbar work can move
-one host-owned action at a time.
+until the host deliberately wires them. The rendered boundary map keeps shared
+command chrome, interaction mode, actor identity, runtime status projection,
+package panel state, and host-owned actions named separately so future toolbar
+work can move one host-owned action at a time.

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -114,7 +114,7 @@ async function main() {
 
     await timed("alice_connected", () => waitForPresence(alice.page, "editing"));
     await timed("bob_connected", () => waitForPresence(bob.page, "editing"));
-    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "viewing"));
+    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "view only"));
     checks.push("browser_alice_connected", "browser_bob_connected", "anonymous_viewer_connected");
 
     await waitForEditableMarkdown(alice.page);
@@ -221,7 +221,7 @@ ${bobMarker}
       }),
     );
     contexts.push(charlie.context);
-    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "viewing"));
+    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "view only"));
     await assertNoEditableMarkdown(charlie.page);
     checks.push("ungranted_editor_downgraded_to_viewer");
 

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -46,7 +46,7 @@ const expectedSourceText =
   process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
-const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "viewing";
+const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "view only";
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", []);
 const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "MathNet topic visualization",

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -35,6 +35,11 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     constructor(notebookId: string);
     static create_bootstrap(actorLabel: string): NotebookHandle;
     static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): NotebookHandle;
+    add_cell_after(
+      cellId: string,
+      cellType: "code" | "markdown" | "raw",
+      afterCellId?: string | null,
+    ): string;
     cell_count(): number;
     cancel_last_flush(): void;
     cancel_last_pool_state_flush(): void;
@@ -50,6 +55,8 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_metadata_snapshot_json(): string | undefined;
     get_runtime_state_doc_id(): string | undefined;
     get_runtime_state(): unknown;
+    move_cell(cellId: string, afterCellId?: string | null): string;
+    delete_cell(cellId: string): boolean;
     get_runtime_state_heads_hex(): string[];
     receive_frame(frameBytes: Uint8Array): unknown;
     reset_sync_state(): void;

--- a/apps/notebook-cloud/test/cloud-cell-id.test.ts
+++ b/apps/notebook-cloud/test/cloud-cell-id.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createCloudNotebookCellId } from "../viewer/cloud-cell-id";
+
+test("cloud notebook cell ids use randomUUID when available", () => {
+  const id = createCloudNotebookCellId({
+    randomUUID: () => "random-id",
+    getRandomValues: () => {
+      throw new Error("getRandomValues should not be called");
+    },
+  });
+
+  assert.equal(id, "random-id");
+});
+
+test("cloud notebook cell ids fall back to random bytes without timestamp collisions", () => {
+  const id = createCloudNotebookCellId({
+    getRandomValues: (bytes: Uint8Array) => {
+      bytes.fill(0xab);
+      return bytes;
+    },
+  });
+
+  assert.equal(id, "cell-abababababababababababababababab");
+});
+
+test("cloud notebook cell ids keep a monotonic fallback when crypto is unavailable", () => {
+  const first = createCloudNotebookCellId(null);
+  const second = createCloudNotebookCellId(null);
+
+  assert.notEqual(first, second);
+  assert.match(first, /^cell-[a-z0-9]+-[a-z0-9]+$/);
+  assert.match(second, /^cell-[a-z0-9]+-[a-z0-9]+$/);
+});

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -39,7 +39,7 @@ describe("cloud viewer presence", () => {
         roomPeerCount: 1,
       },
     );
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_joined",
@@ -50,7 +50,7 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:01.000Z",
     });
     assert.equal(state.roomPeerCount, 2);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "2 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "2 here now");
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_left",
@@ -61,7 +61,7 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:02.000Z",
     });
     assert.equal(state.roomPeerCount, 1);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 viewing");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
   });
 
   it("surfaces disconnected state without losing the last room count", () => {
@@ -102,8 +102,8 @@ describe("cloud viewer presence", () => {
 
     assert.equal(state.ownPeerLabel, "Alice Demo");
     assert.deepEqual(cloudViewerPresenceDisplay(state), {
-      label: "2 viewing",
-      title: "2 readers connected to this notebook room; You are Alice Demo",
+      label: "2 here now",
+      title: "2 participants are in this notebook; You are Alice Demo",
       connected: true,
     });
   });

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -63,15 +63,18 @@ test("cloud viewer keeps theme resolution out of first-class notebook chrome", (
   assert.doesNotMatch(sourceText, /className="cloud-theme-toggle"/);
 });
 
-test("cloud viewer routes notebook header controls through the shared shell header", () => {
+test("cloud viewer routes notebook header controls through the shared command toolbar", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /NotebookDocumentHeader,/);
-  assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
-  assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /codeControls=\{null\}/);
+  assert.match(sourceText, /NotebookCommandToolbar,/);
+  assert.match(
+    sourceText,
+    /<NotebookCommandToolbar[\s\S]*canEditStructure=\{shellCapabilities\.canEditStructure\}/,
+  );
+  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
+  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /leadingControls=\{[\s\S]*<CloudPresenceStatus/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -116,10 +116,8 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   const cssText = readFileSync(cssPath, "utf8");
 
   assert.match(sourceText, /NotebookEditModeButton/);
-  assert.match(
-    sourceText,
-    /<NotebookEditModeButton[\s\S]*mode=\{requestingEdit \? "edit" : "view"\}/,
-  );
+  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*mode=\{interaction\.selectedMode\}/);
+  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*state=\{interaction\.state\}/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
   assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -32,6 +32,9 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canToggleCode, true);
   assert.equal(capabilities.canManageSharing, false);
+  assert.equal(capabilities.interaction?.selectedMode, "view");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "viewing");
   assert.equal(capabilities.access.level, "viewer");
   assert.equal(capabilities.access.source, "cloud");
   assert.equal(capabilities.access.isPublic, true);
@@ -55,6 +58,9 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canToggleCode, false);
   assert.equal(capabilities.canManagePackages, false);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "edit");
+  assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.access.identityLabel, "user@example.test");
   assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
@@ -74,9 +80,29 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.canEditMarkdown, false);
   assert.equal(capabilities.canEditCells, false);
   assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.interaction?.selectedMode, "view");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "viewing");
   assert.equal(capabilities.access.level, "editor");
   assert.equal(capabilities.canToggleCode, true);
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
+});
+
+test("cloud shell capabilities keep requested edit pending until the room grants edit access", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "viewer",
+    hasCodeCells: true,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canRequestEdit, true);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "requested");
+  assert.equal(capabilities.access.level, "viewer");
 });
 
 test("cloud shell capabilities reserve code-cell and structure edits for owners", () => {
@@ -92,6 +118,9 @@ test("cloud shell capabilities reserve code-cell and structure edits for owners"
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canManagePackages, false);
   assert.equal(capabilities.canManageSharing, true);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "edit");
+  assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "owner");
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -79,7 +79,7 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities reserve code-cell source edits for owners", () => {
+test("cloud shell capabilities reserve code-cell and structure edits for owners", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),
     connectionScope: "owner",
@@ -88,7 +88,7 @@ test("cloud shell capabilities reserve code-cell source edits for owners", () =>
 
   assert.equal(capabilities.canEditMarkdown, true);
   assert.equal(capabilities.canEditCells, true);
-  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canEditStructure, true);
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canManagePackages, false);
   assert.equal(capabilities.canManageSharing, true);

--- a/apps/notebook-cloud/viewer/cloud-cell-id.ts
+++ b/apps/notebook-cloud/viewer/cloud-cell-id.ts
@@ -1,0 +1,23 @@
+let fallbackCellIdCounter = 0;
+
+export interface CloudNotebookCellIdRandomSource {
+  randomUUID?: () => string;
+  getRandomValues?: (bytes: Uint8Array) => Uint8Array;
+}
+
+export function createCloudNotebookCellId(
+  randomSource: CloudNotebookCellIdRandomSource | null = globalThis.crypto ?? null,
+): string {
+  if (typeof randomSource?.randomUUID === "function") {
+    return randomSource.randomUUID();
+  }
+
+  if (typeof randomSource?.getRandomValues === "function") {
+    const bytes = new Uint8Array(16);
+    randomSource.getRandomValues(bytes);
+    return `cell-${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  fallbackCellIdCounter += 1;
+  return `cell-${Date.now().toString(36)}-${fallbackCellIdCounter.toString(36)}`;
+}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -85,6 +85,16 @@ body {
   line-height: 1.2;
 }
 
+.cloud-home > .cloud-report-toolbar,
+main.flex > .cloud-report-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding-block: 0.5rem;
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+}
+
 .cloud-home-panel {
   align-self: start;
   justify-self: center;
@@ -193,16 +203,13 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
   border-bottom: 1px solid var(--border);
-  padding-block: 0.5rem;
-  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
   background: color-mix(in srgb, var(--background) 94%, transparent);
   backdrop-filter: blur(12px);
-  pointer-events: none;
+}
+
+.cloud-auth-diagnostics-state {
+  margin-top: 0.5rem;
 }
 
 .cloud-auth-menu {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -39,6 +39,7 @@ import {
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
+  type NotebookInteractionModeProjection,
   type NotebookPackageSection,
   type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
@@ -65,6 +66,7 @@ import {
   withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
+import { createCloudNotebookCellId } from "./cloud-cell-id";
 import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { cloudNotebookShellCapabilities } from "./shell-capabilities";
@@ -1129,7 +1131,7 @@ function NotebookViewer({
       if (!shellCapabilities.canEditStructure) return null;
       const liveRuntime = liveRuntimeRef.current;
       if (!liveRuntime) return null;
-      const cellId = crypto.randomUUID ? crypto.randomUUID() : `cell-${Date.now()}`;
+      const cellId = createCloudNotebookCellId();
       try {
         liveRuntime.handle.add_cell_after(cellId, type, afterCellId ?? null);
         liveRuntime.engine.scheduleFlush();
@@ -1296,7 +1298,7 @@ function NotebookViewer({
           />
           <CloudNotebookEditModeButton
             authState={authState}
-            connectionScope={connectionScope}
+            interaction={shellCapabilities.interaction ?? null}
             onAuthStateChange={refreshAuthState}
           />
           <NotebookIdentityBadge
@@ -1794,26 +1796,24 @@ function CloudSharingControls({
 
 function CloudNotebookEditModeButton({
   authState,
-  connectionScope,
+  interaction,
   onAuthStateChange,
 }: {
   authState: CloudPrototypeAuthState;
-  connectionScope: string | null;
+  interaction: NotebookInteractionModeProjection | null;
   onAuthStateChange: () => void;
 }) {
-  if (authState.mode !== "oidc") {
+  if (
+    authState.mode !== "oidc" ||
+    (!interaction?.canRequestEdit && interaction?.activeMode !== "edit")
+  ) {
     return null;
   }
 
-  const requestedScope = authState.requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
-  const requestingEdit = requestedScope === "editor" || requestedScope === "owner";
-  const editing = connectionScope === "editor" || connectionScope === "owner";
-  const state = editing ? "editing" : requestingEdit ? "requested" : "viewing";
-
   return (
     <NotebookEditModeButton
-      mode={requestingEdit ? "edit" : "view"}
-      state={state}
+      mode={interaction.selectedMode}
+      state={interaction.state}
       onModeChange={(mode) => {
         storeCloudRequestedScope(
           window.localStorage,

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -26,7 +26,7 @@ import { IsolatedRendererProvider } from "@/components/isolated/isolated-rendere
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
-  NotebookDocumentHeader,
+  NotebookCommandToolbar,
   NotebookEditModeButton,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -37,6 +37,9 @@ import {
   NotebookPackageSummaryPanel,
   createNotebookEnvironmentSurface,
   notebookActorIdentityFromAccess,
+  type NotebookCommandRuntimeState,
+  type NotebookEnvironmentManager,
+  type NotebookPackageSection,
   type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -76,6 +79,7 @@ import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { setLoggerHost } from "../../notebook/src/lib/logger";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 import { useNotebookViewModel } from "../../notebook/src/lib/notebook-view-model";
+import type { NotebookCell } from "../../notebook/src/types";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudViewStoreProjection,
@@ -620,6 +624,7 @@ function NotebookViewer({
   const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
   const notebookLanguageRef = useRef("python");
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
+  const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
   const liveMaterializedRef = useRef(false);
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
@@ -965,6 +970,7 @@ function NotebookViewer({
         console.warn("[notebook-cloud] live room materialization failed", error);
       });
     };
+    materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
 
     setPresence(initialCloudViewerPresence());
     setConnectionError(null);
@@ -1052,6 +1058,7 @@ function NotebookViewer({
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
       }
+      materializeLiveRuntimeRef.current = null;
       disposeCurrentRuntime();
       resetCloudViewStoreProjection();
       livePresenceStore = null;
@@ -1090,6 +1097,14 @@ function NotebookViewer({
     setSelectedOutlineItemId(item.id);
     return navigateNotebookOutlineItem(item, href);
   }, []);
+  const handleTogglePackagesRail = useCallback(() => {
+    if (activeRailPanel === "packages" && !railCollapsed) {
+      setActiveRailPanel("outline");
+      return;
+    }
+    setRailCollapsed(false);
+    setActiveRailPanel("packages");
+  }, [activeRailPanel, railCollapsed]);
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -1102,6 +1117,73 @@ function NotebookViewer({
   );
   const canEditMarkdown = shellCapabilities.canEditMarkdown;
   const notebookCellIds = notebookViewModel.cellIds;
+  const packageEnvironmentManager = cloudNotebookEnvironmentManager(
+    notebookViewModel.packages.sections,
+  );
+  const runtimeStatus = cloudNotebookRuntimeStatus(connectionScope, connectionError);
+  const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
+    materializeLiveRuntimeRef.current?.(liveRuntime);
+  }, []);
+  const handleCloudAddCell = useCallback(
+    (type: "code" | "markdown", afterCellId?: string | null): NotebookCell | null => {
+      if (!shellCapabilities.canEditStructure) return null;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return null;
+      const cellId = crypto.randomUUID ? crypto.randomUUID() : `cell-${Date.now()}`;
+      try {
+        liveRuntime.handle.add_cell_after(cellId, type, afterCellId ?? null);
+        liveRuntime.engine.scheduleFlush();
+        requestCloudMaterialization(liveRuntime);
+      } catch (error) {
+        console.warn("[notebook-cloud] add cell failed", error);
+        return null;
+      }
+      const fallback: NotebookCell =
+        type === "markdown"
+          ? { cell_type: "markdown", id: cellId, source: "", metadata: {} }
+          : {
+              cell_type: "code",
+              id: cellId,
+              source: "",
+              execution_count: null,
+              outputs: [],
+              metadata: {},
+            };
+      return fallback;
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
+  const handleCloudDeleteCell = useCallback(
+    (cellId: string) => {
+      if (!shellCapabilities.canEditStructure) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime || liveRuntime.handle.cell_count() <= 1) return;
+      try {
+        if (liveRuntime.handle.delete_cell(cellId)) {
+          liveRuntime.engine.scheduleFlush();
+          requestCloudMaterialization(liveRuntime);
+        }
+      } catch (error) {
+        console.warn("[notebook-cloud] delete cell failed", error);
+      }
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
+  const handleCloudMoveCell = useCallback(
+    (cellId: string, afterCellId?: string | null) => {
+      if (!shellCapabilities.canEditStructure) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return;
+      try {
+        liveRuntime.handle.move_cell(cellId, afterCellId ?? null);
+        liveRuntime.engine.scheduleFlush();
+        requestCloudMaterialization(liveRuntime);
+      } catch (error) {
+        console.warn("[notebook-cloud] move cell failed", error);
+      }
+    },
+    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
   const cloudPresenceContext = useMemo<PresenceContextValue | null>(
     () =>
@@ -1190,41 +1272,62 @@ function NotebookViewer({
   );
 
   const toolbar = (
-    <NotebookDocumentHeader
-      capabilities={shellCapabilities}
-      presence={<CloudPresenceStatus presence={presence} connectionScope={connectionScope} />}
-      utilityControls={null}
-      sharingControls={
-        <CloudSharingControls
-          aclEndpoint={config.aclEndpoint}
-          invitesEndpoint={config.invitesEndpoint}
-          authState={authState}
-        />
+    <NotebookCommandToolbar
+      canEditStructure={shellCapabilities.canEditStructure}
+      canExecute={shellCapabilities.canExecute}
+      canViewPackages={shellCapabilities.canViewPackages}
+      runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+      environmentManager={packageEnvironmentManager}
+      environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+      runtimeStatus={runtimeStatus}
+      addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+      onAddCell={handleCloudAddCell}
+      onTogglePackages={handleTogglePackagesRail}
+      leadingControls={
+        <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
       }
-      authControls={
+      trailingControls={
         <>
           <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-          <CloudAuthControls
-            authConfig={authConfig}
+          <CloudSharingControls
+            aclEndpoint={config.aclEndpoint}
+            invitesEndpoint={config.invitesEndpoint}
             authState={authState}
-            capabilities={shellCapabilities}
-            connectionActorLabel={connectionActorLabel}
-            connectionError={connectionError}
+          />
+          <CloudNotebookEditModeButton
+            authState={authState}
             connectionScope={connectionScope}
             onAuthStateChange={refreshAuthState}
           />
+          <NotebookIdentityBadge
+            actor={notebookActorIdentityFromAccess(
+              shellCapabilities.access,
+              shellCapabilities.auth,
+            )}
+            size="sm"
+            showDetail={false}
+          />
         </>
       }
-      editControls={
-        <CloudNotebookEditModeButton
-          authState={authState}
-          connectionScope={connectionScope}
-          onAuthStateChange={refreshAuthState}
-        />
-      }
-      codeControls={null}
     />
   );
+  const authDiagnostics = shouldShowPrototypeDevControls({
+    oidcConfigured: Boolean(authConfig.oidc),
+    hostname: window.location.hostname,
+    search: window.location.search,
+  }) ? (
+    <div className="cloud-state cloud-auth-diagnostics-state" data-kind="loading">
+      <CloudAuthControls
+        authConfig={authConfig}
+        authState={authState}
+        capabilities={shellCapabilities}
+        connectionActorLabel={connectionActorLabel}
+        connectionError={connectionError}
+        connectionScope={connectionScope}
+        onAuthStateChange={refreshAuthState}
+      />
+    </div>
+  ) : null;
 
   return (
     <NotebookDocumentShell
@@ -1275,6 +1378,8 @@ function NotebookViewer({
         </div>
       ) : null}
 
+      {authDiagnostics}
+
       {status.kind === "ready" ? null : (
         <div className="cloud-state" data-kind={status.kind}>
           {status.message}
@@ -1297,9 +1402,9 @@ function NotebookViewer({
             onFocusCell={setFocusedCellId}
             onExecuteCell={() => {}}
             onInterruptKernel={() => {}}
-            onDeleteCell={() => {}}
-            onAddCell={() => null}
-            onMoveCell={() => {}}
+            onDeleteCell={handleCloudDeleteCell}
+            onAddCell={handleCloudAddCell}
+            onMoveCell={handleCloudMoveCell}
             markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
             outputHostContext={outputHostContext}
           />
@@ -1307,6 +1412,50 @@ function NotebookViewer({
       </PresenceValueProvider>
     </NotebookDocumentShell>
   );
+}
+
+function cloudNotebookEnvironmentManager(
+  sections: readonly NotebookPackageSection[],
+): NotebookEnvironmentManager | null {
+  for (const section of sections) {
+    if (section.manager === "uv" || section.manager === "conda" || section.manager === "pixi") {
+      return section.manager;
+    }
+  }
+  return null;
+}
+
+function cloudNotebookRuntimeStatus(
+  connectionScope: string | null,
+  connectionError: string | null,
+): {
+  state: NotebookCommandRuntimeState;
+  label: ReactNode;
+  ariaLabel: string;
+  title: string;
+} {
+  if (connectionError) {
+    return {
+      state: "error",
+      label: "offline",
+      ariaLabel: "Live room: offline",
+      title: connectionError,
+    };
+  }
+  if (connectionScope) {
+    return {
+      state: "idle",
+      label: "live",
+      ariaLabel: `Live room: ${connectionScope}`,
+      title: `Connected as ${connectionScope}`,
+    };
+  }
+  return {
+    state: "starting",
+    label: "connecting",
+    ariaLabel: "Live room: connecting",
+    title: "Connecting to live room",
+  };
 }
 
 function CloudSharingControls({
@@ -1952,9 +2101,9 @@ function CloudPresenceStatus({
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
   const scopeLabel =
     connectionScope === "editor" || connectionScope === "owner"
-      ? "editing"
+      ? "editing is allowed"
       : connectionScope === "viewer"
-        ? "viewing"
+        ? "view only"
         : null;
 
   return (

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -79,7 +79,7 @@ export function cloudViewerPresenceDisplay(
 
   if (state.connection === "connecting" || state.roomPeerCount === null) {
     return {
-      label: "Connecting",
+      label: "Joining room",
       title: "Connecting to the notebook room",
       connected: false,
     };
@@ -88,11 +88,11 @@ export function cloudViewerPresenceDisplay(
   const count = Math.max(1, state.roomPeerCount);
   const readerTitle =
     count === 1
-      ? "1 reader connected to this notebook room"
-      : `${count} readers connected to this notebook room`;
+      ? "1 participant is in this notebook"
+      : `${count} participants are in this notebook`;
   const selfTitle = state.ownPeerLabel ? `You are ${state.ownPeerLabel}` : null;
   return {
-    label: `${count} viewing`,
+    label: count === 1 ? "1 here now" : `${count} here now`,
     title: selfTitle ? `${readerTitle}; ${selfTitle}` : readerTitle,
     connected: true,
   };

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -24,6 +24,7 @@ export function cloudNotebookShellCapabilities({
   const activeEditLevel = userSelectedViewMode ? "viewer" : accessLevel;
   const canEditMarkdown = activeEditLevel === "editor" || activeEditLevel === "owner";
   const canEditCells = activeEditLevel === "owner";
+  const canEditStructure = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
   const auth = {
@@ -50,7 +51,7 @@ export function cloudNotebookShellCapabilities({
     canRead: true,
     canEditMarkdown,
     canEditCells,
-    canEditStructure: false,
+    canEditStructure,
     canRequestEdit: authState.mode === "oidc",
     canExecute: false,
     canToggleCode: hasCodeCells,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -3,6 +3,7 @@ import {
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook-shell/actor-projection";
 import type { NotebookShellCapabilities } from "@/components/notebook-shell/capabilities";
+import { createNotebookInteractionModeProjection } from "@/components/notebook-shell/interaction-mode";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 export interface CloudNotebookShellCapabilityInput {
@@ -20,13 +21,25 @@ export function cloudNotebookShellCapabilities({
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
   const isRuntimePeer = connectionScope === "runtime_peer";
-  const userSelectedViewMode = authState.requestedScope === "viewer";
-  const activeEditLevel = userSelectedViewMode ? "viewer" : accessLevel;
-  const canEditMarkdown = activeEditLevel === "editor" || activeEditLevel === "owner";
-  const canEditCells = activeEditLevel === "owner";
-  const canEditStructure = activeEditLevel === "owner";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
+  const interaction = createNotebookInteractionModeProjection({
+    selectedMode:
+      authState.requestedScope === "editor" || authState.requestedScope === "owner"
+        ? "edit"
+        : "view",
+    permission: {
+      canEditMarkdown: accessLevel === "editor" || accessLevel === "owner",
+      canEditCells: accessLevel === "owner",
+      canEditStructure: accessLevel === "owner",
+    },
+    hostSupport: {
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+      canRequestEdit: authState.mode === "oidc",
+    },
+  });
   const auth = {
     canSignIn: authState.mode !== "oidc",
     canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
@@ -49,15 +62,16 @@ export function cloudNotebookShellCapabilities({
 
   return {
     canRead: true,
-    canEditMarkdown,
-    canEditCells,
-    canEditStructure,
-    canRequestEdit: authState.mode === "oidc",
+    canEditMarkdown: interaction.canEditMarkdown,
+    canEditCells: interaction.canEditCells,
+    canEditStructure: interaction.canEditStructure,
+    canRequestEdit: interaction.canRequestEdit,
     canExecute: false,
     canToggleCode: hasCodeCells,
     canViewPackages: true,
     canManagePackages: false,
     canManageSharing: connectionScope === "owner",
+    interaction,
     access: {
       ...access,
       actor: notebookActorProjectionFromAccess(access, auth),

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -37,6 +37,8 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookIdentityBadge,
+  notebookActorIdentityFromAccess,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -1962,6 +1964,16 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
+          trailingControls={
+            <NotebookIdentityBadge
+              actor={notebookActorIdentityFromAccess(
+                shellCapabilities.access,
+                shellCapabilities.auth,
+              )}
+              size="sm"
+              showDetail={false}
+            />
+          }
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,17 +1,11 @@
-import {
-  ArrowDownToLine,
-  Copy,
-  ChevronsRight,
-  Code,
-  Info,
-  LetterText,
-  Play,
-  RotateCcw,
-  Square,
-} from "lucide-react";
+import { Copy, Info } from "lucide-react";
 import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
-import { cn } from "@/lib/utils";
+import {
+  NotebookCommandToolbar,
+  type NotebookCommandRuntimeState,
+  type NotebookEnvironmentManager,
+} from "@/components/notebook-shell";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
 import {
@@ -22,11 +16,10 @@ import {
   type RuntimeStatusKey,
 } from "../lib/kernel-status";
 import type { KernelspecInfo } from "../types";
-import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "./icons";
 import { extractCondaEnvCreateCommand } from "./EnvBuildDecisionDialog";
 
 /** Badge color variant for environment sources */
-type EnvBadgeVariant = "uv" | "conda" | "pixi";
+type EnvBadgeVariant = NotebookEnvironmentManager;
 
 interface NotebookToolbarProps {
   kernelStatus: KernelStatus;
@@ -60,6 +53,7 @@ interface NotebookToolbarProps {
   updateStatus?: UpdateStatus;
   updateVersion?: string | null;
   onRestartToUpdate?: () => void;
+  trailingControls?: ReactNode;
 }
 
 export function NotebookToolbar({
@@ -93,6 +87,7 @@ export function NotebookToolbar({
   updateStatus,
   updateVersion,
   onRestartToUpdate,
+  trailingControls,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
   const [condaCommandCopied, setCondaCommandCopied] = useState(false);
@@ -120,11 +115,6 @@ export function NotebookToolbar({
       onStartKernel(spec.name);
     }
   }, [kernelspecs, onStartKernel, listKernelspecs]);
-
-  const isKernelRunning =
-    kernelStatus === KERNEL_STATUS.IDLE ||
-    kernelStatus === KERNEL_STATUS.BUSY ||
-    kernelStatus === KERNEL_STATUS.STARTING;
 
   // `statusKey` is already the throttled runtime vocabulary from
   // `useDaemonKernel` — the `RUNNING_BUSY` ↔ `RUNNING_IDLE` transition
@@ -172,245 +162,74 @@ export function NotebookToolbar({
             : "uv"
         : (envTypeHint ?? null)
       : null;
+  const runtimeStatusState = notebookCommandRuntimeState(kernelStatus, Boolean(envErrorMessage));
+  const runtimeStatusError = envErrorMessage ? (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <span className="cursor-help text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
+          {envStatusText}
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent align="end" className="w-80 max-w-[calc(100vw-2rem)] p-3">
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-red-600 dark:text-red-400">Environment error</p>
+          <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
+            {envErrorMessage}
+          </pre>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  ) : null;
 
   return (
-    <header
-      data-testid="notebook-toolbar"
-      className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
-    >
-      <div className="flex h-10 items-center gap-2 px-3">
-        {/* Add cells */}
-        {canEditStructure && (
-          <>
-            <button
-              type="button"
-              onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title="Add code cell"
-              aria-label="Add code cell"
-              data-testid="add-code-cell-button"
-            >
-              <Code className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Code</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title="Add markdown cell"
-              aria-label="Add markdown cell"
-              data-testid="add-markdown-cell-button"
-            >
-              <LetterText className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Markdown</span>
-            </button>
-          </>
-        )}
-
-        {canEditStructure && canExecute ? <div className="h-4 w-px bg-border" /> : null}
-
-        {/* Kernel controls */}
-        {canExecute && !isKernelRunning && (
-          <button
-            type="button"
-            onClick={handleStartKernel}
-            disabled={listKernelspecs && kernelspecs.length === 0}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-            title="Start kernel"
-            aria-label="Start kernel"
-            data-testid="start-kernel-button"
-          >
-            <Play className="h-3 w-3" fill="currentColor" />
-            <span className="hidden @[40rem]:inline">Start Kernel</span>
-          </button>
-        )}
-        {canExecute && (
-          <>
-            <button
-              type="button"
-              onClick={onRunAllCells}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-              title="Run all cells"
-              aria-label="Run all cells"
-              data-testid="run-all-button"
-            >
-              <ChevronsRight className="h-3.5 w-3.5" />
-              <span className="hidden @[40rem]:inline">Run All</span>
-            </button>
-            <button
-              type="button"
-              onClick={onRestartKernel}
-              className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-              title="Restart kernel"
-              aria-label="Restart kernel"
-              data-testid="restart-kernel-button"
-            >
-              <RotateCcw className="h-3 w-3" />
-              <span className="hidden @[40rem]:inline">Restart</span>
-            </button>
-            <button
-              type="button"
-              onClick={onRestartAndRunAll}
-              className={cn(
-                "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-                depsOutOfSync
-                  ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
-                  : "text-foreground hover:bg-muted",
-              )}
-              title={
-                depsOutOfSync
-                  ? "Dependencies changed — restart kernel and run all cells"
-                  : "Restart kernel and run all cells"
+    <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
+      <NotebookCommandToolbar
+        canEditStructure={canEditStructure}
+        canExecute={canExecute}
+        canViewPackages={canViewPackages}
+        runtime={runtime}
+        environmentManager={envManager}
+        environmentPanelOpen={isDepsOpen}
+        environmentOutOfSync={depsOutOfSync}
+        runtimeStatus={{
+          state: runtimeStatusState,
+          label: envProgress?.isActive ? (
+            envStatusText
+          ) : (
+            <span
+              className={
+                kernelStatus === KERNEL_STATUS.ERROR
+                  ? "capitalize text-red-600 dark:text-red-400"
+                  : "capitalize"
               }
-              data-testid="restart-run-all-button"
             >
-              <RotateCcw className="h-3 w-3" />
-              <ChevronsRight className="h-3 w-3 -ml-1" />
-            </button>
-          </>
-        )}
-        {canExecute && isKernelRunning && (
-          <button
-            type="button"
-            onClick={onInterruptKernel}
-            className={cn(
-              "flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs transition-colors",
-              kernelStatus === KERNEL_STATUS.BUSY
-                ? "text-destructive hover:bg-destructive/10"
-                : "text-foreground hover:bg-muted",
-            )}
-            title="Interrupt kernel"
-            aria-label="Interrupt kernel"
-            data-testid="interrupt-kernel-button"
-          >
-            <Square
-              className="h-3 w-3"
-              fill={kernelStatus === KERNEL_STATUS.BUSY ? "currentColor" : "none"}
-            />
-            <span className="hidden @[40rem]:inline">Interrupt</span>
-          </button>
-        )}
-
-        <div className="flex-1" />
-
-        {/* Update available */}
-        {updateStatus === "available" && onRestartToUpdate && (
-          <button
-            type="button"
-            onClick={onRestartToUpdate}
-            data-testid="update-download-button"
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
-            title={`Prepare to update to v${updateVersion}`}
-          >
-            <ArrowDownToLine className="h-3 w-3" />
-            <span>Update {updateVersion}</span>
-          </button>
-        )}
-
-        {/* Runtime / deps toggle — hidden until runtime is known to avoid flicker */}
-        {runtime && canViewPackages && (
-          <button
-            type="button"
-            onClick={onToggleDependencies}
-            data-testid="deps-toggle"
-            data-runtime={runtime}
-            data-env-manager={envManager || undefined}
-            className={cn(
-              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
-              runtime === "deno"
-                ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
-                : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
-              isDepsOpen && "ring-1 ring-current/25",
-            )}
-            title={(() => {
-              const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
-              const mgr = envManager ? ` · ${envManager}` : "";
-              const action = isDepsOpen ? "close environment panel" : "open environment panel";
-              return `${lang}${mgr} — ${action}`;
-            })()}
-          >
-            {runtime === "deno" ? (
-              <>
-                <DenoIcon className="h-3 w-3" />
-                <span>Deno</span>
-              </>
-            ) : (
-              <>
-                <PythonIcon className="h-3 w-3" />
-                <span>Python</span>
-              </>
-            )}
-            {envManager && (
-              <>
-                <span className="opacity-40">·</span>
-                {envManager === "uv" && (
-                  <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
-                )}
-                {envManager === "conda" && (
-                  <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
-                )}
-                {envManager === "pixi" && (
-                  <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
-                )}
-              </>
-            )}
-          </button>
-        )}
-
-        {/* Kernel status */}
-        <div
-          className="flex items-center gap-1.5 whitespace-nowrap"
-          role="status"
-          aria-label={`Kernel: ${kernelStatusDescription}`}
-          title={envErrorMessage ? undefined : kernelStatusTooltip}
-          data-testid="kernel-status"
-          data-kernel-status={kernelStatus}
-        >
-          <div
-            className={cn(
-              "h-2 w-2 shrink-0 rounded-full",
-              kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
-              kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
-              kernelStatus === KERNEL_STATUS.STARTING && "bg-blue-500 animate-pulse",
-              kernelStatus === KERNEL_STATUS.NOT_STARTED && "bg-blue-500 animate-pulse",
-              kernelStatus === KERNEL_STATUS.SHUTDOWN && "bg-gray-400 dark:bg-gray-500",
-              (kernelStatus === KERNEL_STATUS.ERROR || envErrorMessage) && "bg-red-500",
-            )}
-          />
-          <span className="text-xs text-muted-foreground whitespace-nowrap">
-            {envProgress?.isActive ? (
-              envStatusText
-            ) : envErrorMessage ? (
-              <HoverCard openDelay={150} closeDelay={100}>
-                <HoverCardTrigger asChild>
-                  <span className="cursor-help text-red-600 underline decoration-dotted underline-offset-2 dark:text-red-400">
-                    {envStatusText}
-                  </span>
-                </HoverCardTrigger>
-                <HoverCardContent align="end" className="w-80 max-w-[calc(100vw-2rem)] p-3">
-                  <div className="space-y-1">
-                    <p className="text-xs font-medium text-red-600 dark:text-red-400">
-                      Environment error
-                    </p>
-                    <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-muted-foreground">
-                      {envErrorMessage}
-                    </pre>
-                  </div>
-                </HoverCardContent>
-              </HoverCard>
-            ) : (
-              <span
-                className={cn(
-                  "capitalize",
-                  kernelStatus === KERNEL_STATUS.ERROR && "text-red-600 dark:text-red-400",
-                )}
-              >
-                {kernelStatusText}
-              </span>
-            )}
-          </span>
-        </div>
-      </div>
+              {kernelStatusText}
+            </span>
+          ),
+          ariaLabel: `Kernel: ${kernelStatusDescription}`,
+          title: kernelStatusTooltip,
+          error: runtimeStatusError,
+        }}
+        startDisabled={Boolean(listKernelspecs && kernelspecs.length === 0)}
+        addAfterCellId={focusedCellId ?? lastCellId}
+        onAddCell={onAddCell}
+        onStartRuntime={handleStartKernel}
+        onInterruptRuntime={onInterruptKernel}
+        onRestartRuntime={onRestartKernel}
+        onRunAllCells={onRunAllCells}
+        onRestartAndRunAll={onRestartAndRunAll}
+        onTogglePackages={onToggleDependencies}
+        updateAction={
+          updateStatus === "available" && onRestartToUpdate
+            ? {
+                label: `Update ${updateVersion}`,
+                title: `Prepare to update to v${updateVersion}`,
+                onClick: onRestartToUpdate,
+              }
+            : null
+        }
+        trailingControls={trailingControls}
+      />
 
       {/* Deno install prompt */}
       {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
@@ -455,6 +274,31 @@ export function NotebookToolbar({
       )}
     </header>
   );
+}
+
+function notebookCommandRuntimeState(
+  kernelStatus: KernelStatus,
+  hasEnvironmentError: boolean,
+): NotebookCommandRuntimeState {
+  if (hasEnvironmentError) {
+    return "error";
+  }
+  switch (kernelStatus) {
+    case KERNEL_STATUS.NOT_STARTED:
+    case KERNEL_STATUS.AWAITING_TRUST:
+    case KERNEL_STATUS.AWAITING_ENV_BUILD:
+      return "not_started";
+    case KERNEL_STATUS.STARTING:
+      return "starting";
+    case KERNEL_STATUS.IDLE:
+      return "idle";
+    case KERNEL_STATUS.BUSY:
+      return "busy";
+    case KERNEL_STATUS.ERROR:
+      return "error";
+    case KERNEL_STATUS.SHUTDOWN:
+      return "shutdown";
+  }
 }
 
 /** Remediation copy for `KernelErrorReason::MissingIpykernel`, branched by

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -1,0 +1,397 @@
+import {
+  ArrowDownToLine,
+  ChevronsRight,
+  Code,
+  LetterText,
+  Play,
+  RotateCcw,
+  Square,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type NotebookCommandRuntimeState =
+  | "not_started"
+  | "starting"
+  | "idle"
+  | "busy"
+  | "error"
+  | "shutdown"
+  | "unknown";
+
+export type NotebookEnvironmentManager = "uv" | "conda" | "pixi";
+
+export interface NotebookCommandToolbarStatus {
+  state: NotebookCommandRuntimeState;
+  label: ReactNode;
+  ariaLabel: string;
+  title?: string;
+  error?: ReactNode;
+}
+
+export interface NotebookCommandToolbarUpdateAction {
+  label: string;
+  title: string;
+  onClick: () => void;
+}
+
+export interface NotebookCommandToolbarProps {
+  canEditStructure: boolean;
+  canExecute: boolean;
+  canViewPackages: boolean;
+  runtime?: string | null;
+  environmentManager?: NotebookEnvironmentManager | null;
+  environmentPanelOpen?: boolean;
+  environmentOutOfSync?: boolean;
+  runtimeStatus: NotebookCommandToolbarStatus;
+  startDisabled?: boolean;
+  addAfterCellId?: string | null;
+  onAddCell?: (type: "code" | "markdown", afterCellId?: string | null) => unknown;
+  onStartRuntime?: () => void;
+  onInterruptRuntime?: () => void;
+  onRestartRuntime?: () => void;
+  onRunAllCells?: () => void;
+  onRestartAndRunAll?: () => void;
+  onTogglePackages?: () => void;
+  updateAction?: NotebookCommandToolbarUpdateAction | null;
+  leadingControls?: ReactNode;
+  trailingControls?: ReactNode;
+  className?: string;
+}
+
+export function NotebookCommandToolbar({
+  canEditStructure,
+  canExecute,
+  canViewPackages,
+  runtime = null,
+  environmentManager = null,
+  environmentPanelOpen = false,
+  environmentOutOfSync = false,
+  runtimeStatus,
+  startDisabled = false,
+  addAfterCellId = null,
+  onAddCell,
+  onStartRuntime,
+  onInterruptRuntime,
+  onRestartRuntime,
+  onRunAllCells,
+  onRestartAndRunAll,
+  onTogglePackages,
+  updateAction = null,
+  leadingControls,
+  trailingControls,
+  className,
+}: NotebookCommandToolbarProps) {
+  const isRuntimeRunning =
+    runtimeStatus.state === "idle" ||
+    runtimeStatus.state === "busy" ||
+    runtimeStatus.state === "starting";
+  const showAddCellControls = canEditStructure && Boolean(onAddCell);
+  const showRuntimeStart = canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
+  const showRuntimeActions =
+    canExecute && Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
+  const showInterrupt = canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
+  const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
+
+  return (
+    <div
+      data-testid="notebook-toolbar"
+      data-slot="notebook-command-toolbar"
+      className={cn("@container flex h-10 min-w-0 items-center gap-2 px-3 select-none", className)}
+    >
+      {leadingControls}
+
+      {showAddCellControls ? (
+        <>
+          <button
+            type="button"
+            onClick={() => onAddCell?.("code", addAfterCellId)}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add code cell"
+            aria-label="Add code cell"
+            data-testid="add-code-cell-button"
+          >
+            <Code className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Code</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onAddCell?.("markdown", addAfterCellId)}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add markdown cell"
+            aria-label="Add markdown cell"
+            data-testid="add-markdown-cell-button"
+          >
+            <LetterText className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Markdown</span>
+          </button>
+        </>
+      ) : null}
+
+      {showAddCellControls && (showRuntimeStart || showRuntimeActions || showInterrupt) ? (
+        <div className="h-4 w-px bg-border" />
+      ) : null}
+
+      {showRuntimeStart ? (
+        <button
+          type="button"
+          onClick={onStartRuntime}
+          disabled={startDisabled}
+          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+          title="Start kernel"
+          aria-label="Start kernel"
+          data-testid="start-kernel-button"
+        >
+          <Play className="h-3 w-3" fill="currentColor" />
+          <span className="hidden @[40rem]:inline">Start Kernel</span>
+        </button>
+      ) : null}
+
+      {showRuntimeActions ? (
+        <>
+          <button
+            type="button"
+            onClick={onRunAllCells}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Run all cells"
+            aria-label="Run all cells"
+            data-testid="run-all-button"
+          >
+            <ChevronsRight className="h-3.5 w-3.5" />
+            <span className="hidden @[40rem]:inline">Run All</span>
+          </button>
+          <button
+            type="button"
+            onClick={onRestartRuntime}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Restart kernel"
+            aria-label="Restart kernel"
+            data-testid="restart-kernel-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            <span className="hidden @[40rem]:inline">Restart</span>
+          </button>
+          <button
+            type="button"
+            onClick={onRestartAndRunAll}
+            className={cn(
+              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+              environmentOutOfSync
+                ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
+                : "text-foreground hover:bg-muted",
+            )}
+            title={
+              environmentOutOfSync
+                ? "Dependencies changed - restart kernel and run all cells"
+                : "Restart kernel and run all cells"
+            }
+            data-testid="restart-run-all-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            <ChevronsRight className="h-3 w-3 -ml-1" />
+          </button>
+        </>
+      ) : null}
+
+      {showInterrupt ? (
+        <button
+          type="button"
+          onClick={onInterruptRuntime}
+          className={cn(
+            "flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs transition-colors",
+            runtimeStatus.state === "busy"
+              ? "text-destructive hover:bg-destructive/10"
+              : "text-foreground hover:bg-muted",
+          )}
+          title="Interrupt kernel"
+          aria-label="Interrupt kernel"
+          data-testid="interrupt-kernel-button"
+        >
+          <Square
+            className="h-3 w-3"
+            fill={runtimeStatus.state === "busy" ? "currentColor" : "none"}
+          />
+          <span className="hidden @[40rem]:inline">Interrupt</span>
+        </button>
+      ) : null}
+
+      <div className="flex-1" />
+
+      {updateAction ? (
+        <button
+          type="button"
+          onClick={updateAction.onClick}
+          data-testid="update-download-button"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
+          title={updateAction.title}
+        >
+          <ArrowDownToLine className="h-3 w-3" />
+          <span>{updateAction.label}</span>
+        </button>
+      ) : null}
+
+      {showPackageToggle ? (
+        <button
+          type="button"
+          onClick={onTogglePackages}
+          data-testid="deps-toggle"
+          data-runtime={runtime ?? undefined}
+          data-env-manager={environmentManager || undefined}
+          className={cn(
+            "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+            runtime === "deno"
+              ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
+              : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
+            environmentPanelOpen && "ring-1 ring-current/25",
+          )}
+          title={(() => {
+            const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
+            const manager = environmentManager ? ` / ${environmentManager}` : "";
+            const action = environmentPanelOpen
+              ? "close environment panel"
+              : "open environment panel";
+            return `${lang}${manager} - ${action}`;
+          })()}
+        >
+          {runtime === "deno" ? (
+            <>
+              <DenoIcon className="h-3 w-3" />
+              <span>Deno</span>
+            </>
+          ) : (
+            <>
+              <PythonIcon className="h-3 w-3" />
+              <span>Python</span>
+            </>
+          )}
+          {environmentManager ? (
+            <>
+              <span className="opacity-40">/</span>
+              {environmentManager === "uv" ? (
+                <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
+              ) : null}
+              {environmentManager === "conda" ? (
+                <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
+              ) : null}
+              {environmentManager === "pixi" ? (
+                <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+              ) : null}
+            </>
+          ) : null}
+        </button>
+      ) : null}
+
+      <div
+        className="flex items-center gap-1.5 whitespace-nowrap"
+        role="status"
+        aria-label={runtimeStatus.ariaLabel}
+        title={runtimeStatus.error ? undefined : runtimeStatus.title}
+        data-testid="kernel-status"
+        data-kernel-status={runtimeStatus.state}
+      >
+        <div
+          className={cn(
+            "h-2 w-2 shrink-0 rounded-full",
+            runtimeStatus.state === "idle" && "bg-green-500",
+            runtimeStatus.state === "busy" && "bg-amber-500",
+            (runtimeStatus.state === "starting" || runtimeStatus.state === "not_started") &&
+              "bg-blue-500 animate-pulse",
+            runtimeStatus.state === "shutdown" && "bg-gray-400 dark:bg-gray-500",
+            runtimeStatus.state === "error" && "bg-red-500",
+            runtimeStatus.state === "unknown" && "bg-muted-foreground",
+          )}
+        />
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {runtimeStatus.error ?? runtimeStatus.label}
+        </span>
+      </div>
+
+      {trailingControls}
+    </div>
+  );
+}
+
+function DenoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+      <path d="M13.47 20.882l-1.47 -5.882c-2.649 -.088 -5 -1.624 -5 -3.5c0 -1.933 2.239 -3.5 5 -3.5s4 1 5 3c.024 .048 .69 2.215 2 6.5" />
+      <path d="M12 11h.01" />
+    </svg>
+  );
+}
+
+function PythonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 9h-7a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h3" />
+      <path d="M12 15h7a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-3" />
+      <path d="M8 9v-4a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v5a2 2 0 0 1 -2 2h-4a2 2 0 0 0 -2 2v5a2 2 0 0 0 2 2h4a2 2 0 0 0 2 -2v-4" />
+      <path d="M11 6l0 .01" />
+      <path d="M13 18l0 .01" />
+    </svg>
+  );
+}
+
+function UvIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 41 41"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M-5.28619e-06 0.168629L0.0843098 20.1685L0.151762 36.1683C0.161075 38.3774 1.95947 40.1607 4.16859 40.1514L20.1684 40.084L30.1684 40.0418L31.1852 40.0375C33.3877 40.0282 35.1683 38.2026 35.1683 36V36L37.0003 36L37.0003 39.9992L40.1683 39.9996L39.9996 -9.94653e-07L21.5998 0.0775689L21.6774 16.0185L21.6774 25.9998L20.0774 25.9998L18.3998 25.9998L18.4774 16.032L18.3998 0.0910593L-5.28619e-06 0.168629Z" />
+    </svg>
+  );
+}
+
+function CondaIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 23.565 27.149"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="0.25px"
+      className={className}
+    >
+      <path
+        d="M47.3 23.46c-.69-1.27-2.08-3.82-4.51-6.25-.81 3.47-.81 6.48-.69 7.99-.12 0 2.2-1.16 5.2-1.74zM36.54 28.32c-1.27-1.04-3.7-2.89-7.28-4.4.92 3.82 2.43 6.6 3.24 7.99 0 .23 1.62-1.74 4.05-3.59zM50.67 20.08c.81-2.08 2.31-5.09 4.74-8.22-1.5-2.66-3.58-5.32-6.36-7.64-2.2 2.78-3.7 5.56-4.74 8.33 3.12 2.66 5.09 5.44 6.36 7.52zM29.15 36.66c-1.22-.22-2.56-.41-4-.52a40.19 40.19 0 0 0-5.77-.06c1.01 1.29 2.24 2.71 3.73 4.14A39.43 39.43 0 0 0 26.35 43c.35-1.03.77-2.12 1.28-3.28a43.76 43.76 0 0 1 1.51-3.06zM11.92 49.15c4.16-2.66 8.09-3.82 10.75-4.17-2.08-1.74-5.09-4.51-7.52-8.33-3.47.69-7.01 2.02-10.36 4.33 1.97 3.47 4.47 6.2 7.12 8.17zM25.21 48.11c-1.62.12-5.56.34-10.19 3.12 4.28 2.66 8.22 4.06 10.19 4.52-.35-2.55-.35-5.21 0-7.64zM39.21 14.02c-2.54-1.74-5.78-3.24-9.83-4.17-.81 3.47-.92 6.71-.69 9.49 3.93 1.27 6.94 3.12 9.02 4.63 0-2.31.35-5.9 1.5-9.95z"
+        fillRule="evenodd"
+        transform="matrix(.26458 0 0 .26458 -.189 -.253)"
+      />
+    </svg>
+  );
+}
+
+function PixiIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 27.4 40.2"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M27.116 3.67449C27.0374 1.63273 25.7268 0.270764 23.633 0.19141C16.9597-0.0609578 10.2854-0.0667476 3.61182 0.19175C1.56495 0.270764 0.211498 1.63273 0.128738 3.67449C0.0507459 5.60828 0.00647096 8.27738 0 9.98946C0 10.843 0.666168 11.488 1.56086 11.488C2.04414 11.488 2.46169 11.2956 2.74845 10.988C2.7539 10.985 2.76174 10.9846 2.76548 10.9802C3.03897 10.6791 3.2348 10.3079 3.50385 10.001C3.83217 9.62675 4.21021 9.28515 4.63219 9.0195C5.45945 8.49842 6.37151 8.20655 7.44535 8.20655C10.2694 8.20655 12.5673 10.2745 12.5673 13.3496C12.5673 16.4638 10.3297 18.5679 7.27779 18.5679C5.44514 18.5679 3.82195 17.7733 2.92351 16.2333C2.91193 16.2132 2.89695 16.1978 2.88469 16.1791C2.8789 16.1709 2.87311 16.1631 2.86732 16.1549C2.83019 16.1028 2.78932 16.0558 2.74505 16.0139C2.45862 15.7088 2.0421 15.518 1.5612 15.518C0.777537 15.518 0.169607 16.0132 0.0306519 16.7094C0.00919558 16.7714 0 16.8555 0.000340577 17.0162C0.00613038 18.7246 0.0527894 21.6614 0.129079 23.6953C0.166542 24.6952 0.572169 25.6696 1.34017 26.3269C2.21647 27.0772 3.21028 27.0776 4.28207 27.272C4.6516 27.3391 5.02215 27.4587 5.30585 27.7148C5.7159 28.0853 5.86712 28.6974 5.73531 29.2338C5.59125 29.8185 5.17268 30.2007 4.69996 30.5327C4.26232 30.8403 3.85874 31.1689 3.5168 31.5837C2.78694 32.4686 2.4089 33.5853 2.4089 34.7293C2.4089 37.8435 4.56986 40.0764 7.72326 40.0764C10.8375 40.0764 13.0836 37.9808 13.0836 35.0426C13.0836 33.8976 12.7699 32.7509 12.0912 31.8191C11.7683 31.376 11.3708 30.9935 10.9213 30.6809C10.47 30.3672 10.0136 30.1349 9.78409 29.5989C9.65433 29.2954 9.6104 28.9531 9.68362 28.6296C10.0068 27.1981 11.6052 27.3551 12.7233 27.3592C14.2909 27.365 15.8586 27.3579 17.426 27.3364C19.4956 27.3081 21.565 27.2557 23.6333 27.178C25.5899 27.1045 27.0377 25.6999 27.1164 23.695C27.3783 17.0217 27.3735 10.3474 27.1164 3.67381Z" />
+    </svg>
+  );
+}

--- a/src/components/notebook-shell/NotebookEditModeButton.tsx
+++ b/src/components/notebook-shell/NotebookEditModeButton.tsx
@@ -1,8 +1,9 @@
 import { BookOpen, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { NotebookInteractionMode, NotebookInteractionState } from "./interaction-mode";
 
-export type NotebookEditMode = "view" | "edit";
-export type NotebookEditModeState = "viewing" | "requested" | "editing";
+export type NotebookEditMode = NotebookInteractionMode;
+export type NotebookEditModeState = NotebookInteractionState;
 
 export interface NotebookEditModeButtonProps {
   mode: NotebookEditMode;

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -16,8 +16,8 @@ export function NotebookPresenceStatus({
   modeLabel = null,
   title,
 }: NotebookPresenceStatusProps) {
-  const displayLabel = modeLabel ? `${label} · ${modeLabel}` : label;
-  const displayTitle = modeLabel ? `${title}; ${modeLabel}` : title;
+  const displayLabel = modeLabel ? `${label}, ${modeLabel}` : label;
+  const displayTitle = modeLabel ? `${title}. ${modeLabel}` : title;
 
   return (
     <div

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookCommandToolbar } from "../NotebookCommandToolbar";
+
+const runtimeStatus = {
+  state: "idle" as const,
+  label: "idle",
+  ariaLabel: "Kernel: idle",
+  title: "Kernel is idle",
+};
+
+describe("NotebookCommandToolbar", () => {
+  it("renders shared desktop command controls when host capabilities allow them", () => {
+    const onAddCell = vi.fn();
+    const onRunAllCells = vi.fn();
+
+    render(
+      <NotebookCommandToolbar
+        canEditStructure
+        canExecute
+        canViewPackages
+        runtime="python"
+        environmentManager="uv"
+        runtimeStatus={runtimeStatus}
+        addAfterCellId="cell-1"
+        onAddCell={onAddCell}
+        onRunAllCells={onRunAllCells}
+        onRestartRuntime={() => {}}
+        onRestartAndRunAll={() => {}}
+        onInterruptRuntime={() => {}}
+        onTogglePackages={() => {}}
+        trailingControls={<button type="button">Kyle</button>}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("add-code-cell-button"));
+    fireEvent.click(screen.getByTestId("run-all-button"));
+
+    expect(onAddCell).toHaveBeenCalledWith("code", "cell-1");
+    expect(onRunAllCells).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("deps-toggle")).toHaveAttribute("data-env-manager", "uv");
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
+  });
+
+  it("hides mutation and execution controls when the host does not grant them", () => {
+    render(
+      <NotebookCommandToolbar
+        canEditStructure={false}
+        canExecute={false}
+        canViewPackages
+        runtime="python"
+        runtimeStatus={runtimeStatus}
+        onAddCell={() => {}}
+        onRunAllCells={() => {}}
+        onRestartRuntime={() => {}}
+        onRestartAndRunAll={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("add-code-cell-button")).toBeNull();
+    expect(screen.queryByTestId("run-all-button")).toBeNull();
+    expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
+  });
+});

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -7,17 +7,20 @@ describe("NotebookPresenceStatus", () => {
     const { container } = render(
       <NotebookPresenceStatus
         connected
-        label="2 viewing"
-        modeLabel="editing"
-        title="2 connected viewers"
+        label="2 here now"
+        modeLabel="editing is allowed"
+        title="2 participants are in this notebook"
       />,
     );
 
-    expect(screen.getByText("2 viewing · editing")).toBeVisible();
-    expect(screen.getByLabelText("2 connected viewers")).toHaveAttribute("data-connected", "true");
+    expect(screen.getByText("2 here now, editing is allowed")).toBeVisible();
+    expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
+      "data-connected",
+      "true",
+    );
     expect(container.querySelector("[data-slot='notebook-presence-status']")).toHaveAttribute(
       "title",
-      "2 connected viewers; editing",
+      "2 participants are in this notebook. editing is allowed",
     );
   });
 

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createNotebookInteractionModeProjection } from "../interaction-mode";
+
+describe("createNotebookInteractionModeProjection", () => {
+  it("keeps a user-selected view mode read-only even when edit permission exists", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("treats edit as requested when permission has not been granted", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("intersects granted permission with host support for active edits", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: false,
+        canEditStructure: false,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canRequestEdit: false,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+});

--- a/src/components/notebook-shell/capabilities.ts
+++ b/src/components/notebook-shell/capabilities.ts
@@ -1,3 +1,5 @@
+import type { NotebookInteractionModeProjection } from "./interaction-mode";
+
 export type NotebookShellAccessLevel = "none" | "viewer" | "editor" | "owner";
 
 export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown";
@@ -103,6 +105,7 @@ export interface NotebookShellCapabilities {
   canViewPackages: boolean;
   canManagePackages: boolean;
   canManageSharing: boolean;
+  interaction?: NotebookInteractionModeProjection | null;
   access: NotebookShellAccessCapabilities;
   auth: NotebookShellAuthCapabilities;
   runtime: NotebookShellRuntimeCapabilities;
@@ -119,6 +122,15 @@ export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
   canViewPackages: true,
   canManagePackages: false,
   canManageSharing: false,
+  interaction: {
+    selectedMode: "view",
+    activeMode: "view",
+    state: "viewing",
+    canRequestEdit: false,
+    canEditMarkdown: false,
+    canEditCells: false,
+    canEditStructure: false,
+  },
   access: {
     level: "viewer",
     source: "unknown",

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -66,6 +66,15 @@ export {
   type NotebookEditModeButtonProps,
   type NotebookEditModeState,
 } from "./NotebookEditModeButton";
+export {
+  createNotebookInteractionModeProjection,
+  type CreateNotebookInteractionModeProjectionOptions,
+  type NotebookInteractionHostSupport,
+  type NotebookInteractionMode,
+  type NotebookInteractionModeProjection,
+  type NotebookInteractionPermission,
+  type NotebookInteractionState,
+} from "./interaction-mode";
 export { NotebookCellList, type NotebookCellListProps } from "./NotebookCellList";
 export {
   NotebookPackageSummaryPanel,

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -32,6 +32,14 @@ export {
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export {
+  NotebookCommandToolbar,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandToolbarProps,
+  type NotebookCommandToolbarStatus,
+  type NotebookCommandToolbarUpdateAction,
+  type NotebookEnvironmentManager,
+} from "./NotebookCommandToolbar";
+export {
   NotebookIdentityBadge,
   NotebookIdentityGroup,
   type NotebookIdentityBadgeProps,

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -1,0 +1,57 @@
+export type NotebookInteractionMode = "view" | "edit";
+export type NotebookInteractionState = "viewing" | "requested" | "editing";
+
+export interface NotebookInteractionPermission {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+}
+
+export interface NotebookInteractionHostSupport {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+  canRequestEdit: boolean;
+}
+
+export interface NotebookInteractionModeProjection extends NotebookInteractionPermission {
+  selectedMode: NotebookInteractionMode;
+  activeMode: NotebookInteractionMode;
+  state: NotebookInteractionState;
+  canRequestEdit: boolean;
+}
+
+export interface CreateNotebookInteractionModeProjectionOptions {
+  selectedMode: NotebookInteractionMode;
+  permission: NotebookInteractionPermission;
+  hostSupport: NotebookInteractionHostSupport;
+}
+
+export function createNotebookInteractionModeProjection({
+  hostSupport,
+  permission,
+  selectedMode,
+}: CreateNotebookInteractionModeProjectionOptions): NotebookInteractionModeProjection {
+  const wantsEdit = selectedMode === "edit";
+  const hasAnyEditPermission =
+    permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
+  const canActivateEdit = wantsEdit && hasAnyEditPermission;
+  const activeMode: NotebookInteractionMode = canActivateEdit ? "edit" : "view";
+  const state: NotebookInteractionState = !wantsEdit
+    ? "viewing"
+    : canActivateEdit
+      ? "editing"
+      : "requested";
+
+  return {
+    selectedMode,
+    activeMode,
+    state,
+    canRequestEdit: hostSupport.canRequestEdit,
+    canEditMarkdown:
+      activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown,
+    canEditCells: activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells,
+    canEditStructure:
+      activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
+  };
+}


### PR DESCRIPTION
## Summary

- updates the Elements toolbar catalog to render `NotebookCommandToolbar` directly
- adds desktop owner/read-only/remote, cloud viewer/editor/owner, agent, runtime peer, environment, runtime-error, and update-ready toolbar scenarios
- documents the command-toolbar boundary as shared shell chrome while keeping runtime, package, update, CRDT, and transport actions host-owned

## Stack Order

This PR is stacked on #3273 (`quod/shared-notebook-app-chrome`).

Merge order:

1. #3273
2. This PR after GitHub retargets it to `main`

## Validation

- `pnpm --dir apps/elements build`
- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx src/components/notebook-shell/__tests__/interaction-mode.test.ts`
- `cargo xtask lint --fix`
