### PR TITLE
feat(elements): expose notebook host shell scenarios

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -41,8 +41,11 @@ import {
   type NotebookShellCapabilities,
 } from "@/components/notebook";
 import { EnvironmentSummary } from "@/components/environment";
-import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import { cn } from "@/lib/utils";
+import {
+  ElementsNotebookEnvironment,
+  useElementsNotebookEnvironment,
+} from "@/components/elements-notebook-environment";
 import {
   getElementsNotebookScenario,
   type ElementsNotebookScenario,
@@ -157,10 +160,16 @@ const cloudStateRows = [
 ];
 
 export function CloudNotebookShellExample() {
-  const scenario = getElementsNotebookScenario("cloud-owner");
+  return (
+    <ElementsNotebookEnvironment scenarioId="cloud-owner" initialRailCollapsed>
+      <CloudNotebookShellExampleContent />
+    </ElementsNotebookEnvironment>
+  );
+}
+
+function CloudNotebookShellExampleContent() {
+  const { actions, rail: railState, scenario } = useElementsNotebookEnvironment();
   const [mode, setMode] = useState<CloudModeState>("edit");
-  const [activePanel, setActivePanel] = useState<NotebookRailPanelId>("outline");
-  const [railCollapsed, setRailCollapsed] = useState(true);
   const shellCapabilities = withInteractionProjection(
     scenario.capabilities,
     cloudInteractionProjection(scenario, mode),
@@ -169,8 +178,8 @@ export function CloudNotebookShellExample() {
   const rail = (
     <NotebookDocumentRail
       viewModel={scenario.viewModel}
-      activePanelId={activePanel}
-      collapsed={railCollapsed}
+      activePanelId={railState.activePanelId}
+      collapsed={railState.collapsed}
       packagesPanel={
         <NotebookPackageSummaryPanel
           packages={scenario.viewModel.packages}
@@ -186,8 +195,8 @@ export function CloudNotebookShellExample() {
           }
         />
       }
-      onActivePanelChange={setActivePanel}
-      onCollapsedChange={setRailCollapsed}
+      onActivePanelChange={actions.setActivePanel}
+      onCollapsedChange={actions.setRailCollapsed}
       className="bg-background"
     />
   );

--- a/apps/elements/components/elements-notebook-environment.tsx
+++ b/apps/elements/components/elements-notebook-environment.tsx
@@ -9,6 +9,7 @@ import {
   type ElementsNotebookScenarioId,
   type ElementsNotebookVariable,
   type ElementsNotebookRenderer,
+  type ElementsNotebookNotice,
 } from "@/components/notebook-scenarios";
 
 export interface ElementsNotebookEnvironmentModel {
@@ -27,6 +28,7 @@ export interface ElementsNotebookEnvironmentModel {
     viewModel: ElementsNotebookScenario["viewModel"];
   };
   outputs: ElementsNotebookOutputState;
+  notices: readonly ElementsNotebookNotice[];
   runtime: {
     label: string;
     packageSummary: string;
@@ -92,6 +94,7 @@ export function ElementsNotebookEnvironment({
         viewModel: scenario.viewModel,
       },
       outputs: scenario.outputState,
+      notices: scenario.notices,
       runtime: {
         label: scenario.runtimeLabel,
         packageSummary: scenario.packageSummary,

--- a/apps/elements/components/elements-notebook-environment.tsx
+++ b/apps/elements/components/elements-notebook-environment.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { createContext, useContext, useMemo, useState, type ReactNode } from "react";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookOutputState,
+  type ElementsNotebookScenario,
+  type ElementsNotebookScenarioId,
+  type ElementsNotebookVariable,
+  type ElementsNotebookRenderer,
+} from "@/components/notebook-scenarios";
+
+export interface ElementsNotebookEnvironmentModel {
+  scenario: ElementsNotebookScenario;
+  capabilities: ElementsNotebookScenario["capabilities"];
+  rail: {
+    activePanelId: NotebookRailPanelId;
+    collapsed: boolean;
+    outlineItemCount: number;
+    packageCount: number;
+  };
+  document: {
+    cellCount: number;
+    selectedCellId: string | null;
+    focusedCellId: string | null;
+    viewModel: ElementsNotebookScenario["viewModel"];
+  };
+  outputs: ElementsNotebookOutputState;
+  runtime: {
+    label: string;
+    packageSummary: string;
+    variables: readonly ElementsNotebookVariable[];
+    renderers: readonly ElementsNotebookRenderer[];
+  };
+  actions: {
+    eventLog: readonly string[];
+    setActivePanel: (panelId: NotebookRailPanelId) => void;
+    setRailCollapsed: (collapsed: boolean) => void;
+    selectCell: (cellId: string | null) => void;
+    focusCell: (cellId: string | null) => void;
+    recordHostAction: (label: string) => void;
+    clearEventLog: () => void;
+  };
+}
+
+const ElementsNotebookEnvironmentContext =
+  createContext<ElementsNotebookEnvironmentModel | null>(null);
+
+export interface ElementsNotebookEnvironmentProps {
+  children: ReactNode;
+  initialActivePanelId?: NotebookRailPanelId;
+  initialFocusedCellId?: string | null;
+  initialRailCollapsed?: boolean;
+  initialSelectedCellId?: string | null;
+  scenarioId: ElementsNotebookScenarioId;
+}
+
+export function ElementsNotebookEnvironment({
+  children,
+  initialActivePanelId = "outline",
+  initialFocusedCellId = null,
+  initialRailCollapsed = false,
+  initialSelectedCellId = null,
+  scenarioId,
+}: ElementsNotebookEnvironmentProps) {
+  const scenario = getElementsNotebookScenario(scenarioId);
+  const [activePanelId, setActivePanelId] = useState<NotebookRailPanelId>(initialActivePanelId);
+  const [collapsed, setCollapsed] = useState(initialRailCollapsed);
+  const [selectedCellId, setSelectedCellId] = useState<string | null>(initialSelectedCellId);
+  const [focusedCellId, setFocusedCellId] = useState<string | null>(initialFocusedCellId);
+  const [eventLog, setEventLog] = useState<readonly string[]>([]);
+
+  const model = useMemo<ElementsNotebookEnvironmentModel>(
+    () => ({
+      scenario,
+      capabilities: scenario.capabilities,
+      rail: {
+        activePanelId,
+        collapsed,
+        outlineItemCount: scenario.viewModel.outlineItems.length,
+        packageCount: scenario.viewModel.packages.sections.reduce(
+          (count, section) => count + section.dependencies.length,
+          0,
+        ),
+      },
+      document: {
+        cellCount: scenario.cells.length,
+        selectedCellId,
+        focusedCellId,
+        viewModel: scenario.viewModel,
+      },
+      outputs: scenario.outputState,
+      runtime: {
+        label: scenario.runtimeLabel,
+        packageSummary: scenario.packageSummary,
+        variables: scenario.variables,
+        renderers: scenario.renderers,
+      },
+      actions: {
+        eventLog,
+        setActivePanel: (panelId) => {
+          setActivePanelId(panelId);
+          setEventLog((items) => [`rail:${panelId}`, ...items].slice(0, 6));
+        },
+        setRailCollapsed: (nextCollapsed) => {
+          setCollapsed(nextCollapsed);
+          setEventLog((items) =>
+            [`rail:${nextCollapsed ? "collapsed" : "expanded"}`, ...items].slice(0, 6),
+          );
+        },
+        selectCell: (cellId) => {
+          setSelectedCellId(cellId);
+          setEventLog((items) => [`select:${cellId ?? "none"}`, ...items].slice(0, 6));
+        },
+        focusCell: (cellId) => {
+          setFocusedCellId(cellId);
+          setEventLog((items) => [`focus:${cellId ?? "none"}`, ...items].slice(0, 6));
+        },
+        recordHostAction: (label) => {
+          setEventLog((items) => [`host:${label}`, ...items].slice(0, 6));
+        },
+        clearEventLog: () => setEventLog([]),
+      },
+    }),
+    [activePanelId, collapsed, eventLog, focusedCellId, scenario, selectedCellId],
+  );
+
+  return (
+    <ElementsNotebookEnvironmentContext.Provider value={model}>
+      {children}
+    </ElementsNotebookEnvironmentContext.Provider>
+  );
+}
+
+export function useElementsNotebookEnvironment() {
+  const environment = useContext(ElementsNotebookEnvironmentContext);
+  if (!environment) {
+    throw new Error("useElementsNotebookEnvironment must be used within ElementsNotebookEnvironment.");
+  }
+  return environment;
+}

--- a/apps/elements/components/elements-notebook-environment.tsx
+++ b/apps/elements/components/elements-notebook-environment.tsx
@@ -44,8 +44,9 @@ export interface ElementsNotebookEnvironmentModel {
   };
 }
 
-const ElementsNotebookEnvironmentContext =
-  createContext<ElementsNotebookEnvironmentModel | null>(null);
+const ElementsNotebookEnvironmentContext = createContext<ElementsNotebookEnvironmentModel | null>(
+  null,
+);
 
 export interface ElementsNotebookEnvironmentProps {
   children: ReactNode;
@@ -136,7 +137,9 @@ export function ElementsNotebookEnvironment({
 export function useElementsNotebookEnvironment() {
   const environment = useContext(ElementsNotebookEnvironmentContext);
   if (!environment) {
-    throw new Error("useElementsNotebookEnvironment must be used within ElementsNotebookEnvironment.");
+    throw new Error(
+      "useElementsNotebookEnvironment must be used within ElementsNotebookEnvironment.",
+    );
   }
   return environment;
 }

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -46,6 +46,8 @@ export interface ElementsNotebookScenario {
   title: string;
   eyebrow: string;
   summary: string;
+  sourceFacts: readonly ElementsNotebookSourceFact[];
+  hostBoundaries: readonly ElementsNotebookHostBoundary[];
   capabilities: NotebookShellCapabilities;
   environment: NotebookEnvironmentSurface;
   cells: readonly NotebookViewCell[];
@@ -57,6 +59,17 @@ export interface ElementsNotebookScenario {
   outputState: ElementsNotebookOutputState;
   variables: readonly ElementsNotebookVariable[];
   renderers: readonly ElementsNotebookRenderer[];
+}
+
+export interface ElementsNotebookSourceFact {
+  label: string;
+  value: string;
+}
+
+export interface ElementsNotebookHostBoundary {
+  surface: string;
+  sharedSurface: string;
+  hostAuthority: string;
 }
 
 export interface ElementsNotebookPackageState {
@@ -1497,6 +1510,13 @@ function createScenario({
     title,
     eyebrow,
     summary,
+    sourceFacts: scenarioSourceFacts(projectedCapabilities, {
+      packageSummary,
+      runtimeLabel,
+      syncLabel,
+      trustLabel,
+    }),
+    hostBoundaries: scenarioHostBoundaries(projectedCapabilities),
     capabilities: projectedCapabilities,
     environment,
     cells: notebookCells,
@@ -1509,6 +1529,113 @@ function createScenario({
     variables,
     renderers,
   };
+}
+
+function scenarioSourceFacts(
+  capabilities: NotebookShellCapabilities,
+  {
+    packageSummary,
+    runtimeLabel,
+    syncLabel,
+    trustLabel,
+  }: {
+    packageSummary: string;
+    runtimeLabel: string;
+    syncLabel: string | null;
+    trustLabel: string | null;
+  },
+): readonly ElementsNotebookSourceFact[] {
+  const accessActor =
+    capabilities.access.actor?.principal.label ??
+    capabilities.access.identityLabel ??
+    capabilities.access.actorLabel ??
+    "no actor";
+  const runtimeActor =
+    capabilities.runtime.actor?.operator.label ??
+    capabilities.runtime.identityLabel ??
+    capabilities.runtime.actorLabel ??
+    "no runtime actor";
+  const mutationFacts = [
+    capabilities.canEditMarkdown ? "markdown" : null,
+    capabilities.canEditCells ? "cell source" : null,
+    capabilities.canEditStructure ? "structure" : null,
+    capabilities.canExecute ? "execute" : null,
+    capabilities.canManagePackages ? "packages" : null,
+    capabilities.canManageSharing ? "sharing" : null,
+  ].filter((fact): fact is string => Boolean(fact));
+
+  return [
+    {
+      label: "Access authority",
+      value: `${capabilities.access.source}:${capabilities.access.level} for ${accessActor}`,
+    },
+    {
+      label: "Interaction mode",
+      value: capabilities.interaction
+        ? `${capabilities.interaction.selectedMode} selected, ${capabilities.interaction.activeMode} active`
+        : mutationFacts.length
+          ? "editable from capabilities"
+          : "view-only from capabilities",
+    },
+    {
+      label: "Runtime authority",
+      value: `${capabilities.runtime.source}, ${
+        capabilities.runtime.connected ? "connected" : "detached"
+      }, actor ${runtimeActor}`,
+    },
+    {
+      label: "Environment facts",
+      value: [runtimeLabel, packageSummary, syncLabel, trustLabel].filter(Boolean).join(" / "),
+    },
+    {
+      label: "Mutable affordances",
+      value: mutationFacts.length ? mutationFacts.join(", ") : "none",
+    },
+  ];
+}
+
+function scenarioHostBoundaries(
+  capabilities: NotebookShellCapabilities,
+): readonly ElementsNotebookHostBoundary[] {
+  const accessAuthority = hostAuthorityLabel(capabilities.access.source);
+  const runtimeAuthority = hostAuthorityLabel(capabilities.runtime.source);
+
+  return [
+    {
+      surface: "Notebook rendering",
+      sharedSurface: "NotebookDocumentShell, NotebookDocumentRail, NotebookView",
+      hostAuthority: `${accessAuthority} supplies document bytes, access, and routing facts.`,
+    },
+    {
+      surface: "Notebook writes",
+      sharedSurface: "NotebookShellCapabilities plus shared mutation callbacks",
+      hostAuthority: `${accessAuthority} still enforces markdown, source, structure, sharing, and package authority.`,
+    },
+    {
+      surface: "Runtime and outputs",
+      sharedSurface: "NotebookEnvironmentSurface, runtime actor projection, output frames",
+      hostAuthority: `${runtimeAuthority} owns runtime lifecycle, runtime-state authorship, and output/blob authority.`,
+    },
+    {
+      surface: "Identity display",
+      sharedSurface: "NotebookActorProjection and NotebookToolbarIdentity",
+      hostAuthority:
+        "Host adapters enrich durable actor labels with structured principal/operator profile facts.",
+    },
+  ];
+}
+
+function hostAuthorityLabel(source: NotebookShellCapabilities["access"]["source"]): string {
+  switch (source) {
+    case "cloud":
+      return "Hosted room and ACL service";
+    case "local":
+      return "Desktop daemon and local filesystem";
+    case "fixture":
+      return "Elements fixture host";
+    default:
+      return "Host adapter";
+  }
 }
 
 function actorProjection({

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -11,6 +11,7 @@ import {
   notebookActorProjectionFromAccess,
   notebookActorProjectionFromRuntime,
   type NotebookActorProjection,
+  type NotebookNoticeTone,
   type NotebookShellCapabilities,
   type NotebookViewCell,
   type NotebookViewModel,
@@ -57,6 +58,7 @@ export interface ElementsNotebookScenario {
   packageState: ElementsNotebookPackageState;
   trustState: ElementsNotebookTrustState;
   outputState: ElementsNotebookOutputState;
+  notices: readonly ElementsNotebookNotice[];
   variables: readonly ElementsNotebookVariable[];
   renderers: readonly ElementsNotebookRenderer[];
 }
@@ -70,6 +72,14 @@ export interface ElementsNotebookHostBoundary {
   surface: string;
   sharedSurface: string;
   hostAuthority: string;
+}
+
+export interface ElementsNotebookNotice {
+  tone: NotebookNoticeTone;
+  title: string;
+  body: string;
+  details: string;
+  actionLabel: string | null;
 }
 
 export interface ElementsNotebookPackageState {
@@ -1526,6 +1536,12 @@ function createScenario({
     packageState,
     trustState,
     outputState,
+    notices: scenarioNotices(projectedCapabilities, {
+      runtimeLabel,
+      syncLabel,
+      trustLabel,
+      trustStatus,
+    }),
     variables,
     renderers,
   };
@@ -1622,7 +1638,82 @@ function scenarioHostBoundaries(
       hostAuthority:
         "Host adapters enrich durable actor labels with structured principal/operator profile facts.",
     },
+    {
+      surface: "Host notices",
+      sharedSurface: "NotebookNotice in the shared shell notice slot",
+      hostAuthority:
+        "Host adapters decide notice policy, diagnostics, and actions; the shell owns placement.",
+    },
   ];
+}
+
+function scenarioNotices(
+  capabilities: NotebookShellCapabilities,
+  {
+    runtimeLabel,
+    syncLabel,
+    trustLabel,
+    trustStatus,
+  }: {
+    runtimeLabel: string;
+    syncLabel: string | null;
+    trustLabel: string | null;
+    trustStatus: NotebookTrustStatus | null;
+  },
+): readonly ElementsNotebookNotice[] {
+  const notices: ElementsNotebookNotice[] = [];
+
+  if (capabilities.auth.needsAttention) {
+    notices.push({
+      tone: "warning",
+      title: "Authentication needs attention",
+      body: "The notebook remains readable while the host refreshes or replaces credentials.",
+      details: `${hostAuthorityLabel(capabilities.access.source)} owns sign-in, token renewal, and reset actions.`,
+      actionLabel: capabilities.auth.canSignIn ? "Sign in" : null,
+    });
+  }
+
+  if (!capabilities.runtime.connected) {
+    notices.push({
+      tone: capabilities.canExecute ? "warning" : "info",
+      title: "Runtime detached",
+      body: "Notebook content, outputs, and package facts are rendered from the document projection.",
+      details: `${runtimeLabel}. Runtime lifecycle remains a host adapter responsibility.`,
+      actionLabel: capabilities.canExecute ? "Reconnect runtime" : null,
+    });
+  }
+
+  if (trustStatus === "untrusted") {
+    notices.push({
+      tone: "warning",
+      title: "Dependency trust requires review",
+      body: "Package details stay visible, but execution and package mutation remain disabled.",
+      details: trustLabel ?? "Untrusted dependencies",
+      actionLabel: capabilities.canManagePackages ? "Review trust" : null,
+    });
+  }
+
+  if (capabilities.canRead && !capabilities.canEditMarkdown && !capabilities.canEditCells) {
+    notices.push({
+      tone: "info",
+      title: "Read-only notebook",
+      body: "The shared notebook surface renders the same document projection without mutation affordances.",
+      details: syncLabel ?? `${capabilities.access.source}:${capabilities.access.level}`,
+      actionLabel: capabilities.canRequestEdit ? "Request edit" : null,
+    });
+  }
+
+  if (capabilities.canManageSharing) {
+    notices.push({
+      tone: "success",
+      title: "Owner controls available",
+      body: "Sharing actions are available because the host confirmed owner access.",
+      details: "ACL mutation stays with the hosted room authority.",
+      actionLabel: "Manage sharing",
+    });
+  }
+
+  return notices;
 }
 
 function hostAuthorityLabel(source: NotebookShellCapabilities["access"]["source"]): string {

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -24,6 +24,10 @@ import type { LucideIcon } from "lucide-react";
 import type { NotebookShellCapabilities } from "@/components/notebook";
 import { cn } from "@/lib/utils";
 import {
+  ElementsNotebookEnvironment,
+  useElementsNotebookEnvironment,
+} from "@/components/elements-notebook-environment";
+import {
   getElementsNotebookScenario,
   type ElementsNotebookScenario,
   type ElementsNotebookScenarioId,
@@ -245,6 +249,10 @@ export function NotebookShellCapabilitiesExample() {
         ))}
       </section>
 
+      <ElementsNotebookEnvironment scenarioId="cloud-editor" initialRailCollapsed>
+        <ElementsFixtureEnvironmentCard />
+      </ElementsNotebookEnvironment>
+
       <section className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_360px]">
         <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
           <div className="flex items-center gap-2 border-b border-fd-border p-4">
@@ -352,6 +360,103 @@ export function NotebookShellCapabilitiesExample() {
         </p>
       </section>
     </div>
+  );
+}
+
+function ElementsFixtureEnvironmentCard() {
+  const environment = useElementsNotebookEnvironment();
+  const firstCellId = environment.document.viewModel.cellIds[0] ?? null;
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+      <div className="flex items-center gap-2 border-b border-fd-border p-4">
+        <TestTube2 className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+        <h2 className="text-sm font-semibold">Elements fixture environment</h2>
+      </div>
+      <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)]">
+        <div>
+          <p className="text-xs leading-5 text-fd-muted-foreground">
+            Catalog pages that need notebook context can wrap production shell components in
+            `ElementsNotebookEnvironment`. The provider emits scenario capabilities, rail state,
+            document facts, output fixtures, runtime/package projections, and inert host actions.
+          </p>
+          <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2">
+            <FixtureFact label="Scenario" value={environment.scenario.title} />
+            <FixtureFact
+              label="Access"
+              value={`${environment.capabilities.access.source}:${environment.capabilities.access.level}`}
+            />
+            <FixtureFact
+              label="Document"
+              value={`${environment.document.cellCount} cells, ${environment.rail.outlineItemCount} headings`}
+            />
+            <FixtureFact
+              label="Packages"
+              value={`${environment.rail.packageCount} projected packages`}
+            />
+            <FixtureFact label="Runtime" value={environment.runtime.label} />
+            <FixtureFact
+              label="Outputs"
+              value={`${environment.outputs.outputAreaOutputs.length} outputs, ${environment.outputs.widgetOutputs.length} widget views`}
+            />
+          </dl>
+        </div>
+        <div className="rounded-md border border-fd-border bg-fd-background p-3">
+          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+            Inert host callbacks
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <FixtureActionButton
+              label="Open packages"
+              onClick={() => environment.actions.setActivePanel("packages")}
+            />
+            <FixtureActionButton
+              label={environment.rail.collapsed ? "Expand rail" : "Collapse rail"}
+              onClick={() => environment.actions.setRailCollapsed(!environment.rail.collapsed)}
+            />
+            <FixtureActionButton
+              label="Select first cell"
+              onClick={() => environment.actions.selectCell(firstCellId)}
+            />
+            <FixtureActionButton
+              label="Host action"
+              onClick={() => environment.actions.recordHostAction("request-edit")}
+            />
+            <FixtureActionButton label="Clear" onClick={environment.actions.clearEventLog} />
+          </div>
+          <ol className="mt-3 min-h-20 space-y-1 font-mono text-[11px] text-fd-muted-foreground">
+            {environment.actions.eventLog.length ? (
+              environment.actions.eventLog.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)
+            ) : (
+              <li>No events recorded</li>
+            )}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FixtureFact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-fd-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function FixtureActionButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="rounded-md border border-fd-border bg-fd-card px-2 py-1 text-xs font-medium text-fd-foreground transition-colors hover:bg-fd-muted"
+      onClick={onClick}
+    >
+      {label}
+    </button>
   );
 }
 

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AlertTriangle,
   Check,
   CircleSlash2,
   Cloud,
@@ -8,6 +9,7 @@ import {
   Eye,
   FileCode2,
   GitBranch,
+  Info,
   KeyRound,
   ListTree,
   Monitor,
@@ -21,7 +23,12 @@ import {
   Workflow,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { NotebookShellCapabilities } from "@/components/notebook";
+import {
+  NotebookNotice,
+  NotebookNoticeAction,
+  type NotebookNoticeTone,
+  type NotebookShellCapabilities,
+} from "@/components/notebook";
 import { cn } from "@/lib/utils";
 import {
   ElementsNotebookEnvironment,
@@ -399,7 +406,37 @@ function ElementsFixtureEnvironmentCard() {
               label="Outputs"
               value={`${environment.outputs.outputAreaOutputs.length} outputs, ${environment.outputs.widgetOutputs.length} widget views`}
             />
+            <FixtureFact label="Notices" value={`${environment.notices.length} projected`} />
           </dl>
+          {environment.notices.length ? (
+            <div className="mt-4 space-y-2">
+              {environment.notices.slice(0, 3).map((notice) => (
+                <NotebookNotice
+                  key={`${notice.tone}-${notice.title}`}
+                  tone={notice.tone}
+                  icon={<NoticeIcon tone={notice.tone} />}
+                  title={notice.title}
+                  details={<span>{notice.details}</span>}
+                  actions={
+                    notice.actionLabel ? (
+                      <NotebookNoticeAction
+                        onClick={() =>
+                          environment.actions.recordHostAction(
+                            `notice:${notice.actionLabel?.toLowerCase()}`,
+                          )
+                        }
+                      >
+                        {notice.actionLabel}
+                      </NotebookNoticeAction>
+                    ) : null
+                  }
+                  className="rounded-md border"
+                >
+                  {notice.body}
+                </NotebookNotice>
+              ))}
+            </div>
+          ) : null}
         </div>
         <div className="rounded-md border border-fd-border bg-fd-background p-3">
           <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
@@ -515,6 +552,7 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
         <ScenarioPill label={authLabel} />
         <ScenarioPill label={scenario.runtimeLabel} />
         <ScenarioPill label={scenario.packageSummary} />
+        <ScenarioPill label={`${scenario.notices.length} notices`} />
         <ScenarioPill
           label={enabledLabels.length ? `can change: ${enabledLabels.join(", ")}` : "view only"}
         />
@@ -529,6 +567,21 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
           </div>
         ))}
       </dl>
+      {scenario.notices.length ? (
+        <div className="mt-3 border-t border-fd-border pt-3">
+          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+            Projected notices
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {scenario.notices.map((notice) => (
+              <li key={`${notice.tone}-${notice.title}`} className="text-[11px] leading-4">
+                <span className="font-medium text-fd-foreground">{notice.title}</span>
+                <span className="text-fd-muted-foreground"> · {notice.body}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
       <div className="mt-3 border-t border-fd-border pt-3">
         <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
           Host boundary
@@ -546,6 +599,18 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
       </div>
     </article>
   );
+}
+
+function NoticeIcon({ tone }: { tone: NotebookNoticeTone }) {
+  switch (tone) {
+    case "warning":
+    case "error":
+      return <AlertTriangle className="size-3.5" />;
+    case "success":
+      return <ShieldCheck className="size-3.5" />;
+    default:
+      return <Info className="size-3.5" />;
+  }
 }
 
 function ScenarioPill({ label }: { label: string }) {

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -503,10 +503,8 @@ function CapabilityState({ enabled }: { enabled: boolean }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium",
-        enabled
-          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-          : "border-fd-border bg-fd-muted text-fd-muted-foreground",
+        "inline-flex items-center gap-1.5 text-[11px] font-medium",
+        enabled ? "text-emerald-700 dark:text-emerald-300" : "text-fd-muted-foreground",
       )}
     >
       {enabled ? (
@@ -537,27 +535,33 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
         : "local fixture";
 
   return (
-    <article className="rounded-lg border border-fd-border bg-fd-card p-3 text-xs leading-5">
+    <article className="rounded-lg border border-fd-border bg-fd-card text-xs leading-5">
       <div className="flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0 px-3 pt-3">
           <div className="font-semibold text-fd-foreground">{scenario.title}</div>
           <div className="mt-1 text-[11px] text-fd-muted-foreground">{scenario.eyebrow}</div>
         </div>
-        <span className="shrink-0 rounded-full border border-fd-border bg-fd-background px-2 py-0.5 text-[10px] text-fd-muted-foreground">
-          {scenario.capabilities.access.source}:{scenario.capabilities.access.level}
+        <span className="shrink-0 px-3 pt-3 text-[10px] font-medium text-fd-muted-foreground">
+          {scenario.capabilities.access.source} / {scenario.capabilities.access.level}
         </span>
       </div>
-      <p className="mt-2 text-fd-muted-foreground">{scenario.summary}</p>
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        <ScenarioPill label={authLabel} />
-        <ScenarioPill label={scenario.runtimeLabel} />
-        <ScenarioPill label={scenario.packageSummary} />
-        <ScenarioPill label={`${scenario.notices.length} notices`} />
-        <ScenarioPill
-          label={enabledLabels.length ? `can change: ${enabledLabels.join(", ")}` : "view only"}
+      <p className="px-3 pt-2 text-fd-muted-foreground">{scenario.summary}</p>
+      <div className="mt-3 divide-y divide-fd-border/70 border-y border-fd-border/70">
+        <ScenarioSignal label="Auth" value={authLabel} />
+        <ScenarioSignal
+          label="Runtime"
+          value={`${scenario.runtimeLabel} / ${scenario.packageSummary}`}
+        />
+        <ScenarioSignal
+          label="Notices"
+          value={scenario.notices.length ? `${scenario.notices.length} projected` : "none"}
+        />
+        <ScenarioSignal
+          label="Changes"
+          value={enabledLabels.length ? enabledLabels.join(", ") : "view only"}
         />
       </div>
-      <dl className="mt-3 grid gap-2">
+      <dl className="grid gap-2 px-3 pt-3">
         {scenario.sourceFacts.map((fact) => (
           <div key={fact.label}>
             <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
@@ -568,7 +572,7 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
         ))}
       </dl>
       {scenario.notices.length ? (
-        <div className="mt-3 border-t border-fd-border pt-3">
+        <div className="mt-3 border-t border-fd-border px-3 pt-3">
           <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
             Projected notices
           </div>
@@ -582,7 +586,7 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
           </ul>
         </div>
       ) : null}
-      <div className="mt-3 border-t border-fd-border pt-3">
+      <div className="mt-3 border-t border-fd-border px-3 py-3">
         <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
           Host boundary
         </div>
@@ -613,10 +617,13 @@ function NoticeIcon({ tone }: { tone: NotebookNoticeTone }) {
   }
 }
 
-function ScenarioPill({ label }: { label: string }) {
+function ScenarioSignal({ label, value }: { label: string; value: string }) {
   return (
-    <span className="rounded-full border border-fd-border bg-fd-background px-2 py-0.5 text-[10px] text-fd-muted-foreground">
-      {label}
-    </span>
+    <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-3 px-3 py-1.5">
+      <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+        {label}
+      </div>
+      <div className="min-w-0 text-[11px] text-fd-foreground">{value}</div>
+    </div>
   );
 }

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -426,7 +426,9 @@ function ElementsFixtureEnvironmentCard() {
           </div>
           <ol className="mt-3 min-h-20 space-y-1 font-mono text-[11px] text-fd-muted-foreground">
             {environment.actions.eventLog.length ? (
-              environment.actions.eventLog.map((item, index) => <li key={`${item}-${index}`}>{item}</li>)
+              environment.actions.eventLog.map((item, index) => (
+                <li key={`${item}-${index}`}>{item}</li>
+              ))
             ) : (
               <li>No events recorded</li>
             )}

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -412,6 +412,31 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
           label={enabledLabels.length ? `can change: ${enabledLabels.join(", ")}` : "view only"}
         />
       </div>
+      <dl className="mt-3 grid gap-2">
+        {scenario.sourceFacts.map((fact) => (
+          <div key={fact.label}>
+            <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+              {fact.label}
+            </dt>
+            <dd className="mt-0.5 text-[11px] leading-4 text-fd-foreground">{fact.value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="mt-3 border-t border-fd-border pt-3">
+        <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
+          Host boundary
+        </div>
+        <ul className="mt-2 space-y-2">
+          {scenario.hostBoundaries.map((boundary) => (
+            <li key={boundary.surface} className="text-[11px] leading-4">
+              <span className="font-medium text-fd-foreground">{boundary.surface}: </span>
+              <span className="text-fd-muted-foreground">{boundary.sharedSurface}</span>
+              <span className="text-fd-muted-foreground">; </span>
+              <span className="text-fd-muted-foreground">{boundary.hostAuthority}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </article>
   );
 }

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -36,7 +36,11 @@ ACLs, filesystem permissions, runtime authority, and storage/blob resolution.
   describe which authority still enforces the action.
 - `ElementsNotebookEnvironment` is the docs-local host adapter for shell pages:
   it supplies capabilities, rail state, document facts, outputs, runtime facts,
-  and inert callbacks without daemon, cloud, or catalog-specific side effects.
+  projected host notices, and inert callbacks without daemon, cloud, or
+  catalog-specific side effects.
+- Notice policy is host-owned data. The shared shell owns placement and renders
+  `NotebookNotice`; hosts still own credentials, diagnostics, runtime reconnect,
+  trust review, sharing, and reset actions.
 - Cloud editor access can edit notebook content when the host grants that mode;
   sharing remains owner-only, and execution/package management remain disabled
   in hosted previews for now.

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -19,6 +19,11 @@ desktop-to-remote rooms, public hosted viewing, hosted editing/ownership,
 credential attention, multi-operator attribution, mixed identity providers,
 runtime peers, unavailable runtimes, and untrusted dependencies.
 
+Each scenario also names the source facts and host boundaries behind the shared
+projection. That keeps the catalog honest: the shell may render access,
+identity, package, runtime, and trust state, but the host still owns credentials,
+ACLs, filesystem permissions, runtime authority, and storage/blob resolution.
+
 <NotebookShellCapabilitiesExample />
 
 ## Implementation intent
@@ -27,6 +32,8 @@ runtime peers, unavailable runtimes, and untrusted dependencies.
   state, or Elements fixtures.
 - Shared surfaces consume the capability object and view model instead of
   importing desktop or cloud state directly.
+- Source-fact rows describe what the host adapter supplies; host-boundary rows
+  describe which authority still enforces the action.
 - Cloud editor access can edit notebook content when the host grants that mode;
   sharing remains owner-only, and execution/package management remain disabled
   in hosted previews for now.

--- a/apps/elements/content/docs/notebook-shell-capabilities.mdx
+++ b/apps/elements/content/docs/notebook-shell-capabilities.mdx
@@ -34,6 +34,9 @@ ACLs, filesystem permissions, runtime authority, and storage/blob resolution.
   importing desktop or cloud state directly.
 - Source-fact rows describe what the host adapter supplies; host-boundary rows
   describe which authority still enforces the action.
+- `ElementsNotebookEnvironment` is the docs-local host adapter for shell pages:
+  it supplies capabilities, rail state, document facts, outputs, runtime facts,
+  and inert callbacks without daemon, cloud, or catalog-specific side effects.
 - Cloud editor access can edit notebook content when the host grants that mode;
   sharing remains owner-only, and execution/package management remain disabled
   in hosted previews for now.


### PR DESCRIPTION
## Summary

This branch keeps the shared NotebookView host-convergence work moving through Elements instead of adding more cloud-only UI.

- adds source-fact and host-boundary metadata to `ElementsNotebookScenario`
- renders those source facts and authority boundaries in the Notebook shell capabilities catalog
- adds a docs-local `ElementsNotebookEnvironment` provider for shell pages that need capabilities, rail state, document facts, outputs, runtime/package projections, projected host notices, and inert host callbacks
- projects host notice policy from scenario facts and renders it through the shared `NotebookNotice` primitive
- routes the cloud notebook shell catalog example through that fixture host instead of owning scenario/rail state locally

## Why

The current ADR/PRD direction says desktop, cloud, and Elements should share the notebook app surface while hosts own transport, auth, ACLs, filesystem permissions, runtime authority, notice actions, diagnostics, and storage/blob resolution. This makes Elements a stronger pressure test for that boundary: catalog pages can now show which facts come from the host adapter and which shared components consume them.

## Verification

- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- local visual smoke with Elements dev server for:
  - `http://localhost:5176/docs/notebook-shell-capabilities`
  - `http://localhost:5176/docs/cloud-notebook-shell`
