### PR TITLE
fix(notebook-cloud): span host notices above notebook rail

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -146,6 +146,25 @@ test("cloud rail binds through the shared document rail adapter", () => {
   assert.doesNotMatch(sourceText, /<NotebookRail[\s>]/);
 });
 
+test("cloud host notices sit in the shared shell above the rail and notebook stage", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+  const shellPath = new URL(
+    "../../../src/components/notebook/NotebookDocumentShell.tsx",
+    import.meta.url,
+  );
+  const shellText = readFileSync(shellPath, "utf8");
+
+  assert.match(sourceText, /const hasNotices =/);
+  assert.match(sourceText, /const notices = hasNotices \? \(/);
+  assert.match(sourceText, /notices=\{notices\}/);
+  assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
+  assert.match(
+    shellText,
+    /data-slot="notebook-document-notices"[\s\S]*data-slot="notebook-document-body"[\s\S]*\{rail\}[\s\S]*data-slot="notebook-document-stage"/,
+  );
+});
+
 test("cloud viewer shell uses the shared notebook rail as an adapter surface", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -38,8 +38,12 @@ body {
   overflow: hidden;
 }
 
-.cloud-notebook-stage > .cloud-state {
-  margin-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+.cloud-notebook-notices {
+  display: grid;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--background);
+  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
 }
 
 .cloud-room-toolbar {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1318,20 +1318,15 @@ function NotebookViewer({
       />
     </div>
   ) : null;
-
-  return (
-    <NotebookDocumentShell
-      rootElement="main"
-      className="cloud-notebook-shell"
-      stageClassName="cloud-notebook-stage"
-      toolbar={toolbar}
-      toolbarLabel="Notebook view status and controls"
-      capabilities={shellCapabilities}
-      rail={rail}
-      stageLabel="Hosted notebook"
-    >
-      <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
-
+  const hasNotices =
+    authState.mode === "invalid" ||
+    authState.mode === "oidc_expired" ||
+    authRenewal.kind !== "idle" ||
+    Boolean(connectionError) ||
+    Boolean(authDiagnostics) ||
+    status.kind !== "ready";
+  const notices = hasNotices ? (
+    <>
       {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
         <div className="cloud-state cloud-auth-state" data-kind="error">
           <span>{prototypeAuthSummary(authState)}</span>
@@ -1374,6 +1369,23 @@ function NotebookViewer({
           {status.message}
         </div>
       )}
+    </>
+  ) : null;
+
+  return (
+    <NotebookDocumentShell
+      rootElement="main"
+      className="cloud-notebook-shell"
+      stageClassName="cloud-notebook-stage"
+      toolbar={toolbar}
+      toolbarLabel="Notebook view status and controls"
+      notices={notices}
+      noticesClassName="cloud-notebook-notices"
+      capabilities={shellCapabilities}
+      rail={rail}
+      stageLabel="Hosted notebook"
+    >
+      <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
 
       <PresenceValueProvider value={cloudPresenceContext}>
         <CrdtBridgeProvider

--- a/src/components/notebook/NotebookDocumentShell.tsx
+++ b/src/components/notebook/NotebookDocumentShell.tsx
@@ -39,7 +39,7 @@ export function NotebookDocumentShell({
 
   return (
     <Root
-      className={cn("flex min-h-0 flex-1 overflow-hidden", className)}
+      className={cn("flex min-h-0 flex-1 flex-col overflow-hidden", className)}
       data-authenticated={capabilities?.auth.canUseAuthenticatedIdentity}
       data-access-level={capabilities?.access.level}
       data-access-source={capabilities?.access.source}
@@ -51,28 +51,30 @@ export function NotebookDocumentShell({
       data-runtime-connected={capabilities?.runtime.connected}
       data-slot="notebook-document-shell"
     >
-      {rail}
-      <section
-        className={cn("flex min-w-0 flex-1 flex-col", stageClassName)}
-        aria-label={stageLabel}
-        data-slot="notebook-document-stage"
-      >
-        {toolbar ? (
-          <div
-            className={toolbarClassName}
-            aria-label={toolbarLabel}
-            data-slot="notebook-document-toolbar"
-          >
-            {toolbar}
-          </div>
-        ) : null}
-        {notices ? (
-          <div className={noticesClassName} data-slot="notebook-document-notices">
-            {notices}
-          </div>
-        ) : null}
-        {children}
-      </section>
+      {toolbar ? (
+        <div
+          className={toolbarClassName}
+          aria-label={toolbarLabel}
+          data-slot="notebook-document-toolbar"
+        >
+          {toolbar}
+        </div>
+      ) : null}
+      {notices ? (
+        <div className={noticesClassName} data-slot="notebook-document-notices">
+          {notices}
+        </div>
+      ) : null}
+      <div className="flex min-h-0 flex-1 overflow-hidden" data-slot="notebook-document-body">
+        {rail}
+        <section
+          className={cn("flex min-w-0 flex-1 flex-col", stageClassName)}
+          aria-label={stageLabel}
+          data-slot="notebook-document-stage"
+        >
+          {children}
+        </section>
+      </div>
     </Root>
   );
 }

--- a/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentShell.test.tsx
@@ -10,6 +10,7 @@ describe("NotebookDocumentShell", () => {
         rail={<nav aria-label="Rail">rail</nav>}
         toolbar={<button type="button">Run</button>}
         notices={<p>Syncing</p>}
+        toolbarLabel="Notebook fixture toolbar"
         stageLabel="Hosted notebook"
       >
         <section aria-label="Notebook cells">cells</section>
@@ -19,6 +20,18 @@ describe("NotebookDocumentShell", () => {
     expect(screen.getByLabelText("Rail")).toBeVisible();
     expect(screen.getByRole("button", { name: "Run" })).toBeVisible();
     expect(screen.getByText("Syncing")).toBeVisible();
+    expect(screen.getByLabelText("Notebook fixture toolbar")).toHaveAttribute(
+      "data-slot",
+      "notebook-document-toolbar",
+    );
+    expect(screen.getByText("Syncing").parentElement).toHaveAttribute(
+      "data-slot",
+      "notebook-document-notices",
+    );
+    expect(screen.getByLabelText("Rail").parentElement).toHaveAttribute(
+      "data-slot",
+      "notebook-document-body",
+    );
     expect(screen.getByLabelText("Hosted notebook")).toHaveAttribute(
       "data-slot",
       "notebook-document-stage",


### PR DESCRIPTION
## Summary
- move shared notebook shell toolbar/notices above the rail+stage body
- render notebook-cloud auth/connection/status notices through the shared shell notices slot
- cover the cloud host-notice placement with focused shell/convergence tests

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm test:run src/components/notebook-shell/__tests__/NotebookDocumentShell.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- deployed `preview.runt.run`
- hosted smoke: `https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit`
- visual layout check: toolbar spans the full shell width before rail+stage body

## Notes
- This keeps the rail as part of the notebook app frame while letting cloud host notices span the full notebook surface.
