### PR TITLE
ci: route trusted Linux jobs to custom runners

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -37,6 +37,8 @@ runs:
         run-install: false
 
     - uses: pnpm/action-setup@v6
+      with:
+        dest: ${{ runner.temp }}/setup-pnpm
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -49,6 +49,12 @@ runs:
       shell: bash
       run: pnpm install --frozen-lockfile
 
+    - name: Pin Rust tool paths
+      shell: bash
+      run: |
+        echo "CARGO=$(rustup which cargo)" >> "$GITHUB_ENV"
+        echo "RUSTC=$(rustup which rustc)" >> "$GITHUB_ENV"
+
     - name: Install wasm-pack
       if: inputs.skip-wasm != 'true'
       uses: ./.github/actions/install-wasm-pack

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -45,7 +45,7 @@ runs:
           exit 1
         fi
 
-        install_dir="$HOME/.cargo/bin"
+        install_dir="$RUNNER_TEMP/wasm-pack/bin"
         mkdir -p "$install_dir"
         cp "$bin" "$install_dir/"
         chmod +x "$install_dir/$(basename "$bin")"

--- a/.github/actions/prepare-self-hosted-rust/action.yml
+++ b/.github/actions/prepare-self-hosted-rust/action.yml
@@ -1,0 +1,13 @@
+name: Prepare self-hosted Rust homes
+description: Isolate mutable Rust state for parallel self-hosted runner services.
+
+runs:
+  using: composite
+  steps:
+    - name: Use job-local Rust homes
+      shell: bash
+      run: |
+        mkdir -p "${RUNNER_TEMP}/cargo-home/bin" "${RUNNER_TEMP}/rustup-home"
+        echo "CARGO_HOME=${RUNNER_TEMP}/cargo-home" >> "${GITHUB_ENV}"
+        echo "RUSTUP_HOME=${RUNNER_TEMP}/rustup-home" >> "${GITHUB_ENV}"
+        echo "${RUNNER_TEMP}/cargo-home/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,10 @@ jobs:
 
       - name: Install NSIS
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y nsis
+          sudo flock /var/lock/nteract-ci-apt.lock bash -euo pipefail <<'APT'
+          apt-get -o DPkg::Lock::Timeout=120 update -qq
+          apt-get -o DPkg::Lock::Timeout=120 install -y nsis
+          APT
 
       - name: Compile bootstrap hook fixture
         run: |
@@ -136,8 +138,10 @@ jobs:
 
       - name: Install mingw-w64 and add Windows GNU target
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc-mingw-w64-x86-64 nasm
+          sudo flock /var/lock/nteract-ci-apt.lock bash -euo pipefail <<'APT'
+          apt-get -o DPkg::Lock::Timeout=120 update -qq
+          apt-get -o DPkg::Lock::Timeout=120 install -y gcc-mingw-w64-x86-64 nasm
+          APT
           rustup target add x86_64-pc-windows-gnu
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
@@ -342,8 +346,10 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
+          sudo flock /var/lock/nteract-ci-apt.lock bash -euo pipefail <<'APT'
+          apt-get -o DPkg::Lock::Timeout=120 update
+          apt-get -o DPkg::Lock::Timeout=120 install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
+          APT
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
@@ -699,13 +705,15 @@ jobs:
 
       - name: Install system dependencies
         run: |
-          sudo apt-get -o DPkg::Lock::Timeout=120 update
-          sudo apt-get -o DPkg::Lock::Timeout=120 install -y \
+          sudo flock /var/lock/nteract-ci-apt.lock bash -euo pipefail <<'APT'
+          apt-get -o DPkg::Lock::Timeout=120 update
+          apt-get -o DPkg::Lock::Timeout=120 install -y \
             libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libxdo-dev \
             xvfb \
             webkit2gtk-driver
+          APT
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
         with:
           run-install: false
       - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: "22"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,9 @@ jobs:
     name: Lint & Format
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    # Use the Anaconda runner pool for trusted events. Fork PRs stay on
+    # GitHub-hosted runners because this repository is public.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -99,7 +101,7 @@ jobs:
     name: NSIS Bootstrap Syntax
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -119,7 +121,7 @@ jobs:
     name: Windows (clippy)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -154,7 +156,7 @@ jobs:
     name: WASM + Deno Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -190,7 +192,7 @@ jobs:
     name: Build shared UI artifacts
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -237,7 +239,7 @@ jobs:
     name: JS Tests & Benchmarks
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -424,7 +426,7 @@ jobs:
     name: Linux Rust Clippy
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -459,7 +461,7 @@ jobs:
     name: Linux Rust Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -488,7 +490,7 @@ jobs:
     name: Linux runtimed-node
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -1035,7 +1037,7 @@ jobs:
     name: Python Unit Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           lfs: true
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -131,6 +134,9 @@ jobs:
         with:
           lfs: true
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -168,6 +174,9 @@ jobs:
         with:
           lfs: true
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -203,6 +212,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -251,6 +263,9 @@ jobs:
         with:
           lfs: true
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -285,6 +300,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -355,6 +373,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -443,6 +464,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -478,6 +502,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -503,6 +530,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -611,6 +641,9 @@ jobs:
       - name: Install uv
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         uses: astral-sh/setup-uv@v8.1.0
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && runner.environment == 'self-hosted'
 
       - name: Install rust
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
@@ -941,6 +974,9 @@ jobs:
         with:
           lfs: true
 
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
+
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
 
@@ -1052,6 +1088,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: true
+
+      - uses: ./.github/actions/prepare-self-hosted-rust
+        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,6 +62,8 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
 
       - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - uses: actions/setup-node@v6
         with:
@@ -171,6 +173,8 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
 
       - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - uses: actions/setup-node@v6
         with:
@@ -293,6 +297,8 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           run-install: false
       - uses: pnpm/action-setup@v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: "22"


### PR DESCRIPTION
## Summary

- Routes trusted Linux CI lanes to the `nteract-linux-ci` self-hosted runner pool
- Keeps fork PRs on GitHub-hosted `ubuntu-24.04` runners
- Covers lint, NSIS syntax, Windows cross-clippy, WASM/Deno, UI build, JS tests, Linux Rust shards, runtimed-node, and Python unit tests

## Verification

- `actionlint -color=false .github/workflows/build.yml`
- `cargo xtask lint --fix`
- `git diff --check`

## Runner Notes

The runner pool currently has six active slots:

- `lab-runner1`: `nteract-linux-ci-01` and `nteract-linux-ci-02`
- `lab-runner2`: `nteract-linux-ci-05` through `nteract-linux-ci-08`

`nteract-linux-ci-03` and `nteract-linux-ci-04` remain registered but stopped so the 8-vCPU host does not over-accept heavy jobs.
