### PR TITLE
fix(notebook-cloud): share focused cell projection

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -33,6 +33,23 @@ test("cloud projects live cells into the NotebookView stores", () => {
   assert.doesNotMatch(sourceText, /onSourceChanged=/);
 });
 
+test("cloud projects host focus through the shared cell UI state bridge", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /useNotebookCellUIStateBridge/);
+  assert.match(
+    sourceText,
+    /const \[focusedCellId, setFocusedCellId\] = useState<string \| null>\(null\)/,
+  );
+  assert.match(sourceText, /useNotebookCellUIStateBridge\(\{ focusedCellId \}\)/);
+  assert.match(sourceText, /onFocusCell=\{setFocusedCellId\}/);
+  assert.doesNotMatch(
+    sourceText,
+    /import \{[^}]*setFocusedCellId[^}]*\} from "\.\.\/\.\.\/notebook\/src\/lib\/cell-ui-state"/,
+  );
+});
+
 test("cloud wires shared presence and cleans projected store entries", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -81,7 +81,7 @@ import {
   type PresenceContextValue,
 } from "../../notebook/src/contexts/PresenceContext";
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
-import { flushCellUIState, setFocusedCellId } from "../../notebook/src/lib/cell-ui-state";
+import { useNotebookCellUIStateBridge } from "../../notebook/src/lib/cell-ui-state";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { setLoggerHost } from "../../notebook/src/lib/logger";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
@@ -623,6 +623,7 @@ function NotebookViewer({
     message: loadingPolicy.initialStatusMessage,
   });
   const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(false);
@@ -696,9 +697,7 @@ function NotebookViewer({
 
   useEffect(() => resetCloudViewStoreProjection, []);
 
-  useLayoutEffect(() => {
-    flushCellUIState();
-  }, [cells]);
+  useNotebookCellUIStateBridge({ focusedCellId });
 
   useEffect(() => {
     if (authRenewal.kind === "refreshing") {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,12 +1,4 @@
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   deriveEnvManager,
   deriveRuntimeKind,
@@ -79,14 +71,7 @@ import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
 import { getBlobResolver, useBlobPort } from "./lib/blob-port";
 import { useRuntimeState } from "./lib/runtime-state";
-import {
-  flushCellUIState,
-  setExecutingCellIds as storeSetExecutingCellIds,
-  setFocusedCellId as storeSetFocusedCellId,
-  setQueuedCellIds as storeSetQueuedCellIds,
-  setSearchCurrentMatch as storeSetSearchCurrentMatch,
-  setSearchQuery as storeSetSearchQuery,
-} from "./lib/cell-ui-state";
+import { useNotebookCellUIStateBridge } from "./lib/cell-ui-state";
 import { startCursorDispatch } from "./lib/cursor-registry";
 import { desktopNotebookShellCapabilities } from "./lib/desktop-shell-capabilities";
 import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kernel-status";
@@ -830,23 +815,13 @@ function AppContent() {
     !railCollapsed && activeRailPanel === "outline",
   );
 
-  // ── Sync transient UI state into the cell-ui-state store ────────────
-  // Two-phase update for StrictMode safety:
-  //
-  // Phase 1 (render): Assign module-level variables so child
-  // useSyncExternalStore snapshots return current values. Equality
-  // guards make this idempotent — same inputs produce no mutation.
-  //
-  // Phase 2 (commit): useLayoutEffect calls flushCellUIState() to
-  // notify subscribers. Discarded renders never trigger notifications.
-  storeSetFocusedCellId(focusedCellId);
-  storeSetExecutingCellIds(executingCellIds);
-  storeSetQueuedCellIds(notebookQueueProjection.queued_cell_ids);
-  storeSetSearchQuery(globalFind.query);
-  storeSetSearchCurrentMatch(globalFind.currentMatch);
-
-  useLayoutEffect(() => {
-    flushCellUIState();
+  // ── Sync host-owned transient UI state into shared cell UI store ─────
+  useNotebookCellUIStateBridge({
+    focusedCellId,
+    executingCellIds,
+    queuedCellIds: notebookQueueProjection.queued_cell_ids,
+    searchQuery: globalFind.query,
+    searchCurrentMatch: globalFind.currentMatch,
   });
 
   // Env manager (uv / conda / pixi) — drives the toolbar badge and

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useLayoutEffect, useMemo, useSyncExternalStore } from "react";
 import type { FindMatch } from "../hooks/useGlobalFind";
 import { getCellIdsSnapshot, subscribeIds } from "./notebook-cells";
 
@@ -43,6 +43,39 @@ export function flushCellUIState(): void {
   const batch = [..._dirtySubscribers];
   _dirtySubscribers.clear();
   for (const subs of batch) emit(subs);
+}
+
+export interface NotebookCellUIStateBridgeInput {
+  focusedCellId: string | null;
+  executingCellIds?: Set<string>;
+  queuedCellIds?: Iterable<string>;
+  searchQuery?: string;
+  searchCurrentMatch?: FindMatch | null;
+}
+
+/**
+ * Project host-owned transient notebook UI state into the shared cell UI store.
+ *
+ * Hosts own focus/search/execution state because those facts come from their
+ * transport, runtime, and app shell. Cell components consume the shared store so
+ * desktop, cloud, and fixture hosts do not grow separate focus contracts.
+ */
+export function useNotebookCellUIStateBridge({
+  focusedCellId,
+  executingCellIds,
+  queuedCellIds,
+  searchQuery,
+  searchCurrentMatch,
+}: NotebookCellUIStateBridgeInput): void {
+  setFocusedCellId(focusedCellId);
+  if (executingCellIds) setExecutingCellIds(executingCellIds);
+  if (queuedCellIds) setQueuedCellIds(queuedCellIds);
+  setSearchQuery(searchQuery);
+  setSearchCurrentMatch(searchCurrentMatch ?? null);
+
+  useLayoutEffect(() => {
+    flushCellUIState();
+  });
 }
 
 function setsEqual(a: Set<string>, b: Set<string>): boolean {


### PR DESCRIPTION
## Summary

- add a shared `useNotebookCellUIStateBridge` for host-owned transient cell UI state
- route desktop focus/search/execution projection through the shared bridge
- route cloud focused-cell state through the same bridge instead of calling the shared store setter directly
- add a notebook-cloud convergence guard so cloud does not bypass the focus bridge again

## Why

Cloud could leave multiple markdown cells visually focused after clicking through `lets-edit`. Desktop did not because it kept focus in React state and flushed the shared cell UI store after commits. Cloud was mutating the shared store directly from `NotebookView` callbacks, which could update the module-level focus value without notifying previous cell subscribers.

This keeps the fix at the shared host projection boundary instead of patching focused-cell styling.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts src/components/cell/__tests__/CellContainer.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`

## Review Lens

Please review for desktop/cloud convergence:

- hosts should own transient focus/search/execution facts
- shared notebook cells should consume one projected cell UI state store
- cloud should not call shared store setters directly from notebook callbacks
