### PR TITLE
refactor(notebook-shell): expose header identity slot

### DIFF
--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -105,12 +105,13 @@ export function IdentityEnvironmentSurfacesExample() {
           <NotebookDocumentHeader
             capabilities={cloudOwner.capabilities}
             presence={<NotebookIdentityBadge actor={scenarioActor(cloudOwner)} />}
-            utilityControls={<NotebookIdentityGroup actors={activeActors} />}
+            utilityControls={<HeaderPill icon={<Cloud className="size-3.5" />} label="Cloud" />}
             runtimeControls={
               <HeaderPill icon={<Package className="size-3.5" />} label="Packages" />
             }
             codeControls={<HeaderPill icon={<UserRound className="size-3.5" />} label="Source" />}
             sharingControls={<HeaderPill icon={<KeyRound className="size-3.5" />} label="Share" />}
+            identityControls={<NotebookIdentityGroup actors={activeActors} />}
           />
         </div>
       </section>

--- a/src/components/notebook-shell/NotebookDocumentHeader.tsx
+++ b/src/components/notebook-shell/NotebookDocumentHeader.tsx
@@ -11,6 +11,7 @@ export interface NotebookDocumentHeaderProps {
   sharingControls?: ReactNode;
   editControls?: ReactNode;
   authControls?: ReactNode;
+  identityControls?: ReactNode;
   className?: string;
 }
 
@@ -23,6 +24,7 @@ export function NotebookDocumentHeader({
   sharingControls,
   editControls,
   authControls,
+  identityControls,
   className,
 }: NotebookDocumentHeaderProps) {
   const showCodeControls = capabilities.canToggleCode && Boolean(codeControls);
@@ -83,6 +85,11 @@ export function NotebookDocumentHeader({
         {showAuthControls ? (
           <div className="contents" data-slot="notebook-document-header-auth-controls">
             {authControls}
+          </div>
+        ) : null}
+        {identityControls ? (
+          <div className="contents" data-slot="notebook-document-header-identity-controls">
+            {identityControls}
           </div>
         ) : null}
       </div>

--- a/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
+++ b/src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx
@@ -47,11 +47,13 @@ describe("NotebookDocumentHeader", () => {
         capabilities={capabilities()}
         presence={<span>1 viewing</span>}
         utilityControls={<button type="button">Theme</button>}
+        identityControls={<button type="button">Kyle</button>}
       />,
     );
 
     expect(screen.getByText("1 viewing")).toBeVisible();
     expect(screen.getByRole("button", { name: "Theme" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
   });
 
   it("gates document controls through shared shell capabilities", () => {
@@ -63,6 +65,7 @@ describe("NotebookDocumentHeader", () => {
         sharingControls={<button type="button">Share</button>}
         editControls={<button type="button">Edit</button>}
         authControls={<button type="button">Sign in</button>}
+        identityControls={<button type="button">Anonymous viewer</button>}
       />,
     );
 
@@ -71,6 +74,7 @@ describe("NotebookDocumentHeader", () => {
     expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
     expect(screen.getByRole("button", { name: "Sign in" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Anonymous viewer" })).toBeVisible();
   });
 
   it("exposes all controls when the host grants those capabilities", () => {
@@ -101,6 +105,7 @@ describe("NotebookDocumentHeader", () => {
         sharingControls={<button type="button">Share</button>}
         editControls={<button type="button">Edit</button>}
         authControls={<button type="button">Identity</button>}
+        identityControls={<button type="button">Alice</button>}
       />,
     );
 
@@ -109,6 +114,7 @@ describe("NotebookDocumentHeader", () => {
     expect(screen.getByRole("button", { name: "Share" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Identity" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Alice" })).toBeVisible();
     expect(container.querySelector("[data-slot='notebook-document-header']")).toHaveAttribute(
       "data-can-request-edit",
       "true",


### PR DESCRIPTION
## Summary

- add an explicit `identityControls` slot to `NotebookDocumentHeader`
- keep identity placement separate from auth controls in the shared header contract
- update the Elements identity/environment surface to exercise the new header identity slot

## Stack

- Depends on #3283 (`quod/shared-toolbar-controls`)

Merge order:

1. #3278
2. #3280
3. #3281
4. #3282
5. #3283
6. this PR

## Verification

- `pnpm --workspace-root exec vp test run src/components/notebook-shell/__tests__/NotebookDocumentHeader.test.tsx src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook exec tsc --noEmit --pretty false`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
