### PR TITLE
refactor(notebook-shell): scope command toolbar by capabilities

### DIFF
--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -39,9 +39,7 @@ function toolbarProps(
   const interaction = scenario.capabilities.interaction;
 
   return {
-    canEditStructure: scenario.capabilities.canEditStructure,
-    canExecute: scenario.capabilities.canExecute,
-    canViewPackages: scenario.capabilities.canViewPackages,
+    capabilities: scenario.capabilities,
     runtime: "python",
     environmentManager: "uv",
     environmentPanelOpen: false,

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -101,9 +101,7 @@ export function RailOutlineExample() {
               runtime="python"
               focusedCellId={focusedCellId}
               lastCellId="cell-findings"
-              canEditStructure={scenario.capabilities.canEditStructure}
-              canExecute={scenario.capabilities.canExecute}
-              canViewPackages={scenario.capabilities.canViewPackages}
+              capabilities={scenario.capabilities}
               onStartKernel={noop}
               onInterruptKernel={noop}
               onRestartKernel={noop}

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -68,10 +68,7 @@ test("cloud viewer routes notebook header controls through the shared command to
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookCommandToolbar,/);
-  assert.match(
-    sourceText,
-    /<NotebookCommandToolbar[\s\S]*canEditStructure=\{shellCapabilities\.canEditStructure\}/,
-  );
+  assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1277,9 +1277,7 @@ function NotebookViewer({
 
   const toolbar = (
     <NotebookCommandToolbar
-      canEditStructure={shellCapabilities.canEditStructure}
-      canExecute={shellCapabilities.canExecute}
-      canViewPackages={shellCapabilities.canViewPackages}
+      capabilities={shellCapabilities}
       runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
       environmentManager={packageEnvironmentManager}
       environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1956,9 +1956,7 @@ function AppContent() {
           onAddCell={handleAddCell}
           onToggleDependencies={handleTogglePackagesRail}
           isDepsOpen={packagesRailOpen}
-          canEditStructure={shellCapabilities.canEditStructure}
-          canExecute={shellCapabilities.canExecute}
-          canViewPackages={shellCapabilities.canViewPackages}
+          capabilities={shellCapabilities}
           depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
           updateStatus={updateStatus}
           updateVersion={updateVersion}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -5,6 +5,7 @@ import {
   NotebookCommandToolbar,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
+  type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
@@ -45,9 +46,10 @@ interface NotebookToolbarProps {
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
-  canEditStructure?: boolean;
-  canExecute?: boolean;
-  canViewPackages?: boolean;
+  capabilities: Pick<
+    NotebookShellCapabilities,
+    "canEditStructure" | "canExecute" | "canViewPackages"
+  >;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
   updateStatus?: UpdateStatus;
@@ -79,9 +81,7 @@ export function NotebookToolbar({
   onAddCell,
   onToggleDependencies,
   isDepsOpen = false,
-  canEditStructure = true,
-  canExecute = true,
-  canViewPackages = true,
+  capabilities,
   depsOutOfSync = false,
   listKernelspecs,
   updateStatus,
@@ -184,9 +184,7 @@ export function NotebookToolbar({
   return (
     <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
       <NotebookCommandToolbar
-        canEditStructure={canEditStructure}
-        canExecute={canExecute}
-        canViewPackages={canViewPackages}
+        capabilities={capabilities}
         runtime={runtime}
         environmentManager={envManager}
         environmentPanelOpen={isDepsOpen}

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -69,6 +69,11 @@ const baseProps = {
   onRestartAndRunAll: vi.fn(),
   onAddCell: vi.fn(),
   onToggleDependencies: vi.fn(),
+  capabilities: {
+    canEditStructure: true,
+    canExecute: true,
+    canViewPackages: true,
+  },
 };
 
 describe("NotebookToolbar", () => {

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import type { NotebookShellCapabilities } from "./capabilities";
 
 export type NotebookCommandRuntimeState =
   | "not_started"
@@ -36,9 +37,10 @@ export interface NotebookCommandToolbarUpdateAction {
 }
 
 export interface NotebookCommandToolbarProps {
-  canEditStructure: boolean;
-  canExecute: boolean;
-  canViewPackages: boolean;
+  capabilities: Pick<
+    NotebookShellCapabilities,
+    "canEditStructure" | "canExecute" | "canViewPackages"
+  >;
   runtime?: string | null;
   environmentManager?: NotebookEnvironmentManager | null;
   environmentPanelOpen?: boolean;
@@ -60,9 +62,7 @@ export interface NotebookCommandToolbarProps {
 }
 
 export function NotebookCommandToolbar({
-  canEditStructure,
-  canExecute,
-  canViewPackages,
+  capabilities,
   runtime = null,
   environmentManager = null,
   environmentPanelOpen = false,
@@ -82,6 +82,7 @@ export function NotebookCommandToolbar({
   trailingControls,
   className,
 }: NotebookCommandToolbarProps) {
+  const { canEditStructure, canExecute, canViewPackages } = capabilities;
   const isRuntimeRunning =
     runtimeStatus.state === "idle" ||
     runtimeStatus.state === "busy" ||

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -9,6 +9,12 @@ const runtimeStatus = {
   title: "Kernel is idle",
 };
 
+const editableToolbarCapabilities = {
+  canEditStructure: true,
+  canExecute: true,
+  canViewPackages: true,
+};
+
 describe("NotebookCommandToolbar", () => {
   it("renders shared desktop command controls when host capabilities allow them", () => {
     const onAddCell = vi.fn();
@@ -16,9 +22,7 @@ describe("NotebookCommandToolbar", () => {
 
     render(
       <NotebookCommandToolbar
-        canEditStructure
-        canExecute
-        canViewPackages
+        capabilities={editableToolbarCapabilities}
         runtime="python"
         environmentManager="uv"
         runtimeStatus={runtimeStatus}
@@ -45,9 +49,11 @@ describe("NotebookCommandToolbar", () => {
   it("hides mutation and execution controls when the host does not grant them", () => {
     render(
       <NotebookCommandToolbar
-        canEditStructure={false}
-        canExecute={false}
-        canViewPackages
+        capabilities={{
+          ...editableToolbarCapabilities,
+          canEditStructure: false,
+          canExecute: false,
+        }}
         runtime="python"
         runtimeStatus={runtimeStatus}
         onAddCell={() => {}}


### PR DESCRIPTION
## Summary

- make `NotebookCommandToolbar` consume the shared shell capability projection instead of ad hoc toolbar booleans
- route desktop `NotebookToolbar`, cloud viewer chrome, and Elements toolbar scenarios through the same capability object
- update cloud source checks and toolbar tests so the shared command chrome remains capability-scoped

## Stack

Depends on #3280 / `quod/desktop-interaction-projection`.

## Validation

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
