### PR TITLE
ci: move runtimed-py integration off PR pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -902,7 +902,9 @@ jobs:
     name: runtimed-py Integration Tests
     runs-on: ubuntu-24.04
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    # This daemon-heavy lane is ~30 minutes on stock GitHub runners. Keep it
+    # on post-merge/manual runs so PR pushes do not pay that long tail.
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- skip `runtimed-py Integration Tests` on pull request events
- keep the job on post-merge `push` to `main` and manual `workflow_dispatch` runs

## Context

#3333 proved the job is stable on GitHub-hosted Ubuntu, but it remains the PR long tail: the green run took 29m56s wall clock, with `runtimed-py Integration Tests` alone taking 29m42s. This follow-up keeps that smoke coverage after merge while avoiding the cost on every agent PR push.

## Verification

- `actionlint .github/workflows/*.yml`
- `rg -n "blacksmith" .`
- `cargo xtask lint --fix`
