### PR TITLE
fix(notebook): reconcile markdown edit mode with shared focus

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -267,10 +267,13 @@ export const MarkdownCell = memo(function MarkdownCell({
       setEditing(false);
       return;
     }
+    if (!isFocused && editing && cell.source.trim()) {
+      setEditing(false);
+    }
     if (!isFocused || editing) {
       setPreviewFrameInteractionActive(false);
     }
-  }, [isFocused, editing, readOnly]);
+  }, [cell.source, isFocused, editing, readOnly]);
 
   const handleBlur = useCallback(() => {
     if (cell.source.trim()) {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -262,18 +262,21 @@ export const MarkdownCell = memo(function MarkdownCell({
     [],
   );
 
+  // Derived boundary flag: re-run the focus effect only when source crosses
+  // empty↔non-empty, not on every keystroke.
+  const hasContent = cell.source.trim().length > 0;
   useEffect(() => {
     if (readOnly) {
       setEditing(false);
       return;
     }
-    if (!isFocused && editing && cell.source.trim()) {
+    if (!isFocused && editing && hasContent) {
       setEditing(false);
     }
     if (!isFocused || editing) {
       setPreviewFrameInteractionActive(false);
     }
-  }, [cell.source, isFocused, editing, readOnly]);
+  }, [hasContent, isFocused, editing, readOnly]);
 
   const handleBlur = useCallback(() => {
     if (cell.source.trim()) {

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -342,6 +342,54 @@ describe("MarkdownCell theme sync", () => {
     expect(preview.className).not.toContain("hidden");
   });
 
+  it("exits edit mode when a focused cell with content loses notebook focus", async () => {
+    const cell = { ...makeCell(), source: "# Has content" };
+    mockIsFocused = true;
+
+    const { getByLabelText, rerender } = render(
+      <MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    // Enter edit mode from the preview (plain Enter on the focused view).
+    fireEvent.keyDown(preview, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+
+    // Notebook focus moves to another cell — the focus effect should drop
+    // this cell back to preview because it has content.
+    mockIsFocused = false;
+    rerender(<MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />);
+
+    await waitFor(() => {
+      expect(preview.className).not.toContain("hidden");
+    });
+  });
+
+  it("stays editable when an empty cell loses notebook focus", async () => {
+    // Empty cells begin in edit mode and must not be forced into an
+    // uneditable preview when notebook focus moves away.
+    const cell = { ...makeCell(), source: "" };
+    mockIsFocused = true;
+
+    const { getByLabelText, rerender } = render(
+      <MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(preview.className).toContain("hidden");
+
+    mockIsFocused = false;
+    rerender(<MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />);
+
+    // The editor must remain visible (preview stays hidden) after losing focus.
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+  });
+
   it("keeps view-mode keyboard navigation active for read-only markdown cells", () => {
     const onFocusNext = vi.fn();
     const onFocusPrevious = vi.fn();

--- a/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
+++ b/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
@@ -230,10 +230,6 @@ describe("edit/view toggle conditions", () => {
     return source.trim().length > 0;
   }
 
-  function shouldExitEditWhenUnfocused(source: string, isFocused: boolean): boolean {
-    return !isFocused && source.trim().length > 0;
-  }
-
   it("exits edit mode when cell has content", () => {
     expect(shouldExitEditOnBlur("# Hello")).toBe(true);
   });
@@ -248,18 +244,6 @@ describe("edit/view toggle conditions", () => {
 
   it("exits edit mode for single character content", () => {
     expect(shouldExitEditOnBlur("a")).toBe(true);
-  });
-
-  it("exits edit mode when a non-empty cell loses notebook focus", () => {
-    expect(shouldExitEditWhenUnfocused("# Hello", false)).toBe(true);
-  });
-
-  it("keeps the focused markdown cell in edit mode", () => {
-    expect(shouldExitEditWhenUnfocused("# Hello", true)).toBe(false);
-  });
-
-  it("keeps an unfocused empty markdown cell editable", () => {
-    expect(shouldExitEditWhenUnfocused("", false)).toBe(false);
   });
 
   /**

--- a/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
+++ b/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
@@ -230,6 +230,10 @@ describe("edit/view toggle conditions", () => {
     return source.trim().length > 0;
   }
 
+  function shouldExitEditWhenUnfocused(source: string, isFocused: boolean): boolean {
+    return !isFocused && source.trim().length > 0;
+  }
+
   it("exits edit mode when cell has content", () => {
     expect(shouldExitEditOnBlur("# Hello")).toBe(true);
   });
@@ -244,6 +248,18 @@ describe("edit/view toggle conditions", () => {
 
   it("exits edit mode for single character content", () => {
     expect(shouldExitEditOnBlur("a")).toBe(true);
+  });
+
+  it("exits edit mode when a non-empty cell loses notebook focus", () => {
+    expect(shouldExitEditWhenUnfocused("# Hello", false)).toBe(true);
+  });
+
+  it("keeps the focused markdown cell in edit mode", () => {
+    expect(shouldExitEditWhenUnfocused("# Hello", true)).toBe(false);
+  });
+
+  it("keeps an unfocused empty markdown cell editable", () => {
+    expect(shouldExitEditWhenUnfocused("", false)).toBe(false);
   });
 
   /**


### PR DESCRIPTION
## Summary

Cloud and desktop should share notebook behavior. Cloud can own transport, auth, room state, and host chrome, but cell editing should stay in the shared notebook surface.

This updates the shared `MarkdownCell` so a non-empty markdown cell exits edit mode when it loses notebook-level focus through the shared focus projection. Desktop already handles the normal DOM blur path; this closes the projected-focus path used by shared hosts such as cloud.

Empty markdown cells stay editable when focus moves away, so a freshly-added blank cell does not collapse into an unusable preview.

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx apps/notebook/src/components/__tests__/markdown-formatting.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `cargo xtask lint --fix`
