### PR TITLE
fix(notebook): converge shared host creation path

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -51,6 +51,8 @@ test("cloud notebook mutations route through the shared notebook controller", ()
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.add_cell_after/);
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.delete_cell/);
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.move_cell/);
+  assert.doesNotMatch(sourceText, /canAcceptStructure/);
+  assert.doesNotMatch(sourceText, /cell_count\(\) > 0/);
 });
 
 test("cloud projects host focus through the shared cell UI state bridge", () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1155,7 +1155,6 @@ function NotebookViewer({
         getEngine: () => liveRuntimeRef.current?.engine ?? null,
         canWriteCellSource,
         canEditStructure: () => shellCapabilities.canEditStructure,
-        canAcceptStructure: (handle) => handle.cell_count() > 0,
         createCellId: createCloudNotebookCellId,
         syncMode: {
           structure: "scheduleFlush",

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -267,10 +267,13 @@ export const MarkdownCell = memo(function MarkdownCell({
       setEditing(false);
       return;
     }
+    if (!isFocused && editing && cell.source.trim()) {
+      setEditing(false);
+    }
     if (!isFocused || editing) {
       setPreviewFrameInteractionActive(false);
     }
-  }, [isFocused, editing, readOnly]);
+  }, [cell.source, isFocused, editing, readOnly]);
 
   const handleBlur = useCallback(() => {
     if (cell.source.trim()) {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -702,26 +702,12 @@ function NotebookViewContent({
     }
   }, [searchCurrentMatch]);
 
-  // ── Auto-seed first cell for empty notebooks ───────────────────────
-  // For new notebooks the daemon creates zero cells. Once sync completes
-  // (isLoading becomes false), we create the first code cell locally via
-  // the CRDT so the user gets an instant focused editor. The ref guard
-  // ensures we only seed once even if the effect re-fires before React
-  // processes the focusedCellId update from onAddCell.
-  const didAutoSeed = useRef(false);
+  // Focus the first authoritative cell after initial sync. New notebook
+  // structure is created by the host/daemon, not by this shared view.
   useEffect(() => {
-    if (isLoading || focusedCellId !== null || !canMutateCells) return;
-    if (cellIds.length === 0) {
-      if (!didAutoSeed.current) {
-        const seeded = onAddCell("code");
-        if (seeded !== null) {
-          didAutoSeed.current = true;
-        }
-      }
-    } else {
-      onFocusCell(cellIds[0]);
-    }
-  }, [isLoading, canMutateCells, cellIds, focusedCellId, onFocusCell, onAddCell]);
+    if (isLoading || focusedCellId !== null || cellIds.length === 0) return;
+    onFocusCell(cellIds[0]);
+  }, [isLoading, cellIds, focusedCellId, onFocusCell]);
 
   const renderCell = useCallback(
     (
@@ -1006,7 +992,7 @@ function NotebookViewContent({
         paddingBottom: NOTEBOOK_TAIL_SPACE,
         scrollPaddingBlock: `0rem ${NOTEBOOK_TAIL_SPACE}`,
       }}
-      data-notebook-synced={!isLoading && cellIds.length > 0}
+      data-notebook-synced={!isLoading}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}
       data-cell-count={cellIds.length}

--- a/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
+++ b/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
@@ -230,6 +230,10 @@ describe("edit/view toggle conditions", () => {
     return source.trim().length > 0;
   }
 
+  function shouldExitEditWhenUnfocused(source: string, isFocused: boolean): boolean {
+    return !isFocused && source.trim().length > 0;
+  }
+
   it("exits edit mode when cell has content", () => {
     expect(shouldExitEditOnBlur("# Hello")).toBe(true);
   });
@@ -244,6 +248,18 @@ describe("edit/view toggle conditions", () => {
 
   it("exits edit mode for single character content", () => {
     expect(shouldExitEditOnBlur("a")).toBe(true);
+  });
+
+  it("exits edit mode when a non-empty cell loses notebook focus", () => {
+    expect(shouldExitEditWhenUnfocused("# Hello", false)).toBe(true);
+  });
+
+  it("keeps the focused markdown cell in edit mode", () => {
+    expect(shouldExitEditWhenUnfocused("# Hello", true)).toBe(false);
+  });
+
+  it("keeps an unfocused empty markdown cell editable", () => {
+    expect(shouldExitEditWhenUnfocused("", false)).toBe(false);
   });
 
   /**

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -48,7 +48,9 @@ describe("NotebookView shell capabilities", () => {
 
     expect(sourceText).toMatch(/data-notebook-synced=\{!isLoading\}/);
     expect(sourceText).toMatch(/Focus the first authoritative cell after initial sync/);
-    expect(sourceText).toMatch(/if \(isLoading \|\| focusedCellId !== null \|\| cellIds\.length === 0\) return/);
+    expect(sourceText).toMatch(
+      /if \(isLoading \|\| focusedCellId !== null \|\| cellIds\.length === 0\) return/,
+    );
     const focusAfterSyncEffect = sourceText.match(
       /\/\/ Focus the first authoritative cell after initial sync\.[\s\S]*?\}, \[isLoading, cellIds, focusedCellId, onFocusCell\]\);/,
     )?.[0];

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -39,4 +39,21 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/onExecuteAndInsert:\s+canExecute && onInsertCellAfter/);
     expect(sourceText).toMatch(/canExecute=\{canExecute\}/);
   });
+
+  it("does not seed notebook structure from the shared frontend view", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).toMatch(/data-notebook-synced=\{!isLoading\}/);
+    expect(sourceText).toMatch(/Focus the first authoritative cell after initial sync/);
+    expect(sourceText).toMatch(/if \(isLoading \|\| focusedCellId !== null \|\| cellIds\.length === 0\) return/);
+    const focusAfterSyncEffect = sourceText.match(
+      /\/\/ Focus the first authoritative cell after initial sync\.[\s\S]*?\}, \[isLoading, cellIds, focusedCellId, onFocusCell\]\);/,
+    )?.[0];
+
+    expect(focusAfterSyncEffect).toBeDefined();
+    expect(focusAfterSyncEffect).not.toMatch(/onAddCell/);
+  });
 });

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3058,7 +3058,8 @@ impl Daemon {
 
     /// Handle a CreateNotebook connection.
     ///
-    /// Daemon creates empty room with zero cells, generates env_id as notebook_id.
+    /// Daemon creates an untitled room with one starter code cell and generates
+    /// env_id as notebook_id.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
     #[allow(clippy::too_many_arguments)]
     async fn handle_create_notebook<S>(
@@ -3119,7 +3120,7 @@ impl Daemon {
         .await?;
         self.mark_rooms_ever_seen();
 
-        // Populate the room's doc with the empty notebook content — but only if the
+        // Populate the room's doc with new-notebook content — but only if the
         // room is empty. If a persisted doc was loaded (session restore with notebook_id
         // hint), the room already has cells and we skip creation.
         let (cell_count, create_error, freshly_created) = {

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1011,7 +1011,7 @@ fn durable_or_synthetic_execution(
     }
 }
 
-/// Create a new empty notebook with a single code cell.
+/// Create a new notebook with a single starter code cell.
 ///
 /// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
 /// Uses the provided env_id or generates a new one, and populates the doc
@@ -1046,6 +1046,12 @@ pub fn create_empty_notebook(
 
     doc.set_metadata_snapshot(&metadata_snapshot)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
+
+    if doc.cell_count() == 0 {
+        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+        doc.add_cell_after(&cell_id, "code", None)
+            .map_err(|e| format!("Failed to add starter cell: {}", e))?;
+    }
 
     Ok(env_id)
 }

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3860,8 +3860,10 @@ fn test_create_empty_notebook_python() {
     let env_id = result.unwrap();
     assert!(!env_id.is_empty(), "Should generate an env_id");
 
-    // Should have zero cells (frontend creates the first cell locally)
-    assert_eq!(doc.cell_count(), 0);
+    assert_eq!(doc.cell_count(), 1);
+    let cells = doc.get_cells();
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
 }
 
 #[test]
@@ -3877,7 +3879,10 @@ fn test_create_empty_notebook_deno() {
     );
 
     assert!(result.is_ok());
-    assert_eq!(doc.cell_count(), 0);
+    assert_eq!(doc.cell_count(), 1);
+    let cells = doc.get_cells();
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
 
     // Check metadata was set correctly
     let metadata = doc.get_metadata_snapshot();
@@ -3909,6 +3914,29 @@ fn test_create_empty_notebook_with_provided_env_id() {
         Some(provided_id.to_string()),
         "Metadata should have provided env_id"
     );
+}
+
+#[test]
+fn test_create_empty_notebook_preserves_existing_cells() {
+    let mut doc = NotebookDoc::new("test");
+    doc.add_cell(0, "existing-cell", "markdown").unwrap();
+    doc.update_source("existing-cell", "# Existing").unwrap();
+
+    let result = create_empty_notebook(
+        &mut doc,
+        "python",
+        crate::settings_doc::PythonEnvType::Uv,
+        Some("existing-env-id"),
+        None,
+        &[],
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(doc.cell_count(), 1);
+    let cells = doc.get_cells();
+    assert_eq!(cells[0].id, "existing-cell");
+    assert_eq!(cells[0].cell_type, "markdown");
+    assert_eq!(cells[0].source, "# Existing");
 }
 
 /// Benchmark streaming load phases against a real notebook.

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -225,6 +225,21 @@ where
     false
 }
 
+async fn clear_daemon_seeded_starter_cell(handle: &notebook_sync::DocHandle) {
+    assert!(
+        wait_for_cells_matching(handle, SESSION_READY_TIMEOUT, |cells| {
+            cells.len() == 1 && cells[0].cell_type == "code" && cells[0].source.is_empty()
+        })
+        .await,
+        "new CreateNotebook session should receive the daemon-seeded starter cell, got {:?}",
+        handle.get_cells()
+    );
+
+    let starter_id = handle.get_cells()[0].id.clone();
+    handle.delete_cell(&starter_id).unwrap();
+    handle.confirm_sync().await.unwrap();
+}
+
 async fn wait_for_presence_update_actor_label(
     frame_rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
     peer_label: &str,
@@ -862,7 +877,8 @@ async fn test_notebook_sync_via_unified_socket() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    // Create first notebook via connect_create — should get empty notebook
+    // Create first notebook via connect_create — should get the daemon-owned
+    // starter cell. Clear it because this test constructs an exact fixture.
     let result1 = connect::connect_create(
         socket_path.clone(),
         "python",
@@ -882,8 +898,7 @@ async fn test_notebook_sync_via_unified_socket() {
         "client1 should reach session-ready state within 2s"
     );
 
-    let cells = client1.get_cells();
-    assert!(cells.is_empty(), "new notebook should have no cells");
+    clear_daemon_seeded_starter_cell(&client1).await;
 
     // Add a cell from client1
     client1.add_cell_after("cell-1", "code", None).unwrap();
@@ -925,8 +940,7 @@ async fn test_notebook_sync_via_unified_socket() {
         "client3 should reach session-ready state within 2s"
     );
 
-    let cells = client3.get_cells();
-    assert!(cells.is_empty(), "different notebook should have no cells");
+    clear_daemon_seeded_starter_cell(&client3).await;
 
     // Shutdown
     pool_client.shutdown().await.ok();
@@ -1531,6 +1545,8 @@ async fn test_untitled_notebook_persists_through_eviction() {
             "client1 should reach session-ready state within 2s"
         );
 
+        clear_daemon_seeded_starter_cell(&client1).await;
+
         client1.add_cell_after("c1", "code", None).unwrap();
         client1.update_source("c1", "persisted = True").unwrap();
         client1
@@ -1666,6 +1682,8 @@ async fn test_eviction_flushes_before_reconnect() {
             "client should reach session-ready state within 2s"
         );
 
+        clear_daemon_seeded_starter_cell(&client).await;
+
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "race_test = 1").unwrap();
         client.add_cell_after("c2", "code", Some("c1")).unwrap();
@@ -1760,6 +1778,8 @@ async fn test_kernel_teardown_keeps_room_resident() {
             wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state"
         );
+
+        clear_daemon_seeded_starter_cell(&client).await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "resident = True").unwrap();
@@ -2461,6 +2481,8 @@ async fn test_notebook_cell_delete_propagation() {
         "client1 should reach session-ready state within 2s"
     );
 
+    clear_daemon_seeded_starter_cell(&client1).await;
+
     client1.add_cell_after("keep-1", "code", None).unwrap();
     client1
         .add_cell_after("to-delete", "code", Some("keep-1"))
@@ -2604,6 +2626,12 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         wait_for_session_ready(&nb_c, SESSION_READY_TIMEOUT).await,
         "gamma notebook should reach session-ready state within {:?}",
         SESSION_READY_TIMEOUT
+    );
+
+    let _ = tokio::join!(
+        clear_daemon_seeded_starter_cell(&nb_a),
+        clear_daemon_seeded_starter_cell(&nb_b),
+        clear_daemon_seeded_starter_cell(&nb_c),
     );
 
     // Add cells to each notebook

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -72,12 +72,11 @@ export async function waitForAppReady() {
 }
 
 /**
- * Wait for the notebook to finish initial Automerge sync and render cells.
+ * Wait for the notebook to finish initial Automerge sync.
  *
  * Checks the `data-notebook-synced` attribute set by NotebookView when
- * `isLoading` is false and `cells.length > 0`. This is the canonical
- * signal that the doc has synced and cells are in the DOM — no arbitrary
- * timeouts or cell-count polling needed.
+ * `isLoading` is false. New notebooks are expected to get their starter
+ * structure from the host/daemon; valid empty notebooks can also be synced.
  */
 export async function waitForNotebookSynced(timeout = 15000) {
   await waitForAppReady();

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -306,6 +306,16 @@ async def async_create_cell_and_wait_for_sync(
     return cell_id
 
 
+async def assert_daemon_starter_cell(session):
+    """Assert a daemon-created notebook starts with one blank code cell."""
+    cells = await session.get_cells()
+    assert len(cells) == 1
+    starter = cells[0]
+    assert starter.cell_type == "code"
+    assert starter.source == ""
+    return starter
+
+
 # ============================================================================
 # Fixtures for daemon management
 # ============================================================================
@@ -1566,9 +1576,7 @@ class TestDenoKernel:
         assert ks["display_name"] == "Deno"
         assert ks.get("language") == "typescript"
 
-        # Has zero cells (frontend creates the first cell locally)
-        cells = await deno_session.get_cells()
-        assert len(cells) == 0
+        await assert_daemon_starter_cell(deno_session)
 
         # Verify the kernel is actually Deno by executing TypeScript
         result = await deno_session.execute_cell(
@@ -2512,6 +2520,13 @@ class TestExecutionIdScoping:
         """notebook.queue_all() returns execution handles for each queued cell."""
         await notebook.start()
 
+        for cell in list(notebook.cells):
+            await cell.delete()
+        await async_wait_for_sync(
+            lambda: len(notebook.cells) == 0,
+            description="starter cell deletion",
+        )
+
         first = await notebook.cells.create("print('first')")
         second = await notebook.cells.create("print('second')")
         await asyncio.sleep(0.5)
@@ -2834,23 +2849,21 @@ class TestCreateNotebook:
     """Test Client.create_notebook() - daemon-owned creation."""
 
     async def test_create_python_notebook(self, client):
-        """Creating Python notebook returns session with zero cells."""
+        """Creating Python notebook returns session with daemon starter cell."""
         session = await client.create_notebook(runtime="python")
         assert await session.is_connected()
 
         # notebook_id is UUID (not a path)
         assert len(session.notebook_id) == 36  # UUID format
 
-        # Has zero cells (frontend creates the first cell locally)
-        cells = await session.get_cells()
-        assert len(cells) == 0
+        await assert_daemon_starter_cell(session)
 
     async def test_create_notebook_returns_connection_info(self, client):
         """NotebookConnectionInfo is available for created notebooks."""
         session = await client.create_notebook(runtime="python")
         info = await session.connection_info()
         assert info is not None
-        assert info.cell_count == 0
+        assert info.cell_count == 1
         assert info.notebook_id == session.notebook_id
         # New notebooks don't need trust approval
         assert info.needs_trust_approval is False


### PR DESCRIPTION
## Summary

This is the overnight shared-host convergence branch. It keeps cloud and desktop on the shared NotebookView path while moving structure ownership and focus cleanup into shared/host-owned layers.

- seeds the starter code cell from `create_empty_notebook` instead of `NotebookView`
- keeps valid empty notebooks valid by leaving low-level `NotebookDoc::new` and room construction empty
- makes `NotebookView` readiness reflect authoritative load completion, not cell count
- lets cloud structure edits use the shared controller's cells-map gate instead of treating zero cells as unsynced
- closes non-empty markdown editors when they lose shared NotebookView focus, so cloud and desktop do not accumulate multiple editable markdown surfaces
- adds source-contract guards that keep frontend auto-seeding and cloud cell-count structure gates from returning

## Verification so far

- `cargo test -p runtimed test_create_empty_notebook -- --nocapture`
- `pnpm test:run apps/notebook/src/components/__tests__/markdown-formatting.test.ts`
- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts apps/notebook/src/components/__tests__/markdown-formatting.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts`
- `cargo test -p runtimed --test integration -- --nocapture`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$PWD/target/debug/runtimed" RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH="$PWD" RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 VIRTUAL_ENV="$PWD/.venv" uv run --directory python/runtimed pytest tests/test_daemon_integration.py::TestCreateNotebook::test_create_python_notebook tests/test_daemon_integration.py::TestCreateNotebook::test_create_notebook_returns_connection_info tests/test_daemon_integration.py::TestExecutionIdScoping::test_queue_all_returns_execution_handles tests/test_daemon_integration.py::TestDenoKernel::test_deno_kernelspec_via_typed_api -v --tb=short`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- deployed renderer assets, output document, and notebook-cloud worker to `preview.runt.run`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- Chrome preview validation on `/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit`: switching focused markdown cells leaves one focused/editing surface instead of accumulating green focused cells

## Current status

- draft while GitHub CI and final review run on the latest head
