### PR TITLE
feat(notebook): gate run controls on a host-neutral runtime-availability capability

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -91,6 +91,16 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(withRuntime.runtime.executionAvailable, true);
   assert.equal(withRuntime.canExecute, true);
+
+  // A live runtime is visible to viewers, but viewing is not execution authority.
+  const viewerWithRuntime = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "viewer"),
+    connectionScope: "viewer",
+    hasCodeCells: true,
+    runtimeAvailable: true,
+  });
+  assert.equal(viewerWithRuntime.runtime.executionAvailable, true);
+  assert.equal(viewerWithRuntime.canExecute, false);
 });
 
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -72,6 +72,27 @@ test("cloud shell capabilities grant editors full cell and structure editing wit
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
+test("cloud shell capabilities surface execution only when a runtime is available", () => {
+  const withoutRuntime = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+  });
+  assert.equal(withoutRuntime.runtime.executionAvailable, false);
+  assert.equal(withoutRuntime.canExecute, false);
+
+  const withRuntime = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+  });
+  assert.equal(withRuntime.runtime.executionAvailable, true);
+  assert.equal(withRuntime.canExecute, true);
+});
+
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -15,6 +15,12 @@ export interface CloudNotebookShellCapabilityInput {
   connectionActorLabel?: string | null;
   hasCodeCells: boolean;
   selectedMode?: NotebookInteractionMode;
+  /**
+   * Whether an execution runtime is attached to the room. The hosted prototype
+   * has no kernel provider yet, so this defaults false and run controls stay
+   * hidden. Flip it on once a runtime peer can execute the room's cells.
+   */
+  runtimeAvailable?: boolean;
 }
 
 export function cloudNotebookShellCapabilities({
@@ -23,6 +29,7 @@ export function cloudNotebookShellCapabilities({
   connectionActorLabel = null,
   hasCodeCells,
   selectedMode = "view",
+  runtimeAvailable = false,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
   const isRuntimePeer = connectionScope === "runtime_peer";
@@ -60,9 +67,14 @@ export function cloudNotebookShellCapabilities({
     actorLabel: connectionActorLabel,
     identityLabel,
   };
+  // Executing a cell needs both an attached runtime and document write
+  // authority. The room has no kernel provider yet, so runtimeAvailable
+  // defaults false and run controls stay hidden.
+  const canExecute = runtimeAvailable && (accessLevel === "editor" || accessLevel === "owner");
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
     connected: isRuntimePeer,
+    executionAvailable: runtimeAvailable,
     source: "cloud" as const,
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
     identityLabel: isRuntimePeer ? identityLabel : null,
@@ -80,7 +92,7 @@ export function cloudNotebookShellCapabilities({
     canEditCells: interaction.canEditCells,
     canEditStructure: interaction.canEditStructure,
     canRequestEdit: interaction.canRequestEdit,
-    canExecute: false,
+    canExecute,
     canToggleCode: hasCodeCells,
     canViewPackages: true,
     canManagePackages: false,

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vite-plus/test";
 import { desktopNotebookShellCapabilities } from "../desktop-shell-capabilities";
 
 describe("desktopNotebookShellCapabilities", () => {
+  it("exposes runtime execution availability from the daemon session", () => {
+    const ready = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    expect(ready.runtime.executionAvailable).toBe(true);
+    expect(ready.canExecute).toBe(true);
+
+    const notReady = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: false,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    expect(notReady.runtime.executionAvailable).toBe(false);
+    expect(notReady.canExecute).toBe(false);
+  });
+
   it("maps local notebooks to owner-level writable shell access", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: true,

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -20,6 +20,17 @@ describe("desktopNotebookShellCapabilities", () => {
     });
     expect(notReady.runtime.executionAvailable).toBe(false);
     expect(notReady.canExecute).toBe(false);
+
+    // A ready runtime is available even when the document is not writable, but
+    // execution still requires write authority.
+    const readyReadOnly = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: false,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    expect(readyReadOnly.runtime.executionAvailable).toBe(true);
+    expect(readyReadOnly.canExecute).toBe(false);
   });
 
   it("maps local notebooks to owner-level writable shell access", () => {

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -54,6 +54,9 @@ export function desktopNotebookShellCapabilities({
   const runtime = {
     canWriteRuntimeState,
     connected: sessionReady && (source === "local" || isRuntimePeer),
+    // A ready daemon session is the local execution runtime. `canExecute` below
+    // gates this further by document write authority.
+    executionAvailable: sessionReady,
     source,
     actorLabel: canWriteRuntimeState ? localActor : null,
     identityLabel: null,

--- a/src/components/notebook/capabilities.ts
+++ b/src/components/notebook/capabilities.ts
@@ -88,6 +88,15 @@ export interface NotebookShellRuntimeCapabilities {
    */
   canWriteRuntimeState: boolean;
   connected: boolean;
+  /**
+   * Whether an execution runtime (kernel provider) is available to run cells.
+   * This is the host-neutral signal behind `canExecute`: run/restart/interrupt
+   * stay hidden when no runtime can execute, regardless of edit permission. A
+   * host with no kernel provider (the hosted prototype today) reports false; a
+   * local daemon with a ready session, or a future attached cloud runtime,
+   * reports true. Optional so fixtures need not set it.
+   */
+  executionAvailable?: boolean;
   source: NotebookShellAccessSource;
   actorLabel: string | null;
   identityLabel: string | null;
@@ -146,6 +155,7 @@ export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
   runtime: {
     canWriteRuntimeState: false,
     connected: false,
+    executionAvailable: false,
     source: "unknown",
     actorLabel: null,
     identityLabel: null,


### PR DESCRIPTION
Run / restart / interrupt now hang off a named, host-neutral runtime-availability signal instead of cloud hardwiring `canExecute: false` and desktop conflating "can write" with "can execute." When no execution runtime (kernel provider) is attached, the run controls stay hidden, on any host.

## Design decision

`NotebookShellRuntimeCapabilities` gains an optional `executionAvailable` flag: "is there a runtime that can run this room's cells?" That is distinct from `canExecute`, which is `executionAvailable && write authority`. The distinction matters: a viewer watching a notebook with a live kernel has `executionAvailable: true` but `canExecute: false`. The field is optional so the ~15 elements fixtures that build runtime capabilities by hand do not need to change.

Hosts derive it from the fact they actually have:

- desktop: `executionAvailable = sessionReady` (a ready daemon session is the local kernel).
- cloud: `executionAvailable = runtimeAvailable` input, default false (the hosted prototype has no kernel provider yet). Flip it on when a runtime peer can execute the room's cells.

No behavior change ships today: cloud still has no kernel, so run stays hidden exactly as before. This is the honest model behind that behavior, and it sets up two cases the prototype was missing a vocabulary for: attaching a cloud runtime later, and desktop opening a hosted notebook that has no local kernel.

## Behavioral coverage

| Host / state | `executionAvailable` | `canExecute` | Run controls |
|---|---|---|---|
| cloud editor, no kernel | false | false | hidden |
| cloud editor, runtime attached (future) | true | true | shown |
| cloud viewer, runtime attached (future) | true | false | hidden |
| desktop, daemon session ready + writable | true | true | shown |
| desktop, session not ready | false | false | hidden |

## Notes

- Stacked on #3316 (editor cell editing). Review either branch independently; this one only touches capability derivation.
- Cloud viewer wiring is unchanged: it omits `runtimeAvailable`, so it defaults false. The flip happens when kernel attach lands.

## Test plan

- [x] `apps/notebook-cloud` suite (431 passing; new test proves `canExecute` flips with `runtimeAvailable`)
- [x] desktop `desktop-shell-capabilities` test (new test ties `executionAvailable` to `sessionReady`)
- [x] shared `src/components/notebook` suite (81 passing)
- [x] `cargo xtask lint --fix` clean
