### PR TITLE
refactor(notebook-shell): share toolbar actor identity

### DIFF
--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -1,21 +1,12 @@
 "use client";
 
-import {
-  BadgeCheck,
-  CircleDot,
-  Laptop,
-  PanelTop,
-  PlayCircle,
-  TimerReset,
-  UserRound,
-} from "lucide-react";
+import { BadgeCheck, CircleDot, PanelTop, PlayCircle, TimerReset } from "lucide-react";
 import {
   NotebookCommandToolbar,
   NotebookEditModeButton,
-  NotebookIdentityBadge,
   NotebookPresenceStatus,
-  notebookActorIdentityFromProjection,
-  type NotebookActorIdentity,
+  NotebookToolbarIdentity,
+  notebookToolbarActors,
   type NotebookCommandRuntimeState,
   type NotebookCommandToolbarProps,
 } from "@/components/notebook-shell";
@@ -79,7 +70,7 @@ function toolbarProps(
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
-  const actorCount = Math.max(1, toolbarActors(scenario).length);
+  const actorCount = Math.max(1, notebookToolbarActors(scenario.capabilities).length);
   return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
 }
 
@@ -398,7 +389,6 @@ export function NotebookToolbarSurfacesExample() {
 }
 
 function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScenario }) {
-  const actors = toolbarActors(scenario);
   const interaction = scenario.capabilities.interaction;
 
   return (
@@ -412,40 +402,9 @@ function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScena
           className="h-7 text-xs"
         />
       ) : null}
-      {actors.slice(0, 2).map((actor) => (
-        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={false} />
-      ))}
-      {actors.length === 0 ? (
-        <span className="inline-flex h-7 items-center gap-1.5 rounded-full border border-border bg-background px-2 text-xs text-muted-foreground">
-          {scenario.capabilities.access.source === "local" ? (
-            <Laptop className="size-3.5" aria-hidden="true" />
-          ) : (
-            <UserRound className="size-3.5" aria-hidden="true" />
-          )}
-          anonymous
-        </span>
-      ) : null}
+      <NotebookToolbarIdentity capabilities={scenario.capabilities} />
     </div>
   );
-}
-
-function toolbarActors(scenario: ElementsNotebookScenario): NotebookActorIdentity[] {
-  const accessActor = scenario.capabilities.access.actor;
-  const runtimeActor = scenario.capabilities.runtime.actor;
-  const candidates = [
-    accessActor ? notebookActorIdentityFromProjection(accessActor) : null,
-    runtimeActor ? notebookActorIdentityFromProjection(runtimeActor) : null,
-  ].filter((actor): actor is NonNullable<typeof actor> => Boolean(actor));
-  const actors: NotebookActorIdentity[] = [];
-  const actorIds = new Set<string>();
-
-  for (const actor of candidates) {
-    if (actorIds.has(actor.id)) continue;
-    actorIds.add(actor.id);
-    actors.push(actor);
-  }
-
-  return actors;
 }
 
 function ScenarioPill({ label }: { label: string }) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -35,6 +35,7 @@ import {
   NotebookIdentityBadge,
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
+  NotebookToolbarIdentity,
   createNotebookEnvironmentSurface,
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
@@ -1301,14 +1302,7 @@ function NotebookViewer({
             interaction={shellCapabilities.interaction ?? null}
             onAuthStateChange={refreshAuthState}
           />
-          <NotebookIdentityBadge
-            actor={notebookActorIdentityFromAccess(
-              shellCapabilities.access,
-              shellCapabilities.auth,
-            )}
-            size="sm"
-            showDetail={false}
-          />
+          <NotebookToolbarIdentity capabilities={shellCapabilities} />
         </>
       }
     />

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -37,8 +37,7 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookIdentityBadge,
-  notebookActorIdentityFromAccess,
+  NotebookToolbarIdentity,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -1964,16 +1963,7 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
-          trailingControls={
-            <NotebookIdentityBadge
-              actor={notebookActorIdentityFromAccess(
-                shellCapabilities.access,
-                shellCapabilities.auth,
-              )}
-              size="sm"
-              showDetail={false}
-            />
-          }
+          trailingControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/src/components/notebook-shell/NotebookToolbarIdentity.tsx
+++ b/src/components/notebook-shell/NotebookToolbarIdentity.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+import { NotebookIdentityBadge } from "./NotebookIdentity";
+import {
+  notebookActorIdentityFromAccess,
+  notebookActorIdentityFromRuntime,
+} from "./actor-projection";
+import type { NotebookActorIdentity, NotebookShellCapabilities } from "./capabilities";
+
+export interface NotebookToolbarIdentityProps {
+  capabilities: NotebookShellCapabilities;
+  maxVisible?: number;
+  showDetail?: boolean;
+  className?: string;
+}
+
+export function NotebookToolbarIdentity({
+  capabilities,
+  maxVisible = 2,
+  showDetail = false,
+  className,
+}: NotebookToolbarIdentityProps) {
+  const actors = notebookToolbarActors(capabilities).slice(0, maxVisible);
+
+  return (
+    <div
+      className={cn("flex min-w-0 items-center gap-1.5", className)}
+      data-slot="notebook-toolbar-identity"
+      aria-label="Notebook actors"
+    >
+      {actors.map((actor) => (
+        <NotebookIdentityBadge key={actor.id} actor={actor} size="sm" showDetail={showDetail} />
+      ))}
+    </div>
+  );
+}
+
+export function notebookToolbarActors(
+  capabilities: NotebookShellCapabilities,
+): NotebookActorIdentity[] {
+  const candidates = [
+    notebookActorIdentityFromAccess(capabilities.access, capabilities.auth),
+    notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth),
+  ].filter((actor): actor is NotebookActorIdentity => Boolean(actor));
+  const actors: NotebookActorIdentity[] = [];
+  const actorIds = new Set<string>();
+
+  for (const actor of candidates) {
+    if (actorIds.has(actor.id)) continue;
+    actorIds.add(actor.id);
+    actors.push(actor);
+  }
+
+  return actors;
+}

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { readOnlyNotebookShellCapabilities } from "../capabilities";
+import { NotebookToolbarIdentity, notebookToolbarActors } from "../NotebookToolbarIdentity";
+import type { NotebookShellCapabilities } from "../capabilities";
+
+function capabilities(
+  overrides: Partial<NotebookShellCapabilities> = {},
+): NotebookShellCapabilities {
+  return {
+    ...readOnlyNotebookShellCapabilities,
+    ...overrides,
+    access: {
+      ...readOnlyNotebookShellCapabilities.access,
+      ...overrides.access,
+    },
+    auth: {
+      ...readOnlyNotebookShellCapabilities.auth,
+      ...overrides.auth,
+    },
+    runtime: {
+      ...readOnlyNotebookShellCapabilities.runtime,
+      ...overrides.runtime,
+    },
+  };
+}
+
+describe("NotebookToolbarIdentity", () => {
+  it("dedupes the same actor when document access and runtime authorship match", () => {
+    const actor = {
+      actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+      principal: {
+        id: "user:anaconda:alice",
+        label: "Alice",
+        source: { provider: "anaconda", namespace: "anaconda" },
+      },
+      operator: {
+        id: "runtime:jupyterhub",
+        kind: "runtime",
+        label: "JupyterHub",
+      },
+      scope: "runtime_peer",
+    } satisfies NonNullable<NotebookShellCapabilities["access"]["actor"]>;
+    const actors = notebookToolbarActors(
+      capabilities({
+        access: {
+          level: "editor",
+          source: "cloud",
+          isPublic: false,
+          actorLabel: actor.actorLabel,
+          identityLabel: "Alice",
+          actor,
+        },
+        runtime: {
+          connected: true,
+          canWriteRuntimeState: true,
+          source: "cloud",
+          actorLabel: actor.actorLabel,
+          identityLabel: "Alice",
+          actor,
+        },
+      }),
+    );
+
+    expect(actors).toHaveLength(1);
+    expect(actors[0]?.label).toBe("JupyterHub");
+  });
+
+  it("keeps desktop access, agent, and runtime actors distinct", () => {
+    const actors = notebookToolbarActors(
+      capabilities({
+        access: {
+          level: "editor",
+          source: "local",
+          isPublic: false,
+          actorLabel: "user:local:kyle/agent:codex:s1",
+          identityLabel: "Kyle",
+        },
+        runtime: {
+          connected: true,
+          canWriteRuntimeState: true,
+          source: "local",
+          actorLabel: "user:local:kyle/runtime:python",
+          identityLabel: "Kyle",
+        },
+      }),
+    );
+
+    expect(actors.map((actor) => actor.kind)).toEqual(["agent", "runtime"]);
+    expect(actors.map((actor) => actor.label)).toEqual(["Codex", "Python"]);
+  });
+
+  it("renders the shared toolbar actor badges", () => {
+    render(
+      <NotebookToolbarIdentity
+        capabilities={capabilities({
+          access: {
+            level: "owner",
+            source: "cloud",
+            isPublic: false,
+            actorLabel: "user:anaconda:kyle/browser:tab",
+            identityLabel: "Kyle",
+          },
+          runtime: {
+            connected: true,
+            canWriteRuntimeState: true,
+            source: "cloud",
+            actorLabel: "user:anaconda:kyle/runtime:jupyterhub",
+            identityLabel: "Kyle",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText("Notebook actors")).toBeVisible();
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(screen.getByText("JupyterHub")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -47,6 +47,11 @@ export {
 } from "./NotebookIdentity";
 export { NotebookPresenceStatus, type NotebookPresenceStatusProps } from "./NotebookPresenceStatus";
 export {
+  NotebookToolbarIdentity,
+  notebookToolbarActors,
+  type NotebookToolbarIdentityProps,
+} from "./NotebookToolbarIdentity";
+export {
   NotebookEnvironmentSummary,
   type NotebookEnvironmentSummaryProps,
 } from "./NotebookEnvironmentSummary";


### PR DESCRIPTION
## Summary

- add a shared `NotebookToolbarIdentity` control that derives toolbar actors from `NotebookShellCapabilities`
- use the shared actor control in desktop, notebook-cloud, and Elements toolbar scenarios
- intentionally show access plus runtime authorship actors when both are present, so desktop Codex/Claude operators and runtime peers fit the same toolbar model
- cover deduped access/runtime actors plus distinct agent/runtime actors

## Stack order

1. #3273 `quod/shared-notebook-app-chrome`
2. #3274 `quod/elements-command-toolbar-scenarios`
3. this PR; retarget to `main` after the lower stack lands

## Verification

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
