### PR TITLE
refactor(notebook): share host notice stack

### DIFF
--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import { CloudNotebookNotices } from "../viewer/notices";
+
+globalThis.React = React;
+
+function authState(mode: CloudPrototypeAuthState["mode"]): CloudPrototypeAuthState {
+  return {
+    mode,
+    token: mode === "anonymous" ? null : "token",
+    user: mode === "anonymous" ? null : "user@example.test",
+    oidcClaims: null,
+    requestedScope: "viewer",
+    problem: mode === "invalid" || mode === "oidc_expired" ? "auth problem" : null,
+  };
+}
+
+test("cloud notebook notices render nothing for ready anonymous viewers", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.equal(html, "");
+});
+
+test("cloud notebook notices render auth and connection policy through the shared stack", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc_expired"),
+      authRenewal: { kind: "failed", message: "refresh failed" },
+      connectionError: "websocket failed",
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /data-slot="notebook-notice-stack"/);
+  assert.match(html, /Auth needs attention/);
+  assert.match(html, /Sign-in refresh failed/);
+  assert.match(html, /Live room connection failed/);
+  assert.match(html, /Reset to anonymous/);
+});
+
+test("cloud notebook notices keep dev diagnostics inside the shared stack", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      status: { kind: "ready", message: "Ready" },
+      diagnostics: React.createElement("div", { "data-kind": "diagnostics" }, "diagnostics"),
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /data-slot="notebook-notice-stack"/);
+  assert.match(html, /data-kind="diagnostics"/);
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
-import { CloudNotebookNotices } from "../viewer/notices";
+import { CloudNotebookNotices, cloudNotebookHasNotices } from "../viewer/notices";
 
 globalThis.React = React;
 
@@ -19,6 +19,16 @@ function authState(mode: CloudPrototypeAuthState["mode"]): CloudPrototypeAuthSta
 }
 
 test("cloud notebook notices render nothing for ready anonymous viewers", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    false,
+  );
+
   const html = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {
       authState: authState("anonymous"),

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -40,7 +40,6 @@ body {
 
 .cloud-notebook-notices {
   display: grid;
-  gap: 0.25rem;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -10,14 +10,12 @@ import {
 } from "react";
 import { createRoot } from "react-dom/client";
 import {
-  AlertCircle,
   Copy,
   Globe2,
   KeyRound,
   Link2,
   LogIn,
   LogOut,
-  Loader2,
   Mail,
   RotateCcw,
   Share2,
@@ -31,8 +29,6 @@ import {
   NotebookCommandToolbar,
   NotebookDocumentHeader,
   NotebookEditModeButton,
-  NotebookNotice,
-  NotebookNoticeAction,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
@@ -114,6 +110,7 @@ import {
 import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { materializeCloudNotebookView } from "./cloud-view-model";
+import { CloudNotebookNotices } from "./notices";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
 import {
   buildCloudShareAccessRows,
@@ -1303,96 +1300,16 @@ function NotebookViewer({
       />
     </div>
   ) : null;
-  const hasNotices =
-    authState.mode === "invalid" ||
-    authState.mode === "oidc_expired" ||
-    authRenewal.kind !== "idle" ||
-    Boolean(connectionError) ||
-    Boolean(authDiagnostics) ||
-    status.kind !== "ready";
-  const notices = hasNotices ? (
-    <>
-      {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
-        <NotebookNotice
-          tone="error"
-          icon={<AlertCircle className="h-4 w-4" />}
-          title="Auth needs attention."
-          actions={
-            <NotebookNoticeAction
-              onClick={resetPrototypeAuth}
-              icon={<RotateCcw className="h-3 w-3" />}
-            >
-              Reset to anonymous
-            </NotebookNoticeAction>
-          }
-        >
-          {prototypeAuthSummary(authState)}
-        </NotebookNotice>
-      ) : null}
-
-      {authRenewal.kind !== "idle" ? (
-        <NotebookNotice
-          tone={authRenewal.kind === "failed" ? "error" : "info"}
-          icon={
-            authRenewal.kind === "failed" ? (
-              <AlertCircle className="h-4 w-4" />
-            ) : (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            )
-          }
-          title={authRenewal.kind === "failed" ? "Sign-in refresh failed." : "Refreshing sign-in."}
-          actions={
-            authRenewal.kind === "failed" ? (
-              <NotebookNoticeAction
-                onClick={resetPrototypeAuth}
-                icon={<RotateCcw className="h-3 w-3" />}
-              >
-                Reset to anonymous
-              </NotebookNoticeAction>
-            ) : null
-          }
-        >
-          {authRenewal.message}
-        </NotebookNotice>
-      ) : null}
-
-      {connectionError ? (
-        <NotebookNotice
-          tone="error"
-          icon={<AlertCircle className="h-4 w-4" />}
-          title="Live room connection failed."
-          actions={
-            <NotebookNoticeAction
-              onClick={resetPrototypeAuth}
-              icon={<RotateCcw className="h-3 w-3" />}
-            >
-              Reset to anonymous
-            </NotebookNoticeAction>
-          }
-        >
-          {connectionError}
-        </NotebookNotice>
-      ) : null}
-
-      {authDiagnostics}
-
-      {status.kind === "ready" ? null : (
-        <NotebookNotice
-          tone={status.kind === "error" ? "error" : "info"}
-          icon={
-            status.kind === "error" ? (
-              <AlertCircle className="h-4 w-4" />
-            ) : (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            )
-          }
-          title={status.kind === "error" ? "Unable to load notebook." : "Loading notebook."}
-        >
-          {status.message}
-        </NotebookNotice>
-      )}
-    </>
-  ) : null;
+  const notices = (
+    <CloudNotebookNotices
+      authState={authState}
+      authRenewal={authRenewal}
+      connectionError={connectionError}
+      status={status}
+      diagnostics={authDiagnostics}
+      onResetAuth={resetPrototypeAuth}
+    />
+  );
 
   return (
     <NotebookDocumentShell

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -111,6 +111,7 @@ import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
+import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
 import {
   buildCloudShareAccessRows,
@@ -172,17 +173,6 @@ interface CloudNotebookCatalogRevision {
 interface CloudNotebookCatalog {
   revisions?: CloudNotebookCatalogRevision[];
 }
-
-type CloudAuthRenewalState =
-  | { kind: "idle"; message: null }
-  | { kind: "refreshing"; message: string }
-  | { kind: "failed"; message: string };
-
-type ViewerStatus =
-  | { kind: "loading"; message: string }
-  | { kind: "empty"; message: string }
-  | { kind: "ready"; message: string }
-  | { kind: "error"; message: string };
 
 interface ViewerRuntime {
   config: CloudViewerConfig;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -110,7 +110,7 @@ import {
 import { shouldShowPrototypeDevControls } from "./prototype-dev-controls";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { materializeCloudNotebookView } from "./cloud-view-model";
-import { CloudNotebookNotices } from "./notices";
+import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
 import {
   buildCloudShareAccessRows,
@@ -1300,7 +1300,14 @@ function NotebookViewer({
       />
     </div>
   ) : null;
-  const notices = (
+  const hasNotices = cloudNotebookHasNotices({
+    authState,
+    authRenewal,
+    connectionError,
+    status,
+    diagnostics: authDiagnostics,
+  });
+  const notices = hasNotices ? (
     <CloudNotebookNotices
       authState={authState}
       authRenewal={authRenewal}
@@ -1309,7 +1316,7 @@ function NotebookViewer({
       diagnostics={authDiagnostics}
       onResetAuth={resetPrototypeAuth}
     />
-  );
+  ) : null;
 
   return (
     <NotebookDocumentShell

--- a/apps/notebook-cloud/viewer/notice-types.ts
+++ b/apps/notebook-cloud/viewer/notice-types.ts
@@ -1,0 +1,14 @@
+// Shared notice state types for the cloud viewer. Both index.tsx (which owns
+// the React state) and notices.tsx (which renders it) depend on these, so they
+// live here to keep a single canonical definition and avoid drift.
+
+export type CloudAuthRenewalState =
+  | { kind: "idle"; message: null }
+  | { kind: "refreshing"; message: string }
+  | { kind: "failed"; message: string };
+
+export type ViewerStatus =
+  | { kind: "loading"; message: string }
+  | { kind: "empty"; message: string }
+  | { kind: "ready"; message: string }
+  | { kind: "error"; message: string };

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -6,23 +6,13 @@ import {
   NotebookNoticeStack,
 } from "@/components/notebook/NotebookNotice";
 import { prototypeAuthSummary, type CloudPrototypeAuthState } from "./collaborator-auth";
-
-export type CloudAuthRenewalNoticeState =
-  | { kind: "idle"; message: null }
-  | { kind: "refreshing"; message: string }
-  | { kind: "failed"; message: string };
-
-export type CloudViewerNoticeStatus =
-  | { kind: "loading"; message: string }
-  | { kind: "empty"; message: string }
-  | { kind: "ready"; message: string }
-  | { kind: "error"; message: string };
+import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 
 export interface CloudNotebookNoticesProps {
   authState: CloudPrototypeAuthState;
-  authRenewal: CloudAuthRenewalNoticeState;
+  authRenewal: CloudAuthRenewalState;
   connectionError: string | null;
-  status: CloudViewerNoticeStatus;
+  status: ViewerStatus;
   diagnostics?: ReactNode;
   onResetAuth: () => void;
 }

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -27,6 +27,23 @@ export interface CloudNotebookNoticesProps {
   onResetAuth: () => void;
 }
 
+export function cloudNotebookHasNotices({
+  authState,
+  authRenewal,
+  connectionError,
+  status,
+  diagnostics,
+}: Omit<CloudNotebookNoticesProps, "onResetAuth">): boolean {
+  return (
+    authState.mode === "invalid" ||
+    authState.mode === "oidc_expired" ||
+    authRenewal.kind !== "idle" ||
+    Boolean(connectionError) ||
+    Boolean(diagnostics) ||
+    status.kind !== "ready"
+  );
+}
+
 export function CloudNotebookNotices({
   authState,
   authRenewal,
@@ -35,15 +52,15 @@ export function CloudNotebookNotices({
   diagnostics,
   onResetAuth,
 }: CloudNotebookNoticesProps) {
-  const hasNotices =
-    authState.mode === "invalid" ||
-    authState.mode === "oidc_expired" ||
-    authRenewal.kind !== "idle" ||
-    Boolean(connectionError) ||
-    Boolean(diagnostics) ||
-    status.kind !== "ready";
-
-  if (!hasNotices) {
+  if (
+    !cloudNotebookHasNotices({
+      authState,
+      authRenewal,
+      connectionError,
+      status,
+      diagnostics,
+    })
+  ) {
     return null;
   }
 

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from "react";
+import { AlertCircle, Loader2, RotateCcw } from "lucide-react";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeStack,
+} from "@/components/notebook/NotebookNotice";
+import { prototypeAuthSummary, type CloudPrototypeAuthState } from "./collaborator-auth";
+
+export type CloudAuthRenewalNoticeState =
+  | { kind: "idle"; message: null }
+  | { kind: "refreshing"; message: string }
+  | { kind: "failed"; message: string };
+
+export type CloudViewerNoticeStatus =
+  | { kind: "loading"; message: string }
+  | { kind: "empty"; message: string }
+  | { kind: "ready"; message: string }
+  | { kind: "error"; message: string };
+
+export interface CloudNotebookNoticesProps {
+  authState: CloudPrototypeAuthState;
+  authRenewal: CloudAuthRenewalNoticeState;
+  connectionError: string | null;
+  status: CloudViewerNoticeStatus;
+  diagnostics?: ReactNode;
+  onResetAuth: () => void;
+}
+
+export function CloudNotebookNotices({
+  authState,
+  authRenewal,
+  connectionError,
+  status,
+  diagnostics,
+  onResetAuth,
+}: CloudNotebookNoticesProps) {
+  const hasNotices =
+    authState.mode === "invalid" ||
+    authState.mode === "oidc_expired" ||
+    authRenewal.kind !== "idle" ||
+    Boolean(connectionError) ||
+    Boolean(diagnostics) ||
+    status.kind !== "ready";
+
+  if (!hasNotices) {
+    return null;
+  }
+
+  return (
+    <NotebookNoticeStack>
+      {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
+        <NotebookNotice
+          tone="error"
+          icon={<AlertCircle className="h-4 w-4" />}
+          title="Auth needs attention."
+          actions={<ResetAuthNoticeAction onResetAuth={onResetAuth} />}
+        >
+          {prototypeAuthSummary(authState)}
+        </NotebookNotice>
+      ) : null}
+
+      {authRenewal.kind !== "idle" ? (
+        <NotebookNotice
+          tone={authRenewal.kind === "failed" ? "error" : "info"}
+          icon={
+            authRenewal.kind === "failed" ? (
+              <AlertCircle className="h-4 w-4" />
+            ) : (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            )
+          }
+          title={authRenewal.kind === "failed" ? "Sign-in refresh failed." : "Refreshing sign-in."}
+          actions={
+            authRenewal.kind === "failed" ? (
+              <ResetAuthNoticeAction onResetAuth={onResetAuth} />
+            ) : null
+          }
+        >
+          {authRenewal.message}
+        </NotebookNotice>
+      ) : null}
+
+      {connectionError ? (
+        <NotebookNotice
+          tone="error"
+          icon={<AlertCircle className="h-4 w-4" />}
+          title="Live room connection failed."
+          actions={<ResetAuthNoticeAction onResetAuth={onResetAuth} />}
+        >
+          {connectionError}
+        </NotebookNotice>
+      ) : null}
+
+      {diagnostics}
+
+      {status.kind === "ready" ? null : (
+        <NotebookNotice
+          tone={status.kind === "error" ? "error" : "info"}
+          icon={
+            status.kind === "error" ? (
+              <AlertCircle className="h-4 w-4" />
+            ) : (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            )
+          }
+          title={status.kind === "error" ? "Unable to load notebook." : "Loading notebook."}
+        >
+          {status.message}
+        </NotebookNotice>
+      )}
+    </NotebookNoticeStack>
+  );
+}
+
+function ResetAuthNoticeAction({ onResetAuth }: { onResetAuth: () => void }) {
+  return (
+    <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
+      Reset to anonymous
+    </NotebookNoticeAction>
+  );
+}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -158,6 +158,15 @@ export function NotebookToolbar({
     await navigator.clipboard.writeText(condaEnvCreateCommand);
     setCondaCommandCopied(true);
   }, [condaEnvCreateCommand]);
+  const showDenoInstallNotice =
+    runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && Boolean(kernelErrorMessage);
+  const showIpykernelErrorNotice =
+    runtime === "python" &&
+    lifecycle.lifecycle === "Error" &&
+    Boolean(envSource) &&
+    hasToolbarHandledIpykernelError;
+  const hasNotebookToolbarNotices =
+    showDenoInstallNotice || showIpykernelErrorNotice || showCondaEnvYmlMissingBanner;
 
   // Derive env manager label for the runtime pill (e.g. "uv", "conda", "pixi")
   const envManager: EnvBadgeVariant | null =
@@ -189,10 +198,10 @@ export function NotebookToolbar({
     </HoverCard>
   ) : null;
 
-  const notices = (
+  const notices = hasNotebookToolbarNotices ? (
     <>
       {/* Deno install prompt */}
-      {runtime === "deno" && kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage && (
+      {showDenoInstallNotice && kernelErrorMessage && (
         <NotebookNotice
           tone="warning"
           icon={<Info className="h-3.5 w-3.5" />}
@@ -211,10 +220,8 @@ export function NotebookToolbar({
           mechanisms (pixi.toml scan vs prepared-env scan), but the UX is the
           same shape: explain where ipykernel should go for the current env,
           then tell the user to restart. */}
-      {runtime === "python" &&
-        lifecycle.lifecycle === "Error" &&
+      {showIpykernelErrorNotice &&
         envSource &&
-        hasToolbarHandledIpykernelError &&
         renderIpykernelErrorPrompt({
           envSource,
           errorReason,
@@ -232,7 +239,7 @@ export function NotebookToolbar({
         />
       )}
     </>
-  );
+  ) : null;
 
   return (
     <NotebookToolbarFrame notices={notices}>

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -1,6 +1,10 @@
 import { useNotebookHost } from "@nteract/notebook-host";
 import { AlertTriangle, Clock, Settings } from "lucide-react";
-import { NotebookNotice, NotebookNoticeAction } from "@/components/notebook/NotebookNotice";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  NotebookNoticeStack,
+} from "@/components/notebook/NotebookNotice";
 import type { PoolErrorWithTimestamp } from "../hooks/usePoolState";
 
 interface PoolErrorItemProps {
@@ -93,12 +97,12 @@ export function PoolErrorBanner({
   }
 
   return (
-    <div className="flex flex-col">
+    <NotebookNoticeStack>
       {uvError && <PoolErrorItem envType="UV" error={uvError} onDismiss={onDismissUv} />}
       {condaError && (
         <PoolErrorItem envType="Conda" error={condaError} onDismiss={onDismissConda} />
       )}
       {pixiError && <PoolErrorItem envType="Pixi" error={pixiError} onDismiss={onDismissPixi} />}
-    </div>
+    </NotebookNoticeStack>
   );
 }

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -47,7 +47,7 @@ export function NotebookNoticeStack({
 }: NotebookNoticeStackProps) {
   return (
     <div
-      className={cn("flex flex-col", className)}
+      className={cn("flex flex-col gap-1", className)}
       data-slot="notebook-notice-stack"
       data-testid={dataTestId}
     >

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -18,6 +18,12 @@ export interface NotebookNoticeProps {
   "data-testid"?: string;
 }
 
+export interface NotebookNoticeStackProps {
+  children: ReactNode;
+  className?: string;
+  "data-testid"?: string;
+}
+
 const toneClassName: Record<NotebookNoticeTone, string> = {
   info: "border-sky-500/25 bg-sky-500/10 text-sky-950 dark:text-sky-100",
   warning: "border-amber-500/30 bg-amber-500/10 text-amber-950 dark:text-amber-100",
@@ -33,6 +39,22 @@ const iconClassName: Record<NotebookNoticeTone, string> = {
   success: "text-emerald-600 dark:text-emerald-300",
   debug: "text-violet-600 dark:text-violet-300",
 };
+
+export function NotebookNoticeStack({
+  children,
+  className,
+  "data-testid": dataTestId,
+}: NotebookNoticeStackProps) {
+  return (
+    <div
+      className={cn("flex flex-col", className)}
+      data-slot="notebook-notice-stack"
+      data-testid={dataTestId}
+    >
+      {children}
+    </div>
+  );
+}
 
 export function NotebookNotice({
   tone = "info",

--- a/src/components/notebook/NotebookToolbarFrame.tsx
+++ b/src/components/notebook/NotebookToolbarFrame.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { NotebookNoticeStack } from "./NotebookNotice";
 
 export interface NotebookToolbarFrameProps {
   children: ReactNode;
@@ -17,7 +18,7 @@ export function NotebookToolbarFrame({ children, className, notices }: NotebookT
       data-slot="notebook-toolbar-frame"
     >
       {children}
-      {notices}
+      {notices ? <NotebookNoticeStack>{notices}</NotebookNoticeStack> : null}
     </header>
   );
 }

--- a/src/components/notebook/__tests__/NotebookNotice.test.tsx
+++ b/src/components/notebook/__tests__/NotebookNotice.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { AlertTriangle } from "lucide-react";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { NotebookNotice, NotebookNoticeAction } from "../NotebookNotice";
+import { NotebookNotice, NotebookNoticeAction, NotebookNoticeStack } from "../NotebookNotice";
 
 describe("NotebookNotice", () => {
   it("renders shared title, body, details, tone, and icon slots", () => {
@@ -41,5 +41,18 @@ describe("NotebookNotice", () => {
     await user.click(screen.getByRole("button", { name: "Dismiss" }));
     expect(onAction).toHaveBeenCalledOnce();
     expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("renders a shared stack slot for host notices", () => {
+    render(
+      <NotebookNoticeStack>
+        <NotebookNotice title="Runtime unavailable">Reconnect the daemon.</NotebookNotice>
+        <NotebookNotice title="Auth needs attention">Sign in again.</NotebookNotice>
+      </NotebookNoticeStack>,
+    );
+
+    const stack = screen.getByText("Runtime unavailable").closest("[data-slot='notebook-notice-stack']");
+    expect(stack).not.toBeNull();
+    expect(stack).toContainElement(screen.getByText("Auth needs attention").closest("[data-slot='notebook-notice']"));
   });
 });

--- a/src/components/notebook/__tests__/NotebookNotice.test.tsx
+++ b/src/components/notebook/__tests__/NotebookNotice.test.tsx
@@ -51,8 +51,12 @@ describe("NotebookNotice", () => {
       </NotebookNoticeStack>,
     );
 
-    const stack = screen.getByText("Runtime unavailable").closest("[data-slot='notebook-notice-stack']");
+    const stack = screen
+      .getByText("Runtime unavailable")
+      .closest("[data-slot='notebook-notice-stack']");
     expect(stack).not.toBeNull();
-    expect(stack).toContainElement(screen.getByText("Auth needs attention").closest("[data-slot='notebook-notice']"));
+    expect(stack).toContainElement(
+      screen.getByText("Auth needs attention").closest("[data-slot='notebook-notice']"),
+    );
   });
 });

--- a/src/components/notebook/__tests__/NotebookToolbarFrame.test.tsx
+++ b/src/components/notebook/__tests__/NotebookToolbarFrame.test.tsx
@@ -15,5 +15,9 @@ describe("NotebookToolbarFrame", () => {
     expect(frame).toHaveClass("top-0");
     expect(screen.getByRole("button", { name: "Run" })).toBeVisible();
     expect(screen.getByText("Syncing")).toBeVisible();
+    expect(screen.getByText("Syncing").parentElement).toHaveAttribute(
+      "data-slot",
+      "notebook-notice-stack",
+    );
   });
 });

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -34,8 +34,10 @@ export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./Note
 export {
   NotebookNotice,
   NotebookNoticeAction,
+  NotebookNoticeStack,
   type NotebookNoticeActionProps,
   type NotebookNoticeProps,
+  type NotebookNoticeStackProps,
   type NotebookNoticeTone,
 } from "./NotebookNotice";
 export {


### PR DESCRIPTION
## Summary

- add a shared `NotebookNoticeStack` so host notices use one stack/slot primitive
- route cloud auth, renewal, connection, diagnostics, and loading notices through a hosted notice projection instead of inline viewer render policy
- adopt the shared notice stack for an existing desktop notice group

## Validation

- `pnpm test:run src/components/notebook/__tests__/NotebookNotice.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notices.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`

## Notes

- This branch intentionally leaves PR #3323 untouched. That ready PR remains cherry-pickable independently.
- This is the first host-notice policy slice for the shared NotebookView host convergence goal.
