### PR TITLE
feat(notebook-cloud): grant editors full cell editing in hosted rooms

### DIFF
--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -185,7 +185,29 @@ describe("RoomHostHandle", () => {
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
-      /cannot change notebook metadata/,
+      /editor scope may only edit cells/,
+    );
+  });
+
+  it("rejects editor-scoped runtime_state_doc_id repointing", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+
+    syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
+    editor.set_runtime_state_doc_id("forged-runtime-doc");
+    const message = editor.flush_local_changes();
+    assert.ok(message);
+
+    assert.throws(
+      () =>
+        host.receive_peer_frame(
+          "peer-editor",
+          "user:dev:bob",
+          "editor",
+          false,
+          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
+        ),
+      /editor scope may only edit cells/,
     );
   });
 

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -130,10 +130,11 @@ describe("RoomHostHandle", () => {
     );
   });
 
-  it("rejects editor-scoped source edits to code cells", async () => {
+  it("allows editor-scoped source edits to code cells", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
     const owner = NotebookHandle.create_bootstrap("user:dev:alice/desktop:owner");
     const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+    const viewer = NotebookHandle.create_bootstrap("user:dev:carol/desktop:viewer");
 
     syncHostWithClient(host, "peer-owner", "user:dev:alice", true, true, owner);
     owner.add_cell(0, "code-cell", "code");
@@ -142,28 +143,36 @@ describe("RoomHostHandle", () => {
 
     syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
     editor.update_source("code-cell", "x = 2\n");
-    const message = editor.flush_local_changes();
-    assert.ok(message);
+    applyClientChangesToHost(host, "peer-editor", "user:dev:bob", true, false, editor);
 
-    assert.throws(
-      () =>
-        host.receive_peer_frame(
-          "peer-editor",
-          "user:dev:bob",
-          "editor",
-          false,
-          encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
-        ),
-      /cannot edit code or raw cells/,
-    );
+    syncHostWithClient(host, "peer-viewer", "user:dev:carol", false, false, viewer);
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.equal(cells[0].id, "code-cell");
+    assert.equal(cells[0].source, "x = 2\n");
   });
 
-  it("rejects editor-scoped structural NotebookDoc changes", async () => {
+  it("allows editor-scoped structural NotebookDoc changes", async () => {
+    const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
+    const viewer = NotebookHandle.create_bootstrap("user:dev:carol/desktop:viewer");
+
+    syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
+    editor.add_cell(0, "new-markdown", "markdown");
+    editor.update_source("new-markdown", "Editor created this\n");
+    applyClientChangesToHost(host, "peer-editor", "user:dev:bob", true, false, editor);
+
+    syncHostWithClient(host, "peer-viewer", "user:dev:carol", false, false, viewer);
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.equal(cells[0].id, "new-markdown");
+    assert.equal(cells[0].source, "Editor created this\n");
+  });
+
+  it("rejects editor-scoped notebook metadata changes", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
     const editor = NotebookHandle.create_bootstrap("user:dev:bob/desktop:editor");
 
     syncHostWithClient(host, "peer-editor", "user:dev:bob", true, false, editor);
-    editor.add_cell(0, "new-markdown", "markdown");
+    editor.set_metadata("trust", "tampered");
     const message = editor.flush_local_changes();
     assert.ok(message);
 
@@ -176,7 +185,7 @@ describe("RoomHostHandle", () => {
           false,
           encodeTypedFrame(FrameType.AUTOMERGE_SYNC, message),
         ),
-      /cannot add, remove, or reorder cells/,
+      /cannot change notebook metadata/,
     );
   });
 

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -45,7 +45,7 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities grant editor markdown writes without code, structure, execute, or package management", () => {
+test("cloud shell capabilities grant editors full cell and structure editing without execute or package management", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),
     connectionScope: "editor",
@@ -54,8 +54,8 @@ test("cloud shell capabilities grant editor markdown writes without code, struct
   });
 
   assert.equal(capabilities.canEditMarkdown, true);
-  assert.equal(capabilities.canEditCells, false);
-  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canEditCells, true);
+  assert.equal(capabilities.canEditStructure, true);
   assert.equal(capabilities.canRequestEdit, true);
   assert.equal(capabilities.canExecute, false);
   assert.equal(capabilities.canToggleCode, false);
@@ -134,7 +134,7 @@ test("cloud shell capabilities keep requested edit pending until the room grants
   assert.equal(capabilities.access.level, "viewer");
 });
 
-test("cloud shell capabilities reserve code-cell and structure edits for owners", () => {
+test("cloud shell capabilities grant owners full cell, structure, and sharing control", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),
     connectionScope: "owner",

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -33,9 +33,13 @@ export function cloudNotebookShellCapabilities({
   const interaction = createNotebookInteractionModeProjection({
     selectedMode,
     permission: {
+      // Editors get full collaborative cell editing (markdown/code/raw source +
+      // add/delete/move). This mirrors the room host's editor write surface; the
+      // server still rejects notebook-level metadata edits from non-owners
+      // (validate_editor_notebook_changes in runtimed-wasm).
       canEditMarkdown: accessLevel === "editor" || accessLevel === "owner",
-      canEditCells: accessLevel === "owner",
-      canEditStructure: accessLevel === "owner",
+      canEditCells: accessLevel === "editor" || accessLevel === "owner",
+      canEditStructure: accessLevel === "editor" || accessLevel === "owner",
     },
     hostSupport: {
       canEditMarkdown: true,

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -8,8 +8,10 @@
 // Allow `expect()` and `unwrap()` in tests
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+use automerge::patches::PatchAction;
 use automerge::sync;
 use automerge::sync::SyncDoc;
+use automerge::Prop;
 use notebook_doc::diff::{
     diff_doc, extract_change_actor_hashes, extract_change_actors, CellChangeset, ChangeActor,
     TextPatch,
@@ -901,12 +903,14 @@ fn validate_room_notebook_change_actors_inner<'a>(
 /// Validate that an editor-scope peer's NotebookDoc changes stay within the
 /// collaborative cell-editing surface.
 ///
-/// Editors may add, remove, reorder, and edit cells of any type. Notebook-level
-/// metadata (kernelspec, trust, environment, path, project) stays owner-authored
-/// and is rejected here. Owners skip this check entirely via
-/// `can_write_all_notebook_changes`. Canonical schema-seed changes are folded
-/// into `heads_before` so a fresh room's genesis maps are not read as metadata
-/// edits.
+/// Editors may add, remove, reorder, and edit cells of any type. Everything else
+/// at the document root is owner-authored: notebook metadata (kernelspec, trust,
+/// environment, path, project), `schema_version`, `notebook_id`, and the
+/// `runtime_state_doc_id` pairing. So the policy is an allowlist over the diff —
+/// every patch must land inside the `cells` map; any other root write is
+/// rejected. Owners skip this check entirely via `can_write_all_notebook_changes`.
+/// Canonical schema-seed changes are folded into `heads_before` so a fresh room's
+/// genesis is not read as a write.
 fn validate_editor_notebook_changes<'a>(
     preview: &mut NotebookDoc,
     heads_before: &[automerge::ChangeHash],
@@ -922,13 +926,37 @@ fn validate_editor_notebook_changes<'a>(
     }
 
     let heads_after = preview.get_heads();
-    let changeset = diff_doc(preview.doc_mut(), &effective_heads_before, &heads_after);
-    if changeset.metadata_changed {
-        return Err(
-            "editor scope cannot change notebook metadata; metadata is owner-authored".to_string(),
-        );
+    for patch in preview
+        .doc_mut()
+        .diff(&effective_heads_before, &heads_after)
+    {
+        // A cell op modifies an object at or below `cells`, so its patch path
+        // begins with `cells`. Anything else — root metadata, schema_version,
+        // notebook_id, runtime_state_doc_id, or a root-level replace/delete of
+        // the cells map itself — is owner-authored and rejected.
+        let within_cells =
+            matches!(patch.path.first(), Some((_, Prop::Map(key))) if key == "cells");
+        if !within_cells {
+            return Err(format!(
+                "editor scope may only edit cells; change touched notebook root '{}'",
+                editor_change_root_label(&patch)
+            ));
+        }
     }
     Ok(())
+}
+
+/// Best-effort name of the document root a rejected editor patch touched, for
+/// error messages.
+fn editor_change_root_label(patch: &automerge::Patch) -> String {
+    match patch.path.first() {
+        Some((_, Prop::Map(key))) => key.clone(),
+        Some((_, Prop::Seq(_))) => "<root sequence>".to_string(),
+        None => match &patch.action {
+            PatchAction::PutMap { key, .. } | PatchAction::DeleteMap { key } => key.clone(),
+            _ => "<document root>".to_string(),
+        },
+    }
 }
 
 /// A handle to a local Automerge notebook document.
@@ -3180,6 +3208,28 @@ mod tests {
             )
             .is_err(),
             "editor scope cannot change notebook metadata",
+        );
+    }
+
+    #[test]
+    fn editor_changes_reject_runtime_state_doc_id_writes() {
+        let mut preview = NotebookDoc::bootstrap(
+            notebook_doc::TextEncoding::UnicodeCodePoint,
+            "user:dev:alice/desktop:a",
+        );
+        let heads_before = preview.get_heads();
+        preview
+            .set_runtime_state_doc_id("forged-runtime-doc")
+            .expect("forge runtime_state_doc_id");
+
+        assert!(
+            validate_editor_notebook_changes(
+                &mut preview,
+                &heads_before,
+                std::iter::empty::<&ChangeActor>(),
+            )
+            .is_err(),
+            "editor scope cannot repoint runtime_state_doc_id",
         );
     }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -612,7 +612,8 @@ impl RoomHostHandle {
             let actors = extract_change_actor_hashes(preview.doc_mut(), &heads_before);
             validate_room_notebook_change_actors(principal, actors.iter())?;
             if !can_write_all_notebook_changes {
-                validate_markdown_source_only_changes(&mut preview, &heads_before, actors.iter())?;
+                validate_editor_notebook_changes(&mut preview, &heads_before, actors.iter())
+                    .map_err(|e| JsError::new(&e))?;
             }
         }
 
@@ -897,11 +898,20 @@ fn validate_room_notebook_change_actors_inner<'a>(
     Ok(())
 }
 
-fn validate_markdown_source_only_changes<'a>(
+/// Validate that an editor-scope peer's NotebookDoc changes stay within the
+/// collaborative cell-editing surface.
+///
+/// Editors may add, remove, reorder, and edit cells of any type. Notebook-level
+/// metadata (kernelspec, trust, environment, path, project) stays owner-authored
+/// and is rejected here. Owners skip this check entirely via
+/// `can_write_all_notebook_changes`. Canonical schema-seed changes are folded
+/// into `heads_before` so a fresh room's genesis maps are not read as metadata
+/// edits.
+fn validate_editor_notebook_changes<'a>(
     preview: &mut NotebookDoc,
     heads_before: &[automerge::ChangeHash],
     allowed_changes: impl IntoIterator<Item = &'a ChangeActor>,
-) -> Result<(), JsError> {
+) -> Result<(), String> {
     let mut effective_heads_before = heads_before.to_vec();
     for change in allowed_changes {
         if NotebookDoc::is_canonical_schema_seed_change(&change.actor_label, &change.hash)
@@ -914,26 +924,9 @@ fn validate_markdown_source_only_changes<'a>(
     let heads_after = preview.get_heads();
     let changeset = diff_doc(preview.doc_mut(), &effective_heads_before, &heads_after);
     if changeset.metadata_changed {
-        return Err(JsError::new(
-            "editor scope cannot change notebook metadata in hosted markdown-only mode",
-        ));
-    }
-    if changeset.cells.is_structural() {
-        return Err(JsError::new(
-            "editor scope cannot add, remove, or reorder cells in hosted markdown-only mode",
-        ));
-    }
-    for changed in &changeset.cells.changed {
-        if !changed.fields.is_source_only() {
-            return Err(JsError::new(
-                "editor scope can only edit markdown source in hosted markdown-only mode",
-            ));
-        }
-        if preview.get_cell_type(&changed.cell_id).as_deref() != Some("markdown") {
-            return Err(JsError::new(
-                "editor scope cannot edit code or raw cells in hosted markdown-only mode",
-            ));
-        }
+        return Err(
+            "editor scope cannot change notebook metadata; metadata is owner-authored".to_string(),
+        );
     }
     Ok(())
 }
@@ -3105,7 +3098,7 @@ mod tests {
     }
 
     #[test]
-    fn markdown_only_policy_ignores_canonical_schema_seed_maps() {
+    fn editor_policy_ignores_canonical_schema_seed_maps() {
         let seed_hash = NotebookDoc::canonical_schema_seed_change_hashes()
             .into_iter()
             .next()
@@ -3115,7 +3108,7 @@ mod tests {
             "user:dev:alice/desktop:a",
         );
 
-        validate_markdown_source_only_changes(
+        validate_editor_notebook_changes(
             &mut preview,
             &[],
             [ChangeActor {
@@ -3125,6 +3118,69 @@ mod tests {
             .iter(),
         )
         .expect("canonical schema seed maps are not editor metadata edits");
+    }
+
+    #[test]
+    fn editor_changes_allow_adding_cells() {
+        let mut preview = NotebookDoc::bootstrap(
+            notebook_doc::TextEncoding::UnicodeCodePoint,
+            "user:dev:alice/desktop:a",
+        );
+        let heads_before = preview.get_heads();
+        preview
+            .add_cell_after("cell-1", "code", None)
+            .expect("add cell");
+
+        validate_editor_notebook_changes(
+            &mut preview,
+            &heads_before,
+            std::iter::empty::<&ChangeActor>(),
+        )
+        .expect("editor scope may add cells");
+    }
+
+    #[test]
+    fn editor_changes_allow_editing_code_cell_source() {
+        let mut preview = NotebookDoc::bootstrap(
+            notebook_doc::TextEncoding::UnicodeCodePoint,
+            "user:dev:alice/desktop:a",
+        );
+        preview
+            .add_cell_after("cell-1", "code", None)
+            .expect("add cell");
+        let heads_before = preview.get_heads();
+        preview
+            .update_source("cell-1", "print(1)")
+            .expect("edit source");
+
+        validate_editor_notebook_changes(
+            &mut preview,
+            &heads_before,
+            std::iter::empty::<&ChangeActor>(),
+        )
+        .expect("editor scope may edit code cell source");
+    }
+
+    #[test]
+    fn editor_changes_reject_notebook_metadata_edits() {
+        let mut preview = NotebookDoc::bootstrap(
+            notebook_doc::TextEncoding::UnicodeCodePoint,
+            "user:dev:alice/desktop:a",
+        );
+        let heads_before = preview.get_heads();
+        preview
+            .set_metadata("trust", "tampered")
+            .expect("set metadata");
+
+        assert!(
+            validate_editor_notebook_changes(
+                &mut preview,
+                &heads_before,
+                std::iter::empty::<&ChangeActor>(),
+            )
+            .is_err(),
+            "editor scope cannot change notebook metadata",
+        );
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -908,9 +908,12 @@ fn validate_room_notebook_change_actors_inner<'a>(
 /// environment, path, project), `schema_version`, `notebook_id`, and the
 /// `runtime_state_doc_id` pairing. So the policy is an allowlist over the diff —
 /// every patch must land inside the `cells` map; any other root write is
-/// rejected. Owners skip this check entirely via `can_write_all_notebook_changes`.
-/// Canonical schema-seed changes are folded into `heads_before` so a fresh room's
-/// genesis is not read as a write.
+/// rejected. Cell-level `execution_count`/`execution_id` live under `cells`, so
+/// editors may write them — the live execution authority is RuntimeStateDoc,
+/// gated separately, so this cannot fabricate live execution state. Owners skip
+/// this check entirely via `can_write_all_notebook_changes`. Canonical
+/// schema-seed changes are folded into `heads_before` so a fresh room's genesis
+/// is not read as a write.
 fn validate_editor_notebook_changes<'a>(
     preview: &mut NotebookDoc,
     heads_before: &[automerge::ChangeHash],

--- a/docs/architecture/hosted-room-authorization.md
+++ b/docs/architecture/hosted-room-authorization.md
@@ -264,19 +264,35 @@ author.
 Editor-scope collaborators get the full collaborative cell surface: add, delete,
 reorder, and edit cells of any type (markdown, code, raw source). Creating cells
 with a collaborator is the baseline expectation for an editable notebook, so the
-editor write surface is not restricted to markdown. Notebook-level metadata
-(kernelspec, trust, environment, path, project) stays owner-authored.
+editor write surface is not restricted to markdown. Everything else at the
+document root stays owner-authored: notebook metadata (kernelspec, trust,
+environment, path, project) and the document-identity roots `schema_version`,
+`notebook_id`, and `runtime_state_doc_id`.
 
 UI-only hiding is not an authorization boundary. A malicious browser can send
 arbitrary `NotebookDoc` sync frames, so the room host enforces the editor
 surface server-side with a semantic diff validator: it clone-previews the
-incoming `NotebookDoc` message, diffs the changed cells/fields against the
-heads before the change, and rejects any change that touches notebook-level
-metadata. Owners skip the validator (they may write all notebook changes). This
-is `validate_editor_notebook_changes` in `runtimed-wasm`, reached from
+incoming `NotebookDoc` message, diffs it against the heads before the change,
+and accepts it only if every patch lands inside the `cells` map. The policy is
+an allowlist, not a metadata denylist: any other root write — notebook
+metadata, `schema_version`, `notebook_id`, `runtime_state_doc_id`, or a
+root-level replace/delete of the `cells` map itself — is rejected. Owners skip
+the validator (they may write all notebook changes). This is
+`validate_editor_notebook_changes` in `runtimed-wasm`, reached from
 `receive_notebook_sync` whenever `can_write_all_notebook_changes` is false. The
 diff-validator path stays close to the desktop sync model and preserves
 client-local editing; "only the cloud UI exposes editing" is never sufficient.
+
+Cell-level `execution_count` and `execution_id` live under `cells/{id}`, so the
+allowlist accepts editor writes to them. This is intentional. They are the
+legacy nbformat persisted fallback and a pointer into RuntimeStateDoc; the live
+execution authority is RuntimeStateDoc, which is separately gated, so a
+non-owner editor cannot fabricate live execution state. A cell's
+`execution_count` is also written as part of normal cell creation, so carving
+these fields out would mean special-casing creation. The residual exposure is a
+fabricated persisted count surfacing on `.ipynb` export, which is out of the
+current threat model. Revisit if export fidelity from a malicious editor ever
+enters scope.
 
 Execution is a separate axis from the document write surface. There is no kernel
 provider in the hosted prototype yet, so run/restart/interrupt stay hidden

--- a/docs/architecture/hosted-room-authorization.md
+++ b/docs/architecture/hosted-room-authorization.md
@@ -259,26 +259,31 @@ materializes. Read-only viewers and editors consume the same live
 `NotebookDoc`/`RuntimeStateDoc`; scope only limits what each connection may
 author.
 
-## Decision 7: Markdown-only collaboration needs a semantic gate
+## Decision 7: Editor collaboration is full cell editing behind a semantic gate
 
-The first editable hosted slice should be markdown-only, but UI-only hiding is
-not an authorization boundary. A malicious browser can send arbitrary
-`NotebookDoc` sync frames.
+Editor-scope collaborators get the full collaborative cell surface: add, delete,
+reorder, and edit cells of any type (markdown, code, raw source). Creating cells
+with a collaborator is the baseline expectation for an editable notebook, so the
+editor write surface is not restricted to markdown. Notebook-level metadata
+(kernelspec, trust, environment, path, project) stays owner-authored.
 
-Before exposing editor-scope hosted markdown editing to untrusted clients, the
-room host needs one of these server-side gates:
+UI-only hiding is not an authorization boundary. A malicious browser can send
+arbitrary `NotebookDoc` sync frames, so the room host enforces the editor
+surface server-side with a semantic diff validator: it clone-previews the
+incoming `NotebookDoc` message, diffs the changed cells/fields against the
+heads before the change, and rejects any change that touches notebook-level
+metadata. Owners skip the validator (they may write all notebook changes). This
+is `validate_editor_notebook_changes` in `runtimed-wasm`, reached from
+`receive_notebook_sync` whenever `can_write_all_notebook_changes` is false. The
+diff-validator path stays close to the desktop sync model and preserves
+client-local editing; "only the cloud UI exposes editing" is never sufficient.
 
-1. a semantic diff validator that clone-previews the incoming `NotebookDoc`
-   message, computes the changed cells/fields, and accepts only allowed
-   markdown-cell source edits; or
-2. a scoped request API where the client asks the DO to apply a markdown-cell
-   edit and the DO authors the change under the connection's actor label.
-
-The diff-validator path is closer to the desktop sync model and preserves
-client-local editing. The request path is easier to authorize but adds a second
-mutation API. Either is acceptable for the prototype as long as the accepted
-surface is server-enforced. "Only the cloud UI exposes markdown editing" is not
-sufficient.
+Execution is a separate axis from the document write surface. There is no kernel
+provider in the hosted prototype yet, so run/restart/interrupt stay hidden
+behind a runtime-availability capability rather than an ACL scope. When a kernel
+provider is later attached, execution authority is granted through
+`runtime_peer` scope and the kernel protocol, not by widening the editor
+document surface.
 
 The editor `RuntimeStateDoc` write surface is closed by the shared runtime-doc
 policy used by the hosted room host and daemon. Editor and owner scopes may
@@ -288,8 +293,9 @@ would be privilege escalation into runtime lifecycle, execution status, or
 fabricated outputs, so frames that touch those fields are rejected before the
 real room document mutates.
 
-Full code-cell editing is a later phase. Code cells can render read-only while
-markdown cells are editable.
+Locking the surface down further is a future owner capability, not the baseline:
+an owner-only "freeze structure" or metadata-edit grant can narrow what editors
+may do, but collaborative cell editing is on by default.
 
 ## Decision 8: Runtime peers are just another scoped connection
 
@@ -352,9 +358,10 @@ enforce equivalent access.
    existing widget comm-state values, while queue, execution, kernel,
    environment, output routing, comm topology, and schema/root writes remain
    runtime-owned.
-8. **Markdown-only edit slice.** Add the server-side semantic gate or request
-   API, then expose markdown editing for authenticated `editor`/`owner`
-   connections.
+8. **Editor cell-editing slice.** Server-side semantic gate
+   (`validate_editor_notebook_changes`) accepts full cell editing (any cell
+   type, source, and structure) from authenticated `editor`/`owner`
+   connections while rejecting notebook-level metadata edits from non-owners.
 9. **Runtime peer ingress.** Allow runtime peers to attach and update
    `RuntimeStateDoc` plus blobs without notebook edits.
 10. **Direct OIDC.** Wire real provider validation after ACL lookup is in
@@ -376,8 +383,8 @@ enforce equivalent access.
 
 1. Whether anonymous public viewers should broadcast full cursor/cell presence
    or only document-level aggregate presence.
-2. Whether markdown-only collaboration should use semantic sync validation or a
-   scoped request API.
+2. Whether editors should eventually get a scoped notebook-metadata grant
+   (kernelspec, language) or whether metadata stays owner-only.
 3. How often the DO should checkpoint live room snapshots to R2 and whether
    checkpoint rows are visible as user-facing revisions or internal autosaves.
 4. Whether provider capability bounds should be represented as a set in


### PR DESCRIPTION
Editors in a hosted room can now add, delete, reorder, and edit cells of any type, not just markdown source. Creating cells with a collaborator is the baseline for an editable notebook, so the editor write surface is no longer markdown-only. Notebook-level metadata (kernelspec, trust, environment, path, project) stays owner-authored.

## Design decision

The boundary that matters is server-side, not the capability flag. The room host runs a semantic diff validator (`validate_editor_notebook_changes` in `runtimed-wasm`, reached from `receive_notebook_sync` whenever `can_write_all_notebook_changes` is false): it clone-previews the incoming `NotebookDoc` sync, diffs the changed cells/fields, and rejects any change that touches notebook-level metadata. Owners skip the validator. The cloud capability (`canEditCells`/`canEditStructure` for editor scope) only mirrors what the room already enforces. Flipping the capability alone would have let the client show add-cell while the room rejected the frames, reintroducing the focus/desync class of bug. Both moved together, server-first.

This also converges the two hosts: desktop already granted editors full cell editing. Cloud now derives the same rule instead of an owner-only special case.

Execution stays a separate axis. There is no kernel provider in the hosted prototype, so run/restart/interrupt remain hidden; that gate is kernel availability, not an ACL scope, and generalizing it into a host-neutral runtime-availability capability is a follow-up.

## Behavioral coverage

| Scope | Cell source (md/code/raw) | Add/delete/move | Notebook metadata | Execute |
|-------|---------------------------|-----------------|-------------------|---------|
| viewer | no | no | no | no |
| editor | yes | yes | no (owner-only) | no (no kernel) |
| owner | yes | yes | yes | no (no kernel) |

## Notes

- `validate_markdown_source_only_changes` is renamed to `validate_editor_notebook_changes` and now returns `Result<(), String>` so it is unit-testable on native targets (the caller maps to `JsError`).
- Decision 7 of `docs/architecture/hosted-room-authorization.md` is rewritten to record the new editor surface, with "lock it down later" captured as a future owner capability rather than the baseline.
- Follow-up, not in this PR: a host-neutral runtime-availability capability so run controls hide when no kernel provider is attached (desktop benefits too), and the larger `useAutomergeNotebook` controller extraction tracked in `frontend-sync-bridge.md`.

Predecessor: #3314.

## Test plan

- [x] `cargo test -p runtimed-wasm` (17 passing, incl. 3 new editor-policy tests)
- [x] `apps/notebook-cloud` suite (430 passing; room-materializer integration tests prove editor add/edit-code accepted and editor metadata rejected against rebuilt wasm)
- [x] `cargo xtask lint --fix` clean
- [ ] Manually click "add cell" as an editor in the local cloud viewer and confirm round-trip
