### PR TITLE
refactor(notebook-shell): share toolbar frame

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -68,7 +68,10 @@ test("cloud viewer routes notebook header controls through the shared command to
   const sourceText = readFileSync(sourcePath, "utf8");
 
   assert.match(sourceText, /NotebookCommandToolbar,/);
+  assert.match(sourceText, /NotebookToolbarFrame,/);
+  assert.match(sourceText, /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookCommandToolbar/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
+  assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -36,6 +36,7 @@ import {
   NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
   NotebookToolbarIdentity,
+  NotebookToolbarFrame,
   createNotebookEnvironmentSurface,
   notebookInteractionPresenceLabel,
   notebookActorIdentityFromAccess,
@@ -1276,38 +1277,40 @@ function NotebookViewer({
   );
 
   const toolbar = (
-    <NotebookCommandToolbar
-      capabilities={shellCapabilities}
-      runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
-      environmentManager={packageEnvironmentManager}
-      environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
-      runtimeStatus={runtimeStatus}
-      addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
-      onAddCell={handleCloudAddCell}
-      onTogglePackages={handleTogglePackagesRail}
-      leadingControls={
-        <CloudPresenceStatus
-          presence={presence}
-          interaction={shellCapabilities.interaction ?? null}
-        />
-      }
-      trailingControls={
-        <>
-          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-          <CloudSharingControls
-            aclEndpoint={config.aclEndpoint}
-            invitesEndpoint={config.invitesEndpoint}
-            authState={authState}
-          />
-          <CloudNotebookEditModeButton
-            authState={authState}
+    <NotebookToolbarFrame className="z-20">
+      <NotebookCommandToolbar
+        capabilities={shellCapabilities}
+        runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+        environmentManager={packageEnvironmentManager}
+        environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+        runtimeStatus={runtimeStatus}
+        addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+        onAddCell={handleCloudAddCell}
+        onTogglePackages={handleTogglePackagesRail}
+        leadingControls={
+          <CloudPresenceStatus
+            presence={presence}
             interaction={shellCapabilities.interaction ?? null}
-            onAuthStateChange={refreshAuthState}
           />
-          <NotebookToolbarIdentity capabilities={shellCapabilities} />
-        </>
-      }
-    />
+        }
+        trailingControls={
+          <>
+            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+            <CloudSharingControls
+              aclEndpoint={config.aclEndpoint}
+              invitesEndpoint={config.invitesEndpoint}
+              authState={authState}
+            />
+            <CloudNotebookEditModeButton
+              authState={authState}
+              interaction={shellCapabilities.interaction ?? null}
+              onAuthStateChange={refreshAuthState}
+            />
+            <NotebookToolbarIdentity capabilities={shellCapabilities} />
+          </>
+        }
+      />
+    </NotebookToolbarFrame>
   );
   const authDiagnostics = shouldShowPrototypeDevControls({
     oidcConfigured: Boolean(authConfig.oidc),
@@ -1333,7 +1336,6 @@ function NotebookViewer({
       className="cloud-notebook-shell"
       stageClassName="cloud-notebook-stage"
       toolbar={toolbar}
-      toolbarClassName="cloud-report-toolbar"
       toolbarLabel="Notebook view status and controls"
       capabilities={shellCapabilities}
       rail={rail}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState, type ReactElement, type ReactNode } f
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
   NotebookCommandToolbar,
+  NotebookToolbarFrame,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
   type NotebookShellCapabilities,
@@ -181,8 +182,54 @@ export function NotebookToolbar({
     </HoverCard>
   ) : null;
 
+  const notices = (
+    <>
+      {/* Deno install prompt */}
+      {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
+        <div className="border-t px-3 py-2">
+          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              <span className="font-medium">Deno not available.</span> Auto-install failed. Install
+              manually with{" "}
+              <code className="rounded bg-amber-500/20 px-1">
+                curl -fsSL https://deno.land/install.sh | sh
+              </code>{" "}
+              and restart.
+            </span>
+          </div>
+        </div>
+      )}
+      {/* ipykernel install prompt — only when daemon signals missing_ipykernel.
+          Pixi and uv/conda inline envs reach this state through different
+          mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
+          same shape: explain where ipykernel should go for the current env,
+          then tell the user to restart. */}
+      {runtime === "python" &&
+        lifecycle.lifecycle === "Error" &&
+        envSource &&
+        hasToolbarHandledIpykernelError &&
+        renderIpykernelErrorPrompt({
+          envSource,
+          errorReason,
+          errorDetails: kernelErrorMessage ?? null,
+          condaPython,
+          condaChannels,
+          projectContext,
+        })}
+      {showCondaEnvYmlMissingBanner && (
+        <CondaEnvYmlMissingBanner
+          details={kernelErrorMessage}
+          command={condaEnvCreateCommand}
+          copied={condaCommandCopied}
+          onCopyCommand={copyCondaEnvCommand}
+        />
+      )}
+    </>
+  );
+
   return (
-    <header className="@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none">
+    <NotebookToolbarFrame notices={notices}>
       <NotebookCommandToolbar
         capabilities={capabilities}
         runtime={runtime}
@@ -228,49 +275,7 @@ export function NotebookToolbar({
         }
         trailingControls={trailingControls}
       />
-
-      {/* Deno install prompt */}
-      {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
-        <div className="border-t px-3 py-2">
-          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              <span className="font-medium">Deno not available.</span> Auto-install failed. Install
-              manually with{" "}
-              <code className="rounded bg-amber-500/20 px-1">
-                curl -fsSL https://deno.land/install.sh | sh
-              </code>{" "}
-              and restart.
-            </span>
-          </div>
-        </div>
-      )}
-      {/* ipykernel install prompt — only when daemon signals missing_ipykernel.
-          Pixi and uv/conda inline envs reach this state through different
-          mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
-          same shape: explain where ipykernel should go for the current env,
-          then tell the user to restart. */}
-      {runtime === "python" &&
-        lifecycle.lifecycle === "Error" &&
-        envSource &&
-        hasToolbarHandledIpykernelError &&
-        renderIpykernelErrorPrompt({
-          envSource,
-          errorReason,
-          errorDetails: kernelErrorMessage ?? null,
-          condaPython,
-          condaChannels,
-          projectContext,
-        })}
-      {showCondaEnvYmlMissingBanner && (
-        <CondaEnvYmlMissingBanner
-          details={kernelErrorMessage}
-          command={condaEnvCreateCommand}
-          copied={condaCommandCopied}
-          onCopyCommand={copyCondaEnvCommand}
-        />
-      )}
-    </header>
+    </NotebookToolbarFrame>
   );
 }
 

--- a/src/components/notebook-shell/NotebookToolbarFrame.tsx
+++ b/src/components/notebook-shell/NotebookToolbarFrame.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface NotebookToolbarFrameProps {
+  children: ReactNode;
+  className?: string;
+  notices?: ReactNode;
+}
+
+export function NotebookToolbarFrame({ children, className, notices }: NotebookToolbarFrameProps) {
+  return (
+    <header
+      className={cn(
+        "@container sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none",
+        className,
+      )}
+      data-slot="notebook-toolbar-frame"
+    >
+      {children}
+      {notices}
+    </header>
+  );
+}

--- a/src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { NotebookToolbarFrame } from "../NotebookToolbarFrame";
+
+describe("NotebookToolbarFrame", () => {
+  it("provides the shared sticky notebook toolbar frame", () => {
+    const { container } = render(
+      <NotebookToolbarFrame notices={<p>Syncing</p>}>
+        <button type="button">Run</button>
+      </NotebookToolbarFrame>,
+    );
+
+    const frame = container.querySelector("[data-slot='notebook-toolbar-frame']");
+    expect(frame).toHaveClass("sticky");
+    expect(frame).toHaveClass("top-0");
+    expect(screen.getByRole("button", { name: "Run" })).toBeVisible();
+    expect(screen.getByText("Syncing")).toBeVisible();
+  });
+});

--- a/src/components/notebook-shell/index.ts
+++ b/src/components/notebook-shell/index.ts
@@ -39,6 +39,7 @@ export {
   type NotebookCommandToolbarUpdateAction,
   type NotebookEnvironmentManager,
 } from "./NotebookCommandToolbar";
+export { NotebookToolbarFrame, type NotebookToolbarFrameProps } from "./NotebookToolbarFrame";
 export {
   NotebookIdentityBadge,
   NotebookIdentityGroup,


### PR DESCRIPTION
## Summary

- add a shared `NotebookToolbarFrame` for the sticky notebook app chrome
- move desktop `NotebookToolbar` onto the shared frame without changing its command/runtime behavior
- route hosted notebook pages through the same shared frame instead of the cloud-only `cloud-report-toolbar` shell wrapper

## Stack

Stacked after:

1. #3278
2. #3280
3. #3281

Merge order: #3278, then #3280, then #3281, then this PR.

## Verification

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookToolbarFrame.test.tsx src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
