### PR TITLE
feat(notebook): soften hidden cell reveal rows

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -150,7 +150,7 @@ const contracts = [
   "Runtime state enters as explicit props or fixture data, never through hooks in catalog examples.",
   "The rail owns notebook navigation; the ribbon owns type, focus, insertion intent, and document continuity.",
   "The code-cell current line owns the source/result boundary and run state.",
-  "Hidden source keeps the current line when output remains visible; fully hidden cells collapse to one reveal affordance.",
+  "Hidden input keeps the current line when output remains visible; fully hidden cells collapse to one reveal affordance.",
 ];
 
 const insertionRibbonRows = [

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -56,16 +56,16 @@ const codeCell: CodeCellType = scenarioCodeCellToStandaloneCodeCell(
 const hiddenCodeCellRows = [
   hiddenCodeCellFixture({
     id: "elements-hidden-source-cell",
-    label: "Source hidden",
-    detail: "Production CodeCell renders the source reveal while outputs remain visible.",
+    label: "Input hidden",
+    detail: "Production CodeCell renders a quiet input reveal line while outputs remain visible.",
     sourceHidden: true,
     outputsHidden: false,
   }),
   hiddenCodeCellFixture({
     id: "elements-hidden-output-cell",
-    label: "Outputs hidden",
+    label: "Output hidden",
     detail:
-      "Production CodeCell keeps the source and current line visible while output reveal owns the output row.",
+      "Production CodeCell keeps the input and current line visible while the output reveal owns the result row.",
     sourceHidden: false,
     outputsHidden: true,
   }),
@@ -112,7 +112,7 @@ const fullCellRows = [
     label: "CodeCell",
     source: "apps/notebook/src/components/CodeCell.tsx",
     detail:
-      "Rendered with seeded execution and output stores, ribbon-first CellContainer, code-cell current line, OutputArea, and hidden source/output states.",
+      "Rendered with seeded execution and output stores, ribbon-first CellContainer, code-cell current line, OutputArea, and hidden input/output states.",
   },
   {
     label: "MarkdownCell",
@@ -144,7 +144,7 @@ const fullCellBoundaryRows = [
       "Scenario code cells seed the same execution pointer and output ID stores as production, but queueing, kernel lifecycle, and output mutation still stay outside the docs runtime.",
   },
   {
-    surface: "Hidden source/output state",
+    surface: "Hidden input/output state",
     catalogPath: "fixture metadata.jupyter flags",
     productionBoundary: "NotebookView source/output visibility mutations",
     detail:
@@ -437,9 +437,9 @@ export function FullCellSurfacesExample() {
               <h2 className="text-sm font-semibold">CodeCell hidden states</h2>
             </div>
             <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
-              Source-hidden, output-hidden, and fully-hidden affordances are owned by the production
+              Input-hidden, output-hidden, and fully-hidden affordances are owned by the production
               `CodeCell`. The catalog seeds metadata and output stores, then supplies inert toggle
-              callbacks.
+              callbacks so the rows can be evaluated as document boundary language.
             </p>
           </div>
           <div className="divide-y divide-border bg-background">

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff } from "lucide-react";
+import { ChevronRight, Code2, Eye, EyeOff, type LucideIcon } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
@@ -98,6 +98,62 @@ function historyQueryFromEditor(view: EditorView | null, fallbackSource: string)
   }
 
   return fallbackSource.trim();
+}
+
+interface HiddenCellDisclosureProps {
+  icon: LucideIcon;
+  label: string;
+  detail?: string;
+  alert?: string;
+  disabled?: boolean;
+  pulsing?: boolean;
+  onClick: () => void;
+  title: string;
+  className?: string;
+}
+
+function HiddenCellDisclosure({
+  icon: Icon,
+  label,
+  detail,
+  alert,
+  disabled,
+  pulsing,
+  onClick,
+  title,
+  className,
+}: HiddenCellDisclosureProps) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "group/reveal flex w-full min-w-0 items-center gap-2 py-1 text-left text-xs leading-none",
+        "text-muted-foreground/70 transition-colors hover:text-foreground",
+        disabled && "cursor-default hover:text-muted-foreground/70",
+        pulsing && "animate-pulse",
+        className,
+      )}
+      title={title}
+    >
+      <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/45 transition-colors group-hover/reveal:text-muted-foreground/70">
+        <Icon className="size-3.5" />
+      </span>
+      <span className="shrink-0 font-medium">{label}</span>
+      {detail ? (
+        <span className="min-w-0 truncate font-mono text-muted-foreground/55 transition-colors group-hover/reveal:text-muted-foreground/70">
+          {detail}
+        </span>
+      ) : null}
+      <span
+        className="h-px min-w-4 flex-1 rounded-full bg-border/15 transition-colors group-hover/reveal:bg-border/30"
+        aria-hidden="true"
+      />
+      {alert ? <span className="shrink-0 font-medium text-destructive">{alert}</span> : null}
+      <ChevronRight className="size-3 shrink-0 text-muted-foreground/35 transition-colors group-hover/reveal:text-muted-foreground/70" />
+    </button>
+  );
 }
 
 function normalizeOutputText(text: string | string[]): string {
@@ -203,6 +259,7 @@ export const CodeCell = memo(function CodeCell({
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
   const isSourceEmpty = cell.source.trim().length === 0;
   const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
+  const sourcePreview = cell.source.split("\n")[0]?.trim() || "source";
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -432,31 +489,40 @@ export const CodeCell = memo(function CodeCell({
         outputDimmed={outputDimmed}
         onFocus={onFocus}
         gutterContent={
-          !bothHidden ? (
-            <CompactExecutionButton
-              count={executionCount}
-              isExecuting={isExecuting}
-              isQueued={isQueued}
-              isErrored={isExecutionErrored}
-              submittedByActorLabel={submittedByActorLabel}
-              isCellFocused={isFocused}
-              canExecute={canExecute}
-              onExecute={handleExecute}
-              onInterrupt={onInterrupt}
-            />
-          ) : undefined
+          <CompactExecutionButton
+            count={executionCount}
+            isExecuting={isExecuting || isGroupExecuting}
+            isQueued={isQueued}
+            isErrored={isExecutionErrored}
+            submittedByActorLabel={submittedByActorLabel}
+            isCellFocused={isFocused}
+            canExecute={canExecute}
+            onExecute={handleExecute}
+            onInterrupt={onInterrupt}
+            className={cn(
+              bothHidden &&
+                !isFocused &&
+                !isExecuting &&
+                !isGroupExecuting &&
+                !isQueued &&
+                !isExecutionErrored &&
+                "opacity-0 group-hover:opacity-70",
+            )}
+          />
         }
         rightGutterContent={rightGutterContent}
+        stateLaneClassName={isSourceHidden ? "pt-2 sm:pt-2" : undefined}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
         codeContent={
           <>
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
-              <div className="flex items-center justify-start mt-0.5">
-                <button
-                  type="button"
+              <div className="mt-0.5">
+                <HiddenCellDisclosure
+                  icon={Code2}
                   disabled={readOnly}
+                  pulsing={isExecuting || isGroupExecuting}
                   onClick={() => {
                     if (readOnly) return;
                     if (onExpandHiddenGroup) {
@@ -466,51 +532,36 @@ export const CodeCell = memo(function CodeCell({
                       onToggleOutputsHidden?.(false);
                     }
                   }}
-                  className={cn(
-                    "inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
-                    (isExecuting || isGroupExecuting) && "animate-pulse",
-                    readOnly &&
-                      "cursor-default opacity-70 hover:bg-muted/50 hover:text-muted-foreground",
-                  )}
                   title={
                     hiddenGroupCount && hiddenGroupCount > 1
                       ? `Show ${hiddenGroupCount} cells`
                       : "Show cell"
                   }
-                >
-                  <span>
-                    {hiddenGroupCount && hiddenGroupCount > 1
+                  label={
+                    hiddenGroupCount && hiddenGroupCount > 1
                       ? `${hiddenGroupCount} cells hidden`
-                      : "Cell hidden"}
-                  </span>
-                  {hiddenGroupErrorCount ? (
-                    <span className="text-destructive font-medium">
-                      {hiddenGroupErrorCount === 1 ? "1 error" : `${hiddenGroupErrorCount} errors`}
-                    </span>
-                  ) : null}
-                  <ChevronRight className="h-3 w-3" />
-                </button>
+                      : "Cell hidden"
+                  }
+                  alert={
+                    hiddenGroupErrorCount
+                      ? hiddenGroupErrorCount === 1
+                        ? "1 error"
+                        : `${hiddenGroupErrorCount} errors`
+                      : undefined
+                  }
+                />
               </div>
             ) : isSourceHidden ? (
               <>
-                <div className="flex items-center justify-start mt-0.5">
-                  <button
-                    type="button"
+                <div className="mt-0.5">
+                  <HiddenCellDisclosure
+                    icon={Code2}
                     disabled={readOnly}
                     onClick={() => onToggleSourceHidden?.(false)}
-                    className={cn(
-                      "inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
-                      readOnly &&
-                        "cursor-default opacity-70 hover:bg-muted/50 hover:text-muted-foreground",
-                    )}
-                    title="Show source"
-                  >
-                    <Code2 className="h-3 w-3" />
-                    <span className="font-mono truncate max-w-48">
-                      {cell.source.split("\n")[0] || "source"}
-                    </span>
-                    <ChevronRight className="h-3 w-3" />
-                  </button>
+                    title="Show input"
+                    label="Input hidden"
+                    detail={sourcePreview}
+                  />
                 </div>
                 {currentLine}
               </>
@@ -533,24 +584,15 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && outputs.length > 0 ? (
-            <div className={cn("flex items-center justify-start mt-0.5", cellOutputInnerInset)}>
-              <button
-                type="button"
+            <div className={cn("mt-0.5", cellOutputInnerInset)}>
+              <HiddenCellDisclosure
+                icon={Eye}
                 disabled={readOnly}
                 onClick={() => onToggleOutputsHidden?.(false)}
-                className={cn(
-                  "inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
-                  readOnly &&
-                    "cursor-default opacity-70 hover:bg-muted/50 hover:text-muted-foreground",
-                )}
                 title="Show outputs"
-              >
-                <span>
-                  {outputs.length} output
-                  {outputs.length !== 1 ? "s" : ""}
-                </span>
-                <ChevronRight className="h-3 w-3" />
-              </button>
+                label={outputs.length === 1 ? "Output hidden" : "Outputs hidden"}
+                detail={outputs.length > 1 ? `${outputs.length} outputs` : undefined}
+              />
             </div>
           ) : (
             <OutputArea

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -773,7 +773,7 @@ function NotebookViewContent({
                     "flex items-center justify-center rounded p-1 transition-colors hover:text-foreground",
                     isSourceHidden ? "text-muted-foreground/70" : "text-muted-foreground/40",
                   )}
-                  title={isSourceHidden ? "Show source" : "Hide source"}
+                  title={isSourceHidden ? "Show input" : "Hide input"}
                 >
                   <Code2 className="h-3.5 w-3.5" />
                 </button>
@@ -788,6 +788,17 @@ function NotebookViewContent({
       if (cell.cell_type === "code") {
         // Use TypeScript for Deno, IPython otherwise (for magic/shell highlighting)
         const language = runtime === "deno" ? "typescript" : "ipython";
+        const hiddenGroup = hiddenGroupsRef.current.get(cell.id);
+        const executeCellOrHiddenGroup = () => {
+          if (hiddenGroup && hiddenGroup.count > 1) {
+            for (const hiddenCellId of hiddenGroup.groupCellIds) {
+              onExecuteCell(hiddenCellId);
+            }
+          } else {
+            onExecuteCell(cell.id);
+          }
+        };
+
         return (
           <CodeCell
             key={cell.id}
@@ -805,7 +816,7 @@ function NotebookViewContent({
             outputFocused={outputFocusedCellId === cell.id}
             outputDimmed={outputFocusedCellId !== null && outputFocusedCellId !== cell.id}
             onOutputFocusChange={(focused) => handleOutputFocusChange(cell.id, focused)}
-            onExecute={() => onExecuteCell(cell.id)}
+            onExecute={executeCellOrHiddenGroup}
             onInterrupt={onInterruptKernel}
             onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}
@@ -829,9 +840,9 @@ function NotebookViewContent({
                 ? (hidden: boolean) => onSetCellOutputsHidden(cell.id, hidden)
                 : undefined
             }
-            hiddenGroupCount={hiddenGroupsRef.current.get(cell.id)?.count}
-            hiddenGroupErrorCount={hiddenGroupsRef.current.get(cell.id)?.errorCount}
-            hiddenGroupCellIds={hiddenGroupsRef.current.get(cell.id)?.groupCellIds}
+            hiddenGroupCount={hiddenGroup?.count}
+            hiddenGroupErrorCount={hiddenGroup?.errorCount}
+            hiddenGroupCellIds={hiddenGroup?.groupCellIds}
             onExpandHiddenGroup={
               hiddenGroupsRef.current.has(cell.id) &&
               canMutateCells &&

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -19,6 +19,8 @@ interface CellContainerProps {
   children?: ReactNode;
   /** Content to render in the left state lane (e.g., play button, execution marker) */
   gutterContent?: ReactNode;
+  /** Optional layout override for the left state lane. */
+  stateLaneClassName?: string;
   /** Content to render in the right margin aligned with code row (e.g., cell controls) */
   rightGutterContent?: ReactNode;
   /** Content to render in the right margin aligned with output row (e.g., output controls) */
@@ -90,6 +92,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       hideOutput,
       children,
       gutterContent,
+      stateLaneClassName,
       rightGutterContent,
       outputRightGutterContent,
       presenceIndicators,
@@ -138,7 +141,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {/* Optional state lane - lives inside the source inset so clipped scroll containers do not hide it. */}
         <div
           data-slot="cell-state-lane"
-          className="absolute left-1 top-0 z-10 flex w-[var(--cell-content-column-inset,3.25rem)] flex-col items-center justify-start gap-0.5 pt-[1.125rem] select-none sm:pt-3.5"
+          className={cn(
+            "absolute left-1 top-0 z-10 flex w-[var(--cell-content-column-inset,3.25rem)] flex-col items-center justify-start gap-0.5 pt-[1.125rem] select-none sm:pt-3.5",
+            stateLaneClassName,
+          )}
           onMouseDown={onFocus}
         >
           {gutterContent}


### PR DESCRIPTION
## Summary

- soften hidden input/output affordances into quiet document boundary rows
- keep a hover run affordance available for hidden cells and execute grouped hidden cells together
- document the input/output language in Elements cell anatomy surfaces

## Verification

- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Notes

- This intentionally keeps the runtime/source metadata names unchanged while changing the visible notebook language to input/output.
- The draft is ready for visual review against hidden input/output states before being marked ready.
