### PR TITLE
feat(outputs): add traceback frame navigation

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -12,6 +12,7 @@ import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
@@ -61,7 +62,7 @@ interface CodeCellProps {
   onDelete?: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
-  onNavigateToCell?: (cellId: string) => void;
+  onNavigateToCell?: (target: TracebackCellTarget) => void;
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
@@ -584,8 +585,8 @@ export const CodeCell = memo(function CodeCell({
     return cellId ? { cellId } : null;
   }, []);
   const handleTracebackCellNavigate = useCallback(
-    (target: { cellId: string }) => {
-      onNavigateToCell?.(target.cellId);
+    (target: TracebackCellTarget) => {
+      onNavigateToCell?.(target);
     },
     [onNavigateToCell],
   );

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -28,6 +28,7 @@ import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-headin
 import type { Runtime } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
+import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
@@ -776,11 +777,12 @@ function NotebookViewContent({
         }
       };
 
-      const onNavigateToCell = (targetCellId: string) => {
+      const onNavigateToCell = (target: TracebackCellTarget) => {
+        const targetCellId = target.cellId;
         logger.debug(`[cell-nav] Navigating to traceback cell: ${targetCellId.slice(0, 8)}`);
         onFocusCell(targetCellId);
         presence?.setFocus(targetCellId);
-        focusCell(targetCellId, "start");
+        focusCell(targetCellId, typeof target.line === "number" ? { line: target.line } : "start");
       };
 
       // Build right gutter content — delete button for all cells,

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -36,9 +36,11 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       // Find CodeMirror's content element inside the cell
       const cmContent = cellElement.querySelector(".cm-content");
       if (!cmContent) {
-        const focusTarget = cellElement.querySelector<HTMLElement>("[data-cell-focus-target]");
-        if (focusTarget) {
-          focusTarget.focus({ preventScroll: true });
+        const fallbackFocusElement = cellElement.querySelector<HTMLElement>(
+          "[data-cell-focus-target]",
+        );
+        if (fallbackFocusElement) {
+          fallbackFocusElement.focus({ preventScroll: true });
           return;
         }
 

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -61,7 +61,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       const line = typeof focusTarget.line === "number" ? focusTarget.line : null;
       const pos =
         line !== null && Number.isFinite(line) && line > 0
-          ? doc.line(Math.min(Math.floor(line), doc.lines)).from
+          ? doc.line(Math.max(1, Math.min(Math.floor(line), doc.lines))).from
           : focusTarget.cursorPosition === "end"
             ? doc.length
             : 0;

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -2,55 +2,75 @@ import { EditorView } from "@codemirror/view";
 import { createContext, type ReactNode, useCallback, useContext } from "react";
 import { logger } from "../lib/logger";
 
+type CellCursorPosition = "start" | "end";
+export interface CellFocusTarget {
+  cursorPosition?: CellCursorPosition;
+  line?: number;
+}
+
 interface EditorRegistryContextType {
-  focusCell: (cellId: string, cursorPosition: "start" | "end") => void;
+  focusCell: (cellId: string, target?: CellCursorPosition | CellFocusTarget) => void;
 }
 
 const EditorRegistryContext = createContext<EditorRegistryContextType | null>(null);
 
 export function EditorRegistryProvider({ children }: { children: ReactNode }) {
   // Focus a cell's editor using DOM lookup - bypasses registration timing issues
-  const focusCell = useCallback((cellId: string, cursorPosition: "start" | "end") => {
-    // Find the cell element by data attribute
-    const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
-    if (!cellElement) {
-      logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
-      return;
-    }
+  const focusCell = useCallback(
+    (cellId: string, target: CellCursorPosition | CellFocusTarget = "start") => {
+      const focusTarget =
+        typeof target === "string"
+          ? { cursorPosition: target }
+          : { cursorPosition: "start" as const, ...target };
 
-    // Scroll the cell container into the notebook viewport
-    cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
-
-    // Find CodeMirror's content element inside the cell
-    const cmContent = cellElement.querySelector(".cm-content");
-    if (!cmContent) {
-      const focusTarget = cellElement.querySelector<HTMLElement>("[data-cell-focus-target]");
-      if (focusTarget) {
-        focusTarget.focus({ preventScroll: true });
+      // Find the cell element by data attribute
+      const cellElement = document.querySelector(`[data-cell-id="${CSS.escape(cellId)}"]`);
+      if (!cellElement) {
+        logger.warn(`[cell-nav] Cell element not found: ${cellId.slice(0, 8)}`);
         return;
       }
 
-      // Might be a markdown preview or hidden cell with no explicit fallback.
-      logger.debug(`[cell-nav] No focus target in cell: ${cellId.slice(0, 8)}`);
-      return;
-    }
+      // Scroll the cell container into the notebook viewport
+      cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
 
-    // Use CodeMirror's API to find the EditorView from DOM
-    const view = EditorView.findFromDOM(cmContent as HTMLElement);
-    if (!view) {
-      logger.warn(`[cell-nav] EditorView not found for: ${cellId.slice(0, 8)}`);
-      return;
-    }
+      // Find CodeMirror's content element inside the cell
+      const cmContent = cellElement.querySelector(".cm-content");
+      if (!cmContent) {
+        const focusTarget = cellElement.querySelector<HTMLElement>("[data-cell-focus-target]");
+        if (focusTarget) {
+          focusTarget.focus({ preventScroll: true });
+          return;
+        }
 
-    // Set cursor position and focus
-    const doc = view.state.doc;
-    const pos = cursorPosition === "start" ? 0 : doc.length;
-    view.dispatch({
-      selection: { anchor: pos, head: pos },
-      scrollIntoView: true,
-    });
-    view.focus();
-  }, []);
+        // Might be a markdown preview or hidden cell with no explicit fallback.
+        logger.debug(`[cell-nav] No focus target in cell: ${cellId.slice(0, 8)}`);
+        return;
+      }
+
+      // Use CodeMirror's API to find the EditorView from DOM
+      const view = EditorView.findFromDOM(cmContent as HTMLElement);
+      if (!view) {
+        logger.warn(`[cell-nav] EditorView not found for: ${cellId.slice(0, 8)}`);
+        return;
+      }
+
+      // Set cursor position and focus
+      const doc = view.state.doc;
+      const line = typeof focusTarget.line === "number" ? focusTarget.line : null;
+      const pos =
+        line !== null && Number.isFinite(line) && line > 0
+          ? doc.line(Math.min(Math.floor(line), doc.lines)).from
+          : focusTarget.cursorPosition === "end"
+            ? doc.length
+            : 0;
+      view.dispatch({
+        selection: { anchor: pos, head: pos },
+        scrollIntoView: true,
+      });
+      view.focus();
+    },
+    [],
+  );
 
   return (
     <EditorRegistryContext.Provider value={{ focusCell }}>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -34,6 +34,7 @@ import {
 import { AnsiErrorOutput, AnsiStreamOutput } from "@/components/outputs/ansi-output";
 import { DEFAULT_PRIORITY, MediaRouter } from "@/components/outputs/media-router";
 import {
+  classicTracebackToPayload,
   TracebackOutput,
   type TracebackCellTarget,
   type TracebackCellNavigator,
@@ -404,6 +405,21 @@ function renderOutput(
           <TracebackOutput
             key={key}
             data={output.rich}
+            resolveExecutionTarget={resolveTracebackExecutionTarget}
+            onNavigateToCell={onNavigateToTracebackCell}
+          />
+        );
+      }
+      const classicTraceback = classicTracebackToPayload({
+        ename: output.ename,
+        evalue: output.evalue,
+        traceback: output.traceback,
+      });
+      if (classicTraceback) {
+        return (
+          <TracebackOutput
+            key={key}
+            data={classicTraceback}
             resolveExecutionTarget={resolveTracebackExecutionTarget}
             onNavigateToCell={onNavigateToTracebackCell}
           />

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -356,6 +356,7 @@ export interface TracebackNavigateMessage {
     target: {
       cellId: string;
       label?: string;
+      line?: number;
     };
   };
 }

--- a/src/components/outputs/__tests__/traceback-output.test.tsx
+++ b/src/components/outputs/__tests__/traceback-output.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { TracebackOutput } from "../traceback-output";
+import { classicTracebackToPayload, TracebackOutput } from "../traceback-output";
 
 const payload = {
   ename: "AttributeError",
@@ -67,8 +67,8 @@ describe("TracebackOutput", () => {
       <TracebackOutput data={payload} resolveExecutionTarget={resolveExecutionTarget} />,
     );
 
-    expect(container.textContent).toContain("Line1inCurrent Cell");
-    expect(container.textContent).toContain("Line5inCell cell-defing");
+    expect(container.textContent).toContain("current cell · line 1");
+    expect(container.textContent).toContain("g · line 5");
     expect(container.textContent).not.toContain("In[");
     expect(container.textContent).not.toContain("/var/folders/x/T/ipykernel_39879");
   });
@@ -94,7 +94,7 @@ describe("TracebackOutput", () => {
       />,
     );
 
-    expect(container.textContent).toContain("Line2630in.../polars/lazyframe/frame.pyincollect");
+    expect(container.textContent).toContain(".../polars/lazyframe/frame.py · line 2630 / collect");
     expect(container.textContent).not.toContain("/Users/kylekelley/Library/Caches");
   });
 
@@ -120,7 +120,7 @@ describe("TracebackOutput", () => {
     );
 
     expect(container.textContent).toContain(
-      "Line7in/Users/kyle/project/site-packages/example/runtime/frame.jlinload",
+      "/Users/kyle/project/site-packages/example/runtime/frame.jl · line 7 / load",
     );
     expect(container.textContent).not.toContain(".../example/runtime/frame.jl");
   });
@@ -145,7 +145,7 @@ describe("TracebackOutput", () => {
       />,
     );
 
-    expect(container.textContent).toContain("Line7inUnknown sourceinload");
+    expect(container.textContent).toContain("Unknown source · line 7 / load");
   });
 
   it("navigates to a resolved traceback cell", () => {
@@ -158,9 +158,13 @@ describe("TracebackOutput", () => {
         onNavigateToCell={onNavigateToCell}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-def" }));
+    fireEvent.click(screen.getByRole("button", { name: "Go to cell that defines g, line 5" }));
 
-    expect(onNavigateToCell).toHaveBeenCalledWith({ cellId: "cell-def" });
+    expect(onNavigateToCell).toHaveBeenCalledWith({
+      cellId: "cell-def",
+      line: 5,
+      label: "cell defining g",
+    });
   });
 
   it("uses structured cell ids when execution lookup is unavailable", () => {
@@ -191,9 +195,17 @@ describe("TracebackOutput", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Go to cell cell-helper" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Go to cell that defines image_scatter_records, line 12",
+      }),
+    );
 
-    expect(onNavigateToCell).toHaveBeenCalledWith({ cellId: "cell-helper" });
+    expect(onNavigateToCell).toHaveBeenCalledWith({
+      cellId: "cell-helper",
+      line: 12,
+      label: "cell defining image_scatter_records",
+    });
   });
 
   it("copies the sanitized traceback text", async () => {
@@ -209,10 +221,39 @@ describe("TracebackOutput", () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
     const copied = writeText.mock.calls[0][0] as string;
     expect(copied).toContain("Line 1 in Current Cell (cell_id=cell-run, execution_id=exec-run)");
-    expect(copied).toContain(
-      "Line 5 in Cell cell-def (cell_id=cell-def, execution_id=exec-def), in g",
-    );
+    expect(copied).toContain("Line 5 in run 2 (cell_id=cell-def, execution_id=exec-def), in g");
     expect(copied).not.toContain("In[");
     expect(copied).not.toContain("/var/folders/x/T/ipykernel_39879");
+  });
+
+  it("normalizes classic notebook traceback preview lines into rich frame data", () => {
+    const normalized = classicTracebackToPayload({
+      ename: "AttributeError",
+      evalue: "'NoneType' object has no attribute 'strip'",
+      traceback: [
+        "Traceback (most recent call last):",
+        "  Line 2 in Cell cell-run (cell_id=cell-run, execution_id=exec-run, source_hash=sha256:abc)",
+        "    summarize(records)",
+        "  Line 2 in Cell cell-helper (cell_id=cell-helper, execution_id=exec-helper, source_hash=sha256:def), in summarize",
+        "        return [normalize(record) for record in records]",
+        "AttributeError: 'NoneType' object has no attribute 'strip'",
+      ],
+    });
+
+    render(
+      <TracebackOutput
+        data={normalized}
+        resolveExecutionTarget={(executionId) =>
+          executionId === "exec-helper" ? { cellId: "cell-helper", label: "run 2" } : null
+        }
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Show source frame 1" })).toHaveTextContent(
+      "cell input · line 2",
+    );
+    expect(screen.getByRole("button", { name: "Show source frame 2" })).toHaveTextContent(
+      "summarize · line 2",
+    );
   });
 });

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -1,5 +1,6 @@
 import Anser from "anser";
 import { escapeCarriageReturn } from "escape-carriage";
+import { X } from "lucide-react";
 import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -348,17 +349,27 @@ export function AnsiErrorOutput({
   traceback,
   className = "",
 }: AnsiErrorOutputProps) {
+  const headline = ename && evalue ? `${ename}: ${evalue}` : (ename ?? evalue ?? "Error");
+  const tracebackText = Array.isArray(traceback) ? traceback.join("\n") : traceback;
+
   return (
-    <div data-slot="ansi-error-output" className={cn("not-prose py-3", className)}>
-      {ename && evalue && (
-        <div className="mb-1 font-semibold text-red-700 dark:text-red-400">
-          <AnsiOutput isError>{`${ename}: ${evalue}`}</AnsiOutput>
-        </div>
+    <div
+      data-slot="ansi-error-output"
+      className={cn(
+        "not-prose my-1 rounded-md border border-destructive/15 bg-destructive/[0.018]",
+        "px-2 py-1.5 text-sm shadow-[0_1px_0_rgba(0,0,0,0.02)]",
+        className,
       )}
-      {traceback && (
-        <div className="mt-2 text-xs text-red-600 dark:text-red-400 opacity-80">
-          <AnsiOutput isError>
-            {Array.isArray(traceback) ? traceback.join("\n") : traceback}
+    >
+      <div className="flex items-center gap-2 px-1 py-1.5 font-mono">
+        <X aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
+        <div className="min-w-0 truncate font-semibold text-destructive">{headline}</div>
+        <div className="h-px min-w-6 flex-1 bg-destructive/10" />
+      </div>
+      {tracebackText && (
+        <div className="mx-1 mb-1 rounded-sm bg-background/55 px-2 py-1.5">
+          <AnsiOutput isError className="text-xs leading-5 text-destructive/80">
+            {tracebackText}
           </AnsiOutput>
         </div>
       )}

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -191,18 +191,15 @@ export function TracebackOutput({
   onNavigateToCell,
 }: Props) {
   const payload = toPayload(data);
-  if (!payload) {
-    return <RawJsonFallback data={data} className={className} />;
-  }
-  const frames = payload.frames ?? [];
+  const frames = payload?.frames ?? [];
   const clusters = clusterFrames(frames);
-  const language = payload.language ?? "python";
+  const language = payload?.language ?? "python";
   // Inline `ename: evalue` on one line when the evalue fits. Multi-line
   // evalues (pytest diffs, chained SQL errors) fall through to the
   // two-line layout. Independent of frame count — a short evalue next
   // to the ename reads better whether we show frames below or not.
-  const inlineEvalue = Boolean(payload.evalue) && !payload.evalue.includes("\n");
-  const currentExecutionId = payload.execution?.execution_id;
+  const inlineEvalue = Boolean(payload?.evalue && !payload.evalue.includes("\n"));
+  const currentExecutionId = payload?.execution?.execution_id;
   const defaultSelectedFrame = useMemo(() => preferredFrameIndex(clusters), [clusters]);
   const [selectedFrame, setSelectedFrame] = useState(defaultSelectedFrame);
 
@@ -211,6 +208,10 @@ export function TracebackOutput({
   }, [defaultSelectedFrame]);
 
   const selectedCluster = clusters[selectedFrame] ?? clusters[defaultSelectedFrame] ?? null;
+
+  if (!payload) {
+    return <RawJsonFallback data={data} className={className} />;
+  }
 
   return (
     <div

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -11,8 +11,8 @@
  * no persistence, no plugin build step — main-DOM React all the way.
  */
 
-import { Check, ChevronRight, Copy, LocateFixed, OctagonAlert } from "lucide-react";
-import { useState } from "react";
+import { Check, Copy, LocateFixed, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { highlight } from "@/components/editor/static-highlight";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
@@ -134,6 +134,7 @@ interface Props {
 export interface TracebackCellTarget {
   cellId: string;
   label?: string;
+  line?: number;
 }
 
 export type TracebackExecutionResolver = (
@@ -142,6 +143,13 @@ export type TracebackExecutionResolver = (
 ) => TracebackCellTarget | null | undefined;
 
 export type TracebackCellNavigator = (target: TracebackCellTarget) => void;
+
+export interface ClassicTracebackInput {
+  ename?: string;
+  evalue?: string;
+  traceback?: string[] | string;
+  language?: string;
+}
 
 /** A single frame, or a run of consecutive identical frames (recursion). */
 interface Cluster {
@@ -189,33 +197,27 @@ export function TracebackOutput({
   const frames = payload.frames ?? [];
   const clusters = clusterFrames(frames);
   const language = payload.language ?? "python";
-  // Expand user frames by default, collapse library frames. Matches how
-  // humans read tracebacks: their own code first, stdlib noise tucked
-  // away. Two extra rules:
-  //   - Recursion clusters (count > 1) stay collapsed; they're noise.
-  //   - If everything is library code, open the innermost so something
-  //     useful is visible.
-  const everythingIsLibrary = clusters.length > 0 && clusters.every((c) => c.frame.library);
-  const innermost = clusters.length - 1;
-  const shouldOpen = (c: Cluster, i: number): boolean => {
-    if (c.count > 1) return false;
-    if (everythingIsLibrary) return i === innermost;
-    return !c.frame.library;
-  };
-
   // Inline `ename: evalue` on one line when the evalue fits. Multi-line
   // evalues (pytest diffs, chained SQL errors) fall through to the
   // two-line layout. Independent of frame count — a short evalue next
   // to the ename reads better whether we show frames below or not.
   const inlineEvalue = Boolean(payload.evalue) && !payload.evalue.includes("\n");
   const currentExecutionId = payload.execution?.execution_id;
+  const defaultSelectedFrame = useMemo(() => preferredFrameIndex(clusters), [clusters]);
+  const [selectedFrame, setSelectedFrame] = useState(defaultSelectedFrame);
+
+  useEffect(() => {
+    setSelectedFrame(defaultSelectedFrame);
+  }, [defaultSelectedFrame]);
+
+  const selectedCluster = clusters[selectedFrame] ?? clusters[defaultSelectedFrame] ?? null;
 
   return (
     <div
       data-slot="traceback"
       className={cn(
-        "border-l-2 border-destructive/45 bg-destructive/[0.03] pl-2",
-        "text-sm",
+        "my-1 rounded-md border border-destructive/15 bg-destructive/[0.018]",
+        "px-2 py-1.5 text-sm shadow-[0_1px_0_rgba(0,0,0,0.02)]",
         className,
       )}
     >
@@ -240,23 +242,45 @@ export function TracebackOutput({
         />
       ) : (
         clusters.length > 0 && (
-          <ol className="divide-y divide-destructive/10">
-            {clusters.map((cluster, i) => (
-              <FrameRow
-                key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
-                cluster={cluster}
-                defaultOpen={shouldOpen(cluster, i)}
+          <div className="space-y-1.5 px-1 pb-1">
+            <ol
+              aria-label="Traceback frames"
+              className="flex flex-wrap items-center gap-x-1 gap-y-1"
+            >
+              {clusters.map((cluster, i) => (
+                <FrameStep
+                  key={`${cluster.frame.filename}:${cluster.frame.lineno}:${cluster.firstIndex}`}
+                  cluster={cluster}
+                  index={i}
+                  active={i === selectedFrame}
+                  currentExecutionId={currentExecutionId}
+                  resolveExecutionTarget={resolveExecutionTarget}
+                  onSelect={() => setSelectedFrame(i)}
+                />
+              ))}
+            </ol>
+            {selectedCluster && (
+              <SelectedFrame
+                cluster={selectedCluster}
                 language={language}
                 currentExecutionId={currentExecutionId}
                 resolveExecutionTarget={resolveExecutionTarget}
                 onNavigateToCell={onNavigateToCell}
               />
-            ))}
-          </ol>
+            )}
+          </div>
         )
       )}
     </div>
   );
+}
+
+function preferredFrameIndex(clusters: readonly Cluster[]): number {
+  for (let i = clusters.length - 1; i >= 0; i--) {
+    const frame = clusters[i]?.frame;
+    if (frame && !frame.library) return i;
+  }
+  return Math.max(0, clusters.length - 1);
 }
 
 // ─── Pieces ────────────────────────────────────────────────────────────
@@ -284,30 +308,23 @@ function Header({
   // disagree on edge cases.
   const canInline = inlineEvalue && Boolean(evalue);
   return (
-    <div className="flex items-start gap-2 px-2 py-2 font-mono">
-      <OctagonAlert
-        aria-hidden="true"
-        className="mt-0.5 h-4 w-4 shrink-0 text-destructive"
-        strokeWidth={2.5}
-      />
-      <div className="min-w-0 flex-1">
+    <div className="flex items-center gap-2 px-1 py-1.5 font-mono">
+      <X aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
+      <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
         {canInline ? (
-          <div>
-            <span className="font-semibold text-destructive">{ename}</span>
+          <>
+            <span className="shrink-0 font-semibold text-destructive">{ename}</span>
             <span className="text-destructive/80">: </span>
-            <span className="whitespace-pre-wrap break-words text-foreground/85">{evalue}</span>
-          </div>
+            <span className="min-w-0 truncate text-foreground/80">{evalue}</span>
+          </>
         ) : (
           <>
-            <div className="font-semibold text-destructive">{ename}</div>
-            {evalue && (
-              <div className="mt-0.5 whitespace-pre-wrap break-words text-foreground/85">
-                {evalue}
-              </div>
-            )}
+            <div className="shrink-0 font-semibold text-destructive">{ename}</div>
+            {evalue && <div className="min-w-0 truncate text-foreground/80">{evalue}</div>}
           </>
         )}
       </div>
+      <div className="hidden h-px min-w-0 basis-24 shrink grow-0 bg-destructive/10 sm:block" />
       <CopyButton payload={payload} resolveExecutionTarget={resolveExecutionTarget} />
     </div>
   );
@@ -446,39 +463,70 @@ function CopyButton({
   );
 }
 
-function FrameRow({
+function FrameStep({
   cluster,
-  defaultOpen,
+  index,
+  active,
+  currentExecutionId,
+  resolveExecutionTarget,
+  onSelect,
+}: {
+  cluster: Cluster;
+  index: number;
+  active: boolean;
+  currentExecutionId?: string;
+  resolveExecutionTarget?: TracebackExecutionResolver;
+  onSelect: () => void;
+}) {
+  const { frame, count } = cluster;
+  const location = sourceLocation(frame, currentExecutionId, resolveExecutionTarget);
+  return (
+    <li className="flex min-w-0 items-center gap-1">
+      {index > 0 && (
+        <span aria-hidden="true" className="text-muted-foreground/30">
+          /
+        </span>
+      )}
+      <div className="group/frame flex min-w-0 items-center gap-1 font-mono text-xs">
+        <button
+          type="button"
+          onClick={onSelect}
+          className={cn(
+            "inline-flex min-w-0 items-baseline gap-1 rounded-sm px-1.5 py-0.5",
+            "transition-colors",
+            active
+              ? "text-destructive hover:bg-destructive/[0.035]"
+              : "border-transparent text-muted-foreground/70 hover:bg-muted/60 hover:text-foreground",
+            frame.library && !active && "opacity-65",
+          )}
+          aria-current={active ? "step" : undefined}
+          aria-label={`Show source frame ${index + 1}`}
+        >
+          <FrameLabel location={location} line={frame.lineno} name={frame.name} count={count} />
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function SelectedFrame({
+  cluster,
   language,
   currentExecutionId,
   resolveExecutionTarget,
   onNavigateToCell,
 }: {
   cluster: Cluster;
-  defaultOpen: boolean;
   language: string;
   currentExecutionId?: string;
   resolveExecutionTarget?: TracebackExecutionResolver;
   onNavigateToCell?: TracebackCellNavigator;
 }) {
-  const [open, setOpen] = useState(defaultOpen);
   const { frame, count } = cluster;
   const location = sourceLocation(frame, currentExecutionId, resolveExecutionTarget);
   return (
-    <li className={cn("px-2 py-1.5", frame.library && "opacity-60")}>
-      <div className="flex w-full items-center gap-2 font-mono text-xs">
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          className="rounded-sm text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
-          aria-expanded={open}
-          aria-label={open ? "Collapse traceback frame" : "Expand traceback frame"}
-        >
-          <ChevronRight
-            aria-hidden="true"
-            className={cn("h-3 w-3 shrink-0 transition-transform", open && "rotate-90")}
-          />
-        </button>
+    <div className={cn("rounded-sm bg-background/55 px-2 py-1.5", frame.library && "opacity-70")}>
+      <div className="flex min-w-0 items-center gap-1.5 font-mono text-xs">
         <LocationLabel
           location={location}
           line={frame.lineno}
@@ -489,18 +537,18 @@ function FrameRow({
           <span
             className={cn(
               "ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] tabular-nums",
-              "bg-destructive/15 text-destructive",
+              "bg-destructive/10 text-destructive",
             )}
             title={`${count} consecutive identical frames (collapsed)`}
           >
-            ×{count.toLocaleString()}
+            x{count.toLocaleString()}
           </span>
         )}
       </div>
-      {open && frame.lines && frame.lines.length > 0 && (
+      {frame.lines && frame.lines.length > 0 && (
         <SourceBlock lines={frame.lines} language={language} />
       )}
-    </li>
+    </div>
   );
 }
 
@@ -525,14 +573,29 @@ function LocationLabel({
   onNavigateToCell?: TracebackCellNavigator;
 }) {
   const displayName = typeof name === "string" ? name : undefined;
-  const showName = Boolean(displayName && displayName !== "<module>");
-  const target = location.target && onNavigateToCell ? location.target : undefined;
+  const showName =
+    location.kind !== "notebook" && Boolean(displayName && displayName !== "<module>");
+  const visibleLocation = notebookFrameSourceLabel(location, name);
+  const navigationLabel = notebookFrameNavigationLabel(location, name);
+  const target =
+    location.target && onNavigateToCell
+      ? targetWithLine(location.target, line, visibleLocation)
+      : undefined;
   return (
-    <span className="flex min-w-0 items-center gap-1.5" title={location.title}>
-      <span className="shrink-0 text-muted-foreground">Line</span>
-      <span className="shrink-0 tabular-nums text-muted-foreground">{line}</span>
-      <span className="shrink-0 text-muted-foreground">in</span>
-      {target ? (
+    <span className="flex min-w-0 flex-1 items-center gap-1.5" title={location.title}>
+      <span className="min-w-0 truncate text-muted-foreground">
+        <span>Line </span>
+        <span className="tabular-nums">{line}</span>
+        <span> in </span>
+        <span>{visibleLocation}</span>
+        {showName && (
+          <>
+            <span> in </span>
+            <span className="text-foreground">{displayName}</span>
+          </>
+        )}
+      </span>
+      {target && (
         <button
           type="button"
           onClick={(event) => {
@@ -540,26 +603,86 @@ function LocationLabel({
             onNavigateToCell?.(target);
           }}
           className={cn(
-            "inline-flex min-w-0 items-center gap-1 rounded-sm px-1 py-0.5",
-            "text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive",
+            "inline-flex size-6 shrink-0 items-center justify-center rounded-sm",
+            "text-muted-foreground/65 transition-colors hover:bg-destructive/10 hover:text-destructive",
           )}
-          aria-label={`Go to cell ${target.cellId}`}
-          title={`Go to cell ${target.cellId}`}
+          aria-label={`Go to ${navigationLabel}, line ${line}`}
+          title={`Go to ${navigationLabel}, line ${line}`}
         >
-          <LocateFixed aria-hidden="true" className="h-3 w-3 shrink-0" />
-          <span className="truncate">{location.label}</span>
+          <LocateFixed aria-hidden="true" className="h-3.5 w-3.5" />
         </button>
-      ) : (
-        <span className="truncate text-muted-foreground">{location.label}</span>
-      )}
-      {showName && (
-        <>
-          <span className="shrink-0 text-muted-foreground">in</span>
-          <span className="truncate">{displayName}</span>
-        </>
       )}
     </span>
   );
+}
+
+function FrameLabel({
+  location,
+  line,
+  name,
+  count,
+}: {
+  location: SourceLocation;
+  line: number;
+  name?: string;
+  count: number;
+}) {
+  const displayName = typeof name === "string" && name !== "<module>" ? name : undefined;
+  const visibleLocation = notebookFramePathLabel(location, name);
+  return (
+    <span className="min-w-0 truncate">
+      <span className="font-medium">{visibleLocation}</span>
+      <span className="text-muted-foreground/65"> · line {line}</span>
+      {location.kind !== "notebook" && displayName && (
+        <span className="text-muted-foreground/65"> / {displayName}</span>
+      )}
+      {count > 1 && <span className="text-muted-foreground/65"> / x{count.toLocaleString()}</span>}
+    </span>
+  );
+}
+
+function notebookFramePathLabel(location: SourceLocation, name?: string): string {
+  if (location.kind !== "notebook") {
+    return location.label;
+  }
+
+  if (name && name !== "<module>") {
+    return name;
+  }
+
+  return location.label === "Current Cell" ? "current cell" : "cell input";
+}
+
+function notebookFrameSourceLabel(location: SourceLocation, name?: string): string {
+  if (location.kind !== "notebook") {
+    return location.label;
+  }
+
+  if (name && name !== "<module>") {
+    return `cell defining ${name}`;
+  }
+
+  return location.label === "Current Cell" ? "current cell" : "source cell";
+}
+
+function notebookFrameNavigationLabel(location: SourceLocation, name?: string): string {
+  if (location.kind !== "notebook") {
+    return location.label;
+  }
+
+  if (name && name !== "<module>") {
+    return `cell that defines ${name}`;
+  }
+
+  return location.label === "Current Cell" ? "current cell" : "source cell";
+}
+
+function targetWithLine(
+  target: TracebackCellTarget,
+  line: number,
+  fallbackLabel?: string,
+): TracebackCellTarget {
+  return { ...target, label: target.label ?? fallbackLabel, line };
 }
 
 function sourceLocation(
@@ -577,6 +700,12 @@ function sourceLocation(
   const cellId = asOptionalString(sourceRef?.cell_id) ?? asOptionalString(source.cell_id);
   const sourceHash =
     asOptionalString(sourceRef?.source_hash) ?? asOptionalString(source.source_hash);
+  const executionCount =
+    typeof sourceRef?.execution_count === "number"
+      ? sourceRef.execution_count
+      : typeof source.execution_count === "number"
+        ? source.execution_count
+        : undefined;
   const compiledFilename = asOptionalString(sourceRef?.compiled_filename) ?? filename;
   const titleParts = [];
   if (executionId) titleParts.push(`Execution: ${executionId}`);
@@ -584,7 +713,9 @@ function sourceLocation(
   if (compiledFilename) titleParts.push(`Compiled file: ${compiledFilename}`);
 
   const isNotebookSource =
-    sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(filename);
+    Boolean(cellId) ||
+    sourceRef?.kind === "notebook_execution" ||
+    isSyntheticNotebookFilename(filename);
   const target =
     (executionId ? (resolveExecutionTarget?.(executionId, sourceHash) ?? null) : null) ??
     (cellId ? { cellId } : null);
@@ -602,7 +733,11 @@ function sourceLocation(
   if (target) {
     const label =
       target.label ??
-      (executionId === currentExecutionId ? "Current Cell" : `Cell ${shortCellId(target.cellId)}`);
+      (executionId === currentExecutionId
+        ? "Current Cell"
+        : typeof executionCount === "number"
+          ? `run ${executionCount}`
+          : `Cell ${shortCellId(target.cellId)}`);
     return {
       kind: "notebook",
       label,
@@ -746,7 +881,14 @@ function copyLocationLine(
 function isNotebookSource(source: Pick<Frame | SyntaxInfo, "filename" | "source_ref">): boolean {
   const sourceRef = isObjectRecord(source.source_ref) ? source.source_ref : undefined;
   const filename = asOptionalString(source.filename) ?? "";
-  return sourceRef?.kind === "notebook_execution" || isSyntheticNotebookFilename(filename);
+  const cellId =
+    asOptionalString(sourceRef?.cell_id) ??
+    asOptionalString((source as { cell_id?: unknown }).cell_id);
+  return (
+    Boolean(cellId) ||
+    sourceRef?.kind === "notebook_execution" ||
+    isSyntheticNotebookFilename(filename)
+  );
 }
 
 function asOptionalString(value: unknown): string | undefined {
@@ -892,4 +1034,106 @@ function safeStringify(x: unknown): string {
   } catch {
     return String(x);
   }
+}
+
+export function classicTracebackToPayload({
+  ename,
+  evalue,
+  traceback,
+  language = "python",
+}: ClassicTracebackInput): unknown | null {
+  const lines = Array.isArray(traceback)
+    ? traceback
+    : typeof traceback === "string"
+      ? traceback.split("\n")
+      : [];
+  if (lines.length === 0 || !lines.some((line) => line.includes("Traceback"))) {
+    return null;
+  }
+
+  const frames: Frame[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const frame = parseClassicFrame(lines[index]);
+    if (!frame) continue;
+
+    const sourceLine = classicFrameSourceLine(lines, index + 1);
+    if (sourceLine) {
+      frame.lines = [{ lineno: frame.lineno, source: sourceLine, highlight: true }];
+    }
+    frames.push(frame);
+  }
+
+  if (frames.length === 0) return null;
+
+  return {
+    ename: ename ?? "Error",
+    evalue: evalue ?? "",
+    language,
+    frames,
+    text: lines.join("\n"),
+  };
+}
+
+function parseClassicFrame(line: string): Frame | null {
+  const match = line.match(/^\s*Line\s+(\d+)\s+in\s+(.+?)(?:\s+\((.*?)\))?(?:,\s+in\s+(.+))?\s*$/);
+  if (!match) return null;
+
+  const lineno = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(lineno)) return null;
+
+  const label = (match[2] ?? "Notebook Cell").trim();
+  const detail = match[3] ?? "";
+  const name = (match[4] ?? "<module>").trim();
+  const details = Object.fromEntries(
+    detail
+      .split(",")
+      .map((part) => part.trim())
+      .map((part) => {
+        const separator = part.indexOf("=");
+        if (separator === -1) return null;
+        return [part.slice(0, separator).trim(), part.slice(separator + 1).trim()] as const;
+      })
+      .filter((part): part is readonly [string, string] => part !== null),
+  );
+  const cellId = details.cell_id ?? classicCellIdFromLabel(label);
+  const executionId = details.execution_id;
+  const sourceHash = details.source_hash;
+  const frame: Frame = {
+    filename: cellId ? `cell://${cellId}` : label,
+    lineno,
+    name,
+    cell_id: cellId,
+    execution_id: executionId,
+    source_hash: sourceHash,
+  };
+
+  if (cellId || executionId || sourceHash) {
+    frame.source_ref = {
+      kind: "notebook_execution",
+      cell_id: cellId,
+      execution_id: executionId,
+      source_hash: sourceHash,
+      compiled_filename: frame.filename,
+    };
+  }
+
+  return frame;
+}
+
+function classicCellIdFromLabel(label: string): string | undefined {
+  const match = label.match(/^Cell\s+(\S+)$/);
+  return match?.[1];
+}
+
+function classicFrameSourceLine(lines: readonly string[], startIndex: number): string | null {
+  for (let index = startIndex; index < lines.length; index++) {
+    const line = lines[index];
+    if (!line) continue;
+    if (/^\s*Line\s+\d+\s+in\s+/.test(line)) return null;
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    if (/^\w+(?:Error|Exception|Warning)\b/.test(trimmed)) return null;
+    return trimmed;
+  }
+  return null;
 }

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Check, Copy, LocateFixed, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { highlight } from "@/components/editor/static-highlight";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
@@ -200,7 +200,7 @@ export function TracebackOutput({
   // to the ename reads better whether we show frames below or not.
   const inlineEvalue = Boolean(payload?.evalue && !payload.evalue.includes("\n"));
   const currentExecutionId = payload?.execution?.execution_id;
-  const defaultSelectedFrame = useMemo(() => preferredFrameIndex(clusters), [clusters]);
+  const defaultSelectedFrame = preferredFrameIndex(clusters);
   const [selectedFrame, setSelectedFrame] = useState(defaultSelectedFrame);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Add a quiet traceback frame navigator for notebook errors, including classic traceback normalization.
- Let traceback navigation focus the source cell at the relevant CodeMirror line.
- Restyle the fallback ANSI error output so old/plain tracebacks match the newer surface.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/outputs/__tests__/traceback-output.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`

