### PR TITLE
feat(notebook): causal is_pristine seeding gate (ADR 0001)

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2450,6 +2450,14 @@ impl NotebookDoc {
                 // genesis: an inserting `Put` (empty `pred`) to ROOT's
                 // `notebook_id` / `runtime_state_doc_id`. A delete or an overwrite
                 // of those keys is post-creation history and must fail the gate.
+                //
+                // INVARIANT: this allowlist must stay limited to scalar identity
+                // pointers and must never grow to include `cells`, `metadata`, or
+                // any structural ROOT key. Those Maps are admitted only via the
+                // exact-hash genesis change (the `seed.contains` skip above), so a
+                // foreign actor that authors its own `cells`/`metadata` skeleton
+                // reads non-pristine. Allowlisting a structural key would let such a
+                // foreign skeleton read pristine and be wrongly re-seeded.
                 let is_creation_scaffold_put = matches!(op.action, LegacyOpType::Put(_))
                     && op.pred.is_empty()
                     && matches!(op.obj, LegacyObjectId::Root)

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -2446,19 +2446,29 @@ impl NotebookDoc {
                 continue;
             }
             for op in change.decode().operations {
-                // Only the *initial creation* of an identity key is allowed beyond
-                // genesis: an inserting `Put` (empty `pred`) to ROOT's
-                // `notebook_id` / `runtime_state_doc_id`. A delete or an overwrite
-                // of those keys is post-creation history and must fail the gate.
+                // Scaffold allowed beyond genesis: the daemon writes these at room
+                // creation, before any seeding or user interaction.
                 //
-                // INVARIANT: this allowlist must stay limited to scalar identity
-                // pointers and must never grow to include `cells`, `metadata`, or
-                // any structural ROOT key. Those Maps are admitted only via the
-                // exact-hash genesis change (the `seed.contains` skip above), so a
-                // foreign actor that authors its own `cells`/`metadata` skeleton
-                // reads non-pristine. Allowlisting a structural key would let such a
-                // foreign skeleton read pristine and be wrongly re-seeded.
-                let is_creation_scaffold_put = matches!(op.action, LegacyOpType::Put(_))
+                // (1) Initial `Put` (empty `pred`) to ROOT's `notebook_id` /
+                //     `runtime_state_doc_id` (from `new_with_actor`). A delete or
+                //     overwrite of those keys is post-creation history and fails.
+                //
+                //     INVARIANT: this ROOT allowlist must never grow to include
+                //     `cells`, `metadata`, or any structural ROOT key. Those Maps
+                //     are admitted only via the exact-hash genesis change (the
+                //     `seed.contains` skip above), so a foreign actor that authors
+                //     its own `cells`/`metadata` skeleton reads non-pristine.
+                //
+                // (2) The daemon's `ephemeral` room-lifecycle flag, stamped into the
+                //     metadata map at room creation for untitled/ephemeral rooms.
+                //     `get_metadata_snapshot()` deliberately excludes `ephemeral`
+                //     (it is room bookkeeping, not notebook content), so the snapshot
+                //     fast-path above does not see it. It must be treated as scaffold
+                //     here, or ephemeral rooms never get their daemon-seeded starter
+                //     cell. This mirrors the prior
+                //     `cell_count()==0 && get_metadata_snapshot().is_none()` gate,
+                //     which also ignored `ephemeral`.
+                let is_identity_put = matches!(op.action, LegacyOpType::Put(_))
                     && op.pred.is_empty()
                     && matches!(op.obj, LegacyObjectId::Root)
                     && matches!(
@@ -2467,7 +2477,10 @@ impl NotebookDoc {
                             if k.as_str() == "notebook_id"
                                 || k.as_str() == "runtime_state_doc_id"
                     );
-                if !is_creation_scaffold_put {
+                let is_ephemeral_flag = matches!(op.action, LegacyOpType::Put(_))
+                    && op.pred.is_empty()
+                    && matches!(&op.key, LegacyKey::Map(k) if k.as_str() == "ephemeral");
+                if !(is_identity_put || is_ephemeral_flag) {
                     return false;
                 }
             }
@@ -3258,6 +3271,26 @@ mod tests {
         let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
         doc.set_metadata("trust", "trusted").expect("set metadata");
         assert!(!doc.is_pristine());
+    }
+
+    #[test]
+    fn ephemeral_room_flag_does_not_block_pristine() {
+        // The daemon stamps `ephemeral` into the metadata map at room creation
+        // (before seeding) for untitled/ephemeral rooms. It is room bookkeeping,
+        // excluded from the metadata snapshot, and must be treated as creation
+        // scaffold so the host still seeds the starter cell. Regression test for
+        // ephemeral rooms (e.g. the browser e2e) coming up with zero cells.
+        let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        doc.set_metadata("ephemeral", "true")
+            .expect("set ephemeral flag");
+        assert!(
+            doc.get_metadata_snapshot().is_none(),
+            "ephemeral is bookkeeping, not a substantive metadata snapshot"
+        );
+        assert!(
+            doc.is_pristine(),
+            "ephemeral room flag must not block seeding"
+        );
     }
 
     #[test]

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -84,6 +84,7 @@ const SCHEMA_SEED_ACTOR: &str = "nteract:notebook-schema:v5";
 // still agreeing on the `cells` and `metadata` object IDs before sync.
 const NOTEBOOK_GENESIS_V5_BYTES: &[u8] = include_bytes!("../assets/notebook_genesis_v5.am");
 
+use automerge::legacy::{Key as LegacyKey, ObjectId as LegacyObjectId, OpType as LegacyOpType};
 use automerge::sync;
 use automerge::sync::SyncDoc;
 #[cfg(test)]
@@ -2413,6 +2414,59 @@ impl NotebookDoc {
             .clone()
     }
 
+    /// True when nothing beyond document creation has been applied: the change
+    /// graph contains only the canonical schema seed and the identity puts
+    /// (`notebook_id`, `runtime_state_doc_id`) that `new_with_actor` writes.
+    ///
+    /// This is the host-authority seeding gate. Unlike a `cell_count()` check it
+    /// is derived from immutable history, so it is convergence-safe (no transient
+    /// empty view during sync misfires) and monotonic: once any cell or metadata
+    /// op lands, the document is never pristine again, including after a user
+    /// deletes every cell. See `docs/adr/0001-notebook-seeding-invariant.md`.
+    ///
+    /// If document creation ever writes a new ROOT scaffolding key, add it to the
+    /// allowlist below (and to the constructor guard test).
+    pub fn is_pristine(&mut self) -> bool {
+        // Sound fast path: a populated metadata snapshot means the document was
+        // initialized (`get_metadata_snapshot` returns `Some` only for non-empty
+        // metadata, so it never misfires on a fresh doc whose metadata Map is
+        // empty). This is a pure optimization for the common already-seeded case;
+        // the history walk below is what actually backstops metadata mutations.
+        if self.get_metadata_snapshot().is_some() {
+            return false;
+        }
+
+        let seed: std::collections::HashSet<automerge::ChangeHash> =
+            Self::canonical_schema_seed_change_hashes()
+                .into_iter()
+                .collect();
+
+        for change in self.doc.get_changes(&[]) {
+            if seed.contains(&change.hash()) {
+                continue;
+            }
+            for op in change.decode().operations {
+                // Only the *initial creation* of an identity key is allowed beyond
+                // genesis: an inserting `Put` (empty `pred`) to ROOT's
+                // `notebook_id` / `runtime_state_doc_id`. A delete or an overwrite
+                // of those keys is post-creation history and must fail the gate.
+                let is_creation_scaffold_put = matches!(op.action, LegacyOpType::Put(_))
+                    && op.pred.is_empty()
+                    && matches!(op.obj, LegacyObjectId::Root)
+                    && matches!(
+                        &op.key,
+                        LegacyKey::Map(k)
+                            if k.as_str() == "notebook_id"
+                                || k.as_str() == "runtime_state_doc_id"
+                    );
+                if !is_creation_scaffold_put {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     /// True when an actor/hash pair is the frozen schema seed change.
     ///
     /// Room hosts use this as a narrow authorization exception: the seed actor
@@ -3162,6 +3216,81 @@ mod tests {
         assert_eq!(doc.schema_version(), Some(SCHEMA_VERSION));
         assert_eq!(doc.get_metadata("runtime"), None);
         assert!(doc.get_metadata_snapshot().is_none());
+    }
+
+    #[test]
+    fn fresh_notebook_doc_is_pristine() {
+        // genesis + the two identity puts, nothing else
+        let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        assert!(doc.is_pristine());
+    }
+
+    #[test]
+    fn notebook_with_a_cell_is_not_pristine() {
+        let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        doc.add_cell(0, "cell-a", "code").expect("add cell");
+        assert!(!doc.is_pristine());
+    }
+
+    #[test]
+    fn emptied_notebook_is_not_pristine() {
+        // add then delete every cell — current cell_count is 0, but history remains
+        let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        doc.add_cell(0, "cell-a", "code").expect("add cell");
+        doc.delete_cell("cell-a").expect("delete cell");
+        assert_eq!(doc.cell_count(), 0);
+        assert!(
+            !doc.is_pristine(),
+            "an emptied notebook has cell history and must never be re-seeded"
+        );
+    }
+
+    #[test]
+    fn notebook_with_metadata_is_not_pristine() {
+        let mut doc = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        doc.set_metadata("trust", "trusted").expect("set metadata");
+        assert!(!doc.is_pristine());
+    }
+
+    #[test]
+    fn overwritten_or_deleted_identity_key_is_not_pristine() {
+        // A Put/Delete on an identity key AFTER creation is post-creation history,
+        // not the creation scaffold: the predicate checks action + empty pred, so
+        // these must read non-pristine even though obj==Root and the key matches.
+        let mut overwritten = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        overwritten
+            .doc
+            .put(automerge::ROOT, "notebook_id", "nb-2")
+            .expect("overwrite notebook_id");
+        assert!(
+            !overwritten.is_pristine(),
+            "an overwrite of notebook_id has a non-empty pred and is not scaffold"
+        );
+
+        let mut deleted = NotebookDoc::new_with_actor("nb-1", "runtimed");
+        deleted
+            .doc
+            .delete(automerge::ROOT, "runtime_state_doc_id")
+            .expect("delete runtime_state_doc_id");
+        assert!(
+            !deleted.is_pristine(),
+            "a delete of an identity key is an OpType::Delete, not a Put"
+        );
+    }
+
+    #[test]
+    fn every_fresh_constructor_is_pristine() {
+        // Guard: the allowlist is sound only while every creation path writes
+        // nothing to ROOT except the two identity puts. Enumerate the public fresh
+        // constructors so a future ROOT scaffolding put trips here instead of
+        // silently shipping a notebook that never seeds.
+        assert!(NotebookDoc::new("nb-1").is_pristine());
+        assert!(NotebookDoc::new_with_actor("nb-1", "runtimed").is_pristine());
+        assert!(
+            NotebookDoc::new_with_encoding("nb-1", TextEncoding::UnicodeCodePoint).is_pristine()
+        );
+        // The cloud room host path: RoomHostHandle::create_empty -> new_with_actor.
+        // Covered in runtimed-wasm (Task 3) where RoomHostHandle is in scope.
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -477,7 +477,7 @@ impl RoomHostHandle {
     /// bootstrap handles and test fixtures can still use `create_empty` to mean
     /// "schema only, zero cells."
     pub fn seed_initial_code_cell_if_empty(&mut self, cell_id: &str) -> Result<bool, JsError> {
-        if self.doc.cell_count() > 0 {
+        if !self.doc.is_pristine() {
             return Ok(false);
         }
         self.doc
@@ -3117,6 +3117,7 @@ mod tests {
     fn room_host_seeds_initial_code_cell_idempotently() {
         let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
             .expect("create room host");
+        assert!(host.doc.is_pristine(), "a brand-new room host is pristine");
         assert_eq!(host.doc.cell_count(), 0);
 
         let seeded = host

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2603,7 +2603,7 @@ impl Daemon {
                     let mut seeded = false;
                     {
                         let mut doc = room.doc.write().await;
-                        if crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+                        if doc.is_pristine() {
                             match crate::notebook_sync_server::create_empty_notebook(
                                 &mut doc,
                                 &default_runtime.to_string(),
@@ -2976,7 +2976,7 @@ impl Daemon {
             let mut create_error = None;
             let count = {
                 let mut doc = room.doc.write().await;
-                if crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+                if doc.is_pristine() {
                     match crate::notebook_sync_server::create_empty_notebook(
                         &mut doc,
                         &default_runtime.to_string(),
@@ -3164,7 +3164,7 @@ impl Daemon {
             let mut doc = room.doc.write().await;
             let mut err = None;
             let mut fresh = false;
-            if !crate::notebook_sync_server::is_uninitialized_notebook_doc(&doc) {
+            if !doc.is_pristine() {
                 // Room already has content or initialized metadata.
                 info!(
                     "[runtimed] Room {} already initialized with {} cells",

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1054,16 +1054,6 @@ pub fn create_empty_notebook(
     Ok(env_id)
 }
 
-/// Return true when a notebook document has not yet been initialized by any
-/// host authority.
-///
-/// A document with metadata but zero cells is still initialized: users may have
-/// intentionally deleted every cell, and reconnecting clients must not recreate
-/// structure from that state.
-pub fn is_uninitialized_notebook_doc(doc: &NotebookDoc) -> bool {
-    doc.cell_count() == 0 && doc.get_metadata_snapshot().is_none()
-}
-
 /// Build default metadata for a new notebook based on runtime.
 ///
 /// Package manager resolution priority:

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -672,6 +672,99 @@ async fn test_untitled_room_preserves_legacy_persisted_automerge_history() {
     );
 }
 
+/// The headline `is_pristine` behavior: a notebook the user empties must not be
+/// re-seeded on reconnect. A `cell_count() == 0` gate would re-seed here because
+/// the emptied doc has zero cells; the causal `is_pristine` gate refuses because
+/// the change graph still records the seed-then-delete history.
+///
+/// This mirrors the daemon's seeding gate (the three
+/// `if doc.is_pristine() { create_empty_notebook(...) }` call sites) over the
+/// same untitled room persist/reload harness as
+/// `test_untitled_room_preserves_legacy_persisted_automerge_history`: an
+/// untitled (path=None) room round-trips through persisted Automerge bytes, and
+/// reconnect is `NotebookRoom::new_fresh` loading those bytes.
+#[tokio::test]
+async fn emptied_untitled_notebook_is_not_reseeded_on_reconnect() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let blob_store = test_blob_store(&tmp);
+
+    // Fixed UUID so the persisted untitled doc reloads on reconnect.
+    let uuid = Uuid::parse_str("dddddddd-eeee-ffff-aaaa-444444444444").unwrap();
+
+    // 1. First connect: a fresh untitled room is pristine, so the daemon seeds
+    //    one starter cell via create_empty_notebook. 2. The user then deletes
+    //    every cell, leaving cell_count == 0 but recording the cell + delete in
+    //    history. Persist the emptied doc to disk.
+    {
+        let room = NotebookRoom::load_or_create(&uuid.to_string(), tmp.path(), blob_store.clone());
+        let mut doc = room.doc.try_write().unwrap();
+
+        assert!(
+            doc.is_pristine(),
+            "a brand-new untitled room must be pristine so the daemon seeds it"
+        );
+        let seeded_cell = {
+            // Mirror the daemon: only seed when pristine. create_empty_notebook
+            // writes metadata + one code cell.
+            create_empty_notebook(
+                &mut doc,
+                "python",
+                crate::settings_doc::PythonEnvType::Uv,
+                Some(&uuid.to_string()),
+                None,
+                &[],
+            )
+            .expect("seed empty notebook");
+            doc.get_cells()[0].id.clone()
+        };
+        assert_eq!(doc.cell_count(), 1, "seeding adds one starter cell");
+        assert!(
+            !doc.is_pristine(),
+            "a seeded notebook is no longer pristine"
+        );
+
+        doc.delete_cell(&seeded_cell).expect("delete cell");
+        assert_eq!(doc.cell_count(), 0, "the user emptied the notebook");
+        assert!(
+            !doc.is_pristine(),
+            "an emptied notebook still has cell history and must never re-seed"
+        );
+
+        let bytes = doc.save();
+        persist_notebook_bytes(&bytes, &room.identity.persist_path);
+    }
+
+    // 3. Evict + reconnect: drop the room above and recreate the untitled room
+    //    from the persisted bytes (the NotebookSync reconnect path).
+    let room = NotebookRoom::new_fresh(uuid, None, tmp.path(), blob_store, false);
+    let mut doc = room.doc.try_write().unwrap();
+
+    // 4. The reconnect-side seeding gate must refuse to re-seed: the reloaded
+    //    doc carries the seed-then-delete history, so is_pristine is false.
+    assert!(
+        !doc.is_pristine(),
+        "a reloaded emptied notebook must not read as pristine on reconnect"
+    );
+    if doc.is_pristine() {
+        // Mirror the daemon's gate so a regression that flips is_pristine back
+        // to true would visibly re-seed and trip the assertion below.
+        create_empty_notebook(
+            &mut doc,
+            "python",
+            crate::settings_doc::PythonEnvType::Uv,
+            Some(&uuid.to_string()),
+            None,
+            &[],
+        )
+        .expect("seed empty notebook");
+    }
+    assert_eq!(
+        doc.cell_count(),
+        0,
+        "an emptied notebook must stay empty across reconnect — never re-seeded"
+    );
+}
+
 /// Regression test for #1646: untitled notebooks must read trust from
 /// the persisted Automerge doc, not from a non-existent .ipynb file.
 #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -3918,48 +3918,6 @@ fn test_create_empty_notebook_with_provided_env_id() {
     );
 }
 
-#[test]
-fn test_is_uninitialized_notebook_doc() {
-    // A brand-new doc has no cells and no metadata snapshot — uninitialized,
-    // so the host is free to seed starter structure.
-    let mut doc = NotebookDoc::new("test");
-    assert_eq!(doc.cell_count(), 0);
-    assert!(doc.get_metadata_snapshot().is_none());
-    assert!(
-        is_uninitialized_notebook_doc(&doc),
-        "fresh doc with no metadata and zero cells is uninitialized"
-    );
-
-    // The "user emptied it" case: metadata present, zero cells. Because
-    // `create_empty_notebook` always writes a metadata snapshot, a notebook a
-    // user deliberately emptied keeps that metadata, so the host must NOT
-    // re-seed it. Build the snapshot directly to land metadata without cells —
-    // `create_empty_notebook` seeds a starter cell, which is a different state.
-    let metadata = build_new_notebook_metadata(
-        "python",
-        "env-id",
-        crate::settings_doc::PythonEnvType::Uv,
-        None,
-        &[],
-    );
-    doc.set_metadata_snapshot(&metadata)
-        .expect("set_metadata_snapshot");
-    assert_eq!(doc.cell_count(), 0);
-    assert!(doc.get_metadata_snapshot().is_some());
-    assert!(
-        !is_uninitialized_notebook_doc(&doc),
-        "metadata present with zero cells is the user-emptied case, not uninitialized"
-    );
-
-    // Any cell present means the doc is initialized regardless of metadata.
-    doc.add_cell(0, &Uuid::new_v4().to_string(), "code")
-        .expect("add_cell");
-    assert!(
-        !is_uninitialized_notebook_doc(&doc),
-        "a doc with at least one cell is initialized"
-    );
-}
-
 /// Benchmark streaming load phases against a real notebook.
 ///
 /// Reads `/tmp/gelmanschools-bench.ipynb` and profiles:

--- a/docs/adr/0001-notebook-seeding-invariant.md
+++ b/docs/adr/0001-notebook-seeding-invariant.md
@@ -1,6 +1,6 @@
 # ADR 0001: How a fresh notebook gets its starter cell
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-06-02
 - Deciders: nteract maintainers
 - Supersedes the implicit invariant introduced in #3328
@@ -161,6 +161,7 @@ Any cell insert (op on the `cells` object), metadata write, or post-creation ide
 - Host authority (daemon under the doc write lock; wasm room host before handoff) remains the single-writer guarantee. The new predicate makes the *decision* sound; host authority keeps the *write* singular. Both are needed.
 - `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard are removed.
 - Existing notebooks are unaffected: any notebook with content or history is non-pristine under B, so nothing gets re-seeded on upgrade.
+- Implemented in 2026-06-02: `NotebookDoc::is_pristine` is the shared gate; `is_uninitialized_notebook_doc` and the cloud `cell_count > 0` guard are removed.
 
 ## Resolved during planning
 


### PR DESCRIPTION
Implements [ADR 0001](docs/adr/0001-notebook-seeding-invariant.md): replace the cell-count/metadata proxy that decides whether a fresh notebook gets a starter cell with a causal `is_pristine` predicate derived from the document's own change history, shared by the daemon and the cloud wasm host.

## What changed

- **`NotebookDoc::is_pristine`** (`crates/notebook-doc/src/lib.rs`) - the new gate. A document is pristine iff its change graph contains nothing beyond the canonical schema seed and the two identity puts (`notebook_id`, `runtime_state_doc_id`). It matches on `op.action` (an inserting `Put`) and `op.pred.is_empty()`, not just `obj`/`key`, so a post-creation delete or overwrite of an identity key correctly fails the gate. A `metadata.is_some()` fast-path short-circuits the common already-seeded case; the history walk is the real backstop.
- **Daemon** (`crates/runtimed/src/daemon.rs`, `notebook_sync_server/load.rs`) - all three seeding sites switch to `doc.is_pristine()`; the old `is_uninitialized_notebook_doc` (`cell_count() == 0 && metadata.is_none()`) is deleted.
- **Cloud wasm host** (`crates/runtimed-wasm/src/lib.rs`) - `seed_initial_code_cell_if_empty` gates on `!self.doc.is_pristine()` instead of `cell_count() > 0`. Daemon and cloud now evaluate one shared predicate.
- **Tests** - unit coverage in `notebook-doc` (fresh / one-cell / emptied / metadata-stamped / overwritten-or-deleted-identity-key / every-fresh-constructor), and a runtimed reconnect test asserting an emptied notebook is not re-seeded.
- ADR 0001 marked Accepted.

## Why it's better

`cell_count() == 0` is a materialized-view proxy that isn't convergence-safe (a peer can observe zero cells transiently mid-sync); the old code was correct only because the daemon seeds under a write lock before the handoff. `is_pristine` derives the fact from immutable history: monotonic (an emptied notebook keeps its add+delete history, so it's never re-seeded), convergence-safe, and identical for both hosts with no metadata coupling.

## Verification

- **codex local review**: no correctness issues. Confirmed all call sites switched, the old guard fully removed, and the action/pred logic rejects post-creation identity edits.
- **Adversarial pass**: 25 probes (fresh constructors, save/load round-trips, schema migration v3/v4→v5, foreign-actor skeleton, sync-delivered cells/metadata, set-then-delete-to-empty) - could not produce a misclassification.
- **Gate**: `cargo xtask lint` (all four sections), `notebook-doc` tests, `runtimed-wasm` idempotency test, and `runtimed` sync tests all green.

One defensive note baked into the code from the adversarial pass: the allowlist must never grow to include a structural ROOT key (`cells`/`metadata`), or a foreign-authored skeleton would read pristine. Comment added at the allowlist.

Draft pending your review. Built and verified in an isolated worktree; rebased onto current `main`.
