### PR TITLE
fix(notebook): align hidden cell visibility tests

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -80,7 +80,7 @@ interface CodeCellProps {
   hiddenGroupCellIds?: string[];
   /** Number of error outputs across all cells in a hidden group */
   hiddenGroupErrorCount?: number;
-  /** Content for the right gutter (e.g., delete button, source toggle) */
+  /** Content for the right gutter (e.g., delete button, input toggle) */
   rightGutterContent?: ReactNode;
   readOnly?: boolean;
   canExecute?: boolean;
@@ -257,15 +257,23 @@ export const CodeCell = memo(function CodeCell({
   const isExecutionErrored = execution?.success === false || execution?.status === "error";
   const languageLabel =
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
-  const isSourceEmpty = cell.source.trim().length === 0;
-  const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
-  const sourcePreview = cell.source.split("\n")[0]?.trim() || "source";
-
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
     (cell.metadata?.jupyter as { source_hidden?: boolean })?.source_hidden === true;
   const isOutputsHidden =
     (cell.metadata?.jupyter as { outputs_hidden?: boolean })?.outputs_hidden === true;
+  const isSourceEmpty = cell.source.trim().length === 0;
+  const showOutputChrome = useMemo(() => needsOutputChrome(outputs), [outputs]);
+  const sourcePreview = useMemo(() => {
+    if (!isSourceHidden) {
+      return "source";
+    }
+
+    const firstNewlineIndex = cell.source.indexOf("\n");
+    const firstLine =
+      firstNewlineIndex === -1 ? cell.source : cell.source.slice(0, firstNewlineIndex);
+    return firstLine.trim() || "source";
+  }, [cell.source, isSourceHidden]);
 
   // Fully collapsed when source is hidden AND there's nothing else to show
   // (outputs explicitly hidden, or no outputs at all).

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -737,7 +737,7 @@ function NotebookViewContent({
       };
 
       // Build right gutter content — delete button for all cells,
-      // plus source toggle for code cells
+      // plus input toggle for code cells
       const deleteButton = canMutateCells ? (
         <button
           type="button"
@@ -790,8 +790,9 @@ function NotebookViewContent({
         const language = runtime === "deno" ? "typescript" : "ipython";
         const hiddenGroup = hiddenGroupsRef.current.get(cell.id);
         const executeCellOrHiddenGroup = () => {
-          if (hiddenGroup && hiddenGroup.count > 1) {
-            for (const hiddenCellId of hiddenGroup.groupCellIds) {
+          const latestHiddenGroup = hiddenGroupsRef.current.get(cell.id);
+          if (latestHiddenGroup && latestHiddenGroup.count > 1) {
+            for (const hiddenCellId of latestHiddenGroup.groupCellIds) {
               onExecuteCell(hiddenCellId);
             }
           } else {

--- a/e2e/specs/cell-visibility.spec.js
+++ b/e2e/specs/cell-visibility.spec.js
@@ -1,7 +1,7 @@
 /**
  * E2E Test: Cell Visibility Toggles (fixture-based)
  *
- * Uses a pre-built notebook fixture with source + output already present.
+ * Uses a pre-built notebook fixture with input + output already present.
  * No kernel launch needed — this tests pure UI behavior.
  *
  * Fixture: crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb
@@ -10,7 +10,7 @@
  *   e2e/specs/cell-visibility.spec.js
  *
  * Tests:
- * - Hide/show source via gutter button
+ * - Hide/show input via gutter button
  * - Hide/show outputs via gutter button
  * - Compact "Cell hidden" chip when both are hidden
  */
@@ -21,7 +21,7 @@ import { waitForAppReady, waitForNotebookSynced } from "../helpers.js";
 /**
  * Focus a code cell by clicking its editor area.
  *
- * The right-gutter buttons (Hide source, Hide outputs, Delete) use
+ * The right-gutter buttons (Hide input, Hide outputs, Delete) use
  * `sm:opacity-0 sm:group-hover:opacity-100` with an `isFocused && "sm:opacity-100"`
  * override. WebDriver's moveTo() does not reliably trigger CSS :hover in
  * WebKit/WRY, so we focus the cell instead — setting isFocused makes the
@@ -32,14 +32,14 @@ async function focusCell(codeCell) {
   if (await editor.isExisting()) {
     await editor.click();
   } else {
-    // If source is hidden, click the cell container itself
+    // If input is hidden, click the cell container itself
     await codeCell.click();
   }
   await browser.pause(300);
 }
 
 describe("Cell Visibility Toggles", () => {
-  it("should have a cell with source and output from fixture", async () => {
+  it("should have a cell with input and output from fixture", async () => {
     await waitForAppReady();
     await waitForNotebookSynced();
 
@@ -47,7 +47,7 @@ describe("Cell Visibility Toggles", () => {
     const codeCell = await $('[data-cell-type="code"]');
     await codeCell.waitForExist({ timeout: 10000 });
 
-    // Verify source is present
+    // Verify input is present
     const editor = await codeCell.$(".cm-content[contenteditable]");
     expect(await editor.isExisting()).toBe(true);
 
@@ -56,35 +56,35 @@ describe("Cell Visibility Toggles", () => {
     expect(await outputArea.isExisting()).toBe(true);
   });
 
-  it("should hide source when clicking source toggle button", async () => {
+  it("should hide input when clicking input toggle button", async () => {
     const codeCell = await $('[data-cell-type="code"]');
 
     // Focus the cell to make gutter buttons visible (isFocused → sm:opacity-100).
     // moveTo() doesn't trigger CSS :hover in WRY's WebDriver.
     await focusCell(codeCell);
 
-    // Find and click the source toggle button (Code2 icon with "Hide source" title)
-    const hideSourceButton = await codeCell.$('button[title="Hide source"]');
-    await hideSourceButton.waitForClickable({ timeout: 5000 });
-    await hideSourceButton.click();
+    // Find and click the input toggle button (Code2 icon with "Hide input" title)
+    const hideInputButton = await codeCell.$('button[title="Hide input"]');
+    await hideInputButton.waitForClickable({ timeout: 5000 });
+    await hideInputButton.click();
     await browser.pause(300);
 
-    // Verify the source badge appears (collapsed state)
-    const sourceBadge = await codeCell.$('button[title="Show source"]');
-    expect(await sourceBadge.isExisting()).toBe(true);
+    // Verify the input disclosure appears (collapsed state)
+    const inputDisclosure = await codeCell.$('button[title="Show input"]');
+    expect(await inputDisclosure.isExisting()).toBe(true);
 
     // The editor should no longer be visible
     const editor = await codeCell.$('.cm-content[contenteditable="true"]');
     expect(await editor.isExisting()).toBe(false);
   });
 
-  it("should show source when clicking the source badge", async () => {
+  it("should show input when clicking the input disclosure", async () => {
     const codeCell = await $('[data-cell-type="code"]');
 
-    // Click the source badge to expand
-    const sourceBadge = await codeCell.$('button[title="Show source"]');
-    await sourceBadge.waitForClickable({ timeout: 5000 });
-    await sourceBadge.click();
+    // Click the input disclosure to expand
+    const inputDisclosure = await codeCell.$('button[title="Show input"]');
+    await inputDisclosure.waitForClickable({ timeout: 5000 });
+    await inputDisclosure.click();
     await browser.pause(300);
 
     // The editor should now be visible again
@@ -105,22 +105,22 @@ describe("Cell Visibility Toggles", () => {
     await hideOutputButton.click();
     await browser.pause(300);
 
-    // Verify the outputs badge appears (shows "1 output")
-    const outputsBadge = await codeCell.$('button[title="Show outputs"]');
-    expect(await outputsBadge.isExisting()).toBe(true);
+    // Verify the outputs disclosure appears
+    const outputsDisclosure = await codeCell.$('button[title="Show outputs"]');
+    expect(await outputsDisclosure.isExisting()).toBe(true);
 
-    // The badge should contain the output count
-    const badgeText = await outputsBadge.getText();
-    expect(badgeText).toMatch(/\d+ output/);
+    // The disclosure should use the hidden-output language from the app.
+    const disclosureText = await outputsDisclosure.getText();
+    expect(disclosureText).toContain("Output hidden");
   });
 
-  it("should show outputs when clicking the outputs badge", async () => {
+  it("should show outputs when clicking the outputs disclosure", async () => {
     const codeCell = await $('[data-cell-type="code"]');
 
-    // Click the outputs badge to expand
-    const outputsBadge = await codeCell.$('button[title="Show outputs"]');
-    await outputsBadge.waitForClickable({ timeout: 5000 });
-    await outputsBadge.click();
+    // Click the outputs disclosure to expand
+    const outputsDisclosure = await codeCell.$('button[title="Show outputs"]');
+    await outputsDisclosure.waitForClickable({ timeout: 5000 });
+    await outputsDisclosure.click();
     await browser.pause(300);
 
     // The output should be visible again
@@ -129,19 +129,19 @@ describe("Cell Visibility Toggles", () => {
     expect(await output.isExisting()).toBe(true);
   });
 
-  it("should show compact layout when both source and outputs are hidden", async () => {
+  it("should show compact layout when both input and outputs are hidden", async () => {
     const codeCell = await $('[data-cell-type="code"]');
 
     // Focus the cell to make gutter buttons visible
     await focusCell(codeCell);
 
-    // First hide source
-    const hideSourceButton = await codeCell.$('button[title="Hide source"]');
-    await hideSourceButton.waitForClickable({ timeout: 5000 });
-    await hideSourceButton.click();
+    // First hide input
+    const hideInputButton = await codeCell.$('button[title="Hide input"]');
+    await hideInputButton.waitForClickable({ timeout: 5000 });
+    await hideInputButton.click();
     await browser.pause(300);
 
-    // Re-focus to keep gutter buttons visible (focus may shift after source collapse)
+    // Re-focus to keep gutter buttons visible (focus may shift after input collapse)
     await codeCell.click();
     await browser.pause(300);
 
@@ -151,11 +151,11 @@ describe("Cell Visibility Toggles", () => {
     await hideOutputButton.click();
     await browser.pause(300);
 
-    // A single "Cell hidden" chip should appear (compact layout)
-    const cellHiddenChip = await codeCell.$('button[title="Show cell"]');
-    expect(await cellHiddenChip.isExisting()).toBe(true);
-    const chipText = await cellHiddenChip.getText();
-    expect(chipText).toContain("Cell hidden");
+    // A single "Cell hidden" disclosure should appear (compact layout)
+    const cellHiddenDisclosure = await codeCell.$('button[title="Show cell"]');
+    expect(await cellHiddenDisclosure.isExisting()).toBe(true);
+    const disclosureText = await cellHiddenDisclosure.getText();
+    expect(disclosureText).toContain("Cell hidden");
 
     // The editor should not be visible
     const editor = await codeCell.$('.cm-content[contenteditable="true"]');
@@ -169,13 +169,13 @@ describe("Cell Visibility Toggles", () => {
   it("should restore cell when clicking Show cell from compact layout", async () => {
     const codeCell = await $('[data-cell-type="code"]');
 
-    // Click the "Show cell" chip to expand both source and outputs
-    const cellHiddenChip = await codeCell.$('button[title="Show cell"]');
-    await cellHiddenChip.waitForClickable({ timeout: 5000 });
-    await cellHiddenChip.click();
+    // Click the "Show cell" disclosure to expand both input and outputs
+    const cellHiddenDisclosure = await codeCell.$('button[title="Show cell"]');
+    await cellHiddenDisclosure.waitForClickable({ timeout: 5000 });
+    await cellHiddenDisclosure.click();
     await browser.pause(300);
 
-    // Both source and outputs should now be visible
+    // Both input and outputs should now be visible
     const editor = await codeCell.$('.cm-content[contenteditable="true"]');
     await editor.waitForExist({ timeout: 5000 });
     expect(await editor.isExisting()).toBe(true);
@@ -193,9 +193,9 @@ describe("Cell Visibility Toggles", () => {
 
     // TODO: Use a fixture with pre-existing error output instead of executing code
     await focusCell(codeCell);
-    const hideSourceButton = await codeCell.$('button[title="Hide source"]');
-    await hideSourceButton.waitForClickable({ timeout: 5000 });
-    await hideSourceButton.click();
+    const hideInputButton = await codeCell.$('button[title="Hide input"]');
+    await hideInputButton.waitForClickable({ timeout: 5000 });
+    await hideInputButton.click();
     await browser.pause(300);
 
     await codeCell.click();
@@ -205,14 +205,14 @@ describe("Cell Visibility Toggles", () => {
     await hideOutputButton.click();
     await browser.pause(300);
 
-    // The chip should show "1 error"
-    const cellHiddenChip = await codeCell.$('button[title="Show cell"]');
-    expect(await cellHiddenChip.isExisting()).toBe(true);
-    const chipText = await cellHiddenChip.getText();
+    // The disclosure should show "1 error"
+    const cellHiddenDisclosure = await codeCell.$('button[title="Show cell"]');
+    expect(await cellHiddenDisclosure.isExisting()).toBe(true);
+    const chipText = await cellHiddenDisclosure.getText();
     expect(chipText).toContain("1 error");
 
     // Restore cell for subsequent tests
-    await cellHiddenChip.click();
+    await cellHiddenDisclosure.click();
     await browser.pause(300);
   });
 });


### PR DESCRIPTION
## Summary

- update the cell visibility E2E spec for the new input/output disclosure language
- avoid splitting large cell sources on every render when the input is visible
- read the latest hidden group from the ref when executing a hidden group

## Verification

- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- `cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb e2e/specs/cell-visibility.spec.js` could not reach the spec locally because WebDriver timed out waiting on port 4445.
