### PR TITLE
docs(adr): propose causal pristine-check for notebook seeding

### DIFF
--- a/docs/adr/0001-notebook-seeding-invariant.md
+++ b/docs/adr/0001-notebook-seeding-invariant.md
@@ -1,0 +1,137 @@
+# ADR 0001: How a fresh notebook gets its starter cell
+
+- Status: Proposed
+- Date: 2026-06-02
+- Deciders: nteract maintainers
+- Supersedes the implicit invariant introduced in #3328
+
+## Context
+
+A brand-new notebook should arrive with exactly one starter code cell. That cell must be created **once**, by the **host authority** (daemon for daemon-hosted notebooks, the in-browser wasm room host for cloud rooms), and we must never seed a notebook that already has content or that a user deliberately emptied.
+
+Today that decision is made by reading materialized projections of the document:
+
+```rust
+// crates/runtimed/src/notebook_sync_server/load.rs:1063
+pub fn is_uninitialized_notebook_doc(doc: &NotebookDoc) -> bool {
+    doc.cell_count() == 0 && doc.get_metadata_snapshot().is_none()
+}
+```
+
+The cloud host uses a different, weaker test:
+
+```rust
+// crates/runtimed-wasm/src/lib.rs — seed_initial_code_cell_if_empty
+if self.doc.cell_count() > 0 { return Ok(false); }
+```
+
+### What the document model already knows
+
+A notebook document is not an opaque blob. It has a precise, content-addressed notion of "new" that the seeding path does not use:
+
+- Every notebook boots from a **byte-identical frozen genesis**, `notebook_genesis_v5.am` (`crates/notebook-doc/src/lib.rs:85`), pinned to `SCHEMA_VERSION = 5` and authored by `SCHEMA_SEED_ACTOR = "nteract:notebook-schema:v5"`.
+- The genesis change hashes are computed and cached: `NotebookDoc::canonical_schema_seed_change_hashes()` (`lib.rs:2401`).
+- Authorization already keys on them: `is_canonical_schema_seed_change(actor, hash)` (`lib.rs:2421`) lets the seed actor converge canonical root objects, but only for the exact frozen hashes.
+- A freshly constructed doc (`new_inner`, `lib.rs:989`) is exactly: the frozen genesis (authored by `SCHEMA_SEED_ACTOR`) plus two identity puts, `notebook_id` and `runtime_state_doc_id`, authored by the creating actor. Nothing else.
+- The heads / change-graph API is available: `get_heads()` (`lib.rs:362`), `get_heads_hex()`.
+
+So "genesis" is a first-class causal concept everywhere except the one place this ADR is about.
+
+## Problem
+
+`cell_count() == 0 && metadata.is_none()` is an **observational proxy** standing in for a fact about **history**. Four concrete problems:
+
+1. **It infers intent from a snapshot.** "Uninitialized" means *no one has done anything to this notebook yet* - a statement about the change graph. We reconstruct it from a point-in-time materialized view. In a CRDT those are not the same thing.
+2. **`cell_count() == 0` is not convergence-safe.** A materialized count reflects only what has arrived. A peer can observe zero cells transiently mid-sync, before changes land. The current code is correct only because the daemon seeds under a doc write lock *before* the sync handoff. The safety lives in that choreography, not in the invariant. The boolean reads as if it were self-sufficient; it is not.
+3. **`metadata.is_none()` is load-bearing coupling, not logic.** It distinguishes "pristine" from "user emptied it" only because `create_empty_notebook` happens to always write metadata. Two modules with no stated contract keep that proxy true. Change either side and the invariant silently lies.
+4. **The hosts disagree.** Daemon: `cell_count == 0 && metadata.is_none()`. Cloud: `cell_count > 0`. There is no single definition of "uninitialized," which is exactly the kind of cloud-vs-desktop divergence we are trying to retire.
+
+## Forces
+
+A good answer should be:
+
+- **Convergence-safe** - never misfire on a transient empty view during sync.
+- **Monotonic** - once a notebook has been touched, it is never "new" again, including after a user deletes every cell.
+- **Single definition** - daemon and cloud host evaluate the same predicate.
+- **Double-seed proof** - combined with host authority, exactly one starter cell.
+- **Low blast radius** - avoid a schema-version bump if we can.
+- **Flexible** - keep the door open to varying the starter cell by context (runtime, settings, deps) later. Today it is always one empty code cell, but baking that in is a one-way door.
+
+## Options
+
+### A. Keep the proxy, unify the two hosts
+
+Make the cloud host use `cell_count == 0 && metadata.is_none()` too, so there is one definition.
+
+- **Pros:** smallest change; removes the daemon/cloud divergence.
+- **Cons:** keeps every problem above except (4). The invariant is still a materialized proxy with metadata coupling and no convergence story of its own. This does not address the actual objection.
+
+### B. Causal pristine-check (recommended)
+
+Define "uninitialized" against history, not projections:
+
+> A notebook is **pristine** iff its change graph contains nothing beyond the canonical schema seed and the notebook-identity scaffold - i.e. no change has ever touched the `cells` or `metadata` objects.
+
+Sketch:
+
+```rust
+pub fn is_pristine_notebook_doc(doc: &NotebookDoc) -> bool {
+    // Every change is either a canonical seed change, or the identity
+    // bootstrap (puts to notebook_id / runtime_state_doc_id only).
+    // Any change that touches `cells` or `metadata` => initialized, forever.
+}
+```
+
+- **Pros:**
+  - Monotonic and convergence-safe: history only grows, the seed hashes are fixed and shared, so no transient-empty misfire.
+  - One predicate for daemon and cloud (lives in `notebook-doc`, callable from both `runtimed` and `runtimed-wasm`).
+  - Subsumes the "user emptied it" case for free: an emptied notebook carries add + delete changes on `cells`, so it is non-pristine. No metadata proxy needed.
+  - No schema bump; uses machinery that already exists (`canonical_schema_seed_change_hashes`, `get_heads`).
+  - Preserves the freedom to vary the starter cell later (seeding stays an explicit, runtime-side step).
+- **Cons:**
+  - Must pin down the identity-scaffold boundary precisely: the two identity puts are authored by the creating actor, not the seed actor, so "pristine" is "seed changes + at most the identity-only change," not "heads == seed heads." This is the one subtlety to nail in the plan.
+  - Slightly more than an O(1) count: needs a causal check ("has any cells/metadata change ever applied"). Bounded and cheap for a fresh doc, but not a field read. Mitigation: short-circuit on `get_metadata_snapshot().is_some()` before walking history.
+
+### C. Seed the starter cell into genesis
+
+Bake one code cell into `notebook_genesis_v5.am`. A "new" notebook then already has a cell on load; delete the runtime seeding path entirely.
+
+- **Pros:** conceptually cleanest - the invariant disappears because there is nothing to decide; the starter cell is part of the schema, content-addressed, identical for every peer, so no seeding race can exist.
+- **Cons (decisive):**
+  - **Schema-version bump.** Changing the genesis bytes changes `canonical_schema_seed_change_hashes()`, which feeds `is_canonical_schema_seed_change()` authorization. That is a v5 -> v6 change with a migration/compat path for every existing v5 document. Heavy and ramified.
+  - **Freezes the starter cell.** It can no longer vary by runtime/settings/deps without per-variant genesis assets. A one-way door.
+  - **Shared initial cell id** across all notebooks (doc-scoped, so not a correctness bug, but a property to reason about for templates/publishing).
+  - Removes the ability to represent a genuinely 0-cell *initial* state (a deliberately emptied notebook is still reachable by deletion).
+
+### D. Explicit `initialized` marker
+
+When the host seeds, write a marker (e.g. `ROOT.initialized = true`) in the same change as the cell. Pristine-check becomes `!initialized`.
+
+- **Pros:** O(1) read; records the fact we care about directly, instead of inferring it; convergent under host-authority single-writer.
+- **Cons:** still a stored proxy whose truth depends on a writer doing the right thing (a buggy client could set or clear it); adds a field to maintain; ignores the genesis machinery that already encodes "newness" immutably. It is a better proxy than cell-count, but it is still a proxy.
+
+## Decision
+
+**Recommended: Option B (causal pristine-check).**
+
+It is the option that actually answers the objection - it replaces an inferred snapshot proxy with a fact derived from immutable history - while staying convergence-safe, giving daemon and cloud a single shared predicate, and avoiding a schema bump. It also keeps starter-cell flexibility open, which C forecloses.
+
+**D is the pragmatic fallback** if, during planning, the identity-scaffold boundary in B proves fussier than expected or the history walk is unwelcome on a hot path: a host-authority-written `initialized` marker is still a clear improvement over the current proxy and is convergent under single-writer seeding.
+
+**C is rejected** for now: the schema-version bump and the loss of runtime-varying starter cells outweigh its conceptual tidiness. Revisit only if we are bumping the schema for other reasons.
+
+**A is insufficient:** unifying the hosts is necessary regardless, but on its own it leaves the invariant unprincipled. Whichever of B/D we pick, the predicate moves into `notebook-doc` so both hosts share it - that absorbs A.
+
+## Consequences
+
+- The pristine-check moves into `crates/notebook-doc` so `runtimed` and `runtimed-wasm` call one definition. This is the cloud-converges-on-desktop direction applied to the document model.
+- Host authority (daemon under the doc write lock; wasm room host before handoff) remains the single-writer guarantee. The new predicate makes the *decision* sound; host authority keeps the *write* singular. Both are needed.
+- `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard are removed.
+- Existing notebooks are unaffected: any notebook with content or history is non-pristine under B, so nothing gets re-seeded on upgrade.
+
+## Open questions (resolve in the implementation plan)
+
+1. **Exact pristine predicate for B.** Define it against `get_changes(&[])`: allow the canonical seed hashes plus a single identity-bootstrap change touching only `notebook_id` / `runtime_state_doc_id`; treat any `cells` or `metadata` op as initialized. Confirm op-batching does not split the identity puts in a way that breaks the check.
+2. **Cost.** Is the history walk acceptable on every connect, or do we short-circuit on `metadata.is_some()` first and only walk for the metadata-absent case?
+3. **Cloud parity.** `runtimed-wasm` must call the same `notebook-doc` predicate, not a reimplementation.
+4. **Test surface.** Unit-test the predicate across: fresh doc (pristine), metadata-stamped (not), one cell (not), emptied-after-content (not). Integration-test: empty a notebook, reconnect, expect zero cells (the headline behavior currently only covered indirectly).

--- a/docs/adr/0001-notebook-seeding-invariant.md
+++ b/docs/adr/0001-notebook-seeding-invariant.md
@@ -89,8 +89,8 @@ pub fn is_pristine_notebook_doc(doc: &NotebookDoc) -> bool {
   - No schema bump; uses machinery that already exists (`canonical_schema_seed_change_hashes`, `get_heads`).
   - Preserves the freedom to vary the starter cell later (seeding stays an explicit, runtime-side step).
 - **Cons:**
-  - Must pin down the identity-scaffold boundary precisely: the two identity puts are authored by the creating actor, not the seed actor, so "pristine" is "seed changes + at most the identity-only change," not "heads == seed heads." This is the one subtlety to nail in the plan.
-  - Slightly more than an O(1) count: needs a causal check ("has any cells/metadata change ever applied"). Bounded and cheap for a fresh doc, but not a field read. Mitigation: short-circuit on `get_metadata_snapshot().is_some()` before walking history.
+  - Must pin down the identity-scaffold boundary precisely: the two identity puts are authored by the creating actor, not the seed actor, so "pristine" is "seed changes + at most the identity-only change," not "heads == seed heads." This is the one subtlety to nail in the plan (now resolved - see The predicate).
+  - More than an O(1) count, but the bound is small and concrete: the walk only runs on the metadata-absent path, where a pristine doc's `get_changes(&[])` is exactly two changes - the single seed change (`canonical_schema_seed_change_is_hash_bound` asserts `hashes.len() == 1`) plus the identity batch. So it is O(number of changes), ~2 for a fresh doc, with the `metadata.is_some()` fast-path covering the common already-seeded case. This small bound is the main thing that makes B win over D's O(1).
 
 ### C. Seed the starter cell into genesis
 
@@ -124,26 +124,36 @@ It is the option that actually answers the objection - it replaces an inferred s
 
 ### The predicate
 
-The implementation plan resolved B's open boundary against the pinned automerge fork. A fresh document - daemon **or** cloud - is built by `NotebookDoc::new_with_actor`, which is the frozen genesis plus exactly two ROOT puts (`notebook_id`, `runtime_state_doc_id`); the cloud room host's "schema label" argument is the actor, not a ROOT key, so both hosts produce the identical scaffold. That makes the identity allowlist exact and host-agnostic:
+The implementation plan resolved B's open boundary against the pinned automerge fork. A fresh document - daemon **or** cloud - is built by `NotebookDoc::new_with_actor`, which is the frozen genesis plus exactly two ROOT puts (`notebook_id`, `runtime_state_doc_id`); the cloud room host's "schema label" argument is the actor, not a ROOT key, so both hosts produce the identical scaffold. That makes the allowlist exact and host-agnostic. The op types come from the `automerge::legacy` module (that is what `change.decode().operations` yields), and the gate matches on `op.action` and `op.pred` as well as `obj`/`key`, so that a *delete* or *overwrite* of an identity key after creation - which is post-creation history, not the creation scaffold - is correctly rejected:
 
 ```rust
+use automerge::legacy::{Key, ObjectId, OpType}; // decode() yields legacy ops
+
 pub fn is_pristine(&mut self) -> bool {
-    // Sound fast path: any metadata snapshot means initialized.
+    // Fast path (pure optimization, see below): a *populated* metadata
+    // snapshot means initialized. The history walk is the real backstop.
     if self.doc.get_metadata_snapshot().is_some() { return false; }
     let seed = NotebookDoc::canonical_schema_seed_change_hashes();
     for change in self.doc.get_changes(&[]) {
         if seed.contains(&change.hash()) { continue; }
         for op in change.decode().operations {
-            let identity_put = matches!(op.obj, ObjectId::Root)
+            // only the initial Put (empty pred) of an identity key is scaffold
+            let scaffold_put = matches!(op.action, OpType::Put(_))
+                && op.pred.is_empty()
+                && matches!(op.obj, ObjectId::Root)
                 && matches!(&op.key, Key::Map(k) if k == "notebook_id" || k == "runtime_state_doc_id");
-            if !identity_put { return false; }
+            if !scaffold_put { return false; }
         }
     }
     true
 }
 ```
 
-Any cell insert (op on the `cells` object) or metadata write fails the allowlist, so a notebook a user emptied - which carries add + delete history - is correctly never re-seeded, with no metadata coupling. Full task breakdown in `docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md`.
+Any cell insert (op on the `cells` object), metadata write, or post-creation identity edit fails the gate, so a notebook a user emptied - which carries add + delete history - is correctly never re-seeded, with no metadata coupling.
+
+**On the metadata fast-path:** `get_metadata_snapshot()` returns `Some` only for *populated* metadata (the genesis-created empty `metadata` Map yields `None`), so the short-circuit can never misfire on a fresh doc. But it is a pure optimization, not the soundness mechanism for the metadata case: a metadata mutation that leaves no populated snapshot is caught by the **history walk** (its op targets the `metadata` object, not a ROOT identity key), not by the fast-path. Skipping the fast-path would change no verdict, only cost.
+
+**On the coupling:** B removes the unstated "`create_empty_notebook` always writes metadata" coupling, but in its place the allowlist depends on a new invariant - *every creation path writes nothing to ROOT but the two identity puts*. That is true today (verified across `new`/`new_with_encoding`/`new_with_actor`/`RoomHostHandle::create_empty`), and unlike the old coupling it is local to one crate and enforced by a constructor-guard test, so a future ROOT scaffolding key trips CI instead of silently shipping a notebook that never seeds. Full task breakdown in `docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md`.
 
 ## Consequences
 
@@ -154,10 +164,10 @@ Any cell insert (op on the `cells` object) or metadata write fails the allowlist
 
 ## Resolved during planning
 
-1. **Exact pristine predicate** - settled: canonical seed hashes plus identity puts to ROOT (`notebook_id`, `runtime_state_doc_id`); any other op is initialized. See the predicate above.
-2. **Cost** - settled: short-circuit on `metadata.is_some()` (a sound sufficient condition for non-pristine), so the history walk only runs for the rare metadata-absent case.
+1. **Exact pristine predicate** - settled: canonical seed hashes plus *initial* (`Put`, empty `pred`) identity puts to ROOT (`notebook_id`, `runtime_state_doc_id`); any other op - including a delete or overwrite of an identity key - means initialized. See the predicate above.
+2. **Cost** - settled: O(number of changes), ~2 for a fresh doc, walked only on the metadata-absent path; the `metadata.is_some()` short-circuit is a pure optimization for the common already-seeded case, not the soundness mechanism (see The predicate).
 3. **Cloud parity** - settled: the predicate lives in `notebook-doc`; `runtimed` and `runtimed-wasm` both call `NotebookDoc::is_pristine`, no reimplementation.
-4. **Test surface** - settled: unit tests for fresh / metadata-stamped / one-cell / emptied-after-content, plus an integration test that empties a notebook, reconnects, and expects zero cells (the headline behavior, previously only covered indirectly).
+4. **Test surface** - settled: unit tests for fresh / metadata-stamped / one-cell / emptied-after-content / overwritten-or-deleted-identity-key / every-fresh-constructor, plus an integration test that empties a notebook, reconnects, and expects zero cells (the headline behavior, previously only covered indirectly).
 
 ## Still open
 

--- a/docs/adr/0001-notebook-seeding-invariant.md
+++ b/docs/adr/0001-notebook-seeding-invariant.md
@@ -122,6 +122,29 @@ It is the option that actually answers the objection - it replaces an inferred s
 
 **A is insufficient:** unifying the hosts is necessary regardless, but on its own it leaves the invariant unprincipled. Whichever of B/D we pick, the predicate moves into `notebook-doc` so both hosts share it - that absorbs A.
 
+### The predicate
+
+The implementation plan resolved B's open boundary against the pinned automerge fork. A fresh document - daemon **or** cloud - is built by `NotebookDoc::new_with_actor`, which is the frozen genesis plus exactly two ROOT puts (`notebook_id`, `runtime_state_doc_id`); the cloud room host's "schema label" argument is the actor, not a ROOT key, so both hosts produce the identical scaffold. That makes the identity allowlist exact and host-agnostic:
+
+```rust
+pub fn is_pristine(&mut self) -> bool {
+    // Sound fast path: any metadata snapshot means initialized.
+    if self.doc.get_metadata_snapshot().is_some() { return false; }
+    let seed = NotebookDoc::canonical_schema_seed_change_hashes();
+    for change in self.doc.get_changes(&[]) {
+        if seed.contains(&change.hash()) { continue; }
+        for op in change.decode().operations {
+            let identity_put = matches!(op.obj, ObjectId::Root)
+                && matches!(&op.key, Key::Map(k) if k == "notebook_id" || k == "runtime_state_doc_id");
+            if !identity_put { return false; }
+        }
+    }
+    true
+}
+```
+
+Any cell insert (op on the `cells` object) or metadata write fails the allowlist, so a notebook a user emptied - which carries add + delete history - is correctly never re-seeded, with no metadata coupling. Full task breakdown in `docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md`.
+
 ## Consequences
 
 - The pristine-check moves into `crates/notebook-doc` so `runtimed` and `runtimed-wasm` call one definition. This is the cloud-converges-on-desktop direction applied to the document model.
@@ -129,9 +152,13 @@ It is the option that actually answers the objection - it replaces an inferred s
 - `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard are removed.
 - Existing notebooks are unaffected: any notebook with content or history is non-pristine under B, so nothing gets re-seeded on upgrade.
 
-## Open questions (resolve in the implementation plan)
+## Resolved during planning
 
-1. **Exact pristine predicate for B.** Define it against `get_changes(&[])`: allow the canonical seed hashes plus a single identity-bootstrap change touching only `notebook_id` / `runtime_state_doc_id`; treat any `cells` or `metadata` op as initialized. Confirm op-batching does not split the identity puts in a way that breaks the check.
-2. **Cost.** Is the history walk acceptable on every connect, or do we short-circuit on `metadata.is_some()` first and only walk for the metadata-absent case?
-3. **Cloud parity.** `runtimed-wasm` must call the same `notebook-doc` predicate, not a reimplementation.
-4. **Test surface.** Unit-test the predicate across: fresh doc (pristine), metadata-stamped (not), one cell (not), emptied-after-content (not). Integration-test: empty a notebook, reconnect, expect zero cells (the headline behavior currently only covered indirectly).
+1. **Exact pristine predicate** - settled: canonical seed hashes plus identity puts to ROOT (`notebook_id`, `runtime_state_doc_id`); any other op is initialized. See the predicate above.
+2. **Cost** - settled: short-circuit on `metadata.is_some()` (a sound sufficient condition for non-pristine), so the history walk only runs for the rare metadata-absent case.
+3. **Cloud parity** - settled: the predicate lives in `notebook-doc`; `runtimed` and `runtimed-wasm` both call `NotebookDoc::is_pristine`, no reimplementation.
+4. **Test surface** - settled: unit tests for fresh / metadata-stamped / one-cell / emptied-after-content, plus an integration test that empties a notebook, reconnects, and expects zero cells (the headline behavior, previously only covered indirectly).
+
+## Still open
+
+- Whether matching *current* behavior (a metadata-stamped, zero-cell notebook is treated as initialized and not seeded) is the desired product semantics, or a latent question to reopen separately. The predicate preserves today's behavior either way.

--- a/docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md
+++ b/docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md
@@ -1,0 +1,320 @@
+# Notebook Pristine-Seeding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the cell-count/metadata proxy that decides whether a fresh notebook gets a starter cell with a single causal predicate (`NotebookDoc::is_pristine`) shared by the daemon and the cloud wasm host.
+
+**Architecture:** A notebook document boots from a byte-identical frozen genesis plus exactly two identity puts (`notebook_id`, `runtime_state_doc_id`). "Pristine" means the change graph contains nothing beyond that: every change is either a canonical schema-seed change or an identity put to ROOT. Any cell insert or metadata write makes it non-pristine, forever. This is Option B from `docs/adr/0001-notebook-seeding-invariant.md`.
+
+**Tech Stack:** Rust, automerge (nteract fork), `notebook-doc` / `runtimed` / `runtimed-wasm` crates.
+
+---
+
+## Background the implementer needs
+
+- `NotebookDoc` wraps an automerge `AutoCommit` in `self.doc` (private field, so the predicate is a method on `NotebookDoc`).
+- A fresh doc is built by `NotebookDoc::new_with_actor` (`crates/notebook-doc/src/lib.rs:983`), which loads the frozen genesis (`notebook_genesis_v5.am`, authored by `SCHEMA_SEED_ACTOR`) then does two `put(ROOT, ...)` ops: `notebook_id` and `runtime_state_doc_id`. Both the daemon and the cloud room host create docs this way (`RoomHostHandle::create_empty` -> `new_with_actor`).
+- `NotebookDoc::canonical_schema_seed_change_hashes()` (`lib.rs:2401`) returns the genesis change hashes (cached).
+- automerge API confirmed for this fork (rev f22752b): `AutoCommit::get_changes(&mut self, &[]) -> Vec<Change>`; `Change::decode(&self) -> automerge::ExpandedChange`; `ExpandedChange.operations: Vec<automerge::legacy::Op>`; `Op { obj: automerge::legacy::ObjectId, key: automerge::legacy::Key, .. }`; `ObjectId::{Root, Id(OpId)}`; `Key::{Map(SmolStr), Seq(ElementId)}`. `legacy` is a public module.
+- `get_changes` takes `&mut self`, so `is_pristine` is `&mut self`. All three daemon call sites already hold `let mut doc = room.doc.write().await`, and the wasm caller is `&mut self`, so this is not a constraint.
+
+## File structure
+
+- `crates/notebook-doc/src/lib.rs` - add `pub fn is_pristine(&mut self) -> bool` (the shared predicate) + unit tests. One responsibility: answer "has anything beyond creation happened to this document?"
+- `crates/runtimed/src/notebook_sync_server/load.rs` - delete the daemon-local `is_uninitialized_notebook_doc`.
+- `crates/runtimed/src/daemon.rs` - 3 call sites switch to `doc.is_pristine()`.
+- `crates/runtimed/src/notebook_sync_server/tests.rs` - remove the now-dead daemon predicate test; add the empty-then-reconnect integration coverage.
+- `crates/runtimed-wasm/src/lib.rs` - `seed_initial_code_cell_if_empty` guard switches to `!self.doc.is_pristine()`; update its idempotency test.
+- `docs/adr/0001-notebook-seeding-invariant.md` - flip Status to Accepted once merged.
+
+---
+
+### Task 1: Add `NotebookDoc::is_pristine` with unit tests
+
+**Files:**
+- Modify: `crates/notebook-doc/src/lib.rs` (add method near `canonical_schema_seed_change_hashes`, around `lib.rs:2400`; add import near the top automerge `use` at `lib.rs:92`)
+- Test: `crates/notebook-doc/src/lib.rs` (the in-file `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `crates/notebook-doc/src/lib.rs`:
+
+```rust
+#[test]
+fn fresh_notebook_doc_is_pristine() {
+    // genesis + the two identity puts, nothing else
+    let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    assert!(doc.is_pristine());
+}
+
+#[test]
+fn notebook_with_a_cell_is_not_pristine() {
+    let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    doc.add_cell(0, "cell-a", "code").expect("add cell");
+    assert!(!doc.is_pristine());
+}
+
+#[test]
+fn emptied_notebook_is_not_pristine() {
+    // add then delete every cell — current cell_count is 0, but history remains
+    let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    doc.add_cell(0, "cell-a", "code").expect("add cell");
+    doc.delete_cell("cell-a").expect("delete cell");
+    assert_eq!(doc.cell_count(), 0);
+    assert!(
+        !doc.is_pristine(),
+        "an emptied notebook has cell history and must never be re-seeded"
+    );
+}
+
+#[test]
+fn notebook_with_metadata_is_not_pristine() {
+    let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    doc.set_metadata("trust", "trusted").expect("set metadata");
+    assert!(!doc.is_pristine());
+}
+```
+
+Note: confirm the exact helper names against the file before running - `delete_cell` and `set_metadata` are used elsewhere in this crate (`set_metadata` is exercised at `crates/runtimed-wasm/src/lib.rs:1906`). If a helper differs, use the in-crate equivalent; do not invent one.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p notebook-doc is_pristine -- --include-ignored`
+Expected: FAIL to compile with "no method named `is_pristine`".
+
+- [ ] **Step 3: Implement `is_pristine`**
+
+Add the import alongside the existing automerge `use` at `crates/notebook-doc/src/lib.rs:92`:
+
+```rust
+use automerge::legacy::{Key as LegacyKey, ObjectId as LegacyObjectId};
+```
+
+Add the method inside `impl NotebookDoc`, next to `canonical_schema_seed_change_hashes` (around `lib.rs:2414`):
+
+```rust
+/// True when nothing beyond document creation has been applied: the change
+/// graph contains only the canonical schema seed and the identity puts
+/// (`notebook_id`, `runtime_state_doc_id`) that `new_with_actor` writes.
+///
+/// This is the host-authority seeding gate. Unlike a `cell_count()` check it
+/// is derived from immutable history, so it is convergence-safe (no transient
+/// empty view during sync misfires) and monotonic: once any cell or metadata
+/// op lands, the document is never pristine again, including after a user
+/// deletes every cell. See `docs/adr/0001-notebook-seeding-invariant.md`.
+///
+/// If document creation ever writes a new ROOT scaffolding key, add it to the
+/// identity allowlist below.
+pub fn is_pristine(&mut self) -> bool {
+    // Sound fast path: any metadata snapshot means the document was
+    // initialized. Avoids walking history for the common, already-seeded case.
+    if self.doc.get_metadata_snapshot().is_some() {
+        return false;
+    }
+
+    let seed: std::collections::HashSet<automerge::ChangeHash> =
+        Self::canonical_schema_seed_change_hashes().into_iter().collect();
+
+    for change in self.doc.get_changes(&[]) {
+        if seed.contains(&change.hash()) {
+            continue;
+        }
+        for op in change.decode().operations {
+            let is_identity_put = matches!(op.obj, LegacyObjectId::Root)
+                && matches!(
+                    &op.key,
+                    LegacyKey::Map(k)
+                        if k.as_str() == "notebook_id"
+                            || k.as_str() == "runtime_state_doc_id"
+                );
+            if !is_identity_put {
+                return false;
+            }
+        }
+    }
+    true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p notebook-doc is_pristine`
+Expected: PASS - `fresh_notebook_doc_is_pristine`, `notebook_with_a_cell_is_not_pristine`, `emptied_notebook_is_not_pristine`, `notebook_with_metadata_is_not_pristine` all ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/notebook-doc/src/lib.rs
+git commit -m "feat(notebook-doc): add causal is_pristine seeding gate"
+```
+
+---
+
+### Task 2: Switch the daemon to `is_pristine`
+
+**Files:**
+- Modify: `crates/runtimed/src/notebook_sync_server/load.rs:1063` (delete `is_uninitialized_notebook_doc`)
+- Modify: `crates/runtimed/src/daemon.rs:2606`, `:2979`, `:3167` (call sites)
+- Modify: `crates/runtimed/src/notebook_sync_server/tests.rs:3922` (delete dead test)
+
+- [ ] **Step 1: Delete the daemon-local predicate**
+
+Remove this function from `crates/runtimed/src/notebook_sync_server/load.rs` (lines 1063-1065):
+
+```rust
+pub fn is_uninitialized_notebook_doc(doc: &NotebookDoc) -> bool {
+    doc.cell_count() == 0 && doc.get_metadata_snapshot().is_none()
+}
+```
+
+- [ ] **Step 2: Update the three call sites**
+
+In `crates/runtimed/src/daemon.rs`, each site holds `let mut doc = room.doc.write().await;`:
+
+At `:2606` and `:2979`:
+```rust
+// was: if crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+if doc.is_pristine() {
+```
+
+At `:3167`:
+```rust
+// was: if !crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+if !doc.is_pristine() {
+```
+
+- [ ] **Step 3: Remove the dead daemon test**
+
+Delete `test_is_uninitialized_notebook_doc` from `crates/runtimed/src/notebook_sync_server/tests.rs` (starts at line 3922). The predicate is now unit-tested in `notebook-doc` (Task 1); the daemon behavior is covered by the integration test in Task 4.
+
+- [ ] **Step 4: Build and run the daemon sync tests**
+
+Run: `cargo test -p runtimed --lib notebook_sync_server`
+Expected: PASS, no reference to `is_uninitialized_notebook_doc` remains.
+
+If the build fails with `Missing renderer plugin asset: ...sift.js` in a fresh worktree, copy the gitignored volatile bundle from a built checkout first: `cp <built-checkout>/apps/notebook/src/renderer-plugins/sift.js apps/notebook/src/renderer-plugins/sift.js` (and `crates/sift-wasm/pkg/sift_wasm_bg.wasm` if also required), then retry. Do not commit those assets.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/load.rs crates/runtimed/src/daemon.rs crates/runtimed/src/notebook_sync_server/tests.rs
+git commit -m "refactor(runtimed): gate seeding on NotebookDoc::is_pristine"
+```
+
+---
+
+### Task 3: Switch the cloud wasm host to `is_pristine`
+
+**Files:**
+- Modify: `crates/runtimed-wasm/src/lib.rs:480` (the guard) and the idempotency test around `lib.rs:3110`
+
+- [ ] **Step 1: Update the guard**
+
+In `seed_initial_code_cell_if_empty` (`crates/runtimed-wasm/src/lib.rs:479`):
+
+```rust
+pub fn seed_initial_code_cell_if_empty(&mut self, cell_id: &str) -> Result<bool, JsError> {
+    // was: if self.doc.cell_count() > 0 {
+    if !self.doc.is_pristine() {
+        return Ok(false);
+    }
+    self.doc
+        .add_cell_after(cell_id, "code", None)
+        .map_err(|e| JsError::new(&format!("seed initial code cell failed: {e}")))?;
+    Ok(true)
+}
+```
+
+- [ ] **Step 2: Verify the existing idempotency test still holds**
+
+The test `room_host_seeds_initial_code_cell_idempotently` (around `crates/runtimed-wasm/src/lib.rs:3110`) creates a host via `RoomHostHandle::create_empty`, seeds once (pristine -> seeds, returns true), then seeds again (now has a cell -> not pristine -> returns false). This matches `is_pristine`. No test change expected; confirm by reading it. If it asserted on `cell_count` semantics that diverge, adjust the assertion to the seed return values only.
+
+- [ ] **Step 3: Run the wasm tests**
+
+Run: `cargo test -p runtimed-wasm room_host_seeds_initial_code_cell_idempotently`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/runtimed-wasm/src/lib.rs
+git commit -m "refactor(runtimed-wasm): gate room seeding on NotebookDoc::is_pristine"
+```
+
+---
+
+### Task 4: Integration test - empty a notebook, reconnect, expect zero cells
+
+**Files:**
+- Test: `crates/runtimed/src/notebook_sync_server/tests.rs` (add near the existing `test_untitled_notebook_persists_through_eviction`)
+
+This is the headline behavior the ADR calls out as only-indirectly-covered: a notebook a user empties must not be re-seeded on reconnect.
+
+- [ ] **Step 1: Write the failing/asserting test**
+
+Add a test mirroring the existing eviction/reconnect harness in this file (read `test_untitled_notebook_persists_through_eviction` for the exact daemon-room setup helpers; reuse them rather than constructing a daemon by hand):
+
+```rust
+#[tokio::test]
+async fn emptied_untitled_notebook_is_not_reseeded_on_reconnect() {
+    // 1. Create an untitled notebook room (daemon seeds one starter cell).
+    // 2. Delete every cell so cell_count == 0 but history records the cells.
+    // 3. Evict / drop the room, then reconnect (the NotebookSync path that
+    //    calls doc.is_pristine()).
+    // 4. Assert the reconnected room still has 0 cells — the daemon must NOT
+    //    treat an emptied notebook as pristine.
+    //
+    // Use the same room/eviction helpers as
+    // test_untitled_notebook_persists_through_eviction.
+}
+```
+
+Fill the body using this file's existing helpers (the test above demonstrates room creation, cell access, eviction, and reconnect). Assert `connection_info.cell_count == 0` (or the doc's `cell_count()`) after reconnect.
+
+- [ ] **Step 2: Run it to verify it passes against the Task 2 change**
+
+Run: `cargo test -p runtimed --lib emptied_untitled_notebook_is_not_reseeded_on_reconnect`
+Expected: PASS (the `is_pristine` walk sees the delete history and refuses to re-seed). If it FAILS by re-seeding, the predicate or the connect-path wiring regressed - debug before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/runtimed/src/notebook_sync_server/tests.rs
+git commit -m "test(runtimed): emptied notebook is not re-seeded on reconnect"
+```
+
+---
+
+### Task 5: Promote the ADR and run the full gate
+
+**Files:**
+- Modify: `docs/adr/0001-notebook-seeding-invariant.md`
+
+- [ ] **Step 1: Flip ADR status**
+
+Change the header `- Status: Proposed` to `- Status: Accepted` and add a line under Consequences: "Implemented in <plan date>: `NotebookDoc::is_pristine` is the shared gate; `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard are removed."
+
+- [ ] **Step 2: Run the required pre-commit gate**
+
+Run: `cargo xtask lint --fix`
+Expected: "All checks passed" (or it auto-fixes formatting; re-stage if so).
+
+- [ ] **Step 3: Run the touched crates' tests once more together**
+
+Run: `cargo test -p notebook-doc -p runtimed-wasm && cargo test -p runtimed --lib notebook_sync_server`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/adr/0001-notebook-seeding-invariant.md
+git commit -m "docs(adr): mark 0001 accepted"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** ADR Decision (Option B) -> Task 1 (predicate in `notebook-doc`). ADR Consequence "one predicate for daemon and cloud" -> Tasks 2+3. ADR Consequence "remove `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard" -> Tasks 2+3. ADR Open Question #1 (exact predicate / identity boundary) -> resolved: `{notebook_id, runtime_state_doc_id}` allowlist, verified both hosts create via `new_with_actor`. Open Question #2 (cost) -> resolved: `metadata.is_some()` fast path. Open Question #4 (test surface) -> Tasks 1 + 4.
+- **Type consistency:** `is_pristine(&mut self) -> bool` used identically in Tasks 1-4. `LegacyKey`/`LegacyObjectId` aliases used only in Task 1.
+- **Known verification point:** helper names (`delete_cell`, `set_metadata`, `add_cell_after`, room/eviction test helpers) must be confirmed against the current files at implementation time; the plan flags each spot rather than guessing a signature.

--- a/docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md
+++ b/docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md
@@ -15,7 +15,8 @@
 - `NotebookDoc` wraps an automerge `AutoCommit` in `self.doc` (private field, so the predicate is a method on `NotebookDoc`).
 - A fresh doc is built by `NotebookDoc::new_with_actor` (`crates/notebook-doc/src/lib.rs:983`), which loads the frozen genesis (`notebook_genesis_v5.am`, authored by `SCHEMA_SEED_ACTOR`) then does two `put(ROOT, ...)` ops: `notebook_id` and `runtime_state_doc_id`. Both the daemon and the cloud room host create docs this way (`RoomHostHandle::create_empty` -> `new_with_actor`).
 - `NotebookDoc::canonical_schema_seed_change_hashes()` (`lib.rs:2401`) returns the genesis change hashes (cached).
-- automerge API confirmed for this fork (rev f22752b): `AutoCommit::get_changes(&mut self, &[]) -> Vec<Change>`; `Change::decode(&self) -> automerge::ExpandedChange`; `ExpandedChange.operations: Vec<automerge::legacy::Op>`; `Op { obj: automerge::legacy::ObjectId, key: automerge::legacy::Key, .. }`; `ObjectId::{Root, Id(OpId)}`; `Key::{Map(SmolStr), Seq(ElementId)}`. `legacy` is a public module.
+- automerge API confirmed for this fork (rev f22752b): `AutoCommit::get_changes(&mut self, &[]) -> Vec<Change>`; `Change::decode(&self) -> automerge::ExpandedChange`; `ExpandedChange.operations: Vec<automerge::legacy::Op>`; `Op { action: automerge::legacy::OpType, obj: automerge::legacy::ObjectId, key: automerge::legacy::Key, pred: SortedVec<OpId>, insert: bool }`; `ObjectId::{Root, Id(OpId)}`; `Key::{Map(SmolStr), Seq(ElementId)}`; `OpType::{Put(ScalarValue), Delete, Increment(i64), Make(ObjType), ..}`; `pred.is_empty()` is public. `legacy` is a public module.
+- The predicate matches on `op.action` and `op.pred`, not only `obj`/`key`: a creation-scaffold write is an initial `Put` (`OpType::Put(_)` with empty `pred`). A later *delete* or *overwrite* of an identity key is `OpType::Delete` or a `Put` with non-empty `pred`, and must be rejected - otherwise post-creation identity edits would be misclassified as pristine.
 - `get_changes` takes `&mut self`, so `is_pristine` is `&mut self`. All three daemon call sites already hold `let mut doc = room.doc.write().await`, and the wasm caller is `&mut self`, so this is not a constraint.
 
 ## File structure
@@ -73,9 +74,50 @@ fn notebook_with_metadata_is_not_pristine() {
     doc.set_metadata("trust", "trusted").expect("set metadata");
     assert!(!doc.is_pristine());
 }
+
+#[test]
+fn overwritten_or_deleted_identity_key_is_not_pristine() {
+    // A Put/Delete on an identity key AFTER creation is post-creation history,
+    // not the creation scaffold: the predicate checks action + empty pred, so
+    // these must read non-pristine even though obj==Root and the key matches.
+    let mut overwritten = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    overwritten
+        .doc
+        .put(automerge::ROOT, "notebook_id", "nb-2")
+        .expect("overwrite notebook_id");
+    assert!(
+        !overwritten.is_pristine(),
+        "an overwrite of notebook_id has a non-empty pred and is not scaffold"
+    );
+
+    let mut deleted = NotebookDoc::new_with_actor("nb-1", "runtimed");
+    deleted
+        .doc
+        .delete(automerge::ROOT, "runtime_state_doc_id")
+        .expect("delete runtime_state_doc_id");
+    assert!(
+        !deleted.is_pristine(),
+        "a delete of an identity key is an OpType::Delete, not a Put"
+    );
+}
+
+#[test]
+fn every_fresh_constructor_is_pristine() {
+    // Guard: the allowlist is sound only while every creation path writes
+    // nothing to ROOT except the two identity puts. Enumerate the public fresh
+    // constructors so a future ROOT scaffolding put trips here instead of
+    // silently shipping a notebook that never seeds.
+    assert!(NotebookDoc::new("nb-1").is_pristine());
+    assert!(NotebookDoc::new_with_actor("nb-1", "runtimed").is_pristine());
+    assert!(
+        NotebookDoc::new_with_encoding("nb-1", TextEncoding::UnicodeCodePoint).is_pristine()
+    );
+    // The cloud room host path: RoomHostHandle::create_empty -> new_with_actor.
+    // Covered in runtimed-wasm (Task 3) where RoomHostHandle is in scope.
+}
 ```
 
-Note: confirm the exact helper names against the file before running - `delete_cell` and `set_metadata` are used elsewhere in this crate (`set_metadata` is exercised at `crates/runtimed-wasm/src/lib.rs:1906`). If a helper differs, use the in-crate equivalent; do not invent one.
+Note: `new` / `new_with_actor` / `new_with_encoding` return `NotebookDoc` (not `&mut`), and `is_pristine` is `&mut self`; bind to a `let mut` (as the other tests do) or call on a temporary `let mut d = ...; d.is_pristine()`. `NotebookDoc.doc` is a crate-private field, so the overwrite/delete tests reaching into `.doc.put` / `.doc.delete` only compile inside the `notebook-doc` crate's own test module - which is where these live. Confirm the exact helper names against the file before running - `delete_cell`, `set_metadata`, `new_with_encoding`, and `TextEncoding` all exist in this crate (`set_metadata` is exercised at `crates/runtimed-wasm/src/lib.rs:1906`); if a signature differs, use the in-crate equivalent, do not invent one.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -87,7 +129,7 @@ Expected: FAIL to compile with "no method named `is_pristine`".
 Add the import alongside the existing automerge `use` at `crates/notebook-doc/src/lib.rs:92`:
 
 ```rust
-use automerge::legacy::{Key as LegacyKey, ObjectId as LegacyObjectId};
+use automerge::legacy::{Key as LegacyKey, ObjectId as LegacyObjectId, OpType as LegacyOpType};
 ```
 
 Add the method inside `impl NotebookDoc`, next to `canonical_schema_seed_change_hashes` (around `lib.rs:2414`):
@@ -104,10 +146,13 @@ Add the method inside `impl NotebookDoc`, next to `canonical_schema_seed_change_
 /// deletes every cell. See `docs/adr/0001-notebook-seeding-invariant.md`.
 ///
 /// If document creation ever writes a new ROOT scaffolding key, add it to the
-/// identity allowlist below.
+/// allowlist below (and to the constructor guard test).
 pub fn is_pristine(&mut self) -> bool {
-    // Sound fast path: any metadata snapshot means the document was
-    // initialized. Avoids walking history for the common, already-seeded case.
+    // Sound fast path: a populated metadata snapshot means the document was
+    // initialized (`get_metadata_snapshot` returns `Some` only for non-empty
+    // metadata, so it never misfires on a fresh doc whose metadata Map is
+    // empty). This is a pure optimization for the common already-seeded case;
+    // the history walk below is what actually backstops metadata mutations.
     if self.doc.get_metadata_snapshot().is_some() {
         return false;
     }
@@ -120,14 +165,20 @@ pub fn is_pristine(&mut self) -> bool {
             continue;
         }
         for op in change.decode().operations {
-            let is_identity_put = matches!(op.obj, LegacyObjectId::Root)
+            // Only the *initial creation* of an identity key is allowed beyond
+            // genesis: an inserting `Put` (empty `pred`) to ROOT's
+            // `notebook_id` / `runtime_state_doc_id`. A delete or an overwrite
+            // of those keys is post-creation history and must fail the gate.
+            let is_creation_scaffold_put = matches!(op.action, LegacyOpType::Put(_))
+                && op.pred.is_empty()
+                && matches!(op.obj, LegacyObjectId::Root)
                 && matches!(
                     &op.key,
                     LegacyKey::Map(k)
                         if k.as_str() == "notebook_id"
                             || k.as_str() == "runtime_state_doc_id"
                 );
-            if !is_identity_put {
+            if !is_creation_scaffold_put {
                 return false;
             }
         }
@@ -138,8 +189,8 @@ pub fn is_pristine(&mut self) -> bool {
 
 - [ ] **Step 4: Run tests to verify they pass**
 
-Run: `cargo test -p notebook-doc is_pristine`
-Expected: PASS - `fresh_notebook_doc_is_pristine`, `notebook_with_a_cell_is_not_pristine`, `emptied_notebook_is_not_pristine`, `notebook_with_metadata_is_not_pristine` all ok.
+Run: `cargo test -p notebook-doc -- pristine`
+Expected: PASS - `fresh_notebook_doc_is_pristine`, `notebook_with_a_cell_is_not_pristine`, `emptied_notebook_is_not_pristine`, `notebook_with_metadata_is_not_pristine`, `overwritten_or_deleted_identity_key_is_not_pristine`, `every_fresh_constructor_is_pristine` all ok.
 
 - [ ] **Step 5: Commit**
 
@@ -229,6 +280,16 @@ pub fn seed_initial_code_cell_if_empty(&mut self, cell_id: &str) -> Result<bool,
 
 The test `room_host_seeds_initial_code_cell_idempotently` (around `crates/runtimed-wasm/src/lib.rs:3110`) creates a host via `RoomHostHandle::create_empty`, seeds once (pristine -> seeds, returns true), then seeds again (now has a cell -> not pristine -> returns false). This matches `is_pristine`. No test change expected; confirm by reading it. If it asserted on `cell_count` semantics that diverge, adjust the assertion to the seed return values only.
 
+Add one assertion to that test (or a sibling) completing the constructor-guard coverage from Task 1: a freshly created room host is pristine before any seed.
+
+```rust
+let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+    .expect("create room host");
+assert!(host.doc.is_pristine(), "a brand-new room host is pristine");
+```
+
+(`host.doc` is accessible inside `runtimed-wasm`'s own test module; `is_pristine` is `&mut self`, so `host` must be `let mut`.)
+
 - [ ] **Step 3: Run the wasm tests**
 
 Run: `cargo test -p runtimed-wasm room_host_seeds_initial_code_cell_idempotently`
@@ -316,5 +377,6 @@ git commit -m "docs(adr): mark 0001 accepted"
 ## Self-review notes
 
 - **Spec coverage:** ADR Decision (Option B) -> Task 1 (predicate in `notebook-doc`). ADR Consequence "one predicate for daemon and cloud" -> Tasks 2+3. ADR Consequence "remove `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard" -> Tasks 2+3. ADR Open Question #1 (exact predicate / identity boundary) -> resolved: `{notebook_id, runtime_state_doc_id}` allowlist, verified both hosts create via `new_with_actor`. Open Question #2 (cost) -> resolved: `metadata.is_some()` fast path. Open Question #4 (test surface) -> Tasks 1 + 4.
-- **Type consistency:** `is_pristine(&mut self) -> bool` used identically in Tasks 1-4. `LegacyKey`/`LegacyObjectId` aliases used only in Task 1.
-- **Known verification point:** helper names (`delete_cell`, `set_metadata`, `add_cell_after`, room/eviction test helpers) must be confirmed against the current files at implementation time; the plan flags each spot rather than guessing a signature.
+- **Type consistency:** `is_pristine(&mut self) -> bool` used identically in Tasks 1-4. `LegacyKey`/`LegacyObjectId`/`LegacyOpType` aliases used only in Task 1.
+- **Review fixes folded in (PR #3335):** the predicate matches `op.action` (`OpType::Put(_)`) and `op.pred.is_empty()`, not just `obj`/`key`, so a post-creation delete or overwrite of an identity key fails the gate (rgbkrk). Negative test `overwritten_or_deleted_identity_key_is_not_pristine` and constructor-guard test `every_fresh_constructor_is_pristine` cover the unenforced creation-path invariant (pullfrog). The metadata fast-path is documented as a pure optimization, not the metadata-case soundness mechanism (pullfrog).
+- **Known verification point:** helper names (`delete_cell`, `set_metadata`, `add_cell_after`, `new_with_encoding`, `TextEncoding`, room/eviction test helpers) must be confirmed against the current files at implementation time; the plan flags each spot rather than guessing a signature.


### PR DESCRIPTION
## What this is

A proposed ADR (the first in a new `docs/adr/` home) for how a fresh notebook gets its starter cell. Draft, because the decision is up for review before any implementation.

## The problem

Seeding currently decides "is this a pristine notebook that should get a starter cell?" by reading materialized projections:

```rust
fn is_uninitialized_notebook_doc(doc) -> bool {
    doc.cell_count() == 0 && doc.get_metadata_snapshot().is_none()
}
```

That's an observational proxy for a fact about history. In a CRDT the two diverge:

- `cell_count() == 0` isn't convergence-safe. A materialized count is whatever has arrived so far; a peer can see zero cells transiently mid-sync. The current code is correct only because the daemon seeds under a write lock before the sync handoff. The safety is in the choreography, not the invariant.
- `metadata.is_none()` is cross-module coupling, not logic. It only separates "pristine" from "user emptied it" because `create_empty_notebook` happens to always write metadata.
- The cloud wasm host uses a different test (`cell_count() > 0`), so the two hosts don't even agree on what "uninitialized" means.

## What the ADR proposes

The document model already has a first-class causal notion of "new" that seeding ignores: a byte-identical frozen genesis (`notebook_genesis_v5.am`), content-addressed seed hashes (`canonical_schema_seed_change_hashes`), and a dedicated `SCHEMA_SEED_ACTOR` that authorization already keys on.

The ADR lays out four options (status-quo+unify, causal pristine-check, seed-in-genesis, explicit marker) with trade-offs, and recommends the **causal pristine-check**: a notebook is uninitialized iff its history contains nothing beyond the canonical seed and the identity scaffold (no change has ever touched `cells` or `metadata`). Monotonic, convergence-safe, one predicate shared by daemon and cloud, no schema bump, and it gets the "user emptied it" case for free.

Seed-in-genesis is rejected (forces a v5→v6 schema bump and freezes the starter cell); an explicit `initialized` marker is kept as the pragmatic fallback.

## Also in this PR

- The predicate is now resolved and folded into the ADR: a doc is pristine iff every change beyond the canonical seed is an identity put to ROOT (`notebook_id` / `runtime_state_doc_id`). Verified host-agnostic - daemon and cloud both create via `new_with_actor`, so the scaffold is identical. The four "open questions" are settled (see the ADR).
- A bite-sized TDD implementation plan: `docs/superpowers/plans/2026-06-02-notebook-pristine-seeding.md`. `is_pristine` in `notebook-doc`, daemon + cloud point at it, the old guards go, plus the empty-then-reconnect integration test.

## Review asks

- Does the causal pristine-check land, or do you prefer the explicit marker?
- Is matching current behavior (metadata-present ⇒ not seedable) right, or a latent product question to reopen?

Still no production code here - the ADR and the plan only. Implementation lands as a follow-up PR once the decision is signed off.
