### PR TITLE
fix(notebook): gate package rail controls when read-only

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2018,7 +2018,7 @@ function AppContent() {
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
               packagesPanel={
-                <NotebookPackagesPanel>
+                <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (
                     <div className="rounded-md border border-amber-300 bg-amber-50/60 px-3 py-2 text-xs text-amber-800 dark:border-amber-800 dark:bg-amber-950/20 dark:text-amber-300">
                       <div className="mb-2 flex items-center gap-2 font-medium">
@@ -2027,7 +2027,7 @@ function AppContent() {
                       </div>
                       <div className="flex flex-wrap gap-1.5">
                         <button
-                          disabled={clearingDeps}
+                          disabled={clearingDeps || !shellCapabilities.canManagePackages}
                           onClick={async () => {
                             setClearingDeps(true);
                             try {
@@ -2043,7 +2043,7 @@ function AppContent() {
                           )
                         </button>
                         <button
-                          disabled={clearingDeps}
+                          disabled={clearingDeps || !shellCapabilities.canManagePackages}
                           onClick={async () => {
                             setClearingDeps(true);
                             try {
@@ -2069,6 +2069,7 @@ function AppContent() {
                       denoConfigInfo={denoConfigInfo}
                       flexibleNpmImports={flexibleNpmImports}
                       onSetFlexibleNpmImports={setFlexibleNpmImports}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={denoDerivedSyncState}
                       syncing={kernelStatus === KERNEL_STATUS.STARTING}
                       onSyncNow={handleSyncDeps}
@@ -2083,6 +2084,7 @@ function AppContent() {
                       python={condaDependencies?.python ?? null}
                       loading={condaDepsLoading}
                       envSource={envSource}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={condaDerivedSyncState}
                       onAdd={addCondaDependency}
                       onRemove={removeCondaDependency}
@@ -2102,6 +2104,7 @@ function AppContent() {
                       variant="rail"
                       pixiInfo={pixiInfo}
                       envSource={envSource}
+                      readOnly={!shellCapabilities.canManagePackages}
                       syncState={pixiDerivedSyncState}
                       onSyncNow={handleSyncDeps}
                       justSynced={justSynced}
@@ -2113,6 +2116,7 @@ function AppContent() {
                       dependencies={dependencies?.dependencies ?? []}
                       requiresPython={dependencies?.requires_python ?? null}
                       loading={depsLoading}
+                      readOnly={!shellCapabilities.canManagePackages}
                       onAdd={addDependency}
                       onRemove={removeDependency}
                       onSetRequiresPython={setRequiresPython}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -17,6 +17,7 @@ interface CondaDependencyHeaderProps {
   loading: boolean;
   envSource?: string | null;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   syncState: CondaSyncState | null;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
@@ -43,6 +44,7 @@ export function CondaDependencyHeader({
   loading,
   envSource,
   variant = "header",
+  readOnly = false,
   syncState,
   onAdd,
   onRemove,
@@ -68,11 +70,11 @@ export function CondaDependencyHeader({
   const environmentYmlPython = environmentYmlDeps?.python ?? environmentYmlInfo?.python ?? null;
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       await onAdd(newDep.trim());
       setNewDep("");
     }
-  }, [newDep, onAdd]);
+  }, [newDep, onAdd, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -85,7 +87,7 @@ export function CondaDependencyHeader({
   );
 
   const handleAddChannel = useCallback(async () => {
-    if (newChannel.trim()) {
+    if (!readOnly && newChannel.trim()) {
       const trimmed = newChannel.trim();
       let updated: string[];
       if (channels.length === 0 && trimmed !== "conda-forge") {
@@ -99,23 +101,25 @@ export function CondaDependencyHeader({
       setNewChannel("");
       setShowChannelInput(false);
     }
-  }, [newChannel, channels, onSetChannels, onResetProgress]);
+  }, [newChannel, channels, onSetChannels, onResetProgress, readOnly]);
 
   const handleRemoveChannel = useCallback(
     async (channel: string) => {
+      if (readOnly) return;
       const updated = channels.filter((c) => c !== channel);
       onResetProgress?.();
       await onSetChannels(updated);
     },
-    [channels, onSetChannels, onResetProgress],
+    [channels, onSetChannels, onResetProgress, readOnly],
   );
 
   const handlePythonChange = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (readOnly) return;
       const value = e.target.value.trim();
       await onSetPython(value || null);
     },
-    [onSetPython],
+    [onSetPython, readOnly],
   );
 
   // Default channels if none specified
@@ -188,35 +192,39 @@ export function CondaDependencyHeader({
                 <pre className="mt-1 whitespace-pre-wrap font-mono text-[10px] opacity-80 overflow-x-auto">
                   {envProgress.error}
                 </pre>
-                <div className="mt-2 text-[11px] text-red-600/80 dark:text-red-400/80">
-                  Fix channels or dependencies above, then retry.
-                </div>
-              </div>
-              <div className="flex items-center gap-1 shrink-0">
-                <button
-                  type="button"
-                  disabled={loading}
-                  onClick={() => {
-                    onResetProgress?.();
-                    (onRetryLaunch ?? onSyncNow)();
-                  }}
-                  className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Retry environment creation"
-                >
-                  <RefreshCw className="h-3 w-3" />
-                  Retry
-                </button>
-                {onResetProgress && (
-                  <button
-                    type="button"
-                    onClick={onResetProgress}
-                    className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
-                    title="Dismiss"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                {!readOnly && (
+                  <div className="mt-2 text-[11px] text-red-600/80 dark:text-red-400/80">
+                    Fix channels or dependencies above, then retry.
+                  </div>
                 )}
               </div>
+              {!readOnly && (
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    disabled={loading}
+                    onClick={() => {
+                      onResetProgress?.();
+                      (onRetryLaunch ?? onSyncNow)();
+                    }}
+                    className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Retry environment creation"
+                  >
+                    <RefreshCw className="h-3 w-3" />
+                    Retry
+                  </button>
+                  {onResetProgress && (
+                    <button
+                      type="button"
+                      onClick={onResetProgress}
+                      className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
+                      title="Dismiss"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         )}
@@ -300,7 +308,7 @@ export function CondaDependencyHeader({
         )}
 
         {/* Environment drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && (
+        {!readOnly && syncState?.status === "dirty" && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -344,7 +352,7 @@ export function CondaDependencyHeader({
                     {isUsingDefault && (
                       <span className="text-[10px] text-muted-foreground ml-0.5">(default)</span>
                     )}
-                    {channels.length > 0 && (
+                    {!readOnly && channels.length > 0 && (
                       <button
                         type="button"
                         onClick={() => handleRemoveChannel(channel)}
@@ -357,7 +365,7 @@ export function CondaDependencyHeader({
                     )}
                   </div>
                 ))}
-                {showChannelInput ? (
+                {!readOnly && showChannelInput ? (
                   <div className="flex gap-1">
                     <input
                       type="text"
@@ -388,7 +396,7 @@ export function CondaDependencyHeader({
                       Add
                     </button>
                   </div>
-                ) : (
+                ) : !readOnly ? (
                   <button
                     type="button"
                     onClick={() => setShowChannelInput(true)}
@@ -398,32 +406,40 @@ export function CondaDependencyHeader({
                     <Plus className="h-3 w-3" />
                     channel
                   </button>
-                )}
+                ) : null}
               </div>
             </div>
 
             {/* Python version */}
-            <label
-              className={cn(
-                "mb-2 flex items-center gap-2",
-                isRail && "flex-col items-stretch gap-1.5",
-              )}
-            >
-              <span className="text-xs font-medium text-muted-foreground">Python</span>
-              <input
-                type="text"
-                value={python ?? ""}
-                onChange={handlePythonChange}
-                placeholder="3.11"
+            {readOnly ? (
+              python ? (
+                <div className="mb-2 text-xs text-muted-foreground">
+                  Python: <span className="font-mono">{python}</span>
+                </div>
+              ) : null
+            ) : (
+              <label
                 className={cn(
-                  "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
-                  isRail ? "w-full" : "w-20",
+                  "mb-2 flex items-center gap-2",
+                  isRail && "flex-col items-stretch gap-1.5",
                 )}
-                disabled={loading}
-                autoComplete="off"
-                spellCheck={false}
-              />
-            </label>
+              >
+                <span className="text-xs font-medium text-muted-foreground">Python</span>
+                <input
+                  type="text"
+                  value={python ?? ""}
+                  onChange={handlePythonChange}
+                  placeholder="3.11"
+                  className={cn(
+                    "rounded border bg-background px-1.5 py-0.5 font-mono text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary",
+                    isRail ? "w-full" : "w-20",
+                  )}
+                  disabled={loading}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+              </label>
+            )}
 
             {/* Dependencies list */}
             {isRail ? (
@@ -432,7 +448,7 @@ export function CondaDependencyHeader({
                 tone="conda"
                 emptyLabel="No dependencies. Add conda packages to create an isolated environment."
                 loading={loading}
-                onRemove={onRemove}
+                onRemove={readOnly ? undefined : onRemove}
                 className="mb-3"
               />
             ) : dependencies.length > 0 ? (
@@ -443,15 +459,17 @@ export function CondaDependencyHeader({
                     className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
                   >
                     <span className="min-w-0 truncate font-mono">{dep}</span>
-                    <button
-                      type="button"
-                      onClick={() => onRemove(dep)}
-                      className="text-muted-foreground hover:text-foreground transition-colors"
-                      disabled={loading}
-                      title={`Remove ${dep}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => onRemove(dep)}
+                        className="text-muted-foreground hover:text-foreground transition-colors"
+                        disabled={loading}
+                        title={`Remove ${dep}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
@@ -462,30 +480,32 @@ export function CondaDependencyHeader({
             )}
 
             {/* Add dependency input */}
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={newDep}
-                onChange={(e) => setNewDep(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="package or package>=version"
-                data-testid="conda-deps-add-input"
-                className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
-                disabled={loading}
-                autoComplete="off"
-                spellCheck={false}
-              />
-              <button
-                type="button"
-                onClick={handleAdd}
-                disabled={loading || !newDep.trim()}
-                data-testid="conda-deps-add-button"
-                className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
-              >
-                <Plus className="h-3 w-3" />
-                Add
-              </button>
-            </div>
+            {!readOnly && (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={newDep}
+                  onChange={(e) => setNewDep(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="package or package>=version"
+                  data-testid="conda-deps-add-input"
+                  className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                  disabled={loading}
+                  autoComplete="off"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={loading || !newDep.trim()}
+                  data-testid="conda-deps-add-button"
+                  className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -9,6 +9,7 @@ interface DenoDependencyHeaderProps {
   flexibleNpmImports: boolean;
   onSetFlexibleNpmImports: (enabled: boolean) => void;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   // Sync state props - shows banner when config drifts from running kernel
   syncState?: { status: "synced" | "dirty" } | null;
   syncing?: boolean;
@@ -22,6 +23,7 @@ export function DenoDependencyHeader({
   flexibleNpmImports,
   onSetFlexibleNpmImports,
   variant = "header",
+  readOnly = false,
   syncState,
   syncing,
   onSyncNow,
@@ -65,7 +67,7 @@ export function DenoDependencyHeader({
         )}
 
         {/* Config drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -139,12 +141,18 @@ export function DenoDependencyHeader({
           <Checkbox
             id="flexible-npm-imports"
             checked={flexibleNpmImports}
-            onCheckedChange={(checked) => onSetFlexibleNpmImports(checked === true)}
+            onCheckedChange={(checked) => {
+              if (!readOnly) onSetFlexibleNpmImports(checked === true);
+            }}
             className="mt-0.5"
+            disabled={readOnly}
           />
           <Label
             htmlFor="flexible-npm-imports"
-            className="flex-1 flex-col items-start gap-1 cursor-pointer"
+            className={cn(
+              "flex-1 flex-col items-start gap-1",
+              readOnly ? "cursor-default" : "cursor-pointer",
+            )}
           >
             <span className="text-xs font-medium text-foreground">Auto-install npm packages</span>
             <p className="text-xs text-muted-foreground font-normal">

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -11,6 +11,7 @@ interface DependencyHeaderProps {
   requiresPython: string | null;
   loading: boolean;
   variant?: DependencyPanelVariant;
+  readOnly?: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
   onSetRequiresPython: (version: string | null) => Promise<void>;
@@ -35,6 +36,7 @@ export function DependencyHeader({
   requiresPython,
   loading,
   variant = "header",
+  readOnly = false,
   onAdd,
   onRemove,
   onSetRequiresPython,
@@ -64,11 +66,11 @@ export function DependencyHeader({
   }, [requiresPython]);
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       await onAdd(newDep.trim());
       setNewDep("");
     }
-  }, [newDep, onAdd]);
+  }, [newDep, onAdd, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -83,9 +85,10 @@ export function DependencyHeader({
   const commitPythonSpec = useCallback(async () => {
     const next = pythonSpec.trim();
     const current = requiresPython ?? "";
+    if (readOnly) return;
     if (next === current) return;
     await onSetRequiresPython(next || null);
-  }, [onSetRequiresPython, pythonSpec, requiresPython]);
+  }, [onSetRequiresPython, pythonSpec, readOnly, requiresPython]);
 
   const handlePythonKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -132,7 +135,7 @@ export function DependencyHeader({
         )}
 
         {/* Environment drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -192,7 +195,7 @@ export function DependencyHeader({
                 </span>
               </div>
               <div className={cn("flex items-center gap-2", isRail && "flex-wrap justify-end")}>
-                {onUseProjectEnv && !isUsingProjectEnv && (
+                {!readOnly && onUseProjectEnv && !isUsingProjectEnv && (
                   <button
                     type="button"
                     onClick={onUseProjectEnv}
@@ -208,7 +211,7 @@ export function DependencyHeader({
                     Active
                   </span>
                 )}
-                {onImportFromPyproject && (
+                {!readOnly && onImportFromPyproject && (
                   <button
                     type="button"
                     onClick={onImportFromPyproject}
@@ -290,6 +293,12 @@ export function DependencyHeader({
               Python: <span className="font-mono">{requiresPython}</span>
             </div>
           )
+        ) : readOnly ? (
+          requiresPython ? (
+            <div className="mb-2 text-xs text-muted-foreground">
+              Python: <span className="font-mono">{requiresPython}</span>
+            </div>
+          ) : null
         ) : (
           <label
             className={cn(
@@ -325,7 +334,7 @@ export function DependencyHeader({
               tone="uv"
               emptyLabel="No inline dependencies. Add packages to create an isolated environment."
               loading={loading}
-              onRemove={onRemove}
+              onRemove={readOnly ? undefined : onRemove}
               className="mb-3"
             />
           ) : dependencies.length > 0 ? (
@@ -336,15 +345,17 @@ export function DependencyHeader({
                   className="flex max-w-full items-center gap-1 rounded border bg-background px-2 py-1 text-xs"
                 >
                   <span className="min-w-0 truncate font-mono">{dep}</span>
-                  <button
-                    type="button"
-                    onClick={() => onRemove(dep)}
-                    className="text-muted-foreground hover:text-foreground transition-colors"
-                    disabled={loading}
-                    title={`Remove ${dep}`}
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
+                  {!readOnly && (
+                    <button
+                      type="button"
+                      onClick={() => onRemove(dep)}
+                      className="text-muted-foreground hover:text-foreground transition-colors"
+                      disabled={loading}
+                      title={`Remove ${dep}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
                 </div>
               ))}
             </div>
@@ -355,7 +366,7 @@ export function DependencyHeader({
           ))}
 
         {/* Add dependency input (hidden when using project env) */}
-        {!isUsingProjectEnv && (
+        {!readOnly && !isUsingProjectEnv && (
           <div className="flex gap-2">
             <input
               type="text"

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -11,6 +11,7 @@ interface PixiDependencyHeaderProps {
   pixiInfo: PixiInfo | null;
   envSource: string | null;
   variant?: "header" | "rail";
+  readOnly?: boolean;
   syncState?: EnvSyncState | null;
   onSyncNow?: () => Promise<boolean>;
   justSynced?: boolean;
@@ -20,6 +21,7 @@ export function PixiDependencyHeader({
   pixiInfo,
   envSource,
   variant = "header",
+  readOnly = false,
   syncState,
   onSyncNow,
   justSynced,
@@ -34,7 +36,7 @@ export function PixiDependencyHeader({
     : [];
 
   const handleAdd = useCallback(async () => {
-    if (newDep.trim()) {
+    if (!readOnly && newDep.trim()) {
       setLoading(true);
       try {
         await addPixiDependency(newDep.trim());
@@ -43,7 +45,7 @@ export function PixiDependencyHeader({
       }
       setNewDep("");
     }
-  }, [newDep]);
+  }, [newDep, readOnly]);
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -55,14 +57,18 @@ export function PixiDependencyHeader({
     [handleAdd],
   );
 
-  const handleRemove = useCallback(async (pkg: string) => {
-    setLoading(true);
-    try {
-      await removePixiDependency(pkg);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const handleRemove = useCallback(
+    async (pkg: string) => {
+      if (readOnly) return;
+      setLoading(true);
+      try {
+        await removePixiDependency(pkg);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [readOnly],
+  );
 
   return (
     <div
@@ -103,7 +109,7 @@ export function PixiDependencyHeader({
         )}
 
         {/* Sync state drift banner */}
-        {syncState?.status === "dirty" && onSyncNow && (
+        {!readOnly && syncState?.status === "dirty" && onSyncNow && (
           <div
             className={cn(
               "mb-3 rounded bg-amber-500/10 text-xs text-amber-700 dark:text-amber-400",
@@ -217,7 +223,7 @@ export function PixiDependencyHeader({
                 tone="pixi"
                 emptyLabel="No Pixi dependencies yet."
                 loading={loading}
-                onRemove={handleRemove}
+                onRemove={readOnly ? undefined : handleRemove}
                 className="mb-2"
               />
             ) : pixiDeps && pixiDeps.dependencies.length > 0 ? (
@@ -228,39 +234,43 @@ export function PixiDependencyHeader({
                     className="flex max-w-full items-center gap-1 rounded border border-amber-200 bg-amber-100 px-2 py-0.5 text-xs dark:border-amber-800 dark:bg-amber-900/30"
                   >
                     <span className="min-w-0 truncate">{dep}</span>
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(dep)}
-                      disabled={loading}
-                      className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(dep)}
+                        disabled={loading}
+                        className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
             ) : null}
 
             {/* Add dep input */}
-            <div className="mb-3 flex gap-1.5">
-              <input
-                type="text"
-                value={newDep}
-                onChange={(e) => setNewDep(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Add conda package..."
-                className="flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
-              />
-              <button
-                type="button"
-                onClick={handleAdd}
-                disabled={loading || !newDep.trim()}
-                className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
-              >
-                <Plus className="h-3 w-3" />
-                Add
-              </button>
-            </div>
+            {!readOnly && (
+              <div className="mb-3 flex gap-1.5">
+                <input
+                  type="text"
+                  value={newDep}
+                  onChange={(e) => setNewDep(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Add conda package..."
+                  className="flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
+                />
+                <button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={loading || !newDep.trim()}
+                  className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              </div>
+            )}
           </>
         )}
 

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { CondaDependencyHeader } from "../CondaDependencyHeader";
+import { DenoDependencyHeader } from "../DenoDependencyHeader";
 import { DependencyHeader } from "../DependencyHeader";
 import { PackageSpecList, parsePackageSpec } from "../PackageSpecList";
 import { PixiDependencyHeader } from "../PixiDependencyHeader";
@@ -70,6 +71,113 @@ describe("DependencyHeader rail package copy", () => {
     expect(screen.getByText("Using")).toBeVisible();
     expect(screen.getAllByText("pyproject.toml").length).toBeGreaterThan(0);
     expect(screen.getByText("Re-initialize after dependency changes.")).toBeVisible();
+  });
+
+  it("keeps uv package details visible while read-only", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas>=2"]}
+        requiresPython=">=3.12"
+        loading={false}
+        readOnly
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+        syncState={{ status: "dirty", added: ["pandas"], removed: [] }}
+        onSyncNow={async () => true}
+        pyprojectInfo={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          has_dependencies: true,
+          has_dev_dependencies: false,
+          dependency_count: 1,
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          has_venv: false,
+        }}
+        onImportFromPyproject={async () => undefined}
+        onUseProjectEnv={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByText("pandas")).toBeVisible();
+    expect(screen.getByText(">=2")).toBeVisible();
+    expect(screen.getByText("Python:")).toBeVisible();
+    expect(screen.queryByTestId("uv-python-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-add-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-restart-button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove pandas/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /use project env/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy to notebook/i })).not.toBeInTheDocument();
+  });
+});
+
+describe("read-only package rails", () => {
+  it("keeps conda package details visible without mutation controls", () => {
+    render(
+      <CondaDependencyHeader
+        variant="rail"
+        dependencies={["scipy"]}
+        channels={["conda-forge"]}
+        python="3.12"
+        loading={false}
+        readOnly
+        envSource="conda:inline"
+        syncState={{ status: "dirty", added: ["scipy"], removed: [] }}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetChannels={async () => undefined}
+        onSetPython={async () => undefined}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("scipy")).toBeVisible();
+    expect(screen.getByText("conda-forge")).toBeVisible();
+    expect(screen.getByText("Python:")).toBeVisible();
+    expect(screen.queryByTestId("conda-deps-add-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deps-restart-button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove scipy/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /remove conda-forge/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^channel$/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps Deno package guidance visible but makes settings read-only", () => {
+    const onSetFlexibleNpmImports = vi.fn();
+    render(
+      <DenoDependencyHeader
+        variant="rail"
+        denoConfigInfo={null}
+        flexibleNpmImports
+        onSetFlexibleNpmImports={onSetFlexibleNpmImports}
+        readOnly
+        syncState={{ status: "dirty" }}
+        syncing={false}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("Import modules directly in your code:")).toBeVisible();
+    expect(screen.getByRole("checkbox", { name: /auto-install npm packages/i })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps inline Pixi details visible while read-only", () => {
+    render(
+      <PixiDependencyHeader
+        variant="rail"
+        envSource="pixi:inline"
+        pixiInfo={null}
+        readOnly
+        syncState={{ status: "dirty", added: ["numpy"], removed: [] }}
+        onSyncNow={async () => true}
+      />,
+    );
+
+    expect(screen.getByText("No Pixi dependencies yet.")).toBeVisible();
+    expect(screen.queryByPlaceholderText("Add conda package...")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- gate the desktop package rail through `NotebookShellCapabilities.canManagePackages`
- keep uv, conda, Deno, and Pixi package/environment details visible in read-only hosts
- hide or disable package mutation controls so read-only/package-view surfaces do not trigger metadata or runtime changes

## Stack order

1. #3273
2. #3274
3. #3275
4. This PR

This targets `quod/shared-toolbar-identity-group`; merge the stack in order or retarget after lower branches land.

## Verification

- `pnpm --workspace-root exec vp test run apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/notebook/src/components/__tests__/dependency-header.test.tsx apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
