### PR TITLE
docs(elements): document cloud notebook shell chrome

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import {
   ArrowRight,
+  BookOpen,
   Boxes,
   Cloud,
   FileCode2,
@@ -29,6 +30,12 @@ const entries = [
     description: "Runtime-state matrix for the current notebook toolbar.",
     href: "/docs/notebook-toolbar-surfaces",
     icon: PanelTop,
+  },
+  {
+    title: "Cloud notebook shell",
+    description: "Presence, sync, mode, sharing, and auth composed around the shared shell.",
+    href: "/docs/cloud-notebook-shell",
+    icon: Cloud,
   },
   {
     title: "Package managers",
@@ -76,7 +83,7 @@ const entries = [
     title: "Read-only notebooks",
     description: "Hosted and cloud notebook cells rendered through shared components.",
     href: "/docs/read-only-notebook-surfaces",
-    icon: Cloud,
+    icon: BookOpen,
   },
   {
     title: "Runtime surfaces",

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -1,0 +1,545 @@
+"use client";
+
+import {
+  BookOpen,
+  CheckCircle2,
+  Cloud,
+  CloudOff,
+  Code2,
+  Globe2,
+  LogIn,
+  Pencil,
+  Play,
+  Radio,
+  Share2,
+  UsersRound,
+  WifiOff,
+  type LucideIcon,
+} from "lucide-react";
+import { useState } from "react";
+import {
+  NotebookDocumentHeader,
+  NotebookDocumentRail,
+  NotebookDocumentShell,
+  NotebookEnvironmentSummary,
+  NotebookPackageSummaryPanel,
+  notebookActorIdentityFromAccess,
+  type NotebookActorIdentity,
+} from "@/components/notebook-shell";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
+import { cn } from "@/lib/utils";
+import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+
+type CloudConnectionState = "live" | "reconnecting" | "offline";
+type CloudModeState = "view" | "edit";
+
+const activePeople: NotebookActorIdentity[] = [
+  {
+    id: "kyle",
+    label: "Kyle",
+    detail: "editing from browser",
+    kind: "human",
+    status: "active",
+  },
+  {
+    id: "morgan",
+    label: "Morgan",
+    detail: "viewing",
+    kind: "human",
+    status: "idle",
+  },
+];
+
+const shellStates = [
+  {
+    title: "Owner editing",
+    description: "Presence, live sync, mode, sharing, and account all fit on one quiet line.",
+    scenarioId: "cloud-owner" as const,
+    connection: "live" as const,
+    mode: "edit" as const,
+    people: activePeople,
+  },
+  {
+    title: "Public viewer",
+    description:
+      "The same shell reads as published and view-only without pretending a runtime exists.",
+    scenarioId: "cloud-public-viewer" as const,
+    connection: "live" as const,
+    mode: "view" as const,
+    people: [activePeople[1]],
+  },
+  {
+    title: "Reconnecting",
+    description: "Transport state is a document concern, separate from Python or kernel state.",
+    scenarioId: "cloud-editor" as const,
+    connection: "reconnecting" as const,
+    mode: "edit" as const,
+    people: activePeople,
+  },
+  {
+    title: "Offline viewer",
+    description: "Auth and access stay legible while the notebook waits to reconnect.",
+    scenarioId: "cloud-public-viewer" as const,
+    connection: "offline" as const,
+    mode: "view" as const,
+    people: [],
+  },
+];
+
+const cloudStateRows = [
+  {
+    surface: "Presence",
+    owner: "Room session",
+    language: "2 here now, Kyle editing",
+    reason: "People are peers on the document, not kernel state.",
+  },
+  {
+    surface: "Connection",
+    owner: "Document transport",
+    language: "Live, reconnecting, offline",
+    reason: "Online/offline belongs to sync health and save confidence.",
+  },
+  {
+    surface: "Mode",
+    owner: "Access request",
+    language: "View or Edit",
+    reason: "Mode is the user's current affordance, not a permission dump.",
+  },
+  {
+    surface: "Runtime",
+    owner: "Notebook capability",
+    language: "Python, runtime detached",
+    reason: "Cloud previews can show language context without implying local execution.",
+  },
+  {
+    surface: "Account",
+    owner: "Host auth",
+    language: "Kyle, sign in, expired session",
+    reason: "Identity controls stay with the cloud host while actor badges remain shared.",
+  },
+];
+
+export function CloudNotebookShellExample() {
+  const scenario = getElementsNotebookScenario("cloud-owner");
+  const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
+  const [railCollapsed, setRailCollapsed] = useState(true);
+  const actor = notebookActorIdentityFromAccess(
+    scenario.capabilities.access,
+    scenario.capabilities.auth,
+  );
+
+  const rail = (
+    <NotebookDocumentRail
+      viewModel={scenario.viewModel}
+      activePanelId={activePanel}
+      collapsed={railCollapsed}
+      packagesPanel={
+        <NotebookPackageSummaryPanel
+          packages={scenario.viewModel.packages}
+          readOnly
+          header={
+            <NotebookEnvironmentSummary
+              capabilities={scenario.capabilities}
+              packages={scenario.viewModel.packages}
+              environment={scenario.environment}
+              showPackageDetails={false}
+              className="shadow-none"
+            />
+          }
+        />
+      }
+      onActivePanelChange={setActivePanel}
+      onCollapsedChange={setRailCollapsed}
+      className="bg-background"
+    />
+  );
+
+  return (
+    <div className="not-prose space-y-6" data-elements-slot="cloud-notebook-shell">
+      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-fd-foreground">
+        <div className="flex items-start gap-3">
+          <Cloud
+            className="mt-0.5 size-4 flex-none text-emerald-700 dark:text-emerald-300"
+            aria-hidden="true"
+          />
+          <div>
+            <h2 className="text-sm font-semibold">Cloud shell direction</h2>
+            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+              The cloud layer should compose around the shared notebook shell. Presence, document
+              connection, edit mode, sharing, and account controls are host state. Runtime remains a
+              notebook capability so the chrome does not imply that online/offline is a kernel
+              status.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-xl border border-fd-border bg-fd-card shadow-sm">
+        <BrowserFrame />
+        <NotebookDocumentShell
+          rootElement="div"
+          className="h-[720px] bg-background text-foreground"
+          stageClassName="bg-background"
+          toolbar={
+            <CloudHeader
+              actor={actor}
+              connection="live"
+              mode="edit"
+              people={activePeople}
+              scenario={scenario}
+            />
+          }
+          toolbarClassName="border-b bg-background/95 px-3 py-2 backdrop-blur"
+          toolbarLabel="Cloud notebook session"
+          rail={rail}
+          capabilities={scenario.capabilities}
+        >
+          <CloudNotebookDocument />
+        </NotebookDocumentShell>
+      </section>
+
+      <section className="grid gap-3 lg:grid-cols-2">
+        {shellStates.map((state) => {
+          const stateScenario = getElementsNotebookScenario(state.scenarioId);
+          const stateActor = notebookActorIdentityFromAccess(
+            stateScenario.capabilities.access,
+            stateScenario.capabilities.auth,
+          );
+          return (
+            <article
+              key={state.title}
+              className="overflow-hidden rounded-lg border border-fd-border bg-fd-card"
+            >
+              <div className="border-b border-fd-border p-4">
+                <h2 className="text-sm font-semibold">{state.title}</h2>
+                <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+                  {state.description}
+                </p>
+              </div>
+              <div className="bg-background p-3 text-foreground">
+                <CloudHeader
+                  actor={stateActor}
+                  connection={state.connection}
+                  mode={state.mode}
+                  people={state.people}
+                  scenario={stateScenario}
+                  compact
+                />
+              </div>
+            </article>
+          );
+        })}
+      </section>
+
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border p-4">
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+            <h2 className="text-sm font-semibold">State vocabulary</h2>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            The mockup keeps each cloud feature in its own source of truth, then gives the shell
+            quiet phrases that can collapse at small widths.
+          </p>
+        </div>
+        <div className="divide-y divide-fd-border">
+          {cloudStateRows.map((row) => (
+            <div
+              key={row.surface}
+              className="grid gap-3 p-4 text-sm md:grid-cols-[9rem_11rem_minmax(0,1fr)_minmax(0,1.4fr)]"
+            >
+              <div className="font-semibold">{row.surface}</div>
+              <div className="text-fd-muted-foreground">{row.owner}</div>
+              <div className="font-mono text-xs text-fd-foreground">{row.language}</div>
+              <div className="text-xs leading-5 text-fd-muted-foreground">{row.reason}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function BrowserFrame() {
+  return (
+    <div className="flex h-11 items-center gap-2 border-b border-fd-border bg-muted/50 px-4 text-xs text-muted-foreground">
+      <div className="flex gap-1.5">
+        <span className="size-2.5 rounded-full bg-red-400" />
+        <span className="size-2.5 rounded-full bg-amber-400" />
+        <span className="size-2.5 rounded-full bg-emerald-400" />
+      </div>
+      <div className="ml-2 flex h-7 min-w-0 flex-1 items-center rounded-full bg-background px-3">
+        <Globe2 className="mr-2 size-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">preview.runt.run/n/topic-viz/topic-viz</span>
+      </div>
+    </div>
+  );
+}
+
+function CloudHeader({
+  actor,
+  compact = false,
+  connection,
+  mode,
+  people,
+  scenario,
+}: {
+  actor: NotebookActorIdentity;
+  compact?: boolean;
+  connection: CloudConnectionState;
+  mode: CloudModeState;
+  people: readonly NotebookActorIdentity[];
+  scenario: ReturnType<typeof getElementsNotebookScenario>;
+}) {
+  return (
+    <NotebookDocumentHeader
+      capabilities={scenario.capabilities}
+      className={cn(compact && "gap-2")}
+      presence={<CloudPresence people={people} mode={mode} compact={compact} />}
+      utilityControls={<CloudConnectionPill state={connection} compact={compact} />}
+      runtimeControls={<CloudRuntimePill compact={compact} />}
+      sharingControls={<CloudShareButton compact={compact} />}
+      editControls={<CloudModeButton mode={mode} compact={compact} />}
+      authControls={<CloudAccountButton actor={actor} compact={compact} />}
+    />
+  );
+}
+
+function CloudPresence({
+  compact,
+  mode,
+  people,
+}: {
+  compact: boolean;
+  mode: CloudModeState;
+  people: readonly NotebookActorIdentity[];
+}) {
+  const connectedCount = Math.max(1, people.length);
+  const modeLabel = mode === "edit" ? "editing" : "viewing";
+  const label = compact ? `${connectedCount} here` : `${connectedCount} here now`;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex h-8 max-w-[min(18rem,54vw)] items-center gap-2 px-1 text-sm text-foreground",
+        people.length === 0 && "text-muted-foreground",
+      )}
+      title={`${label}, ${modeLabel}`}
+    >
+      <span className="relative inline-flex size-5 shrink-0 items-center justify-center">
+        <UsersRound className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        {people.length > 0 ? (
+          <span className="absolute bottom-0 right-0 size-1.5 rounded-full bg-emerald-500" />
+        ) : null}
+      </span>
+      <span className="min-w-0 truncate">
+        {label}
+        <span className="text-muted-foreground">, {modeLabel}</span>
+      </span>
+    </div>
+  );
+}
+
+function CloudConnectionPill({
+  compact,
+  state,
+}: {
+  compact: boolean;
+  state: CloudConnectionState;
+}) {
+  const detail = connectionDetail(state);
+  const Icon = detail.icon;
+  return (
+    <span
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium transition-colors hover:bg-muted/60",
+        detail.className,
+      )}
+      title={detail.title}
+    >
+      <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+      <span>{compact ? detail.shortLabel : detail.label}</span>
+    </span>
+  );
+}
+
+function CloudRuntimePill({ compact }: { compact: boolean }) {
+  return (
+    <span
+      className="inline-flex h-8 max-w-[10rem] items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-500/10 dark:text-blue-300"
+      title="Notebook language, runtime detached in cloud preview"
+    >
+      <Code2 className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{compact ? "Python" : "Python"}</span>
+      {!compact ? <span className="text-blue-700/50 dark:text-blue-300/50">detached</span> : null}
+    </span>
+  );
+}
+
+function CloudShareButton({ compact }: { compact: boolean }) {
+  return (
+    <button
+      type="button"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+    >
+      <Share2 className="size-3.5" aria-hidden="true" />
+      {compact ? null : <span>Share</span>}
+    </button>
+  );
+}
+
+function CloudModeButton({ compact, mode }: { compact: boolean; mode: CloudModeState }) {
+  const Icon = mode === "edit" ? BookOpen : Pencil;
+  const label = mode === "edit" ? "View" : "Edit";
+
+  return (
+    <button
+      type="button"
+      aria-pressed={mode === "edit"}
+      className={cn(
+        "inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium transition-colors hover:bg-muted/70",
+        mode === "edit" ? "text-emerald-700 dark:text-emerald-300" : "text-foreground",
+      )}
+      title={mode === "edit" ? "Return to read-only viewing" : "Request edit access"}
+    >
+      <Icon className="size-3.5" aria-hidden="true" />
+      {compact ? null : <span>{label}</span>}
+    </button>
+  );
+}
+
+function CloudAccountButton({
+  actor,
+  compact,
+}: {
+  actor: NotebookActorIdentity;
+  compact: boolean;
+}) {
+  if (actor.kind === "public") {
+    return (
+      <button
+        type="button"
+        className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+      >
+        <LogIn className="size-3.5" aria-hidden="true" />
+        {compact ? null : <span>Sign in</span>}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="inline-flex h-8 max-w-[min(14rem,34vw)] items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+      title={actor.detail ?? actor.label}
+    >
+      <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+        <span className="size-3.5 rounded-sm border border-border bg-muted" />
+        <span className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full bg-emerald-500" />
+      </span>
+      {compact ? null : <span className="min-w-0 truncate">{actor.label}</span>}
+    </button>
+  );
+}
+
+function CloudNotebookDocument() {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <article className="mx-auto max-w-5xl px-8 py-12 text-[17px] leading-8 max-sm:px-5">
+        <h1 className="text-4xl font-semibold tracking-normal">MathNet topic visualization</h1>
+        <p className="mt-6 max-w-4xl">
+          The <a className="font-medium text-blue-600">MathNet dataset</a> collects competition math
+          problems from around the world, each annotated with a hierarchical topic path like{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.9em]">
+            Geometry &gt; Plane Geometry &gt; Triangles
+          </code>
+          . This notebook asks what that hierarchy actually looks like.
+        </p>
+        <p className="mt-5 max-w-4xl">
+          Two views land it. A <strong>sunburst</strong> for the radial sense of where the mass
+          lives, and a <strong>treemap</strong> for proportional comparison at a glance.
+        </p>
+
+        <h2 className="mt-9 text-2xl font-semibold">Loading the slice</h2>
+        <p className="mt-4 max-w-4xl">
+          200 rows, shuffled with a fixed seed so the picture is reproducible. The{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.9em]">map</code> step pre-computes{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.9em]">problem_length</code> and{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.9em]">has_images</code>.
+        </p>
+
+        <div className="mt-12 grid grid-cols-[2rem_minmax(0,1fr)] gap-4">
+          <button
+            type="button"
+            className="mt-2 flex size-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Run cell"
+          >
+            <Play className="size-4" aria-hidden="true" />
+          </button>
+          <div className="min-w-0 font-mono text-lg leading-8">
+            <div>
+              <span className="text-red-500">from</span>{" "}
+              <span className="text-blue-700">datasets</span>{" "}
+              <span className="text-red-500">import</span>{" "}
+              <span className="text-blue-700">load_dataset</span>
+            </div>
+            <div className="mt-7">
+              <span className="text-blue-700">columns</span> = [
+              <br />
+              <span className="pl-8 text-slate-700">"id",</span>
+              <br />
+              <span className="pl-8 text-slate-700">"problem_markdown",</span>
+              <br />
+              <span className="pl-8 text-slate-700">"problem_length",</span>
+              <br />]
+            </div>
+            <div className="mt-7 flex items-center gap-3 text-sm font-sans text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                <Radio className="size-3.5 text-emerald-600" aria-hidden="true" />
+                Python
+              </span>
+              <span>/</span>
+              <span>run 8</span>
+              <span className="h-px flex-1 bg-border" />
+            </div>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function connectionDetail(state: CloudConnectionState): {
+  icon: LucideIcon;
+  label: string;
+  shortLabel: string;
+  title: string;
+  className: string;
+} {
+  switch (state) {
+    case "live":
+      return {
+        icon: Cloud,
+        label: "Live",
+        shortLabel: "Live",
+        title: "Document sync is live",
+        className: "text-emerald-700 dark:text-emerald-300",
+      };
+    case "reconnecting":
+      return {
+        icon: CloudOff,
+        label: "Reconnecting",
+        shortLabel: "Sync",
+        title: "Trying to reconnect to the notebook room",
+        className: "text-amber-700 dark:text-amber-300",
+      };
+    case "offline":
+      return {
+        icon: WifiOff,
+        label: "Offline",
+        shortLabel: "Off",
+        title: "Document edits are not connected",
+        className: "text-muted-foreground",
+      };
+  }
+}

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -291,10 +291,21 @@ function CloudHeader({
   people: readonly NotebookActorIdentity[];
   scenario: ReturnType<typeof getElementsNotebookScenario>;
 }) {
+  if (compact) {
+    return (
+      <CloudHeaderStrip
+        actor={actor}
+        connection={connection}
+        mode={mode}
+        people={people}
+        scenario={scenario}
+      />
+    );
+  }
+
   return (
     <NotebookDocumentHeader
       capabilities={scenario.capabilities}
-      className={cn(compact && "gap-2")}
       presence={<CloudPresence people={people} mode={mode} compact={compact} />}
       utilityControls={<CloudConnectionPill state={connection} compact={compact} />}
       runtimeControls={<CloudRuntimePill compact={compact} />}
@@ -302,6 +313,41 @@ function CloudHeader({
       editControls={<CloudModeButton mode={mode} compact={compact} />}
       authControls={<CloudAccountButton actor={actor} compact={compact} />}
     />
+  );
+}
+
+function CloudHeaderStrip({
+  actor,
+  connection,
+  mode,
+  people,
+  scenario,
+}: {
+  actor: NotebookActorIdentity;
+  connection: CloudConnectionState;
+  mode: CloudModeState;
+  people: readonly NotebookActorIdentity[];
+  scenario: ReturnType<typeof getElementsNotebookScenario>;
+}) {
+  return (
+    <div
+      className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
+      data-slot="cloud-notebook-header-strip"
+      role="toolbar"
+      aria-label="Cloud notebook state"
+    >
+      <CloudPresence people={people} mode={mode} compact />
+      <span className="h-4 w-px bg-border/70" aria-hidden="true" />
+      <CloudConnectionPill state={connection} compact />
+      <CloudRuntimePill compact />
+      {scenario.capabilities.canManageSharing ? <CloudShareButton compact /> : null}
+      {scenario.capabilities.canRequestEdit ? <CloudModeButton mode={mode} compact /> : null}
+      {scenario.capabilities.auth.canSignIn ||
+      scenario.capabilities.auth.canUseAuthenticatedIdentity ||
+      scenario.capabilities.auth.needsAttention ? (
+        <CloudAccountButton actor={actor} compact />
+      ) : null}
+    </div>
   );
 }
 
@@ -422,7 +468,7 @@ function CloudAccountButton({
         className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
       >
         <LogIn className="size-3.5" aria-hidden="true" />
-        {compact ? null : <span>Sign in</span>}
+        <span className={cn(compact && "sr-only")}>Sign in</span>
       </button>
     );
   }
@@ -433,11 +479,8 @@ function CloudAccountButton({
       className="inline-flex h-8 max-w-[min(14rem,34vw)] items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
       title={actor.detail ?? actor.label}
     >
-      <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
-        <span className="size-3.5 rounded-sm border border-border bg-muted" />
-        <span className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full bg-emerald-500" />
-      </span>
-      {compact ? null : <span className="min-w-0 truncate">{actor.label}</span>}
+      <span className="size-2 rounded-full bg-emerald-500" aria-hidden="true" />
+      <span className={cn("min-w-0 truncate", compact && "max-w-16")}>{actor.label}</span>
     </button>
   );
 }

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -18,7 +18,6 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import {
-  NotebookDocumentHeader,
   NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookEnvironmentSummary,
@@ -90,7 +89,7 @@ const cloudStateRows = [
   {
     surface: "Presence",
     owner: "Room session",
-    language: "2 here now, Kyle editing",
+    language: "2 here now, editing",
     reason: "People are peers on the document, not kernel state.",
   },
   {
@@ -107,8 +106,8 @@ const cloudStateRows = [
   },
   {
     surface: "Runtime",
-    owner: "Notebook capability",
-    language: "Python, runtime detached",
+    owner: "Notebook toolbar",
+    language: "Python / detached",
     reason: "Cloud previews can show language context without implying local execution.",
   },
   {
@@ -181,7 +180,7 @@ export function CloudNotebookShellExample() {
           className="h-[720px] bg-background text-foreground"
           stageClassName="bg-background"
           toolbar={
-            <CloudHeader
+            <CloudNotebookChrome
               actor={actor}
               connection="live"
               mode="edit"
@@ -189,7 +188,7 @@ export function CloudNotebookShellExample() {
               scenario={scenario}
             />
           }
-          toolbarClassName="border-b bg-background/95 px-3 py-2 backdrop-blur"
+          toolbarClassName="border-b bg-background/95 backdrop-blur"
           toolbarLabel="Cloud notebook session"
           rail={rail}
           capabilities={scenario.capabilities}
@@ -216,14 +215,13 @@ export function CloudNotebookShellExample() {
                   {state.description}
                 </p>
               </div>
-              <div className="bg-background p-3 text-foreground">
-                <CloudHeader
+              <div className="bg-background text-foreground">
+                <CloudStatePreview
                   actor={stateActor}
                   connection={state.connection}
                   mode={state.mode}
                   people={state.people}
                   scenario={stateScenario}
-                  compact
                 />
               </div>
             </article>
@@ -276,47 +274,34 @@ function BrowserFrame() {
   );
 }
 
-function CloudHeader({
+function CloudNotebookChrome({
   actor,
-  compact = false,
   connection,
   mode,
   people,
   scenario,
 }: {
   actor: NotebookActorIdentity;
-  compact?: boolean;
   connection: CloudConnectionState;
   mode: CloudModeState;
   people: readonly NotebookActorIdentity[];
   scenario: ReturnType<typeof getElementsNotebookScenario>;
 }) {
-  if (compact) {
-    return (
-      <CloudHeaderStrip
+  return (
+    <div className="flex min-w-0 flex-col" data-slot="cloud-notebook-chrome">
+      <CloudAppToolbar
         actor={actor}
         connection={connection}
         mode={mode}
         people={people}
         scenario={scenario}
       />
-    );
-  }
-
-  return (
-    <NotebookDocumentHeader
-      capabilities={scenario.capabilities}
-      presence={<CloudPresence people={people} mode={mode} compact={compact} />}
-      utilityControls={<CloudConnectionPill state={connection} compact={compact} />}
-      runtimeControls={<CloudRuntimePill compact={compact} />}
-      sharingControls={<CloudShareButton compact={compact} />}
-      editControls={<CloudModeButton mode={mode} compact={compact} />}
-      authControls={<CloudAccountButton actor={actor} compact={compact} />}
-    />
+      <CloudNotebookToolbar scenario={scenario} />
+    </div>
   );
 }
 
-function CloudHeaderStrip({
+function CloudAppToolbar({
   actor,
   connection,
   mode,
@@ -331,22 +316,83 @@ function CloudHeaderStrip({
 }) {
   return (
     <div
-      className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1"
-      data-slot="cloud-notebook-header-strip"
+      className="flex min-h-14 min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-border/70 px-4 py-2"
+      data-slot="cloud-app-toolbar"
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <CloudPresence people={people} mode={mode} compact={false} />
+        <CloudConnectionPill state={connection} compact={false} />
+      </div>
+      <div className="flex shrink-0 items-center gap-3">
+        {scenario.capabilities.canManageSharing ? <CloudShareButton compact={false} /> : null}
+        {scenario.capabilities.canRequestEdit ? (
+          <CloudModeButton mode={mode} compact={false} />
+        ) : null}
+        {scenario.capabilities.auth.canSignIn ||
+        scenario.capabilities.auth.canUseAuthenticatedIdentity ||
+        scenario.capabilities.auth.needsAttention ? (
+          <CloudAccountButton actor={actor} compact={false} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CloudNotebookToolbar({
+  scenario,
+}: {
+  scenario: ReturnType<typeof getElementsNotebookScenario>;
+}) {
+  const canShowRuntime =
+    scenario.capabilities.canExecute ||
+    scenario.capabilities.canViewPackages ||
+    scenario.capabilities.canManagePackages;
+
+  return (
+    <div
+      className="flex min-h-12 min-w-0 items-center justify-end gap-3 px-4 py-2"
+      data-slot="cloud-notebook-toolbar"
+    >
+      {canShowRuntime ? <CloudRuntimePill compact={false} /> : null}
+    </div>
+  );
+}
+
+function CloudStatePreview({
+  actor,
+  connection,
+  mode,
+  people,
+  scenario,
+}: {
+  actor: NotebookActorIdentity;
+  connection: CloudConnectionState;
+  mode: CloudModeState;
+  people: readonly NotebookActorIdentity[];
+  scenario: ReturnType<typeof getElementsNotebookScenario>;
+}) {
+  return (
+    <div
+      className="divide-y divide-border/70"
+      data-slot="cloud-state-preview"
       role="toolbar"
       aria-label="Cloud notebook state"
     >
-      <CloudPresence people={people} mode={mode} compact />
-      <span className="h-4 w-px bg-border/70" aria-hidden="true" />
-      <CloudConnectionPill state={connection} compact />
-      <CloudRuntimePill compact />
-      {scenario.capabilities.canManageSharing ? <CloudShareButton compact /> : null}
-      {scenario.capabilities.canRequestEdit ? <CloudModeButton mode={mode} compact /> : null}
-      {scenario.capabilities.auth.canSignIn ||
-      scenario.capabilities.auth.canUseAuthenticatedIdentity ||
-      scenario.capabilities.auth.needsAttention ? (
-        <CloudAccountButton actor={actor} compact />
-      ) : null}
+      <div className="flex min-h-11 min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-1.5">
+        <CloudPresence people={people} mode={mode} compact />
+        <span className="h-4 w-px bg-border/70" aria-hidden="true" />
+        <CloudConnectionPill state={connection} compact />
+        {scenario.capabilities.canManageSharing ? <CloudShareButton compact /> : null}
+        {scenario.capabilities.canRequestEdit ? <CloudModeButton mode={mode} compact /> : null}
+        {scenario.capabilities.auth.canSignIn ||
+        scenario.capabilities.auth.canUseAuthenticatedIdentity ||
+        scenario.capabilities.auth.needsAttention ? (
+          <CloudAccountButton actor={actor} compact />
+        ) : null}
+      </div>
+      <div className="flex min-h-9 items-center justify-end px-3 py-1">
+        <CloudRuntimePill compact />
+      </div>
     </div>
   );
 }
@@ -360,30 +406,54 @@ function CloudPresence({
   mode: CloudModeState;
   people: readonly NotebookActorIdentity[];
 }) {
-  const connectedCount = Math.max(1, people.length);
-  const modeLabel = mode === "edit" ? "editing" : "viewing";
-  const label = compact ? `${connectedCount} here` : `${connectedCount} here now`;
+  const summary = presenceSummary(people, mode, compact);
+  const hasPeers = people.length > 0;
 
   return (
     <div
       className={cn(
-        "inline-flex h-8 max-w-[min(18rem,54vw)] items-center gap-2 px-1 text-sm text-foreground",
-        people.length === 0 && "text-muted-foreground",
+        "inline-flex h-8 min-w-0 items-center gap-2 px-1 text-sm text-foreground",
+        compact ? "max-w-[min(18rem,54vw)]" : "max-w-[min(16rem,28vw)]",
+        !hasPeers && "text-muted-foreground",
       )}
-      title={`${label}, ${modeLabel}`}
+      title={summary.title}
     >
       <span className="relative inline-flex size-5 shrink-0 items-center justify-center">
         <UsersRound className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        {people.length > 0 ? (
+        {hasPeers ? (
           <span className="absolute bottom-0 right-0 size-1.5 rounded-full bg-emerald-500" />
         ) : null}
       </span>
-      <span className="min-w-0 truncate">
-        {label}
-        <span className="text-muted-foreground">, {modeLabel}</span>
-      </span>
+      <span className="min-w-0 truncate">{summary.label}</span>
     </div>
   );
+}
+
+function presenceSummary(
+  people: readonly NotebookActorIdentity[],
+  mode: CloudModeState,
+  compact: boolean,
+): { label: string; title: string } {
+  const modeLabel = mode === "edit" ? "editing" : "viewing";
+
+  if (people.length === 0) {
+    return {
+      label: compact ? "No live peers" : "No one live here",
+      title: "No live collaborators are connected",
+    };
+  }
+
+  if (compact) {
+    return {
+      label: `${people.length} here, ${modeLabel}`,
+      title: people.map((person) => `${person.label}: ${person.detail ?? "connected"}`).join(", "),
+    };
+  }
+
+  return {
+    label: `${people.length} here now, ${modeLabel}`,
+    title: people.map((person) => `${person.label}: ${person.detail ?? "connected"}`).join(", "),
+  };
 }
 
 function CloudConnectionPill({
@@ -416,8 +486,13 @@ function CloudRuntimePill({ compact }: { compact: boolean }) {
       title="Notebook language, runtime detached in cloud preview"
     >
       <Code2 className="size-3.5 shrink-0" aria-hidden="true" />
-      <span className="truncate">{compact ? "Python" : "Python"}</span>
-      {!compact ? <span className="text-blue-700/50 dark:text-blue-300/50">detached</span> : null}
+      <span className="truncate">Python</span>
+      {!compact ? (
+        <>
+          <span className="text-blue-700/45 dark:text-blue-300/45">/</span>
+          <span className="text-blue-700/60 dark:text-blue-300/60">detached</span>
+        </>
+      ) : null}
     </span>
   );
 }

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -1,36 +1,45 @@
 "use client";
 
 import {
-  BookOpen,
   CheckCircle2,
   Cloud,
   CloudOff,
-  Code2,
   Globe2,
   LogIn,
-  Pencil,
   Play,
   Radio,
   Share2,
-  UsersRound,
   WifiOff,
   type LucideIcon,
 } from "lucide-react";
 import { useState } from "react";
 import {
+  createNotebookInteractionModeProjection,
+  NotebookCommandToolbar,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookEditModeButton,
   NotebookEnvironmentSummary,
+  NotebookIdentityBadge,
   NotebookPackageSummaryPanel,
+  NotebookPresenceStatus,
   notebookActorIdentityFromAccess,
   type NotebookActorIdentity,
+  type NotebookInteractionMode,
+  type NotebookInteractionModeProjection,
+  type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import { cn } from "@/lib/utils";
-import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+} from "@/components/notebook-scenarios";
 
 type CloudConnectionState = "live" | "reconnecting" | "offline";
-type CloudModeState = "view" | "edit";
+type CloudModeState = NotebookInteractionMode;
+
+const noop = () => {};
 
 const activePeople: NotebookActorIdentity[] = [
   {
@@ -52,7 +61,7 @@ const activePeople: NotebookActorIdentity[] = [
 const shellStates = [
   {
     title: "Owner editing",
-    description: "Presence, live sync, mode, sharing, and account all fit on one quiet line.",
+    description: "Presence and sync stay app-level while the notebook row owns language.",
     scenarioId: "cloud-owner" as const,
     connection: "live" as const,
     mode: "edit" as const,
@@ -89,8 +98,8 @@ const cloudStateRows = [
   {
     surface: "Presence",
     owner: "Room session",
-    language: "2 here now, editing",
-    reason: "People are peers on the document, not kernel state.",
+    language: "2 here now",
+    reason: "People are peers on the document; mode belongs to the view/edit control.",
   },
   {
     surface: "Connection",
@@ -100,15 +109,15 @@ const cloudStateRows = [
   },
   {
     surface: "Mode",
-    owner: "Access request",
-    language: "View or Edit",
-    reason: "Mode is the user's current affordance, not a permission dump.",
+    owner: "Frontend affordance",
+    language: "Viewing or Editing",
+    reason: "Users with edit access can locally step out of editing without requesting access.",
   },
   {
     surface: "Runtime",
     owner: "Notebook toolbar",
-    language: "Python / detached",
-    reason: "Cloud previews can show language context without implying local execution.",
+    language: "Python / uv",
+    reason: "Language and package affordances stay on the notebook command toolbar.",
   },
   {
     surface: "Account",
@@ -120,11 +129,16 @@ const cloudStateRows = [
 
 export function CloudNotebookShellExample() {
   const scenario = getElementsNotebookScenario("cloud-owner");
+  const [mode, setMode] = useState<CloudModeState>("edit");
   const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(true);
   const actor = notebookActorIdentityFromAccess(
     scenario.capabilities.access,
     scenario.capabilities.auth,
+  );
+  const shellCapabilities = withInteractionProjection(
+    scenario.capabilities,
+    cloudInteractionProjection(scenario, mode),
   );
 
   const rail = (
@@ -138,7 +152,7 @@ export function CloudNotebookShellExample() {
           readOnly
           header={
             <NotebookEnvironmentSummary
-              capabilities={scenario.capabilities}
+              capabilities={shellCapabilities}
               packages={scenario.viewModel.packages}
               environment={scenario.environment}
               showPackageDetails={false}
@@ -183,7 +197,8 @@ export function CloudNotebookShellExample() {
             <CloudNotebookChrome
               actor={actor}
               connection="live"
-              mode="edit"
+              mode={mode}
+              onModeChange={setMode}
               people={activePeople}
               scenario={scenario}
             />
@@ -191,7 +206,7 @@ export function CloudNotebookShellExample() {
           toolbarClassName="border-b bg-background/95 backdrop-blur"
           toolbarLabel="Cloud notebook session"
           rail={rail}
-          capabilities={scenario.capabilities}
+          capabilities={shellCapabilities}
         >
           <CloudNotebookDocument />
         </NotebookDocumentShell>
@@ -278,14 +293,16 @@ function CloudNotebookChrome({
   actor,
   connection,
   mode,
+  onModeChange,
   people,
   scenario,
 }: {
   actor: NotebookActorIdentity;
   connection: CloudConnectionState;
   mode: CloudModeState;
+  onModeChange: (mode: CloudModeState) => void;
   people: readonly NotebookActorIdentity[];
-  scenario: ReturnType<typeof getElementsNotebookScenario>;
+  scenario: ElementsNotebookScenario;
 }) {
   return (
     <div className="flex min-w-0 flex-col" data-slot="cloud-notebook-chrome">
@@ -293,10 +310,11 @@ function CloudNotebookChrome({
         actor={actor}
         connection={connection}
         mode={mode}
+        onModeChange={onModeChange}
         people={people}
         scenario={scenario}
       />
-      <CloudNotebookToolbar scenario={scenario} />
+      <CloudNotebookToolbar mode={mode} scenario={scenario} />
     </div>
   );
 }
@@ -305,33 +323,41 @@ function CloudAppToolbar({
   actor,
   connection,
   mode,
+  onModeChange,
   people,
   scenario,
 }: {
   actor: NotebookActorIdentity;
   connection: CloudConnectionState;
   mode: CloudModeState;
+  onModeChange?: (mode: CloudModeState) => void;
   people: readonly NotebookActorIdentity[];
-  scenario: ReturnType<typeof getElementsNotebookScenario>;
+  scenario: ElementsNotebookScenario;
 }) {
+  const interaction = cloudInteractionProjection(scenario, mode);
+  const effectiveCapabilities = withInteractionProjection(scenario.capabilities, interaction);
+
   return (
     <div
       className="flex min-h-14 min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-border/70 px-4 py-2"
       data-slot="cloud-app-toolbar"
     >
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <CloudPresence people={people} mode={mode} compact={false} />
+      <div className="flex min-w-0 flex-1 basis-56 items-center gap-3">
+        <CloudPresence people={people} compact={false} />
         <CloudConnectionPill state={connection} compact={false} />
       </div>
-      <div className="flex shrink-0 items-center gap-3">
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
         {scenario.capabilities.canManageSharing ? <CloudShareButton compact={false} /> : null}
-        {scenario.capabilities.canRequestEdit ? (
-          <CloudModeButton mode={mode} compact={false} />
-        ) : null}
+        <CloudModeToggle
+          compact={false}
+          interaction={interaction}
+          mode={mode}
+          onModeChange={onModeChange}
+        />
         {scenario.capabilities.auth.canSignIn ||
         scenario.capabilities.auth.canUseAuthenticatedIdentity ||
         scenario.capabilities.auth.needsAttention ? (
-          <CloudAccountButton actor={actor} compact={false} />
+          <CloudAccountButton actor={actor} capabilities={effectiveCapabilities} compact={false} />
         ) : null}
       </div>
     </div>
@@ -339,21 +365,35 @@ function CloudAppToolbar({
 }
 
 function CloudNotebookToolbar({
+  mode,
   scenario,
 }: {
-  scenario: ReturnType<typeof getElementsNotebookScenario>;
+  mode: CloudModeState;
+  scenario: ElementsNotebookScenario;
 }) {
-  const canShowRuntime =
-    scenario.capabilities.canExecute ||
-    scenario.capabilities.canViewPackages ||
-    scenario.capabilities.canManagePackages;
+  const firstRunnableCell = scenario.cells.find((cell) => cell.cellType === "code");
+  const cellIds = scenario.viewModel.cellIds;
+  const interaction = cloudInteractionProjection(scenario, mode);
+  const capabilities = withInteractionProjection(scenario.capabilities, interaction);
 
   return (
-    <div
-      className="flex min-h-12 min-w-0 items-center justify-end gap-3 px-4 py-2"
-      data-slot="cloud-notebook-toolbar"
-    >
-      {canShowRuntime ? <CloudRuntimePill compact={false} /> : null}
+    <div className="min-w-0 overflow-hidden" data-slot="cloud-notebook-toolbar">
+      <NotebookCommandToolbar
+        capabilities={capabilities}
+        runtime="python"
+        environmentManager="uv"
+        environmentOutOfSync={scenario.packageState.syncState.status === "dirty"}
+        runtimeStatus={null}
+        addAfterCellId={firstRunnableCell?.id ?? cellIds[cellIds.length - 1] ?? null}
+        onAddCell={noop}
+        onStartRuntime={noop}
+        onInterruptRuntime={noop}
+        onRestartRuntime={noop}
+        onRunAllCells={noop}
+        onRestartAndRunAll={noop}
+        onTogglePackages={noop}
+        className="h-12 px-4"
+      />
     </div>
   );
 }
@@ -369,8 +409,11 @@ function CloudStatePreview({
   connection: CloudConnectionState;
   mode: CloudModeState;
   people: readonly NotebookActorIdentity[];
-  scenario: ReturnType<typeof getElementsNotebookScenario>;
+  scenario: ElementsNotebookScenario;
 }) {
+  const interaction = cloudInteractionProjection(scenario, mode);
+  const effectiveCapabilities = withInteractionProjection(scenario.capabilities, interaction);
+
   return (
     <div
       className="divide-y divide-border/70"
@@ -379,19 +422,19 @@ function CloudStatePreview({
       aria-label="Cloud notebook state"
     >
       <div className="flex min-h-11 min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-1.5">
-        <CloudPresence people={people} mode={mode} compact />
+        <CloudPresence people={people} compact />
         <span className="h-4 w-px bg-border/70" aria-hidden="true" />
         <CloudConnectionPill state={connection} compact />
         {scenario.capabilities.canManageSharing ? <CloudShareButton compact /> : null}
-        {scenario.capabilities.canRequestEdit ? <CloudModeButton mode={mode} compact /> : null}
+        <CloudModeToggle compact={false} interaction={interaction} mode={mode} />
         {scenario.capabilities.auth.canSignIn ||
         scenario.capabilities.auth.canUseAuthenticatedIdentity ||
         scenario.capabilities.auth.needsAttention ? (
-          <CloudAccountButton actor={actor} compact />
+          <CloudAccountButton actor={actor} capabilities={effectiveCapabilities} compact />
         ) : null}
       </div>
-      <div className="flex min-h-9 items-center justify-end px-3 py-1">
-        <CloudRuntimePill compact />
+      <div className="[&_[data-slot=notebook-command-toolbar]]:h-9 [&_[data-slot=notebook-command-toolbar]]:px-3">
+        <CloudNotebookToolbar mode={mode} scenario={scenario} />
       </div>
     </div>
   );
@@ -399,43 +442,33 @@ function CloudStatePreview({
 
 function CloudPresence({
   compact,
-  mode,
   people,
 }: {
   compact: boolean;
-  mode: CloudModeState;
   people: readonly NotebookActorIdentity[];
 }) {
-  const summary = presenceSummary(people, mode, compact);
+  const summary = presenceSummary(people, compact);
   const hasPeers = people.length > 0;
 
   return (
-    <div
+    <NotebookPresenceStatus
+      connected={hasPeers}
+      label={summary.label}
+      title={summary.title}
+      variant="inline"
       className={cn(
-        "inline-flex h-8 min-w-0 items-center gap-2 px-1 text-sm text-foreground",
-        compact ? "max-w-[min(18rem,54vw)]" : "max-w-[min(16rem,28vw)]",
+        "px-1",
+        compact ? "max-w-[min(18rem,54vw)]" : "max-w-[min(18rem,42vw)]",
         !hasPeers && "text-muted-foreground",
       )}
-      title={summary.title}
-    >
-      <span className="relative inline-flex size-5 shrink-0 items-center justify-center">
-        <UsersRound className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-        {hasPeers ? (
-          <span className="absolute bottom-0 right-0 size-1.5 rounded-full bg-emerald-500" />
-        ) : null}
-      </span>
-      <span className="min-w-0 truncate">{summary.label}</span>
-    </div>
+    />
   );
 }
 
 function presenceSummary(
   people: readonly NotebookActorIdentity[],
-  mode: CloudModeState,
   compact: boolean,
 ): { label: string; title: string } {
-  const modeLabel = mode === "edit" ? "editing" : "viewing";
-
   if (people.length === 0) {
     return {
       label: compact ? "No live peers" : "No one live here",
@@ -445,13 +478,13 @@ function presenceSummary(
 
   if (compact) {
     return {
-      label: `${people.length} here, ${modeLabel}`,
+      label: `${people.length} here`,
       title: people.map((person) => `${person.label}: ${person.detail ?? "connected"}`).join(", "),
     };
   }
 
   return {
-    label: `${people.length} here now, ${modeLabel}`,
+    label: `${people.length} here now`,
     title: people.map((person) => `${person.label}: ${person.detail ?? "connected"}`).join(", "),
   };
 }
@@ -479,24 +512,6 @@ function CloudConnectionPill({
   );
 }
 
-function CloudRuntimePill({ compact }: { compact: boolean }) {
-  return (
-    <span
-      className="inline-flex h-8 max-w-[10rem] items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-blue-700 transition-colors hover:bg-blue-500/10 dark:text-blue-300"
-      title="Notebook language, runtime detached in cloud preview"
-    >
-      <Code2 className="size-3.5 shrink-0" aria-hidden="true" />
-      <span className="truncate">Python</span>
-      {!compact ? (
-        <>
-          <span className="text-blue-700/45 dark:text-blue-300/45">/</span>
-          <span className="text-blue-700/60 dark:text-blue-300/60">detached</span>
-        </>
-      ) : null}
-    </span>
-  );
-}
-
 function CloudShareButton({ compact }: { compact: boolean }) {
   return (
     <button
@@ -509,31 +524,92 @@ function CloudShareButton({ compact }: { compact: boolean }) {
   );
 }
 
-function CloudModeButton({ compact, mode }: { compact: boolean; mode: CloudModeState }) {
-  const Icon = mode === "edit" ? BookOpen : Pencil;
-  const label = mode === "edit" ? "View" : "Edit";
+function CloudModeToggle({
+  compact,
+  interaction,
+  mode,
+  onModeChange,
+}: {
+  compact: boolean;
+  interaction: NotebookInteractionModeProjection;
+  mode: CloudModeState;
+  onModeChange?: (mode: CloudModeState) => void;
+}) {
+  if (!interaction.canRequestEdit && interaction.state === "viewing") {
+    return (
+      <span
+        className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-muted-foreground"
+        title="This notebook is view-only for the current identity"
+      >
+        <CheckCircle2 className="size-3.5" aria-hidden="true" />
+        {compact ? null : <span>View only</span>}
+      </span>
+    );
+  }
+
+  if (compact) {
+    return (
+      <NotebookEditModeButton
+        mode={mode}
+        state={interaction.state}
+        onModeChange={(nextMode) => onModeChange?.(nextMode)}
+        className="border-0 bg-transparent px-1.5 shadow-none"
+      />
+    );
+  }
 
   return (
-    <button
-      type="button"
-      aria-pressed={mode === "edit"}
-      className={cn(
-        "inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium transition-colors hover:bg-muted/70",
-        mode === "edit" ? "text-emerald-700 dark:text-emerald-300" : "text-foreground",
-      )}
-      title={mode === "edit" ? "Return to read-only viewing" : "Request edit access"}
-    >
-      <Icon className="size-3.5" aria-hidden="true" />
-      {compact ? null : <span>{label}</span>}
-    </button>
+    <NotebookEditModeButton
+      mode={mode}
+      state={interaction.state}
+      onModeChange={(nextMode) => onModeChange?.(nextMode)}
+      variant="segmented"
+      className="h-8 rounded-md bg-muted/35 p-0.5 text-sm"
+    />
   );
+}
+
+function cloudInteractionProjection(
+  scenario: ElementsNotebookScenario,
+  mode: CloudModeState,
+): NotebookInteractionModeProjection {
+  return createNotebookInteractionModeProjection({
+    selectedMode: mode,
+    permission: {
+      canEditMarkdown: scenario.capabilities.canEditMarkdown,
+      canEditCells: scenario.capabilities.canEditCells,
+      canEditStructure: scenario.capabilities.canEditStructure,
+    },
+    hostSupport: {
+      canEditMarkdown: scenario.capabilities.canEditMarkdown,
+      canEditCells: scenario.capabilities.canEditCells,
+      canEditStructure: scenario.capabilities.canEditStructure,
+      canRequestEdit: scenario.capabilities.canRequestEdit,
+    },
+  });
+}
+
+function withInteractionProjection(
+  capabilities: NotebookShellCapabilities,
+  interaction: NotebookInteractionModeProjection,
+): NotebookShellCapabilities {
+  return {
+    ...capabilities,
+    canEditMarkdown: interaction.canEditMarkdown,
+    canEditCells: interaction.canEditCells,
+    canEditStructure: interaction.canEditStructure,
+    canRequestEdit: interaction.canRequestEdit,
+    interaction,
+  };
 }
 
 function CloudAccountButton({
   actor,
+  capabilities,
   compact,
 }: {
   actor: NotebookActorIdentity;
+  capabilities: NotebookShellCapabilities;
   compact: boolean;
 }) {
   if (actor.kind === "public") {
@@ -551,11 +627,16 @@ function CloudAccountButton({
   return (
     <button
       type="button"
-      className="inline-flex h-8 max-w-[min(14rem,34vw)] items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
+      className="inline-flex h-8 max-w-[min(14rem,34vw)] items-center rounded-md px-1.5 transition-colors hover:bg-muted/70"
       title={actor.detail ?? actor.label}
     >
-      <span className="size-2 rounded-full bg-emerald-500" aria-hidden="true" />
-      <span className={cn("min-w-0 truncate", compact && "max-w-16")}>{actor.label}</span>
+      <NotebookIdentityBadge
+        actor={actor}
+        variant="inline"
+        showDetail={false}
+        className={cn("max-w-full", compact && "max-w-16")}
+      />
+      <span className="sr-only">{capabilities.access.level} account</span>
     </button>
   );
 }

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -1,0 +1,26 @@
+---
+title: Cloud notebook shell
+description: A fluid cloud notebook chrome mockup for presence, access, sync, mode, and auth.
+---
+
+import { CloudNotebookShellExample } from "@/components/cloud-notebook-shell-example";
+
+Cloud notebooks reuse the document shell, rail, cells, and output language from
+desktop, but the host adds a few top-level concerns: room presence, document
+sync health, view/edit mode, sharing, and account controls.
+
+This mockup separates those concerns from runtime state. A cloud notebook can be
+live, reconnecting, signed out, public, or edit-requested without making the
+Python runtime chip carry those meanings.
+
+<CloudNotebookShellExample />
+
+## Implementation intent
+
+- `NotebookDocumentHeader` should keep slot policy shared while cloud provides
+  host-owned controls for presence, document sync, sharing, mode, and auth.
+- Online/offline state should be projected from cloud transport and room state,
+  not from `RuntimeStateDoc`.
+- Runtime state should describe language and execution capability only.
+- Elements scenarios should continue to model desktop and cloud differences
+  through capability facts, not forked shell components.

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -13,14 +13,43 @@ This mockup separates those concerns from runtime state. A cloud notebook can be
 live, reconnecting, signed out, public, or edit-requested without making the
 Python runtime chip carry those meanings.
 
+The first toolbar row is app-level cloud chrome. It answers "who is here, is the
+document connected, can I share, am I viewing or editing, and which account is
+active?" The second row is notebook chrome. It should continue to use the shared
+`NotebookCommandToolbar` for cell insertion, package/runtime language, and
+execution controls.
+
 <CloudNotebookShellExample />
 
 ## Implementation intent
 
-- `NotebookDocumentHeader` should keep slot policy shared while cloud provides
-  host-owned controls for presence, document sync, sharing, mode, and auth.
+- Cloud should own an app-level toolbar for presence, document sync, sharing,
+  view/edit state, and auth.
+- The notebook toolbar should remain the normal notebook-level surface for cell
+  insertion, package/runtime language, and execution controls.
+- The app row should compose shared primitives where possible:
+  `NotebookPresenceStatus`, `NotebookEditModeButton`, and account identity
+  surfaces. Cloud-specific transport and sharing controls can remain host-owned
+  slots.
 - Online/offline state should be projected from cloud transport and room state,
   not from `RuntimeStateDoc`.
-- Runtime state should describe language and execution capability only.
+- Runtime state should describe language and execution capability only; cloud
+  transport should not be folded into the Python badge.
+- Presence copy should name the room population only. View/edit state already
+  has its own control, so labels like `2 here now, viewing` are redundant.
+- View/edit is a local interaction mode over host permissions. Users with edit
+  permission can step into read-only viewing without requesting access again;
+  denied users stay gated by the host capability projection.
 - Elements scenarios should continue to model desktop and cloud differences
   through capability facts, not forked shell components.
+
+## Surface split
+
+| Surface           | Shared component         | Host-owned input                            |
+| ----------------- | ------------------------ | ------------------------------------------- |
+| Presence          | `NotebookPresenceStatus` | room participant projection                 |
+| View/edit mode    | `NotebookEditModeButton` | ACL plus selected interaction mode          |
+| Notebook commands | `NotebookCommandToolbar` | runtime, package, and cell action callbacks |
+| Connection        | cloud slot               | room transport health                       |
+| Sharing           | cloud slot               | invite and ACL actions                      |
+| Account           | identity slot            | signed-in user and auth attention state     |

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -34,6 +34,7 @@ The catalog should make it obvious which surfaces are nteract-owned notebook
 concepts and which boundaries still need a notebook-semantic wrapper.
 
 - [Notebook shell capabilities](/docs/notebook-shell-capabilities)
+- [Cloud notebook shell](/docs/cloud-notebook-shell)
 - [Identity and environment surfaces](/docs/identity-environment-surfaces)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)


### PR DESCRIPTION
## Summary

- Add an Elements page for the cloud notebook shell direction.
- Document the app-level versus notebook-level toolbar split for cloud.
- Show cloud presence, sync, sharing, view/edit mode, auth, and notebook command chrome using shared shell primitives.
- Keep presence copy focused on room population, with view/edit state represented by the mode toggle.

## Verification

- `pnpm exec vp check --fix apps/elements/components/cloud-notebook-shell-example.tsx apps/elements/content/docs/cloud-notebook-shell.mdx`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Playwright smoke at wide and compact viewports against `/docs/cloud-notebook-shell`

## Notes

The page is intentionally documentation and design guidance. It uses inert callbacks and fixture scenarios so cloud can follow the language without coupling Elements to hosted runtime state.
