### PR TITLE
fix(notebook): make fresh notebook seeding daemon-owned

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -225,10 +225,13 @@ export class RoomMaterializer {
       this.loadedPublishedRevisionId = null;
       this.loadedPublishedNotebookHeads = null;
       this.loadedPublishedRuntimeStateHeads = null;
-      const host = createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
+      const host = await createEmptyRoomHost(this.notebookId, ROOM_HOST_ACTOR_LABEL);
+      const initialCellId = `cell-${crypto.randomUUID()}`;
+      host.seed_initial_code_cell_if_empty(initialCellId);
       cloudLog("info", "room.materializer.loaded", {
         notebook_id: this.notebookId,
         source: "empty_room",
+        initial_cell_id: initialCellId,
         duration_ms: durationMs(startedAt),
         counter: "materializer_loads",
         counter_delta: 1,

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -83,6 +83,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     remove_peer(peerId: string): void;
     save_notebook(): Uint8Array;
     save_runtime_state_doc(): Uint8Array;
+    seed_initial_code_cell_if_empty(cellId: string): boolean;
     sync_peer(
       peerId: string,
       connectionScope: "viewer" | "editor" | "runtime_peer" | "owner",

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -442,6 +442,25 @@ describe("RoomHostHandle", () => {
 });
 
 describe("RoomMaterializer", () => {
+  it("seeds a brand-new hosted room with one initial code cell", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+
+    await syncMaterializerWithClient(
+      materializer,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
+  });
+
   it("persists and reloads a durable room checkpoint", async () => {
     const state = fakeState();
     const editorIdentity = authenticateDevRequest(
@@ -487,11 +506,11 @@ describe("RoomMaterializer", () => {
     );
 
     const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
-    assert.deepEqual(
-      cells.map((cell) => cell.id),
-      ["cell-1"],
-    );
+    assert.equal(cells.length, 2);
+    assert.equal(cells[0].id, "cell-1");
     assert.equal(cells[0].source, "Durable room checkpoint\n");
+    assert.match(cells[1].id, /^cell-/);
+    assert.equal(cells[1].source, "");
   });
 
   it("ignores unversioned prototype checkpoints so published snapshots can hydrate rooms", async () => {
@@ -534,7 +553,7 @@ describe("RoomMaterializer", () => {
       viewer,
     );
 
-    assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
   });
 
   it("keeps legacy versioned checkpoints when no published snapshot is available", async () => {
@@ -784,7 +803,7 @@ describe("RoomMaterializer", () => {
       viewer,
     );
 
-    assert.deepEqual(JSON.parse(viewer.get_cells_json()), []);
+    assertInitialEmptyCodeCell(JSON.parse(viewer.get_cells_json()));
   });
 
   it("uses the latest published snapshot instead of stale revision checkpoints", async () => {
@@ -1339,6 +1358,23 @@ async function createNotebookRoomSnapshot(
     notebookHeads: Array.from(host.get_heads_hex()),
     runtimeStateHeads: Array.from(host.get_runtime_state_heads_hex()),
   };
+}
+
+function assertInitialEmptyCodeCell(cells: unknown): void {
+  assert.ok(Array.isArray(cells), "expected cells array");
+  assert.equal(cells.length, 1);
+  const [cell] = cells as Array<{
+    id?: unknown;
+    cell_type?: unknown;
+    source?: unknown;
+  }>;
+  if (typeof cell.id !== "string") {
+    assert.fail("expected seeded cell id to be a string");
+  }
+  const cellId: string = cell.id;
+  assert.match(cellId, /^cell-/);
+  assert.equal(cell.cell_type, "code");
+  assert.equal(cell.source, "");
 }
 
 async function syncMaterializerWithRuntimePeer(

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -3,6 +3,8 @@ import { expect, type Locator, type Page } from "@playwright/test";
 export async function waitForNotebookReady(page: Page, path = "/") {
   await page.goto(path);
   await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
+  // NotebookView marks sync complete once loading has finished without a load
+  // error. Zero-cell notebooks are valid once the host has initialized them.
   await expect(page.locator("[data-notebook-synced]")).toHaveAttribute(
     "data-notebook-synced",
     "true",

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -702,26 +702,12 @@ function NotebookViewContent({
     }
   }, [searchCurrentMatch]);
 
-  // ── Auto-seed first cell for empty notebooks ───────────────────────
-  // For new notebooks the daemon creates zero cells. Once sync completes
-  // (isLoading becomes false), we create the first code cell locally via
-  // the CRDT so the user gets an instant focused editor. The ref guard
-  // ensures we only seed once even if the effect re-fires before React
-  // processes the focusedCellId update from onAddCell.
-  const didAutoSeed = useRef(false);
   useEffect(() => {
-    if (isLoading || focusedCellId !== null || !canMutateCells) return;
-    if (cellIds.length === 0) {
-      if (!didAutoSeed.current) {
-        const seeded = onAddCell("code");
-        if (seeded !== null) {
-          didAutoSeed.current = true;
-        }
-      }
-    } else {
+    if (isLoading || focusedCellId !== null) return;
+    if (cellIds.length > 0) {
       onFocusCell(cellIds[0]);
     }
-  }, [isLoading, canMutateCells, cellIds, focusedCellId, onFocusCell, onAddCell]);
+  }, [isLoading, cellIds, focusedCellId, onFocusCell]);
 
   const renderCell = useCallback(
     (
@@ -1006,7 +992,7 @@ function NotebookViewContent({
         paddingBottom: NOTEBOOK_TAIL_SPACE,
         scrollPaddingBlock: `0rem ${NOTEBOOK_TAIL_SPACE}`,
       }}
-      data-notebook-synced={!isLoading && cellIds.length > 0}
+      data-notebook-synced={!isLoading && !loadError}
       data-session-runtime-state={sessionRuntimeState ?? "unknown"}
       data-session-ready={sessionRuntimeState === "ready"}
       data-cell-count={cellIds.length}

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -28,6 +28,17 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/canMutateCells && onSetCellOutputsHidden/);
   });
 
+  it("does not create cells from a transient empty sync state", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).not.toContain("Auto-seed first cell");
+    expect(sourceText).not.toContain("didAutoSeed");
+    expect(sourceText).toMatch(/data-notebook-synced=\{!isLoading && !loadError\}/);
+  });
+
   it("does not install code execution keybindings when execution is unavailable", () => {
     const sourceText = readFileSync(
       join(process.cwd(), "apps/notebook/src/components/CodeCell.tsx"),

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -471,6 +471,21 @@ impl RoomHostHandle {
         })
     }
 
+    /// Seed the room with one initial code cell if the authoritative NotebookDoc is empty.
+    ///
+    /// Hosted room creation uses this after creating a brand-new room host. Sync
+    /// bootstrap handles and test fixtures can still use `create_empty` to mean
+    /// "schema only, zero cells."
+    pub fn seed_initial_code_cell_if_empty(&mut self, cell_id: &str) -> Result<bool, JsError> {
+        if self.doc.cell_count() > 0 {
+            return Ok(false);
+        }
+        self.doc
+            .add_cell_after(cell_id, "code", None)
+            .map_err(|e| JsError::new(&format!("seed initial code cell failed: {e}")))?;
+        Ok(true)
+    }
+
     /// Load a room host from persisted NotebookDoc + RuntimeStateDoc bytes.
     pub fn load_snapshot(
         notebook_bytes: &[u8],
@@ -3096,6 +3111,30 @@ mod tests {
         val: serde_json::Value,
     ) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
         resolve_comm_state_for_frontend(&val, 1234, true)
+    }
+
+    #[test]
+    fn room_host_seeds_initial_code_cell_idempotently() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        assert_eq!(host.doc.cell_count(), 0);
+
+        let seeded = host
+            .seed_initial_code_cell_if_empty("cell-initial")
+            .expect("seed initial cell");
+        assert!(seeded);
+        assert_eq!(host.doc.cell_count(), 1);
+        assert_eq!(
+            host.doc.get_cell_type("cell-initial").as_deref(),
+            Some("code")
+        );
+
+        let seeded_again = host
+            .seed_initial_code_cell_if_empty("cell-second")
+            .expect("skip second seed");
+        assert!(!seeded_again);
+        assert_eq!(host.doc.cell_count(), 1);
+        assert!(host.doc.get_cell("cell-second").is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2543,7 +2543,9 @@ impl Daemon {
                 // reaper could remove the resumed room and a new room
                 // would replace it, losing the in-memory doc and outputs
                 // the resident-room cache is meant to preserve.
-                let (room, _room_guard) = if let Ok(parsed) = uuid::Uuid::parse_str(&notebook_id) {
+                let parsed_notebook_id = uuid::Uuid::parse_str(&notebook_id).ok();
+                let is_uuid_notebook_id = parsed_notebook_id.is_some();
+                let (room, _room_guard) = if let Some(parsed) = parsed_notebook_id {
                     crate::notebook_sync_server::get_or_create_room_result(
                         &self.notebook_rooms,
                         parsed,
@@ -2596,6 +2598,40 @@ impl Daemon {
                 let settings = self.settings.read().await.get_all();
                 let default_runtime = settings.default_runtime;
                 let default_python_env = settings.default_python_env;
+                if is_uuid_notebook_id {
+                    let mut seed_error = None;
+                    let mut seeded = false;
+                    {
+                        let mut doc = room.doc.write().await;
+                        if crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+                            match crate::notebook_sync_server::create_empty_notebook(
+                                &mut doc,
+                                &default_runtime.to_string(),
+                                default_python_env.clone(),
+                                Some(&notebook_id),
+                                None,
+                                &[],
+                            ) {
+                                Ok(_) => {
+                                    seeded = true;
+                                }
+                                Err(e) => {
+                                    seed_error = Some(e);
+                                }
+                            }
+                        }
+                    }
+                    if let Some(e) = seed_error {
+                        return Err(anyhow::anyhow!(
+                            "Failed to initialize notebook '{}': {}",
+                            notebook_id,
+                            e
+                        ));
+                    }
+                    if seeded {
+                        info!("[runtimed] Initialized fresh notebook room {}", notebook_id);
+                    }
+                }
                 // Convert working_dir String to PathBuf
                 let working_dir_path = working_dir.map(std::path::PathBuf::from);
                 let connection_identity =
@@ -2940,7 +2976,7 @@ impl Daemon {
             let mut create_error = None;
             let count = {
                 let mut doc = room.doc.write().await;
-                if doc.cell_count() == 0 {
+                if crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
                     match crate::notebook_sync_server::create_empty_notebook(
                         &mut doc,
                         &default_runtime.to_string(),
@@ -3058,7 +3094,8 @@ impl Daemon {
 
     /// Handle a CreateNotebook connection.
     ///
-    /// Daemon creates empty room with zero cells, generates env_id as notebook_id.
+    /// Daemon creates a room, seeds fresh notebooks with default metadata and
+    /// one starter cell, and generates env_id as notebook_id.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
     #[allow(clippy::too_many_arguments)]
     async fn handle_create_notebook<S>(
@@ -3119,17 +3156,18 @@ impl Daemon {
         .await?;
         self.mark_rooms_ever_seen();
 
-        // Populate the room's doc with the empty notebook content — but only if the
-        // room is empty. If a persisted doc was loaded (session restore with notebook_id
-        // hint), the room already has cells and we skip creation.
+        // Populate the room's doc with new-notebook content only when the
+        // daemon owns a genuinely fresh document. If a persisted doc was
+        // loaded (including one the user intentionally emptied), metadata is
+        // already present and we skip seeding.
         let (cell_count, create_error, freshly_created) = {
             let mut doc = room.doc.write().await;
             let mut err = None;
             let mut fresh = false;
-            if doc.cell_count() > 0 {
-                // Room already has content (loaded from persisted doc)
+            if !crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+                // Room already has content or initialized metadata.
                 info!(
-                    "[runtimed] Room {} already has {} cells (restored from persisted doc)",
+                    "[runtimed] Room {} already initialized with {} cells",
                     notebook_id,
                     doc.cell_count()
                 );

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1011,11 +1011,13 @@ fn durable_or_synthetic_execution(
     }
 }
 
-/// Create a new empty notebook with a single code cell.
+/// Create a new notebook with daemon-owned default metadata and one code cell.
 ///
 /// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
 /// Uses the provided env_id or generates a new one, and populates the doc
-/// with default metadata for the specified runtime.
+/// with default metadata for the specified runtime. Fresh notebook structure
+/// is seeded here so clients never need to infer "new notebook" from a
+/// transient zero-cell sync state.
 ///
 /// Returns the env_id used on success.
 pub fn create_empty_notebook(
@@ -1046,8 +1048,20 @@ pub fn create_empty_notebook(
 
     doc.set_metadata_snapshot(&metadata_snapshot)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
+    doc.add_cell(0, &uuid::Uuid::new_v4().to_string(), "code")
+        .map_err(|e| format!("Failed to seed first cell: {}", e))?;
 
     Ok(env_id)
+}
+
+/// Return true when a notebook document has not yet been initialized by any
+/// host authority.
+///
+/// A document with metadata but zero cells is still initialized: users may have
+/// intentionally deleted every cell, and reconnecting clients must not recreate
+/// structure from that state.
+pub fn is_uninitialized_notebook_doc(doc: &NotebookDoc) -> bool {
+    doc.cell_count() == 0 && doc.get_metadata_snapshot().is_none()
 }
 
 /// Build default metadata for a new notebook based on runtime.

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3918,6 +3918,48 @@ fn test_create_empty_notebook_with_provided_env_id() {
     );
 }
 
+#[test]
+fn test_is_uninitialized_notebook_doc() {
+    // A brand-new doc has no cells and no metadata snapshot — uninitialized,
+    // so the host is free to seed starter structure.
+    let mut doc = NotebookDoc::new("test");
+    assert_eq!(doc.cell_count(), 0);
+    assert!(doc.get_metadata_snapshot().is_none());
+    assert!(
+        is_uninitialized_notebook_doc(&doc),
+        "fresh doc with no metadata and zero cells is uninitialized"
+    );
+
+    // The "user emptied it" case: metadata present, zero cells. Because
+    // `create_empty_notebook` always writes a metadata snapshot, a notebook a
+    // user deliberately emptied keeps that metadata, so the host must NOT
+    // re-seed it. Build the snapshot directly to land metadata without cells —
+    // `create_empty_notebook` seeds a starter cell, which is a different state.
+    let metadata = build_new_notebook_metadata(
+        "python",
+        "env-id",
+        crate::settings_doc::PythonEnvType::Uv,
+        None,
+        &[],
+    );
+    doc.set_metadata_snapshot(&metadata)
+        .expect("set_metadata_snapshot");
+    assert_eq!(doc.cell_count(), 0);
+    assert!(doc.get_metadata_snapshot().is_some());
+    assert!(
+        !is_uninitialized_notebook_doc(&doc),
+        "metadata present with zero cells is the user-emptied case, not uninitialized"
+    );
+
+    // Any cell present means the doc is initialized regardless of metadata.
+    doc.add_cell(0, &Uuid::new_v4().to_string(), "code")
+        .expect("add_cell");
+    assert!(
+        !is_uninitialized_notebook_doc(&doc),
+        "a doc with at least one cell is initialized"
+    );
+}
+
 /// Benchmark streaming load phases against a real notebook.
 ///
 /// Reads `/tmp/gelmanschools-bench.ipynb` and profiles:

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3860,8 +3860,12 @@ fn test_create_empty_notebook_python() {
     let env_id = result.unwrap();
     assert!(!env_id.is_empty(), "Should generate an env_id");
 
-    // Should have zero cells (frontend creates the first cell locally)
-    assert_eq!(doc.cell_count(), 0);
+    // Fresh notebook structure is daemon-owned. The frontend must not infer
+    // "new notebook" from an empty sync state and create this locally.
+    assert_eq!(doc.cell_count(), 1);
+    let cells = doc.get_cells();
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
 }
 
 #[test]
@@ -3877,7 +3881,10 @@ fn test_create_empty_notebook_deno() {
     );
 
     assert!(result.is_ok());
-    assert_eq!(doc.cell_count(), 0);
+    assert_eq!(doc.cell_count(), 1);
+    let cells = doc.get_cells();
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
 
     // Check metadata was set correctly
     let metadata = doc.get_metadata_snapshot();

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -225,6 +225,32 @@ where
     false
 }
 
+async fn remove_daemon_starter_cell(handle: &notebook_sync::DocHandle) {
+    assert!(
+        wait_for_cell_count(handle, 1, SESSION_READY_TIMEOUT).await,
+        "daemon starter cell did not arrive within {:?}: {:?}",
+        SESSION_READY_TIMEOUT,
+        handle.get_cells()
+    );
+    let starter = handle
+        .get_cells()
+        .into_iter()
+        .find(|cell| cell.cell_type == "code" && cell.source.is_empty())
+        .expect("fresh notebook should include an empty daemon starter code cell");
+    handle.delete_cell(&starter.id).unwrap();
+    handle.confirm_sync().await.unwrap();
+}
+
+fn assert_daemon_starter_cell(cells: &[notebook_doc::CellSnapshot]) {
+    assert_eq!(
+        cells.len(),
+        1,
+        "fresh notebook should have exactly one daemon starter cell"
+    );
+    assert_eq!(cells[0].cell_type, "code");
+    assert!(cells[0].source.is_empty());
+}
+
 async fn wait_for_presence_update_actor_label(
     frame_rx: &mut mpsc::UnboundedReceiver<Vec<u8>>,
     peer_label: &str,
@@ -862,7 +888,7 @@ async fn test_notebook_sync_via_unified_socket() {
     let pool_client = PoolClient::new(socket_path.clone());
     assert!(wait_for_daemon(&pool_client).await);
 
-    // Create first notebook via connect_create — should get empty notebook
+    // Create first notebook via connect_create — should get daemon starter cell
     let result1 = connect::connect_create(
         socket_path.clone(),
         "python",
@@ -883,11 +909,13 @@ async fn test_notebook_sync_via_unified_socket() {
     );
 
     let cells = client1.get_cells();
-    assert!(cells.is_empty(), "new notebook should have no cells");
+    assert_daemon_starter_cell(&cells);
+    let starter_id = cells[0].id.clone();
 
-    // Add a cell from client1
-    client1.add_cell_after("cell-1", "code", None).unwrap();
-    client1.update_source("cell-1", "print('hello')").unwrap();
+    // Update the daemon starter from client1
+    client1
+        .update_source(&starter_id, "print('hello')")
+        .unwrap();
 
     // Connect second client to the same notebook — should see the cell
     let client2 = connect::connect(socket_path.clone(), notebook_id_1, "test")
@@ -902,7 +930,7 @@ async fn test_notebook_sync_via_unified_socket() {
 
     let cells = client2.get_cells();
     assert_eq!(cells.len(), 1, "client2 should see the cell from client1");
-    assert_eq!(cells[0].id, "cell-1");
+    assert_eq!(cells[0].id, starter_id);
     assert_eq!(cells[0].source, "print('hello')");
     assert_eq!(cells[0].cell_type, "code");
 
@@ -926,7 +954,7 @@ async fn test_notebook_sync_via_unified_socket() {
     );
 
     let cells = client3.get_cells();
-    assert!(cells.is_empty(), "different notebook should have no cells");
+    assert_daemon_starter_cell(&cells);
 
     // Shutdown
     pool_client.shutdown().await.ok();
@@ -1530,6 +1558,7 @@ async fn test_untitled_notebook_persists_through_eviction() {
             wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
             "client1 should reach session-ready state within 2s"
         );
+        remove_daemon_starter_cell(&client1).await;
 
         client1.add_cell_after("c1", "code", None).unwrap();
         client1.update_source("c1", "persisted = True").unwrap();
@@ -1665,6 +1694,7 @@ async fn test_eviction_flushes_before_reconnect() {
             wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state within 2s"
         );
+        remove_daemon_starter_cell(&client).await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "race_test = 1").unwrap();
@@ -1760,6 +1790,7 @@ async fn test_kernel_teardown_keeps_room_resident() {
             wait_for_session_ready(&client, SESSION_READY_TIMEOUT).await,
             "client should reach session-ready state"
         );
+        remove_daemon_starter_cell(&client).await;
 
         client.add_cell_after("c1", "code", None).unwrap();
         client.update_source("c1", "resident = True").unwrap();
@@ -2460,6 +2491,7 @@ async fn test_notebook_cell_delete_propagation() {
         wait_for_session_ready(&client1, SESSION_READY_TIMEOUT).await,
         "client1 should reach session-ready state within 2s"
     );
+    remove_daemon_starter_cell(&client1).await;
 
     client1.add_cell_after("keep-1", "code", None).unwrap();
     client1
@@ -2607,6 +2639,11 @@ async fn test_multiple_notebooks_concurrent_isolation() {
     );
 
     // Add cells to each notebook
+    let ((), (), ()) = tokio::join!(
+        remove_daemon_starter_cell(&nb_a),
+        remove_daemon_starter_cell(&nb_b),
+        remove_daemon_starter_cell(&nb_c),
+    );
     nb_a.add_cell_after("alpha-1", "code", None).unwrap();
     nb_a.update_source("alpha-1", "print('alpha')").unwrap();
 
@@ -3060,6 +3097,7 @@ async fn test_pipe_mode_forwards_sync_frames() {
         "initial sync did not deliver the cells map within {:?}",
         SESSION_READY_TIMEOUT
     );
+    remove_daemon_starter_cell(&client2).await;
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2
         .update_source("cell-1", "print('hello from pipe test')")
@@ -3343,6 +3381,7 @@ async fn test_pipe_mode_preserves_frame_order() {
         "initial sync did not deliver the cells map within {:?}",
         SESSION_READY_TIMEOUT
     );
+    remove_daemon_starter_cell(&client2).await;
     client2.add_cell_after("cell-1", "code", None).unwrap();
     client2
         .add_cell_after("cell-2", "code", Some("cell-1"))

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -306,6 +306,13 @@ async def async_create_cell_and_wait_for_sync(
     return cell_id
 
 
+def assert_daemon_starter_cell(cells):
+    """Fresh daemon-owned notebooks start with one empty code cell."""
+    assert len(cells) == 1
+    assert cells[0].cell_type == "code"
+    assert cells[0].source == ""
+
+
 # ============================================================================
 # Fixtures for daemon management
 # ============================================================================
@@ -1566,9 +1573,9 @@ class TestDenoKernel:
         assert ks["display_name"] == "Deno"
         assert ks.get("language") == "typescript"
 
-        # Has zero cells (frontend creates the first cell locally)
+        # Has the daemon-owned starter cell
         cells = await deno_session.get_cells()
-        assert len(cells) == 0
+        assert_daemon_starter_cell(cells)
 
         # Verify the kernel is actually Deno by executing TypeScript
         result = await deno_session.execute_cell(
@@ -2512,6 +2519,12 @@ class TestExecutionIdScoping:
         """notebook.queue_all() returns execution handles for each queued cell."""
         await notebook.start()
 
+        assert len(notebook.cells) == 1
+        starter = notebook.cells.get_by_index(0)
+        assert starter.cell_type == "code"
+        assert starter.source == ""
+        starter_id = starter.id
+
         first = await notebook.cells.create("print('first')")
         second = await notebook.cells.create("print('second')")
         await asyncio.sleep(0.5)
@@ -2519,7 +2532,7 @@ class TestExecutionIdScoping:
         executions = await notebook.queue_all()
 
         execution_by_cell = {execution.cell_id: execution for execution in executions}
-        assert set(execution_by_cell) == {first.id, second.id}
+        assert set(execution_by_cell) == {starter_id, first.id, second.id}
         for execution in executions:
             assert isinstance(execution.execution_id, str)
             assert len(execution.execution_id) == 36
@@ -2834,23 +2847,23 @@ class TestCreateNotebook:
     """Test Client.create_notebook() - daemon-owned creation."""
 
     async def test_create_python_notebook(self, client):
-        """Creating Python notebook returns session with zero cells."""
+        """Creating Python notebook returns session with daemon starter cell."""
         session = await client.create_notebook(runtime="python")
         assert await session.is_connected()
 
         # notebook_id is UUID (not a path)
         assert len(session.notebook_id) == 36  # UUID format
 
-        # Has zero cells (frontend creates the first cell locally)
+        # Has the daemon-owned starter cell
         cells = await session.get_cells()
-        assert len(cells) == 0
+        assert_daemon_starter_cell(cells)
 
     async def test_create_notebook_returns_connection_info(self, client):
         """NotebookConnectionInfo is available for created notebooks."""
         session = await client.create_notebook(runtime="python")
         info = await session.connection_info()
         assert info is not None
-        assert info.cell_count == 0
+        assert info.cell_count == 1
         assert info.notebook_id == session.notebook_id
         # New notebooks don't need trust approval
         assert info.needs_trust_approval is False


### PR DESCRIPTION
## Summary

Move starter-cell seeding off the client and onto whichever component is the host authority, so a brand-new notebook gets exactly one code cell from the host and transient empty sync state never makes the client create local structure.

- Daemon-hosted notebooks: seed a fresh daemon-owned doc with default metadata and one starter code cell.
- Cloud rooms: the host runs in-browser via the `runtimed-wasm` `RoomHostHandle` and never touches the daemon, so it seeds itself. `RoomMaterializer` calls `seed_initial_code_cell_if_empty` once on the brand-new empty-room path.
- Client: remove `NotebookView`'s first-cell auto-seed so an empty-but-synced notebook is no longer treated as "needs a cell."

## Initialization policy

The "should I seed?" gate is `is_uninitialized_notebook_doc`: zero cells **and** no metadata snapshot. Because `create_empty_notebook` always writes metadata, a notebook a user deliberately emptied still reports `metadata.is_some()` and is never re-seeded. The same predicate guards every daemon entry point: CreateNotebook, OpenNotebook new-file, and the UUID NotebookSync connect/reconnect path.

The cloud `seed_initial_code_cell_if_empty` guard is `cell_count() > 0` rather than metadata-aware. That's safe in context: it only runs on the materializer's `source: "empty_room"` branch, which by definition has no persisted revision, so it can't fire against a user-emptied room (those hydrate from a checkpoint instead).

## Consolidation note

This branch is the survivor of three overlapping attempts at the same feature (closes #3323 and #3326). It keeps the metadata-aware daemon guard and the dual daemon-path coverage from this branch, and grafts the cloud/wasm seed path that only #3326 had. #3323 used a `cell_count`-only guard, covered only the CreateNotebook handshake, and removed the cloud `canAcceptStructure` fallback without a replacement; its unrelated markdown-editor change is being salvaged as its own PR.

## Verification

- `cargo test -p runtimed-wasm room_host_seeds_initial_code_cell_idempotently` ✅
- `apps/notebook-cloud` room-materializer suite: 29/29 ✅ (includes the new hosted-room seeding tests)
- `cargo test -p runtimed create_empty_notebook`
- `notebook-view-capabilities-source.test.ts`
- `cargo xtask lint --fix`

## Suggested merge order

Land after #3325 (shared state stores) to avoid re-touching `NotebookView.tsx` import churn, then #3329 (edit gating) rebases on top.
