### PR TITLE
fix(notebook): stop frontend first-cell seeding

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -15,6 +15,7 @@ test("cloud notebook body renders through the desktop NotebookView surface", () 
   assert.doesNotMatch(sourceText, /<CloudLiveNotebook/);
   assert.doesNotMatch(sourceText, /NotebookReadOnlyView/);
   assert.doesNotMatch(sourceText, /<NotebookReadOnlyView/);
+  assert.doesNotMatch(sourceText, /autoSeedFirstCell/);
 });
 
 test("cloud projects live cells into the NotebookView stores", () => {

--- a/apps/notebook/e2e/code-cell-placeholder-layout.spec.ts
+++ b/apps/notebook/e2e/code-cell-placeholder-layout.spec.ts
@@ -1,13 +1,12 @@
 import { expect, test } from "@playwright/test";
-import { openNotebookRoom, waitForCellCount } from "./helpers";
+import { ensureCodeCell, openNotebookRoom } from "./helpers";
 
 test.describe("code cell placeholder layout", () => {
   test("keeps the empty placeholder aligned in a compact viewport", async ({ page }) => {
     await page.setViewportSize({ width: 624, height: 540 });
     await openNotebookRoom(page, crypto.randomUUID());
-    await waitForCellCount(page, 1);
 
-    const cell = page.locator('[data-cell-type="code"]').first();
+    const cell = await ensureCodeCell(page);
     const metrics = await cell.evaluate((cellElement) => {
       const rectFor = (selector: string) => {
         const element = cellElement.querySelector(selector);

--- a/apps/notebook/e2e/execute-cell-output.spec.ts
+++ b/apps/notebook/e2e/execute-cell-output.spec.ts
@@ -26,7 +26,7 @@ test.describe("browser execution with MCP peer", () => {
     await mcp.connectNotebook(notebookId);
     await mcp.createCell("print('browser executes MCP-created cell')");
 
-    await waitForCellCount(page, 2);
+    await waitForCellCount(page, 1);
     const cell = await waitForCodeCellContaining(page, "browser executes MCP-created cell");
 
     await executeCell(cell);

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -29,7 +29,7 @@ test.describe("notebook rail outline", () => {
     await mcp.createCell("## Clean columns\n\nTighten types and null handling.", "markdown");
     await mcp.createCell("### Validate ranges\n\nCheck outliers before model fitting.", "markdown");
     await mcp.createCell('print("validate")', "code");
-    await waitForCellCount(page, 6);
+    await waitForCellCount(page, 5);
 
     await expect(page.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "true");
     await page.getByLabel("Outline").click();
@@ -68,7 +68,7 @@ test.describe("notebook rail outline", () => {
       ].join("\n\n"),
       "markdown",
     );
-    await waitForCellCount(page, 2);
+    await waitForCellCount(page, 1);
 
     const childHeading = page
       .frameLocator('iframe[data-slot="isolated-frame"][name^="md-"]')

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -702,27 +702,6 @@ function NotebookViewContent({
     }
   }, [searchCurrentMatch]);
 
-  // ── Auto-seed first cell for empty notebooks ───────────────────────
-  // For new notebooks the daemon creates zero cells. Once sync completes
-  // (isLoading becomes false), we create the first code cell locally via
-  // the CRDT so the user gets an instant focused editor. The ref guard
-  // ensures we only seed once even if the effect re-fires before React
-  // processes the focusedCellId update from onAddCell.
-  const didAutoSeed = useRef(false);
-  useEffect(() => {
-    if (isLoading || focusedCellId !== null || !canMutateCells) return;
-    if (cellIds.length === 0) {
-      if (!didAutoSeed.current) {
-        const seeded = onAddCell("code");
-        if (seeded !== null) {
-          didAutoSeed.current = true;
-        }
-      }
-    } else {
-      onFocusCell(cellIds[0]);
-    }
-  }, [isLoading, canMutateCells, cellIds, focusedCellId, onFocusCell, onAddCell]);
-
   const renderCell = useCallback(
     (
       cell: NotebookCell,
@@ -1006,7 +985,7 @@ function NotebookViewContent({
         paddingBottom: NOTEBOOK_TAIL_SPACE,
         scrollPaddingBlock: `0rem ${NOTEBOOK_TAIL_SPACE}`,
       }}
-      data-notebook-synced={!isLoading && cellIds.length > 0}
+      data-notebook-synced={!isLoading}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}
       data-cell-count={cellIds.length}

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -28,6 +28,23 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/canMutateCells && onSetCellOutputsHidden/);
   });
 
+  it("does not implicitly seed cells from frontend emptiness", () => {
+    const notebookViewSource = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+    const desktopAppSource = readFileSync(join(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
+    const cloudViewerSource = readFileSync(
+      join(process.cwd(), "apps/notebook-cloud/viewer/index.tsx"),
+      "utf8",
+    );
+
+    expect(notebookViewSource).not.toMatch(/autoSeedFirstCell/);
+    expect(notebookViewSource).not.toMatch(/onAddCell\("code"\)[\s\S]*didAutoSeed/);
+    expect(desktopAppSource).not.toMatch(/autoSeedFirstCell/);
+    expect(cloudViewerSource).not.toMatch(/autoSeedFirstCell/);
+  });
+
   it("does not install code execution keybindings when execution is unavailable", () => {
     const sourceText = readFileSync(
       join(process.cwd(), "apps/notebook/src/components/CodeCell.tsx"),

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -75,9 +75,8 @@ export async function waitForAppReady() {
  * Wait for the notebook to finish initial Automerge sync and render cells.
  *
  * Checks the `data-notebook-synced` attribute set by NotebookView when
- * `isLoading` is false and `cells.length > 0`. This is the canonical
- * signal that the doc has synced and cells are in the DOM — no arbitrary
- * timeouts or cell-count polling needed.
+ * `isLoading` is false. Empty notebooks are a valid synced state; tests that
+ * need a cell should create one through the same toolbar users use.
  */
 export async function waitForNotebookSynced(timeout = 15000) {
   await waitForAppReady();

--- a/e2e/specs/dx-bootstrap-repr-llm.spec.js
+++ b/e2e/specs/dx-bootstrap-repr-llm.spec.js
@@ -10,6 +10,7 @@ import { browser } from "@wdio/globals";
 import {
   getKernelStatus,
   setCellSource,
+  setupCodeCell,
   waitForCellOutputMatching,
   waitForKernelReady,
   waitForNotebookSynced,
@@ -25,8 +26,7 @@ describe("DX bootstrap LLM formatter", () => {
 
     await waitForNotebookSynced();
 
-    const codeCell = await $('[data-cell-type="code"]');
-    await codeCell.waitForExist({ timeout: 5000 });
+    const codeCell = await setupCodeCell();
 
     await setCellSource(
       codeCell,

--- a/e2e/specs/smoke.spec.js
+++ b/e2e/specs/smoke.spec.js
@@ -13,6 +13,7 @@ import { browser } from "@wdio/globals";
 import {
   getKernelStatus,
   setCellSource,
+  setupCodeCell,
   waitForAppReady,
   waitForCellOutput,
   waitForKernelReady,
@@ -38,9 +39,7 @@ describe("E2E Smoke Test", () => {
     // Wait for the notebook to finish Automerge sync and render cells.
     await waitForNotebookSynced();
 
-    // Find the first code cell
-    const codeCell = await $('[data-cell-type="code"]');
-    await codeCell.waitForExist({ timeout: 5000 });
+    const codeCell = await setupCodeCell();
 
     // Set cell source via CodeMirror dispatch API (reliable with any WebDriver)
     await setCellSource(codeCell, "print('hello from e2e')");


### PR DESCRIPTION
## Summary

- Remove NotebookView's implicit first-cell auto-seeding effect.
- Keep empty frontend projections as render-only states; hosts/daemons own initial document seeding.
- Preserve explicit empty-notebook add buttons for users with cell mutation capabilities.

## Why

Hosted cloud joins can briefly have an empty React cell store while the live Automerge handle already contains cells. The previous shared NotebookView effect interpreted that UI projection as an empty notebook and called `onAddCell("code")`. The cloud controller can accept that mutation once the CRDT handle has cells, producing an extra cell during room join.

The frontend should not infer document genesis from projected emptiness. New-notebook seeding belongs to the authoritative host/daemon path, while the frontend renders loading, empty, or synced states without authoring cells implicitly.

## Verification

- `pnpm --workspace-root exec vp test run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
