### PR TITLE
refactor(elements): extract generic rail shell

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -13,6 +13,7 @@
 @source "../../../src/components/notebook-rail/**/*.{ts,tsx}";
 @source "../../../src/components/notebook-shell/**/*.{ts,tsx}";
 @source "../../../src/components/outputs/**/*.{ts,tsx}";
+@source "../../../src/components/rail/**/*.{ts,tsx}";
 @source "../../../src/components/ui/**/*.{ts,tsx}";
 @source "../../../src/components/widgets/**/*.{ts,tsx}";
 @source "../../../apps/notebook/src/components/**/*.{ts,tsx}";

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -27,7 +27,8 @@ variant instead of adding docs-only chrome inside the rail.
 - `NotebookToolbar` is imported from `apps/notebook/src/components` with inert
   fixture callbacks and runtime status props.
 - `NotebookDocumentRail` comes from `src/components/notebook-shell`; its
-  packages panel uses `NotebookPackagesPanel` from `src/components/notebook-rail`.
+  generic rail frame comes from `src/components/rail`, and its packages panel
+  uses `NotebookPackagesPanel` from `src/components/notebook-rail`.
   Docs own active panel, collapsed state, outline selection, and inert
   navigation callbacks.
 - The package panel imports `DependencyHeader` from the notebook app with

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -20,6 +20,8 @@
       "@/components/notebook-rail": ["../../src/components/notebook-rail/index.ts"],
       "@/components/notebook-rail/*": ["../../src/components/notebook-rail/*"],
       "@/components/outputs/*": ["../../src/components/outputs/*"],
+      "@/components/rail": ["../../src/components/rail/index.ts"],
+      "@/components/rail/*": ["../../src/components/rail/*"],
       "@/components/ui/*": ["../../src/components/ui/*"],
       "@/components/widgets/*": ["../../src/components/widgets/*"],
       "@/hooks/*": ["../../src/hooks/*"],

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, ListTree, Package, type LucideIcon } from "lucide-react";
+import { ListTree, Package } from "lucide-react";
 import { useMemo, type DragEvent, type MouseEvent, type ReactNode } from "react";
 import {
   buildNotebookOutlineTree,
@@ -6,14 +6,20 @@ import {
   type NotebookOutlineItem,
   type NotebookOutlineTreeNode,
 } from "runtimed";
+import {
+  Rail,
+  RAIL_TAKEOVER_MEDIA_QUERY,
+  RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+  RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  type RailItem,
+} from "@/components/rail";
 import { cn } from "@/lib/utils";
 
 export type NotebookRailPanelId = "outline" | "packages";
 
-export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
-export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
-export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES =
-  "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
+export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = RAIL_TAKEOVER_MEDIA_QUERY;
+export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = RAIL_TAKEOVER_STAGE_CLASS_NAME;
+export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES = RAIL_TAKEOVER_PANEL_CLASS_NAMES;
 const NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,18rem)] min-w-60";
 const NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,17rem)] min-w-60";
 
@@ -35,11 +41,7 @@ export interface NotebookRailProps {
   className?: string;
 }
 
-const railButtons: Array<{
-  id: NotebookRailPanelId;
-  label: string;
-  icon: LucideIcon;
-}> = [
+const railButtons: Array<RailItem<NotebookRailPanelId>> = [
   { id: "outline", label: "Outline", icon: ListTree },
   { id: "packages", label: "Packages", icon: Package },
 ];
@@ -63,131 +65,50 @@ export function NotebookRail({
 }: NotebookRailProps) {
   const title = activePanelId === "outline" ? "Outline" : "Packages";
   const summary = activePanelId === "packages" ? packagesSummary : null;
+  const panelClassName =
+    activePanelId === "packages"
+      ? NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME
+      : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME;
 
   return (
-    <aside
-      className={cn("flex min-h-0 shrink-0 border-r bg-background", className)}
-      data-testid="notebook-rail"
-      data-collapsed={collapsed ? "true" : "false"}
+    <Rail
+      activePanelId={activePanelId}
+      collapsed={collapsed}
+      items={railButtons}
+      panelEyebrow="Notebook"
+      panelTitle={title}
+      panelSummary={summary}
+      panelClassName={panelClassName}
+      className={className}
+      dataTestId="notebook-rail"
+      collapseButtonSlot="notebook-rail-collapse-button"
+      panelSlot="notebook-rail-panel"
+      panelTitleRowSlot="notebook-rail-panel-title-row"
+      onActivePanelChange={onActivePanelChange}
+      onCollapsedChange={onCollapsedChange}
     >
-      <div className="flex w-12 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 px-2 py-3">
-        <NotebookRailButton
-          label={collapsed ? "Expand rail" : "Collapse rail"}
-          icon={collapsed ? ChevronRight : ChevronLeft}
-          active={false}
-          dataSlot="notebook-rail-collapse-button"
-          onClick={() => onCollapsedChange(!collapsed)}
+      {activePanelId === "outline" ? (
+        <NotebookOutlinePanel
+          items={outlineItems}
+          cellIds={outlineCellIds}
+          activeItemId={activeOutlineItemId}
+          selectedItemId={selectedOutlineItemId}
+          selectedCellId={selectedOutlineCellId}
+          onSelectItem={onSelectOutlineItem}
+          onNavigateItem={onNavigateOutlineItem}
+          getItemHref={getOutlineItemHref}
         />
-        {railButtons.map((item) => (
-          <NotebookRailButton
-            key={item.id}
-            label={item.label}
-            icon={item.icon}
-            active={!collapsed && activePanelId === item.id}
-            onClick={() => {
-              if (!collapsed && activePanelId === item.id) {
-                onCollapsedChange(true);
-                return;
-              }
-              onActivePanelChange(item.id);
-              onCollapsedChange(false);
-            }}
-          />
-        ))}
-      </div>
-
-      {!collapsed && (
-        <div
-          className={cn(
-            "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
-            activePanelId === "packages"
-              ? NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME
-              : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME,
-            NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
-          )}
-          data-slot="notebook-rail-panel"
-        >
-          <div className="border-b px-4 py-3">
-            <div className="flex flex-col gap-1.5">
-              <div className="min-w-0">
-                <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
-                  Notebook
-                </p>
-              </div>
-              <div
-                className="flex min-w-0 flex-wrap items-center justify-between gap-2"
-                data-slot="notebook-rail-panel-title-row"
-              >
-                <h2 className="text-sm font-semibold text-foreground">{title}</h2>
-                {summary && (
-                  <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
-                    {summary}
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto p-3">
-            {activePanelId === "outline" ? (
-              <NotebookOutlinePanel
-                items={outlineItems}
-                cellIds={outlineCellIds}
-                activeItemId={activeOutlineItemId}
-                selectedItemId={selectedOutlineItemId}
-                selectedCellId={selectedOutlineCellId}
-                onSelectItem={onSelectOutlineItem}
-                onNavigateItem={onNavigateOutlineItem}
-                getItemHref={getOutlineItemHref}
-              />
-            ) : (
-              packagesPanel
-            )}
-          </div>
-        </div>
+      ) : (
+        packagesPanel
       )}
-    </aside>
+    </Rail>
   );
 }
 
-export interface NotebookRailButtonProps {
-  label: string;
-  icon: LucideIcon;
-  dataSlot?: string;
-  active?: boolean;
-  disabled?: boolean;
-  onClick?: () => void;
-}
-
-export function NotebookRailButton({
-  label,
-  icon: Icon,
-  dataSlot,
-  active = false,
-  disabled = false,
-  onClick,
-}: NotebookRailButtonProps) {
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-pressed={active}
-      title={label}
-      disabled={disabled}
-      onClick={onClick}
-      data-slot={dataSlot}
-      className={cn(
-        "flex size-8 items-center justify-center rounded-md border text-xs transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
-        active
-          ? "border-primary bg-primary text-primary-foreground"
-          : "border-transparent text-muted-foreground hover:border-border hover:bg-background hover:text-foreground",
-        disabled && "cursor-not-allowed opacity-40 hover:border-transparent hover:bg-transparent",
-      )}
-    >
-      <Icon className="size-4" aria-hidden="true" />
-    </button>
-  );
-}
+export {
+  RailButton as NotebookRailButton,
+  type RailButtonProps as NotebookRailButtonProps,
+} from "@/components/rail";
 
 export interface NotebookOutlinePanelProps {
   items: readonly NotebookOutlineItem[];

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -1,0 +1,162 @@
+import { ChevronLeft, ChevronRight, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export const RAIL_TAKEOVER_MEDIA_QUERY = "(max-width: 599.98px)";
+export const RAIL_TAKEOVER_STAGE_CLASS_NAME = "max-[599.98px]:hidden";
+export const RAIL_TAKEOVER_PANEL_CLASS_NAMES =
+  "max-[599.98px]:w-[calc(100vw-3rem)] max-[599.98px]:min-w-0 max-[599.98px]:max-w-none";
+
+export interface RailItem<PanelId extends string = string> {
+  id: PanelId;
+  label: string;
+  icon: LucideIcon;
+  disabled?: boolean;
+}
+
+export interface RailProps<PanelId extends string = string> {
+  activePanelId: PanelId;
+  collapsed: boolean;
+  items: readonly RailItem<PanelId>[];
+  panelTitle: string;
+  children: ReactNode;
+  onActivePanelChange: (panelId: PanelId) => void;
+  onCollapsedChange: (collapsed: boolean) => void;
+  panelEyebrow?: string;
+  panelSummary?: string | null;
+  panelClassName?: string;
+  className?: string;
+  dataTestId?: string;
+  collapseButtonSlot?: string;
+  panelSlot?: string;
+  panelTitleRowSlot?: string;
+}
+
+export function Rail<PanelId extends string = string>({
+  activePanelId,
+  collapsed,
+  items,
+  panelTitle,
+  panelEyebrow,
+  panelSummary = null,
+  panelClassName,
+  children,
+  onActivePanelChange,
+  onCollapsedChange,
+  className,
+  dataTestId = "rail",
+  collapseButtonSlot = "rail-collapse-button",
+  panelSlot = "rail-panel",
+  panelTitleRowSlot = "rail-panel-title-row",
+}: RailProps<PanelId>) {
+  return (
+    <aside
+      className={cn("flex min-h-0 shrink-0 border-r bg-background", className)}
+      data-testid={dataTestId}
+      data-collapsed={collapsed ? "true" : "false"}
+    >
+      <div className="flex w-12 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 px-2 py-3">
+        <RailButton
+          label={collapsed ? "Expand rail" : "Collapse rail"}
+          icon={collapsed ? ChevronRight : ChevronLeft}
+          active={false}
+          dataSlot={collapseButtonSlot}
+          onClick={() => onCollapsedChange(!collapsed)}
+        />
+        {items.map((item) => (
+          <RailButton
+            key={item.id}
+            label={item.label}
+            icon={item.icon}
+            active={!collapsed && activePanelId === item.id}
+            disabled={item.disabled}
+            onClick={() => {
+              if (item.disabled) return;
+              if (!collapsed && activePanelId === item.id) {
+                onCollapsedChange(true);
+                return;
+              }
+              onActivePanelChange(item.id);
+              onCollapsedChange(false);
+            }}
+          />
+        ))}
+      </div>
+
+      {!collapsed && (
+        <div
+          className={cn(
+            "flex min-h-0 max-w-[calc(100vw-3rem)] flex-col bg-background",
+            panelClassName,
+            RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+          )}
+          data-slot={panelSlot}
+        >
+          <div className="border-b px-4 py-3">
+            <div className="flex flex-col gap-1.5">
+              {panelEyebrow && (
+                <div className="min-w-0">
+                  <p className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                    {panelEyebrow}
+                  </p>
+                </div>
+              )}
+              <div
+                className="flex min-w-0 flex-wrap items-center justify-between gap-2"
+                data-slot={panelTitleRowSlot}
+              >
+                <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
+                {panelSummary && (
+                  <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+                    {panelSummary}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-3">{children}</div>
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export interface RailButtonProps {
+  label: string;
+  icon: LucideIcon;
+  dataSlot?: string;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export function RailButton({
+  label,
+  icon: Icon,
+  dataSlot,
+  active = false,
+  disabled = false,
+  onClick,
+}: RailButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      data-slot={dataSlot}
+      className={cn(
+        "flex size-8 items-center justify-center rounded-md border text-xs transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-transparent text-muted-foreground hover:border-border hover:bg-background hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-40 hover:border-transparent hover:bg-transparent",
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Boxes, ListTree } from "lucide-react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+  RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  Rail,
+  RailButton,
+} from "../Rail";
+
+type PanelId = "outline" | "packages";
+
+const items = [
+  { id: "outline", label: "Outline", icon: ListTree },
+  { id: "packages", label: "Packages", icon: Boxes },
+] satisfies Array<{ id: PanelId; label: string; icon: typeof ListTree }>;
+
+describe("Rail", () => {
+  it("renders the active panel chrome and content", () => {
+    const { container } = render(
+      <Rail
+        activePanelId="packages"
+        collapsed={false}
+        items={items}
+        panelEyebrow="Notebook"
+        panelTitle="Packages"
+        panelSummary="uv · 2 packages"
+        panelClassName="w-64"
+        dataTestId="example-rail"
+        panelSlot="example-rail-panel"
+        panelTitleRowSlot="example-rail-title-row"
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        <div data-testid="panel-content">Dependencies</div>
+      </Rail>,
+    );
+
+    expect(screen.getByTestId("example-rail")).toHaveAttribute("data-collapsed", "false");
+    expect(screen.getByText("Notebook")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
+    expect(screen.getByText("uv · 2 packages")).toHaveClass("w-fit", "max-w-full");
+    expect(screen.getByTestId("panel-content")).toHaveTextContent("Dependencies");
+    expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass(
+      "w-64",
+      ...RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
+    );
+    expect(container.querySelector('[data-slot="example-rail-title-row"]')).toHaveClass(
+      "flex-wrap",
+    );
+  });
+
+  it("collapses the expanded active panel button", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={items}
+        panelTitle="Outline"
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      >
+        Outline
+      </Rail>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Outline" }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+    expect(onActivePanelChange).not.toHaveBeenCalled();
+  });
+
+  it("expands and selects a panel while collapsed", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <Rail
+        activePanelId="outline"
+        collapsed
+        items={items}
+        panelTitle="Outline"
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      >
+        Outline
+      </Rail>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Packages" }));
+    expect(onActivePanelChange).toHaveBeenCalledWith("packages");
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not invoke callbacks for disabled rail items", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={[items[0], { ...items[1], disabled: true }]}
+        panelTitle="Outline"
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      >
+        Outline
+      </Rail>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Packages" }));
+    expect(onActivePanelChange).not.toHaveBeenCalled();
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("RailButton", () => {
+  it("uses icon-button semantics", () => {
+    render(<RailButton label="Outline" icon={ListTree} active />);
+
+    expect(screen.getByRole("button", { name: "Outline" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Outline" })).toHaveClass(
+      "border-primary",
+      "bg-primary",
+    );
+  });
+
+  it("exports the stage takeover class with the rail contract", () => {
+    expect(RAIL_TAKEOVER_STAGE_CLASS_NAME).toBe("max-[599.98px]:hidden");
+  });
+});

--- a/src/components/rail/index.ts
+++ b/src/components/rail/index.ts
@@ -1,0 +1,10 @@
+export {
+  Rail,
+  RailButton,
+  RAIL_TAKEOVER_MEDIA_QUERY,
+  RAIL_TAKEOVER_PANEL_CLASS_NAMES,
+  RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  type RailButtonProps,
+  type RailItem,
+  type RailProps,
+} from "./Rail";


### PR DESCRIPTION
## Summary

- Extract generic rail frame/button behavior into `src/components/rail`
- Keep notebook-specific outline/package panels in `src/components/notebook-rail`
- Add direct rail shell tests and wire Elements docs/build scanning to the new shared namespace

## Verification

- `pnpm test:run -- src/components/rail/__tests__/Rail.test.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- Playwright smoke check: `http://localhost:5176/docs/notebook-outline`
