### PR TITLE
docs(architecture): refresh identity surface audit

### DIFF
--- a/docs/architecture/identity-and-trust.md
+++ b/docs/architecture/identity-and-trust.md
@@ -286,22 +286,28 @@ nteract-identity/
 +-- lib.rs            # ActorLabel, Principal, AuthenticatedUser, AuthError, Credential, IdentityProvider enum
 +-- local.rs          # LocalProvider (peer creds)
 +-- oidc.rs           # OidcProvider (JWKS bearer; configurable for Anaconda, Clerk, Auth0, Okta, WorkOS, generic OIDC)
-\-- jupyterhub.rs     # JupyterHubProvider (Hub cookie/token via /hub/api/user)
+\-- jupyterhub.rs     # JupyterHubProvider placeholder, pending /hub/api/user validation
 ```
 
 Multi-crate decomposition (`nteract-identity-local`, `-oidc`, `-jupyterhub`) would put `Credential`, `AuthenticatedUser`, and `AuthError` in `nteract-identity` while the implementor crates also need those types; the enum then has to depend back on its implementors, producing a Cargo cycle. One crate avoids it.
 
-Provider-specific dependencies (jose, jwks, openidconnect for OIDC; reqwest for JupyterHub) are gated by Cargo features so a build that only needs `LocalProvider` does not pull them in:
+Provider-specific dependencies are gated by Cargo features so a build that only
+needs `LocalProvider` does not pull them in. The current crate uses
+`jsonwebtoken` for OIDC/JWKS validation. `JupyterHubProvider` is feature-gated
+and present in the dispatch enum, but still returns
+`ProviderUnavailable("jupyterhub")` until the Hub API validation path lands:
 
 ```toml
 [features]
 default = ["local"]
 local = []
-oidc = ["dep:openidconnect", "dep:jose"]
-jupyterhub = ["dep:reqwest"]
+oidc = ["dep:jsonwebtoken"]
+jupyterhub = []
 ```
 
-Each provider module is testable in isolation against fixture credentials and a fake IdP. The crate has no dependency on `runtimed`, `kernel-env`, or any daemon internals.
+Implemented provider modules are testable in isolation against fixture
+credentials and fake IdP material. The crate has no dependency on `runtimed`,
+`kernel-env`, or any daemon internals.
 
 **Client-side: `Credential` keyring**
 
@@ -343,13 +349,16 @@ Base options by provider:
 
 The Worker DO extracts the credential at upgrade time, validates via the configured `IdentityProvider`, and rejects the upgrade with HTTP 401 (or closes immediately with a typed close code) if validation fails. After upgrade, the WebSocket carries no further auth; per-frame validation runs against the in-memory `AuthenticatedConnection`.
 
-The `Credential` enum therefore covers all of these:
+The `Credential` enum therefore covers all of these. The current
+implementation names local peer credentials explicitly and includes a
+`OneTimeTicket` variant for listener-side ticket consumption:
 
 ```rust
 pub enum Credential {
     BearerToken(String),     // from subprotocol, ticket exchange, or Authorization header
     Cookie(String),          // from upgrade-request cookies
-    UnixPeer(PeerCredInfo),  // SO_PEERCRED for the local daemon's listener
+    OneTimeTicket(String),   // short-lived ticket issued by the listener/host
+    LocalPeer(LocalPeerCredential), // listener-verified local peer credentials
 }
 ```
 

--- a/docs/architecture/notebook-host-shell-convergence.md
+++ b/docs/architecture/notebook-host-shell-convergence.md
@@ -34,6 +34,7 @@ NotebookDocumentShell
   rail
   document stage
   NotebookDocumentHeader control slots
+  NotebookToolbarFrame / NotebookCommandToolbar
   notice slots
   package/runtime/presence slots
 
@@ -48,6 +49,11 @@ NotebookShellCapabilities
   runtime
     canWriteRuntimeState
     actor
+  interaction
+    selectedMode
+    activeMode
+    state
+    canRequestEdit
   canRead
   canEditMarkdown
   canEditCells
@@ -83,6 +89,8 @@ The shared component surface should be the preferred place for:
 
 - notebook rail and outline behavior;
 - document header layout and capability-scoped control slots;
+- shared command toolbar chrome, toolbar identity, and interaction-mode
+  presentation;
 - markdown editing and preview rendering;
 - read-only and editable cell chrome;
 - output frame policy and widget-state rendering;
@@ -126,6 +134,13 @@ request/sign-in affordance before the room grants editor access. The write path
 must still check `canEditMarkdown`/`canEditCells` and the room's authorization
 policy before mutating Automerge.
 
+`NotebookInteractionModeProjection` separates what the user selected from what
+the host can actively perform. `selectedMode = "edit"` with
+`state = "requested"` is an edit request or sign-in/request-access state, not a
+write grant. `activeMode = "edit"` and the `canEdit*` booleans are still
+display affordances; room, daemon, and filesystem authorities enforce the write
+path.
+
 `NotebookDocumentHeader` owns shared slot visibility for document-level
 controls:
 
@@ -138,6 +153,13 @@ controls:
 
 The controls themselves can stay host-specific while the visibility policy stays
 in the shared shell contract.
+
+The split should be explicit in code review. If a branch needs a new notebook
+presentation pattern for cloud, first ask whether desktop and Elements should
+consume the same component. If a branch needs a new desktop control, first ask
+whether cloud should receive the same typed projection and provide different
+callbacks. Divergence is justified for authority and side effects, not for
+duplicating notebook chrome.
 
 ## Anchor And Navigation Contract
 
@@ -185,7 +207,8 @@ they need notebook-level context. Lower-level fixtures remain useful for
 isolated component tests, but they should not become a second app model.
 
 When a catalog page needs toolbar or header context, it should use
-`NotebookDocumentHeader` with fixture capabilities rather than inventing
+`NotebookDocumentHeader`, `NotebookToolbarFrame`, `NotebookCommandToolbar`, and
+`NotebookToolbarIdentity` with fixture capabilities rather than inventing
 page-local visibility rules. This keeps the catalog useful as an early warning
 when shared shell controls are still coupled to desktop or cloud specifics.
 

--- a/docs/architecture/notebook-identity-environment-surface-audit.md
+++ b/docs/architecture/notebook-identity-environment-surface-audit.md
@@ -1,6 +1,6 @@
 # Notebook Identity and Environment Surface Audit
 
-**Status:** Audit, 2026-05-31.
+**Status:** Audit, refreshed 2026-06-01.
 
 **Related:**
 
@@ -40,16 +40,17 @@ Current evidence came from:
 
 | Surface | Current state | Gap |
 |---------|---------------|-----|
-| Shell capabilities | `NotebookShellCapabilities` is the shared input for read/edit/execute/package/share/auth affordances. Desktop, cloud, and Elements already feed it, including separate `access.actor` and `runtime.actor` projections. | Environment and package state are still spread across strings and package view models rather than a typed shared environment projection. |
+| Shell capabilities | `NotebookShellCapabilities` is the shared input for read/edit/execute/package/share/auth affordances. Desktop, cloud, and Elements already feed it, including separate `access.actor`, `runtime.actor`, and `interaction` projections. | Capability projection is in good shape; the next risk is making sure new sharing/activity controls consume it instead of reintroducing host-specific gates. |
 | Identity badge/group | `NotebookIdentityBadge`, `NotebookIdentityGroup`, and actor projection helpers render current actor, public viewer, local identity, delegated agent, runtime, and system states. | React still has fallback parsing for raw actor labels while hosts finish sending structured projections. Presence, execution attribution, and future activity surfaces do not yet all consume the same projection. |
-| Environment summary | `NotebookEnvironmentSummary` renders runtime label, package source label, sync label, trust label, and package access from existing package view models. | Runtime status, package source, sync state, and trust state are still string props. There is no shared environment surface model with typed status. |
+| Interaction mode and command toolbar | `NotebookInteractionModeProjection` is now the shared selected/active/requested view-edit projection. Desktop, cloud, and Elements feed it into shared toolbar chrome: `NotebookToolbarFrame`, `NotebookCommandToolbar`, `NotebookToolbarIdentity`, and the edit-mode button. | Keep interaction state host-neutral. It should drive labels and affordances, not become the authority for writes or replace room/daemon enforcement. |
+| Environment summary | `NotebookEnvironmentSummary` consumes `NotebookEnvironmentSurface`, a typed shared projection with access, runtime, package, sync, and trust sections. Elements scenarios build it through `createNotebookEnvironmentSurface()`. Cloud no longer renders the environment summary in its package rail after #3273; the cloud rail is package-only. | Desktop/cloud still need to keep mapping real daemon, ACL, credential, and package facts into this surface wherever they intentionally render an environment summary, instead of passing ad hoc labels at page boundaries. |
 | Desktop adapter | `desktopNotebookShellCapabilities()` maps local sessions and remote connection scopes into the shared shell. Local notebooks default to owner-level local access, and `runtime_peer` maps to viewer document access plus runtime write capability. | Desktop remote room identity is still only distinguished by actor/source shape. The product model is desktop app plus local daemon/socket identity plus remote service credential or API key. Auth attention is always false. |
-| Cloud adapter | `cloudNotebookShellCapabilities()` maps hosted auth and ACL scope into the shared shell. `invalid` and `oidc_expired` modes set auth attention. Public viewers become read-only cloud viewers, and `runtime_peer` maps to runtime authorship rather than document edit access. | Cloud exposes credential transport metadata such as `anaconda-api-key`; shared UI should continue deriving principal authority from the principal namespace/projection, not from that transport field. Elements does not yet render a dedicated credential-attention scenario. |
+| Cloud adapter | `cloudNotebookShellCapabilities()` maps hosted auth and ACL scope into the shared shell. `invalid` and `oidc_expired` modes set auth attention. Public viewers become read-only cloud viewers, and `runtime_peer` maps to runtime authorship rather than document edit access. | Cloud still exposes credential transport metadata such as `anaconda-api-key`; shared UI should continue deriving principal authority from the principal namespace/projection, not from that transport field. |
 | Hosted authority | Cloud auth and storage treat `runtime_peer` as a first-class current scope, public viewers are explicit ACL rows, and anonymous public viewer presence is local/aggregate-only today. | Request-scope enforcement and hosted execution-intent semantics still need clearer current-vs-target documentation across the architecture docs. |
-| Elements scenarios | `ElementsNotebookScenario` centralizes fixture cells, package state, trust state, outputs, variables, renderers, and shell capabilities. Current scenario ids include desktop local owner, cloud public viewer, cloud editor, cloud owner, agent on behalf, runtime peer, system schema, and runtime unavailable. | Missing PRD scenarios: desktop read-only, desktop remote room, credential attention, one principal with multiple operators, mixed-IdP room, and a dedicated untrusted-dependency scenario separate from the shared trust fixture. |
+| Elements scenarios | `ElementsNotebookScenario` centralizes fixture cells, package state, trust state, outputs, variables, renderers, shell capabilities, and the typed environment surface. Scenario ids now cover desktop local owner, desktop read-only, desktop remote room, cloud public viewer, cloud editor, cloud owner, agent on behalf, credential attention, one principal with multiple operators, mixed-IdP, runtime peer, system schema, runtime unavailable, and untrusted dependencies. | Scenario coverage is now adequate; the gap is keeping new catalog pages and production adapters on these fixtures/projections rather than adding page-local mock state. |
 | Elements catalog | The catalog already covers cell anatomy, editor, runtime, package manager, identity/environment, search, output renderers, output isolation, read-only notebooks, toolbar, theme, and widget surfaces with runtime-free fixtures. | Identity/environment guidance is newer than many pages, so pages do not all name how their state should flow through actor, access, environment, package, and trust projections. |
 | Cell attribution | Code cells can receive submitted durable actor labels, and Elements shows an agent badge in the current-line example. | Execution attribution, presence, editor attribution, and activity are not yet driven by one structured actor projection. |
-| Package rail direction | Package-manager docs render current app dependency components with fixture metadata, and the shell has `NotebookDocumentRail` plus `NotebookPackageSummaryPanel` for host-neutral package viewing. | The rail package/environment panel is not yet a single shared environment surface fed by typed runtime/package/trust state. |
+| Package rail direction | Package-manager docs render current app dependency components with fixture metadata, and the shell has `NotebookDocumentRail` plus `NotebookPackageSummaryPanel` for host-neutral package viewing. Cloud now keeps the package rail package-only, while Elements can still render `NotebookEnvironmentSummary` in dedicated identity/environment and rail examples. | The remaining work is connecting more production rail actions to host-owned callbacks while keeping Elements inert, and deciding where environment summaries should appear outside the package-only rail. |
 
 ## What Is Already Solid
 
@@ -60,33 +61,59 @@ The repo now has a useful convergence spine:
 - `NotebookShellCapabilities` is the common adapter vocabulary for desktop,
   cloud, and catalog fixtures, including the separate runtime-authority
   projection that keeps `runtime_peer` out of document access.
+- `NotebookInteractionModeProjection`, `NotebookToolbarFrame`,
+  `NotebookCommandToolbar`, and `NotebookToolbarIdentity` are shared across
+  desktop, cloud, and Elements, so toolbar interaction language is no longer
+  a cloud-only or desktop-only concern.
 - Elements is using fixture-backed scenarios rather than daemon, sync,
   generated WASM, Cloudflare, or local filesystem dependencies.
+- Elements now covers the identity/environment PRD scenario set, including
+  desktop remote, credential attention, mixed-IdP, multi-operator, runtime-peer,
+  and untrusted dependency states.
+- `NotebookEnvironmentSurface` exists as a typed shared projection consumed by
+  `NotebookEnvironmentSummary`.
 - Cloud already owns the authority decisions for hosted ACL scope, public
   viewer rows, anonymous public viewer presence policy, and runtime-peer
   capability.
 - Desktop already maps local mutability and session readiness into the same
   shell capability object.
 
+## Cross-Host Convergence Notes
+
+Cloud should keep converging toward the desktop/shared shell by moving notebook
+presentation into `src/components/notebook-shell/**` whenever the behavior is
+not inherently hosted:
+
+- command toolbar chrome, identity controls, interaction mode, and cell surfaces
+  should stay shared;
+- package rail rendering should use shared package components with cloud-owned
+  callbacks and authority checks;
+- presence, activity, execution attribution, and sharing surfaces should consume
+  the same actor/access/interaction projections instead of cloud-local labels;
+- hosted auth, ACL, public viewer policy, credential refresh, and room mutation
+  should remain cloud adapter responsibilities.
+
+Desktop should be more explicit about the facts it projects into the same shell:
+
+- local file mutability, daemon/session readiness, package trust, and dependency
+  sync should map into shell/environment projections rather than toolbar-local
+  booleans;
+- desktop remote rooms should project a distinct identity path: desktop app,
+  local daemon/socket identity, and remote service credential or API key;
+- remote credential attention should eventually be represented instead of
+  leaving desktop auth attention always false;
+- local read-only notebooks should continue to distinguish readable notebook
+  state from writable document/package/runtime capabilities.
+
+The maintainability rule is: duplicate host adapters when the host authority is
+different; do not duplicate notebook presentation just because the source facts
+come from different authorities. Shared components should receive typed
+projections plus host callbacks, while desktop/cloud keep enforcement, auth,
+filesystem, daemon, and room-host side effects outside the shared shell.
+
 ## Highest-Leverage Follow-Up Slices
 
-### 1. Complete Elements Scenario Coverage
-
-Add missing fixture scenarios without changing production behavior:
-
-- desktop read-only file;
-- desktop remote room with local daemon/socket identity plus remote service
-  credential;
-- credential needs attention;
-- one principal with multiple operators;
-- mixed-IdP room;
-- dedicated untrusted dependencies.
-
-This should update `apps/elements/components/notebook-scenarios.ts`, the
-identity/environment page, and the notebook shell capabilities page. It is the
-smallest PR that makes the PRD visible in the catalog.
-
-### 2. Finish Structured Actor Projection Adoption
+### 1. Finish Structured Actor Projection Adoption
 
 The shared component contract now has structured actor projections. The next
 step is to remove remaining page-local/raw-label assumptions:
@@ -103,7 +130,7 @@ This should continue in `src/components/notebook-shell/**` and host adapters,
 then feed the same projection to Elements fixtures. The important direction is
 shared projection, not cloud-specific display fixes.
 
-### 3. Keep Runtime Peer Semantics Explicit
+### 2. Keep Runtime Peer Semantics Explicit
 
 `runtime_peer` is now intentionally outside `NotebookShellAccessLevel`.
 Continue treating it as runtime authorship/capability that lets UI show runtime
@@ -120,10 +147,22 @@ Keep the docs and adapters reconciled across:
 - shell display level `none | viewer | editor | owner`;
 - runtime actor badges and output/lifecycle attribution.
 
-### 4. Type The Environment Projection
+### 3. Keep Interaction And Command Chrome Host-Neutral
 
-Replace loose runtime/package/trust strings with a typed environment surface
-that can be shared by Elements, desktop, and cloud:
+`NotebookInteractionModeProjection` now separates requested edit state from
+active edit permission and host support. Keep new toolbar, presence, and
+activity work on that projection:
+
+- selected mode says what the user asked for;
+- active mode and `canEdit*` say what this host can currently perform;
+- room, daemon, or filesystem authorities still enforce all writes;
+- shared toolbar chrome should keep receiving capabilities and callbacks rather
+  than importing cloud or desktop state directly.
+
+### 4. Keep Environment Projection Typed End-To-End
+
+`NotebookEnvironmentSurface` now exists, so the follow-up is not inventing the
+shape. It is mapping every host source into it consistently:
 
 - runtime status: ready, detached, unavailable, launching, error;
 - package summary and source;
@@ -131,15 +170,17 @@ that can be shared by Elements, desktop, and cloud:
 - trust status and attention;
 - package view/manage capabilities.
 
-`NotebookEnvironmentSummary` can remain the first renderer, but the facts should
-come from a shared projection rather than page-local strings.
+`NotebookEnvironmentSummary` is the first renderer. The facts should continue to
+come from the shared projection rather than page-local strings.
 
-### 5. Move Package/Environment Rail Toward The Shared Surface
+### 5. Keep Package Rail Package-Focused
 
 The rail-forward direction is right: outline, packages, variables, renderers,
-and future activity belong beside the notebook, not inside cell chrome. The next
-package rail slice should consume the shared environment projection and reuse
-existing dependency components through adapters.
+and future activity belong beside the notebook, not inside cell chrome. After
+#3273, cloud's package rail is deliberately package-only. Environment/access,
+runtime, sync, and trust summary facts should render through
+`NotebookEnvironmentSummary` or a sibling shared component where product wants
+that summary, not by overloading the package panel.
 
 Keep daemon-owned actions inert in Elements and host-owned in production:
 
@@ -193,20 +234,18 @@ dispatch once the next hosted mutation/runtime slices land.
 
 ## Suggested Next PR Order
 
-Slices 1 and 2 can land in either order. If shared identity work is already in
-flight, prefer landing runtime/system/delegated-operator support before adding
-decorative Elements scenarios that cannot yet consume faithful projections.
-
-1. Add missing Elements scenarios and update identity/capability catalog pages,
-   or land immediately after slice 2 if the actor projection is actively
-   changing.
+1. Keep interaction-mode and command-toolbar semantics aligned across desktop,
+   cloud, and Elements.
 2. Finish projection adoption for presence, execution attribution, editor
    attribution, and activity.
 3. Keep runtime-peer shell projection and architecture docs aligned with
    `NotebookShellCapabilities.runtime`.
-4. Introduce a typed `NotebookEnvironmentSurface` view model.
-5. Refactor package/environment rail rendering onto that model.
-6. Start activity and sharing composites once actor/access projection is stable.
+4. Keep desktop/cloud environment facts flowing through
+   `NotebookEnvironmentSurface`.
+5. Refactor package rail actions onto package-focused host callbacks and decide
+   where environment summaries belong.
+6. Start activity and sharing composites once actor/access/interaction
+   projection is stable.
 
 ## Open Questions
 

--- a/docs/architecture/notebook-identity-environment-surfaces.md
+++ b/docs/architecture/notebook-identity-environment-surfaces.md
@@ -22,7 +22,11 @@ Prototype and shared component surfaces:
 
 - `src/components/notebook-shell/capabilities.ts`
 - `src/components/notebook-shell/NotebookIdentity.tsx`
+- `src/components/notebook-shell/NotebookCommandToolbar.tsx`
+- `src/components/notebook-shell/NotebookToolbarFrame.tsx`
+- `src/components/notebook-shell/NotebookToolbarIdentity.tsx`
 - `src/components/notebook-shell/NotebookEnvironmentSummary.tsx`
+- `src/components/notebook-shell/interaction-mode.ts`
 - `apps/elements/components/notebook-scenarios.ts`
 
 ## Problem
@@ -150,16 +154,21 @@ Elements and production host adapters should cover these states first:
    paths still must enforce authorization in the host/room/daemon layer.
 3. `canRequestEdit` remains distinct from edit permission. It is a sign-in or
    request-access affordance, not a write grant.
-4. Cloud and desktop should feed the same header, rail, identity, and package
-   components whenever they are expressing the same notebook state.
-5. Runtime-peer authority should not be collapsed into editor or owner UI.
+4. `NotebookInteractionModeProjection` carries the selected view/edit mode,
+   active mode, requested-edit state, and effective edit booleans. The booleans
+   remain rendering affordances only; hosts and room authorities still gate
+   writes.
+5. Cloud and desktop should feed the same header, command toolbar, rail,
+   identity, and package components whenever they are expressing the same
+   notebook state.
+6. Runtime-peer authority should not be collapsed into editor or owner UI.
    Runtime-peer capability is about lifecycle/output authorship, not notebook
    structure edits or ACL management.
-6. `NotebookShellCapabilities.runtime` carries runtime authorship separately
+7. `NotebookShellCapabilities.runtime` carries runtime authorship separately
    from `NotebookShellCapabilities.access`. A `runtime_peer` connection can
    project `runtime.canWriteRuntimeState = true` while still projecting
    `access.level = "viewer"` for document editing, package, and sharing UI.
-7. Desktop remote rooms should use the same capability projection as cloud
+8. Desktop remote rooms should use the same capability projection as cloud
    rooms while preserving their separate identity path: desktop app, local
    daemon/socket identity, and remote service credential or API key.
 
@@ -196,11 +205,20 @@ Elements and production host adapters should cover these states first:
 5. Current Elements visuals, including the surfaces introduced around #3240,
    are illustrative scenario chrome. They should validate semantics and
    component composition, not freeze final production appearance.
+6. Current Elements fixtures cover the scenario set above. Future catalog work
+   should reuse `ElementsNotebookScenario` instead of reintroducing page-local
+   identity, access, runtime, package, or trust mock state.
+7. Elements should call out convergence gaps directly: when cloud has a richer
+   hosted behavior or desktop has a richer daemon/local behavior, the catalog
+   should show the shared projection and identify which host-owned callback or
+   authority still needs to be wired.
 
 ## Shared Surface Projection
 
-This is a product contract, not a final TypeScript API. Implementation can land
-incrementally, but adapter props should move toward these shapes.
+This is a product contract. The current shared implementation already exposes
+`NotebookActorProjection`, `NotebookInteractionModeProjection`, and
+`NotebookEnvironmentSurface`; host adapters should move facts into those shapes
+instead of adding page-local strings.
 
 ```ts
 interface NotebookPrincipalSurface {
@@ -227,23 +245,60 @@ interface NotebookActorSurface {
   status?: "active" | "attention" | "idle" | "offline";
 }
 
+interface NotebookInteractionModeProjection {
+  selectedMode: "view" | "edit";
+  activeMode: "view" | "edit";
+  state: "viewing" | "requested" | "editing";
+  canRequestEdit: boolean;
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+}
+
 interface NotebookEnvironmentSurface {
-  runtimeLabel: string;
-  runtimeStatus: "ready" | "detached" | "unavailable" | "launching" | "error";
-  packageSummary: string;
-  packageSourceLabel: string | null;
-  packageSyncLabel: string | null;
-  trustLabel: string | null;
-  trustStatus: "trusted" | "untrusted" | "attention" | "unknown";
-  canViewPackages: boolean;
-  canManagePackages: boolean;
-  canExecute: boolean;
+  access: {
+    level: "none" | "viewer" | "editor" | "owner";
+    source: "cloud" | "local" | "fixture" | "unknown";
+    label: string;
+    sourceLabel: string;
+    visibilityLabel: string;
+    isPublic: boolean;
+  };
+  runtime: {
+    status: "ready" | "detached" | "unavailable" | "launching" | "error";
+    label: string;
+    detail: string | null;
+    muted: boolean;
+  };
+  packages: {
+    summary: string;
+    sourceLabel: string;
+    accessLabel: string;
+    muted: boolean;
+  };
+  sync: {
+    status:
+      | "synced"
+      | "dirty"
+      | "not_running"
+      | "not_uv_managed"
+      | "unavailable"
+      | "unknown";
+    label: string;
+    muted: boolean;
+  };
+  trust: {
+    status: "trusted" | "untrusted" | "not_required" | "unknown";
+    label: string;
+    attention: boolean;
+  };
 }
 ```
 
-Short-term code can keep the smaller existing `NotebookActorIdentity` and
-`NotebookEnvironmentSummary` props, but new host adapter work should avoid
-adding more page-local strings that cannot map into the structured projection.
+Short-term code can keep deriving display-friendly `NotebookActorIdentity`
+objects and `NotebookEnvironmentSummary` cards from these surfaces, but new
+host adapter work should avoid adding more page-local strings that cannot map
+into the structured projection.
 Presentation helpers can derive actor categories such as agent, runtime, system,
 public, or human from the principal source and operator kind instead of storing a
 second enum that can drift. Display labels like "Codex for Kyle" are also
@@ -262,9 +317,10 @@ notebook UI sees provider `anaconda`.
 | Current actor | Notebook header identity group and presence slots. |
 | Delegated agent | Header identity badge, cell attribution, and activity/presence surfaces. |
 | Access scope | Header/share/edit affordances and read-only notices. |
-| Runtime state | Header runtime controls, rail package/environment panel, and execution controls. |
-| Package state | Rail package/environment panel and future package management drawer. |
-| Trust state | Package/environment panel and runtime launch affordance. |
+| Interaction mode | Shared command toolbar, edit-mode control, presence copy, and read/edit notices. |
+| Runtime state | Header runtime controls, environment summary, and execution controls. |
+| Package state | Package rail, environment summary, and future package management drawer. |
+| Trust state | Environment summary and runtime launch affordance. |
 | Public viewer state | Header identity/access area and share controls for owners. |
 
 ## Acceptance Criteria
@@ -274,12 +330,13 @@ notebook UI sees provider `anaconda`.
    shell props or shared view-model projections instead of duplicating component
    logic.
 3. `NotebookIdentityBadge`, `NotebookIdentityGroup`, and
-   `NotebookEnvironmentSummary` can render the cloud owner, public viewer,
-   delegated agent, local owner, desktop remote room, read-only,
-   credential-attention, mixed-IdP, runtime-unavailable, runtime-peer, and
-   untrusted states without host imports.
-4. Code-cell current-line, execution attribution, and presence can be pointed at
-   the same actor projection.
+   `NotebookToolbarIdentity`, plus `NotebookCommandToolbar`,
+   `NotebookToolbarFrame`, and `NotebookEnvironmentSummary`, can render the
+   cloud owner, public viewer, delegated agent, local owner, desktop remote
+   room, read-only, credential-attention, mixed-IdP, runtime-unavailable,
+   runtime-peer, and untrusted states without host imports.
+4. Code-cell current-line, execution attribution, toolbar interaction state,
+   and presence can be pointed at the same actor and interaction projections.
 5. The hosted public viewer path does not display anonymous viewers as named
    collaborators, and public viewer presence remains connection-local or
    aggregate-only until a separate public-presence policy changes it.
@@ -289,17 +346,21 @@ notebook UI sees provider `anaconda`.
 
 ## Suggested Work Slices
 
-1. Expand the Elements scenario layer to include read-only local, desktop
-   remote room, credential-attention, mixed-IdP, one-principal/multiple-operator,
-   runtime peer, and untrusted dependency fixtures.
-2. Extend the shared actor projection to represent runtime and system actors
+1. Use the now-complete Elements scenario layer as a regression surface for
+   desktop/cloud identity, access, runtime, package, and trust mappings.
+2. Continue replacing React-side raw actor-label fallbacks with host/backend
+   supplied structured projections for presence, execution attribution, editor
+   attribution, and activity.
+3. Extend the shared actor projection to represent runtime and system actors
    without parsing demo-only agent labels.
-3. Teach desktop and cloud adapters to map their current facts into the shared
-   identity/environment projection.
-4. Move package/environment rail content onto `NotebookEnvironmentSummary` or a
-   sibling shared component.
-5. Connect execution/cell attribution to the shared actor projection.
-6. Revisit this PRD and split out an ADR only when a durable code-level boundary
+4. Keep desktop and cloud adapters mapping their current facts into the shared
+   identity, interaction, and environment projections as new host capabilities
+   land.
+5. Keep package rail content package-focused and host-owned; render
+   `NotebookEnvironmentSummary` or a sibling shared component only where the
+   product intentionally shows environment/access/runtime/trust summary facts.
+6. Connect execution/cell attribution to the shared actor projection.
+7. Revisit this PRD and split out an ADR only when a durable code-level boundary
    needs acceptance, such as the final TypeScript projection API or a runtime
    peer capability extension.
 


### PR DESCRIPTION
## Summary

- refresh identity/trust ADR implementation details against current `nteract-identity`
- update notebook identity/environment surfaces to name the current structured projections
- revise the identity/environment audit now that Elements scenarios, `NotebookEnvironmentSurface`, shared toolbar chrome, and `NotebookInteractionModeProjection` exist
- align the audit with #3273: cloud now uses shared command toolbar/identity and keeps the package rail package-only

## Verification

- `cargo xtask lint --fix`
- `git diff --check`
