### PR TITLE
feat(notebook): refine hidden and output surfaces

### DIFF
--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -2,7 +2,7 @@
 
 import { FileCode2, FileText, Rows3, ShieldCheck } from "lucide-react";
 import { useLayoutEffect, useMemo, useState } from "react";
-import { CodeCell } from "@/notebook-components/CodeCell";
+import { CodeCell, type HiddenGroupCellSummary } from "@/notebook-components/CodeCell";
 import { MarkdownCell } from "@/notebook-components/MarkdownCell";
 import { NotebookView } from "@/notebook-components/NotebookView";
 import { RawCell } from "@/notebook-components/RawCell";
@@ -77,6 +77,41 @@ const hiddenCodeCellRows = [
     outputsHidden: true,
     hiddenGroupCount: 1,
   }),
+  hiddenCodeCellFixture({
+    id: "elements-hidden-group-cell",
+    label: "Hidden group",
+    detail:
+      "Consecutive fully-hidden cells merge into one quiet document line with targeted reveal rows.",
+    sourceHidden: true,
+    outputsHidden: true,
+    hiddenGroupCount: 5,
+    hiddenGroupItems: [
+      {
+        id: "elements-hidden-group-load",
+        preview: "load_dataset('mathnet/topic-viz')",
+        outputCount: 1,
+        hasError: false,
+      },
+      {
+        id: "elements-hidden-group-schema",
+        preview: "schema = topics_df.dtypes",
+        outputCount: 1,
+        hasError: false,
+      },
+      {
+        id: "elements-hidden-group-sunburst",
+        preview: "fig = px.sunburst(topic_tree)",
+        outputCount: 2,
+        hasError: false,
+      },
+      {
+        id: "elements-hidden-group-invalid",
+        preview: "render_topic_panel(topic='missing')",
+        outputCount: 1,
+        hasError: true,
+      },
+    ],
+  }),
 ];
 
 const markdownFixtureSource = [
@@ -148,7 +183,7 @@ const fullCellBoundaryRows = [
     catalogPath: "fixture metadata.jupyter flags",
     productionBoundary: "NotebookView source/output visibility mutations",
     detail:
-      "The catalog renders production CodeCell hidden affordances from static metadata. Production writes those flags back through notebook document mutations.",
+      "The catalog renders production CodeCell hidden affordances from static metadata, including grouped hidden-cell previews. Production writes those flags back through notebook document mutations.",
   },
   {
     surface: "Transient cell UI state",
@@ -208,6 +243,7 @@ function hiddenCodeCellFixture({
   sourceHidden,
   outputsHidden,
   hiddenGroupCount,
+  hiddenGroupItems,
 }: {
   id: string;
   label: string;
@@ -215,6 +251,7 @@ function hiddenCodeCellFixture({
   sourceHidden: boolean;
   outputsHidden: boolean;
   hiddenGroupCount?: number;
+  hiddenGroupItems?: HiddenGroupCellSummary[];
 }) {
   const outputs = primaryScenarioCodeCell.outputs.map((output, index) => ({
     ...output,
@@ -238,6 +275,7 @@ function hiddenCodeCellFixture({
     sourceHidden,
     outputsHidden,
     hiddenGroupCount,
+    hiddenGroupItems,
     executionId: `${id}:execution`,
     outputs,
     cell,
@@ -463,7 +501,9 @@ export function FullCellSurfacesExample() {
                     onToggleSourceHidden={noop}
                     onToggleOutputsHidden={noop}
                     hiddenGroupCount={row.hiddenGroupCount}
+                    hiddenGroupItems={row.hiddenGroupItems}
                     onExpandHiddenGroup={noop}
+                    onExpandHiddenGroupCell={noop}
                   />
                 </div>
               </div>

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -78,6 +78,10 @@ interface CodeCellProps {
   onExpandHiddenGroup?: () => void;
   /** Cell IDs in this hidden group (for executing indicator) */
   hiddenGroupCellIds?: string[];
+  /** Compact previews for cells in a hidden group. */
+  hiddenGroupItems?: HiddenGroupCellSummary[];
+  /** Callback to reveal one cell from a hidden group. */
+  onExpandHiddenGroupCell?: (cellId: string) => void;
   /** Number of error outputs across all cells in a hidden group */
   hiddenGroupErrorCount?: number;
   /** Content for the right gutter (e.g., delete button, input toggle) */
@@ -85,6 +89,13 @@ interface CodeCellProps {
   readOnly?: boolean;
   canExecute?: boolean;
   outputHostContext?: NteractEmbedHostContextPatch;
+}
+
+export interface HiddenGroupCellSummary {
+  id: string;
+  preview: string;
+  outputCount: number;
+  hasError: boolean;
 }
 
 function historyQueryFromEditor(view: EditorView | null, fallbackSource: string): string {
@@ -153,6 +164,94 @@ function HiddenCellDisclosure({
       {alert ? <span className="shrink-0 font-medium text-destructive">{alert}</span> : null}
       <ChevronRight className="size-3 shrink-0 text-muted-foreground/35 transition-colors group-hover/reveal:text-muted-foreground/70" />
     </button>
+  );
+}
+
+function HiddenGroupDisclosure({
+  count,
+  items,
+  alert,
+  disabled,
+  pulsing,
+  onRevealAll,
+  onRevealCell,
+}: {
+  count: number;
+  items: readonly HiddenGroupCellSummary[];
+  alert?: string;
+  disabled?: boolean;
+  pulsing?: boolean;
+  onRevealAll: () => void;
+  onRevealCell?: (cellId: string) => void;
+}) {
+  const visibleItems = items.slice(0, 4);
+  const hiddenItemCount = Math.max(0, count - visibleItems.length);
+
+  return (
+    <div className={cn("group/reveal w-full min-w-0 py-1 text-xs", pulsing && "animate-pulse")}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onRevealAll}
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2 text-left leading-none",
+          "text-muted-foreground/70 transition-colors hover:text-foreground",
+          disabled && "cursor-default hover:text-muted-foreground/70",
+        )}
+        title={`Show all ${count} hidden cells`}
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/45 transition-colors group-hover/reveal:text-muted-foreground/70">
+          <Code2 className="size-3.5" />
+        </span>
+        <span className="shrink-0 font-medium">{count} cells hidden</span>
+        <span
+          className="h-px min-w-4 flex-1 rounded-full bg-border/15 transition-colors group-hover/reveal:bg-border/30"
+          aria-hidden="true"
+        />
+        {alert ? <span className="shrink-0 font-medium text-destructive">{alert}</span> : null}
+        <span className="shrink-0 font-medium text-muted-foreground/50 transition-colors group-hover/reveal:text-muted-foreground/80">
+          Show all
+        </span>
+        <ChevronRight className="size-3 shrink-0 text-muted-foreground/35 transition-colors group-hover/reveal:text-muted-foreground/70" />
+      </button>
+      {visibleItems.length > 0 ? (
+        <div className="mt-1.5 ml-6 space-y-0.5 border-l border-border/20 pl-2">
+          {visibleItems.map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              disabled={disabled || !onRevealCell}
+              onClick={() => onRevealCell?.(item.id)}
+              className={cn(
+                "grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-sm py-1 text-left",
+                "text-muted-foreground/60 transition-colors hover:text-foreground",
+                "disabled:cursor-default disabled:hover:text-muted-foreground/60",
+              )}
+              title={`Show hidden cell ${index + 1}: ${item.preview}`}
+            >
+              <span className="min-w-0 flex-1 truncate font-mono">{item.preview}</span>
+              {item.hasError || item.outputCount > 0 ? (
+                <span
+                  className={cn(
+                    "shrink-0 text-[10px] tabular-nums text-muted-foreground/45",
+                    item.hasError && "font-medium text-destructive/80",
+                  )}
+                >
+                  {item.hasError
+                    ? "error"
+                    : `${item.outputCount} ${item.outputCount === 1 ? "output" : "outputs"}`}
+                </span>
+              ) : null}
+            </button>
+          ))}
+          {hiddenItemCount > 0 ? (
+            <div className="py-1 text-[10px] text-muted-foreground/45">
+              + {hiddenItemCount} more hidden
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -225,6 +324,8 @@ export const CodeCell = memo(function CodeCell({
   hiddenGroupCount,
   onExpandHiddenGroup,
   hiddenGroupCellIds,
+  hiddenGroupItems,
+  onExpandHiddenGroupCell,
   hiddenGroupErrorCount,
   rightGutterContent,
   readOnly = false,
@@ -527,37 +628,58 @@ export const CodeCell = memo(function CodeCell({
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
               <div className="mt-0.5">
-                <HiddenCellDisclosure
-                  icon={Code2}
-                  disabled={readOnly}
-                  pulsing={isExecuting || isGroupExecuting}
-                  onClick={() => {
-                    if (readOnly) return;
-                    if (onExpandHiddenGroup) {
-                      onExpandHiddenGroup();
-                    } else {
+                {hiddenGroupCount && hiddenGroupCount > 1 ? (
+                  <HiddenGroupDisclosure
+                    count={hiddenGroupCount}
+                    items={hiddenGroupItems ?? []}
+                    disabled={readOnly}
+                    pulsing={isExecuting || isGroupExecuting}
+                    onRevealAll={() => {
+                      if (readOnly) return;
+                      if (onExpandHiddenGroup) {
+                        onExpandHiddenGroup();
+                      } else {
+                        onToggleSourceHidden?.(false);
+                        onToggleOutputsHidden?.(false);
+                      }
+                    }}
+                    onRevealCell={
+                      onExpandHiddenGroupCell
+                        ? (cellId) => {
+                            if (readOnly) return;
+                            onExpandHiddenGroupCell(cellId);
+                          }
+                        : undefined
+                    }
+                    alert={
+                      hiddenGroupErrorCount
+                        ? hiddenGroupErrorCount === 1
+                          ? "1 error"
+                          : `${hiddenGroupErrorCount} errors`
+                        : undefined
+                    }
+                  />
+                ) : (
+                  <HiddenCellDisclosure
+                    icon={Code2}
+                    disabled={readOnly}
+                    pulsing={isExecuting || isGroupExecuting}
+                    onClick={() => {
+                      if (readOnly) return;
                       onToggleSourceHidden?.(false);
                       onToggleOutputsHidden?.(false);
+                    }}
+                    title="Show cell"
+                    label="Cell hidden"
+                    alert={
+                      hiddenGroupErrorCount
+                        ? hiddenGroupErrorCount === 1
+                          ? "1 error"
+                          : `${hiddenGroupErrorCount} errors`
+                        : undefined
                     }
-                  }}
-                  title={
-                    hiddenGroupCount && hiddenGroupCount > 1
-                      ? `Show ${hiddenGroupCount} cells`
-                      : "Show cell"
-                  }
-                  label={
-                    hiddenGroupCount && hiddenGroupCount > 1
-                      ? `${hiddenGroupCount} cells hidden`
-                      : "Cell hidden"
-                  }
-                  alert={
-                    hiddenGroupErrorCount
-                      ? hiddenGroupErrorCount === 1
-                        ? "1 error"
-                        : `${hiddenGroupErrorCount} errors`
-                      : undefined
-                  }
-                />
+                  />
+                )}
               </div>
             ) : isSourceHidden ? (
               <>

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -32,14 +32,19 @@ import { usePresenceContext } from "../contexts/PresenceContext";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
 import { logger } from "../lib/logger";
-import { getNotebookCellsSnapshot, useCell, useMaterializeVersion } from "../lib/notebook-cells";
+import {
+  getCellById,
+  getNotebookCellsSnapshot,
+  useCell,
+  useMaterializeVersion,
+} from "../lib/notebook-cells";
 import {
   getCellOutputsSnapshot,
   subscribeOutputsVersion,
   useOutputStructureVersion,
 } from "../lib/notebook-outputs";
 import type { CodeCell as CodeCellType, NotebookCell } from "../types";
-import { CodeCell } from "./CodeCell";
+import { CodeCell, type HiddenGroupCellSummary } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
 
@@ -195,6 +200,24 @@ function isCellFullyHidden(cell: NotebookCell): boolean {
   // output-only frames.
   if (jupyter.outputs_hidden === true) return true;
   return getCellOutputsSnapshot(cell.id).length === 0;
+}
+
+function hiddenGroupCellSummary(
+  cell: NotebookCell,
+  outputCount: number,
+  hasError: boolean,
+): HiddenGroupCellSummary {
+  const firstLine = cell.source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  return {
+    id: cell.id,
+    preview: firstLine ?? "empty cell",
+    outputCount,
+    hasError,
+  };
 }
 
 /**
@@ -532,6 +555,7 @@ function NotebookViewContent({
         count: number;
         isFirst: boolean;
         groupCellIds: string[];
+        items: HiddenGroupCellSummary[];
         errorCount: number;
       }
     >();
@@ -539,16 +563,18 @@ function NotebookViewContent({
     while (i < cells.length) {
       if (isCellFullyHidden(cells[i])) {
         const groupCellIds: string[] = [];
+        const groupItems: HiddenGroupCellSummary[] = [];
         let groupErrorCount = 0;
         while (i < cells.length && isCellFullyHidden(cells[i])) {
           const c = cells[i];
+          const outputs = c.cell_type === "code" ? getCellOutputsSnapshot(c.id) : [];
+          const errorCount = outputs.filter((o) => o.output_type === "error").length;
           groupCellIds.push(c.id);
+          groupItems.push(hiddenGroupCellSummary(c, outputs.length, errorCount > 0));
           if (c.cell_type === "code") {
             // Read from the outputs store - `c.outputs` is stale under
             // Phase C-lite on output-only frame updates.
-            groupErrorCount += getCellOutputsSnapshot(c.id).filter(
-              (o) => o.output_type === "error",
-            ).length;
+            groupErrorCount += errorCount;
           }
           i++;
         }
@@ -557,6 +583,7 @@ function NotebookViewContent({
             count: groupCellIds.length,
             isFirst: j === 0,
             groupCellIds,
+            items: groupItems,
             errorCount: groupErrorCount,
           });
         }
@@ -568,6 +595,26 @@ function NotebookViewContent({
   }, [cellIds, materializeVersion, outputStructureVersion]);
   const hiddenGroupsRef = useRef(hiddenGroups);
   hiddenGroupsRef.current = hiddenGroups;
+  const pendingRevealFocusCellIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const cellId = pendingRevealFocusCellIdRef.current;
+    if (!cellId) return;
+
+    const cell = getCellById(cellId);
+    if (!cell) {
+      pendingRevealFocusCellIdRef.current = null;
+      return;
+    }
+
+    if (isCellFullyHidden(cell)) return;
+
+    pendingRevealFocusCellIdRef.current = null;
+    const frame = window.requestAnimationFrame(() => {
+      focusCell(cellId, "start");
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [focusCell, hiddenGroups, materializeVersion, outputStructureVersion]);
 
   // Prevent horizontal scroll drift (can happen during text selection) and
   // remember whether the user is already reading at the notebook tail.
@@ -844,6 +891,7 @@ function NotebookViewContent({
             hiddenGroupCount={hiddenGroup?.count}
             hiddenGroupErrorCount={hiddenGroup?.errorCount}
             hiddenGroupCellIds={hiddenGroup?.groupCellIds}
+            hiddenGroupItems={hiddenGroup?.items}
             onExpandHiddenGroup={
               hiddenGroupsRef.current.has(cell.id) &&
               canMutateCells &&
@@ -857,6 +905,20 @@ function NotebookViewContent({
                         onSetCellOutputsHidden(id, false);
                       }
                     }
+                  }
+                : undefined
+            }
+            onExpandHiddenGroupCell={
+              hiddenGroupsRef.current.has(cell.id) &&
+              canMutateCells &&
+              onSetCellSourceHidden &&
+              onSetCellOutputsHidden
+                ? (hiddenCellId: string) => {
+                    pendingRevealFocusCellIdRef.current = hiddenCellId;
+                    onSetCellSourceHidden(hiddenCellId, false);
+                    onSetCellOutputsHidden(hiddenCellId, false);
+                    onFocusCell(hiddenCellId);
+                    presence?.setFocus(hiddenCellId);
                   }
                 : undefined
             }

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -20,6 +20,8 @@ type RunningSignalPhase = "resting" | "building" | "active" | "settling";
 
 const RUNNING_SIGNAL_DELAY_MS = 120;
 const RUNNING_SIGNAL_SETTLE_MS = 320;
+const RUNNING_SIGNAL_WAVE_PATH =
+  "M-120 6 C-115 1 -110 1 -105 6 S-95 11 -90 6 S-80 1 -75 6 S-65 11 -60 6 S-50 1 -45 6 S-35 11 -30 6 S-20 1 -15 6 S-5 11 0 6 S10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6 S250 1 255 6 S265 11 270 6 S280 1 285 6 S295 11 300 6 S310 1 315 6 S325 11 330 6 S340 1 345 6 S355 11 360 6";
 
 function formatExecutionCount(count: number): string {
   return count > 999 ? "999+" : String(count);
@@ -195,12 +197,12 @@ function ExecutionBoundaryRule({
             aria-hidden="true"
           >
             <svg
-              className="absolute inset-y-0 left-0 h-full w-[200%] animate-exec-signal-wave"
-              viewBox="0 0 240 12"
+              className="absolute inset-y-0 left-0 h-full w-[300%] animate-exec-signal-wave"
+              viewBox="0 0 360 12"
               preserveAspectRatio="none"
             >
               <path
-                d="M0 6 C5 1 10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6"
+                d={RUNNING_SIGNAL_WAVE_PATH}
                 fill="none"
                 stroke="currentColor"
                 strokeLinecap="round"

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -291,30 +291,39 @@ export function AnsiStreamOutput({ text, streamName, className = "" }: AnsiStrea
       {preview.isLong && (
         <div
           className={cn(
-            "mb-2 flex flex-wrap items-center gap-2 rounded-md border px-2 py-1 text-xs",
-            isStderr
-              ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300"
-              : "border-slate-200 bg-slate-50 text-slate-600 dark:border-slate-800 dark:bg-slate-900/50 dark:text-slate-300",
+            "mb-2 flex flex-wrap items-center gap-2 text-xs leading-none",
+            isStderr ? "text-red-700/80 dark:text-red-300/80" : "text-muted-foreground/70",
           )}
         >
-          <span className="font-semibold">{label}</span>
-          <span>
+          <span className="font-mono font-semibold">{label}</span>
+          <span
+            className={cn(
+              "h-px min-w-8 flex-1 rounded-full",
+              isStderr ? "bg-red-500/20 dark:bg-red-300/20" : "bg-border/20",
+            )}
+            aria-hidden="true"
+          />
+          <span className="tabular-nums">
             {preview.lineCount.toLocaleString()} lines · {formatBytes(text.length)}
           </span>
           {!expanded && preview.omittedLines > 0 && (
-            <span>{preview.omittedLines.toLocaleString()} lines hidden</span>
+            <span className="tabular-nums text-muted-foreground/55">
+              {preview.omittedLines.toLocaleString()} lines hidden
+            </span>
           )}
           <button
             type="button"
             className={cn(
-              "ml-auto rounded px-1.5 py-0.5 font-medium transition-colors",
+              "rounded-sm px-1.5 py-1 font-medium transition-colors",
               isStderr
-                ? "hover:bg-red-100 dark:hover:bg-red-900/50"
-                : "hover:bg-slate-200 dark:hover:bg-slate-800",
+                ? "hover:bg-red-500/10 hover:text-red-700 dark:hover:bg-red-300/10 dark:hover:text-red-200"
+                : "hover:bg-muted hover:text-foreground",
             )}
             onClick={() => setExpanded((value) => !value)}
+            aria-expanded={expanded}
+            aria-label={expanded ? "Collapse log" : "Show full log"}
           >
-            {expanded ? "Collapse log" : "Show full log"}
+            {expanded ? "Collapse" : "Show full"}
           </button>
         </div>
       )}

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -214,7 +214,7 @@ export function TracebackOutput({
     <div
       data-slot="traceback"
       className={cn(
-        "rounded-md border border-destructive/25 bg-destructive/5",
+        "border-l-2 border-destructive/45 bg-destructive/[0.03] pl-2",
         "text-sm",
         className,
       )}
@@ -240,7 +240,7 @@ export function TracebackOutput({
         />
       ) : (
         clusters.length > 0 && (
-          <ol className="divide-y divide-destructive/15">
+          <ol className="divide-y divide-destructive/10">
             {clusters.map((cluster, i) => (
               <FrameRow
                 key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
@@ -284,7 +284,7 @@ function Header({
   // disagree on edge cases.
   const canInline = inlineEvalue && Boolean(evalue);
   return (
-    <div className="flex items-start gap-2 px-3 py-2 font-mono">
+    <div className="flex items-start gap-2 px-2 py-2 font-mono">
       <OctagonAlert
         aria-hidden="true"
         className="mt-0.5 h-4 w-4 shrink-0 text-destructive"
@@ -358,7 +358,7 @@ function SyntaxErrorBlock({
   const location = sourceLocation(syntax, currentExecutionId, resolveExecutionTarget);
 
   return (
-    <div className="px-3 pb-2">
+    <div className="px-2 pb-2">
       <div className="mb-1.5 font-mono text-xs text-muted-foreground" title={location.title}>
         <LocationLabel
           location={location}
@@ -368,7 +368,7 @@ function SyntaxErrorBlock({
       </div>
       <pre
         className={cn(
-          "overflow-x-auto rounded border border-destructive/15 bg-muted/40",
+          "overflow-x-auto border-l-2 border-destructive/20 bg-muted/30",
           "px-2 py-1.5 leading-5",
         )}
         style={{ fontFamily: CM_FONT_FAMILY, fontSize: "13px" }}
@@ -430,7 +430,7 @@ function CopyButton({
       aria-label={copied ? "Copied" : "Copy traceback"}
       title={copied ? "Copied" : "Copy traceback"}
       className={cn(
-        "shrink-0 rounded px-1.5 py-1 text-xs font-mono transition-colors",
+        "shrink-0 rounded-sm px-1.5 py-1 text-xs font-mono transition-colors",
         "text-muted-foreground hover:bg-destructive/10 hover:text-destructive",
       )}
     >
@@ -465,12 +465,12 @@ function FrameRow({
   const { frame, count } = cluster;
   const location = sourceLocation(frame, currentExecutionId, resolveExecutionTarget);
   return (
-    <li className={cn("px-3 py-1.5", frame.library && "opacity-60")}>
+    <li className={cn("px-2 py-1.5", frame.library && "opacity-60")}>
       <div className="flex w-full items-center gap-2 font-mono text-xs">
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
-          className="rounded-sm text-muted-foreground transition-colors hover:text-destructive"
+          className="rounded-sm text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
           aria-expanded={open}
           aria-label={open ? "Collapse traceback frame" : "Expand traceback frame"}
         >
@@ -782,7 +782,7 @@ function SourceBlock({ lines, language }: { lines: Line[]; language: string }) {
   return (
     <pre
       className={cn(
-        "mt-1.5 overflow-x-auto rounded border border-destructive/15 bg-muted/40",
+        "mt-1.5 overflow-x-auto border-l-2 border-destructive/20 bg-muted/30",
         "px-2 py-1.5 leading-5",
       )}
       style={{ fontFamily: CM_FONT_FAMILY, fontSize: "13px" }}

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -145,7 +145,7 @@
     transform: translateX(0);
   }
   to {
-    transform: translateX(-50%);
+    transform: translateX(-33.333333%);
   }
 }
 


### PR DESCRIPTION
## Summary

- add targeted reveal rows for grouped fully-hidden cells so one hidden cell can be opened without expanding the whole group
- soften long stream and traceback surfaces into quieter inline document language
- tile the running execution signal as a periodic wave so long runs do not show a loop seam
- document the grouped hidden-cell state in the Elements full-cell surfaces catalog

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx src/components/outputs/__tests__/ansi-output.test.tsx src/components/outputs/__tests__/traceback-output.test.tsx`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
- Playwright smoke screenshot against `http://localhost:9866/?path=.../.context/ribbon-fixture.ipynb`
