### PR TITLE
feat: refine cloud sharing surfaces

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -2,14 +2,23 @@
 
 import {
   CheckCircle2,
+  Clock3,
   Cloud,
   CloudOff,
+  Copy,
+  Eye,
+  FilePenLine,
   Globe2,
+  KeyRound,
   LogIn,
+  Mail,
   Play,
   Radio,
   Share2,
+  ShieldCheck,
+  UserRound,
   WifiOff,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -114,6 +123,12 @@ const cloudStateRows = [
     reason: "Users with edit access can locally step out of editing without requesting access.",
   },
   {
+    surface: "Permissions",
+    owner: "Cloud ACL",
+    language: "Owner, can edit, can view, pending",
+    reason: "Sharing is document access; it should read as a quiet ledger, not generic account UI.",
+  },
+  {
     surface: "Runtime",
     owner: "Notebook toolbar",
     language: "Python / uv",
@@ -211,6 +226,8 @@ export function CloudNotebookShellExample() {
           <CloudNotebookDocument />
         </NotebookDocumentShell>
       </section>
+
+      <CloudPermissionsSurface />
 
       <section className="grid gap-3 lg:grid-cols-2">
         {shellStates.map((state) => {
@@ -347,7 +364,7 @@ function CloudAppToolbar({
         <CloudConnectionPill state={connection} compact={false} />
       </div>
       <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
-        {scenario.capabilities.canManageSharing ? <CloudShareButton compact={false} /> : null}
+        {scenario.capabilities.canManageSharing ? <CloudShareMenu compact={false} /> : null}
         <CloudModeToggle
           compact={false}
           interaction={interaction}
@@ -425,7 +442,7 @@ function CloudStatePreview({
         <CloudPresence people={people} compact />
         <span className="h-4 w-px bg-border/70" aria-hidden="true" />
         <CloudConnectionPill state={connection} compact />
-        {scenario.capabilities.canManageSharing ? <CloudShareButton compact /> : null}
+        {scenario.capabilities.canManageSharing ? <CloudShareMenu compact /> : null}
         <CloudModeToggle compact={false} interaction={interaction} mode={mode} />
         {scenario.capabilities.auth.canSignIn ||
         scenario.capabilities.auth.canUseAuthenticatedIdentity ||
@@ -512,15 +529,264 @@ function CloudConnectionPill({
   );
 }
 
-function CloudShareButton({ compact }: { compact: boolean }) {
+function CloudShareMenu({ compact }: { compact: boolean }) {
   return (
-    <button
-      type="button"
-      className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70"
-    >
-      <Share2 className="size-3.5" aria-hidden="true" />
-      {compact ? null : <span>Share</span>}
-    </button>
+    <details className="group relative">
+      <summary
+        className="inline-flex h-8 cursor-pointer list-none items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden"
+        title="Share notebook"
+      >
+        <Share2 className="size-3.5" aria-hidden="true" />
+        {compact ? <span className="sr-only">Share</span> : <span>Share</span>}
+      </summary>
+      <div className="absolute right-0 top-[calc(100%+0.5rem)] z-30 hidden w-[min(34rem,calc(100vw-2rem))] group-open:block">
+        <CloudSharePanel variant="owner" />
+      </div>
+    </details>
+  );
+}
+
+function CloudPermissionsSurface() {
+  return (
+    <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+      <div className="border-b border-fd-border p-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Permissions and sharing language</h2>
+        </div>
+        <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+          Sharing should feel like document access. Use compact rows, inline state, and restrained
+          color so owners can scan who can view, who can edit, and what still needs attention.
+        </p>
+      </div>
+      <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(20rem,0.7fr)]">
+        <div className="min-w-0">
+          <CloudSharePanel variant="owner" />
+        </div>
+        <div className="grid content-start gap-4">
+          <CloudAccessRequestCard />
+          <CloudAuthAttentionCard />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+type CloudSharePanelVariant = "owner" | "public";
+
+function CloudSharePanel({ variant }: { variant: CloudSharePanelVariant }) {
+  const publicEnabled = variant === "owner";
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-background text-foreground shadow-sm">
+      <div className="grid gap-1 border-b border-border/70 px-4 py-3">
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-semibold">Share notebook</h3>
+            <p className="mt-0.5 text-xs leading-5 text-muted-foreground">
+              Public link, collaborators, and pending invites for this notebook.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Copy className="size-3.5" aria-hidden="true" />
+            Copy link
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 px-4 py-3">
+        <section
+          className="grid gap-3 border-l-2 border-emerald-400/80 bg-emerald-500/[0.06] py-2 pl-3 pr-2"
+          aria-label="Public link"
+        >
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="flex min-w-0 items-start gap-2.5">
+              <Globe2
+                className="mt-0.5 size-4 shrink-0 text-emerald-700 dark:text-emerald-300"
+                aria-hidden="true"
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-semibold">Anyone with the link</div>
+                <div className="text-xs leading-5 text-muted-foreground">
+                  {publicEnabled
+                    ? "Can view this notebook without signing in."
+                    : "Only explicitly invited people can open this notebook."}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-500/10 dark:text-emerald-300"
+            >
+              {publicEnabled ? "Disable" : "Enable"}
+            </button>
+          </div>
+        </section>
+
+        <form className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_9rem_auto]" aria-label="Invite">
+          <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+            Invite by email
+            <input
+              className="h-9 min-w-0 rounded-md border border-border bg-background px-3 text-sm font-normal text-foreground"
+              placeholder="name@example.com"
+              type="email"
+            />
+          </label>
+          <label className="grid gap-1 text-xs font-medium text-muted-foreground">
+            Access
+            <select className="h-9 rounded-md border border-border bg-background px-2 text-sm font-normal text-foreground">
+              <option>Can view</option>
+              <option>Can edit</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            className="inline-flex h-9 items-center justify-center gap-1.5 self-end rounded-md bg-foreground px-3 text-sm font-medium text-background"
+          >
+            <Mail className="size-3.5" aria-hidden="true" />
+            Invite
+          </button>
+        </form>
+      </div>
+
+      <section className="border-t border-border/70 px-4 py-3" aria-label="Current access">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+            Current access
+          </h4>
+          <span className="text-xs text-muted-foreground">4 people, 1 invite</span>
+        </div>
+        <div className="divide-y divide-border/70">
+          {shareRows.map((row) => (
+            <CloudShareAccessRow key={row.label} row={row} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+const shareRows = [
+  {
+    icon: UserRound,
+    label: "Kyle",
+    detail: "kyle@notebook.local",
+    access: "Owner",
+    state: "Signed in",
+    tone: "default",
+  },
+  {
+    icon: FilePenLine,
+    label: "Morgan",
+    detail: "morgan@example.com",
+    access: "Can edit",
+    state: "Live now",
+    tone: "success",
+  },
+  {
+    icon: Eye,
+    label: "Public link",
+    detail: "Anyone with the link",
+    access: "Can view",
+    state: "Enabled",
+    tone: "success",
+  },
+  {
+    icon: Clock3,
+    label: "riley@example.com",
+    detail: "Invited by Kyle",
+    access: "Can edit",
+    state: "Pending",
+    tone: "pending",
+  },
+] satisfies Array<{
+  icon: LucideIcon;
+  label: string;
+  detail: string;
+  access: string;
+  state: string;
+  tone: "default" | "success" | "pending";
+}>;
+
+function CloudShareAccessRow({ row }: { row: (typeof shareRows)[number] }) {
+  const Icon = row.icon;
+  return (
+    <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-3 py-2.5">
+      <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">{row.label}</div>
+        <div className="truncate text-xs text-muted-foreground">{row.detail}</div>
+      </div>
+      <div className="hidden text-sm text-muted-foreground sm:block">{row.access}</div>
+      <div
+        className={cn(
+          "text-xs font-medium",
+          row.tone === "success" && "text-emerald-700 dark:text-emerald-300",
+          row.tone === "pending" && "text-amber-700 dark:text-amber-300",
+          row.tone === "default" && "text-muted-foreground",
+        )}
+      >
+        {row.state}
+      </div>
+    </div>
+  );
+}
+
+function CloudAccessRequestCard() {
+  return (
+    <div className="rounded-lg border border-border bg-background p-4 text-foreground">
+      <div className="flex items-start gap-3">
+        <KeyRound className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold">Need edit access?</h3>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Viewers should stay in the live document and ask for edit access without changing
+            connection mode or runtime state.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-sm font-medium text-background"
+            >
+              <FilePenLine className="size-3.5" aria-hidden="true" />
+              Request edit access
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-8 items-center rounded-md px-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Stay viewing
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CloudAuthAttentionCard() {
+  return (
+    <div className="rounded-lg border border-red-500/25 bg-red-500/[0.04] p-4 text-foreground">
+      <div className="flex items-start gap-3">
+        <X className="mt-0.5 size-4 text-red-600" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold">Session needs attention</h3>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Auth problems should sit with account controls. The notebook can remain readable while
+            cloud write actions wait for a renewed identity.
+          </p>
+          <button
+            type="button"
+            className="mt-3 inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-red-700 transition-colors hover:bg-red-500/10 dark:text-red-300"
+          >
+            <LogIn className="size-3.5" aria-hidden="true" />
+            Sign in again
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -229,6 +229,8 @@ export function CloudNotebookShellExample() {
 
       <CloudPermissionsSurface />
 
+      <CloudAccountSurface />
+
       <section className="grid gap-3 lg:grid-cols-2">
         {shellStates.map((state) => {
           const stateScenario = getElementsNotebookScenario(state.scenarioId);
@@ -786,6 +788,152 @@ function CloudAuthAttentionCard() {
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function CloudAccountSurface() {
+  const ownerScenario = getElementsNotebookScenario("cloud-owner");
+  const publicScenario = getElementsNotebookScenario("cloud-public-viewer");
+  const editorScenario = getElementsNotebookScenario("cloud-editor");
+  const ownerActor = notebookActorIdentityFromAccess(
+    ownerScenario.capabilities.access,
+    ownerScenario.capabilities.auth,
+  );
+  const publicActor = notebookActorIdentityFromAccess(
+    publicScenario.capabilities.access,
+    publicScenario.capabilities.auth,
+  );
+  const editorActor = notebookActorIdentityFromAccess(editorScenario.capabilities.access, {
+    ...editorScenario.capabilities.auth,
+    needsAttention: true,
+  });
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+      <div className="border-b border-fd-border p-4">
+        <div className="flex items-center gap-2">
+          <UserRound className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+          <h2 className="text-sm font-semibold">Account and session language</h2>
+        </div>
+        <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+          Account controls should explain who the browser is acting as and what recovery is
+          available. They should not repeat presence, collaborator roles, or runtime state.
+        </p>
+      </div>
+      <div className="grid gap-4 p-4 xl:grid-cols-3">
+        <CloudAccountPanel
+          actor={ownerActor}
+          title="Signed in"
+          description="Write actions use this browser identity."
+          rows={[
+            ["Document access", "Owner"],
+            ["Session", "Live"],
+            ["Auth", "Anaconda"],
+          ]}
+          action="Sign out"
+        />
+        <CloudAccountPanel
+          actor={publicActor}
+          title="Public viewer"
+          description="The document stays live while edit requests wait for sign-in."
+          rows={[
+            ["Document access", "Can view"],
+            ["Session", "Anonymous"],
+            ["Edit path", "Sign in to request"],
+          ]}
+          action="Sign in"
+        />
+        <CloudAccountPanel
+          actor={editorActor}
+          title="Session attention"
+          description="Notebook reads remain available while cloud write actions pause."
+          tone="attention"
+          rows={[
+            ["Document access", "Can edit"],
+            ["Session", "Expired"],
+            ["Recovery", "Sign in again"],
+          ]}
+          action="Renew session"
+        />
+      </div>
+    </section>
+  );
+}
+
+function CloudAccountPanel({
+  action,
+  actor,
+  description,
+  rows,
+  title,
+  tone = "default",
+}: {
+  action: string;
+  actor: NotebookActorIdentity;
+  description: string;
+  rows: ReadonlyArray<readonly [string, string]>;
+  title: string;
+  tone?: "default" | "attention";
+}) {
+  return (
+    <div
+      className={cn(
+        "grid gap-3 rounded-lg border border-border bg-background p-4 text-foreground",
+        tone === "attention" && "border-red-500/25 bg-red-500/[0.04]",
+      )}
+    >
+      <div className="flex min-w-0 items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold">{title}</h3>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p>
+        </div>
+        {tone === "attention" ? (
+          <X className="mt-0.5 size-4 shrink-0 text-red-600" aria-hidden="true" />
+        ) : (
+          <CheckCircle2
+            className="mt-0.5 size-4 shrink-0 text-emerald-700 dark:text-emerald-300"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+      <NotebookIdentityBadge
+        actor={actor}
+        variant="inline"
+        showDetail={false}
+        className="justify-start"
+      />
+      <dl className="grid gap-1.5 border-l-2 border-border/80 pl-3 text-xs">
+        {rows.map(([label, value]) => (
+          <div key={label} className="grid grid-cols-[7rem_minmax(0,1fr)] gap-2">
+            <dt className="text-muted-foreground">{label}</dt>
+            <dd
+              className={cn(
+                "min-w-0 truncate font-medium text-foreground",
+                tone === "attention" && label === "Session" && "text-red-700 dark:text-red-300",
+              )}
+            >
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      <button
+        type="button"
+        className={cn(
+          "inline-flex h-8 w-fit items-center gap-1.5 rounded-md px-2 text-sm font-medium transition-colors hover:bg-muted hover:text-foreground",
+          tone === "attention"
+            ? "text-red-700 hover:bg-red-500/10 dark:text-red-300"
+            : "text-muted-foreground",
+        )}
+      >
+        {tone === "attention" ? (
+          <LogIn className="size-3.5" aria-hidden="true" />
+        ) : (
+          <KeyRound className="size-3.5" aria-hidden="true" />
+        )}
+        {action}
+      </button>
     </div>
   );
 }

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -515,18 +515,14 @@ function CloudConnectionPill({
 
 function CloudShareMenu({ compact }: { compact: boolean }) {
   return (
-    <details className="group relative">
-      <summary
-        className="inline-flex h-8 cursor-pointer list-none items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden"
-        title="Share notebook"
-      >
-        <Share2 className="size-3.5" aria-hidden="true" />
-        {compact ? <span className="sr-only">Share</span> : <span>Share</span>}
-      </summary>
-      <div className="absolute right-0 top-[calc(100%+0.5rem)] z-30 hidden w-[min(34rem,calc(100vw-2rem))] group-open:block">
-        <CloudSharePanel variant="owner" />
-      </div>
-    </details>
+    <button
+      type="button"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md px-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+      title="Share notebook"
+    >
+      <Share2 className="size-3.5" aria-hidden="true" />
+      {compact ? <span className="sr-only">Share</span> : <span>Share</span>}
+    </button>
   );
 }
 

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -184,24 +184,6 @@ export function CloudNotebookShellExample() {
 
   return (
     <div className="not-prose space-y-6" data-elements-slot="cloud-notebook-shell">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-fd-foreground">
-        <div className="flex items-start gap-3">
-          <Cloud
-            className="mt-0.5 size-4 flex-none text-emerald-700 dark:text-emerald-300"
-            aria-hidden="true"
-          />
-          <div>
-            <h2 className="text-sm font-semibold">Cloud shell direction</h2>
-            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-              The cloud layer should compose around the shared notebook shell. Presence, document
-              connection, edit mode, sharing, and account controls are host state. Runtime remains a
-              notebook capability so the chrome does not imply that online/offline is a kernel
-              status.
-            </p>
-          </div>
-        </div>
-      </section>
-
       <section className="overflow-hidden rounded-xl border border-fd-border bg-fd-card shadow-sm">
         <BrowserFrame />
         <NotebookDocumentShell
@@ -554,13 +536,14 @@ function CloudPermissionsSurface() {
       <div className="border-b border-fd-border p-4">
         <div className="flex items-center gap-2">
           <ShieldCheck className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Permissions and sharing language</h2>
+          <h2 className="text-sm font-semibold">Sharing and access</h2>
         </div>
         <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-          Sharing should feel like document access. Use compact rows, inline state, and restrained
-          color so owners can scan who can view, who can edit, and what still needs attention.
+          Owners should see link access, people, requests, and session health in one calm pass.
+          Viewers and editors get quieter paths that match what they can actually do.
         </p>
       </div>
+      <CloudAccessLedger />
       <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(20rem,0.7fr)]">
         <div className="min-w-0">
           <CloudSharePanel variant="owner" />
@@ -572,6 +555,73 @@ function CloudPermissionsSurface() {
       </div>
       <CloudAccessPathways />
     </section>
+  );
+}
+
+const accessLedgerRows = [
+  {
+    icon: Globe2,
+    label: "Link access",
+    value: "Anyone can view",
+    detail: "public, read-only",
+    tone: "live",
+  },
+  {
+    icon: UserRound,
+    label: "People",
+    value: "4 people",
+    detail: "owner, editor, public, invite",
+    tone: "default",
+  },
+  {
+    icon: Clock3,
+    label: "Requests",
+    value: "1 pending",
+    detail: "waiting on owner",
+    tone: "pending",
+  },
+  {
+    icon: KeyRound,
+    label: "Session",
+    value: "Kyle can share",
+    detail: "cloud account is live",
+    tone: "live",
+  },
+] satisfies Array<{
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  detail: string;
+  tone: "default" | "live" | "pending";
+}>;
+
+function CloudAccessLedger() {
+  return (
+    <div className="grid border-b border-fd-border bg-background/60 text-foreground sm:grid-cols-2 xl:grid-cols-4">
+      {accessLedgerRows.map((row) => {
+        const Icon = row.icon;
+        return (
+          <div
+            key={row.label}
+            className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 border-t border-border/70 px-4 py-3 first:border-t-0 sm:[&:nth-child(-n+2)]:border-t-0 xl:border-t-0 xl:border-l xl:first:border-l-0"
+          >
+            <Icon
+              className={cn(
+                "mt-0.5 size-4 text-muted-foreground",
+                row.tone === "live" && "text-emerald-700 dark:text-emerald-300",
+                row.tone === "pending" && "text-amber-700 dark:text-amber-300",
+              )}
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-muted-foreground">{row.label}</div>
+              <div className="truncate text-sm font-semibold">{row.value}</div>
+              <div className="truncate text-xs text-muted-foreground">{row.detail}</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -784,7 +834,7 @@ function CloudAccessPathways() {
     <section className="border-t border-fd-border px-4 py-3" aria-label="Cloud access pathways">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-          Access pathways
+          What each role sees
         </h3>
         <span className="text-xs text-muted-foreground">
           sharing appears only where the role can act
@@ -914,11 +964,11 @@ function CloudAccountSurface() {
       <div className="border-b border-fd-border p-4">
         <div className="flex items-center gap-2">
           <UserRound className="size-4 text-fd-muted-foreground" aria-hidden="true" />
-          <h2 className="text-sm font-semibold">Account and session language</h2>
+          <h2 className="text-sm font-semibold">Account and session</h2>
         </div>
         <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
-          Account controls should explain who the browser is acting as and what recovery is
-          available. They should not repeat presence, collaborator roles, or runtime state.
+          The account surface explains who the browser is acting as, what document access that
+          identity has, and how to recover without repeating presence or runtime state.
         </p>
       </div>
       <div className="grid gap-4 p-4 xl:grid-cols-3">

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -570,6 +570,7 @@ function CloudPermissionsSurface() {
           <CloudAuthAttentionCard />
         </div>
       </div>
+      <CloudAccessPathways />
     </section>
   );
 }
@@ -733,6 +734,105 @@ function CloudShareAccessRow({ row }: { row: (typeof shareRows)[number] }) {
         {row.state}
       </div>
     </div>
+  );
+}
+
+const accessPathways = [
+  {
+    icon: ShieldCheck,
+    label: "Owner",
+    state: "Share notebook",
+    detail: "Public link, invites, role changes, and removals stay owner-owned.",
+    action: "Manage access",
+    tone: "default",
+  },
+  {
+    icon: FilePenLine,
+    label: "Editor",
+    state: "Editing",
+    detail: "Editors can change notebook content without becoming sharing admins.",
+    action: "Owner shares",
+    tone: "default",
+  },
+  {
+    icon: Eye,
+    label: "Viewer",
+    state: "Viewing live",
+    detail: "The document stays connected while the viewer requests edit access.",
+    action: "Request edit",
+    tone: "request",
+  },
+  {
+    icon: X,
+    label: "Expired",
+    state: "Session paused",
+    detail: "Read access remains calm; write, share, and invite actions wait for renewal.",
+    action: "Renew session",
+    tone: "attention",
+  },
+] satisfies Array<{
+  icon: LucideIcon;
+  label: string;
+  state: string;
+  detail: string;
+  action: string;
+  tone: "default" | "request" | "attention";
+}>;
+
+function CloudAccessPathways() {
+  return (
+    <section className="border-t border-fd-border px-4 py-3" aria-label="Cloud access pathways">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          Access pathways
+        </h3>
+        <span className="text-xs text-muted-foreground">
+          sharing appears only where the role can act
+        </span>
+      </div>
+      <div className="divide-y divide-border/70">
+        {accessPathways.map((pathway) => {
+          const Icon = pathway.icon;
+          return (
+            <div
+              key={pathway.label}
+              className="grid min-w-0 gap-2 py-3 sm:grid-cols-[auto_7rem_minmax(0,1fr)_auto]"
+            >
+              <Icon
+                className={cn(
+                  "mt-0.5 size-4 text-muted-foreground",
+                  pathway.tone === "request" && "text-emerald-700 dark:text-emerald-300",
+                  pathway.tone === "attention" && "text-red-600",
+                )}
+                aria-hidden="true"
+              />
+              <div className="min-w-0">
+                <div className="text-sm font-semibold">{pathway.label}</div>
+                <div
+                  className={cn(
+                    "text-xs font-medium text-muted-foreground",
+                    pathway.tone === "request" && "text-emerald-700 dark:text-emerald-300",
+                    pathway.tone === "attention" && "text-red-700 dark:text-red-300",
+                  )}
+                >
+                  {pathway.state}
+                </div>
+              </div>
+              <p className="m-0 text-xs leading-5 text-muted-foreground">{pathway.detail}</p>
+              <div
+                className={cn(
+                  "text-sm font-medium text-muted-foreground",
+                  pathway.tone === "request" && "text-emerald-700 dark:text-emerald-300",
+                  pathway.tone === "attention" && "text-red-700 dark:text-red-300",
+                )}
+              >
+                {pathway.action}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -10,8 +10,8 @@ desktop, but the host adds a few top-level concerns: room presence, document
 sync health, view/edit mode, sharing, and account controls.
 
 This mockup separates those concerns from runtime state. A cloud notebook can be
-live, reconnecting, signed out, public, or edit-requested without making the
-Python runtime chip carry those meanings.
+live, reconnecting, signed out, public, shared, or edit-requested without making
+the Python runtime chip carry those meanings.
 
 The first toolbar row is app-level cloud chrome. It answers "who is here, is the
 document connected, can I share, am I viewing or editing, and which account is
@@ -40,6 +40,11 @@ execution controls.
 - View/edit is a local interaction mode over host permissions. Users with edit
   permission can step into read-only viewing without requesting access again;
   denied users stay gated by the host capability projection.
+- Sharing should read as document permissions: public link state, people,
+  pending invites, and roles. Avoid generic bubbles, stacked badges, or account
+  language that makes collaborators look like runtime actors.
+- Auth controls should explain the current account and recovery path. They
+  should not duplicate presence, sharing roles, or notebook runtime state.
 - Elements scenarios should continue to model desktop and cloud differences
   through capability facts, not forked shell components.
 

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -45,6 +45,9 @@ execution controls.
   language that makes collaborators look like runtime actors.
 - Auth controls should explain the current account and recovery path. They
   should not duplicate presence, sharing roles, or notebook runtime state.
+- Account/session panels should use the same quiet ledger language as sharing:
+  signed-in identity, document access, session health, and recovery actions
+  without raised avatar bubbles.
 - Elements scenarios should continue to model desktop and cloud differences
   through capability facts, not forked shell components.
 

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -43,6 +43,9 @@ execution controls.
 - Sharing should read as document permissions: public link state, people,
   pending invites, and roles. Avoid generic bubbles, stacked badges, or account
   language that makes collaborators look like runtime actors.
+- Sharing controls should appear where the role can act. Non-owner editors and
+  viewers need their own quiet pathways: owner shares, viewer requests edit,
+  expired sessions renew before changing access.
 - Auth controls should explain the current account and recovery path. They
   should not duplicate presence, sharing roles, or notebook runtime state.
 - Account/session panels should use the same quiet ledger language as sharing:

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -6,16 +6,11 @@ description: A fluid cloud notebook chrome mockup for presence, access, sync, mo
 import { CloudNotebookShellExample } from "@/components/cloud-notebook-shell-example";
 
 Cloud notebooks reuse the document shell, rail, cells, and output language from
-desktop, but the host adds a few top-level concerns: room presence, document
-sync health, view/edit mode, sharing, and account controls.
+desktop. The host adds the cloud concerns: who is here, whether the document is
+connected, who can share, which mode I am in, and which account is active.
 
-This mockup separates those concerns from runtime state. A cloud notebook can be
-live, reconnecting, signed out, public, shared, or edit-requested without making
-the Python runtime chip carry those meanings.
-
-The first toolbar row is app-level cloud chrome. It answers "who is here, is the
-document connected, can I share, am I viewing or editing, and which account is
-active?" The second row is notebook chrome. It should continue to use the shared
+This mockup keeps those concerns out of runtime state. The app row carries room,
+sync, access, mode, and account context; the notebook row keeps the shared
 `NotebookCommandToolbar` for cell insertion, package/runtime language, and
 execution controls.
 

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -27,8 +27,8 @@ runtime peers, unavailable runtimes, and untrusted dependencies.
   state, or Elements fixtures.
 - Shared surfaces consume the capability object and view model instead of
   importing desktop or cloud state directly.
-- Cloud editor access can edit markdown, but code-cell source edits and sharing
-  are owner-only; execution and package management remain disabled in hosted
-  previews for now.
+- Cloud editor access can edit notebook content when the host grants that mode;
+  sharing remains owner-only, and execution/package management remain disabled
+  in hosted previews for now.
 - The catalog should reuse these scenarios whenever a page needs notebook-level
   context so component examples do not drift from the desktop/cloud shells.

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -247,10 +247,10 @@ main.flex > .cloud-report-toolbar {
   justify-content: center;
   gap: 0.375rem;
   min-width: 0;
-  max-width: min(12rem, 38vw);
+  max-width: min(13rem, 38vw);
   height: 2.25rem;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 6px;
   padding-inline: 0.625rem;
   color: var(--foreground);
   background: transparent;
@@ -263,10 +263,10 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-auth-menu summary.cloud-auth-identity-summary {
-  height: auto;
-  max-width: min(12rem, 34vw);
+  height: 2.25rem;
+  max-width: min(13rem, 34vw);
   border: 0;
-  padding: 0;
+  padding-inline: 0.625rem;
   color: inherit;
   background: transparent;
   box-shadow: none;
@@ -274,7 +274,7 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-auth-identity-summary [data-slot="notebook-identity-badge"] {
-  height: 2.25rem;
+  height: auto;
   max-width: 100%;
 }
 
@@ -348,20 +348,21 @@ main.flex > .cloud-report-toolbar {
   width: min(28rem, calc(100vw - 1.5rem));
   max-height: min(42rem, calc(100vh - 5rem));
   overflow: auto;
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 8px;
-  padding: 0.875rem;
+  padding: 0;
   color: var(--foreground);
   background: var(--background);
-  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
+  box-shadow: 0 12px 36px color-mix(in srgb, #000 16%, transparent);
 }
 
-.cloud-share-panel header,
-.cloud-share-public {
+.cloud-share-panel header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 1rem;
 }
 
 .cloud-share-panel h2,
@@ -421,10 +422,14 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-share-public {
-  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  border-radius: 8px;
-  padding: 0.75rem;
-  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin: 0.75rem 1rem;
+  border-left: 2px solid color-mix(in srgb, #10b981 72%, transparent);
+  padding: 0.625rem 0.625rem 0.625rem 0.75rem;
+  background: color-mix(in srgb, #10b981 6%, var(--background));
 }
 
 .cloud-share-public > div {
@@ -457,6 +462,7 @@ main.flex > .cloud-report-toolbar {
   grid-template-columns: minmax(0, 1fr) minmax(6rem, 0.35fr) auto;
   gap: 0.5rem;
   align-items: end;
+  padding: 0 1rem 0.75rem;
 }
 
 .cloud-share-invite label {
@@ -480,11 +486,12 @@ main.flex > .cloud-report-toolbar {
 .cloud-share-current {
   display: grid;
   gap: 0.5rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 1rem;
 }
 
 .cloud-share-current ul {
   display: grid;
-  gap: 0.375rem;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -496,10 +503,12 @@ main.flex > .cloud-report-toolbar {
   gap: 0.5rem;
   align-items: center;
   min-width: 0;
-  border: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
-  border-radius: 8px;
-  padding: 0.5rem;
-  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 9%, transparent);
+  padding: 0.625rem 0;
+}
+
+.cloud-share-current li:first-child {
+  border-top: 0;
 }
 
 .cloud-share-current li > svg,
@@ -512,11 +521,8 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-share-badge {
-  border-radius: 999px;
-  padding: 0.1875rem 0.5rem;
   color: color-mix(in srgb, var(--foreground) 72%, transparent);
-  background: color-mix(in srgb, var(--foreground) 9%, transparent);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -528,6 +534,7 @@ main.flex > .cloud-report-toolbar {
 }
 
 .cloud-share-message {
+  margin: 0 1rem 0.875rem;
   border: 1px solid color-mix(in srgb, #0f766e 30%, transparent);
   border-radius: 6px;
   padding: 0.5rem 0.625rem;
@@ -551,12 +558,12 @@ main.flex > .cloud-report-toolbar {
   display: grid;
   gap: 0.625rem;
   width: min(20rem, calc(100vw - 1.5rem));
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 8px;
-  padding: 0.875rem;
+  padding: 0.875rem 1rem;
   color: var(--foreground);
   background: var(--background);
-  box-shadow: 0 8px 32px color-mix(in srgb, #000 18%, transparent);
+  box-shadow: 0 12px 36px color-mix(in srgb, #000 16%, transparent);
 }
 
 .cloud-auth-menu p {
@@ -570,10 +577,8 @@ main.flex > .cloud-report-toolbar {
   display: grid;
   gap: 0.375rem;
   margin: 0;
-  border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  border-radius: 6px;
-  padding: 0.5rem;
-  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+  border-left: 2px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  padding: 0.25rem 0 0.25rem 0.625rem;
 }
 
 .cloud-auth-diagnostics div {
@@ -675,6 +680,12 @@ main.flex > .cloud-report-toolbar {
 }
 
 @media (max-width: 640px) {
+  .cloud-share-menu summary,
+  .cloud-auth-menu summary,
+  .cloud-sign-in-button {
+    max-width: min(10rem, 36vw);
+  }
+
   .cloud-share-invite {
     grid-template-columns: 1fr;
   }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -556,18 +556,47 @@ main.flex > .cloud-report-toolbar {
   right: 0;
   z-index: 30;
   display: grid;
-  gap: 0.625rem;
-  width: min(20rem, calc(100vw - 1.5rem));
+  gap: 0.75rem;
+  width: min(22rem, calc(100vw - 1.5rem));
+  max-height: min(42rem, calc(100vh - 5rem));
+  overflow: auto;
   border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 8px;
-  padding: 0.875rem 1rem;
+  padding: 0;
   color: var(--foreground);
   background: var(--background);
   box-shadow: 0 12px 36px color-mix(in srgb, #000 16%, transparent);
 }
 
+.cloud-auth-panel-header {
+  display: grid;
+  gap: 0.1875rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 1rem 0.75rem;
+}
+
+.cloud-auth-menu h2,
+.cloud-auth-menu h3,
 .cloud-auth-menu p {
   margin: 0;
+}
+
+.cloud-auth-menu h2 {
+  overflow-wrap: anywhere;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.cloud-auth-menu h3 {
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.cloud-auth-menu p {
   color: color-mix(in srgb, var(--foreground) 72%, transparent);
   font-size: 0.8125rem;
   line-height: 1.35;
@@ -576,7 +605,7 @@ main.flex > .cloud-report-toolbar {
 .cloud-auth-diagnostics {
   display: grid;
   gap: 0.375rem;
-  margin: 0;
+  margin: 0 1rem;
   border-left: 2px solid color-mix(in srgb, var(--foreground) 16%, transparent);
   padding: 0.25rem 0 0.25rem 0.625rem;
 }
@@ -612,6 +641,13 @@ main.flex > .cloud-report-toolbar {
   color: #0f766e;
 }
 
+.cloud-auth-dev-section {
+  display: grid;
+  gap: 0.625rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 1rem 0;
+}
+
 .cloud-auth-menu label {
   display: grid;
   gap: 0.25rem;
@@ -640,6 +676,10 @@ main.flex > .cloud-report-toolbar {
   line-height: 1.35;
 }
 
+.cloud-auth-menu .cloud-auth-form-error {
+  margin: 0 1rem;
+}
+
 .cloud-auth-form-error[data-kind="info"] {
   border-color: color-mix(in srgb, var(--foreground) 16%, transparent);
   color: color-mix(in srgb, var(--foreground) 72%, transparent);
@@ -650,6 +690,8 @@ main.flex > .cloud-report-toolbar {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 1rem;
 }
 
 .cloud-auth-actions button,

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1988,8 +1988,11 @@ function CloudAuthControls({
         />
       </summary>
       <form onSubmit={applyDevAuth}>
-        <p>{prototypeAuthSummary(authState)}</p>
-        <dl className="cloud-auth-diagnostics" aria-label="Prototype auth diagnostics">
+        <div className="cloud-auth-panel-header">
+          <h2>{summary}</h2>
+          <p>{prototypeAuthSummary(authState)}</p>
+        </div>
+        <dl className="cloud-auth-diagnostics" aria-label="Cloud account session">
           {diagnostics.rows.map((row) => (
             <div key={row.label} data-tone={row.tone ?? "default"}>
               <dt>{row.label}</dt>
@@ -1998,7 +2001,8 @@ function CloudAuthControls({
           ))}
         </dl>
         {showPrototypeDevControls ? (
-          <>
+          <section className="cloud-auth-dev-section" aria-label="Prototype identity">
+            <h3>Prototype identity</h3>
             <label>
               <span>Dev token</span>
               <input
@@ -2030,7 +2034,7 @@ function CloudAuthControls({
                 <option value="viewer">viewer</option>
               </select>
             </label>
-          </>
+          </section>
         ) : null}
         {formError ? (
           <div className="cloud-auth-form-error" role="alert">

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1981,6 +1981,7 @@ function CloudAuthControls({
       >
         <NotebookIdentityBadge
           actor={actor}
+          variant="inline"
           size="sm"
           showDetail={false}
           className="cloud-auth-identity-badge"


### PR DESCRIPTION
## Summary

- expand the Elements cloud notebook shell page with a permissions/sharing surface for public links, invites, roles, request-edit, and auth attention states
- add an account/session surface for signed-in, public-viewer, and expired-session states using the same quiet ledger language
- document role-specific access pathways so owner sharing, editor limits, viewer edit requests, and expired-session recovery each have a named surface
- add a compact access ledger for link access, people, pending requests, and session health so the sharing surface reads before the full panel
- flatten the cloud viewer sharing/auth controls so access reads as a quiet document ledger instead of raised collaborator bubbles
- clarify the Elements capability docs around cloud editor access versus owner-only sharing

## Verification

- pnpm --dir apps/elements build
- pnpm --dir apps/notebook-cloud build:viewer
- cargo xtask lint --fix
- Playwright screenshots of /docs/cloud-notebook-shell at wide and narrow widths

## Notes

This is a design branch for cloud permissions and sharing language. The backend remains the existing prototype ACL/invite stubs; the goal here is to establish the surface vocabulary and production CSS direction.
