### PR TITLE
fix(notebook): keep hidden cell keyboard navigation moving

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -120,6 +120,7 @@ interface HiddenCellDisclosureProps {
   pulsing?: boolean;
   onClick: () => void;
   title: string;
+  focusTarget?: boolean;
   className?: string;
 }
 
@@ -132,6 +133,7 @@ function HiddenCellDisclosure({
   pulsing,
   onClick,
   title,
+  focusTarget,
   className,
 }: HiddenCellDisclosureProps) {
   return (
@@ -139,6 +141,7 @@ function HiddenCellDisclosure({
       type="button"
       disabled={disabled}
       onClick={onClick}
+      data-cell-focus-target={focusTarget ? "" : undefined}
       className={cn(
         "group/reveal flex w-full min-w-0 items-center gap-2 py-1 text-left text-xs leading-none",
         "text-muted-foreground/70 transition-colors hover:text-foreground",
@@ -193,6 +196,7 @@ function HiddenGroupDisclosure({
         type="button"
         disabled={disabled}
         onClick={onRevealAll}
+        data-cell-focus-target=""
         className={cn(
           "flex w-full min-w-0 items-center gap-2 text-left leading-none",
           "text-muted-foreground/70 transition-colors hover:text-foreground",
@@ -459,6 +463,28 @@ export const CodeCell = memo(function CodeCell({
     onExecute();
   }, [canExecute, onExecute]);
 
+  const handleHiddenDisclosureKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (
+        !(event.target instanceof HTMLElement) ||
+        !event.target.hasAttribute("data-cell-focus-target")
+      ) {
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        onFocusNext?.("start");
+        event.preventDefault();
+        event.stopPropagation();
+      } else if (event.key === "ArrowUp") {
+        onFocusPrevious?.("end");
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
+    [onFocusNext, onFocusPrevious],
+  );
+
   // Get keyboard navigation bindings
   const navigationKeyMap = useCellKeyboardNavigation({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
@@ -627,7 +653,7 @@ export const CodeCell = memo(function CodeCell({
           <>
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
-              <div className="mt-0.5">
+              <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
                 {hiddenGroupCount && hiddenGroupCount > 1 ? (
                   <HiddenGroupDisclosure
                     count={hiddenGroupCount}
@@ -671,6 +697,7 @@ export const CodeCell = memo(function CodeCell({
                     }}
                     title="Show cell"
                     label="Cell hidden"
+                    focusTarget
                     alert={
                       hiddenGroupErrorCount
                         ? hiddenGroupErrorCount === 1
@@ -683,7 +710,7 @@ export const CodeCell = memo(function CodeCell({
               </div>
             ) : isSourceHidden ? (
               <>
-                <div className="mt-0.5">
+                <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
                   <HiddenCellDisclosure
                     icon={Code2}
                     disabled={readOnly}
@@ -691,6 +718,7 @@ export const CodeCell = memo(function CodeCell({
                     title="Show input"
                     label="Input hidden"
                     detail={sourcePreview}
+                    focusTarget
                   />
                 </div>
                 {currentLine}

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -546,4 +546,90 @@ describe("CodeCell output focus", () => {
     expect(queryByTitle("Constrain output height")).toBeNull();
     expect(queryByTitle("Expand output")).toBeNull();
   });
+
+  it("marks hidden-cell disclosure as the fallback focus target", () => {
+    mockOutputs = [];
+    const { getByTitle } = render(
+      <CodeCell
+        cell={makeCell({
+          metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+        })}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleSourceHidden={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(getByTitle("Show cell").hasAttribute("data-cell-focus-target")).toBe(true);
+  });
+
+  it("lets arrow keys leave a focused hidden group", () => {
+    mockOutputs = [];
+    const onFocusPrevious = vi.fn();
+    const onFocusNext = vi.fn();
+
+    const { getByTitle } = render(
+      <CodeCell
+        cell={makeCell({
+          metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+        })}
+        hiddenGroupCount={3}
+        hiddenGroupItems={[
+          { id: "code-1", preview: "first()", outputCount: 0, hasError: false },
+          { id: "code-2", preview: "second()", outputCount: 1, hasError: false },
+          { id: "code-3", preview: "third()", outputCount: 0, hasError: false },
+        ]}
+        onFocus={() => {}}
+        onFocusPrevious={onFocusPrevious}
+        onFocusNext={onFocusNext}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleSourceHidden={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    const disclosure = getByTitle("Show all 3 hidden cells");
+    fireEvent.keyDown(disclosure, { key: "ArrowDown" });
+    fireEvent.keyDown(disclosure, { key: "ArrowUp" });
+
+    expect(onFocusNext).toHaveBeenCalledWith("start");
+    expect(onFocusPrevious).toHaveBeenCalledWith("end");
+  });
+
+  it("does not navigate away from hidden group preview rows with arrow keys", () => {
+    mockOutputs = [];
+    const onFocusNext = vi.fn();
+    const onExpandHiddenGroupCell = vi.fn();
+
+    const { getByTitle } = render(
+      <CodeCell
+        cell={makeCell({
+          metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+        })}
+        hiddenGroupCount={3}
+        hiddenGroupItems={[
+          { id: "code-1", preview: "first()", outputCount: 0, hasError: false },
+          { id: "code-2", preview: "second()", outputCount: 1, hasError: false },
+          { id: "code-3", preview: "third()", outputCount: 0, hasError: false },
+        ]}
+        onExpandHiddenGroupCell={onExpandHiddenGroupCell}
+        onFocus={() => {}}
+        onFocusNext={onFocusNext}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleSourceHidden={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    fireEvent.keyDown(getByTitle("Show hidden cell 2: second()"), { key: "ArrowDown" });
+
+    expect(onFocusNext).not.toHaveBeenCalled();
+  });
 });

--- a/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
+++ b/apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { EditorRegistryProvider, useEditorRegistry } from "../useEditorRegistry";
+
+function FocusProbe({
+  cellId,
+  cursorPosition = "start",
+}: {
+  cellId: string;
+  cursorPosition?: "start" | "end";
+}) {
+  const { focusCell } = useEditorRegistry();
+
+  useEffect(() => {
+    focusCell(cellId, cursorPosition);
+  }, [cellId, cursorPosition, focusCell]);
+
+  return null;
+}
+
+describe("useEditorRegistry", () => {
+  it("focuses a cell focus target when the cell has no CodeMirror editor", () => {
+    Element.prototype.scrollIntoView = vi.fn();
+
+    render(
+      <EditorRegistryProvider>
+        <div data-cell-id="hidden-cell">
+          <button type="button" data-cell-focus-target="">
+            Show hidden cell
+          </button>
+        </div>
+        <FocusProbe cellId="hidden-cell" />
+      </EditorRegistryProvider>,
+    );
+
+    expect(document.activeElement?.textContent).toBe("Show hidden cell");
+  });
+});

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -24,8 +24,14 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
     // Find CodeMirror's content element inside the cell
     const cmContent = cellElement.querySelector(".cm-content");
     if (!cmContent) {
-      // Might be a markdown cell in view mode - no editor to focus
-      logger.debug(`[cell-nav] No CM content in cell (markdown?): ${cellId.slice(0, 8)}`);
+      const focusTarget = cellElement.querySelector<HTMLElement>("[data-cell-focus-target]");
+      if (focusTarget) {
+        focusTarget.focus({ preventScroll: true });
+        return;
+      }
+
+      // Might be a markdown preview or hidden cell with no explicit fallback.
+      logger.debug(`[cell-nav] No focus target in cell: ${cellId.slice(0, 8)}`);
       return;
     }
 


### PR DESCRIPTION
## Summary

- Focus hidden-cell disclosure controls when keyboard navigation lands on cells without a CodeMirror editor.
- Let focused hidden-cell disclosures continue ArrowUp/ArrowDown navigation to adjacent visible cells.
- Cover the fallback focus target and hidden-group arrow behavior with focused tests.

## Verification

- `pnpm test:run apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `cargo xtask lint --fix`
- Playwright smoke against `.context/hidden-cell-fluidity.ipynb`: ArrowDown moved from a visible editor to an input-hidden disclosure, then into the following editor.
