### PR TITLE
refactor(notebook): share notebook mutation controller

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -27,10 +27,30 @@ test("cloud projects live cells into the NotebookView stores", () => {
   );
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*canWriteSource=\{canWriteCellSource\}/);
+  assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*onSyncNeeded=\{handleSourceSyncNeeded\}/);
   assert.match(sourceText, /cell\.cellType === "markdown"/);
   assert.match(sourceText, /return shellCapabilities\.canEditMarkdown/);
   assert.match(sourceText, /return shellCapabilities\.canEditCells/);
+  assert.match(
+    sourceText,
+    /if \(!shellCapabilities\.canEditCells && !shellCapabilities\.canEditMarkdown\) return;/,
+  );
+  assert.doesNotMatch(sourceText, /handleMarkdownSyncNeeded/);
   assert.doesNotMatch(sourceText, /onSourceChanged=/);
+});
+
+test("cloud notebook mutations route through the shared notebook controller", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /createNotebookController/);
+  assert.match(sourceText, /const cloudNotebookController = useMemo/);
+  assert.match(sourceText, /cloudNotebookController\.addCell\(type, afterCellId\)/);
+  assert.match(sourceText, /cloudNotebookController\.deleteCell\(cellId\)/);
+  assert.match(sourceText, /cloudNotebookController\.moveCell\(cellId, afterCellId\)/);
+  assert.doesNotMatch(sourceText, /liveRuntime\.handle\.add_cell_after/);
+  assert.doesNotMatch(sourceText, /liveRuntime\.handle\.delete_cell/);
+  assert.doesNotMatch(sourceText, /liveRuntime\.handle\.move_cell/);
 });
 
 test("cloud projects host focus through the shared cell UI state bridge", () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -82,11 +82,11 @@ import {
 } from "../../notebook/src/contexts/PresenceContext";
 import { CrdtBridgeProvider } from "../../notebook/src/hooks/useCrdtBridge";
 import { useNotebookCellUIStateBridge } from "../../notebook/src/lib/cell-ui-state";
+import { createNotebookController } from "../../notebook/src/lib/notebook-controller";
 import { startCursorDispatch } from "../../notebook/src/lib/cursor-registry";
 import { setLoggerHost } from "../../notebook/src/lib/logger";
 import { emitBroadcast, emitPresence } from "../../notebook/src/lib/notebook-frame-bus";
 import { useNotebookViewModel } from "../../notebook/src/lib/notebook-view-model";
-import type { NotebookCell } from "../../notebook/src/types";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudViewStoreProjection,
@@ -1128,7 +1128,19 @@ function NotebookViewer({
       }),
     [authState, codeCellCount, connectionActorLabel, connectionScope, selectedInteractionMode],
   );
-  const canEditMarkdown = shellCapabilities.canEditMarkdown;
+  const canWriteCellSource = useCallback(
+    (cellId: string) => {
+      const cell = cellsByIdRef.current.get(cellId);
+      if (!cell) {
+        return false;
+      }
+      if (cell.cellType === "markdown") {
+        return shellCapabilities.canEditMarkdown;
+      }
+      return shellCapabilities.canEditCells;
+    },
+    [shellCapabilities],
+  );
   const notebookCellIds = notebookViewModel.cellIds;
   const packageEnvironmentManager = cloudNotebookEnvironmentManager(
     notebookViewModel.packages.sections,
@@ -1136,65 +1148,48 @@ function NotebookViewer({
   const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
     materializeLiveRuntimeRef.current?.(liveRuntime);
   }, []);
+  const cloudNotebookController = useMemo(
+    () =>
+      createNotebookController({
+        getHandle: () => liveRuntimeRef.current?.handle ?? null,
+        getEngine: () => liveRuntimeRef.current?.engine ?? null,
+        canWriteCellSource,
+        canEditStructure: () => shellCapabilities.canEditStructure,
+        canAcceptStructure: (handle) => handle.cell_count() > 0,
+        createCellId: createCloudNotebookCellId,
+        syncMode: {
+          structure: "scheduleFlush",
+          outputs: "scheduleFlush",
+          visibility: "scheduleFlush",
+        },
+        afterMutation: (handle) => {
+          const liveRuntime = liveRuntimeRef.current;
+          if (liveRuntime?.handle === handle) {
+            requestCloudMaterialization(liveRuntime);
+          }
+        },
+        onFocusCell: setFocusedCellId,
+        logPrefix: "[notebook-cloud]",
+      }),
+    [canWriteCellSource, requestCloudMaterialization, shellCapabilities.canEditStructure],
+  );
   const handleCloudAddCell = useCallback(
-    (type: "code" | "markdown", afterCellId?: string | null): NotebookCell | null => {
-      if (!shellCapabilities.canEditStructure) return null;
-      const liveRuntime = liveRuntimeRef.current;
-      if (!liveRuntime) return null;
-      const cellId = createCloudNotebookCellId();
-      try {
-        liveRuntime.handle.add_cell_after(cellId, type, afterCellId ?? null);
-        liveRuntime.engine.scheduleFlush();
-        requestCloudMaterialization(liveRuntime);
-      } catch (error) {
-        console.warn("[notebook-cloud] add cell failed", error);
-        return null;
-      }
-      const fallback: NotebookCell =
-        type === "markdown"
-          ? { cell_type: "markdown", id: cellId, source: "", metadata: {} }
-          : {
-              cell_type: "code",
-              id: cellId,
-              source: "",
-              execution_count: null,
-              outputs: [],
-              metadata: {},
-            };
-      return fallback;
+    (type: "code" | "markdown", afterCellId?: string | null) => {
+      return cloudNotebookController.addCell(type, afterCellId);
     },
-    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+    [cloudNotebookController],
   );
   const handleCloudDeleteCell = useCallback(
     (cellId: string) => {
-      if (!shellCapabilities.canEditStructure) return;
-      const liveRuntime = liveRuntimeRef.current;
-      if (!liveRuntime || liveRuntime.handle.cell_count() <= 1) return;
-      try {
-        if (liveRuntime.handle.delete_cell(cellId)) {
-          liveRuntime.engine.scheduleFlush();
-          requestCloudMaterialization(liveRuntime);
-        }
-      } catch (error) {
-        console.warn("[notebook-cloud] delete cell failed", error);
-      }
+      cloudNotebookController.deleteCell(cellId);
     },
-    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+    [cloudNotebookController],
   );
   const handleCloudMoveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
-      if (!shellCapabilities.canEditStructure) return;
-      const liveRuntime = liveRuntimeRef.current;
-      if (!liveRuntime) return;
-      try {
-        liveRuntime.handle.move_cell(cellId, afterCellId ?? null);
-        liveRuntime.engine.scheduleFlush();
-        requestCloudMaterialization(liveRuntime);
-      } catch (error) {
-        console.warn("[notebook-cloud] move cell failed", error);
-      }
+      cloudNotebookController.moveCell(cellId, afterCellId);
     },
-    [requestCloudMaterialization, shellCapabilities.canEditStructure],
+    [cloudNotebookController],
   );
   const getLiveNotebookHandle = useCallback(() => liveRuntimeRef.current?.handle ?? null, []);
   const cloudPresenceContext = useMemo<PresenceContextValue | null>(
@@ -1219,23 +1214,10 @@ function NotebookViewer({
         : null,
     [connectionPeerId],
   );
-  const handleMarkdownSyncNeeded = useCallback(() => {
-    if (!canEditMarkdown) return;
+  const handleSourceSyncNeeded = useCallback(() => {
+    if (!shellCapabilities.canEditCells && !shellCapabilities.canEditMarkdown) return;
     liveRuntimeRef.current?.engine.scheduleFlush();
-  }, [canEditMarkdown]);
-  const canWriteCellSource = useCallback(
-    (cellId: string) => {
-      const cell = cellsByIdRef.current.get(cellId);
-      if (!cell) {
-        return false;
-      }
-      if (cell.cellType === "markdown") {
-        return shellCapabilities.canEditMarkdown;
-      }
-      return shellCapabilities.canEditCells;
-    },
-    [shellCapabilities],
-  );
+  }, [shellCapabilities.canEditCells, shellCapabilities.canEditMarkdown]);
   const resetPrototypeAuth = useCallback(() => {
     clearCloudPrototypeDevAuth(window.localStorage);
     setSelectedInteractionMode("view");
@@ -1431,7 +1413,7 @@ function NotebookViewer({
         <CrdtBridgeProvider
           getHandle={getLiveNotebookHandle}
           canWriteSource={canWriteCellSource}
-          onSyncNeeded={handleMarkdownSyncNeeded}
+          onSyncNeeded={handleSourceSyncNeeded}
           localActor={connectionActorLabel ?? ""}
         >
           <NotebookView

--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -88,7 +88,7 @@ Prefer extending `NotebookRequest` for daemon-owned notebook behavior. Add host 
 
 | Hook | Role |
 |------|------|
-| `useAutomergeNotebook` | Owns WASM NotebookHandle, `scheduleMaterialize`, `CellChangeset` dispatch |
+| `useNotebook` | Owns the active notebook controller: WASM NotebookHandle, materialization, `CellChangeset` dispatch |
 | `useDaemonKernel` | Kernel execution and ephemeral runtime event callbacks |
 | `usePresence` | Remote cursor/selection tracking via presence frames |
 | `useEnvProgress` | RuntimeStateDoc-backed environment progress projection |
@@ -108,7 +108,7 @@ Prefer extending `NotebookRequest` for daemon-owned notebook behavior. Add host 
 ## Data flow
 
 ```
-Tauri relay ── "notebook:frame" ──► useAutomergeNotebook
+Tauri relay ── "notebook:frame" ──► useNotebook
                                      (WASM receive_frame demux)
                                        │          │         │
                   sync_applied ────────┘          │         │
@@ -137,7 +137,7 @@ Tauri relay ── "notebook:frame" ──► useAutomergeNotebook
 
 ### Incremental sync pipeline
 
-1. **useAutomergeNotebook** — Single frame ingress. Demuxes via WASM `receive_frame()`, applies sync locally. Returns a `CellChangeset` with field-level granularity. Broadcasts and presence dispatch via in-memory frame bus.
+1. **useNotebook** — Single frame ingress. Demuxes via WASM `receive_frame()`, applies sync locally. Returns a `CellChangeset` with field-level granularity. Broadcasts and presence dispatch via in-memory frame bus. The current implementation lives in `useAutomergeNotebook.ts` during the controller extraction.
 
 2. **scheduleMaterialize** — Coalesces sync frames within a 32ms window via `mergeChangesets()`:
    - **Structural changes** (cells added/removed/reordered) → full `cellSnapshotsToNotebookCells()`
@@ -170,7 +170,7 @@ Shape originates in Rust (`notebook-doc/src/diff.rs`). TypeScript source of trut
 ## Invariants
 
 - Use `@nteract/notebook-host` for host-platform effects. No direct `@tauri-apps/*` imports outside the Tauri host implementation and narrow relay glue.
-- `useAutomergeNotebook` is the single daemon-frame ingress for notebook state.
+- `useNotebook` is the single daemon-frame ingress for notebook state.
 - Cell editing mutates the WASM Automerge handle first; flush pending source sync before execute/save.
 - Persistent runtime state comes from RuntimeStateDoc projections. Broadcasts are ephemeral only.
 - Preserve split cell-store behavior: update individual cells by id when possible, reserve full replacement for structural changes.
@@ -182,7 +182,8 @@ Shape originates in Rust (`notebook-doc/src/diff.rs`). TypeScript source of trut
 |------|------|
 | `apps/notebook/tsconfig.json` | Path alias configuration |
 | `apps/notebook/src/App.tsx` | Root component, provider setup |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, materialization |
+| `apps/notebook/src/hooks/useNotebook.ts` | Product-facing notebook controller hook |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Current WASM handle owner and materialization implementation |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | Pub/sub for broadcast and presence |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -54,7 +54,7 @@ import {
 } from "./components/KernelLaunchErrorBanner";
 import { UntrustedBanner } from "./components/UntrustedBanner";
 import { PresenceProvider } from "./contexts/PresenceContext";
-import { useAutomergeNotebook } from "./hooks/useAutomergeNotebook";
+import { useNotebook } from "./hooks/useNotebook";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { CrdtBridgeProvider } from "./hooks/useCrdtBridge";
 import { useDaemonKernel } from "./hooks/useDaemonKernel";
@@ -374,7 +374,7 @@ function AppContent() {
     triggerSync,
     localActor,
     connectionScope,
-  } = useAutomergeNotebook();
+  } = useNotebook();
 
   // Daemon sync status. Drives the kernel-action gate: until the daemon
   // has confirmed the first RuntimeStateSync round-trip (`runtime_state ==
@@ -571,7 +571,7 @@ function AppContent() {
 
   // NotebookClient for sending kernel commands via transport. The host's
   // transport is the single instance shared with the SyncEngine in
-  // useAutomergeNotebook — no more separate connection per consumer.
+  // useNotebook — no more separate connection per consumer.
   const notebookClient = useMemo(
     () =>
       new NotebookClient({

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -17,12 +17,12 @@ import {
   cellSnapshotsToNotebookCellsSync,
 } from "../lib/materialize-cells";
 import {
-  getNotebookCellsSnapshot,
   replaceNotebookCells,
   resetNotebookCells,
   updateCellById,
   useCellIds,
 } from "../lib/notebook-cells";
+import { createNotebookController } from "../lib/notebook-controller";
 import {
   applyExecutionViewChangeset,
   resetRuntimeStoresProjection,
@@ -80,7 +80,7 @@ function projectExecutionViewChangeset(handle: NotebookHandle) {
  * document. The external store is derived from the doc. Sync messages
  * flow through the SyncEngine → host.transport to the daemon.
  */
-export function useAutomergeNotebook() {
+export function useNotebook() {
   const host = useNotebookHost();
   const cellIds = useCellIds();
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
@@ -197,29 +197,25 @@ export function useAutomergeNotebook() {
     [handleHost],
   );
 
-  /**
-   * Guard + commit helper for WASM mutations.
-   * After the mutation callback runs, re-materializes and syncs.
-   */
-  const commitMutation = useCallback(
-    (mutate: (handle: NotebookHandle) => boolean) => {
-      const handle = handleHost.current;
-      const engine = engineRef.current;
-      if (!handle || !engine) {
-        logger.debug("[automerge-notebook] commitMutation skipped: no handle/engine");
-        return false;
-      }
-      if (!canWriteNotebookRef.current) {
-        logger.debug("[automerge-notebook] commitMutation skipped: connection is read-only");
-        return false;
-      }
-      if (!mutate(handle)) return false;
-      rematerializeCellsSync(handle);
-      applyExecutionViewChangeset(projectExecutionViewChangeset(handle));
-      engine.flush();
-      return true;
-    },
-    [handleHost, rematerializeCellsSync],
+  const notebookController = useMemo(
+    () =>
+      createNotebookController<NotebookHandle>({
+        getHandle: () => handleHost.current,
+        getEngine: () => engineRef.current,
+        canWriteCellSource: () => canWriteNotebookRef.current,
+        canEditStructure: () => canWriteNotebookRef.current,
+        canAcceptStructure: (handle) => handle.has_cells_map(),
+        afterMutation: (handle, kind) => {
+          rematerializeCellsSync(handle);
+          if (kind === "outputs" || kind === "visibility" || kind === "structure") {
+            applyExecutionViewChangeset(projectExecutionViewChangeset(handle));
+          }
+        },
+        refreshCanAcceptCellMutations,
+        onFocusCell: setFocusedCellId,
+        logPrefix: "[automerge-notebook]",
+      }),
+    [handleHost, refreshCanAcceptCellMutations, rematerializeCellsSync],
   );
 
   // ── Bootstrap ──────────────────────────────────────────────────────
@@ -372,141 +368,53 @@ export function useAutomergeNotebook() {
 
   // ── Cell mutations ─────────────────────────────────────────────────
 
-  const updateCellSource = useCallback((cellId: string, source: string) => {
-    const handle = handleHost.current;
-    const engine = engineRef.current;
-    if (!handle || !engine) return;
-    if (!canWriteNotebookRef.current) {
-      logger.debug("[automerge-notebook] updateCellSource skipped: connection is read-only");
-      return;
-    }
-
-    const updated = handle.update_source(cellId, source);
-    if (!updated) return;
-
-    updateCellById(cellId, (c) => ({ ...c, source }));
-    engine.scheduleFlush();
-  }, []);
+  const updateCellSource = useCallback(
+    (cellId: string, source: string) => {
+      notebookController.updateCellSource(cellId, source);
+    },
+    [notebookController],
+  );
 
   const addCell = useCallback(
     (cellType: "code" | "markdown" | "raw", afterCellId?: string | null): NotebookCell | null => {
-      const handle = handleHost.current;
-      const engine = engineRef.current;
-
-      if (!handle || !engine) {
-        logger.debug("[automerge-notebook] addCell skipped: no handle/engine");
-        return null;
-      }
-      if (!canWriteNotebookRef.current) {
-        logger.debug("[automerge-notebook] addCell skipped: connection is read-only");
-        return null;
-      }
-
-      if (!handle.has_cells_map()) {
-        logger.debug("[automerge-notebook] addCell skipped: cells map not synced yet");
-        setCanAcceptCellMutations(false);
-        return null;
-      }
-
-      const cellId = crypto.randomUUID();
-      try {
-        handle.add_cell_after(cellId, cellType, afterCellId ?? null);
-      } catch (error) {
-        logger.warn("[automerge-notebook] addCell failed:", error);
-        refreshCanAcceptCellMutations(handle);
-        return null;
-      }
-      rematerializeCellsSync(handle);
-      engine.flush();
-      setFocusedCellId(cellId);
-
-      const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
-      if (cell) return cell;
-      if (cellType === "code") {
-        return {
-          cell_type: "code",
-          id: cellId,
-          source: "",
-          outputs: [],
-          execution_count: null,
-          metadata: {},
-        };
-      }
-      return {
-        cell_type: cellType,
-        id: cellId,
-        source: "",
-        metadata: {},
-      };
+      return notebookController.addCell(cellType, afterCellId);
     },
-    [refreshCanAcceptCellMutations, rematerializeCellsSync],
+    [notebookController],
   );
 
   const moveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
-      commitMutation((handle) => {
-        handle.move_cell(cellId, afterCellId ?? null);
-        return true;
-      });
+      notebookController.moveCell(cellId, afterCellId);
     },
-    [commitMutation],
+    [notebookController],
   );
 
   const deleteCell = useCallback(
     (cellId: string) => {
-      commitMutation((handle) => {
-        if (handle.cell_count() <= 1) return false;
-        return !!handle.delete_cell(cellId);
-      });
+      notebookController.deleteCell(cellId);
     },
-    [commitMutation],
+    [notebookController],
   );
 
   const clearOutputs = useCallback(
     (cellIds: string | string[]) => {
-      const ids = Array.isArray(cellIds) ? cellIds : [cellIds];
-      if (ids.length === 0) return false;
-      const handle = handleHost.current;
-      const engine = engineRef.current;
-      if (!handle || !engine) {
-        logger.debug("[automerge-notebook] clearOutputs skipped: no handle/engine");
-        return false;
-      }
-      if (!canWriteNotebookRef.current) {
-        logger.debug("[automerge-notebook] clearOutputs skipped: connection is read-only");
-        return false;
-      }
-
-      let changed = false;
-      for (const cellId of ids) {
-        changed = !!handle.clear_outputs(cellId) || changed;
-      }
-      if (!changed) return false;
-
-      rematerializeCellsSync(handle);
-      applyExecutionViewChangeset(projectExecutionViewChangeset(handle));
-      engine.flush();
-      return true;
+      return notebookController.clearOutputs(cellIds);
     },
-    [rematerializeCellsSync],
+    [notebookController],
   );
 
   const setCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
-      commitMutation((handle) => {
-        return !!handle.set_cell_source_hidden(cellId, hidden);
-      });
+      notebookController.setCellSourceHidden(cellId, hidden);
     },
-    [commitMutation],
+    [notebookController],
   );
 
   const setCellOutputsHidden = useCallback(
     (cellId: string, hidden: boolean) => {
-      commitMutation((handle) => {
-        return !!handle.set_cell_outputs_hidden(cellId, hidden);
-      });
+      notebookController.setCellOutputsHidden(cellId, hidden);
     },
-    [commitMutation],
+    [notebookController],
   );
 
   // ── Sync flush ─────────────────────────────────────────────────────
@@ -608,3 +516,9 @@ export function useAutomergeNotebook() {
     connectionScope,
   };
 }
+
+/**
+ * @deprecated Use `useNotebook`. The hook still owns an Automerge-backed
+ * notebook handle, but the product-facing API should be host-neutral.
+ */
+export const useAutomergeNotebook = useNotebook;

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -1,0 +1,1 @@
+export { useNotebook } from "./useAutomergeNotebook";

--- a/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { NotebookCell } from "../../types";
+import { createNotebookController, type NotebookControllerHandle } from "../notebook-controller";
+import { getCellById, resetNotebookCells, replaceNotebookCells } from "../notebook-cells";
+
+function codeCell(id: string, source = ""): NotebookCell {
+  return {
+    cell_type: "code",
+    id,
+    source,
+    execution_count: null,
+    outputs: [],
+    metadata: {},
+  };
+}
+
+function createHandle(): NotebookControllerHandle & {
+  sources: Map<string, string>;
+  cells: string[];
+} {
+  const sources = new Map<string, string>([["cell-a", "old"]]);
+  const cells = ["cell-a"];
+  return {
+    sources,
+    cells,
+    update_source(cellId, source) {
+      if (!sources.has(cellId)) return false;
+      sources.set(cellId, source);
+      return true;
+    },
+    add_cell_after(cellId) {
+      cells.push(cellId);
+    },
+    move_cell(cellId, afterCellId) {
+      const previousIndex = cells.indexOf(cellId);
+      if (previousIndex >= 0) cells.splice(previousIndex, 1);
+      const afterIndex = afterCellId ? cells.indexOf(afterCellId) : -1;
+      cells.splice(afterIndex + 1, 0, cellId);
+    },
+    cell_count() {
+      return cells.length;
+    },
+    delete_cell(cellId) {
+      const index = cells.indexOf(cellId);
+      if (index < 0) return false;
+      cells.splice(index, 1);
+      return true;
+    },
+    clear_outputs() {
+      return true;
+    },
+    set_cell_source_hidden() {
+      return true;
+    },
+    set_cell_outputs_hidden() {
+      return true;
+    },
+    has_cells_map() {
+      return true;
+    },
+  };
+}
+
+afterEach(() => {
+  resetNotebookCells();
+});
+
+describe("createNotebookController", () => {
+  it("updates source through the handle and mirrors the shared cell store", () => {
+    replaceNotebookCells([codeCell("cell-a", "old")]);
+    const handle = createHandle();
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => true,
+      canEditStructure: () => true,
+    });
+
+    controller.updateCellSource("cell-a", "new");
+
+    expect(handle.sources.get("cell-a")).toBe("new");
+    expect(getCellById("cell-a")?.source).toBe("new");
+    expect(engine.scheduleFlush).toHaveBeenCalledTimes(1);
+    expect(engine.flush).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate source when capabilities deny the edit", () => {
+    replaceNotebookCells([codeCell("cell-a", "old")]);
+    const handle = createHandle();
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => false,
+      canEditStructure: () => true,
+    });
+
+    controller.updateCellSource("cell-a", "new");
+
+    expect(handle.sources.get("cell-a")).toBe("old");
+    expect(getCellById("cell-a")?.source).toBe("old");
+    expect(engine.scheduleFlush).not.toHaveBeenCalled();
+  });
+
+  it("lets hosts choose scheduled sync for structural mutations", () => {
+    const handle = createHandle();
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const afterMutation = vi.fn();
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => true,
+      canEditStructure: () => true,
+      createCellId: () => "cell-b",
+      syncMode: { structure: "scheduleFlush" },
+      afterMutation,
+    });
+
+    const added = controller.addCell("markdown", "cell-a");
+
+    expect(handle.cells).toEqual(["cell-a", "cell-b"]);
+    expect(added).toMatchObject({ id: "cell-b", cell_type: "markdown" });
+    expect(afterMutation).toHaveBeenCalledWith(handle, "structure");
+    expect(engine.scheduleFlush).toHaveBeenCalledTimes(1);
+    expect(engine.flush).not.toHaveBeenCalled();
+  });
+
+  it("keeps structural mutations closed when the host has not accepted the cells map", () => {
+    const handle = createHandle();
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const refresh = vi.fn();
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => true,
+      canEditStructure: () => true,
+      canAcceptStructure: () => false,
+      refreshCanAcceptCellMutations: refresh,
+    });
+
+    expect(controller.addCell("code", "cell-a")).toBeNull();
+    expect(handle.cells).toEqual(["cell-a"]);
+    expect(refresh).toHaveBeenCalledWith(handle);
+    expect(engine.flush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/notebook/src/lib/notebook-controller.ts
+++ b/apps/notebook/src/lib/notebook-controller.ts
@@ -1,0 +1,221 @@
+import type { SyncEngine } from "runtimed";
+import { logger } from "./logger";
+import { getNotebookCellsSnapshot, updateCellById } from "./notebook-cells";
+import type { NotebookCell } from "../types";
+
+export type NotebookControllerCellType = "code" | "markdown" | "raw";
+export type NotebookControllerMutationKind =
+  | "source"
+  | "structure"
+  | "outputs"
+  | "visibility";
+export type NotebookControllerSyncMode = "flush" | "scheduleFlush";
+
+export interface NotebookControllerHandle {
+  update_source(cellId: string, source: string): boolean;
+  add_cell_after(cellId: string, cellType: NotebookControllerCellType, afterCellId: string | null): void;
+  move_cell(cellId: string, afterCellId: string | null): void;
+  cell_count(): number;
+  delete_cell(cellId: string): boolean;
+  clear_outputs(cellId: string): boolean;
+  set_cell_source_hidden(cellId: string, hidden: boolean): boolean;
+  set_cell_outputs_hidden(cellId: string, hidden: boolean): boolean;
+  has_cells_map?(): boolean;
+}
+
+export interface NotebookControllerOptions<THandle extends NotebookControllerHandle> {
+  getHandle: () => THandle | null;
+  getEngine: () => Pick<SyncEngine, "flush" | "scheduleFlush"> | null;
+  canWriteCellSource: (cellId: string) => boolean;
+  canEditStructure: () => boolean;
+  canEditOutputs?: () => boolean;
+  canEditVisibility?: () => boolean;
+  canAcceptStructure?: (handle: THandle) => boolean;
+  createCellId?: () => string;
+  syncMode?: Partial<Record<NotebookControllerMutationKind, NotebookControllerSyncMode>>;
+  afterMutation?: (handle: THandle, kind: NotebookControllerMutationKind) => void;
+  refreshCanAcceptCellMutations?: (handle?: THandle) => void;
+  onFocusCell?: (cellId: string) => void;
+  fallbackCell?: (
+    cellId: string,
+    cellType: NotebookControllerCellType,
+  ) => NotebookCell | null;
+  logPrefix?: string;
+}
+
+export interface NotebookController {
+  updateCellSource: (cellId: string, source: string) => void;
+  addCell: (
+    cellType: NotebookControllerCellType,
+    afterCellId?: string | null,
+  ) => NotebookCell | null;
+  moveCell: (cellId: string, afterCellId?: string | null) => void;
+  deleteCell: (cellId: string) => void;
+  clearOutputs: (cellIds: string | string[]) => boolean;
+  setCellSourceHidden: (cellId: string, hidden: boolean) => void;
+  setCellOutputsHidden: (cellId: string, hidden: boolean) => void;
+}
+
+export function createNotebookController<THandle extends NotebookControllerHandle>({
+  getHandle,
+  getEngine,
+  canWriteCellSource,
+  canEditStructure,
+  canEditOutputs = canEditStructure,
+  canEditVisibility = canEditStructure,
+  canAcceptStructure = (handle) => handle.has_cells_map?.() ?? true,
+  createCellId = () => crypto.randomUUID(),
+  syncMode = {},
+  afterMutation,
+  refreshCanAcceptCellMutations,
+  onFocusCell,
+  fallbackCell = defaultFallbackCell,
+  logPrefix = "[notebook-controller]",
+}: NotebookControllerOptions<THandle>): NotebookController {
+  const syncAfterMutation = (
+    engine: Pick<SyncEngine, "flush" | "scheduleFlush">,
+    kind: NotebookControllerMutationKind,
+  ) => {
+    const mode = syncMode[kind] ?? (kind === "source" ? "scheduleFlush" : "flush");
+    if (mode === "scheduleFlush") {
+      engine.scheduleFlush();
+      return;
+    }
+    engine.flush();
+  };
+
+  const commit = (
+    kind: NotebookControllerMutationKind,
+    canWrite: () => boolean,
+    mutate: (handle: THandle) => boolean,
+  ): boolean => {
+    const handle = getHandle();
+    const engine = getEngine();
+    if (!handle || !engine) {
+      logger.debug(`${logPrefix} ${kind} mutation skipped: no handle/engine`);
+      return false;
+    }
+    if (!canWrite()) {
+      logger.debug(`${logPrefix} ${kind} mutation skipped: capability denied`);
+      return false;
+    }
+    if (!mutate(handle)) return false;
+
+    afterMutation?.(handle, kind);
+    syncAfterMutation(engine, kind);
+    return true;
+  };
+
+  return {
+    updateCellSource(cellId, source) {
+      const handle = getHandle();
+      const engine = getEngine();
+      if (!handle || !engine) return;
+      if (!canWriteCellSource(cellId)) {
+        logger.debug(`${logPrefix} updateCellSource skipped: capability denied`);
+        return;
+      }
+
+      const updated = handle.update_source(cellId, source);
+      if (!updated) return;
+
+      updateCellById(cellId, (cell) => ({ ...cell, source }));
+      syncAfterMutation(engine, "source");
+    },
+
+    addCell(cellType, afterCellId = null) {
+      const handle = getHandle();
+      const engine = getEngine();
+      if (!handle || !engine) {
+        logger.debug(`${logPrefix} addCell skipped: no handle/engine`);
+        return null;
+      }
+      if (!canEditStructure()) {
+        logger.debug(`${logPrefix} addCell skipped: capability denied`);
+        return null;
+      }
+      if (!canAcceptStructure(handle)) {
+        logger.debug(`${logPrefix} addCell skipped: cells map not synced yet`);
+        refreshCanAcceptCellMutations?.(handle);
+        return null;
+      }
+
+      const cellId = createCellId();
+      try {
+        handle.add_cell_after(cellId, cellType, afterCellId);
+      } catch (error) {
+        logger.warn(`${logPrefix} addCell failed:`, error);
+        refreshCanAcceptCellMutations?.(handle);
+        return null;
+      }
+
+      afterMutation?.(handle, "structure");
+      syncAfterMutation(engine, "structure");
+      onFocusCell?.(cellId);
+
+      return getNotebookCellsSnapshot().find((cell) => cell.id === cellId) ?? fallbackCell(cellId, cellType);
+    },
+
+    moveCell(cellId, afterCellId = null) {
+      commit("structure", canEditStructure, (handle) => {
+        handle.move_cell(cellId, afterCellId);
+        return true;
+      });
+    },
+
+    deleteCell(cellId) {
+      commit("structure", canEditStructure, (handle) => {
+        if (handle.cell_count() <= 1) return false;
+        return !!handle.delete_cell(cellId);
+      });
+    },
+
+    clearOutputs(cellIds) {
+      const ids = Array.isArray(cellIds) ? cellIds : [cellIds];
+      if (ids.length === 0) return false;
+
+      return commit("outputs", canEditOutputs, (handle) => {
+        let changed = false;
+        for (const cellId of ids) {
+          changed = !!handle.clear_outputs(cellId) || changed;
+        }
+        return changed;
+      });
+    },
+
+    setCellSourceHidden(cellId, hidden) {
+      commit("visibility", canEditVisibility, (handle) => {
+        return !!handle.set_cell_source_hidden(cellId, hidden);
+      });
+    },
+
+    setCellOutputsHidden(cellId, hidden) {
+      commit("visibility", canEditVisibility, (handle) => {
+        return !!handle.set_cell_outputs_hidden(cellId, hidden);
+      });
+    },
+  };
+}
+
+function defaultFallbackCell(
+  cellId: string,
+  cellType: NotebookControllerCellType,
+): NotebookCell | null {
+  if (cellType === "code") {
+    return {
+      cell_type: "code",
+      id: cellId,
+      source: "",
+      outputs: [],
+      execution_count: null,
+      metadata: {},
+    };
+  }
+
+  return {
+    cell_type: cellType,
+    id: cellId,
+    source: "",
+    metadata: {},
+  };
+}


### PR DESCRIPTION
## Summary

- introduce a shared `createNotebookController` for WASM-backed notebook mutations
- expose the product-facing desktop hook as `useNotebook`, keeping `useAutomergeNotebook` as a temporary alias
- route notebook-cloud add/delete/move mutations through the shared controller instead of direct hosted-handle calls
- generalize cloud source sync so code/raw edits flush alongside markdown edits

## Direction

This is a controller cutover slice, not a cloud UI patch. Desktop remains the reference host. Cloud supplies handle, engine, capability, materialization, and ID adapters while using the same controller for source and structure mutations.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-controller.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`

## Preview

- Deployed this branch to `preview.runt.run`
- Renderer assets version: `bf8a4a47-ed47-4702-a252-d95943724f94`
- Output document version: `b2b85d8b-822b-4899-83a1-72006b6f31d8`
- Main worker version: `ed5b6a3d-2c8c-44bb-9175-ad939c6c0f4c`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
  - `source_text`: 2357ms
  - `rendered_cell_marker`: 2393ms
  - `frame_texts`: 7932ms
  - `total`: 16557ms
