### PR TITLE
ci: stabilize github-hosted runner smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:
@@ -289,7 +289,7 @@ jobs:
         run: pnpm --filter notebook-ui exec playwright install --with-deps chromium
 
       - name: Run browser E2E
-        run: pnpm --filter notebook-ui test:e2e:browser -- --project=chromium
+        run: pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1
         env:
           NTERACT_BROWSER_E2E_READY_TIMEOUT_MS: 900000
 
@@ -903,7 +903,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6
         with:
@@ -986,7 +986,7 @@ jobs:
           # timeout = 600). uv-installed bindings landed in
           # ${GITHUB_WORKSPACE}/.venv via VIRTUAL_ENV in the previous step.
           export VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv"
-          export RUNTIMED_PYTEST_WORKERS=3
+          export RUNTIMED_PYTEST_WORKERS=1
           uv run pytest \
             tests/test_daemon_integration.py \
             tests/test_dx_integration.py \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -986,7 +986,7 @@ jobs:
           # timeout = 600). uv-installed bindings landed in
           # ${GITHUB_WORKSPACE}/.venv via VIRTUAL_ENV in the previous step.
           export VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv"
-          export RUNTIMED_PYTEST_WORKERS=6
+          export RUNTIMED_PYTEST_WORKERS=3
           uv run pytest \
             tests/test_daemon_integration.py \
             tests/test_dx_integration.py \

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2918,6 +2918,9 @@ class TestTrustApproval:
     async def test_untrusted_notebook_needs_approval(self, client, tmp_path):
         """Notebook with inline deps from unknown source needs trust."""
         import json
+        import uuid
+
+        dep_name = f"nteract-unapproved-uv-dep-{uuid.uuid4().hex}"
 
         nb_path = tmp_path / "untrusted.ipynb"
         nb_path.write_text(
@@ -2928,7 +2931,7 @@ class TestTrustApproval:
                     "metadata": {
                         "runt": {
                             "schema_version": "1",
-                            "uv": {"dependencies": ["requests"]},
+                            "uv": {"dependencies": [dep_name]},
                             # No trust_signature - untrusted
                         }
                     },


### PR DESCRIPTION
## Summary

- serialize `runtimed-py` integration pytest on GitHub-hosted Ubuntu
- run Browser E2E with one Playwright worker on GitHub-hosted Ubuntu
- raise the GitHub-hosted job caps for the slower daemon-heavy lanes
- isolate the `runtimed-py` untrusted-notebook assertion from prior package approvals

## Context

After #3332 moved CI off Blacksmith, the GitHub-hosted `runtimed-py Integration Tests` job first failed with daemon health-check timeouts from xdist oversubscription. Reducing the lane to three workers removed the broad health-check failures, but the next run still showed daemon contention in both `runtimed-py` and Browser E2E. The job now runs on lower-throughput standard GitHub runners, so the daemon-heavy lanes need to favor serialized smoke coverage over Blacksmith-shaped parallelism.

The serialized `runtimed-py` run then completed the suite with only the trust approval test failing. That test used `requests`, which other integration tests can approve into the daemon trust allowlist first. The test now uses a unique fake package name so it keeps asserting the untrusted-notebook path.

## Verification

- `rg -n "blacksmith" .`
- `actionlint .github/workflows/*.yml`
- `cargo xtask lint --fix`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$PWD/target/release/runtimed" RUNTIMED_WORKSPACE_PATH="$PWD" RUNTIMED_LOG_LEVEL=debug RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 uv run --directory python/runtimed pytest tests/test_daemon_integration.py::TestTrustApproval::test_untrusted_notebook_needs_approval -v --tb=short`
