### PR TITLE
fix(notebook-shell): label operator actors naturally

### DIFF
--- a/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookEnvironmentSummary.test.tsx
@@ -63,7 +63,7 @@ describe("NotebookEnvironmentSummary", () => {
 
     expect(screen.getByRole("heading", { name: "Notebook environment" })).toBeVisible();
     expect(screen.getByText("Python - local runtime ready")).toBeVisible();
-    expect(screen.getByText("Python authors runtime state")).toBeVisible();
+    expect(screen.getByText("Python authors runtime state for Kyle")).toBeVisible();
     expect(screen.getByText("uv + pixi - 3 packages")).toBeVisible();
     expect(screen.getByText("pyproject.toml")).toBeVisible();
     expect(screen.getByText("dirty - 1 pending change")).toBeVisible();

--- a/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx
@@ -36,8 +36,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for Kyle")).toBeVisible();
+    expect(screen.getByText("Codex for Kyle")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
   });
 
   it("projects durable principal/operator labels for delegated agents", () => {
@@ -53,8 +53,26 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for kyle@example.com")).toBeVisible();
+    expect(screen.getByText("Codex for kyle@example.com")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
+  });
+
+  it("keeps delegated agent attribution when access scope is absent", () => {
+    const actor = notebookActorIdentityFromAccess({
+      level: "none",
+      source: "local",
+      isPublic: false,
+      actorLabel: "user:local:kyle/agent:claude:s1",
+      identityLabel: "Kyle",
+    });
+
+    expect(actor.kind).toBe("agent");
+    expect(actor.detail).toBeNull();
+
+    render(<NotebookIdentityBadge actor={actor} />);
+
+    expect(screen.getByText("Claude for Kyle")).toBeVisible();
+    expect(screen.getByTitle("Claude for Kyle")).toBeVisible();
   });
 
   it("prefers structured actor projections over durable label fallback", () => {
@@ -114,8 +132,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("Codex")).toBeVisible();
-    expect(screen.getByText("for Alice Appleseed")).toBeVisible();
+    expect(screen.getByText("Codex for Alice Appleseed")).toBeVisible();
+    expect(screen.getByText("Editor")).toBeVisible();
     expect(screen.queryByText("Legacy")).toBeNull();
     expect(screen.queryByText("for Someone Else")).toBeNull();
   });
@@ -133,8 +151,8 @@ describe("NotebookIdentity", () => {
 
     render(<NotebookIdentityBadge actor={actor} />);
 
-    expect(screen.getByText("JupyterHub")).toBeVisible();
-    expect(screen.getByText("for Alice")).toBeVisible();
+    expect(screen.getByText("JupyterHub for Alice")).toBeVisible();
+    expect(screen.getByText("Viewer")).toBeVisible();
   });
 
   it("projects durable system operators separately from human identity", () => {

--- a/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx
@@ -63,7 +63,8 @@ describe("NotebookToolbarIdentity", () => {
     );
 
     expect(actors).toHaveLength(1);
-    expect(actors[0]?.label).toBe("JupyterHub");
+    expect(actors[0]?.label).toBe("JupyterHub for Alice");
+    expect(actors[0]?.detail).toBe("Runtime peer");
   });
 
   it("keeps desktop access, agent, and runtime actors distinct", () => {
@@ -87,7 +88,8 @@ describe("NotebookToolbarIdentity", () => {
     );
 
     expect(actors.map((actor) => actor.kind)).toEqual(["agent", "runtime"]);
-    expect(actors.map((actor) => actor.label)).toEqual(["Codex", "Python"]);
+    expect(actors.map((actor) => actor.label)).toEqual(["Codex for Kyle", "Python for Kyle"]);
+    expect(actors.map((actor) => actor.detail)).toEqual(["Editor", "Runtime peer"]);
   });
 
   it("renders the shared toolbar actor badges", () => {
@@ -114,6 +116,6 @@ describe("NotebookToolbarIdentity", () => {
 
     expect(screen.getByLabelText("Notebook actors")).toBeVisible();
     expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getByText("JupyterHub")).toBeVisible();
+    expect(screen.getByText("JupyterHub for Kyle")).toBeVisible();
   });
 });

--- a/src/components/notebook-shell/actor-projection.ts
+++ b/src/components/notebook-shell/actor-projection.ts
@@ -88,7 +88,7 @@ export function notebookActorIdentityFromProjection(
   actor: NotebookActorProjection,
 ): NotebookActorIdentity {
   const kind = actorKindFromProjection(actor);
-  const detail = actorDetailFromProjection(actor, kind);
+  const detail = actorDetailFromProjection(actor);
 
   return {
     id: actor.actorLabel,
@@ -218,22 +218,35 @@ function actorKindFromProjection(actor: NotebookActorProjection): NotebookActorK
 
 function actorLabelFromProjection(actor: NotebookActorProjection, kind: NotebookActorKind): string {
   if (kind === "agent" || kind === "runtime" || kind === "system") {
-    return actor.operator.label;
+    return operatorActorLabel(actor);
   }
   return actor.principal.label;
 }
 
-function actorDetailFromProjection(
-  actor: NotebookActorProjection,
-  kind: NotebookActorKind,
-): string | null {
-  if (kind === "agent" || kind === "runtime" || kind === "system") {
-    const principalLabel = actor.principal.label;
-    return kind === "system" && actor.principal.id === "system"
-      ? accessScopeLabel(actor.scope)
-      : `for ${principalLabel}`;
-  }
+function actorDetailFromProjection(actor: NotebookActorProjection): string | null {
   return accessScopeLabel(actor.scope);
+}
+
+function operatorActorLabel(actor: NotebookActorProjection): string {
+  const principalLabel = actor.principal.label.trim();
+  if (
+    principalLabel &&
+    principalLabel !== actor.operator.label &&
+    !isGenericPrincipalLabel(principalLabel)
+  ) {
+    return `${actor.operator.label} for ${principalLabel}`;
+  }
+  return actor.operator.label;
+}
+
+function isGenericPrincipalLabel(label: string): boolean {
+  return (
+    label === "Runtime principal" ||
+    label === "Unknown viewer" ||
+    label === "Public viewer" ||
+    label === "System" ||
+    label === "Peer"
+  );
 }
 
 function accessScopeLabel(scope: NotebookActorProjection["scope"]): string | null {

--- a/src/components/notebook-shell/environment-surface.ts
+++ b/src/components/notebook-shell/environment-surface.ts
@@ -1,5 +1,6 @@
 import { notebookActorIdentityFromRuntime } from "./actor-projection";
 import type {
+  NotebookActorIdentity,
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
   NotebookShellCapabilities,
@@ -81,7 +82,7 @@ export function createNotebookEnvironmentSurface({
     runtimeLabel ?? (capabilities.canExecute ? "Runtime ready" : "No runtime");
   const runtimeActor = notebookActorIdentityFromRuntime(capabilities.runtime, capabilities.auth);
   const runtimeDetail = capabilities.runtime.canWriteRuntimeState
-    ? `${runtimeActor?.label ?? "Connected runtime"} authors runtime state`
+    ? runtimeAuthorshipDetail(runtimeActor)
     : capabilities.runtime.connected
       ? `Runtime connected through ${accessSourceLabel(capabilities.runtime.source)}`
       : null;
@@ -159,4 +160,12 @@ export function accessSourceLabel(source: NotebookShellAccessSource): string {
     case "unknown":
       return "unknown host";
   }
+}
+
+function runtimeAuthorshipDetail(actor: NotebookActorIdentity | null): string {
+  if (!actor) return "Connected runtime authors runtime state";
+  if (actor.operatorLabel && actor.principalLabel && actor.operatorLabel !== actor.principalLabel) {
+    return `${actor.operatorLabel} authors runtime state for ${actor.principalLabel}`;
+  }
+  return `${actor.label} authors runtime state`;
 }


### PR DESCRIPTION
## Summary

- derive shared operator actor labels like `Codex for Kyle` and `JupyterHub for Alice`
- keep access/scope as secondary detail instead of the primary actor label
- update notebook-shell identity tests so desktop agents, runtime peers, and cloud actors share the same display contract

## Stack

This targets `quod/desktop-package-readonly-controls` and should merge after:

1. #3273
2. #3274
3. #3275
4. #3276

## Verification

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx src/components/notebook-shell/__tests__/actor-projection.test.ts src/components/notebook-shell/__tests__/actor-labels.test.ts`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-presence.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
