### PR TITLE
fix(notebook-cloud): decouple view mode from room scope

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -123,6 +123,16 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*state=\{interaction\.state\}/);
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
+  assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
+  assert.match(sourceText, /selectedMode: selectedInteractionMode/);
+  assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
+  assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
+  assert.match(
+    sourceText,
+    /if \(mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner"\) \{/,
+  );
+  assert.match(sourceText, /storeCloudRequestedScope\(window\.localStorage, "editor"\)/);
+  assert.doesNotMatch(sourceText, /mode === "edit" \? "editor" : NOTEBOOK_CLOUD_DEFAULT_SCOPE/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
   assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);
 });

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -6,12 +6,13 @@ import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 function authState(
   mode: CloudPrototypeAuthState["mode"],
   requestedScope: CloudPrototypeAuthState["requestedScope"] = null,
+  oidcClaims: CloudPrototypeAuthState["oidcClaims"] = null,
 ): CloudPrototypeAuthState {
   return {
     mode,
     token: mode === "anonymous" ? null : "token",
     user: mode === "anonymous" ? null : "user@example.test",
-    oidcClaims: null,
+    oidcClaims,
     requestedScope,
     problem: mode === "invalid" || mode === "oidc_expired" ? "auth problem" : null,
   };
@@ -49,6 +50,7 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
     authState: authState("oidc", "editor"),
     connectionScope: "editor",
     hasCodeCells: false,
+    selectedMode: "edit",
   });
 
   assert.equal(capabilities.canEditMarkdown, true);
@@ -62,8 +64,8 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
   assert.equal(capabilities.interaction?.activeMode, "edit");
   assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "editor");
-  assert.equal(capabilities.access.identityLabel, "user@example.test");
-  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.access.identityLabel, "user");
+  assert.equal(capabilities.access.actor?.principal.label, "user");
   assert.equal(capabilities.access.actor?.principal.source?.provider, "oidc");
   assert.equal(capabilities.access.actor?.operator.kind, "browser");
   assert.equal(capabilities.auth.canUseAuthenticatedIdentity, true);
@@ -72,9 +74,10 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
 
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {
   const capabilities = cloudNotebookShellCapabilities({
-    authState: authState("oidc", "viewer"),
+    authState: authState("oidc", "editor"),
     connectionScope: "editor",
     hasCodeCells: true,
+    selectedMode: "view",
   });
 
   assert.equal(capabilities.canEditMarkdown, false);
@@ -88,11 +91,37 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
+test("cloud shell capabilities keep selected mode separate from requested auth scope", () => {
+  const viewerMode = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "view",
+  });
+  const editorMode = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "viewer"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+  });
+
+  assert.equal(viewerMode.access.level, "editor");
+  assert.equal(viewerMode.interaction?.selectedMode, "view");
+  assert.equal(viewerMode.interaction?.activeMode, "view");
+  assert.equal(viewerMode.canEditMarkdown, false);
+
+  assert.equal(editorMode.access.level, "editor");
+  assert.equal(editorMode.interaction?.selectedMode, "edit");
+  assert.equal(editorMode.interaction?.activeMode, "edit");
+  assert.equal(editorMode.canEditMarkdown, true);
+});
+
 test("cloud shell capabilities keep requested edit pending until the room grants edit access", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),
     connectionScope: "viewer",
     hasCodeCells: true,
+    selectedMode: "edit",
   });
 
   assert.equal(capabilities.canEditMarkdown, false);
@@ -110,6 +139,7 @@ test("cloud shell capabilities reserve code-cell and structure edits for owners"
     authState: authState("oidc", "owner"),
     connectionScope: "owner",
     hasCodeCells: true,
+    selectedMode: "edit",
   });
 
   assert.equal(capabilities.canEditMarkdown, true);
@@ -168,9 +198,29 @@ test("cloud shell capabilities preserve room actor labels for shared access UI",
 
   assert.equal(capabilities.access.level, "owner");
   assert.equal(capabilities.access.actorLabel, "user:anaconda:alice/browser:tab");
-  assert.equal(capabilities.access.identityLabel, "user@example.test");
+  assert.equal(capabilities.access.identityLabel, "user");
   assert.equal(capabilities.access.actor?.actorLabel, "user:anaconda:alice/browser:tab");
-  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.access.actor?.principal.label, "user");
+});
+
+test("cloud shell capabilities prefer OIDC display names and pictures over raw emails", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor", {
+      sub: "anaconda-user-123",
+      email: "alice@example.com",
+      email_verified: true,
+      name: "Alice Example",
+      picture: "https://profiles.example/alice.png",
+    }),
+    connectionScope: "editor",
+    connectionActorLabel: "user:anaconda:alice/browser:tab",
+    hasCodeCells: false,
+    selectedMode: "edit",
+  });
+
+  assert.equal(capabilities.access.identityLabel, "Alice Example");
+  assert.equal(capabilities.access.actor?.principal.label, "Alice Example");
+  assert.equal(capabilities.access.actor?.principal.imageUrl, "https://profiles.example/alice.png");
 });
 
 test("cloud shell capabilities keep runtime peer authority separate from document access", () => {
@@ -190,9 +240,9 @@ test("cloud shell capabilities keep runtime peer authority separate from documen
   assert.equal(capabilities.runtime.connected, true);
   assert.equal(capabilities.runtime.source, "cloud");
   assert.equal(capabilities.runtime.actorLabel, "user:anaconda:alice/runtime:jupyterhub");
-  assert.equal(capabilities.runtime.identityLabel, "user@example.test");
+  assert.equal(capabilities.runtime.identityLabel, "user");
   assert.equal(capabilities.runtime.actor?.scope, "runtime_peer");
-  assert.equal(capabilities.runtime.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.runtime.actor?.principal.label, "user");
   assert.equal(capabilities.runtime.actor?.operator.kind, "runtime");
   assert.equal(capabilities.runtime.actor?.operator.label, "JupyterHub");
 });

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -39,6 +39,7 @@ import {
   NotebookToolbarFrame,
   notebookActorIdentityFromAccess,
   type NotebookEnvironmentManager,
+  type NotebookInteractionMode,
   type NotebookInteractionModeProjection,
   type NotebookPackageSection,
   type NotebookShellCapabilities,
@@ -638,6 +639,12 @@ function NotebookViewer({
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectAttempt, setConnectAttempt] = useState(0);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
+  const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
+    () =>
+      authState.requestedScope === "editor" || authState.requestedScope === "owner"
+        ? "edit"
+        : "view",
+  );
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
@@ -1114,8 +1121,9 @@ function NotebookViewer({
         connectionScope,
         connectionActorLabel,
         hasCodeCells: codeCellCount > 0,
+        selectedMode: selectedInteractionMode,
       }),
-    [authState, codeCellCount, connectionActorLabel, connectionScope],
+    [authState, codeCellCount, connectionActorLabel, connectionScope, selectedInteractionMode],
   );
   const canEditMarkdown = shellCapabilities.canEditMarkdown;
   const notebookCellIds = notebookViewModel.cellIds;
@@ -1227,6 +1235,12 @@ function NotebookViewer({
   );
   const resetPrototypeAuth = useCallback(() => {
     clearCloudPrototypeDevAuth(window.localStorage);
+    setSelectedInteractionMode("view");
+    refreshAuthState();
+  }, [refreshAuthState]);
+  const requestCloudEditAccess = useCallback(() => {
+    storeCloudRequestedScope(window.localStorage, "editor");
+    setSelectedInteractionMode("edit");
     refreshAuthState();
   }, [refreshAuthState]);
   const rail = (
@@ -1267,7 +1281,9 @@ function NotebookViewer({
           <CloudNotebookEditModeButton
             authState={authState}
             interaction={shellCapabilities.interaction ?? null}
-            onAuthStateChange={refreshAuthState}
+            accessLevel={shellCapabilities.access.level}
+            onModeChange={setSelectedInteractionMode}
+            onRequestEditAccess={requestCloudEditAccess}
           />
         }
         identityControls={
@@ -1734,12 +1750,16 @@ function CloudSharingControls({
 
 function CloudNotebookEditModeButton({
   authState,
+  accessLevel,
   interaction,
-  onAuthStateChange,
+  onModeChange,
+  onRequestEditAccess,
 }: {
   authState: CloudPrototypeAuthState;
+  accessLevel: NotebookShellCapabilities["access"]["level"];
   interaction: NotebookInteractionModeProjection | null;
-  onAuthStateChange: () => void;
+  onModeChange: (mode: NotebookInteractionMode) => void;
+  onRequestEditAccess: () => void;
 }) {
   if (
     authState.mode !== "oidc" ||
@@ -1754,11 +1774,11 @@ function CloudNotebookEditModeButton({
       state={interaction.state}
       variant="segmented"
       onModeChange={(mode) => {
-        storeCloudRequestedScope(
-          window.localStorage,
-          mode === "edit" ? "editor" : NOTEBOOK_CLOUD_DEFAULT_SCOPE,
-        );
-        onAuthStateChange();
+        if (mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner") {
+          onRequestEditAccess();
+          return;
+        }
+        onModeChange(mode);
       }}
     />
   );

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -3,7 +3,10 @@ import {
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook-shell/actor-projection";
 import type { NotebookShellCapabilities } from "@/components/notebook-shell/capabilities";
-import { createNotebookInteractionModeProjection } from "@/components/notebook-shell/interaction-mode";
+import {
+  createNotebookInteractionModeProjection,
+  type NotebookInteractionMode,
+} from "@/components/notebook-shell/interaction-mode";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 
 export interface CloudNotebookShellCapabilityInput {
@@ -11,6 +14,7 @@ export interface CloudNotebookShellCapabilityInput {
   connectionScope: string | null;
   connectionActorLabel?: string | null;
   hasCodeCells: boolean;
+  selectedMode?: NotebookInteractionMode;
 }
 
 export function cloudNotebookShellCapabilities({
@@ -18,16 +22,16 @@ export function cloudNotebookShellCapabilities({
   connectionScope,
   connectionActorLabel = null,
   hasCodeCells,
+  selectedMode = "view",
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
   const isRuntimePeer = connectionScope === "runtime_peer";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
+  const identityLabel = cloudIdentityDisplayLabel(authState);
+  const identityImageUrl = cloudIdentityImageUrl(authState);
   const interaction = createNotebookInteractionModeProjection({
-    selectedMode:
-      authState.requestedScope === "editor" || authState.requestedScope === "owner"
-        ? "edit"
-        : "view",
+    selectedMode,
     permission: {
       canEditMarkdown: accessLevel === "editor" || accessLevel === "owner",
       canEditCells: accessLevel === "owner",
@@ -50,15 +54,21 @@ export function cloudNotebookShellCapabilities({
     source: "cloud" as const,
     isPublic: !authenticated && accessLevel === "viewer",
     actorLabel: connectionActorLabel,
-    identityLabel: authState.user,
+    identityLabel,
   };
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
     connected: isRuntimePeer,
     source: "cloud" as const,
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
-    identityLabel: isRuntimePeer ? authState.user : null,
+    identityLabel: isRuntimePeer ? identityLabel : null,
   };
+  const accessActor = withCloudIdentityImage(notebookActorProjectionFromAccess(access, auth), {
+    imageUrl: identityImageUrl,
+  });
+  const runtimeActor = withCloudIdentityImage(notebookActorProjectionFromRuntime(runtime, auth), {
+    imageUrl: identityImageUrl,
+  });
 
   return {
     canRead: true,
@@ -74,12 +84,12 @@ export function cloudNotebookShellCapabilities({
     interaction,
     access: {
       ...access,
-      actor: notebookActorProjectionFromAccess(access, auth),
+      actor: accessActor,
     },
     auth,
     runtime: {
       ...runtime,
-      actor: notebookActorProjectionFromRuntime(runtime, auth),
+      actor: runtimeActor,
     },
   };
 }
@@ -91,4 +101,44 @@ function cloudConnectionAccessLevel(
     return connectionScope;
   }
   return "viewer";
+}
+
+function cloudIdentityDisplayLabel(authState: CloudPrototypeAuthState): string | null {
+  const claimName = authState.oidcClaims?.name?.trim();
+  if (claimName) {
+    return claimName;
+  }
+  const claimEmail = compactEmailLabel(authState.oidcClaims?.email);
+  if (claimEmail) {
+    return claimEmail;
+  }
+  return compactEmailLabel(authState.user) ?? authState.user;
+}
+
+function cloudIdentityImageUrl(authState: CloudPrototypeAuthState): string | null {
+  return authState.oidcClaims?.picture?.trim() || null;
+}
+
+function compactEmailLabel(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const match = /^([^@\s]+)@([^@\s]+\.[^@\s]+)$/.exec(trimmed);
+  return match?.[1] ?? null;
+}
+
+function withCloudIdentityImage<
+  T extends ReturnType<typeof notebookActorProjectionFromAccess> | null,
+>(actor: T, { imageUrl }: { imageUrl: string | null }): T {
+  if (!actor || !imageUrl) {
+    return actor;
+  }
+  return {
+    ...actor,
+    principal: {
+      ...actor.principal,
+      imageUrl,
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- separates cloud selected view/edit mode from requested room scope
- keeps editor-authorized view mode local so it does not downgrade the sync connection to viewer
- keeps edit requests explicit: viewer connections still request `scope=editor` when the user asks to edit
- prefers OIDC display names and profile pictures in the shared identity projection, compacting email-shaped labels before they reach toolbar chrome

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-theme.test.ts test/html.test.ts test/collaborator-auth.test.ts test/live-sync.test.ts test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Notes

This keeps cloud on the shared `NotebookView` surface. The important behavior change is that switching an editor into Viewing mode now only updates local capabilities/read-only behavior; it should not reconnect or rematerialize the live Automerge room.
