### PR TITLE
feat(cell): drive run signal from monotonic time

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -118,7 +118,7 @@ const currentLineStateFixtures = [
   {
     label: "Running",
     detail:
-      "Runtime work starts as a line, then earns the green wave if it stays busy long enough.",
+      "Runtime work starts as a line, then earns a monotonic green wave if it stays busy long enough.",
     line: <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
   },
   {

--- a/apps/elements/content/docs/cell-execution-language.mdx
+++ b/apps/elements/content/docs/cell-execution-language.mdx
@@ -10,6 +10,10 @@ copy second. This page renders the current production execution components
 directly: `CompactExecutionButton` for the state lane and
 `CodeCellCurrentLine` for the source/result boundary.
 
+The running signal starts as a quiet rule, waits out fast executions, then builds
+into a green wave driven from monotonic time. That keeps long-running cells
+alive without exposing a CSS animation loop boundary.
+
 Fixture state drives the examples, but there are no alternate catalog-only
 execution-line components here. If the visual language changes, it should
 change in `src/components/cell` first.

--- a/apps/elements/content/docs/cell-execution-language.mdx
+++ b/apps/elements/content/docs/cell-execution-language.mdx
@@ -13,6 +13,8 @@ directly: `CompactExecutionButton` for the state lane and
 The running signal starts as a quiet rule, waits out fast executions, then builds
 into a green wave driven from monotonic time. That keeps long-running cells
 alive without exposing a CSS animation loop boundary.
+Reduced-motion users keep the same delayed state change, but the signal rests
+as a still line instead of advancing frame by frame.
 
 Fixture state drives the examples, but there are no alternate catalog-only
 execution-line components here. If the visual language changes, it should

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -55,8 +55,13 @@ function subscribeToReducedMotion(enabled: boolean, onStoreChange: () => void): 
   }
 
   const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
-  mediaQuery.addEventListener?.("change", onStoreChange);
-  return () => mediaQuery.removeEventListener?.("change", onStoreChange);
+  if (typeof mediaQuery.addEventListener === "function") {
+    mediaQuery.addEventListener("change", onStoreChange);
+    return () => mediaQuery.removeEventListener("change", onStoreChange);
+  }
+
+  mediaQuery.addListener?.(onStoreChange);
+  return () => mediaQuery.removeListener?.(onStoreChange);
 }
 
 function usePrefersReducedMotion(enabled: boolean): boolean {
@@ -67,36 +72,6 @@ function usePrefersReducedMotion(enabled: boolean): boolean {
   const getSnapshot = useCallback(() => readPrefersReducedMotion(enabled), [enabled]);
 
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
-}
-
-function useMonotonicAnimationClock(enabled: boolean): number {
-  const prefersReducedMotion = usePrefersReducedMotion(enabled);
-  const [now, setNow] = useState(() => (enabled ? getMonotonicNow() : 0));
-
-  useEffect(() => {
-    if (!enabled) return;
-
-    setNow(getMonotonicNow());
-
-    if (
-      prefersReducedMotion ||
-      typeof window === "undefined" ||
-      typeof window.requestAnimationFrame !== "function"
-    ) {
-      return;
-    }
-
-    let frameId = 0;
-    const tick = (timestamp: number) => {
-      setNow(timestamp);
-      frameId = window.requestAnimationFrame(tick);
-    };
-
-    frameId = window.requestAnimationFrame(tick);
-    return () => window.cancelAnimationFrame(frameId);
-  }, [enabled, prefersReducedMotion]);
-
-  return prefersReducedMotion ? 0 : now;
 }
 
 function runningSignalWavePath(now: number): string {
@@ -251,6 +226,55 @@ function useRunningSignalPhase(isExecuting: boolean): RunningSignalPhase {
   return phase;
 }
 
+function RunningSignalWave({ active }: { active: boolean }) {
+  const pathRef = useRef<SVGPathElement | null>(null);
+  const lastPathRef = useRef(runningSignalWavePath(getMonotonicNow()));
+  const prefersReducedMotion = usePrefersReducedMotion(active);
+
+  useEffect(() => {
+    if (!active || prefersReducedMotion) return;
+
+    const updatePath = (timestamp: number) => {
+      const nextPath = runningSignalWavePath(timestamp);
+      lastPathRef.current = nextPath;
+      pathRef.current?.setAttribute("d", nextPath);
+    };
+
+    updatePath(getMonotonicNow());
+
+    if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") {
+      return;
+    }
+
+    let frameId = 0;
+    const tick = (timestamp: number) => {
+      updatePath(timestamp);
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    frameId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [active, prefersReducedMotion]);
+
+  return (
+    <svg
+      className="absolute inset-y-0 left-0 h-full w-full"
+      viewBox={`0 0 ${RUNNING_SIGNAL_WAVE_WIDTH} ${RUNNING_SIGNAL_WAVE_HEIGHT}`}
+      preserveAspectRatio="none"
+    >
+      <path
+        ref={pathRef}
+        d={prefersReducedMotion ? runningSignalWavePath(0) : lastPathRef.current}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.4"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}
+
 function ExecutionBoundaryRule({
   state,
   runningSignalPhase,
@@ -264,9 +288,6 @@ function ExecutionBoundaryRule({
 }) {
   const showRunningSignal =
     state === "running" && (runningSignalPhase === "active" || runningSignalPhase === "settling");
-  const runningSignalNow = useMonotonicAnimationClock(
-    showRunningSignal && runningSignalPhase === "active",
-  );
 
   if (state === "running") {
     return (
@@ -292,20 +313,7 @@ function ExecutionBoundaryRule({
             )}
             aria-hidden="true"
           >
-            <svg
-              className="absolute inset-y-0 left-0 h-full w-full"
-              viewBox={`0 0 ${RUNNING_SIGNAL_WAVE_WIDTH} ${RUNNING_SIGNAL_WAVE_HEIGHT}`}
-              preserveAspectRatio="none"
-            >
-              <path
-                d={runningSignalWavePath(runningSignalNow)}
-                fill="none"
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeWidth="1.4"
-                vectorEffect="non-scaling-stroke"
-              />
-            </svg>
+            <RunningSignalWave active={runningSignalPhase === "active"} />
           </span>
         ) : null}
       </div>

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -229,7 +229,7 @@ function useRunningSignalPhase(isExecuting: boolean): RunningSignalPhase {
 function RunningSignalWave({ active }: { active: boolean }) {
   const pathRef = useRef<SVGPathElement | null>(null);
   const lastPathRef = useRef(runningSignalWavePath(getMonotonicNow()));
-  const prefersReducedMotion = usePrefersReducedMotion(active);
+  const prefersReducedMotion = usePrefersReducedMotion(true);
 
   useEffect(() => {
     if (!active || prefersReducedMotion) return;

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { cn } from "@/lib/utils";
 
 export interface CodeCellCurrentLineProps {
@@ -33,31 +41,32 @@ function getMonotonicNow(): number {
   return typeof performance === "undefined" ? 0 : performance.now();
 }
 
+function readPrefersReducedMotion(enabled: boolean): boolean {
+  if (!enabled || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function subscribeToReducedMotion(enabled: boolean, onStoreChange: () => void): () => void {
+  if (!enabled || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener?.("change", onStoreChange);
+  return () => mediaQuery.removeEventListener?.("change", onStoreChange);
+}
+
 function usePrefersReducedMotion(enabled: boolean): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
-    if (!enabled || typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return false;
-    }
-    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
-  });
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => subscribeToReducedMotion(enabled, onStoreChange),
+    [enabled],
+  );
+  const getSnapshot = useCallback(() => readPrefersReducedMotion(enabled), [enabled]);
 
-  useEffect(() => {
-    if (!enabled) {
-      setPrefersReducedMotion(false);
-      return;
-    }
-
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
-
-    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
-    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
-
-    handleChange();
-    mediaQuery.addEventListener?.("change", handleChange);
-    return () => mediaQuery.removeEventListener?.("change", handleChange);
-  }, [enabled]);
-
-  return prefersReducedMotion;
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
 function useMonotonicAnimationClock(enabled: boolean): number {

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -20,8 +20,91 @@ type RunningSignalPhase = "resting" | "building" | "active" | "settling";
 
 const RUNNING_SIGNAL_DELAY_MS = 120;
 const RUNNING_SIGNAL_SETTLE_MS = 320;
-const RUNNING_SIGNAL_WAVE_PATH =
-  "M-120 6 C-115 1 -110 1 -105 6 S-95 11 -90 6 S-80 1 -75 6 S-65 11 -60 6 S-50 1 -45 6 S-35 11 -30 6 S-20 1 -15 6 S-5 11 0 6 S10 1 15 6 S25 11 30 6 S40 1 45 6 S55 11 60 6 S70 1 75 6 S85 11 90 6 S100 1 105 6 S115 11 120 6 S130 1 135 6 S145 11 150 6 S160 1 165 6 S175 11 180 6 S190 1 195 6 S205 11 210 6 S220 1 225 6 S235 11 240 6 S250 1 255 6 S265 11 270 6 S280 1 285 6 S295 11 300 6 S310 1 315 6 S325 11 330 6 S340 1 345 6 S355 11 360 6";
+const RUNNING_SIGNAL_WAVE_WIDTH = 360;
+const RUNNING_SIGNAL_WAVE_HEIGHT = 12;
+const RUNNING_SIGNAL_WAVE_CENTER = RUNNING_SIGNAL_WAVE_HEIGHT / 2;
+const RUNNING_SIGNAL_WAVE_AMPLITUDE = 2.2;
+const RUNNING_SIGNAL_WAVE_LENGTH = 86;
+const RUNNING_SIGNAL_WAVE_PERIOD_MS = 1_850;
+const RUNNING_SIGNAL_WAVE_SAMPLES = 64;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function getMonotonicNow(): number {
+  return typeof performance === "undefined" ? 0 : performance.now();
+}
+
+function usePrefersReducedMotion(enabled: boolean): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (!enabled || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return false;
+    }
+    return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setPrefersReducedMotion(false);
+      return;
+    }
+
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const handleChange = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    handleChange();
+    mediaQuery.addEventListener?.("change", handleChange);
+    return () => mediaQuery.removeEventListener?.("change", handleChange);
+  }, [enabled]);
+
+  return prefersReducedMotion;
+}
+
+function useMonotonicAnimationClock(enabled: boolean): number {
+  const prefersReducedMotion = usePrefersReducedMotion(enabled);
+  const [now, setNow] = useState(() => (enabled ? getMonotonicNow() : 0));
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    setNow(getMonotonicNow());
+
+    if (
+      prefersReducedMotion ||
+      typeof window === "undefined" ||
+      typeof window.requestAnimationFrame !== "function"
+    ) {
+      return;
+    }
+
+    let frameId = 0;
+    const tick = (timestamp: number) => {
+      setNow(timestamp);
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    frameId = window.requestAnimationFrame(tick);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [enabled, prefersReducedMotion]);
+
+  return prefersReducedMotion ? 0 : now;
+}
+
+function runningSignalWavePath(now: number): string {
+  const phase = (now / RUNNING_SIGNAL_WAVE_PERIOD_MS) * Math.PI * 2;
+  const points: string[] = [];
+
+  for (let index = 0; index <= RUNNING_SIGNAL_WAVE_SAMPLES; index += 1) {
+    const x = (RUNNING_SIGNAL_WAVE_WIDTH / RUNNING_SIGNAL_WAVE_SAMPLES) * index;
+    const y =
+      RUNNING_SIGNAL_WAVE_CENTER +
+      Math.sin((x / RUNNING_SIGNAL_WAVE_LENGTH) * Math.PI * 2 - phase) *
+        RUNNING_SIGNAL_WAVE_AMPLITUDE;
+    points.push(`${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`);
+  }
+
+  return points.join(" ");
+}
 
 function formatExecutionCount(count: number): string {
   return count > 999 ? "999+" : String(count);
@@ -170,23 +253,27 @@ function ExecutionBoundaryRule({
   queuePriority: number;
   isFocused: boolean;
 }) {
-  if (state === "running") {
-    const showSignal = runningSignalPhase === "active" || runningSignalPhase === "settling";
+  const showRunningSignal =
+    state === "running" && (runningSignalPhase === "active" || runningSignalPhase === "settling");
+  const runningSignalNow = useMonotonicAnimationClock(
+    showRunningSignal && runningSignalPhase === "active",
+  );
 
+  if (state === "running") {
     return (
       <div
         data-slot="code-cell-current-line-rule"
         data-execution-signal={runningSignalPhase}
         className="relative h-3 min-w-14 flex-1 overflow-hidden text-emerald-500/65 dark:text-emerald-300/65 [mask-image:linear-gradient(to_right,transparent,black_0.75rem,black_calc(100%-0.5rem),transparent)]"
       >
-        {!showSignal ? (
+        {!showRunningSignal ? (
           <span
             data-slot="code-cell-current-line-resting-rule"
             className="absolute left-0 top-1/2 h-px w-full -translate-y-1/2 rounded-full bg-current/25"
             aria-hidden="true"
           />
         ) : null}
-        {showSignal ? (
+        {showRunningSignal ? (
           <span
             data-slot="code-cell-current-line-signal"
             className={cn(
@@ -197,12 +284,12 @@ function ExecutionBoundaryRule({
             aria-hidden="true"
           >
             <svg
-              className="absolute inset-y-0 left-0 h-full w-[300%] animate-exec-signal-wave"
-              viewBox="0 0 360 12"
+              className="absolute inset-y-0 left-0 h-full w-full"
+              viewBox={`0 0 ${RUNNING_SIGNAL_WAVE_WIDTH} ${RUNNING_SIGNAL_WAVE_HEIGHT}`}
               preserveAspectRatio="none"
             >
               <path
-                d={RUNNING_SIGNAL_WAVE_PATH}
+                d={runningSignalWavePath(runningSignalNow)}
                 fill="none"
                 stroke="currentColor"
                 strokeLinecap="round"

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -211,7 +211,7 @@ describe("CodeCellCurrentLine", () => {
     const restoreMatchMedia = mockReducedMotionPreference(true);
 
     try {
-      const { container } = render(
+      const { container, rerender } = render(
         <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
       );
 
@@ -232,6 +232,11 @@ describe("CodeCellCurrentLine", () => {
         vi.advanceTimersByTime(480);
       });
 
+      expect(rule?.querySelector("svg path")?.getAttribute("d")).toEqual(firstWavePath);
+
+      rerender(<CodeCellCurrentLine languageLabel="Python" count={13} />);
+
+      expect(rule).toHaveAttribute("data-execution-signal", "settling");
       expect(rule?.querySelector("svg path")?.getAttribute("d")).toEqual(firstWavePath);
     } finally {
       restoreMatchMedia();

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -141,7 +141,16 @@ describe("CodeCellCurrentLine", () => {
       expect(
         rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
       ).not.toBeInTheDocument();
-      expect(rule?.querySelector("svg")).toHaveClass("animate-exec-signal-wave");
+      const wave = rule?.querySelector("svg path");
+      expect(wave).toHaveAttribute("d", expect.stringMatching(/^M0\.00 /));
+      expect(rule?.querySelector("svg")).not.toHaveClass("animate-exec-signal-wave");
+      const firstWavePath = wave?.getAttribute("d");
+
+      act(() => {
+        vi.advanceTimersByTime(48);
+      });
+
+      expect(rule?.querySelector("svg path")?.getAttribute("d")).not.toEqual(firstWavePath);
 
       rerender(<CodeCellCurrentLine languageLabel="Python" count={13} />);
 

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -2,6 +2,37 @@ import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { CodeCellCurrentLine } from "../CodeCellCurrentLine";
 
+function mockReducedMotionPreference(matches: boolean): () => void {
+  const originalMatchMedia = window.matchMedia;
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  return () => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      });
+    } else {
+      delete (window as Partial<Window>).matchMedia;
+    }
+  };
+}
+
 describe("CodeCellCurrentLine", () => {
   it("keeps idle language in the stable right readout slot", () => {
     const { container } = render(<CodeCellCurrentLine languageLabel="Python" count={null} />);
@@ -171,6 +202,39 @@ describe("CodeCellCurrentLine", () => {
       expect(rule).not.toHaveAttribute("data-execution-signal");
       expect(rule?.querySelector("svg")).toBeNull();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the running signal still for reduced-motion users", () => {
+    vi.useFakeTimers();
+    const restoreMatchMedia = mockReducedMotionPreference(true);
+
+    try {
+      const { container } = render(
+        <CodeCellCurrentLine languageLabel="Python" count={12} isExecuting />,
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(120);
+      });
+
+      const footer = container.querySelector('[data-slot="code-cell-current-line"]');
+      const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      const wave = rule?.querySelector("svg path");
+      const firstWavePath = wave?.getAttribute("d");
+
+      expect(footer).toHaveAttribute("data-execution-visual-state", "running");
+      expect(rule).toHaveAttribute("data-execution-signal", "active");
+      expect(firstWavePath).toEqual(expect.stringMatching(/^M0\.00 /));
+
+      act(() => {
+        vi.advanceTimersByTime(480);
+      });
+
+      expect(rule?.querySelector("svg path")?.getAttribute("d")).toEqual(firstWavePath);
+    } finally {
+      restoreMatchMedia();
       vi.useRealTimers();
     }
   });

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -140,19 +140,6 @@
   transform-origin: center center;
 }
 
-@keyframes exec-signal-wave {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-33.333333%);
-  }
-}
-
-.animate-exec-signal-wave {
-  animation: exec-signal-wave 1.6s linear infinite;
-}
-
 @keyframes exec-signal-build {
   0% {
     clip-path: inset(0 100% 0 0);
@@ -215,7 +202,6 @@
   .animate-exec-squish,
   .animate-exec-signal-build,
   .animate-exec-signal-settle,
-  .animate-exec-signal-wave,
   .animate-exec-signal-tail {
     animation: none;
   }

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -173,36 +173,12 @@
   animation: exec-signal-settle 320ms ease-out both;
 }
 
-@keyframes exec-signal-tail {
-  0% {
-    opacity: 0;
-    transform: scaleX(0.2);
-  }
-  20% {
-    opacity: 0.6;
-  }
-  70% {
-    opacity: 0.6;
-    transform: scaleX(1);
-  }
-  100% {
-    opacity: 0;
-    transform: scaleX(1);
-  }
-}
-
-.animate-exec-signal-tail {
-  animation: exec-signal-tail 2.4s ease-out infinite;
-  transform-origin: left center;
-}
-
 @media (prefers-reduced-motion: reduce) {
   .animate-queue-breathe,
   .animate-queue-boundary-pulse,
   .animate-exec-squish,
   .animate-exec-signal-build,
-  .animate-exec-signal-settle,
-  .animate-exec-signal-tail {
+  .animate-exec-signal-settle {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary

- replace the running cell signal's CSS-looped wave with a monotonic-time SVG path
- keep the existing fast-execution delay, build, and settle behavior
- document the monotonic run-signal language in Elements
- scope reduced-motion media-query listening to the visible run signal
- update the active SVG path imperatively so the line can move without rerendering the cell each frame
- add regression coverage for reduced-motion users so the signal stays present but motionless
- remove the stale CSS-only execution tail animation vocabulary
- document the reduced-motion run signal behavior in Elements
- keep reduced-motion signals still through the active-to-settling transition

## Verification

- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Visual check

- sampled the live `ribbon-fixture.ipynb` on `http://localhost:9866`
- reran the 4s sleep cell and confirmed the generated wave path changes over time without `animate-exec-signal-wave`
