### PR TITLE
fix(notebook): hide local desktop identity chrome

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -43,7 +43,6 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookToolbarIdentity,
 } from "@/components/notebook-shell";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import { type DaemonStatus, DaemonStatusBanner } from "./components/DaemonStatusBanner";
@@ -2028,7 +2027,6 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
-          trailingControls={<NotebookToolbarIdentity capabilities={shellCapabilities} />}
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -21,6 +21,7 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canExecute).toBe(true);
     expect(capabilities.canManagePackages).toBe(true);
     expect(capabilities.canManageSharing).toBe(false);
+    expect(capabilities.auth.canUseAuthenticatedIdentity).toBe(false);
     expect(capabilities.interaction).toMatchObject({
       selectedMode: "edit",
       activeMode: "edit",
@@ -70,6 +71,7 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(capabilities.canRequestEdit).toBe(false);
     expect(capabilities.canExecute).toBe(false);
     expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.auth.canUseAuthenticatedIdentity).toBe(true);
     expect(capabilities.interaction).toMatchObject({
       selectedMode: "view",
       activeMode: "view",

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -77,7 +77,7 @@ export function desktopNotebookShellCapabilities({
     },
     auth: {
       canSignIn: false,
-      canUseAuthenticatedIdentity: Boolean(localActor),
+      canUseAuthenticatedIdentity: source === "cloud" && Boolean(localActor),
       needsAttention: false,
     },
     runtime: {

--- a/src/components/notebook-shell/NotebookIdentity.tsx
+++ b/src/components/notebook-shell/NotebookIdentity.tsx
@@ -54,9 +54,7 @@ export function NotebookIdentityBadge({
     <div
       className={cn(
         "inline-flex min-w-0 items-center text-foreground",
-        inline
-          ? "gap-2"
-          : "gap-2 rounded-full border border-border bg-background px-2 py-1 shadow-sm",
+        inline ? "gap-2" : "gap-2 rounded-md border border-border/70 bg-muted/35 px-2 py-1",
         size === "sm" && !inline && "gap-1.5 px-1.5 py-0.5",
         className,
       )}


### PR DESCRIPTION
## Summary

- removes the local desktop identity badge from the notebook toolbar
- stops local desktop actor labels from being projected as authenticated app chrome
- flattens the shared identity badge treatment so Elements no longer teaches the raised bubble look

## Verification

- `pnpm exec vp test run apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts src/components/notebook-shell/__tests__/NotebookToolbarIdentity.test.tsx src/components/notebook-shell/__tests__/NotebookCommandToolbar.test.tsx`
- `pnpm exec vp check --fix apps/notebook/src/App.tsx apps/notebook/src/lib/desktop-shell-capabilities.ts apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts src/components/notebook-shell/NotebookIdentity.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- Playwright smoke against `http://localhost:9866/` verified `identityCount: 0` for `[data-slot=notebook-toolbar-identity]`

## Notes

The latest tag, `v2.5.2-nightly.202606011601`, already includes the shared chrome work and identity audit. This cleanup is one commit after the tag on current `origin/main`.
