### PR TITLE
ci: move workflows off blacksmith runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
-self-hosted-runner:
-  labels:
-    - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-4vcpu-ubuntu-2204
-    - blacksmith-4vcpu-windows-2025
-    - blacksmith-6vcpu-macos-15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -291,7 +291,7 @@ jobs:
       - name: Run browser E2E
         run: pnpm --filter notebook-ui test:e2e:browser -- --project=chromium
         env:
-          NTERACT_BROWSER_E2E_READY_TIMEOUT_MS: 300000
+          NTERACT_BROWSER_E2E_READY_TIMEOUT_MS: 900000
 
       - name: Upload Playwright report
         if: failure()
@@ -903,6 +903,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   changes:
     name: Detect source changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       source_changed: ${{ steps.filter.outputs.source }}
     steps:
@@ -61,7 +61,7 @@ jobs:
     name: Lint & Format
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,7 +98,7 @@ jobs:
     name: NSIS Bootstrap Syntax
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -118,7 +118,7 @@ jobs:
     name: Windows (clippy)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -153,7 +153,7 @@ jobs:
     name: WASM + Deno Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -189,7 +189,7 @@ jobs:
     name: Build shared UI artifacts
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -236,7 +236,7 @@ jobs:
     name: JS Tests & Benchmarks
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -265,7 +265,7 @@ jobs:
     name: Browser E2E (Playwright)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -413,7 +413,7 @@ jobs:
     name: Linux Rust Clippy
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -448,7 +448,7 @@ jobs:
     name: Linux Rust Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -477,7 +477,7 @@ jobs:
     name: Linux runtimed-node
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -521,7 +521,7 @@ jobs:
       - linux-rust-tests
       - linux-runtimed-node
     if: always() && needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Check shard results
         run: |
@@ -900,7 +900,7 @@ jobs:
   # Python daemon integration tests — builds its own runtimed binary
   runtimed-py-integration:
     name: runtimed-py Integration Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
@@ -1014,7 +1014,7 @@ jobs:
     name: Python Unit Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   label:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/labeler@v6

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   update-hashes:
     name: Update Nix hashes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   resolve-pr:
     name: Resolve PR metadata
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       pr_number: ${{ steps.resolve.outputs.pr_number }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
@@ -68,7 +68,7 @@ jobs:
   build:
     name: Build ${{ inputs.target_os == 'linux' && 'Linux x64' || inputs.target_os == 'macos' && 'macOS' || 'Windows x64' }} binary
     needs: [resolve-pr]
-    runs-on: ${{ inputs.target_os == 'linux' && 'blacksmith-4vcpu-ubuntu-2204' || inputs.target_os == 'macos' && 'blacksmith-6vcpu-macos-15' || 'blacksmith-4vcpu-windows-2025' }}
+    runs-on: ${{ inputs.target_os == 'linux' && 'ubuntu-22.04' || inputs.target_os == 'macos' && 'macos-15' || 'windows-2025' }}
     env:
       NTERACT_BUILD_GIT_HASH: ${{ needs.resolve-pr.outputs.head_sha }}
 

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   compute-version:
     name: Compute Version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
       timestamp: ${{ steps.version.outputs.TIMESTAMP }}
@@ -81,7 +81,7 @@ jobs:
 
   build-wasm:
     name: Build WASM artifacts
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -111,7 +111,7 @@ jobs:
 
   build-linux:
     name: Build Linux Executables
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -249,7 +249,7 @@ jobs:
 
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
-    runs-on: blacksmith-6vcpu-macos-15
+    runs-on: macos-15
     needs: [compute-version, build-wasm]
     steps:
       - name: Checkout
@@ -594,7 +594,7 @@ jobs:
 
   build-notebook-windows-x64:
     name: Build Windows x64 Notebook
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-2025
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -768,7 +768,7 @@ jobs:
 
   build-notebook-linux-x64:
     name: Build Linux x64 Notebook
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: [compute-version, build-wasm]
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -892,7 +892,7 @@ jobs:
 
   smoke-fedora-appimage:
     name: Smoke Fedora AppImage
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: [build-notebook-linux-x64]
     steps:
       - name: Checkout
@@ -930,16 +930,16 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: blacksmith-6vcpu-macos-15
+          - runner: macos-15
             target: aarch64-apple-darwin
             sccache: false
           - runner: macos-14
             target: x86_64-apple-darwin
             sccache: false
-          - runner: blacksmith-4vcpu-ubuntu-2404
+          - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             sccache: true
-          - runner: blacksmith-4vcpu-windows-2025
+          - runner: windows-2025
             target: x86_64-pc-windows-msvc
             sccache: true
     steps:
@@ -1068,7 +1068,7 @@ jobs:
     # testing can opt out).
     name: Publish agent plugins
     if: inputs.publish_plugin_channel != ''
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       [
         compute-version,
@@ -1169,7 +1169,7 @@ jobs:
 
   prerelease:
     name: ${{ inputs.release_title }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   deploy:
     name: Build & Deploy Sift Preview
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- replace all remaining Blacksmith runner labels with GitHub-hosted runner labels
- keep Ubuntu 22.04 for Linux release/package jobs that were already pinned to 22.04
- remove the now-unused actionlint custom runner allowlist
- give Browser E2E a longer daemon startup window on GitHub-hosted Ubuntu and cap the long runtimed-py integration job at 60 minutes
- reduce runtimed-py integration parallelism on GitHub-hosted Ubuntu to avoid daemon health-check timeouts under lower runner throughput

## Runner mapping

- `blacksmith-4vcpu-ubuntu-2404` -> `ubuntu-24.04`
- `blacksmith-4vcpu-ubuntu-2204` -> `ubuntu-22.04`
- `blacksmith-4vcpu-windows-2025` -> `windows-2025`
- `blacksmith-6vcpu-macos-15` -> `macos-15`

## Verification

- `rg -n "blacksmith" .`
- `actionlint .github/workflows/*.yml`
- `cargo xtask lint --fix`
