### PR TITLE
fix(notebook): gate structure edits on host support

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -130,26 +130,12 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(
-    sourceText,
-    /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState\) && !showCloudIdentityControls/,
-  );
+  assert.match(sourceText, /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState\) \? \(/);
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
-  assert.match(sourceText, /identityControls=\{[\s\S]*showCloudIdentityControls \? \(/);
-  assert.match(sourceText, /identityControls=\{[\s\S]*<CloudAuthControls/);
-  assert.match(sourceText, /<NotebookIdentityBadge[\s\S]*showStatus=\{false\}/);
-  assert.match(
-    sourceText,
-    /<UserRound className="cloud-auth-identity-icon" aria-hidden="true" \/>/,
-  );
-  assert.match(
-    sourceText,
-    /function shouldShowCloudIdentityControls[\s\S]*authState\.mode === "anonymous"[\s\S]*return showPrototypeDevControls && hasExplicitPrototypeDevAuthSearch\(search\);/,
-  );
+  assert.match(sourceText, /identityControls=\{null\}/);
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
   assert.match(sourceText, /matchMedia\("\(max-width: 599\.98px\)"\)/);
-  assert.match(sourceText, /function hasExplicitPrototypeDevAuthSearch/);
   assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
   assert.match(sourceText, /cloudViewerPresenceDisplay,/);
   assert.match(sourceText, /Public link, collaborators, and pending invites for this notebook\./);
@@ -167,34 +153,18 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /Only invited people can open this notebook/);
   assert.match(sourceText, /const copyLinkLabel =[\s\S]*"Copy link"/);
   assert.match(sourceText, /const compactCopyLinkLabel =[\s\S]*"Copy"/);
-  assert.match(sourceText, /const accessRow = connectedScope/);
   assert.match(
     sourceText,
-    /const requestedAccessRow =[\s\S]*connectedScope && connectedScope !== requestedScope/,
-  );
-  assert.match(sourceText, /description: accessDescription/);
-  assert.match(
-    sourceText,
-    /`\$\{cloudRequestedAccessLabel\(requestedScope\)\} requested for this notebook\.`/,
+    /const accessRows = useMemo\(\(\) => buildCloudShareAccessRows\(\{ acl, invites \}\), \[acl, invites\]\)/,
   );
   assert.match(
     sourceText,
-    /`\$\{cloudRequestedAccessLabel\(requestedScope\)\} requested from a local dev identity\.`/,
+    /accessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,
   );
-  assert.match(sourceText, /function cloudRequestedAccessLabel/);
-  assert.match(sourceText, /function cloudGrantedAccessDescription/);
-  assert.match(
-    sourceText,
-    /`\$\{granted\} \$\{cloudRequestedAccessLabel\(requestedScope\)\} is still requested\.`/,
-  );
+  assert.match(sourceText, /aria-label=\{`Remove \$\{row\.label\}`\}/);
   assert.match(
     sourceText,
     /function CloudPresenceStatus[\s\S]*const presenceDisplay = cloudViewerPresenceDisplay\(presence\);[\s\S]*if \(!presenceDisplay\.connected\) \{[\s\S]*return null;/,
-  );
-  assert.match(cssText, /@media \(max-width: 360px\) \{[\s\S]*cloud-auth-identity-icon/);
-  assert.match(
-    cssText,
-    /cloud-auth-identity-summary \.cloud-auth-identity-badge > span[\s\S]*display: none;/,
   );
   assert.match(
     cssText,
@@ -202,7 +172,11 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(
     cssText,
-    /@media \(max-width: 520px\) \{[\s\S]*cloud-room-toolbar \.cloud-connection-status[\s\S]*width: 2rem;[\s\S]*cloud-room-toolbar \.cloud-connection-status span[\s\S]*display: none;/,
+    /\.cloud-connection-status \{[\s\S]*width: 1\.875rem;[\s\S]*height: 1\.875rem;/,
+  );
+  assert.match(
+    cssText,
+    /\.cloud-connection-status span \{[\s\S]*position: absolute;[\s\S]*width: 1px;[\s\S]*clip: rect\(0, 0, 0, 0\);/,
   );
   assert.match(
     cssText,
@@ -235,27 +209,26 @@ test("cloud viewer routes notebook header controls through the shared shell chro
 test("cloud viewer presents live-room failures as one host notice", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
+  const noticesPath = new URL("../viewer/notices.tsx", import.meta.url);
+  const noticesText = readFileSync(noticesPath, "utf8");
 
-  assert.match(sourceText, /const connectionNotice = connectionError/);
   assert.match(sourceText, /const notebookHasReadableSnapshot =/);
   assert.match(
     sourceText,
     /notebookCellIds\.length > 0 \|\|[\s\S]*!\s*connectionError && snapshotResolvedRef\.current && status\.kind === "ready"/,
   );
-  assert.match(
-    sourceText,
-    /cloudConnectionNoticeDisplay\(connectionError, notebookHasReadableSnapshot\)/,
-  );
-  assert.match(sourceText, /const shouldShowStatusNotice =/);
-  assert.match(sourceText, /isStatusDerivedFromConnectionError\(status, connectionError\)/);
-  assert.match(sourceText, /function isStatusDerivedFromConnectionError/);
-  assert.match(sourceText, /function cloudConnectionNoticeDisplay/);
-  assert.match(sourceText, /hasReadableSnapshot: boolean/);
-  assert.match(sourceText, /Live room unavailable\./);
-  assert.match(sourceText, /The notebook will load once the account or connection is refreshed\./);
-  assert.match(sourceText, /tone=\{connectionNotice\.tone\}/);
-  assert.match(sourceText, /Live room reconnecting\./);
-  assert.match(sourceText, /tone: "warning"/);
+  assert.match(noticesText, /const connectionNotice = connectionError/);
+  assert.match(noticesText, /cloudConnectionNoticeDisplay\(connectionError, hasReadableSnapshot\)/);
+  assert.match(noticesText, /const shouldShowStatusNotice =/);
+  assert.match(noticesText, /isStatusDerivedFromConnectionError\(status, connectionError\)/);
+  assert.match(noticesText, /function isStatusDerivedFromConnectionError/);
+  assert.match(noticesText, /function cloudConnectionNoticeDisplay/);
+  assert.match(noticesText, /hasReadableSnapshot: boolean/);
+  assert.match(noticesText, /Live room unavailable\./);
+  assert.match(noticesText, /The notebook will load once the account or connection is refreshed\./);
+  assert.match(noticesText, /tone=\{connectionNotice\.tone\}/);
+  assert.match(noticesText, /Live room reconnecting\./);
+  assert.match(noticesText, /tone: "warning"/);
   assert.match(sourceText, /function cloudConnectionStatusErrorTitle/);
   assert.match(sourceText, /aria-label=\{title\}/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -10,6 +10,7 @@ test("cloud notebook body renders through the desktop NotebookView surface", () 
   assert.match(sourceText, /<NotebookView[\s\S]*cellIds=\{notebookCellIds\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*autoSeedEmptyNotebook=\{false\}/);
+  assert.match(sourceText, /<NotebookView[\s\S]*canAcceptCellMutations=\{canAcceptCellMutations\}/);
   assert.doesNotMatch(sourceText, /canAcceptCellMutations=\{false\}/);
   assert.doesNotMatch(sourceText, /readOnly=\{!canEditMarkdown\}/);
   assert.doesNotMatch(sourceText, /import \{ CloudLiveNotebook \}/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -9,7 +9,6 @@ test("cloud notebook body renders through the desktop NotebookView surface", () 
   assert.match(sourceText, /from "\.\.\/\.\.\/notebook\/src\/components\/NotebookView"/);
   assert.match(sourceText, /<NotebookView[\s\S]*cellIds=\{notebookCellIds\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(sourceText, /<NotebookView[\s\S]*autoSeedEmptyNotebook=\{false\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*canAcceptCellMutations=\{canAcceptCellMutations\}/);
   assert.doesNotMatch(sourceText, /canAcceptCellMutations=\{false\}/);
   assert.doesNotMatch(sourceText, /readOnly=\{!canEditMarkdown\}/);
@@ -120,17 +119,14 @@ test("cloud package rail stays package-only and leaves sync/env state to app chr
 });
 
 test("cloud identity chrome renders through the shared actor projection surface", () => {
-  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourcePath = new URL("../viewer/shell-capabilities.ts", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /NotebookIdentityBadge/);
-  assert.match(sourceText, /notebookActorIdentityFromAccess/);
-  assert.match(sourceText, /capabilities=\{shellCapabilities\}/);
-  assert.match(
-    sourceText,
-    /const actor = notebookActorIdentityFromAccess\(capabilities\.access, capabilities\.auth\)/,
-  );
-  assert.match(sourceText, /<NotebookIdentityBadge[\s\S]*actor=\{actor\}/);
+  assert.match(sourceText, /notebookActorProjectionFromAccess/);
+  assert.match(sourceText, /notebookActorProjectionFromRuntime/);
+  assert.match(sourceText, /const accessActor = withCloudIdentityImage/);
+  assert.match(sourceText, /actor: accessActor/);
+  assert.match(sourceText, /actor: runtimeActor/);
 });
 
 test("cloud presence chrome renders through the shared shell component", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -72,6 +72,24 @@ test("cloud shell capabilities grant editors full cell and structure editing wit
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
+test("cloud shell capabilities wait for host mutation support before activating editor mode", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    canAcceptCellMutations: false,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "requested");
+  assert.equal(capabilities.access.level, "editor");
+});
+
 test("cloud shell capabilities surface execution only when a runtime is available", () => {
   const withoutRuntime = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1163,6 +1163,10 @@ function NotebookViewer({
     setRailCollapsed(false);
     setActiveRailPanel("packages");
   }, [activeRailPanel, railCollapsed]);
+  const canAcceptCellMutations =
+    Boolean(connectionPeerId) &&
+    !connectionError &&
+    (status.kind === "ready" || status.kind === "empty");
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -1171,8 +1175,16 @@ function NotebookViewer({
         connectionActorLabel,
         hasCodeCells: codeCellCount > 0,
         selectedMode: selectedInteractionMode,
+        canAcceptCellMutations,
       }),
-    [authState, codeCellCount, connectionActorLabel, connectionScope, selectedInteractionMode],
+    [
+      authState,
+      canAcceptCellMutations,
+      codeCellCount,
+      connectionActorLabel,
+      connectionScope,
+      selectedInteractionMode,
+    ],
   );
   const canWriteCellSource = useCallback(
     (cellId: string) => {
@@ -1395,6 +1407,7 @@ function NotebookViewer({
             cellIds={notebookCellIds}
             isLoading={notebookViewIsLoading}
             capabilities={shellCapabilities}
+            canAcceptCellMutations={canAcceptCellMutations}
             runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
             sessionRuntimeState={connectionError ? "error" : "ready"}
             onFocusCell={setFocusedCellId}

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -16,6 +16,12 @@ export interface CloudNotebookShellCapabilityInput {
   hasCodeCells: boolean;
   selectedMode?: NotebookInteractionMode;
   /**
+   * Whether the hosted live room is connected and the NotebookDoc materialized
+   * enough to accept local cell/source mutations. Access can grant editing
+   * before the local host is ready to safely write.
+   */
+  canAcceptCellMutations?: boolean;
+  /**
    * Whether an execution runtime is attached to the room. The hosted prototype
    * has no kernel provider yet, so this defaults false and run controls stay
    * hidden. Flip it on once a runtime peer can execute the room's cells.
@@ -29,6 +35,7 @@ export function cloudNotebookShellCapabilities({
   connectionActorLabel = null,
   hasCodeCells,
   selectedMode = "view",
+  canAcceptCellMutations = true,
   runtimeAvailable = false,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
@@ -49,9 +56,9 @@ export function cloudNotebookShellCapabilities({
       canEditStructure: accessLevel === "editor" || accessLevel === "owner",
     },
     hostSupport: {
-      canEditMarkdown: true,
-      canEditCells: true,
-      canEditStructure: true,
+      canEditMarkdown: canAcceptCellMutations,
+      canEditCells: canAcceptCellMutations,
+      canEditStructure: canAcceptCellMutations,
       canRequestEdit: authState.mode === "dev" || authState.mode === "oidc",
     },
   });

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -376,7 +376,8 @@ function NotebookViewContent({
   const tailScrollFrameRef = useRef<number | null>(null);
   const canEditCodeCellSources = capabilities?.canEditCells ?? !readOnly;
   const canEditMarkdownSources = capabilities?.canEditMarkdown ?? !readOnly;
-  const canMutateCells = capabilities?.canEditStructure ?? (canAcceptCellMutations && !readOnly);
+  const canMutateCells =
+    canAcceptCellMutations && (capabilities?.canEditStructure ?? !readOnly);
   const canExecuteCells = capabilities?.canExecute ?? !readOnly;
 
   // Read transient UI state from the store instead of props

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -33,6 +33,7 @@ import { usePresenceContext } from "../contexts/PresenceContext";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import { useFocusedCellId, useSearchCurrentMatch } from "@/components/notebook/state/cell-ui-state";
 import { logger } from "../lib/logger";
+import { computeCanMutateCells } from "../lib/notebook-mutation-gate";
 import {
   getCellById,
   getNotebookCellsSnapshot,
@@ -376,7 +377,7 @@ function NotebookViewContent({
   const tailScrollFrameRef = useRef<number | null>(null);
   const canEditCodeCellSources = capabilities?.canEditCells ?? !readOnly;
   const canEditMarkdownSources = capabilities?.canEditMarkdown ?? !readOnly;
-  const canMutateCells = canAcceptCellMutations && (capabilities?.canEditStructure ?? !readOnly);
+  const canMutateCells = computeCanMutateCells({ canAcceptCellMutations, capabilities, readOnly });
   const canExecuteCells = capabilities?.canExecute ?? !readOnly;
 
   // Read transient UI state from the store instead of props

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -376,8 +376,7 @@ function NotebookViewContent({
   const tailScrollFrameRef = useRef<number | null>(null);
   const canEditCodeCellSources = capabilities?.canEditCells ?? !readOnly;
   const canEditMarkdownSources = capabilities?.canEditMarkdown ?? !readOnly;
-  const canMutateCells =
-    canAcceptCellMutations && (capabilities?.canEditStructure ?? !readOnly);
+  const canMutateCells = canAcceptCellMutations && (capabilities?.canEditStructure ?? !readOnly);
   const canExecuteCells = capabilities?.canExecute ?? !readOnly;
 
   // Read transient UI state from the store instead of props

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -12,8 +12,12 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/capabilities\?: NotebookShellCapabilities;/);
     expect(sourceText).toMatch(/capabilities\?\.canEditCells \?\? !readOnly/);
     expect(sourceText).toMatch(/capabilities\?\.canEditMarkdown \?\? !readOnly/);
+    // Structure-edit gating now lives in computeCanMutateCells (see
+    // notebook-view-mutation-gate.test.ts for the behavioral truth table).
+    // NotebookView must still route through that helper with the host gate,
+    // capabilities, and readOnly fallback.
     expect(sourceText).toMatch(
-      /canAcceptCellMutations && \(capabilities\?\.canEditStructure \?\? !readOnly\)/,
+      /canMutateCells = computeCanMutateCells\(\{ canAcceptCellMutations, capabilities, readOnly \}\)/,
     );
     expect(sourceText).toMatch(/capabilities\?\.canExecute \?\? !readOnly/);
     expect(sourceText).toMatch(/<CodeCell[\s\S]*canExecute=\{canExecuteCells\}/);

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -13,7 +13,7 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/capabilities\?\.canEditCells \?\? !readOnly/);
     expect(sourceText).toMatch(/capabilities\?\.canEditMarkdown \?\? !readOnly/);
     expect(sourceText).toMatch(
-      /capabilities\?\.canEditStructure \?\? \(canAcceptCellMutations && !readOnly\)/,
+      /canAcceptCellMutations && \(capabilities\?\.canEditStructure \?\? !readOnly\)/,
     );
     expect(sourceText).toMatch(/capabilities\?\.canExecute \?\? !readOnly/);
     expect(sourceText).toMatch(/<CodeCell[\s\S]*canExecute=\{canExecuteCells\}/);

--- a/apps/notebook/src/components/__tests__/notebook-view-mutation-gate.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-mutation-gate.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Behavioral coverage for the cell-mutation gate that NotebookView applies to
+ * add/delete/move and source/output-hiding affordances.
+ *
+ * This exercises `computeCanMutateCells` directly across the truth table rather
+ * than grepping the source string, so it proves the resolved boolean — the same
+ * value NotebookView feeds into every `canMutateCells ? ... : undefined` prop —
+ * rather than the shape of the expression that produces it.
+ */
+
+import { describe, expect, it } from "vite-plus/test";
+import type { NotebookShellCapabilities } from "@/components/notebook";
+import { computeCanMutateCells } from "../../lib/notebook-mutation-gate";
+
+/** Minimal capability projection: only `canEditStructure` is consulted. */
+function caps(canEditStructure: boolean): Pick<NotebookShellCapabilities, "canEditStructure"> {
+  return { canEditStructure };
+}
+
+describe("computeCanMutateCells", () => {
+  describe("canAcceptCellMutations is a hard gate", () => {
+    it("blocks mutations when the host rejects them, even if the capability allows structure edits", () => {
+      // canEditStructure=true would normally enable add/delete/move, but a host
+      // that cannot accept mutations (e.g. cloud notebook with no editing host)
+      // overrides it.
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: false,
+          capabilities: caps(true),
+          readOnly: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("blocks mutations when the host rejects them and readOnly is false with no capabilities", () => {
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: false,
+          capabilities: undefined,
+          readOnly: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("once the host accepts mutations, capability decides", () => {
+    it("allows mutations when canEditStructure is true", () => {
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: true,
+          capabilities: caps(true),
+          readOnly: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("blocks mutations when canEditStructure is false (capability overrides readOnly fallback)", () => {
+      // Even with readOnly=false, an explicit capability projection saying
+      // structure edits are not permitted wins.
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: true,
+          capabilities: caps(false),
+          readOnly: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("readOnly fallback when no capability projection is supplied", () => {
+    it("allows mutations when readOnly is false", () => {
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: true,
+          capabilities: undefined,
+          readOnly: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("blocks mutations when readOnly is true", () => {
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: true,
+          capabilities: undefined,
+          readOnly: true,
+        }),
+      ).toBe(false);
+    });
+
+    it("treats null capabilities the same as undefined", () => {
+      expect(
+        computeCanMutateCells({
+          canAcceptCellMutations: true,
+          capabilities: null,
+          readOnly: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("full truth table", () => {
+    // canAcceptCellMutations × canEditStructure (capability present) × readOnly
+    const cases: Array<{
+      accept: boolean;
+      structure: boolean | "none";
+      readOnly: boolean;
+      expected: boolean;
+    }> = [
+      // Host rejects: always false regardless of anything else.
+      { accept: false, structure: true, readOnly: false, expected: false },
+      { accept: false, structure: false, readOnly: false, expected: false },
+      { accept: false, structure: "none", readOnly: false, expected: false },
+      { accept: false, structure: "none", readOnly: true, expected: false },
+      // Host accepts + explicit capability: capability decides.
+      { accept: true, structure: true, readOnly: false, expected: true },
+      { accept: true, structure: true, readOnly: true, expected: true },
+      { accept: true, structure: false, readOnly: false, expected: false },
+      { accept: true, structure: false, readOnly: true, expected: false },
+      // Host accepts + no capability: readOnly fallback decides.
+      { accept: true, structure: "none", readOnly: false, expected: true },
+      { accept: true, structure: "none", readOnly: true, expected: false },
+    ];
+
+    for (const { accept, structure, readOnly, expected } of cases) {
+      it(`accept=${accept} structure=${structure} readOnly=${readOnly} → ${expected}`, () => {
+        expect(
+          computeCanMutateCells({
+            canAcceptCellMutations: accept,
+            capabilities: structure === "none" ? undefined : caps(structure),
+            readOnly,
+          }),
+        ).toBe(expected);
+      });
+    }
+  });
+});

--- a/apps/notebook/src/lib/notebook-mutation-gate.ts
+++ b/apps/notebook/src/lib/notebook-mutation-gate.ts
@@ -1,0 +1,26 @@
+import type { NotebookShellCapabilities } from "@/components/notebook";
+
+/**
+ * Resolves whether cell-structure mutations (add/delete/move, source/output
+ * hiding) are allowed in the notebook view.
+ *
+ * `canAcceptCellMutations` is a hard gate: a live host that cannot accept
+ * structure changes (e.g. a cloud notebook with no editing host attached)
+ * forces this to `false` regardless of the resolved capability. Only once the
+ * host accepts mutations does the shell capability `canEditStructure` — or the
+ * `readOnly` fallback when no capability projection is supplied — decide.
+ *
+ * Kept in its own module (no React, no WASM imports) so the gate's truth table
+ * can be unit-tested without pulling in the full NotebookView module graph.
+ */
+export function computeCanMutateCells({
+  canAcceptCellMutations,
+  capabilities,
+  readOnly,
+}: {
+  canAcceptCellMutations: boolean;
+  capabilities?: Pick<NotebookShellCapabilities, "canEditStructure"> | null;
+  readOnly: boolean;
+}): boolean {
+  return canAcceptCellMutations && (capabilities?.canEditStructure ?? !readOnly);
+}


### PR DESCRIPTION
## Summary

- Require `NotebookView` structure mutation UI to have both shared edit capability and explicit host mutation acceptance.
- Teach notebook-cloud capabilities that editor access is not active editing until the live room can accept local mutations.
- Pass cloud's live host mutation acceptance into the shared NotebookView surface and cover it with focused tests.

## Why

This keeps permission, selected mode, and host support as separate axes. Cloud can connect as an editor while the room is still loading, reconnecting, or unavailable without surfacing local add/delete/reorder affordances that would desync from the CRDT/server source of truth.

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
