### PR TITLE
fix(notebook): seed empty notebooks from host authority

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -225,10 +225,13 @@ export class RoomMaterializer {
       this.loadedPublishedRevisionId = null;
       this.loadedPublishedNotebookHeads = null;
       this.loadedPublishedRuntimeStateHeads = null;
-      const host = createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
+      const host = await createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
+      const initialCellId = `cell-${crypto.randomUUID()}`;
+      host.seed_initial_code_cell_if_empty(initialCellId);
       cloudLog("info", "room.materializer.loaded", {
         notebook_id: this.notebookId,
         source: "empty_room",
+        initial_cell_id: initialCellId,
         duration_ms: durationMs(startedAt),
         counter: "materializer_loads",
         counter_delta: 1,

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -83,6 +83,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     remove_peer(peerId: string): void;
     save_notebook(): Uint8Array;
     save_runtime_state_doc(): Uint8Array;
+    seed_initial_code_cell_if_empty(cellId: string): boolean;
     sync_peer(
       peerId: string,
       connectionScope: "viewer" | "editor" | "runtime_peer" | "owner",

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -442,6 +442,25 @@ describe("RoomHostHandle", () => {
 });
 
 describe("RoomMaterializer", () => {
+  it("seeds a brand-new hosted room with one initial code cell", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+
+    await syncMaterializerWithClient(
+      materializer,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
+  });
+
   it("persists and reloads a durable room checkpoint", async () => {
     const state = fakeState();
     const editorIdentity = authenticateDevRequest(
@@ -487,11 +506,11 @@ describe("RoomMaterializer", () => {
     );
 
     const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
-    assert.deepEqual(
-      cells.map((cell) => cell.id),
-      ["cell-1"],
-    );
+    assert.equal(cells.length, 2);
+    assert.equal(cells[0].id, "cell-1");
     assert.equal(cells[0].source, "Durable room checkpoint\n");
+    assert.match(cells[1].id, /^cell-/);
+    assert.equal(cells[1].source, "");
   });
 
   it("ignores unversioned prototype checkpoints so published snapshots can hydrate rooms", async () => {
@@ -534,7 +553,7 @@ describe("RoomMaterializer", () => {
       viewer,
     );
 
-    assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
   });
 
   it("keeps legacy versioned checkpoints when no published snapshot is available", async () => {
@@ -784,7 +803,7 @@ describe("RoomMaterializer", () => {
       viewer,
     );
 
-    assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
   });
 
   it("uses the latest published snapshot instead of stale revision checkpoints", async () => {
@@ -1339,6 +1358,20 @@ async function createNotebookRoomSnapshot(
     notebookHeads: Array.from(host.get_heads_hex()),
     runtimeStateHeads: Array.from(host.get_runtime_state_heads_hex()),
   };
+}
+
+function assertInitialEmptyCodeCell(cells: unknown): void {
+  assert.ok(Array.isArray(cells), "expected cells array");
+  assert.equal(cells.length, 1);
+  const [cell] = cells as Array<{
+    id?: unknown;
+    cell_type?: unknown;
+    source?: unknown;
+  }>;
+  assert.equal(typeof cell.id, "string");
+  assert.match(cell.id, /^cell-/);
+  assert.equal(cell.cell_type, "code");
+  assert.equal(cell.source, "");
 }
 
 async function syncMaterializerWithRuntimePeer(

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1368,8 +1368,11 @@ function assertInitialEmptyCodeCell(cells: unknown): void {
     cell_type?: unknown;
     source?: unknown;
   }>;
-  assert.equal(typeof cell.id, "string");
-  assert.match(cell.id, /^cell-/);
+  if (typeof cell.id !== "string") {
+    assert.fail("expected seeded cell id to be a string");
+  }
+  const cellId: string = cell.id;
+  assert.match(cellId, /^cell-/);
   assert.equal(cell.cell_type, "code");
   assert.equal(cell.source, "");
 }

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -702,26 +702,12 @@ function NotebookViewContent({
     }
   }, [searchCurrentMatch]);
 
-  // ── Auto-seed first cell for empty notebooks ───────────────────────
-  // For new notebooks the daemon creates zero cells. Once sync completes
-  // (isLoading becomes false), we create the first code cell locally via
-  // the CRDT so the user gets an instant focused editor. The ref guard
-  // ensures we only seed once even if the effect re-fires before React
-  // processes the focusedCellId update from onAddCell.
-  const didAutoSeed = useRef(false);
+  // Focus the first materialized cell once sync settles. New notebook
+  // structure is seeded by the host/document authority, not by NotebookView.
   useEffect(() => {
-    if (isLoading || focusedCellId !== null || !canMutateCells) return;
-    if (cellIds.length === 0) {
-      if (!didAutoSeed.current) {
-        const seeded = onAddCell("code");
-        if (seeded !== null) {
-          didAutoSeed.current = true;
-        }
-      }
-    } else {
-      onFocusCell(cellIds[0]);
-    }
-  }, [isLoading, canMutateCells, cellIds, focusedCellId, onFocusCell, onAddCell]);
+    if (isLoading || focusedCellId !== null || cellIds.length === 0) return;
+    onFocusCell(cellIds[0]);
+  }, [isLoading, cellIds, focusedCellId, onFocusCell]);
 
   const renderCell = useCallback(
     (
@@ -1006,7 +992,7 @@ function NotebookViewContent({
         paddingBottom: NOTEBOOK_TAIL_SPACE,
         scrollPaddingBlock: `0rem ${NOTEBOOK_TAIL_SPACE}`,
       }}
-      data-notebook-synced={!isLoading && cellIds.length > 0}
+      data-notebook-synced={!isLoading}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}
       data-cell-count={cellIds.length}

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -16,6 +16,7 @@ describe("NotebookView shell capabilities", () => {
       /capabilities\?\.canEditStructure \?\? \(canAcceptCellMutations && !readOnly\)/,
     );
     expect(sourceText).toMatch(/capabilities\?\.canExecute \?\? !readOnly/);
+    expect(sourceText).toMatch(/data-notebook-synced=\{!isLoading\}/);
     expect(sourceText).toMatch(/<CodeCell[\s\S]*canExecute=\{canExecuteCells\}/);
     expect(sourceText).toMatch(/<MarkdownCell[\s\S]*readOnly=\{!canEditMarkdownSources\}/);
     expect(sourceText).toMatch(
@@ -26,6 +27,18 @@ describe("NotebookView shell capabilities", () => {
     );
     expect(sourceText).toMatch(/canMutateCells && onSetCellSourceHidden/);
     expect(sourceText).toMatch(/canMutateCells && onSetCellOutputsHidden/);
+  });
+
+  it("does not create notebook cells from transient empty render state", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).not.toContain("Auto-seed first cell");
+    expect(sourceText).not.toMatch(
+      /cellIds\.length === 0[\s\S]{0,300}onAddCell\("code"\)/,
+    );
   });
 
   it("does not install code execution keybindings when execution is unavailable", () => {

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -36,9 +36,7 @@ describe("NotebookView shell capabilities", () => {
     );
 
     expect(sourceText).not.toContain("Auto-seed first cell");
-    expect(sourceText).not.toMatch(
-      /cellIds\.length === 0[\s\S]{0,300}onAddCell\("code"\)/,
-    );
+    expect(sourceText).not.toMatch(/cellIds\.length === 0[\s\S]{0,300}onAddCell\("code"\)/);
   });
 
   it("does not install code execution keybindings when execution is unavailable", () => {

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -3115,9 +3115,8 @@ mod tests {
 
     #[test]
     fn room_host_seeds_initial_code_cell_idempotently() {
-        let mut host =
-            RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
-                .expect("create room host");
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
         assert_eq!(host.doc.cell_count(), 0);
 
         let seeded = host

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -471,6 +471,21 @@ impl RoomHostHandle {
         })
     }
 
+    /// Seed the room with one initial code cell if the authoritative NotebookDoc is empty.
+    ///
+    /// Hosted room creation uses this after creating a brand-new room host. Sync
+    /// bootstrap handles and test fixtures can still use `create_empty` to mean
+    /// "schema only, zero cells."
+    pub fn seed_initial_code_cell_if_empty(&mut self, cell_id: &str) -> Result<bool, JsError> {
+        if self.doc.cell_count() > 0 {
+            return Ok(false);
+        }
+        self.doc
+            .add_cell_after(cell_id, "code", None)
+            .map_err(|e| JsError::new(&format!("seed initial code cell failed: {e}")))?;
+        Ok(true)
+    }
+
     /// Load a room host from persisted NotebookDoc + RuntimeStateDoc bytes.
     pub fn load_snapshot(
         notebook_bytes: &[u8],
@@ -3096,6 +3111,31 @@ mod tests {
         val: serde_json::Value,
     ) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
         resolve_comm_state_for_frontend(&val, 1234, true)
+    }
+
+    #[test]
+    fn room_host_seeds_initial_code_cell_idempotently() {
+        let mut host =
+            RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+                .expect("create room host");
+        assert_eq!(host.doc.cell_count(), 0);
+
+        let seeded = host
+            .seed_initial_code_cell_if_empty("cell-initial")
+            .expect("seed initial cell");
+        assert!(seeded);
+        assert_eq!(host.doc.cell_count(), 1);
+        assert_eq!(
+            host.doc.get_cell_type("cell-initial").as_deref(),
+            Some("code")
+        );
+
+        let seeded_again = host
+            .seed_initial_code_cell_if_empty("cell-second")
+            .expect("skip second seed");
+        assert!(!seeded_again);
+        assert_eq!(host.doc.cell_count(), 1);
+        assert!(host.doc.get_cell("cell-second").is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2949,9 +2949,22 @@ impl Daemon {
                         None,
                         &[],
                     ) {
-                        Ok(_cell_id) => {
-                            info!("[runtimed] Created new notebook at {}", path);
-                            created_new_at_path = true;
+                        Ok(_) => {
+                            match crate::notebook_sync_server::seed_initial_code_cell_if_empty(
+                                &mut doc,
+                            ) {
+                                Ok(_) => {
+                                    info!("[runtimed] Created new notebook at {}", path);
+                                    created_new_at_path = true;
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "[runtimed] Failed to seed initial cell at {}: {}",
+                                        path, e
+                                    );
+                                    create_error = Some(e);
+                                }
+                            }
                         }
                         Err(e) => {
                             error!(
@@ -3143,7 +3156,15 @@ impl Daemon {
                     &dependencies,
                 ) {
                     Ok(_) => {
-                        fresh = true;
+                        match crate::notebook_sync_server::seed_initial_code_cell_if_empty(&mut doc)
+                        {
+                            Ok(_) => {
+                                fresh = true;
+                            }
+                            Err(e) => {
+                                err = Some(e);
+                            }
+                        }
                     }
                     Err(e) => {
                         err = Some(e);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3058,7 +3058,7 @@ impl Daemon {
 
     /// Handle a CreateNotebook connection.
     ///
-    /// Daemon creates empty room with zero cells, generates env_id as notebook_id.
+    /// Daemon creates the initial room document, generates env_id as notebook_id.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
     #[allow(clippy::too_many_arguments)]
     async fn handle_create_notebook<S>(
@@ -3119,7 +3119,7 @@ impl Daemon {
         .await?;
         self.mark_rooms_ever_seen();
 
-        // Populate the room's doc with the empty notebook content — but only if the
+        // Populate the room's doc with initial notebook content — but only if the
         // room is empty. If a persisted doc was loaded (session restore with notebook_id
         // hint), the room already has cells and we skip creation.
         let (cell_count, create_error, freshly_created) = {
@@ -3262,7 +3262,7 @@ impl Daemon {
             working_dir_path,
             None,  // No initial_metadata - doc is already populated
             true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
-            None,  // No streaming load - doc was just created with empty cell
+            None,  // No streaming load - doc was just created with initial content
             false, // UUID-based new notebook, handled by is_new_notebook check
             connection_identity,
             client_protocol_version,

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1011,7 +1011,7 @@ fn durable_or_synthetic_execution(
     }
 }
 
-/// Create a new empty notebook with a single code cell.
+/// Create a new notebook with metadata and a single initial code cell.
 ///
 /// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
 /// Uses the provided env_id or generates a new one, and populates the doc
@@ -1046,6 +1046,11 @@ pub fn create_empty_notebook(
 
     doc.set_metadata_snapshot(&metadata_snapshot)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
+    if doc.cell_count() == 0 {
+        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+        doc.add_cell_after(&cell_id, "code", None)
+            .map_err(|e| format!("Failed to add initial cell: {}", e))?;
+    }
 
     Ok(env_id)
 }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1011,7 +1011,7 @@ fn durable_or_synthetic_execution(
     }
 }
 
-/// Create a new notebook with metadata and a single initial code cell.
+/// Create a new notebook with metadata.
 ///
 /// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
 /// Uses the provided env_id or generates a new one, and populates the doc
@@ -1046,13 +1046,25 @@ pub fn create_empty_notebook(
 
     doc.set_metadata_snapshot(&metadata_snapshot)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
-    if doc.cell_count() == 0 {
-        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
-        doc.add_cell_after(&cell_id, "code", None)
-            .map_err(|e| format!("Failed to add initial cell: {}", e))?;
-    }
 
     Ok(env_id)
+}
+
+/// Seed a starter code cell when a daemon authority creates a brand-new
+/// user-facing notebook.
+///
+/// Keep this separate from `create_empty_notebook`: reconnect/restore paths and
+/// test fixture setup also need metadata-only documents.
+pub fn seed_initial_code_cell_if_empty(doc: &mut NotebookDoc) -> Result<Option<String>, String> {
+    if doc.cell_count() > 0 {
+        return Ok(None);
+    }
+
+    let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+    doc.add_cell_after(&cell_id, "code", None)
+        .map_err(|e| format!("Failed to add initial cell: {}", e))?;
+
+    Ok(Some(cell_id))
 }
 
 /// Build default metadata for a new notebook based on runtime.

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3860,8 +3860,19 @@ fn test_create_empty_notebook_python() {
     let env_id = result.unwrap();
     assert!(!env_id.is_empty(), "Should generate an env_id");
 
-    // Daemon-owned notebook creation seeds the initial document structure.
+    // Metadata creation stays separate from daemon-owned starter cell seeding.
+    assert_eq!(doc.cell_count(), 0);
+    let seeded = seed_initial_code_cell_if_empty(&mut doc).unwrap();
+    assert!(
+        seeded.is_some(),
+        "empty notebook should receive a starter cell"
+    );
     assert_eq!(doc.cell_count(), 1);
+    let second_seed = seed_initial_code_cell_if_empty(&mut doc).unwrap();
+    assert!(
+        second_seed.is_none(),
+        "starter cell seeding should be idempotent"
+    );
 }
 
 #[test]
@@ -3877,6 +3888,8 @@ fn test_create_empty_notebook_deno() {
     );
 
     assert!(result.is_ok());
+    assert_eq!(doc.cell_count(), 0);
+    assert!(seed_initial_code_cell_if_empty(&mut doc).unwrap().is_some());
     assert_eq!(doc.cell_count(), 1);
 
     // Check metadata was set correctly

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3860,8 +3860,8 @@ fn test_create_empty_notebook_python() {
     let env_id = result.unwrap();
     assert!(!env_id.is_empty(), "Should generate an env_id");
 
-    // Should have zero cells (frontend creates the first cell locally)
-    assert_eq!(doc.cell_count(), 0);
+    // Daemon-owned notebook creation seeds the initial document structure.
+    assert_eq!(doc.cell_count(), 1);
 }
 
 #[test]
@@ -3877,7 +3877,7 @@ fn test_create_empty_notebook_deno() {
     );
 
     assert!(result.is_ok());
-    assert_eq!(doc.cell_count(), 0);
+    assert_eq!(doc.cell_count(), 1);
 
     // Check metadata was set correctly
     let metadata = doc.get_metadata_snapshot();

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -225,6 +225,30 @@ where
     false
 }
 
+async fn remove_daemon_seed_cell(handle: &notebook_sync::DocHandle, context: &str) {
+    assert_session_ready(handle, context).await;
+    let cells = handle.get_cells();
+    assert_eq!(
+        cells.len(),
+        1,
+        "{context} should start with exactly the daemon seed cell, got: {:?}",
+        cells
+    );
+    let seed = &cells[0];
+    assert_eq!(seed.cell_type, "code", "{context} seed cell should be code");
+    assert!(
+        seed.source.is_empty(),
+        "{context} seed cell should be empty"
+    );
+    handle
+        .delete_cell(&seed.id)
+        .expect("test should be able to remove daemon seed cell");
+    handle
+        .confirm_sync()
+        .await
+        .expect("seed deletion should sync");
+}
+
 async fn wait_for_presence_update_actor_label(
     frame_rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
     peer_label: &str,
@@ -862,7 +886,7 @@ async fn test_notebook_sync_via_unified_socket() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    // Create first notebook via connect_create — should get empty notebook
+    // Create first notebook via connect_create — daemon seeds one starter cell.
     let result1 = connect::connect_create(
         socket_path.clone(),
         "python",
@@ -882,8 +906,7 @@ async fn test_notebook_sync_via_unified_socket() {
         "client1 should reach session-ready state within 2s"
     );
 
-    let cells = client1.get_cells();
-    assert!(cells.is_empty(), "new notebook should have no cells");
+    remove_daemon_seed_cell(&client1, "client1").await;
 
     // Add a cell from client1
     client1.add_cell_after("cell-1", "code", None).unwrap();
@@ -926,7 +949,13 @@ async fn test_notebook_sync_via_unified_socket() {
     );
 
     let cells = client3.get_cells();
-    assert!(cells.is_empty(), "different notebook should have no cells");
+    assert_eq!(
+        cells.len(),
+        1,
+        "different notebook should have its own daemon seed cell"
+    );
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
 
     // Shutdown
     pool_client.shutdown().await.ok();
@@ -1530,6 +1559,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
             wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
             "client1 should reach session-ready state within 2s"
         );
+        remove_daemon_seed_cell(&client1, "untitled persistence client").await;
 
         client1.add_cell_after("c1", "code", None).unwrap();
         client1.update_source("c1", "persisted = True").unwrap();
@@ -1665,6 +1695,7 @@ async fn test_eviction_flushes_before_reconnect() {
             wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state within 2s"
         );
+        remove_daemon_seed_cell(&client, "eviction flush client").await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "race_test = 1").unwrap();
@@ -1760,6 +1791,7 @@ async fn test_kernel_teardown_keeps_room_resident() {
             wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state"
         );
+        remove_daemon_seed_cell(&client, "kernel teardown client").await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "resident = True").unwrap();
@@ -2460,6 +2492,7 @@ async fn test_notebook_cell_delete_propagation() {
         wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
         "client1 should reach session-ready state within 2s"
     );
+    remove_daemon_seed_cell(&client1, "delete propagation client").await;
 
     client1.add_cell_after("keep-1", "code", None).unwrap();
     client1
@@ -2605,6 +2638,9 @@ async fn test_multiple_notebooks_concurrent_isolation() {
         "gamma notebook should reach session-ready state within {:?}",
         SESSION_READY_TIMEOUT
     );
+    remove_daemon_seed_cell(&nb_a, "alpha notebook").await;
+    remove_daemon_seed_cell(&nb_b, "beta notebook").await;
+    remove_daemon_seed_cell(&nb_c, "gamma notebook").await;
 
     // Add cells to each notebook
     nb_a.add_cell_after("alpha-1", "code", None).unwrap();

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -72,12 +72,12 @@ export async function waitForAppReady() {
 }
 
 /**
- * Wait for the notebook to finish initial Automerge sync and render cells.
+ * Wait for the notebook to finish initial Automerge sync and render.
  *
  * Checks the `data-notebook-synced` attribute set by NotebookView when
- * `isLoading` is false and `cells.length > 0`. This is the canonical
- * signal that the doc has synced and cells are in the DOM — no arbitrary
- * timeouts or cell-count polling needed.
+ * `isLoading` is false. This is the canonical signal that the doc has synced
+ * and the notebook surface is ready, including legitimate empty documents —
+ * no arbitrary timeouts or cell-count polling needed.
  */
 export async function waitForNotebookSynced(timeout = 15000) {
   await waitForAppReady();

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1566,9 +1566,11 @@ class TestDenoKernel:
         assert ks["display_name"] == "Deno"
         assert ks.get("language") == "typescript"
 
-        # Has zero cells (frontend creates the first cell locally)
+        # Daemon-owned creation seeds the initial document structure.
         cells = await deno_session.get_cells()
-        assert len(cells) == 0
+        assert len(cells) == 1
+        assert cells[0].cell_type == "code"
+        assert cells[0].source == ""
 
         # Verify the kernel is actually Deno by executing TypeScript
         result = await deno_session.execute_cell(
@@ -2512,6 +2514,7 @@ class TestExecutionIdScoping:
         """notebook.queue_all() returns execution handles for each queued cell."""
         await notebook.start()
 
+        await notebook.cells.get_by_index(0).delete()
         first = await notebook.cells.create("print('first')")
         second = await notebook.cells.create("print('second')")
         await asyncio.sleep(0.5)
@@ -2834,23 +2837,25 @@ class TestCreateNotebook:
     """Test Client.create_notebook() - daemon-owned creation."""
 
     async def test_create_python_notebook(self, client):
-        """Creating Python notebook returns session with zero cells."""
+        """Creating Python notebook returns session with a daemon seed cell."""
         session = await client.create_notebook(runtime="python")
         assert await session.is_connected()
 
         # notebook_id is UUID (not a path)
         assert len(session.notebook_id) == 36  # UUID format
 
-        # Has zero cells (frontend creates the first cell locally)
+        # Daemon-owned creation seeds the initial document structure.
         cells = await session.get_cells()
-        assert len(cells) == 0
+        assert len(cells) == 1
+        assert cells[0].cell_type == "code"
+        assert cells[0].source == ""
 
     async def test_create_notebook_returns_connection_info(self, client):
         """NotebookConnectionInfo is available for created notebooks."""
         session = await client.create_notebook(runtime="python")
         info = await session.connection_info()
         assert info is not None
-        assert info.cell_count == 0
+        assert info.cell_count == 1
         assert info.notebook_id == session.notebook_id
         # New notebooks don't need trust approval
         assert info.needs_trust_approval is False


### PR DESCRIPTION
## Summary

- seed new desktop daemon-created notebooks with one initial code cell
- remove NotebookView's frontend auto-seed path and keep it focused on rendering/materialized focus
- seed brand-new hosted cloud rooms from the RoomHost authority path
- keep generic empty room/bootstrap helpers available for zero-cell sync fixtures

## Why

NotebookView was creating a first cell when it observed an empty synced cell list. That made transient empty sync states look like document structure and could create extra cells when a room was still hydrating. New notebook structure should come from the document/host authority, not from the shared React view.

## Verification

- `cargo xtask wasm runtimed`
- `cargo test -p runtimed-wasm room_host_seeds_initial_code_cell_idempotently -- --nocapture`
- `cargo test -p runtimed test_create_empty_notebook -- --nocapture`
- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts src/components/notebook/__tests__/NotebookCellList.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

This keeps the branch split into coherent commits so the daemon/desktop seed change and the cloud room-host seed change can be cherry-picked separately if needed.
