### PR TITLE
refactor(cell): share cell support surfaces

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -9,10 +9,10 @@ import {
   Search,
   ShieldCheck,
 } from "lucide-react";
-import { useEffect, type ReactNode } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { CellInsertionRibbon } from "@/components/cell/CellInsertionRibbon";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
+import { CellPresenceIndicators } from "@/components/cell/CellPresenceIndicators";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import {
@@ -20,9 +20,6 @@ import {
   getElementsNotebookScenario,
   resolveElementsNotebookLanguage,
 } from "@/components/notebook-scenarios";
-import { CellPresenceIndicators } from "@/notebook-components/cell/CellPresenceIndicators";
-import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
-import { emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 
 const anatomyScenario = getElementsNotebookScenario("desktop-local-owner");
 const primaryCell = getElementsNotebookPrimaryCodeCell(anatomyScenario.cells);
@@ -55,8 +52,8 @@ const layers = [
   },
   {
     name: "CellPresenceIndicators",
-    source: "apps/notebook/src/components/cell/CellPresenceIndicators.tsx",
-    role: "Remote peer markers backed by the cursor registry and presence bus.",
+    source: "src/components/cell/CellPresenceIndicators.tsx",
+    role: "Remote peer markers rendered from adapter-provided presence peers.",
     status: "rendered",
   },
   {
@@ -169,71 +166,11 @@ const insertionRibbonRows = [
   },
 ];
 
-const presenceSnapshot = {
-  type: "snapshot",
-  peer_id: "local-docs-peer",
-  peers: [
-    {
-      peer_id: "peer-forecast",
-      peer_label: "forecast reviewer",
-      actor_label: "Forecast Reviewer",
-      channels: [
-        {
-          channel: "cursor",
-          data: { cell_id: primaryCellId, line: 2, column: 18 },
-        },
-      ],
-    },
-    {
-      peer_id: "peer-runtime",
-      peer_label: "runtime analyst",
-      actor_label: "Runtime Analyst",
-      channels: [
-        {
-          channel: "focus",
-          data: { cell_id: primaryCellId },
-        },
-      ],
-    },
-    {
-      peer_id: "peer-output",
-      peer_label: "output reviewer",
-      actor_label: "Output Reviewer",
-      channels: [
-        {
-          channel: "selection",
-          data: {
-            cell_id: primaryCellId,
-            anchor_line: 1,
-            anchor_col: 0,
-            head_line: 1,
-            head_col: 16,
-          },
-        },
-        {
-          channel: "cursor",
-          data: { cell_id: primaryCellId, line: 1, column: 16 },
-        },
-      ],
-    },
-  ],
-};
-
-function PresenceFixtureProvider({ children }: { children: ReactNode }) {
-  useEffect(() => {
-    const stopCursorDispatch = startCursorDispatch("local-docs-peer");
-
-    emitPresence(presenceSnapshot);
-    const retry = window.setTimeout(() => emitPresence(presenceSnapshot), 0);
-
-    return () => {
-      window.clearTimeout(retry);
-      stopCursorDispatch();
-    };
-  }, []);
-
-  return children;
-}
+const presencePeers = [
+  { peerId: "peer-forecast", peerLabel: "forecast reviewer", color: "#0ea5e9" },
+  { peerId: "peer-runtime", peerLabel: "runtime analyst", color: "#10b981" },
+  { peerId: "peer-output", peerLabel: "output reviewer", color: "#a855f7" },
+];
 
 function SourceFixture() {
   return (
@@ -272,7 +209,7 @@ function SourceFixture() {
         elapsedMs={1476}
         isFocused
         activityContent={
-          <CellPresenceIndicators cellId={primaryCellId} variant="inline" prefixSeparator />
+          <CellPresenceIndicators peers={presencePeers} variant="inline" prefixSeparator />
         }
       />
     </div>
@@ -339,27 +276,25 @@ export function CellAnatomyExample() {
           <div className="hidden text-right sm:block">real shell, fixture content</div>
         </div>
         <div className="bg-background py-4 pl-4 pr-2">
-          <PresenceFixtureProvider>
-            <CellContainer
-              id={primaryCellId}
-              cellType="code"
-              isFocused
-              className="mx-0 px-0"
-              codeContent={<SourceFixture />}
-              outputContent={<OutputFixture />}
-              rightGutterContent={
-                <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-900">
-                  real
-                </span>
-              }
-              outputRightGutterContent={
-                <span className="rounded-full bg-fd-muted px-1.5 py-0.5 text-[10px] font-medium text-fd-muted-foreground">
-                  fixture
-                </span>
-              }
-              dragHandleProps={{ "aria-label": "Fixture drag handle" }}
-            />
-          </PresenceFixtureProvider>
+          <CellContainer
+            id={primaryCellId}
+            cellType="code"
+            isFocused
+            className="mx-0 px-0"
+            codeContent={<SourceFixture />}
+            outputContent={<OutputFixture />}
+            rightGutterContent={
+              <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-900">
+                real
+              </span>
+            }
+            outputRightGutterContent={
+              <span className="rounded-full bg-fd-muted px-1.5 py-0.5 text-[10px] font-medium text-fd-muted-foreground">
+                fixture
+              </span>
+            }
+            dragHandleProps={{ "aria-label": "Fixture drag handle" }}
+          />
         </div>
       </section>
 

--- a/apps/elements/components/read-only-notebook-surfaces-example.tsx
+++ b/apps/elements/components/read-only-notebook-surfaces-example.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Cloud, Eye, FileCode2, Loader2, Rows3 } from "lucide-react";
-import { CellSkeleton } from "@/notebook-components/CellSkeleton";
+import { CellSkeleton } from "@/components/cell/CellSkeleton";
 import { ReadOnlyNotebook } from "@/components/cell/ReadOnlyNotebook";
 import { ReadOnlyNotebookCell } from "@/components/cell/ReadOnlyNotebookCell";
 import {
@@ -94,7 +94,7 @@ export function ReadOnlyNotebookSurfacesExample() {
               <div className="min-w-0">
                 <h2 className="text-sm font-semibold">CellSkeleton</h2>
                 <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
-                  apps/notebook/src/components/CellSkeleton.tsx
+                  src/components/cell/CellSkeleton.tsx
                 </div>
               </div>
             </div>

--- a/apps/elements/content/docs/read-only-notebook-surfaces.mdx
+++ b/apps/elements/content/docs/read-only-notebook-surfaces.mdx
@@ -20,7 +20,7 @@ until a host-authenticated flow is active.
 
 - `ReadOnlyNotebook` and `ReadOnlyNotebookCell` come from `src/components/cell`
   for static report and embed use cases, not as a separate cloud notebook app.
-- `CellSkeleton` comes from the notebook app loading state.
+- `CellSkeleton` comes from the shared cell loading state.
 - The examples exercise `OutputArea` through static outputs, not a kernel,
   daemon, CRDT handle, live room, or generated WASM binding.
 - Markdown output uses the docs app isolated-frame adapter so the production

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -20,6 +20,7 @@ import { Code2, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId } from "runtimed";
 import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
+import { CellSkeleton } from "@/components/cell/CellSkeleton";
 import { Button } from "@/components/ui/button";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookShellCapabilities } from "@/components/notebook-shell";
@@ -38,7 +39,6 @@ import {
   useOutputStructureVersion,
 } from "../lib/notebook-outputs";
 import type { CodeCell as CodeCellType, NotebookCell } from "../types";
-import { CellSkeleton } from "./CellSkeleton";
 import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";

--- a/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
+++ b/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
@@ -1,40 +1,20 @@
-/**
- * Cell-level presence indicators.
- *
- * Shows colored dots for remote peers that have their cursor in this cell.
- * Uses the cursor registry's subscription mechanism for efficient updates.
- */
-
 import { useEffect, useState } from "react";
-import { cn } from "@/lib/utils";
+import {
+  CellPresenceIndicators as SharedCellPresenceIndicators,
+  type CellPresenceIndicatorsProps as SharedCellPresenceIndicatorsProps,
+} from "@/components/cell/CellPresenceIndicators";
 import { getPeersForCell, type PeerCursorInfo, subscribeToCell } from "../../lib/cursor-registry";
 
-interface CellPresenceIndicatorsProps {
+interface CellPresenceIndicatorsProps extends Omit<SharedCellPresenceIndicatorsProps, "peers"> {
   cellId: string;
-  variant?: "stack" | "inline";
-  maxVisible?: number;
-  prefixSeparator?: boolean;
-  className?: string;
 }
 
-/** Maximum visible indicators before showing overflow count */
-const MAX_VISIBLE = 3;
-
-export function CellPresenceIndicators({
-  cellId,
-  variant = "stack",
-  maxVisible = MAX_VISIBLE,
-  prefixSeparator = false,
-  className,
-}: CellPresenceIndicatorsProps) {
+export function CellPresenceIndicators({ cellId, ...props }: CellPresenceIndicatorsProps) {
   const [peers, setPeers] = useState<PeerCursorInfo[]>([]);
 
-  // Subscribe to presence changes for this cell
   useEffect(() => {
-    // Initial fetch
     setPeers(getPeersForCell(cellId));
 
-    // Subscribe to updates
     const unsubscribe = subscribeToCell(cellId, () => {
       setPeers(getPeersForCell(cellId));
     });
@@ -42,66 +22,5 @@ export function CellPresenceIndicators({
     return unsubscribe;
   }, [cellId]);
 
-  if (peers.length === 0) {
-    return null;
-  }
-
-  const visiblePeers = peers.slice(0, maxVisible);
-  const overflowCount = peers.length - maxVisible;
-
-  return (
-    <div
-      data-slot="cell-presence-indicators"
-      className={cn(
-        "flex items-center gap-0.5",
-        variant === "stack" ? "flex-col" : "flex-row",
-        className,
-      )}
-      title={formatTooltip(peers)}
-      aria-label={formatTooltip(peers)}
-    >
-      {prefixSeparator && (
-        <span className="text-muted-foreground/30" aria-hidden="true">
-          ·
-        </span>
-      )}
-      {visiblePeers.map((peer) => (
-        <PresenceDot key={peer.peerId} peer={peer} />
-      ))}
-      {overflowCount > 0 && (
-        <span className="text-[9px] leading-none font-medium text-muted-foreground">
-          +{overflowCount}
-        </span>
-      )}
-    </div>
-  );
-}
-
-interface PresenceDotProps {
-  peer: PeerCursorInfo;
-}
-
-function PresenceDot({ peer }: PresenceDotProps) {
-  return (
-    <div
-      className="w-2 h-2 rounded-full shrink-0 transition-colors"
-      style={{ backgroundColor: peer.color }}
-      title={peer.peerLabel || "Peer"}
-    />
-  );
-}
-
-function formatTooltip(peers: PeerCursorInfo[]): string {
-  if (peers.length === 0) return "";
-  if (peers.length === 1) {
-    return peers[0].peerLabel || "1 peer";
-  }
-  const labels = peers
-    .map((p) => p.peerLabel)
-    .filter(Boolean)
-    .join(", ");
-  if (labels) {
-    return labels;
-  }
-  return `${peers.length} peers`;
+  return <SharedCellPresenceIndicators peers={peers} {...props} />;
 }

--- a/src/components/cell/CellPresenceIndicators.tsx
+++ b/src/components/cell/CellPresenceIndicators.tsx
@@ -1,0 +1,85 @@
+import { cn } from "@/lib/utils";
+
+export interface CellPresencePeer {
+  peerId: string;
+  peerLabel?: string | null;
+  color: string;
+}
+
+export interface CellPresenceIndicatorsProps {
+  peers: readonly CellPresencePeer[];
+  variant?: "stack" | "inline";
+  maxVisible?: number;
+  prefixSeparator?: boolean;
+  className?: string;
+}
+
+const MAX_VISIBLE = 3;
+
+export function CellPresenceIndicators({
+  peers,
+  variant = "stack",
+  maxVisible = MAX_VISIBLE,
+  prefixSeparator = false,
+  className,
+}: CellPresenceIndicatorsProps) {
+  if (peers.length === 0) {
+    return null;
+  }
+
+  const visiblePeers = peers.slice(0, maxVisible);
+  const overflowCount = peers.length - visiblePeers.length;
+  const label = formatCellPresenceTooltip(peers);
+
+  return (
+    <div
+      data-slot="cell-presence-indicators"
+      className={cn(
+        "flex items-center gap-0.5",
+        variant === "stack" ? "flex-col" : "flex-row",
+        className,
+      )}
+      title={label}
+      aria-label={label}
+    >
+      {prefixSeparator && (
+        <span className="text-muted-foreground/30" aria-hidden="true">
+          ·
+        </span>
+      )}
+      {visiblePeers.map((peer) => (
+        <PresenceDot key={peer.peerId} peer={peer} />
+      ))}
+      {overflowCount > 0 && (
+        <span className="text-[9px] leading-none font-medium text-muted-foreground">
+          +{overflowCount}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function PresenceDot({ peer }: { peer: CellPresencePeer }) {
+  return (
+    <div
+      className="w-2 h-2 rounded-full shrink-0 transition-colors"
+      style={{ backgroundColor: peer.color }}
+      title={peer.peerLabel || "Peer"}
+    />
+  );
+}
+
+export function formatCellPresenceTooltip(peers: readonly CellPresencePeer[]): string {
+  if (peers.length === 0) return "";
+  if (peers.length === 1) {
+    return peers[0].peerLabel || "1 peer";
+  }
+  const labels = peers
+    .map((peer) => peer.peerLabel)
+    .filter(Boolean)
+    .join(", ");
+  if (labels) {
+    return labels;
+  }
+  return `${peers.length} peers`;
+}

--- a/src/components/cell/CellSkeleton.tsx
+++ b/src/components/cell/CellSkeleton.tsx
@@ -1,10 +1,3 @@
-/**
- * Skeleton placeholder shown while the notebook document is loading from the daemon.
- *
- * Renders several placeholder cells with varying heights to mimic a real notebook.
- * The staggered animation delays give a subtle wave effect while loading.
- */
-
 import { cellContentColumnInset, notebookCellLayoutVars } from "@/components/cell/cell-layout";
 import { cn } from "@/lib/utils";
 
@@ -17,10 +10,8 @@ const skeletonCells = [
 function SkeletonCell({ height, delay }: { height: string; delay: string }) {
   return (
     <div className={cn("flex py-4", notebookCellLayoutVars)}>
-      {/* Ribbon — self-stretch to fill container height */}
       <div className="w-1 self-stretch rounded-sm bg-muted/40" />
 
-      {/* Editor area placeholder */}
       <div className={cn("min-w-0 flex-1 py-3 pr-3", cellContentColumnInset)}>
         <div
           className="rounded bg-muted/30 animate-pulse"
@@ -34,8 +25,8 @@ function SkeletonCell({ height, delay }: { height: string; delay: string }) {
 export function CellSkeleton() {
   return (
     <div>
-      {skeletonCells.map((cell, i) => (
-        <SkeletonCell key={i} height={cell.height} delay={cell.delay} />
+      {skeletonCells.map((cell, index) => (
+        <SkeletonCell key={index} height={cell.height} delay={cell.delay} />
       ))}
     </div>
   );

--- a/src/components/cell/__tests__/CellPresenceIndicators.test.tsx
+++ b/src/components/cell/__tests__/CellPresenceIndicators.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  CellPresenceIndicators,
+  formatCellPresenceTooltip,
+  type CellPresencePeer,
+} from "../CellPresenceIndicators";
+
+const peers: CellPresencePeer[] = [
+  { peerId: "ada", peerLabel: "Ada", color: "#0ea5e9" },
+  { peerId: "ben", peerLabel: "Ben", color: "#10b981" },
+  { peerId: "cara", peerLabel: "Cara", color: "#a855f7" },
+];
+
+describe("CellPresenceIndicators", () => {
+  it("renders peer dots from adapter-provided presence data", () => {
+    const { container } = render(
+      <CellPresenceIndicators peers={peers} variant="inline" prefixSeparator className="extra" />,
+    );
+
+    const indicators = container.querySelector('[data-slot="cell-presence-indicators"]');
+    expect(indicators).toHaveClass("flex-row");
+    expect(indicators).toHaveClass("extra");
+    expect(indicators).toHaveAccessibleName("Ada, Ben, Cara");
+    expect(screen.getByText("·")).toBeInTheDocument();
+    expect(container.querySelectorAll(".rounded-full")).toHaveLength(3);
+  });
+
+  it("summarizes overflow peers", () => {
+    render(<CellPresenceIndicators peers={peers} maxVisible={2} />);
+
+    expect(screen.getByText("+1")).toBeInTheDocument();
+  });
+
+  it("does not render without peers", () => {
+    const { container } = render(<CellPresenceIndicators peers={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("formats labels for unnamed peers", () => {
+    expect(
+      formatCellPresenceTooltip([
+        { peerId: "one", color: "#0ea5e9" },
+        { peerId: "two", color: "#10b981" },
+      ]),
+    ).toBe("2 peers");
+  });
+});

--- a/src/components/cell/__tests__/CellSkeleton.test.tsx
+++ b/src/components/cell/__tests__/CellSkeleton.test.tsx
@@ -1,0 +1,15 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { CellSkeleton } from "../CellSkeleton";
+
+describe("CellSkeleton", () => {
+  it("renders loading placeholders using the shared cell layout", () => {
+    const { container } = render(<CellSkeleton />);
+
+    const placeholders = container.querySelectorAll(".animate-pulse");
+    expect(placeholders).toHaveLength(3);
+    expect(placeholders[0]).toHaveStyle({ minHeight: "2.5rem", animationDelay: "0ms" });
+    expect(placeholders[1]).toHaveStyle({ minHeight: "5rem", animationDelay: "75ms" });
+    expect(placeholders[2]).toHaveStyle({ minHeight: "2rem", animationDelay: "150ms" });
+  });
+});


### PR DESCRIPTION
## Summary

- move `CellSkeleton` into the shared `src/components/cell` namespace
- split `CellPresenceIndicators` into a shared presentational component plus the notebook app cursor-registry adapter
- update Elements docs/examples to consume shared cell support components without notebook runtime/presence imports

## Verification

- `pnpm test:run -- src/components/cell/__tests__/CellPresenceIndicators.test.tsx src/components/cell/__tests__/CellSkeleton.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Playwright smoke against `http://localhost:5176/docs/cell-anatomy` and `http://localhost:5176/docs/read-only-notebook-surfaces`

## Notes

- The notebook app still owns live presence subscription through its app-local adapter.
- Elements now uses fixture peer data for the catalog surface instead of importing notebook presence bus helpers.
