### PR TITLE
feat(notebook-shell): project execution actor labels

### DIFF
--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -39,7 +39,7 @@ const executionStates: ExecutionState[] = [
     count: 12,
     isQueued: true,
     queuePriority: 0.7,
-    submittedByActorLabel: "Kyle Kelley",
+    submittedByActorLabel: "user:anaconda:kyle/browser:cloud",
   },
   {
     id: "running",
@@ -47,7 +47,7 @@ const executionStates: ExecutionState[] = [
     detail: "Active execution moves through the compact stop button and current-line signal.",
     count: 12,
     isExecuting: true,
-    submittedByActorLabel: "Kyle Kelley",
+    submittedByActorLabel: "user:anaconda:kyle/agent:codex:s1",
   },
   {
     id: "completed",

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -133,5 +133,11 @@ describe("cloud viewer presence", () => {
       }),
       "alice@example.com",
     );
+    assert.equal(
+      cloudFriendlyPeerLabel({
+        actorLabel: "user:anaconda:kyle/agent:codex:s1",
+      }),
+      "Codex for Kyle",
+    );
   });
 });

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,5 +1,8 @@
 import type { SessionControlMessage } from "../src/protocol";
-import { friendlyNotebookActorLabel } from "@/components/notebook-shell/actor-labels";
+import {
+  notebookActorIdentityFromProjection,
+  notebookActorProjectionFromLabel,
+} from "@/components/notebook-shell/actor-projection";
 
 export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
 
@@ -131,7 +134,12 @@ export function cloudFriendlyPeerLabel({
     return trimmedEmail;
   }
 
-  return friendlyNotebookActorLabel(actorLabel) ?? "Peer";
+  const trimmedActorLabel = actorLabel?.trim();
+  if (!trimmedActorLabel) return "Peer";
+
+  return notebookActorIdentityFromProjection(
+    notebookActorProjectionFromLabel(trimmedActorLabel, { source: "cloud", isPublic: false }),
+  ).label;
 }
 
 function safeRoomPeerCount(value: number): number {

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -1,4 +1,8 @@
 import { Play, Square } from "lucide-react";
+import {
+  notebookActorIdentityFromProjection,
+  notebookActorProjectionFromLabel,
+} from "@/components/notebook-shell/actor-projection";
 import { cn } from "@/lib/utils";
 
 interface CompactExecutionButtonProps {
@@ -26,6 +30,11 @@ interface CompactExecutionButtonProps {
 
 function formatExecutionCount(count: number): string {
   return count > 999 ? "999" : String(count);
+}
+
+function submittedByDisplayLabel(actorLabel: string | null): string | null {
+  if (!actorLabel) return null;
+  return notebookActorIdentityFromProjection(notebookActorProjectionFromLabel(actorLabel)).label;
 }
 
 /**
@@ -56,6 +65,7 @@ export function CompactExecutionButton({
           ? "ran"
           : "idle";
   const displayCount = count === null ? null : formatExecutionCount(count);
+  const submittedByLabel = submittedByDisplayLabel(submittedByActorLabel);
   const handleClick = () => {
     if (!canExecute) return;
     if (isQueued) return; // already in queue — no-op
@@ -68,12 +78,12 @@ export function CompactExecutionButton({
 
   const title = canExecute
     ? isExecuting
-      ? submittedByActorLabel
-        ? `Stop execution submitted by ${submittedByActorLabel}`
+      ? submittedByLabel
+        ? `Stop execution submitted by ${submittedByLabel}`
         : "Stop execution"
       : isQueued
-        ? submittedByActorLabel
-          ? `Queued for execution by ${submittedByActorLabel}`
+        ? submittedByLabel
+          ? `Queued for execution by ${submittedByLabel}`
           : "Queued for execution"
         : count !== null
           ? isErrored

--- a/src/components/cell/__tests__/CompactExecutionButton.test.tsx
+++ b/src/components/cell/__tests__/CompactExecutionButton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CompactExecutionButton } from "../CompactExecutionButton";
+
+describe("CompactExecutionButton", () => {
+  it("uses shared actor projection labels for queued execution attribution", () => {
+    render(
+      <CompactExecutionButton
+        count={1}
+        isQueued
+        submittedByActorLabel="user:anaconda:kyle/browser:cloud"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Queued for execution by Kyle" })).toBeTruthy();
+  });
+
+  it("uses delegated operator labels for active execution attribution", () => {
+    render(
+      <CompactExecutionButton
+        count={1}
+        isExecuting
+        submittedByActorLabel="user:anaconda:kyle/agent:codex:s1"
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Stop execution submitted by Codex for Kyle" }),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/notebook-shell/actor-projection.ts
+++ b/src/components/notebook-shell/actor-projection.ts
@@ -84,6 +84,44 @@ export function notebookActorProjectionFromRuntime(
   );
 }
 
+export interface NotebookActorProjectionFromLabelOptions {
+  source?: NotebookShellAccessCapabilities["source"];
+  scope?: NotebookActorProjection["scope"];
+  identityLabel?: string | null;
+  isPublic?: boolean;
+  status?: NotebookActorProjection["status"];
+}
+
+export function notebookActorProjectionFromLabel(
+  actorLabel: string,
+  options: NotebookActorProjectionFromLabelOptions = {},
+): NotebookActorProjection {
+  const source = options.source ?? "unknown";
+  const isPublic = options.isPublic ?? actorLabel.startsWith("anonymous:");
+  const [principalId, operatorId] = splitNotebookActorPrincipalOperator(actorLabel);
+  const legacyProjection = parseNotebookActorLabel(actorLabel);
+  const principalLabel =
+    options.identityLabel ??
+    legacyProjection?.onBehalfOf ??
+    friendlyNotebookActorLabel(principalId) ??
+    (isPublic ? "Public viewer" : "Unknown viewer");
+
+  return {
+    actorLabel,
+    principal: {
+      id: principalId,
+      label: isPublic ? "Public viewer" : principalLabel,
+      source: principalSource(principalId, source, isPublic),
+    },
+    operator:
+      legacyProjection && (isLegacyAgentLabel(actorLabel) || !operatorId)
+        ? legacyOperatorFromProjection(actorLabel, legacyProjection)
+        : operatorFromLabel(operatorId, source),
+    scope: options.scope,
+    status: options.status,
+  };
+}
+
 export function notebookActorIdentityFromProjection(
   actor: NotebookActorProjection,
 ): NotebookActorIdentity {


### PR DESCRIPTION
## Summary

- add a shared helper that projects durable actor labels into `NotebookActorProjection`
- route compact execution attribution through the shared actor projection/display identity path
- route cloud presence fallback labels through the same shared projection path
- update the Elements execution-language fixture to use durable actor labels instead of pre-friendly display strings

## Verification

- `pnpm test:run src/components/cell/__tests__/CompactExecutionButton.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-presence.test.ts test/live-presence.test.ts`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
