### PR TITLE
fix(runtimed): stabilize noisy stdout reconciliation

### DIFF
--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -60,6 +60,10 @@ pub enum ExecutionTerminalError {
 /// the caller does not override it. Bounded so a genuinely output-free
 /// execution cannot block the caller indefinitely.
 pub const DEFAULT_OUTPUT_SYNC_GRACE: Duration = Duration::from_millis(500);
+/// Default output-sync grace for blob-backed terminal streams, which can lag
+/// behind terminal status under CI load because the manifest update and blob
+/// write are larger than ordinary inline outputs.
+pub const DEFAULT_BLOB_OUTPUT_SYNC_GRACE: Duration = Duration::from_secs(3);
 
 /// Poll frequency while waiting for terminal status.
 const TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -67,6 +71,8 @@ const TERMINAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const OUTPUT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Quiet period after the last observed terminal stream-output mutation.
 const STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(100);
+/// Quiet period for blob-backed terminal streams.
+const BLOB_STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(500);
 
 /// Wait for a specific execution to reach terminal status in the
 /// `RuntimeStateDoc` and return the final outputs, execution count, and
@@ -140,19 +146,21 @@ pub async fn await_execution_terminal(
     // behind. Stream outputs are also updated in place, so a non-empty output
     // list can still contain the penultimate stream blob. Poll briefly until
     // stream outputs are quiet.
-    if final_state.output_manifests.is_empty() || has_stream_output(&final_state.output_manifests) {
-        let grace = output_sync_grace.unwrap_or(DEFAULT_OUTPUT_SYNC_GRACE);
+    if final_state.output_manifests.is_empty()
+        || stream_output_settle_window(&final_state.output_manifests).is_some()
+    {
+        let (default_quiet_period, default_grace) =
+            stream_output_settle_window(&final_state.output_manifests)
+                .unwrap_or((STREAM_OUTPUT_QUIET_PERIOD, DEFAULT_OUTPUT_SYNC_GRACE));
+        let grace = output_sync_grace.unwrap_or(default_grace);
         let remaining_until_deadline = deadline.saturating_duration_since(Instant::now());
         let output_deadline = Instant::now() + grace.min(remaining_until_deadline);
-        let mut stream_quiet_since = if has_stream_output(&final_state.output_manifests) {
-            Some(Instant::now())
-        } else {
-            None
-        };
+        let mut stream_quiet_since =
+            stream_output_settle_window(&final_state.output_manifests).map(|_| Instant::now());
+        let mut quiet_period = default_quiet_period;
 
         while Instant::now() < output_deadline {
-            if stream_quiet_since.is_some_and(|since| since.elapsed() >= STREAM_OUTPUT_QUIET_PERIOD)
-            {
+            if stream_quiet_since.is_some_and(|since| since.elapsed() >= quiet_period) {
                 break;
             }
 
@@ -163,14 +171,17 @@ pub async fn await_execution_terminal(
                         if final_state.execution_count.is_none() {
                             final_state.execution_count = exec.execution_count;
                         }
-                        stream_quiet_since = if has_stream_output(&final_state.output_manifests) {
-                            Some(Instant::now())
+                        let stream_window =
+                            stream_output_settle_window(&final_state.output_manifests);
+                        if let Some((next_quiet_period, _)) = stream_window {
+                            quiet_period = next_quiet_period;
+                            stream_quiet_since = Some(Instant::now());
                         } else {
-                            None
-                        };
+                            stream_quiet_since = None;
+                        }
 
                         if !final_state.output_manifests.is_empty()
-                            && !has_stream_output(&final_state.output_manifests)
+                            && stream_output_settle_window(&final_state.output_manifests).is_none()
                         {
                             break;
                         }
@@ -184,8 +195,23 @@ pub async fn await_execution_terminal(
     Ok(final_state)
 }
 
-fn has_stream_output(outputs: &[serde_json::Value]) -> bool {
+fn stream_output_settle_window(outputs: &[serde_json::Value]) -> Option<(Duration, Duration)> {
+    let has_blob_stream = outputs.iter().any(|output| {
+        output.get("output_type").and_then(|t| t.as_str()) == Some("stream")
+            && output
+                .get("text")
+                .and_then(|text| text.get("blob"))
+                .is_some()
+    });
+    if has_blob_stream {
+        return Some((
+            BLOB_STREAM_OUTPUT_QUIET_PERIOD,
+            DEFAULT_BLOB_OUTPUT_SYNC_GRACE,
+        ));
+    }
+
     outputs
         .iter()
         .any(|output| output.get("output_type").and_then(|t| t.as_str()) == Some("stream"))
+        .then_some((STREAM_OUTPUT_QUIET_PERIOD, DEFAULT_OUTPUT_SYNC_GRACE))
 }

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -11,6 +11,8 @@ use crate::handle::DocHandle;
 
 const TERMINAL_STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(100);
 const TERMINAL_STREAM_OUTPUT_MAX_GRACE: Duration = Duration::from_millis(500);
+const TERMINAL_BLOB_STREAM_OUTPUT_QUIET_PERIOD: Duration = Duration::from_millis(500);
+const TERMINAL_BLOB_STREAM_OUTPUT_MAX_GRACE: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionTerminalReason {
@@ -184,12 +186,14 @@ impl ExecutionWatcher {
         &mut self,
         mut progress: ExecutionProgressState,
     ) -> ExecutionProgressState {
-        if !has_stream_output(&progress.output_manifests) {
+        let Some((mut quiet_period, max_grace)) =
+            stream_output_settle_window(&progress.output_manifests)
+        else {
             return progress;
-        }
+        };
 
-        let max_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_MAX_GRACE;
-        let mut quiet_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_QUIET_PERIOD;
+        let max_deadline = Instant::now() + max_grace;
+        let mut quiet_deadline = Instant::now() + quiet_period;
 
         loop {
             let now = Instant::now();
@@ -204,10 +208,13 @@ impl ExecutionWatcher {
                     if let Some(next) = self.progress_from_state(&state) {
                         if next.terminal {
                             progress = next;
-                            if !has_stream_output(&progress.output_manifests) {
+                            let Some((next_quiet_period, _)) =
+                                stream_output_settle_window(&progress.output_manifests)
+                            else {
                                 return progress;
-                            }
-                            quiet_deadline = Instant::now() + TERMINAL_STREAM_OUTPUT_QUIET_PERIOD;
+                            };
+                            quiet_period = next_quiet_period;
+                            quiet_deadline = Instant::now() + quiet_period;
                         }
                     }
                 }
@@ -226,10 +233,28 @@ fn terminal_reason_for(entry: &ExecutionState) -> Option<ExecutionTerminalReason
     }
 }
 
-fn has_stream_output(outputs: &[serde_json::Value]) -> bool {
+fn stream_output_settle_window(outputs: &[serde_json::Value]) -> Option<(Duration, Duration)> {
+    let has_blob_stream = outputs.iter().any(|output| {
+        output.get("output_type").and_then(|t| t.as_str()) == Some("stream")
+            && output
+                .get("text")
+                .and_then(|text| text.get("blob"))
+                .is_some()
+    });
+    if has_blob_stream {
+        return Some((
+            TERMINAL_BLOB_STREAM_OUTPUT_QUIET_PERIOD,
+            TERMINAL_BLOB_STREAM_OUTPUT_MAX_GRACE,
+        ));
+    }
+
     outputs
         .iter()
         .any(|output| output.get("output_type").and_then(|t| t.as_str()) == Some("stream"))
+        .then_some((
+            TERMINAL_STREAM_OUTPUT_QUIET_PERIOD,
+            TERMINAL_STREAM_OUTPUT_MAX_GRACE,
+        ))
 }
 
 #[cfg(test)]
@@ -377,6 +402,50 @@ mod tests {
             Some(ExecutionTerminalReason::Done)
         );
         assert_eq!(terminal.output_manifests[0]["text"]["inline"], "final");
+    }
+
+    #[tokio::test]
+    async fn watcher_waits_longer_for_blob_terminal_stream_output() {
+        let (handle, tx) = make_handle();
+        let mut watcher = ExecutionWatcher::new(&handle, "cell-1", "exec-1");
+
+        set_execution(&tx, "exec-1", "cell-1", "running", Vec::new());
+        let _ = watcher.next().await.expect("first progress");
+
+        set_execution(
+            &tx,
+            "exec-1",
+            "cell-1",
+            "done",
+            vec![serde_json::json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": {"blob": "partial", "size": 7},
+            })],
+        );
+
+        let tx_for_task = tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            set_execution(
+                &tx_for_task,
+                "exec-1",
+                "cell-1",
+                "done",
+                vec![serde_json::json!({
+                    "output_type": "stream",
+                    "name": "stdout",
+                    "text": {"blob": "final", "size": 5},
+                })],
+            );
+        });
+
+        let terminal = watcher.next().await.expect("terminal progress");
+        assert_eq!(
+            terminal.terminal_reason,
+            Some(ExecutionTerminalReason::Done)
+        );
+        assert_eq!(terminal.output_manifests[0]["text"]["blob"], "final");
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -500,6 +500,21 @@ mod tests {
     }
 
     #[test]
+    fn test_noisy_line_stream_preserves_full_scrollback() {
+        let mut terminals = StreamTerminals::new();
+        let line_count = 2_000;
+
+        for i in 0..line_count {
+            terminals.feed_chunk("cell-1", "stdout", &format!("chunk-{i}\n"));
+        }
+
+        let result = terminals.render("cell-1", "stdout").unwrap();
+        assert!(result.contains("chunk-0\n"));
+        assert!(result.contains("chunk-1999\n"));
+        assert_eq!(result.matches("chunk-").count(), line_count);
+    }
+
+    #[test]
     fn test_feed_chunk_renders_later() {
         let mut terminals = StreamTerminals::new();
 

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1079,7 +1079,8 @@ for i in range({line_count}):
     sys.stdout.flush()
 """,
         )
-        result = await session.execute_cell(cell_id, timeout_secs=30)
+        # CI can take >45s to reconcile this blob-backed stress stream under load.
+        result = await session.execute_cell(cell_id, timeout_secs=90)
 
         assert result.success, result.stderr
         assert "chunk-0\n" in result.stdout


### PR DESCRIPTION
## Summary

- extend terminal stream settling for blob-backed outputs so Python execution results wait for late final stream manifests under CI load
- keep the fast settle path for inline streams
- raise the noisy stdout stress-test timeout and add regression coverage for blob stream settling plus 2,000-line terminal rendering

## Verification

- `cargo test -p notebook-sync execution_watch::tests::watcher_waits`
- `cargo test -p runtimed stream_terminal::tests::test_noisy_line_stream_preserves_full_scrollback`
- `python/runtimed/tests/run-integration.sh --build --ci tests/test_daemon_integration.py::TestTerminalEmulation::test_noisy_stdout_final_output_reconciles -v --tb=short`
- `cargo xtask lint --fix`
