### PR TITLE
test(e2e): migrate notebook coverage to Playwright

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -9,7 +9,8 @@ description: Run tests, verify changes, and collect diagnostics. Use when runnin
 
 | Type | Location | Command | Framework |
 |------|----------|---------|-----------|
-| E2E | `e2e/specs/` | `cargo xtask e2e test` | WebdriverIO + Mocha |
+| Browser E2E | `apps/notebook/e2e/` | `pnpm --filter notebook-ui test:e2e:browser` | Playwright |
+| Native E2E | `e2e/specs/` | `cargo xtask e2e test` | WebdriverIO + Mocha |
 | Frontend unit | `src/**/__tests__/`, `apps/notebook/src/**/__tests__/` | `pnpm test` | Vitest + jsdom |
 | Rust unit | inline `#[cfg(test)]` | `cargo test` | built-in |
 | CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone |
@@ -101,14 +102,30 @@ SKIP_INTEGRATION_TESTS=1 pytest python/runtimed/tests/ -v     # Skip integration
 RUNTIMED_INTEGRATION_TEST=1 pytest python/runtimed/tests/ -v  # CI mode (spawns daemon)
 ```
 
-## E2E Tests
+## Browser E2E Tests
+
+Playwright tests in `apps/notebook/e2e/` are the preferred E2E surface for
+notebook UI, runtime, fixture, and renderer behavior. They use the Vite browser
+relay plus the dev daemon, avoiding the slower Tauri WebDriver app build.
+
+```bash
+pnpm --filter notebook-ui test:e2e:browser -- --project=chromium
+pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/execute-cell-output.spec.ts
+pnpm --filter notebook-ui test:e2e:browser:portless -- --project=chromium
+```
+
+## Native E2E Tests
+
+Native WebDriverIO tests should stay focused on Tauri-specific setup: app shell
+boot, cwd-derived untitled notebook behavior, launcher/bootstrap behavior, and
+other issues that require the real Tauri process.
 
 ### Running
 
 ```bash
 cargo xtask e2e build       # Build with WebDriver support (required first)
-cargo xtask e2e test        # Smoke/default run
-cargo xtask e2e test-all    # Full suite including fixtures
+cargo xtask e2e test        # Native smoke/default run
+cargo xtask e2e test-all    # Native smoke plus long-tail Tauri fixtures
 cargo xtask e2e test-fixture <notebook> <spec>  # Single fixture test
 ```
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
         run: vp test bench --run apps/notebook/src/lib/__tests__/
 
   browser-e2e:
-    name: Browser E2E (Vite)
+    name: Browser E2E (Playwright)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -575,8 +575,9 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         run: cargo test --workspace --exclude runtimed-node --exclude runtimed-py --verbose
 
-  # Build Tauri app once and share with E2E shards
-  # E2E smoke test - verifies basic app functionality
+  # Native WebDriver E2E stays focused on Tauri shell behavior. Notebook UI,
+  # runtime, and fixture coverage run in the faster Browser E2E (Playwright)
+  # job above.
   e2e:
     name: "E2E: ${{ matrix.name }}"
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -589,36 +590,6 @@ jobs:
           - name: Smoke
             spec: "e2e/specs/smoke.spec.js"
             notebook: ""
-            uv_pool: 3
-            conda_pool: 0
-            timeout: 12
-          - name: Tab Completion
-            spec: "e2e/specs/tab-completion.spec.js"
-            notebook: ""
-            uv_pool: 3
-            conda_pool: 0
-            timeout: 12
-          - name: UI (Cell Visibility)
-            spec: "e2e/specs/cell-visibility.spec.js"
-            notebook: "crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb"
-            uv_pool: 0
-            conda_pool: 0
-            timeout: 5
-          - name: UV Prewarmed
-            spec: "e2e/specs/prewarmed-uv.spec.js"
-            notebook: "crates/notebook/fixtures/audit-test/1-vanilla.ipynb"
-            uv_pool: 3
-            conda_pool: 0
-            timeout: 12
-          - name: Deno
-            spec: "e2e/specs/deno.spec.js"
-            notebook: "crates/notebook/fixtures/audit-test/10-deno.ipynb"
-            uv_pool: 0
-            conda_pool: 0
-            timeout: 8
-          - name: UV Pyproject
-            spec: "e2e/specs/uv-pyproject.spec.js"
-            notebook: "crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb"
             uv_pool: 3
             conda_pool: 0
             timeout: 12

--- a/apps/notebook/e2e/cell-visibility.spec.ts
+++ b/apps/notebook/e2e/cell-visibility.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Locator } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { openNotebookPath } from "./helpers";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const fixturePath = path.join(
+  repoRoot,
+  "crates",
+  "notebook",
+  "fixtures",
+  "audit-test",
+  "14-cell-visibility.ipynb",
+);
+
+function copyFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nteract-cell-visibility-"));
+  const notebookPath = path.join(dir, "cell-visibility.ipynb");
+  fs.copyFileSync(fixturePath, notebookPath);
+  return { dir, notebookPath };
+}
+
+async function focusCell(cell: Locator) {
+  const editor = cell.locator('.cm-content[contenteditable="true"]');
+  if ((await editor.count()) > 0) {
+    await editor.click();
+    return;
+  }
+  await cell.click();
+}
+
+async function clickCellButton(cell: Locator, title: string) {
+  await focusCell(cell);
+  const button = cell.getByRole("button", { name: title });
+  await expect(button).toBeVisible({ timeout: 5_000 });
+  await button.click();
+}
+
+test.describe("cell visibility toggles", () => {
+  test("hides and restores source and outputs from an existing notebook", async ({ page }) => {
+    const { dir, notebookPath } = copyFixture();
+    try {
+      await openNotebookPath(page, notebookPath, { environmentMode: "notebook" });
+
+      const cell = page.locator('[data-cell-type="code"]').first();
+      await expect(cell.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+      await expect(cell.locator('[data-slot="ansi-stream-output"]')).toContainText(
+        "visibility test",
+      );
+
+      await clickCellButton(cell, "Hide input");
+      const showInputButton = cell.locator('button[title="Show input"]').first();
+      await expect(showInputButton).toBeVisible();
+      await expect(cell.locator('.cm-content[contenteditable="true"]')).toHaveCount(0);
+
+      await showInputButton.click();
+      await expect(cell.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+
+      await clickCellButton(cell, "Hide outputs");
+      const outputsBadge = cell.locator('button[title="Show outputs"]').first();
+      await expect(outputsBadge).toBeVisible();
+      await expect(outputsBadge).toContainText("Output hidden");
+
+      await outputsBadge.click();
+      await expect(cell.locator('[data-slot="ansi-stream-output"]')).toContainText(
+        "visibility test",
+      );
+
+      await clickCellButton(cell, "Hide input");
+      await clickCellButton(cell, "Hide outputs");
+      const hiddenCell = cell.locator('button[title="Show cell"]').first();
+      await expect(hiddenCell).toContainText("Cell hidden");
+      await expect(cell.locator('.cm-content[contenteditable="true"]')).toHaveCount(0);
+      await expect(cell.locator('[data-slot="ansi-stream-output"]')).toHaveCount(0);
+
+      await hiddenCell.click();
+      await expect(cell.locator('.cm-content[contenteditable="true"]')).toBeVisible();
+      await expect(cell.locator('[data-slot="ansi-stream-output"]')).toContainText(
+        "visibility test",
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/notebook/e2e/environment-kernels.spec.ts
+++ b/apps/notebook/e2e/environment-kernels.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  executeCell,
+  openNotebookPath,
+  setCellSource,
+  waitForKernelStatus,
+  waitForOutputContaining,
+  waitForOutputMatching,
+} from "./helpers";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const auditFixtureRoot = path.join(repoRoot, "crates", "notebook", "fixtures", "audit-test");
+
+function fixturePath(...segments: string[]) {
+  return path.join(auditFixtureRoot, ...segments);
+}
+
+function copyFixtureNotebook(...segments: string[]) {
+  const source = fixturePath(...segments);
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nteract-browser-fixture-"));
+  const notebookPath = path.join(dir, path.basename(source));
+  fs.copyFileSync(source, notebookPath);
+  return { dir, notebookPath };
+}
+
+function copyFixtureProject(projectName: string, notebookName: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `nteract-${projectName}-`));
+  fs.cpSync(fixturePath(projectName), dir, { recursive: true });
+  return { dir, notebookPath: path.join(dir, notebookName) };
+}
+
+test.describe("browser runtime fixture coverage", () => {
+  test.describe.configure({ timeout: 360_000 });
+
+  test("runs a saved Python notebook through the UV-managed runtime", async ({ page }) => {
+    const { dir, notebookPath } = copyFixtureNotebook("1-vanilla.ipynb");
+    try {
+      await openNotebookPath(page, notebookPath, {
+        environmentMode: "notebook",
+      });
+      await waitForKernelStatus(page, "idle", 300_000);
+
+      const depsToggle = page.getByTestId("deps-toggle");
+      await expect(depsToggle).toHaveAttribute("data-runtime", "python");
+      await expect(depsToggle).toHaveAttribute("data-env-manager", "uv", {
+        timeout: 30_000,
+      });
+
+      const cell = page.locator('[data-cell-type="code"]').first();
+      await setCellSource(cell, "import sys; print('browser-python-ok:' + sys.executable)");
+      await executeCell(cell);
+
+      const output = await waitForOutputContaining(cell, "browser-python-ok:", 60_000);
+      await expect(output).toContainText(/python/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("detects and executes a Deno kernelspec notebook", async ({ page }) => {
+    const { dir, notebookPath } = copyFixtureNotebook("10-deno.ipynb");
+    try {
+      await openNotebookPath(page, notebookPath);
+      await waitForKernelStatus(page, "idle", 300_000);
+
+      await expect(page.getByTestId("deps-toggle")).toHaveAttribute("data-runtime", "deno");
+
+      const cell = page.locator('[data-cell-type="code"]').first();
+      await setCellSource(cell, 'console.log("browser-deno-ok");');
+      await executeCell(cell);
+
+      await waitForOutputContaining(cell, "browser-deno-ok", 60_000);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses pyproject.toml dependencies for a saved Python notebook", async ({ page }) => {
+    const { dir, notebookPath } = copyFixtureProject("pyproject-project", "5-pyproject.ipynb");
+    try {
+      await openNotebookPath(page, notebookPath, {
+        environmentMode: "auto",
+      });
+      await waitForKernelStatus(page, "idle", 300_000);
+
+      await expect(page.getByTestId("deps-toggle")).toHaveAttribute("data-env-manager", "uv", {
+        timeout: 30_000,
+      });
+
+      const cell = page.locator('[data-cell-type="code"]').first();
+      await setCellSource(cell, "import httpx; print('browser-httpx-ok', httpx.__version__)");
+      await executeCell(cell);
+
+      await waitForOutputMatching(cell, /browser-httpx-ok\s+\d+\.\d+/, 120_000);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -21,6 +21,17 @@ export async function openNotebookRoom(page: Page, notebookId: string) {
   await waitForNotebookReady(page, `/?${params.toString()}`);
 }
 
+export async function openNotebookPath(
+  page: Page,
+  notebookPath: string,
+  options: { environmentMode?: "auto" | "project" | "notebook"; runtime?: string } = {},
+) {
+  const params = new URLSearchParams({ path: notebookPath });
+  if (options.environmentMode) params.set("environment_mode", options.environmentMode);
+  if (options.runtime) params.set("runtime", options.runtime);
+  await waitForNotebookReady(page, `/?${params.toString()}`);
+}
+
 export async function waitForKernelStatus(page: Page, status: string, timeout = 60_000) {
   await expect(page.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", status, {
     timeout,
@@ -56,6 +67,7 @@ export async function setCellSource(cell: Locator, source: string) {
         view?: {
           state: { doc: { length: number } };
           dispatch: (transaction: unknown) => void;
+          focus: () => void;
         };
       };
     };
@@ -67,7 +79,9 @@ export async function setCellSource(cell: Locator, source: string) {
         to: editor.state.doc.length,
         insert: text,
       },
+      selection: { anchor: text.length },
     });
+    editor.focus();
   }, source);
 }
 
@@ -114,5 +128,15 @@ export async function executeCell(cell: Locator) {
 export async function waitForOutputContaining(cell: Locator, text: string, timeout = 60_000) {
   const output = cell.locator('[data-slot="ansi-stream-output"]');
   await expect(output).toContainText(text, { timeout });
+  return output;
+}
+
+export async function waitForOutputMatching(cell: Locator, matcher: RegExp, timeout = 60_000) {
+  const output = cell.locator('[data-slot="ansi-stream-output"]');
+  await expect
+    .poll(async () => ((await output.count()) > 0 ? output.innerText() : ""), {
+      timeout,
+    })
+    .toMatch(matcher);
   return output;
 }

--- a/apps/notebook/e2e/tab-completion.spec.ts
+++ b/apps/notebook/e2e/tab-completion.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import {
+  ensureCodeCell,
+  getCellSource,
+  openNotebookRoom,
+  setCellSource,
+  waitForKernelStatus,
+} from "./helpers";
+
+test.describe("code cell Tab behavior", () => {
+  test("indents blank lines and accepts completions without leaving the editor", async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    await openNotebookRoom(page, crypto.randomUUID());
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const cell = await ensureCodeCell(page);
+
+    await setCellSource(cell, "");
+    await page.keyboard.press("Tab");
+
+    await expect.poll(() => getCellSource(cell)).toMatch(/^\s+$/);
+    await expect(page.locator(".cm-editor.cm-focused")).toBeVisible();
+
+    await setCellSource(cell, "prin");
+    await page.keyboard.press("Tab");
+
+    await expect(page.locator(".cm-tooltip-autocomplete")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.keyboard.press("Tab");
+
+    await expect.poll(() => getCellSource(cell), { timeout: 15_000 }).toMatch(/^print\b/);
+    await expect(page.locator(".cm-editor.cm-focused")).toBeVisible();
+  });
+});

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1191,39 +1191,23 @@ fn cmd_e2e_test_fixture(args: Vec<String>) {
 }
 
 fn cmd_e2e_test_all() {
-    println!("Running all E2E tests...\n");
+    println!("Running native Tauri E2E tests...\n");
     let mut failed = false;
 
-    // 1. Smoke tests (default specs, excluding fixtures)
-    println!("=== Smoke Tests ===");
+    // 1. Native smoke tests. Most notebook UI/runtime coverage runs through
+    // Playwright via `pnpm --filter notebook-ui test:e2e:browser`.
+    println!("=== Native Smoke Tests ===");
     if run_e2e_session(None, None, None) != 0 {
         eprintln!("Smoke tests failed.");
         failed = true;
     }
 
-    // 2. Fixture tests (mirroring CI e2e-fixtures job)
-    let fixtures: &[(&str, &str, &str)] = &[
-        (
-            "crates/notebook/fixtures/audit-test/14-cell-visibility.ipynb",
-            "e2e/specs/cell-visibility.spec.js",
-            "Cell Visibility Test",
-        ),
-        (
-            "crates/notebook/fixtures/audit-test/1-vanilla.ipynb",
-            "e2e/specs/prewarmed-uv.spec.js",
-            "Prewarmed Pool Test",
-        ),
-        (
-            "crates/notebook/fixtures/audit-test/10-deno.ipynb",
-            "e2e/specs/deno.spec.js",
-            "Deno Kernel Test",
-        ),
-        (
-            "crates/notebook/fixtures/audit-test/16-widget-slider.ipynb",
-            "e2e/specs/widget-slider-stall.spec.js",
-            "Widget Slider Stall Reproducer",
-        ),
-    ];
+    // 2. Long-tail native-only fixture tests.
+    let fixtures: &[(&str, &str, &str)] = &[(
+        "crates/notebook/fixtures/audit-test/16-widget-slider.ipynb",
+        "e2e/specs/widget-slider-stall.spec.js",
+        "Widget Slider Stall Reproducer",
+    )];
 
     for (notebook, spec, name) in fixtures {
         println!("\n=== {name} ===");
@@ -1256,7 +1240,7 @@ fn cmd_e2e_test_all() {
         eprintln!("\nSome E2E tests failed.");
         exit(1);
     }
-    println!("\nAll E2E tests passed!");
+    println!("\nNative Tauri E2E tests passed!");
 }
 
 fn cmd_wasm(target: Option<&str>, skip_renderer_plugins: bool) {

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -25,18 +25,20 @@ const SCREENSHOT_FAILURES_DIR = path.join(SCREENSHOT_DIR, "failures");
 // Ensure screenshot directories exist
 fs.mkdirSync(SCREENSHOT_FAILURES_DIR, { recursive: true });
 
-// Fixture specs require special setup (NOTEBOOK_PATH or working directory) and are excluded
-// from the default run. Use ./e2e/dev.sh test-fixture or test-untitled-pyproject to run them.
-const FIXTURE_SPECS = [
-  "cell-visibility.spec.js", // Requires fixture notebook with pre-existing outputs
+// Native WebDriver default runs should stay small and Tauri-specific. Most
+// notebook behavior coverage lives in apps/notebook/e2e Playwright specs.
+// These specs remain available via E2E_SPEC for targeted native debugging.
+const NON_DEFAULT_NATIVE_SPECS = [
+  "tab-completion.spec.js", // Covered by apps/notebook/e2e/tab-completion.spec.ts
+  "cell-visibility.spec.js", // Covered by apps/notebook/e2e/cell-visibility.spec.ts
   "conda-inline.spec.js",
-  "deno.spec.js",
+  "deno.spec.js", // Covered by apps/notebook/e2e/environment-kernels.spec.ts
   "dx-bootstrap-repr-llm.spec.js", // Requires nteract launcher before daemon startup
-  "prewarmed-uv.spec.js",
+  "prewarmed-uv.spec.js", // Covered by apps/notebook/e2e/environment-kernels.spec.ts
   "trust-dialog-dismiss.spec.js",
   "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory
   "uv-inline.spec.js",
-  "uv-pyproject.spec.js",
+  "uv-pyproject.spec.js", // Covered by apps/notebook/e2e/environment-kernels.spec.ts
   "widget-slider-stall.spec.js", // Requires fixture notebook with ipywidgets slider
 ];
 
@@ -76,10 +78,10 @@ export const config = {
     ? [path.resolve(process.env.E2E_SPEC)]
     : [path.join(__dirname, "specs", "*.spec.js")],
 
-  // Exclude fixture specs from default run (they require NOTEBOOK_PATH)
+  // Exclude migrated and long-tail specs from the default native smoke run.
   exclude: process.env.E2E_SPEC
     ? []
-    : FIXTURE_SPECS.map((spec) => path.join(__dirname, "specs", spec)),
+    : NON_DEFAULT_NATIVE_SPECS.map((spec) => path.join(__dirname, "specs", spec)),
 
   // Don't run tests in parallel - we have one app instance
   maxInstances: 1,


### PR DESCRIPTION
## Summary

- add Playwright coverage for saved Python/UV, Deno, pyproject dependencies, tab completion, and cell visibility
- keep migrated fixture tests on temporary notebook copies so browser runs do not mutate shared fixtures
- shrink native WebDriver CI to Tauri-specific coverage while Browser E2E runs the notebook UI/runtime suite
- update native E2E defaults, `test-all`, and testing docs to describe the Playwright-first split

## Verification

- `NTERACT_BROWSER_E2E_READY_TIMEOUT_MS=300000 pnpm --filter notebook-ui test:e2e:browser -- --project=chromium e2e/cell-visibility.spec.ts e2e/tab-completion.spec.ts e2e/environment-kernels.spec.ts`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm exec actionlint .github/workflows/build.yml`
- `git diff --check`
