### PR TITLE
fix(notebook-shell): derive presence copy from interaction mode

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -74,7 +74,11 @@ test("cloud viewer routes notebook header controls through the shared command to
   );
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /leadingControls=\{[\s\S]*<CloudPresenceStatus/);
+  assert.match(
+    sourceText,
+    /leadingControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
+  );
+  assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canManageSharing \? \(/);
   assert.doesNotMatch(sourceText, /shellCapabilities\.canToggleCode \? \(/);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -37,6 +37,7 @@ import {
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
   createNotebookEnvironmentSurface,
+  notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
@@ -1287,7 +1288,10 @@ function NotebookViewer({
       onAddCell={handleCloudAddCell}
       onTogglePackages={handleTogglePackagesRail}
       leadingControls={
-        <CloudPresenceStatus presence={presence} connectionScope={connectionScope} />
+        <CloudPresenceStatus
+          presence={presence}
+          interaction={shellCapabilities.interaction ?? null}
+        />
       }
       trailingControls={
         <>
@@ -2087,18 +2091,13 @@ function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
 
 function CloudPresenceStatus({
   presence,
-  connectionScope,
+  interaction,
 }: {
   presence: CloudViewerPresenceState;
-  connectionScope: string | null;
+  interaction: NotebookInteractionModeProjection | null;
 }) {
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
-  const scopeLabel =
-    connectionScope === "editor" || connectionScope === "owner"
-      ? "editing is allowed"
-      : connectionScope === "viewer"
-        ? "view only"
-        : null;
+  const scopeLabel = notebookInteractionPresenceLabel(interaction);
 
   return (
     <NotebookPresenceStatus

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -8,19 +8,19 @@ describe("NotebookPresenceStatus", () => {
       <NotebookPresenceStatus
         connected
         label="2 here now"
-        modeLabel="editing is allowed"
+        modeLabel="editing"
         title="2 participants are in this notebook"
       />,
     );
 
-    expect(screen.getByText("2 here now, editing is allowed")).toBeVisible();
+    expect(screen.getByText("2 here now, editing")).toBeVisible();
     expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
       "data-connected",
       "true",
     );
     expect(container.querySelector("[data-slot='notebook-presence-status']")).toHaveAttribute(
       "title",
-      "2 participants are in this notebook. editing is allowed",
+      "2 participants are in this notebook. editing",
     );
   });
 

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createNotebookInteractionModeProjection } from "../interaction-mode";
+import {
+  createNotebookInteractionModeProjection,
+  notebookInteractionPresenceLabel,
+} from "../interaction-mode";
 
 describe("createNotebookInteractionModeProjection", () => {
   it("keeps a user-selected view mode read-only even when edit permission exists", () => {
@@ -79,5 +82,70 @@ describe("createNotebookInteractionModeProjection", () => {
       canEditCells: false,
       canEditStructure: false,
     });
+  });
+
+  it("uses selected mode, permission, and host support for shared presence copy", () => {
+    const editableView = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+        canRequestEdit: true,
+      },
+    });
+    const activeEdit = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: false,
+        canRequestEdit: true,
+      },
+    });
+    const requestedEdit = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+    const readOnlyView = createNotebookInteractionModeProjection({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(notebookInteractionPresenceLabel(editableView)).toBe("viewing");
+    expect(notebookInteractionPresenceLabel(activeEdit)).toBe("editing");
+    expect(notebookInteractionPresenceLabel(requestedEdit)).toBe("waiting for edit access");
+    expect(notebookInteractionPresenceLabel(readOnlyView)).toBe("view only");
+    expect(notebookInteractionPresenceLabel(null)).toBeNull();
   });
 });

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -73,6 +73,7 @@ export {
 } from "./NotebookEditModeButton";
 export {
   createNotebookInteractionModeProjection,
+  notebookInteractionPresenceLabel,
   type CreateNotebookInteractionModeProjectionOptions,
   type NotebookInteractionHostSupport,
   type NotebookInteractionMode,

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -55,3 +55,18 @@ export function createNotebookInteractionModeProjection({
       activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
   };
 }
+
+export function notebookInteractionPresenceLabel(
+  interaction: NotebookInteractionModeProjection | null | undefined,
+): string | null {
+  if (!interaction) return null;
+
+  switch (interaction.state) {
+    case "editing":
+      return "editing";
+    case "requested":
+      return "waiting for edit access";
+    case "viewing":
+      return interaction.canRequestEdit ? "viewing" : "view only";
+  }
+}


### PR DESCRIPTION
## Summary

- derive shared presence mode copy from `NotebookInteractionModeProjection`
- route cloud presence through selected/active interaction state instead of connection scope
- keep cloud scope/ACL as permission while the presence pill says `viewing`, `editing`, `waiting for edit access`, or `view only`

## Validation

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/interaction-mode.test.ts src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-presence.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Stack

- Builds on #3277 (`quod/shared-actor-display-labels`).
