### PR TITLE
[probe] ci: shard linux clippy test gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,8 +405,8 @@ jobs:
       - name: Test notebook crate
         run: cargo test -p notebook --verbose
 
-  clippy-and-tests:
-    name: Clippy & Tests (Linux)
+  linux-rust-clippy:
+    name: Linux Rust Clippy
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -414,11 +414,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -428,7 +423,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-clippy
+          shared-key: ubuntu-linux-clippy
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts
@@ -445,11 +440,54 @@ jobs:
       - name: Dependency budget check
         run: cargo xtask check-dep-budget
 
+  linux-rust-tests:
+    name: Linux Rust Tests
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-linux-tests
+
+      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      - uses: ./.github/actions/build-runtime-artifacts
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+
       - name: Run tests
         run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --verbose
 
-      - name: Run nteract-mcp tests
-        run: cargo test -p nteract-mcp --verbose
+  linux-runtimed-node:
+    name: Linux runtimed-node
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-runtimed-node
+
+      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      - uses: ./.github/actions/build-runtime-artifacts
 
       - name: Build runtimed-node N-API package
         run: pnpm --dir packages/runtimed-node build:debug
@@ -470,6 +508,36 @@ jobs:
 
       - name: Check nteract pi package tarball
         run: pnpm --dir plugins/nteract/pi pack:dry-run
+
+  clippy-and-tests:
+    name: Clippy & Tests (Linux)
+    needs:
+      - changes
+      - linux-rust-clippy
+      - linux-rust-tests
+      - linux-runtimed-node
+    if: always() && needs.changes.outputs.source_changed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Check shard results
+        run: |
+          failed=0
+
+          check_result() {
+            local name="$1"
+            local result="$2"
+
+            if [ "$result" != "success" ]; then
+              echo "::error::${name} finished with result ${result}"
+              failed=1
+            fi
+          }
+
+          check_result "Linux Rust Clippy" "${{ needs.linux-rust-clippy.result }}"
+          check_result "Linux Rust Tests" "${{ needs.linux-rust-tests.result }}"
+          check_result "Linux runtimed-node" "${{ needs.linux-runtimed-node.result }}"
+
+          exit "$failed"
 
   build:
     name: ${{ matrix.platform.name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,7 +423,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-linux-clippy
+          shared-key: ubuntu-clippy
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts
@@ -458,7 +458,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-linux-tests
+          shared-key: ubuntu-clippy
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts
@@ -484,7 +484,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-runtimed-node
+          shared-key: ubuntu-clippy
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts


### PR DESCRIPTION
## Summary

- splits the required Linux clippy/test gate into parallel clippy, Rust test, and runtimed-node shards
- preserves the branch-protected `Clippy & Tests (Linux)` check as an aggregate job
- removes GTK/WebKit/XDO apt setup from this gate; app build and E2E jobs still install those dependencies where needed
- drops the duplicate `cargo test -p nteract-mcp` run because the workspace test shard still includes `crates/nteract-mcp`
- reuses the existing `ubuntu-clippy` rust cache key for the split Linux shards so the first protected gate after this split stays on the warm cache path

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
- `actionlint -color .github/workflows/build.yml`
- `git diff --check`
- `uv run pr-review https://github.com/nteract/nteract/pull/3298 --max-turns 120 --out .context/reviews/pr-3298-r4.json` (`clear`, no findings)

## Probe Notes

This is intentionally a `[probe]` PR while we compare live CI timing. The branch-protected status context remains `Clippy & Tests (Linux)`.

Latest probe after rebasing on `origin/main` at `94cd110c`:

- `Linux Rust Clippy`: `19:22:30Z` to `19:24:10Z`
- `Linux Rust Tests`: `19:22:30Z` to `19:24:59Z`
- `Linux runtimed-node`: `19:22:30Z` to `19:24:20Z`
- aggregate `Clippy & Tests (Linux)`: passed at `19:25:05Z`

Wall-clock from shard start to protected aggregate success was about 2m35s.

Full GitHub checks are green on workflow attempt 2. The native `E2E: Smoke` job failed once with `Kernel/session runtime not ready (kernel=error, session=ready)` and passed on failed-job rerun; the required contexts stayed green throughout.
