### PR TITLE
refactor(notebook-shell): name toolbar control slots

### DIFF
--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -53,7 +53,7 @@ function toolbarProps(
     onRunAllCells: noop,
     onRestartAndRunAll: noop,
     onTogglePackages: noop,
-    leadingControls: (
+    presenceControls: (
       <NotebookPresenceStatus
         connected={scenario.capabilities.runtime.connected || scenario.capabilities.canRead}
         label={presenceLabel(scenario)}
@@ -62,14 +62,14 @@ function toolbarProps(
         className="h-7 text-xs"
       />
     ),
-    trailingControls: <ToolbarIdentityControls scenario={scenario} />,
+    identityControls: <ToolbarIdentityControls scenario={scenario} />,
     ...overrides,
   };
 }
 
 function presenceLabel(scenario: ElementsNotebookScenario): string {
   const actorCount = Math.max(1, notebookToolbarActors(scenario.capabilities).length);
-  return actorCount === 1 ? "1 actor here" : `${actorCount} actors here`;
+  return actorCount === 1 ? "1 participant here" : `${actorCount} participants here`;
 }
 
 function runtimeStatus(

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -72,11 +72,13 @@ test("cloud viewer routes notebook header controls through the shared command to
   assert.match(sourceText, /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookCommandToolbar/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
-  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudSharingControls/);
-  assert.match(sourceText, /trailingControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
+  assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
+  assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
+  assert.match(sourceText, /identityControls=\{[\s\S]*<NotebookToolbarIdentity/);
   assert.match(
     sourceText,
-    /leadingControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
+    /presenceControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*interaction=\{shellCapabilities\.interaction \?\? null\}/,
   );
   assert.doesNotMatch(sourceText, /<CloudPresenceStatus[^>]*connectionScope=\{connectionScope\}/);
   assert.doesNotMatch(sourceText, /className="cloud-code-toggle"/);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1287,28 +1287,28 @@ function NotebookViewer({
         addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
         onAddCell={handleCloudAddCell}
         onTogglePackages={handleTogglePackagesRail}
-        leadingControls={
+        presenceControls={
           <CloudPresenceStatus
             presence={presence}
             interaction={shellCapabilities.interaction ?? null}
           />
         }
-        trailingControls={
-          <>
-            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-            <CloudSharingControls
-              aclEndpoint={config.aclEndpoint}
-              invitesEndpoint={config.invitesEndpoint}
-              authState={authState}
-            />
-            <CloudNotebookEditModeButton
-              authState={authState}
-              interaction={shellCapabilities.interaction ?? null}
-              onAuthStateChange={refreshAuthState}
-            />
-            <NotebookToolbarIdentity capabilities={shellCapabilities} />
-          </>
+        authControls={<CloudNotebookSignInButton authConfig={authConfig} authState={authState} />}
+        sharingControls={
+          <CloudSharingControls
+            aclEndpoint={config.aclEndpoint}
+            invitesEndpoint={config.invitesEndpoint}
+            authState={authState}
+          />
         }
+        editControls={
+          <CloudNotebookEditModeButton
+            authState={authState}
+            interaction={shellCapabilities.interaction ?? null}
+            onAuthStateChange={refreshAuthState}
+          />
+        }
+        identityControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
       />
     </NotebookToolbarFrame>
   );

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -49,7 +49,12 @@ interface NotebookToolbarProps {
   isDepsOpen?: boolean;
   capabilities: Pick<
     NotebookShellCapabilities,
-    "canEditStructure" | "canExecute" | "canViewPackages"
+    | "canEditStructure"
+    | "canExecute"
+    | "canViewPackages"
+    | "canManageSharing"
+    | "canRequestEdit"
+    | "auth"
   >;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
@@ -273,7 +278,7 @@ export function NotebookToolbar({
               }
             : null
         }
-        trailingControls={trailingControls}
+        identityControls={trailingControls}
       />
     </NotebookToolbarFrame>
   );

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -73,6 +73,13 @@ const baseProps = {
     canEditStructure: true,
     canExecute: true,
     canViewPackages: true,
+    canManageSharing: false,
+    canRequestEdit: false,
+    auth: {
+      canSignIn: false,
+      canUseAuthenticatedIdentity: false,
+      needsAttention: false,
+    },
   },
 };
 

--- a/src/components/notebook-shell/NotebookCommandToolbar.tsx
+++ b/src/components/notebook-shell/NotebookCommandToolbar.tsx
@@ -39,7 +39,12 @@ export interface NotebookCommandToolbarUpdateAction {
 export interface NotebookCommandToolbarProps {
   capabilities: Pick<
     NotebookShellCapabilities,
-    "canEditStructure" | "canExecute" | "canViewPackages"
+    | "canEditStructure"
+    | "canExecute"
+    | "canViewPackages"
+    | "canManageSharing"
+    | "canRequestEdit"
+    | "auth"
   >;
   runtime?: string | null;
   environmentManager?: NotebookEnvironmentManager | null;
@@ -56,6 +61,12 @@ export interface NotebookCommandToolbarProps {
   onRestartAndRunAll?: () => void;
   onTogglePackages?: () => void;
   updateAction?: NotebookCommandToolbarUpdateAction | null;
+  presenceControls?: ReactNode;
+  utilityControls?: ReactNode;
+  sharingControls?: ReactNode;
+  editControls?: ReactNode;
+  authControls?: ReactNode;
+  identityControls?: ReactNode;
   leadingControls?: ReactNode;
   trailingControls?: ReactNode;
   className?: string;
@@ -78,11 +89,18 @@ export function NotebookCommandToolbar({
   onRestartAndRunAll,
   onTogglePackages,
   updateAction = null,
+  presenceControls,
+  utilityControls,
+  sharingControls,
+  editControls,
+  authControls,
+  identityControls,
   leadingControls,
   trailingControls,
   className,
 }: NotebookCommandToolbarProps) {
-  const { canEditStructure, canExecute, canViewPackages } = capabilities;
+  const { auth, canEditStructure, canExecute, canManageSharing, canRequestEdit, canViewPackages } =
+    capabilities;
   const isRuntimeRunning =
     runtimeStatus.state === "idle" ||
     runtimeStatus.state === "busy" ||
@@ -93,6 +111,9 @@ export function NotebookCommandToolbar({
     canExecute && Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
   const showInterrupt = canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
   const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
+  const showAuthControls =
+    Boolean(authControls) &&
+    (auth.canSignIn || auth.canUseAuthenticatedIdentity || auth.needsAttention);
 
   return (
     <div
@@ -100,7 +121,7 @@ export function NotebookCommandToolbar({
       data-slot="notebook-command-toolbar"
       className={cn("@container flex h-10 min-w-0 items-center gap-2 px-3 select-none", className)}
     >
-      {leadingControls}
+      {presenceControls ?? leadingControls}
 
       {showAddCellControls ? (
         <>
@@ -218,6 +239,8 @@ export function NotebookCommandToolbar({
 
       <div className="flex-1" />
 
+      {utilityControls}
+
       {updateAction ? (
         <button
           type="button"
@@ -307,6 +330,10 @@ export function NotebookCommandToolbar({
         </span>
       </div>
 
+      {canManageSharing ? sharingControls : null}
+      {canRequestEdit ? editControls : null}
+      {showAuthControls ? authControls : null}
+      {identityControls}
       {trailingControls}
     </div>
   );

--- a/src/components/notebook-shell/NotebookPresenceStatus.tsx
+++ b/src/components/notebook-shell/NotebookPresenceStatus.tsx
@@ -29,7 +29,7 @@ export function NotebookPresenceStatus({
       data-slot="notebook-presence-status"
       data-connected={String(connected)}
       title={displayTitle}
-      aria-label={title}
+      aria-label={displayTitle}
       aria-live="polite"
     >
       <UsersRound className="size-4 shrink-0" aria-hidden="true" />

--- a/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx
@@ -13,6 +13,13 @@ const editableToolbarCapabilities = {
   canEditStructure: true,
   canExecute: true,
   canViewPackages: true,
+  canManageSharing: true,
+  canRequestEdit: true,
+  auth: {
+    canSignIn: true,
+    canUseAuthenticatedIdentity: true,
+    needsAttention: false,
+  },
 };
 
 describe("NotebookCommandToolbar", () => {
@@ -33,7 +40,7 @@ describe("NotebookCommandToolbar", () => {
         onRestartAndRunAll={() => {}}
         onInterruptRuntime={() => {}}
         onTogglePackages={() => {}}
-        trailingControls={<button type="button">Kyle</button>}
+        identityControls={<button type="button">Kyle</button>}
       />,
     );
 
@@ -46,6 +53,28 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
   });
 
+  it("renders host chrome through named capability-scoped slots", () => {
+    render(
+      <NotebookCommandToolbar
+        capabilities={editableToolbarCapabilities}
+        runtimeStatus={runtimeStatus}
+        presenceControls={<div>2 here now, editing</div>}
+        utilityControls={<button type="button">Utility</button>}
+        sharingControls={<button type="button">Share</button>}
+        editControls={<button type="button">View</button>}
+        authControls={<button type="button">Sign in</button>}
+        identityControls={<button type="button">Kyle</button>}
+      />,
+    );
+
+    expect(screen.getByText("2 here now, editing")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Utility" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Share" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "View" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
+  });
+
   it("hides mutation and execution controls when the host does not grant them", () => {
     render(
       <NotebookCommandToolbar
@@ -53,6 +82,13 @@ describe("NotebookCommandToolbar", () => {
           ...editableToolbarCapabilities,
           canEditStructure: false,
           canExecute: false,
+          canManageSharing: false,
+          canRequestEdit: false,
+          auth: {
+            canSignIn: false,
+            canUseAuthenticatedIdentity: false,
+            needsAttention: false,
+          },
         }}
         runtime="python"
         runtimeStatus={runtimeStatus}
@@ -60,11 +96,17 @@ describe("NotebookCommandToolbar", () => {
         onRunAllCells={() => {}}
         onRestartRuntime={() => {}}
         onRestartAndRunAll={() => {}}
+        sharingControls={<button type="button">Share</button>}
+        editControls={<button type="button">Edit</button>}
+        authControls={<button type="button">Sign in</button>}
       />,
     );
 
     expect(screen.queryByTestId("add-code-cell-button")).toBeNull();
     expect(screen.queryByTestId("run-all-button")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Sign in" })).toBeNull();
     expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
   });
 });

--- a/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx
@@ -14,7 +14,7 @@ describe("NotebookPresenceStatus", () => {
     );
 
     expect(screen.getByText("2 here now, editing")).toBeVisible();
-    expect(screen.getByLabelText("2 participants are in this notebook")).toHaveAttribute(
+    expect(screen.getByLabelText("2 participants are in this notebook. editing")).toHaveAttribute(
       "data-connected",
       "true",
     );


### PR DESCRIPTION
## Summary

- add named shared toolbar slots for presence, utility, sharing, edit, auth, and identity controls
- gate share/edit/auth slots through `NotebookShellCapabilities` instead of cloud-side conditional wrappers
- move cloud and Elements toolbar usage onto the named slots while preserving desktop toolbar behavior
- include interaction mode in the shared presence aria label

## Stack

- Depends on #3282 (`quod/shared-toolbar-frame`)

Merge order:

1. #3278
2. #3280
3. #3281
4. #3282
5. this PR

## Verification

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx src/components/notebook-shell/__tests__/NotebookPresenceStatus.test.tsx apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts test/viewer-presence.test.ts`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
