### PR TITLE
fix(notebook): tune fluid rail and execution context

### DIFF
--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -79,7 +79,7 @@ export function RailOutlineExample() {
 
   return (
     <NotebookDocumentShell
-      className="not-prose min-h-[560px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm md:min-h-[700px] max-md:[&_[data-slot=notebook-document-stage]]:hidden max-md:[&_[data-slot=notebook-rail-panel]]:min-w-0 max-md:[&_[data-slot=notebook-rail-panel]]:max-w-none max-md:[&_[data-slot=notebook-rail-panel]]:flex-1 max-md:[&_[data-testid=notebook-rail]]:w-full"
+      className="not-prose min-h-[560px] overflow-hidden rounded-lg border border-fd-border bg-fd-card text-fd-card-foreground shadow-sm md:min-h-[700px] max-[599.98px]:[&_[data-slot=notebook-document-stage]]:hidden max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:min-w-0 max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:max-w-none max-[599.98px]:[&_[data-slot=notebook-rail-panel]]:flex-1 max-[599.98px]:[&_[data-testid=notebook-rail]]:w-full"
       stageClassName="min-w-[320px] bg-fd-muted/20"
       toolbarClassName="border-b border-fd-border"
       toolbarLabel="Notebook fixture toolbar"

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -224,7 +224,7 @@ function DependencyHeaderFixture({ scenario }: { scenario: ElementsNotebookScena
         </p>
       </div>
       <div className="bg-fd-muted/20 p-4">
-        <div className="mx-auto w-[clamp(14rem,19vw,16rem)] max-w-full">
+        <div className="mx-auto w-[clamp(15rem,20vw,17rem)] max-w-full">
           <DependencyHeader
             dependencies={[...scenario.packageState.dependencies]}
             requiresPython={scenario.packageState.requiresPython}

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -224,7 +224,7 @@ function DependencyHeaderFixture({ scenario }: { scenario: ElementsNotebookScena
         </p>
       </div>
       <div className="bg-fd-muted/20 p-4">
-        <div className="mx-auto w-full max-w-[22rem]">
+        <div className="mx-auto w-[clamp(14rem,19vw,16rem)] max-w-full">
           <DependencyHeader
             dependencies={[...scenario.packageState.dependencies]}
             requiresPython={scenario.packageState.requiresPython}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -33,7 +33,12 @@ import { WidgetView } from "@/components/widgets/widget-view";
 import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
-import { NotebookPackagesPanel, type NotebookRailPanelId } from "@/components/notebook-rail";
+import {
+  NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
+  NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  NotebookPackagesPanel,
+  type NotebookRailPanelId,
+} from "@/components/notebook-rail";
 import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -105,15 +110,13 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
-const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
-
 function focusRailCollapseButtonWhenStageIsHidden(
   railCollapsed: boolean,
   stageHadFocusBeforeTakeover: boolean,
 ): void {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
-  const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
+  const takeoverQuery = window.matchMedia?.(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY);
   if (!takeoverQuery?.matches || railCollapsed) return;
 
   const activeElement = document.activeElement;
@@ -450,7 +453,7 @@ function AppContent() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const takeoverQuery = window.matchMedia?.(RAIL_TAKEOVER_MEDIA_QUERY);
+    const takeoverQuery = window.matchMedia?.(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY);
     if (!takeoverQuery) return;
 
     const handleTakeoverChange = () => {
@@ -2064,7 +2067,10 @@ function AppContent() {
         <NotebookDocumentShell
           capabilities={shellCapabilities}
           stageLabel="Notebook editor"
-          stageClassName={cn("flex-row min-w-0 flex-1", !railCollapsed && "max-[599.98px]:hidden")}
+          stageClassName={cn(
+            "flex-row min-w-0 flex-1",
+            !railCollapsed && NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+          )}
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -140,14 +140,16 @@ export function CondaDependencyHeader({
           className={cn(
             "mb-2 flex items-center gap-2",
             isRail &&
-              "mb-3 justify-between rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
+              "mb-3 flex-wrap justify-between gap-x-2 gap-y-1 rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
           )}
         >
-          <div className="flex min-w-0 items-center gap-2">
+          <div className={cn("flex min-w-0 items-center gap-2", isRail && "shrink-0")}>
             <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
               conda
             </span>
-            {isRail && <span className="truncate text-xs text-muted-foreground">Environment</span>}
+            {isRail && (
+              <span className="whitespace-nowrap text-xs text-muted-foreground">Environment</span>
+            )}
           </div>
           {isRail && (
             <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -470,7 +470,7 @@ export function CondaDependencyHeader({
                 onKeyDown={handleKeyDown}
                 placeholder="package or package>=version"
                 data-testid="conda-deps-add-input"
-                className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                 disabled={loading}
                 autoComplete="off"
                 spellCheck={false}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -151,11 +151,6 @@ export function CondaDependencyHeader({
               <span className="whitespace-nowrap text-xs text-muted-foreground">Environment</span>
             )}
           </div>
-          {isRail && (
-            <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-              {packageCountLabel(dependencies.length)}
-            </span>
-          )}
         </div>
 
         {/* Environment preparation progress */}
@@ -493,8 +488,4 @@ export function CondaDependencyHeader({
       </div>
     </div>
   );
-}
-
-function packageCountLabel(count: number): string {
-  return count === 1 ? "1 package" : `${count} packages`;
 }

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -40,14 +40,21 @@ export function DenoDependencyHeader({
           className={cn(
             "mb-2 flex items-center gap-2",
             isRail &&
-              "mb-3 justify-between rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
+              "mb-3 flex-wrap justify-between gap-x-2 gap-y-1 rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
           )}
         >
-          <div className="flex min-w-0 items-center gap-2">
+          <div className={cn("flex min-w-0 items-center gap-2", isRail && "shrink-0")}>
             <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
               Deno
             </span>
-            <span className="truncate text-xs text-muted-foreground">Dependencies</span>
+            <span
+              className={cn(
+                "text-xs text-muted-foreground",
+                isRail ? "whitespace-nowrap" : "truncate",
+              )}
+            >
+              Dependencies
+            </span>
           </div>
           {isRail && (
             <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -364,7 +364,7 @@ export function DependencyHeader({
               onKeyDown={handleKeyDown}
               placeholder="package or package>=version"
               data-testid="deps-add-input"
-              className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               disabled={loading}
               autoComplete="off"
               spellCheck={false}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -178,8 +178,13 @@ export function DependencyHeader({
 
         {/* pyproject.toml detected banner */}
         {hasPyprojectDependencies && !isUsingProjectEnv && (
-          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
-            <div className={cn("flex items-center justify-between", isRail && "items-start gap-3")}>
+          <div
+            className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground"
+            data-slot="deps-pyproject-banner"
+          >
+            <div
+              className={cn(isRail ? "flex flex-col gap-2" : "flex items-center justify-between")}
+            >
               <div className="flex min-w-0 items-start gap-2">
                 <FileText className="h-3.5 w-3.5 shrink-0" />
                 <span className="min-w-0">
@@ -191,7 +196,10 @@ export function DependencyHeader({
                   )}
                 </span>
               </div>
-              <div className={cn("flex items-center gap-2", isRail && "flex-wrap justify-end")}>
+              <div
+                data-slot="deps-pyproject-actions"
+                className={cn("flex items-center gap-2", isRail && "flex-wrap justify-start pl-5")}
+              >
                 {onUseProjectEnv && !isUsingProjectEnv && (
                   <button
                     type="button"

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -109,12 +109,14 @@ export function DependencyHeader({
           className={cn(
             "mb-2 flex items-center gap-2",
             isRail &&
-              "mb-3 justify-between rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
+              "mb-3 flex-wrap justify-between gap-x-2 gap-y-1 rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
           )}
         >
-          <div className="flex min-w-0 items-center gap-2">
+          <div className={cn("flex min-w-0 items-center gap-2", isRail && "shrink-0")}>
             <span className="rounded bg-uv/20 px-1.5 py-0.5 text-xs font-medium text-uv">uv</span>
-            {isRail && <span className="truncate text-xs text-muted-foreground">Python</span>}
+            {isRail && (
+              <span className="whitespace-nowrap text-xs text-muted-foreground">Python</span>
+            )}
           </div>
           {isRail && (
             <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -118,9 +118,9 @@ export function DependencyHeader({
               <span className="whitespace-nowrap text-xs text-muted-foreground">Python</span>
             )}
           </div>
-          {isRail && (
+          {isRail && isUsingProjectEnv && (
             <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-              {isUsingProjectEnv ? "Project env" : packageCountLabel(dependencies.length)}
+              Project env
             </span>
           )}
         </div>
@@ -145,22 +145,7 @@ export function DependencyHeader({
           >
             <div className="flex items-start gap-2">
               <Info className="h-3.5 w-3.5 shrink-0" />
-              <span>
-                Re-initialize the environment to use{" "}
-                {syncState.added.length > 0 && (
-                  <span>
-                    {syncState.added.length} new package
-                    {syncState.added.length > 1 ? "s" : ""}
-                  </span>
-                )}
-                {syncState.added.length > 0 && syncState.removed.length > 0 && " and remove "}
-                {syncState.removed.length > 0 && (
-                  <span>
-                    {syncState.removed.length} package
-                    {syncState.removed.length > 1 ? "s" : ""}
-                  </span>
-                )}
-              </span>
+              <span>Re-initialize the environment to apply dependency changes.</span>
             </div>
             <button
               type="button"
@@ -394,8 +379,4 @@ export function DependencyHeader({
       </div>
     </div>
   );
-}
-
-function packageCountLabel(count: number): string {
-  return count === 1 ? "1 package" : `${count} packages`;
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -401,7 +401,6 @@ export function NotebookToolbar({
             ) : (
               <span
                 className={cn(
-                  "capitalize",
                   kernelStatus === KERNEL_STATUS.ERROR && "text-red-600 dark:text-red-400",
                 )}
               >

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -221,7 +221,7 @@ export function NotebookToolbar({
             data-testid="start-kernel-button"
           >
             <Play className="h-3 w-3" fill="currentColor" />
-            <span className="hidden @[40rem]:inline">Start Kernel</span>
+            <span className="hidden @[40rem]:inline">Start kernel</span>
           </button>
         )}
         {canExecute && (
@@ -235,7 +235,7 @@ export function NotebookToolbar({
               data-testid="run-all-button"
             >
               <ChevronsRight className="h-3.5 w-3.5" />
-              <span className="hidden @[40rem]:inline">Run All</span>
+              <span className="hidden @[40rem]:inline">Run all</span>
             </button>
             <button
               type="button"

--- a/apps/notebook/src/components/PackageSpecList.tsx
+++ b/apps/notebook/src/components/PackageSpecList.tsx
@@ -20,13 +20,6 @@ const toneClasses: Record<PackageSpecTone, string> = {
   neutral: "text-muted-foreground bg-muted/70 ring-border/60",
 };
 
-const toneDotClasses: Record<PackageSpecTone, string> = {
-  uv: "bg-uv/60",
-  conda: "bg-emerald-500/60",
-  pixi: "bg-amber-500/60",
-  neutral: "bg-muted-foreground/50",
-};
-
 const markerStartPattern =
   /^(?:python_version|python_full_version|os_name|sys_platform|platform_release|platform_system|platform_version|platform_machine|platform_python_implementation|implementation_name|implementation_version|extra)\b/;
 
@@ -56,7 +49,6 @@ export function PackageSpecList({
         const parsed = parsePackageSpec(value);
         const hasEnvironmentMarker = findEnvironmentMarkerStart(value.trim()) > 0;
         const showIcon = framed || Boolean(onRemove);
-        const showDot = !showIcon;
         return (
           <div
             key={`${index}-${value}`}
@@ -65,7 +57,7 @@ export function PackageSpecList({
               "grid items-center gap-x-2 gap-y-0.5 border-b px-2.5 py-1.5 text-xs last:border-b-0",
               showIcon
                 ? "min-h-9 grid-cols-[auto_minmax(0,1fr)_auto_auto]"
-                : "min-h-8 grid-cols-[auto_minmax(0,1fr)_auto_auto]",
+                : "min-h-8 grid-cols-[minmax(0,1fr)_auto_auto]",
               !framed && "px-0",
             )}
           >
@@ -81,22 +73,15 @@ export function PackageSpecList({
                 <Package className="size-3" />
               </span>
             )}
-            {showDot && (
-              <span
-                className={cn(
-                  "mt-1.5 size-1.5 self-start rounded-full",
-                  hasEnvironmentMarker && parsed.spec && "row-span-2",
-                  toneDotClasses[tone],
-                )}
-                aria-hidden="true"
-              />
-            )}
             <span className="min-w-0 flex-1 truncate font-mono text-foreground" title={parsed.name}>
               {parsed.name}
             </span>
             {parsed.spec && hasEnvironmentMarker ? (
               <span
-                className="col-span-3 col-start-2 min-w-0 whitespace-normal break-words text-[11px] leading-snug text-muted-foreground"
+                className={cn(
+                  "min-w-0 whitespace-normal break-words text-[11px] leading-snug text-muted-foreground",
+                  showIcon ? "col-span-3 col-start-2" : "col-span-3 col-start-1",
+                )}
                 title={parsed.spec}
               >
                 {parsed.spec}

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -249,7 +249,7 @@ export function PixiDependencyHeader({
                 onChange={(e) => setNewDep(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="Add conda package..."
-                className="flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
+                className="min-w-0 flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
               />
               <button
                 type="button"

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -92,9 +92,9 @@ export function PixiDependencyHeader({
               {isInlineMode ? "Dependencies" : "Environment"}
             </span>
           </div>
-          {isRail && (
+          {isRail && !isInlineMode && (
             <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-              {isInlineMode ? packageCountLabel(pixiDeps?.dependencies.length ?? 0) : "Project"}
+              Project
             </span>
           )}
         </div>
@@ -119,11 +119,7 @@ export function PixiDependencyHeader({
           >
             <div className="flex items-start gap-2">
               <Info className="h-3.5 w-3.5 shrink-0" />
-              <span>
-                Dependencies changed
-                {syncState.added.length > 0 && ` — ${syncState.added.length} added`}
-                {syncState.removed.length > 0 && ` — ${syncState.removed.length} removed`}
-              </span>
+              <span>Dependencies changed.</span>
             </div>
             <button
               type="button"
@@ -294,8 +290,4 @@ export function PixiDependencyHeader({
       </div>
     </div>
   );
-}
-
-function packageCountLabel(count: number): string {
-  return count === 1 ? "1 package" : `${count} packages`;
 }

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -75,15 +75,20 @@ export function PixiDependencyHeader({
           className={cn(
             "mb-2 flex items-center gap-2",
             isRail &&
-              "mb-3 justify-between rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
+              "mb-3 flex-wrap justify-between gap-x-2 gap-y-1 rounded-md border bg-background px-3 py-2 shadow-sm shadow-black/[0.02]",
           )}
         >
-          <div className="flex min-w-0 items-center gap-2">
+          <div className={cn("flex min-w-0 items-center gap-2", isRail && "shrink-0")}>
             <span className="flex items-center gap-1 rounded bg-amber-500/20 px-1.5 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
               <PixiIcon className="h-2.5 w-2.5" />
               Pixi
             </span>
-            <span className="truncate text-xs text-muted-foreground">
+            <span
+              className={cn(
+                "text-xs text-muted-foreground",
+                isRail ? "whitespace-nowrap" : "truncate",
+              )}
+            >
               {isInlineMode ? "Dependencies" : "Environment"}
             </span>
           </div>

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -135,6 +135,40 @@ describe("DependencyHeader rail package copy", () => {
     expect(screen.getByTestId("deps-add-input")).toHaveClass("min-w-0");
   });
 
+  it("stacks pyproject actions under the file label in the rail", () => {
+    const { container } = render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas"]}
+        requiresPython=">=3.12"
+        loading={false}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+        onImportFromPyproject={async () => undefined}
+        onUseProjectEnv={async () => undefined}
+        pyprojectInfo={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          has_dependencies: true,
+          has_dev_dependencies: false,
+          dependency_count: 1,
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          has_venv: false,
+        }}
+      />,
+    );
+
+    const banner = container.querySelector('[data-slot="deps-pyproject-banner"]');
+    const actions = container.querySelector('[data-slot="deps-pyproject-actions"]');
+
+    expect(banner?.firstElementChild).toHaveClass("flex-col");
+    expect(actions).toHaveClass("pl-5");
+    expect(actions).toHaveTextContent("Use project env");
+    expect(actions).toHaveTextContent("Copy to notebook");
+  });
+
   it("splits project environment copy into fact and action lines", () => {
     render(
       <DependencyHeader

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -119,6 +119,22 @@ describe("PackageSpecList", () => {
 });
 
 describe("DependencyHeader rail package copy", () => {
+  it("keeps the package add row shrinkable inside the rail", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas"]}
+        requiresPython=">=3.12"
+        loading={false}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("deps-add-input")).toHaveClass("min-w-0");
+  });
+
   it("splits project environment copy into fact and action lines", () => {
     render(
       <DependencyHeader

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -139,6 +139,55 @@ describe("DependencyHeader rail package copy", () => {
     expect(screen.getByTestId("deps-add-input")).toHaveClass("min-w-0");
   });
 
+  it("leaves package counts to the rail title summary", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={["pandas", "polars"]}
+        requiresPython=">=3.12"
+        loading={false}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+      />,
+    );
+
+    expect(screen.queryByText("2 packages")).not.toBeInTheDocument();
+  });
+
+  it("describes dirty dependencies without overstating all packages as new", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={[
+          "pandas",
+          "polars",
+          "matplotlib",
+          "plotly",
+          "altair",
+          "vega_datasets",
+          "kyle",
+        ]}
+        requiresPython=">=3.13"
+        loading={false}
+        syncState={{
+          status: "dirty",
+          added: ["pandas", "polars", "matplotlib", "plotly", "altair", "vega_datasets", "kyle"],
+          removed: [],
+        }}
+        onSyncNow={async () => true}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByText("Re-initialize the environment to apply dependency changes."),
+    ).toBeVisible();
+    expect(screen.queryByText(/7 new packages/)).not.toBeInTheDocument();
+  });
+
   it("stacks pyproject actions under the file label in the rail", () => {
     const { container } = render(
       <DependencyHeader
@@ -243,6 +292,7 @@ describe("file-backed package rail variants", () => {
     );
 
     expect(screen.getByText("environment.yaml")).toBeVisible();
+    expect(screen.queryByText("0 packages")).not.toBeInTheDocument();
     expect(screen.getByText("python")).toBeVisible();
     expect(screen.getByText("=3.13")).toBeVisible();
     expect(screen.getByText("scipy")).toBeVisible();
@@ -273,6 +323,8 @@ describe("file-backed package rail variants", () => {
     );
 
     expect(screen.getByText("pixi.toml")).toBeVisible();
+    expect(screen.getByText("Project")).toBeVisible();
+    expect(screen.queryByText("0 packages")).not.toBeInTheDocument();
     expect(screen.getByText("python")).toBeVisible();
     expect(screen.getAllByText(">=3.13").length).toBeGreaterThan(0);
     expect(screen.getByText("numpy")).toBeVisible();

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -22,7 +22,7 @@ describe("PackageSpecList", () => {
     expect(screen.getAllByText("numpy")).toHaveLength(2);
   });
 
-  it("quiets read-only package rows without dropping tone", () => {
+  it("quiets read-only package rows without redundant markers", () => {
     const { container } = render(
       <PackageSpecList
         values={["nteract", "gremlin ; sys_platform == 'darwin'"]}
@@ -33,7 +33,10 @@ describe("PackageSpecList", () => {
     );
 
     expect(container.querySelector("svg")).not.toBeInTheDocument();
-    expect(container.querySelector(".bg-uv\\/60")).toBeInTheDocument();
+    expect(container.querySelector(".bg-uv\\/60")).not.toBeInTheDocument();
+    expect(screen.getByText("nteract").parentElement).toHaveClass(
+      "grid-cols-[minmax(0,1fr)_auto_auto]",
+    );
     expect(screen.getByText("nteract")).toBeVisible();
     expect(screen.getByText("gremlin")).toHaveAttribute("title", "gremlin");
     expect(screen.getByText("sys_platform == 'darwin'")).toBeVisible();
@@ -43,6 +46,7 @@ describe("PackageSpecList", () => {
     );
     expect(screen.getByText("sys_platform == 'darwin'")).not.toHaveClass("truncate");
     expect(screen.getByText("sys_platform == 'darwin'")).toHaveClass("whitespace-normal");
+    expect(screen.getByText("sys_platform == 'darwin'")).toHaveClass("col-start-1");
   });
 
   it("keeps full package specs available when rail text truncates", () => {

--- a/apps/notebook/src/components/__tests__/dependency-header.test.tsx
+++ b/apps/notebook/src/components/__tests__/dependency-header.test.tsx
@@ -53,7 +53,7 @@ describe("DependencyHeader", () => {
     });
 
     expect(screen.getByTestId("deps-panel").getAttribute("data-variant")).toBe("rail");
-    expect(screen.getByText("2 packages")).toBeDefined();
+    expect(screen.queryByText("2 packages")).not.toBeInTheDocument();
 
     await user.type(screen.getByTestId("deps-add-input"), "  numpy  {Enter}");
 

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -252,6 +252,8 @@ describe("NotebookToolbar", () => {
       render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.IDLE)} />);
       const status = screen.getByTestId("kernel-status");
       expect(status.dataset.kernelStatus).toBe("idle");
+      expect(screen.getByText("idle")).toBeInTheDocument();
+      expect(screen.queryByText("Idle")).not.toBeInTheDocument();
     });
 
     it("shows env progress status text when active", () => {

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -91,6 +91,8 @@ describe("NotebookToolbar", () => {
     it("shows start button when kernel is not started", () => {
       render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.NOT_STARTED)} />);
       expect(screen.getByTestId("start-kernel-button")).toBeInTheDocument();
+      expect(screen.getByText("Start kernel")).toBeInTheDocument();
+      expect(screen.queryByText("Start Kernel")).not.toBeInTheDocument();
     });
 
     it("shows start button when kernel is shut down", () => {
@@ -254,6 +256,8 @@ describe("NotebookToolbar", () => {
       expect(status.dataset.kernelStatus).toBe("idle");
       expect(screen.getByText("idle")).toBeInTheDocument();
       expect(screen.queryByText("Idle")).not.toBeInTheDocument();
+      expect(screen.getByText("Run all")).toBeInTheDocument();
+      expect(screen.queryByText("Run All")).not.toBeInTheDocument();
     });
 
     it("shows env progress status text when active", () => {

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -150,8 +150,8 @@ export function CellInsertionRibbon({
       <button
         type="button"
         data-slot="cell-adder-primary-hit-target"
-        title="Add code cell from insertion margin"
-        aria-label="Add code cell from insertion margin"
+        title="Add code cell here"
+        aria-label="Add code cell here"
         onPointerEnter={() => setActiveType("code")}
         onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
@@ -174,7 +174,7 @@ export function CellInsertionRibbon({
           )}
           aria-hidden="true"
         />
-        <span className="sr-only">Add code cell</span>
+        <span className="sr-only">Add code cell here</span>
       </button>
       <div
         data-slot="cell-adder-actions"

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -331,19 +331,6 @@ export function CodeCellCurrentLine({
           isFocused={isFocused}
         />
       ) : null}
-      {!isCompactIdle && activityContent ? (
-        <div
-          data-slot="code-cell-current-line-activity"
-          className={cn(
-            "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
-            isQuietResting
-              ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
-              : "max-w-24 opacity-100",
-          )}
-        >
-          {activityContent}
-        </div>
-      ) : null}
       <span
         data-slot="code-cell-current-line-status"
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
@@ -404,6 +391,19 @@ export function CodeCellCurrentLine({
           {detailLabel}
         </span>
       </span>
+      {!isCompactIdle && activityContent ? (
+        <div
+          data-slot="code-cell-current-line-activity"
+          className={cn(
+            "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
+            isQuietResting
+              ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
+              : "max-w-24 opacity-100",
+          )}
+        >
+          {activityContent}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -24,6 +24,8 @@ describe("CellInsertionRibbon", () => {
     const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
 
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    expect(hitTarget).toHaveAttribute("aria-label", "Add code cell here");
+    expect(hitTarget).toHaveAttribute("title", "Add code cell here");
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
 
     fireEvent.pointerEnter(hitTarget!);

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -320,7 +320,7 @@ describe("CodeCellCurrentLine", () => {
 
     expect(footer).toHaveTextContent("Kyle");
     expect(activity).toHaveClass("max-w-0");
-    expect(activity?.compareDocumentPosition(status as Element)).toBe(
+    expect(status?.compareDocumentPosition(activity as Element)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(screen.getByTestId("peer-activity")).toBeInTheDocument();

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -94,7 +94,7 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(13rem,19vw,16rem)] min-w-52"
+              ? "w-[clamp(14rem,19vw,16rem)] min-w-56"
               : "w-[clamp(13rem,18vw,16rem)] min-w-52",
             "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none",
           )}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -14,6 +14,8 @@ export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
 export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
 export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES =
   "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
+const NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,18rem)] min-w-60";
+const NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,17rem)] min-w-60";
 
 export interface NotebookRailProps {
   activePanelId: NotebookRailPanelId;
@@ -99,8 +101,8 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(12.5rem,17vw,14rem)] min-w-[12.5rem]"
-              : "w-[clamp(13rem,18vw,16rem)] min-w-52",
+              ? NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME
+              : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME,
             NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
           )}
           data-slot="notebook-rail-panel"

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -10,6 +10,11 @@ import { cn } from "@/lib/utils";
 
 export type NotebookRailPanelId = "outline" | "packages";
 
+export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
+export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
+export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES =
+  "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
+
 export interface NotebookRailProps {
   activePanelId: NotebookRailPanelId;
   collapsed: boolean;
@@ -96,7 +101,7 @@ export function NotebookRail({
             activePanelId === "packages"
               ? "w-[clamp(14rem,19vw,16rem)] min-w-56"
               : "w-[clamp(13rem,18vw,16rem)] min-w-52",
-            "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none",
+            NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
           )}
           data-slot="notebook-rail-panel"
         >

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -106,18 +106,23 @@ export function NotebookRail({
           data-slot="notebook-rail-panel"
         >
           <div className="border-b px-4 py-3">
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1.5">
               <div className="min-w-0">
                 <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
                   Notebook
                 </p>
-                <h2 className="mt-1 text-sm font-semibold text-foreground">{title}</h2>
               </div>
-              {summary && (
-                <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
-                  {summary}
-                </span>
-              )}
+              <div
+                className="flex min-w-0 flex-wrap items-center justify-between gap-2"
+                data-slot="notebook-rail-panel-title-row"
+              >
+                <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+                {summary && (
+                  <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+                    {summary}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto p-3">

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -94,8 +94,8 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(14rem,21vw,18rem)] min-w-56"
-              : "w-[clamp(14rem,20vw,17rem)] min-w-56",
+              ? "w-[clamp(13rem,19vw,16rem)] min-w-52"
+              : "w-[clamp(13rem,18vw,16rem)] min-w-52",
             "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none",
           )}
           data-slot="notebook-rail-panel"

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -99,7 +99,7 @@ export function NotebookRail({
           className={cn(
             "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
             activePanelId === "packages"
-              ? "w-[clamp(14rem,19vw,16rem)] min-w-56"
+              ? "w-[clamp(12.5rem,17vw,14rem)] min-w-[12.5rem]"
               : "w-[clamp(13rem,18vw,16rem)] min-w-52",
             NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
           )}

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -209,12 +209,13 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(13rem,18vw,16rem)]",
+      "w-[clamp(15rem,20vw,18rem)]",
+      "min-w-60",
       ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
   });
 
-  it("keeps package details compact until the rail owns the viewport", () => {
+  it("gives package details enough room until the rail owns the viewport", () => {
     const { container } = render(
       <NotebookRail
         activePanelId="packages"
@@ -227,8 +228,8 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(12.5rem,17vw,14rem)]",
-      "min-w-[12.5rem]",
+      "w-[clamp(15rem,20vw,17rem)]",
+      "min-w-60",
       ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
   });

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -108,6 +108,11 @@ describe("NotebookRail", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
+    expect(
+      screen
+        .getByText("../pyproject.toml · 25 packages")
+        .closest('[data-slot="notebook-rail-panel-title-row"]'),
+    ).toHaveClass("flex-wrap", "justify-between");
     expect(screen.getByText("../pyproject.toml · 25 packages")).toHaveClass("w-fit", "max-w-full");
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -216,8 +216,8 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(13rem,19vw,16rem)]",
-      "min-w-52",
+      "w-[clamp(14rem,19vw,16rem)]",
+      "min-w-56",
       "max-[599.98px]:w-[calc(100vw-3rem)]",
     );
   });

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -198,12 +198,12 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(14rem,20vw,17rem)]",
+      "w-[clamp(13rem,18vw,16rem)]",
       "max-[599.98px]:w-[calc(100vw-3rem)]",
     );
   });
 
-  it("gives package details a wider rail than outline navigation", () => {
+  it("keeps package details compact until the rail owns the viewport", () => {
     const { container } = render(
       <NotebookRail
         activePanelId="packages"
@@ -216,8 +216,9 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(14rem,21vw,18rem)]",
-      "min-w-56",
+      "w-[clamp(13rem,19vw,16rem)]",
+      "min-w-52",
+      "max-[599.98px]:w-[calc(100vw-3rem)]",
     );
   });
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -222,8 +222,8 @@ describe("NotebookRail", () => {
     );
 
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(14rem,19vw,16rem)]",
-      "min-w-56",
+      "w-[clamp(12.5rem,17vw,14rem)]",
+      "min-w-[12.5rem]",
       ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
   });

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { NotebookPackagesPanel, NotebookRail } from "../NotebookRail";
+import {
+  NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
+  NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+  NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  NotebookPackagesPanel,
+  NotebookRail,
+} from "../NotebookRail";
 
 const outlineItems = [
   {
@@ -199,7 +205,7 @@ describe("NotebookRail", () => {
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(13rem,18vw,16rem)]",
-      "max-[599.98px]:w-[calc(100vw-3rem)]",
+      ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
   });
 
@@ -218,6 +224,14 @@ describe("NotebookRail", () => {
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(14rem,19vw,16rem)]",
       "min-w-56",
+      ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
+    );
+  });
+
+  it("keeps the stage and panel takeover breakpoint in one rail contract", () => {
+    expect(NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY).toBe("(max-width: 599.98px)");
+    expect(NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME).toBe("max-[599.98px]:hidden");
+    expect(NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES).toContain(
       "max-[599.98px]:w-[calc(100vw-3rem)]",
     );
   });

--- a/src/components/notebook-rail/index.ts
+++ b/src/components/notebook-rail/index.ts
@@ -1,4 +1,7 @@
 export {
+  NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
+  NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+  NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
   NotebookOutlinePanel,
   NotebookPackagesPanel,
   NotebookRail,


### PR DESCRIPTION
## Summary

- moves cell activity/presence context after the code-cell execution readout so the line reads as `Python / run ...` followed by peer context
- keeps the existing quiet reveal behavior for resting completed cells
- makes the package rail more compact in split layouts while preserving enough width for package controls
- tightens the package rail's desktop width while keeping the under-600px takeover behavior
- widens the default expanded rail panel so outline headings and package rows have more natural room
- removes redundant package row dots from read-only rail package lists where separators already carry the structure
- leaves package counts to the rail title summary instead of repeating them in each manager header
- describes dirty package state as dependency changes instead of overstating every pending package as newly added
- lets rail package manager headers wrap intentionally so manager names stay readable in narrower rails
- keeps rail panel summaries on the title row when they fit so package panels feel less top-heavy
- keeps package add rows shrinkable so narrow rail widths do not clip the add button
- renames the insertion lane's primary target from implementation language to `Add code cell here`
- stacks pyproject actions under the file label in rail-sized package panels
- aligns the Elements notebook-outline rail preview with the same responsive breakpoint as the main app
- shares the rail takeover media query and stage/panel classes through the notebook rail contract so responsive tuning stays in one place
- lets toolbar runtime status labels render in their existing sentence-style vocabulary instead of title-casing them with CSS

## Screenshots

Execution activity now trails the run state:

![Execution activity trailing run state](https://img.runt.run/2026/06/01/bdd0408513cc.png)

Package rail split at 620px:

![Package rail split at 620px](https://img.runt.run/2026/06/01/c1b6200c8c22.png)

Package rail takeover at 590px:

![Package rail takeover at 590px](https://img.runt.run/2026/06/01/5365575be3e6.png)

Package rail split at 700px after responsive tightening:

![Package rail split at 700px](https://img.runt.run/2026/06/01/50e8ebba6266.png)

Package rail takeover after responsive tightening:

![Package rail takeover after responsive tightening](https://img.runt.run/2026/06/01/02315fb0789a.png)

Package rail title row after header tightening:

![Package rail title row at 700px](https://img.runt.run/2026/06/01/9c001857da95.png)

Package rail title row in takeover:

![Package rail title row in takeover](https://img.runt.run/2026/06/01/c2594d17d0a9.png)

Runtime package fixture at 520px:

![Runtime package fixture at 520px](https://img.runt.run/2026/06/01/728ee45a1332.png)

Toolbar status vocabulary at 520px:

![Toolbar status vocabulary at 520px](https://img.runt.run/2026/06/01/96ae327e3695.png)

Toolbar command labels at 900px:

![Toolbar command labels at 900px](https://img.runt.run/2026/06/01/7e3041ad8afe.png)

Outline rail at 760px after default width tuning:

![Outline rail at 760px after default width tuning](https://img.runt.run/2026/06/01/49fc2bd06566.png)

Package rail at 760px after default width tuning:

![Package rail at 760px after default width tuning](https://img.runt.run/2026/06/01/4842ea6e447f.png)

## Verification

- `pnpm exec vp check src/components/cell/CodeCellCurrentLine.tsx src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm test:run -- src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm exec vp check src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/elements/components/rail-outline-example.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/DependencyHeader.tsx apps/notebook/src/components/CondaDependencyHeader.tsx apps/notebook/src/components/PixiDependencyHeader.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/elements/components/rail-outline-example.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/DependencyHeader.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/elements/components/runtime-surfaces-example.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm exec vp check apps/notebook/src/App.tsx src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/index.ts src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/NotebookToolbar.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm exec vp check src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/DependencyHeader.tsx apps/notebook/src/components/CondaDependencyHeader.tsx apps/notebook/src/components/PixiDependencyHeader.tsx apps/notebook/src/components/DenoDependencyHeader.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm exec vp check src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm exec vp check src/components/cell/CellInsertionRibbon.tsx src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `pnpm test:run -- src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/NotebookToolbar.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm exec vp check src/components/notebook-rail/NotebookRail.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/PackageSpecList.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/elements/components/runtime-surfaces-example.tsx`
- `pnpm test:run -- src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm exec vp check apps/notebook/src/components/DependencyHeader.tsx apps/notebook/src/components/CondaDependencyHeader.tsx apps/notebook/src/components/PixiDependencyHeader.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx apps/notebook/src/components/__tests__/dependency-header.test.tsx`
- `pnpm test:run -- apps/notebook/src/components/__tests__/dependency-header.test.tsx apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- Playwright elements check: current-line DOM order is rule, status, activity
- Playwright responsive check: main app and Elements rail stay split at 620px and take over at 590px; package add button remains inside the 620px rail; pyproject actions stack without vertical overlap at 520px
- Playwright responsive check: package rail takes over at 599px and stays split at 600px / 960px after sharing the rail takeover contract
- Playwright toolbar check: kernel status renders as `connecting to kernel` at 520px
- Playwright responsive check: package rail is 200px at 700px and takes over below 600px, with readable package manager header copy
- Playwright responsive check: package rail panel summary stays on the title row at 700px and in takeover
- Playwright toolbar check: command labels render as `Run all` rather than `Run All`
- Playwright label check: insertion lane primary targets expose `Add code cell here`
- Playwright responsive check: outline and package rail panels are 240px at 760px, with read-only package rows using separators instead of leading dots
- `cargo xtask lint --fix`
