### PR TITLE
fix(notebook): project desktop interaction mode

### DIFF
--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -21,6 +21,15 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canExecute).toBe(true);
     expect(capabilities.canManagePackages).toBe(true);
     expect(capabilities.canManageSharing).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+      canRequestEdit: false,
+    });
     expect(capabilities.runtime).toMatchObject({
       canWriteRuntimeState: true,
       connected: true,
@@ -61,6 +70,14 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canRequestEdit).toBe(false);
     expect(capabilities.canExecute).toBe(false);
     expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
     expect(capabilities.runtime).toMatchObject({
       canWriteRuntimeState: false,
       connected: false,
@@ -91,6 +108,14 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canEditStructure).toBe(false);
     expect(capabilities.canExecute).toBe(false);
     expect(capabilities.runtime.canWriteRuntimeState).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
   });
 
   it("maps local read-only files to viewer access without cloud source", () => {
@@ -118,6 +143,14 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "local",
       actorLabel: null,
     });
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
   });
 
   it("keeps runtime peer authority separate from document editing access", () => {
@@ -143,6 +176,40 @@ describe("desktopNotebookShellCapabilities", () => {
       principal: { label: "Alice" },
       operator: { kind: "runtime", label: "JupyterHub" },
       scope: "runtime_peer",
+    });
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("projects desktop agent actors without treating desktop as a single human", () => {
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:kyle%40example.com/agent:codex:s1",
+      connectionScope: "editor",
+    });
+
+    expect(capabilities.access.level).toBe("editor");
+    expect(capabilities.canEditMarkdown).toBe(true);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+    });
+    expect(capabilities.access.actor).toMatchObject({
+      actorLabel: "user:anaconda:kyle%40example.com/agent:codex:s1",
+      principal: {
+        label: "kyle@example.com",
+        source: { provider: "anaconda", namespace: "anaconda" },
+      },
+      operator: { kind: "agent", label: "Codex" },
+      scope: "editor",
     });
   });
 });

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -2,6 +2,7 @@ import {
   notebookActorProjectionFromAccess,
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook-shell/actor-projection";
+import { createNotebookInteractionModeProjection } from "@/components/notebook-shell/interaction-mode";
 import type {
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
@@ -24,10 +25,25 @@ export function desktopNotebookShellCapabilities({
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
   const source = desktopAccessSourceFromActor(connectionScope, localActor);
   const isRuntimePeer = connectionScope === "runtime_peer";
+  const hasDocumentEditPermission = accessLevel === "editor" || accessLevel === "owner";
   const canWriteDocument =
-    canAcceptCellMutations && (accessLevel === "editor" || accessLevel === "owner");
+    canAcceptCellMutations && hasDocumentEditPermission;
   const canWriteRuntimeState =
     sessionReady && (isRuntimePeer || (source === "local" && canWriteDocument));
+  const interaction = createNotebookInteractionModeProjection({
+    selectedMode: hasDocumentEditPermission ? "edit" : "view",
+    permission: {
+      canEditMarkdown: hasDocumentEditPermission,
+      canEditCells: hasDocumentEditPermission,
+      canEditStructure: hasDocumentEditPermission,
+    },
+    hostSupport: {
+      canEditMarkdown: canAcceptCellMutations,
+      canEditCells: canAcceptCellMutations,
+      canEditStructure: canAcceptCellMutations,
+      canRequestEdit: false,
+    },
+  });
   const access = {
     level: accessLevel,
     source,
@@ -54,6 +70,7 @@ export function desktopNotebookShellCapabilities({
     canViewPackages: true,
     canManagePackages: canWriteDocument,
     canManageSharing: accessLevel === "owner" && source === "cloud",
+    interaction,
     access: {
       ...access,
       actor: notebookActorProjectionFromAccess(access),

--- a/src/components/notebook-shell/__tests__/interaction-mode.test.ts
+++ b/src/components/notebook-shell/__tests__/interaction-mode.test.ts
@@ -84,6 +84,32 @@ describe("createNotebookInteractionModeProjection", () => {
     });
   });
 
+  it("treats edit as requested when the host cannot accept edits yet", () => {
+    const interaction = createNotebookInteractionModeProjection({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: false,
+        canEditCells: false,
+        canEditStructure: false,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
   it("uses selected mode, permission, and host support for shared presence copy", () => {
     const editableView = createNotebookInteractionModeProjection({
       selectedMode: "view",

--- a/src/components/notebook-shell/interaction-mode.ts
+++ b/src/components/notebook-shell/interaction-mode.ts
@@ -35,7 +35,11 @@ export function createNotebookInteractionModeProjection({
   const wantsEdit = selectedMode === "edit";
   const hasAnyEditPermission =
     permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
-  const canActivateEdit = wantsEdit && hasAnyEditPermission;
+  const hasAnyHostEditSupport =
+    (permission.canEditMarkdown && hostSupport.canEditMarkdown) ||
+    (permission.canEditCells && hostSupport.canEditCells) ||
+    (permission.canEditStructure && hostSupport.canEditStructure);
+  const canActivateEdit = wantsEdit && hasAnyEditPermission && hasAnyHostEditSupport;
   const activeMode: NotebookInteractionMode = canActivateEdit ? "edit" : "view";
   const state: NotebookInteractionState = !wantsEdit
     ? "viewing"


### PR DESCRIPTION
## Summary

- give desktop notebooks the same `NotebookInteractionModeProjection` shape that cloud already uses
- require both document permission and host mutation support before shared interaction mode becomes active editing
- cover desktop local, cloud-backed viewer, local read-only, runtime peer, and delegated agent actor cases

## Validation

- `pnpm --workspace-root exec vp test run apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts src/components/notebook-shell/__tests__/interaction-mode.test.ts src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Stack

- Builds on #3278 (`quod/shared-presence-mode-copy`).
