### PR TITLE
refactor(outputs): remove unused output collapse API

### DIFF
--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -872,7 +872,6 @@ export function OutputRenderersExample() {
   const [siftManifestLoadMilestones, setSiftManifestLoadMilestones] = useState<SiftLoadMilestone[]>(
     [],
   );
-  const [outputAreaCollapsed, setOutputAreaCollapsed] = useState(false);
   const [outputAreaMatchCount, setOutputAreaMatchCount] = useState(0);
   const handleSiftUrlLoadMilestone = useCallback((milestone: SiftLoadMilestone) => {
     setSiftUrlLoadMilestones((current) => [...current.slice(-7), milestone]);
@@ -1047,13 +1046,10 @@ export function OutputRenderersExample() {
               <div className="mt-2 font-mono text-xs text-fd-foreground">
                 query=fold · matches={outputAreaMatchCount}
               </div>
-              <button
-                type="button"
-                className="mt-3 rounded-md border border-fd-border px-2 py-1 text-xs font-medium text-fd-foreground transition-colors hover:bg-fd-muted"
-                onClick={() => setOutputAreaCollapsed((value) => !value)}
-              >
-                {outputAreaCollapsed ? "Show outputs" : "Collapse outputs"}
-              </button>
+              <div className="mt-3 text-xs leading-5 text-fd-muted-foreground">
+                Output hiding is a notebook-cell metadata state. The shared output lane stays
+                expanded so renderer boundaries and search counts remain stable.
+              </div>
             </div>
           </div>
           <div className="rounded-md border border-fd-border bg-background py-3">
@@ -1061,8 +1057,6 @@ export function OutputRenderersExample() {
               outputs={[...outputFixtures.outputAreaOutputs]}
               cellId="elements-output-area"
               executionCount={12}
-              collapsed={outputAreaCollapsed}
-              onToggleCollapse={() => setOutputAreaCollapsed((value) => !value)}
               searchQuery="fold"
               onSearchMatchCount={setOutputAreaMatchCount}
               hostContext={{

--- a/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
+++ b/apps/notebook-cloud/e2e/render-parity/cloud-output-parity.spec.ts
@@ -253,13 +253,13 @@ test.describe("cloud renderer parity harness", () => {
       { timeout: 90_000 },
     );
 
-    const collapsible = page.getByTestId("collapsible-sift-boundary");
-    await expect(collapsible.getByRole("button", { name: "Hide outputs" })).toHaveCount(1);
-    await expect(collapsible).toContainText(cloudOutputParityExpectedMarkers.boundaryStream);
-    await expect(collapsible.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
+    const boundary = page.getByTestId("sift-boundary");
+    await expect(boundary.getByRole("button", { name: /outputs/i })).toHaveCount(0);
+    await expect(boundary).toContainText(cloudOutputParityExpectedMarkers.boundaryStream);
+    await expect(boundary.locator('iframe[data-slot="isolated-frame"]')).toHaveCount(2, {
       timeout: 60_000,
     });
-    await expect(collapsible.locator('[data-sift-output="true"]')).toHaveCount(1);
+    await expect(boundary.locator('[data-sift-output="true"]')).toHaveCount(1);
   });
 
   test("locks wheel scroll inside engaged Sift frames at table boundaries", async ({ page }) => {

--- a/apps/notebook-cloud/test/render-parity/src/main.tsx
+++ b/apps/notebook-cloud/test/render-parity/src/main.tsx
@@ -30,7 +30,6 @@ function CloudRendererParityHarness() {
   const { store: widgetStore } = useWidgetStoreRequired();
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const [cells, setCells] = useState<Awaited<ReturnType<typeof resolveCloudOutputParityCells>>>([]);
-  const [boundaryCollapsed, setBoundaryCollapsed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hostContext = useMemo(() => cloudOutputParityHostContext(), []);
   const boundaryOutputs = useMemo(
@@ -115,13 +114,11 @@ function CloudRendererParityHarness() {
                   hostContext={hostContext}
                 />
               </div>
-              <div data-testid="collapsible-sift-boundary">
-                <h2>Collapsible Sift boundary</h2>
+              <div data-testid="sift-boundary">
+                <h2>Sift boundary</h2>
                 <OutputArea
-                  cellId="collapsible-sift-boundary"
+                  cellId="sift-boundary"
                   outputs={boundaryOutputs}
-                  collapsed={boundaryCollapsed}
-                  onToggleCollapse={() => setBoundaryCollapsed((value) => !value)}
                   priority={CLOUD_VIEWER_PRIORITY}
                   hostContext={hostContext}
                 />

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,6 +1,5 @@
 import { SiftScrollHandoffCue } from "@nteract/sift/handoff";
 import "@nteract/sift/handoff.css";
-import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   type KeyboardEvent,
   type ReactNode,
@@ -198,19 +197,6 @@ interface OutputAreaProps {
    * meaningful instead of a stack of identical `localhost` rows.
    */
   executionCount?: number | null;
-  /**
-   * Whether the output area is collapsed.
-   */
-  collapsed?: boolean;
-  /**
-   * Callback when collapse state is toggled.
-   */
-  onToggleCollapse?: () => void;
-  /**
-   * Total output count to report when a segmented output area shares one
-   * collapse control across multiple rendered lanes.
-   */
-  collapseOutputCount?: number;
   /**
    * Maximum height before scrolling. Set to enable scroll behavior.
    */
@@ -513,36 +499,20 @@ function withTracebackExecutionTargets(
  * OutputArea renders multiple Jupyter outputs with proper layout.
  *
  * Handles all Jupyter output types: execute_result, display_data, stream, and error.
- * Supports collapsible state. Outputs render in natural document flow by
- * default; callers opt into wrapper scrolling with `maxHeight` or by marking
- * an isolated output as focused.
- *
- * @example
- * ```tsx
- * <OutputArea
- *   outputs={cell.outputs}
- *   collapsed={outputsCollapsed}
- *   onToggleCollapse={() => setOutputsCollapsed(!outputsCollapsed)}
- * />
- * ```
+ * Outputs render in natural document flow by default; callers opt into wrapper
+ * scrolling with `maxHeight` or by marking an isolated output as focused.
  */
 export function OutputArea({
   outputs,
   isolated = "auto",
-  onToggleCollapse,
   priority = DEFAULT_PRIORITY,
   ...props
 }: OutputAreaProps) {
-  const {
-    onSearchMatchCount,
-    preloadIframe = false,
-    collapsed = false,
-    ...passthroughProps
-  } = props;
+  const { onSearchMatchCount, preloadIframe = false, ...passthroughProps } = props;
   const segmentedSearchMatchCountsRef = useRef(new Map<string, number>());
   const outputSegments = segmentedOutputLanes(outputs, {
     isolated,
-    hasCollapseControl: onToggleCollapse !== undefined,
+    hasCollapseControl: false,
     priority,
   });
   const outputSegmentKeys = outputSegments.map(outputSegmentKey);
@@ -551,14 +521,11 @@ export function OutputArea({
     return (
       <>
         {outputSegments.map((segment, index) => {
-          if (collapsed && index > 0) return null;
           const segmentKey = outputSegmentKeys[index] ?? outputSegmentKey(segment, index);
           return (
             <OutputAreaSingle
               key={segmentKey}
               {...passthroughProps}
-              collapsed={collapsed}
-              collapseOutputCount={outputs.length}
               outputs={segment.outputs}
               isolated="auto"
               onSearchMatchCount={
@@ -578,7 +545,6 @@ export function OutputArea({
                     }
                   : undefined
               }
-              onToggleCollapse={index === 0 ? onToggleCollapse : undefined}
               preloadIframe={segment.lane === "dom" ? false : preloadIframe}
               priority={priority}
             />
@@ -591,11 +557,9 @@ export function OutputArea({
   return (
     <OutputAreaSingle
       {...passthroughProps}
-      collapsed={collapsed}
       outputs={outputs}
       isolated={isolated}
       onSearchMatchCount={onSearchMatchCount}
-      onToggleCollapse={onToggleCollapse}
       preloadIframe={preloadIframe}
       priority={priority}
     />
@@ -606,9 +570,6 @@ function OutputAreaSingle({
   outputs,
   cellId,
   executionCount,
-  collapsed = false,
-  collapseOutputCount = outputs.length,
-  onToggleCollapse,
   maxHeight,
   focused = false,
   useOutputWell = true,
@@ -677,9 +638,9 @@ function OutputAreaSingle({
 
   // When preloading, we render the iframe even with no outputs (hidden)
   // This allows it to bootstrap ahead of time for instant rendering
-  const showPreloadedIframe = preloadIframe && !collapsed;
+  const showPreloadedIframe = preloadIframe;
   const shouldDeferIsolatedFrame =
-    deferIsolatedFrameUntilVisible && shouldIsolate && !showPreloadedIframe && !collapsed;
+    deferIsolatedFrameUntilVisible && shouldIsolate && !showPreloadedIframe;
   const deferredIsolatedFrame = useDeferredIsolatedFrame({
     enabled: shouldDeferIsolatedFrame,
     rootMargin: deferredIsolatedFrameRootMargin,
@@ -741,8 +702,6 @@ function OutputAreaSingle({
         minHeight: `${hasSiftOutputs ? MIN_OUTPUT_WELL_HEIGHT : DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT}px`,
       }
     : undefined;
-
-  const hasCollapseControl = onToggleCollapse !== undefined;
 
   useEffect(() => {
     if (!shouldUseScrollPassthroughFrame && staticFrameInteractionActive) {
@@ -1036,143 +995,123 @@ function OutputAreaSingle({
         className,
       )}
     >
-      {/* Collapse toggle */}
-      {hasCollapseControl && (
-        <button
-          type="button"
-          onClick={onToggleCollapse}
-          className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-          aria-expanded={!collapsed}
-          aria-controls={id}
-        >
-          {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-          <span>
-            {collapsed
-              ? `Show ${collapseOutputCount} output${collapseOutputCount > 1 ? "s" : ""}`
-              : "Hide outputs"}
-          </span>
-        </button>
-      )}
-
       {/* Output content */}
-      {!collapsed && (
-        <div
-          id={id}
-          className={cn(
-            "space-y-2",
-            !shouldIsolate && inDomMaxHeight !== null && "overflow-y-auto",
-            shouldConstrainIsolatedOutput && "overflow-y-auto",
-          )}
-          style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
-        >
-          {/* Preloaded or active isolated frame */}
-          {(shouldIsolate || showPreloadedIframe) && (
-            <div
-              ref={setStaticFrameInteractionNode}
-              className={cn(
-                shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
-                hasWheelOwningOutputs && "group/sift rounded-md overflow-hidden",
-                hasWheelOwningOutputs &&
-                  shouldUseScrollPassthroughFrame &&
-                  !staticFrameInteractionActive &&
-                  "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
-                hasWheelOwningOutputs && staticFrameInteractionActive && "bg-background",
-              )}
-              style={interactionFrameStyle}
-              data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
-              data-sift-output={hasSiftOutputs ? "true" : undefined}
-              tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
-              onPointerDown={
-                shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
-              }
-              onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
-            >
-              {shouldMountIsolatedFrame ? (
-                <IsolatedFrame
-                  ref={setIsolatedFrameHandle}
-                  name={frameName}
-                  darkMode={darkMode}
-                  colorTheme={colorTheme}
-                  minHeight={24}
-                  maxHeight={isolatedOutputWellMaxHeight}
-                  autoHeight={shouldIsolate && !focused}
-                  allowWheelBoundaryScroll={allowWheelBoundaryScroll}
-                  scrollPassthrough={shouldScrollPassthroughFrame}
-                  onReady={handleIsolatedFrameReady}
-                  onLinkClick={onLinkClick}
-                  onMouseDown={activateStaticFrameInteraction}
-                  onWidgetUpdate={onWidgetUpdate}
-                  onMessage={handleIframeMessage}
-                  onError={handleIframeError}
-                  onDiagnostic={onDiagnostic}
-                  hostContext={hostContext}
-                  outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
+      <div
+        id={id}
+        className={cn(
+          "space-y-2",
+          !shouldIsolate && inDomMaxHeight !== null && "overflow-y-auto",
+          shouldConstrainIsolatedOutput && "overflow-y-auto",
+        )}
+        style={shouldIsolate ? isolatedOutputWellStyle : maxHeightStyle}
+      >
+        {/* Preloaded or active isolated frame */}
+        {(shouldIsolate || showPreloadedIframe) && (
+          <div
+            ref={setStaticFrameInteractionNode}
+            className={cn(
+              shouldIsolate ? "relative outline-none transition-shadow" : "hidden",
+              hasWheelOwningOutputs && "group/sift rounded-md overflow-hidden",
+              hasWheelOwningOutputs &&
+                shouldUseScrollPassthroughFrame &&
+                !staticFrameInteractionActive &&
+                "hover:ring-1 hover:ring-[var(--notebook-sift-focus-hover)]",
+              hasWheelOwningOutputs && staticFrameInteractionActive && "bg-background",
+            )}
+            style={interactionFrameStyle}
+            data-frame-interaction-active={staticFrameInteractionActive ? "true" : undefined}
+            data-sift-output={hasSiftOutputs ? "true" : undefined}
+            tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
+            onPointerDown={
+              shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
+            }
+            onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
+          >
+            {shouldMountIsolatedFrame ? (
+              <IsolatedFrame
+                ref={setIsolatedFrameHandle}
+                name={frameName}
+                darkMode={darkMode}
+                colorTheme={colorTheme}
+                minHeight={24}
+                maxHeight={isolatedOutputWellMaxHeight}
+                autoHeight={shouldIsolate && !focused}
+                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+                scrollPassthrough={shouldScrollPassthroughFrame}
+                onReady={handleIsolatedFrameReady}
+                onLinkClick={onLinkClick}
+                onMouseDown={activateStaticFrameInteraction}
+                onWidgetUpdate={onWidgetUpdate}
+                onMessage={handleIframeMessage}
+                onError={handleIframeError}
+                onDiagnostic={onDiagnostic}
+                hostContext={hostContext}
+                outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
+              />
+            ) : (
+              <div
+                aria-hidden="true"
+                className="rounded-md"
+                data-slot="isolated-frame-deferred"
+                style={deferredIsolatedFramePlaceholderStyle}
+              />
+            )}
+            {showSiftInteractionCue && (
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
+                <SiftScrollHandoffCue
+                  className="pointer-events-auto"
+                  onPointerDown={(event) => {
+                    event.stopPropagation();
+                    activateStaticFrameInteraction();
+                  }}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    activateStaticFrameInteraction();
+                  }}
                 />
-              ) : (
-                <div
-                  aria-hidden="true"
-                  className="rounded-md"
-                  data-slot="isolated-frame-deferred"
-                  style={deferredIsolatedFramePlaceholderStyle}
-                />
-              )}
-              {showSiftInteractionCue && (
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-end rounded-b-md pb-[9px] pr-[84px] opacity-0 transition-opacity duration-150 group-hover/sift:opacity-100 group-focus-within/sift:opacity-100">
-                  <SiftScrollHandoffCue
-                    className="pointer-events-auto"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                      activateStaticFrameInteraction();
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      activateStaticFrameInteraction();
-                    }}
-                  />
-                </div>
-              )}
-            </div>
-          )}
+              </div>
+            )}
+          </div>
+        )}
 
-          {/* In-DOM outputs (when not using isolation) */}
-          {!shouldIsolate && (
-            <div ref={inDomOutputRef}>
-              {outputs.map((output, index) => {
-                // Prefer daemon-stamped output_id for stable React keys so a
-                // stream append doesn't re-mount sibling outputs. Fall back
-                // to positional when a render path skipped the id.
-                const key = output.output_id ?? `output-${index}`;
-                return (
-                  <div key={key} data-slot="output-item" data-output-index={index}>
-                    <ErrorBoundary
-                      resetKeys={[output]}
-                      fallback={(error, reset) => (
-                        <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
-                      )}
-                      onError={(error, errorInfo) => {
-                        console.error(
-                          `[OutputArea] Error rendering output ${index}:`,
-                          error,
-                          errorInfo.componentStack,
-                        );
-                      }}
-                    >
-                      {renderOutput(
-                        output,
-                        index,
-                        renderers,
-                        priority,
-                        resolveTracebackExecutionTarget,
-                        onNavigateToTracebackCell,
-                      )}
-                    </ErrorBoundary>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
+        {/* In-DOM outputs (when not using isolation) */}
+        {!shouldIsolate && (
+          <div ref={inDomOutputRef}>
+            {outputs.map((output, index) => {
+              // Prefer daemon-stamped output_id for stable React keys so a
+              // stream append doesn't re-mount sibling outputs. Fall back
+              // to positional when a render path skipped the id.
+              const key = output.output_id ?? `output-${index}`;
+              return (
+                <div key={key} data-slot="output-item" data-output-index={index}>
+                  <ErrorBoundary
+                    resetKeys={[output]}
+                    fallback={(error, reset) => (
+                      <OutputErrorFallback error={error} outputIndex={index} onRetry={reset} />
+                    )}
+                    onError={(error, errorInfo) => {
+                      console.error(
+                        `[OutputArea] Error rendering output ${index}:`,
+                        error,
+                        errorInfo.componentStack,
+                      );
+                    }}
+                  >
+                    {renderOutput(
+                      output,
+                      index,
+                      renderers,
+                      priority,
+                      resolveTracebackExecutionTarget,
+                      onNavigateToTracebackCell,
+                    )}
+                  </ErrorBoundary>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -709,43 +709,20 @@ describe("OutputArea iframe theme sync", () => {
     expect(screen.getAllByTestId("isolated-frame")).toHaveLength(1);
   });
 
-  it("keeps one collapse control while splitting Sift into its own boundary", () => {
+  it("splits Sift into its own boundary without output collapse controls", () => {
     const outputs: JupyterOutput[] = [
       ...makeStreamOutput("stdout one\n"),
       makeWidgetOutput("widget-progress-1", "model-progress-1"),
       ...makeParquetOutput(),
     ];
 
-    render(<OutputArea outputs={outputs} onToggleCollapse={vi.fn()} />);
+    render(<OutputArea outputs={outputs} />);
 
-    expect(screen.getAllByRole("button", { name: "Hide outputs" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: /outputs/i })).toBeNull();
     const frames = screen.getAllByTestId("isolated-frame");
     expect(frames).toHaveLength(2);
     expect(frames[0].parentElement?.getAttribute("data-sift-output")).toBeNull();
     expect(frames[1].parentElement?.getAttribute("data-sift-output")).toBe("true");
-  });
-
-  it("reports the full collapsed output count for segmented Sift boundaries", () => {
-    const outputs: JupyterOutput[] = [
-      ...makeStreamOutput("stdout one\n"),
-      makeWidgetOutput("widget-progress-1", "model-progress-1"),
-      ...makeParquetOutput(),
-    ];
-
-    render(<OutputArea outputs={outputs} collapsed onToggleCollapse={vi.fn()} />);
-
-    expect(screen.getAllByRole("button", { name: "Show 3 outputs" })).toHaveLength(1);
-    expect(screen.queryByTestId("isolated-frame")).toBeNull();
-  });
-
-  it("preserves collapsed state for non-segmented mixed outputs", () => {
-    render(
-      <OutputArea outputs={makeMixedDocumentOutputs()} collapsed onToggleCollapse={vi.fn()} />,
-    );
-
-    expect(screen.getAllByRole("button", { name: "Show 3 outputs" })).toHaveLength(1);
-    expect(screen.queryByText("stream before")).toBeNull();
-    expect(screen.queryByTestId("isolated-frame")).toBeNull();
   });
 
   it("keeps forced-isolated non-Sift mixed outputs together", async () => {


### PR DESCRIPTION
## Summary

- remove the unused `OutputArea` collapsed-output API and control chrome
- update the Elements output renderer docs to describe output hiding as cell metadata state
- update cloud render parity to assert Sift boundaries render expanded without collapse controls

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## TypeScript caller check

- removed `collapsed`, `onToggleCollapse`, and `collapseOutputCount` from `OutputAreaProps`
- verified notebook, notebook-cloud, and Elements TypeScript builds pass
- `rg "onToggleCollapse|collapseOutputCount|outputAreaCollapsed|setOutputAreaCollapsed|Collapse outputs|collapsible-sift-boundary"` returns no matches in app/shared TS sources
