### PR TITLE
feat(notebook): show shared toolbar identity

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -3,11 +3,12 @@ import { useCallback, useEffect, useState, type ReactElement, type ReactNode } f
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import {
   NotebookCommandToolbar,
+  NotebookToolbarIdentity,
   NotebookToolbarFrame,
   type NotebookCommandRuntimeState,
   type NotebookEnvironmentManager,
-  type NotebookShellCapabilities,
 } from "@/components/notebook-shell";
+import type { NotebookShellCapabilities } from "@/components/notebook-shell";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import { KERNEL_ERROR_REASON, type EnvProgressState, type ProjectContext } from "runtimed";
 import {
@@ -47,15 +48,7 @@ interface NotebookToolbarProps {
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
-  capabilities: Pick<
-    NotebookShellCapabilities,
-    | "canEditStructure"
-    | "canExecute"
-    | "canViewPackages"
-    | "canManageSharing"
-    | "canRequestEdit"
-    | "auth"
-  >;
+  capabilities: NotebookShellCapabilities;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
   depsOutOfSync?: boolean;
   updateStatus?: UpdateStatus;
@@ -169,6 +162,9 @@ export function NotebookToolbar({
         : (envTypeHint ?? null)
       : null;
   const runtimeStatusState = notebookCommandRuntimeState(kernelStatus, Boolean(envErrorMessage));
+  const identityControls = trailingControls ?? (
+    <NotebookToolbarIdentity capabilities={capabilities} variant="inline" />
+  );
   const runtimeStatusError = envErrorMessage ? (
     <HoverCard openDelay={150} closeDelay={100}>
       <HoverCardTrigger asChild>
@@ -278,7 +274,7 @@ export function NotebookToolbar({
               }
             : null
         }
-        identityControls={trailingControls}
+        identityControls={identityControls}
       />
     </NotebookToolbarFrame>
   );

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -75,15 +75,56 @@ const baseProps = {
     canViewPackages: true,
     canManageSharing: false,
     canRequestEdit: false,
+    access: {
+      level: "owner",
+      source: "local",
+      isPublic: false,
+      actorLabel: "local:kyle/desktop:window",
+      identityLabel: null,
+      actor: {
+        actorLabel: "local:kyle/desktop:window",
+        principal: {
+          id: "local:kyle",
+          label: "Kyle",
+          source: { provider: "local", namespace: "kyle" },
+        },
+        operator: { id: "desktop:window", kind: "desktop", label: "Desktop" },
+        scope: "owner",
+      },
+    },
     auth: {
       canSignIn: false,
       canUseAuthenticatedIdentity: false,
       needsAttention: false,
     },
+    runtime: {
+      canWriteRuntimeState: true,
+      connected: true,
+      source: "local",
+      actorLabel: "local:kyle/desktop:window",
+      identityLabel: null,
+      actor: {
+        actorLabel: "local:kyle/desktop:window",
+        principal: {
+          id: "local:kyle",
+          label: "Kyle",
+          source: { provider: "local", namespace: "kyle" },
+        },
+        operator: { id: "desktop:window", kind: "desktop", label: "Desktop" },
+        scope: "runtime_peer",
+      },
+    },
   },
 };
 
 describe("NotebookToolbar", () => {
+  it("renders desktop actor identity through the shared toolbar identity surface", () => {
+    render(<NotebookToolbar {...baseProps} />);
+
+    expect(screen.getByLabelText("Notebook actors")).toBeInTheDocument();
+    expect(screen.getByText("Kyle")).toBeInTheDocument();
+  });
+
   describe("start button visibility", () => {
     it("hides start button when kernel is idle", () => {
       render(<NotebookToolbar {...baseProps} {...propsForStatus(KERNEL_STATUS.IDLE)} />);


### PR DESCRIPTION
## Summary

- show desktop notebook actor identity through the shared `NotebookToolbarIdentity` surface
- make `NotebookToolbar` consume the full `NotebookShellCapabilities` projection instead of a command-only subset
- cover the desktop toolbar identity path with a focused component test

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Notes

This keeps the work in the shared notebook toolbar path: desktop now renders the same identity primitive cloud uses, while host-specific actor facts still come from each host capability adapter.
