### PR TITLE
refactor(notebook-cloud): converge preview shell capabilities

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -122,7 +122,7 @@ const cloudStateRows = [
   {
     surface: "Presence",
     owner: "Room session",
-    language: "2 here now",
+    language: "2",
     reason: "People are peers on the document; mode belongs to the view/edit control.",
   },
   {

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -583,24 +583,23 @@ function CloudEntrySurface() {
       <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,0.85fr)]">
         <div className="grid content-start gap-3">
           <p className="m-0 text-xs font-semibold uppercase tracking-normal text-muted-foreground">
-            Cloud notebooks
+            Notebook cloud
           </p>
-          <h3 className="m-0 max-w-[18ch] text-4xl font-bold leading-none text-foreground">
-            Stay in the document.
+          <h3 className="m-0 max-w-[12ch] text-4xl font-bold leading-none text-foreground">
+            nteract
           </h3>
           <p className="m-0 max-w-xl text-sm leading-6 text-muted-foreground">
-            Public notebooks open calmly. Account controls appear only when someone needs to edit,
-            share, or renew access.
+            preview realtime notebooks
           </p>
         </div>
         <div className="grid content-start gap-3 border-l-2 border-foreground/25 bg-gradient-to-r from-muted/35 to-transparent py-3 pl-4">
           <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-3">
             <KeyRound className="mt-0.5 size-5 text-muted-foreground" aria-hidden="true" />
             <div className="min-w-0">
-              <h3 className="m-0 truncate text-base font-semibold">Public viewer</h3>
+              <h3 className="m-0 truncate text-base font-semibold">Notebook cloud</h3>
               <p className="m-0 mt-1 text-xs leading-5 text-muted-foreground">
-                Public notebooks stay readable without an account. Sign in when edit access or
-                sharing controls are needed.
+                Sign in to open private previews or request edit access. Public notebooks stay
+                readable without an account.
               </p>
             </div>
           </div>
@@ -616,8 +615,8 @@ function CloudEntrySurface() {
         </div>
       </div>
       <div className="border-t border-fd-border px-4 py-3 text-xs leading-5 text-fd-muted-foreground">
-        Local development identity stays in the account panel after a notebook opens, where it can
-        act like host auth instead of document content.
+        After a notebook opens, account and sharing actions belong to the room host. The notebook
+        shell receives capabilities from that host instead of guessing from runtime state.
       </div>
     </section>
   );

--- a/apps/elements/content/docs/cloud-notebook-shell.mdx
+++ b/apps/elements/content/docs/cloud-notebook-shell.mdx
@@ -44,6 +44,9 @@ package/runtime language, and execution controls.
 - Sharing should read as document permissions: public link state, people,
   pending invites, and roles. Avoid generic bubbles, stacked badges, or account
   language that makes collaborators look like runtime actors.
+- Sharing is a room-host capability. Desktop and cloud shells should both show
+  it only when the active `NotebookRoom` advertises sharing and the current
+  identity can use authenticated owner access.
 - Sharing controls should appear where the role can act. Non-owner editors and
   viewers need their own quiet pathways: owner shares, viewer requests edit,
   expired sessions renew before changing access.

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1755,6 +1755,9 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
     runtimeSnapshotBasePath: `${notebookApiBasePath}/runtime-snapshots/`,
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
+    hostCapabilities: {
+      canManageSharing: true,
+    },
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),
     rendererAssetsBasePath: rendererAssetsBasePath(env),

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -95,6 +95,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /"runtimeSnapshotBasePath":"\/api\/n\/demo\/runtime-snapshots\/"/);
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
+    assert.match(html, /"hostCapabilities":\{"canManageSharing":true\}/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -141,9 +141,14 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /identityControls=\{null\}/);
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
-  assert.match(sourceText, /matchMedia\("\(max-width: 599\.98px\)"\)/);
+  assert.match(
+    sourceText,
+    /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/,
+  );
+  assert.match(sourceText, /<EnvironmentSummary[\s\S]*showPackageDetails=\{false\}/);
   assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
   assert.match(sourceText, /cloudViewerPresenceDisplay,/);
+  assert.match(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
   assert.match(sourceText, /Public link, collaborators, and pending invites for this notebook\./);
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -142,7 +142,12 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
   assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);
-  assert.match(sourceText, /<EnvironmentSummary[\s\S]*showPackageDetails=\{false\}/);
+  assert.match(sourceText, /packagesSummary=\{null\}/);
+  assert.match(
+    sourceText,
+    /const shouldShowPackageEnvironmentSummary =[\s\S]*shellCapabilities\.canExecute \|\| shellCapabilities\.canManagePackages/,
+  );
+  assert.match(sourceText, /shouldShowPackageEnvironmentSummary \? \([\s\S]*<EnvironmentSummary/);
   assert.match(sourceText, /autoFocusFirstCell=\{false\}/);
   assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
   assert.match(sourceText, /cloudViewerPresenceDisplay,/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -77,12 +77,17 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
     cssText.indexOf(".cloud-home-status"),
   );
 
-  assert.match(homeSource, /homeStatusTitle[\s\S]*"Public viewer"/);
+  assert.match(homeSource, /homeStatusTitle[\s\S]*"Notebook cloud"/);
   assert.match(homeSource, /className="cloud-home-layout"/);
   assert.match(homeSource, /className="cloud-home-copy"/);
+  assert.match(homeSource, /<h1>nteract<\/h1>/);
+  assert.match(homeSource, /preview realtime notebooks/);
+  assert.match(homeSource, /Open topic viz/);
   assert.doesNotMatch(homeSource, /showPrototypeDevControls/);
   assert.doesNotMatch(homeSource, /className="cloud-home-scope"/);
   assert.doesNotMatch(homeSource, /<select/);
+  assert.doesNotMatch(homeSource, /cloud-report-toolbar/);
+  assert.doesNotMatch(homeSource, /requesting viewer/);
   assert.match(cssText, /\.cloud-home-layout/);
   assert.doesNotMatch(cssText, /\.cloud-home-scope/);
   assert.doesNotMatch(homePanelCss, /box-shadow/);
@@ -102,9 +107,10 @@ test("cloud callback keeps sign-in handoff in the entry surface language", () =>
   assert.match(callbackSource, /className="cloud-home"/);
   assert.match(callbackSource, /className="cloud-home-layout"/);
   assert.match(callbackSource, /className="cloud-home-panel"/);
-  assert.match(callbackSource, /Returning to the notebook\./);
+  assert.match(callbackSource, /returning to the notebook/);
   assert.match(callbackSource, /data-mode=\{status\.kind\}/);
   assert.match(cssText, /\.cloud-home-status-spinner/);
+  assert.doesNotMatch(callbackSource, /cloud-report-toolbar/);
   assert.doesNotMatch(callbackSource, /className="flex min-h-screen/);
 });
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -141,11 +141,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /identityControls=\{null\}/);
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
-  assert.match(
-    sourceText,
-    /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/,
-  );
+  assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);
   assert.match(sourceText, /<EnvironmentSummary[\s\S]*showPackageDetails=\{false\}/);
+  assert.match(sourceText, /autoFocusFirstCell=\{false\}/);
   assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
   assert.match(sourceText, /cloudViewerPresenceDisplay,/);
   assert.match(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -189,6 +189,7 @@ test("cloud shell capabilities grant owners full cell, structure, and sharing co
     connectionScope: "owner",
     hasCodeCells: true,
     selectedMode: "edit",
+    hostCapabilities: { canManageSharing: true },
   });
 
   assert.equal(capabilities.canEditMarkdown, true);
@@ -210,6 +211,7 @@ test("cloud shell capabilities reserve sharing for owners", () => {
       authState: authState("dev"),
       connectionScope: "owner",
       hasCodeCells: true,
+      hostCapabilities: { canManageSharing: true },
     }).canManageSharing,
     true,
   );
@@ -219,9 +221,27 @@ test("cloud shell capabilities reserve sharing for owners", () => {
       authState: authState("dev"),
       connectionScope: "editor",
       hasCodeCells: true,
+      hostCapabilities: { canManageSharing: true },
     }).canManageSharing,
     false,
   );
+});
+
+test("cloud shell capabilities require the host room to advertise sharing", () => {
+  const ownerWithoutSharingHost = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+  });
+  assert.equal(ownerWithoutSharingHost.canManageSharing, false);
+
+  const expiredOwnerWithSharingHost = cloudNotebookShellCapabilities({
+    authState: authState("oidc_expired", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    hostCapabilities: { canManageSharing: true },
+  });
+  assert.equal(expiredOwnerWithSharingHost.canManageSharing, false);
 });
 
 test("cloud shell capabilities expose interaction mode for local dev identities", () => {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -255,83 +255,41 @@ body {
 .cloud-home {
   display: grid;
   min-height: 100vh;
-  grid-template-rows: auto 1fr;
+  place-items: center;
   background: var(--background);
 }
 
-.cloud-home-title {
-  display: grid;
-  min-width: 0;
-  gap: 0.125rem;
-}
-
-.cloud-home-title span,
-.cloud-home-title small {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.cloud-home-title span {
-  color: var(--foreground);
-  font-size: 1rem;
-  font-weight: 650;
-  line-height: 1.15;
-}
-
-.cloud-home-title small {
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
-  font-size: 0.75rem;
-  line-height: 1.2;
-}
-
 .cloud-home-layout {
-  align-self: start;
-  justify-self: center;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(19rem, 0.9fr);
-  gap: clamp(1.25rem, 4vw, 3rem);
-  width: min(54rem, calc(100vw - clamp(2rem, 8vw, 6rem)));
-  padding-block: clamp(2rem, 10vh, 5rem);
+  gap: clamp(2rem, 7vh, 4.5rem);
+  width: min(34rem, calc(100vw - clamp(2rem, 8vw, 6rem)));
+  padding-block: clamp(2rem, 10vh, 6rem);
 }
 
 .cloud-home-copy {
   display: grid;
-  align-content: start;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
+  justify-items: center;
+  gap: 0.375rem;
+  text-align: center;
 }
 
-.cloud-home-copy p,
 .cloud-home-copy h1,
 .cloud-home-copy span {
   margin: 0;
 }
 
-.cloud-home-copy p {
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
-  font-size: 0.8125rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.1;
-  text-transform: uppercase;
-}
-
 .cloud-home-copy h1 {
-  max-width: 18ch;
   color: var(--foreground);
-  font-size: 2.75rem;
-  font-weight: 720;
+  font-size: clamp(3rem, 8vw, 5rem);
+  font-weight: 760;
   letter-spacing: 0;
-  line-height: 1;
+  line-height: 0.95;
 }
 
 .cloud-home-copy span {
-  max-width: 32rem;
-  color: color-mix(in srgb, var(--foreground) 68%, transparent);
-  font-size: 1.125rem;
-  line-height: 1.55;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  line-height: 1.35;
 }
 
 .cloud-home > .cloud-report-toolbar,
@@ -479,26 +437,9 @@ main.flex > .cloud-report-toolbar {
 }
 
 @media (max-width: 760px) {
-  .cloud-home-title small {
-    display: none;
-  }
-
   .cloud-home-layout {
-    grid-template-columns: 1fr;
-    gap: 1.25rem;
     width: min(100%, calc(100vw - 2rem));
-    padding-block: 2rem;
-  }
-
-  .cloud-home-copy h1 {
-    max-width: 18ch;
-    font-size: 2.5rem;
-  }
-}
-
-@media (max-width: 420px) {
-  .cloud-home-copy h1 {
-    font-size: 2.25rem;
+    padding-block: 3rem;
   }
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -149,6 +149,9 @@ interface CloudViewerConfig {
   runtimeSnapshotBasePath: string;
   aclEndpoint: string;
   invitesEndpoint: string;
+  hostCapabilities?: {
+    canManageSharing?: boolean;
+  };
   syncEndpoint: string;
   blobBasePath: string;
   rendererAssetsBasePath: string;
@@ -215,6 +218,9 @@ function loadConfig(): CloudViewerConfig {
     runtimeSnapshotBasePath: parsed.runtimeSnapshotBasePath,
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
+    hostCapabilities: {
+      canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
+    },
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
     rendererAssetsBasePath: parsed.rendererAssetsBasePath,
@@ -1156,16 +1162,13 @@ function NotebookViewer({
         hasCodeCells: codeCellCount > 0,
         selectedMode: selectedInteractionMode,
         canAcceptCellMutations,
-        hostCapabilities: {
-          canManageSharing: Boolean(config.aclEndpoint && config.invitesEndpoint),
-        },
+        hostCapabilities: config.hostCapabilities,
       }),
     [
       authState,
       canAcceptCellMutations,
       codeCellCount,
-      config.aclEndpoint,
-      config.invitesEndpoint,
+      config.hostCapabilities,
       connectionActorLabel,
       connectionScope,
       selectedInteractionMode,

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1271,23 +1271,28 @@ function NotebookViewer({
     setSelectedInteractionMode("edit");
     refreshAuthState();
   }, [refreshAuthState]);
+  const shouldShowPackageEnvironmentSummary =
+    shellCapabilities.canExecute || shellCapabilities.canManagePackages;
   const rail = (
     <NotebookDocumentRail
       viewModel={notebookViewModel}
       activePanelId={activeRailPanel}
       collapsed={railCollapsed}
       selectedOutlineItemId={selectedOutlineItemId}
+      packagesSummary={null}
       packagesPanel={
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}
           readOnly={!shellCapabilities.canManagePackages}
           header={
-            <EnvironmentSummary
-              capabilities={shellCapabilities}
-              packages={notebookViewModel.packages}
-              showPackageDetails={false}
-              className="cloud-package-summary-header"
-            />
+            shouldShowPackageEnvironmentSummary ? (
+              <EnvironmentSummary
+                capabilities={shellCapabilities}
+                packages={notebookViewModel.packages}
+                showPackageDetails={false}
+                className="cloud-package-summary-header"
+              />
+            ) : undefined
           }
         />
       }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -60,7 +60,6 @@ import {
   fetchWithCloudPrototypeAuth,
   isCloudPrototypeAuthStorageKey,
   prepareCloudOidcViewerLogin,
-  prototypeAuthSummary,
   storeCloudRequestedScope,
   withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
@@ -448,28 +447,17 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   };
 
   const signedIn = authState.mode === "oidc";
-  const homeStatusTitle = signedIn ? (authState.user ?? "Signed in") : "Public viewer";
+  const homeStatusTitle = signedIn ? (authState.user ?? "Signed in") : "Notebook cloud";
   const homeStatusDescription = signedIn
-    ? prototypeAuthSummary(authState)
-    : "Public notebooks stay readable without an account. Sign in when you need edit access or sharing controls.";
+    ? "Open the preview notebook or sign out of this browser session."
+    : "Sign in to open private previews or request edit access.";
 
   return (
     <main className="cloud-home">
-      <header className="cloud-report-toolbar" aria-label="Notebook cloud entry controls">
-        <div className="cloud-home-title">
-          <span>nteract cloud notebooks</span>
-          <small>live documents for shared computation</small>
-        </div>
-      </header>
-
       <section className="cloud-home-layout" aria-label="Notebook cloud entry">
         <div className="cloud-home-copy">
-          <p>Cloud notebooks</p>
-          <h1>Stay in the document.</h1>
-          <span>
-            Public notebooks open calmly. Account controls appear only when you need to edit, share,
-            or renew access.
-          </span>
+          <h1>nteract</h1>
+          <span>preview realtime notebooks</span>
         </div>
 
         <section
@@ -501,6 +489,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
           ) : null}
 
           <div className="cloud-home-actions">
+            <a href="/n/topic-viz/topic-viz">Open topic viz</a>
             {signedIn ? (
               <button
                 type="button"
@@ -613,21 +602,10 @@ function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig })
 
   return (
     <main className="cloud-home">
-      <header className="cloud-report-toolbar" aria-label="Sign-in status and controls">
-        <div className="cloud-home-title">
-          <span>nteract cloud notebooks</span>
-          <small>account handoff</small>
-        </div>
-      </header>
-
       <section className="cloud-home-layout" aria-label="Notebook cloud sign-in callback">
         <div className="cloud-home-copy">
-          <p>Cloud sign-in</p>
-          <h1>Returning to the notebook.</h1>
-          <span>
-            The browser is finishing the account handoff. The notebook stays readable while access
-            renews.
-          </span>
+          <h1>nteract</h1>
+          <span>returning to the notebook</span>
         </div>
 
         <section

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1411,6 +1411,7 @@ function NotebookViewer({
             onMoveCell={handleCloudMoveCell}
             markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
             outputHostContext={outputHostContext}
+            autoFocusFirstCell={false}
           />
         </CrdtBridgeProvider>
       </PresenceValueProvider>

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -50,6 +50,7 @@ import { MediaProvider } from "@/components/outputs/media-provider";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
+import { EnvironmentSummary } from "@/components/environment";
 import type { NotebookOutlineItem } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import {
@@ -1280,6 +1281,14 @@ function NotebookViewer({
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}
           readOnly={!shellCapabilities.canManagePackages}
+          header={
+            <EnvironmentSummary
+              capabilities={shellCapabilities}
+              packages={notebookViewModel.packages}
+              showPackageDetails={false}
+              className="cloud-package-summary-header"
+            />
+          }
         />
       }
       onActivePanelChange={setActiveRailPanel}
@@ -1295,7 +1304,7 @@ function NotebookViewer({
       <NotebookDocumentHeader
         capabilities={shellCapabilities}
         className="cloud-room-toolbar"
-        presence={<CloudNotebookTitle notebookId={config.notebookId} />}
+        presence={<CloudNotebookTitle />}
         utilityControls={
           <>
             <CloudConnectionStatus connection={presence.connection} error={connectionError} />
@@ -1874,10 +1883,7 @@ function shouldShowCloudNotebookCommandToolbar(capabilities: NotebookShellCapabi
 }
 
 function initialCloudRailCollapsed(): boolean {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return false;
-  }
-  return window.matchMedia("(max-width: 599.98px)").matches;
+  return true;
 }
 
 function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
@@ -1894,8 +1900,8 @@ function shouldShowCloudHeaderSignIn(authState: CloudPrototypeAuthState): boolea
   );
 }
 
-function CloudNotebookTitle({ notebookId }: { notebookId: string }) {
-  const title = cloudNotebookRouteTitle(notebookId);
+function CloudNotebookTitle() {
+  const title = cloudNotebookRouteTitle();
 
   return (
     <div className="cloud-notebook-title" title={title.title}>
@@ -1905,30 +1911,28 @@ function CloudNotebookTitle({ notebookId }: { notebookId: string }) {
   );
 }
 
-function cloudNotebookRouteTitle(notebookId: string): {
+function cloudNotebookRouteTitle(): {
   label: string;
   detail: string | null;
   title: string;
 } {
   const pathParts = window.location.pathname.split("/").filter(Boolean);
-  const routeNotebookId = pathParts[0] === "n" ? pathParts[1] : null;
   const routeSlug = pathParts[0] === "n" ? pathParts[2] : null;
   const decodedSlug = safeDecodeRouteSegment(routeSlug);
-  const decodedNotebookId = safeDecodeRouteSegment(routeNotebookId) ?? notebookId;
 
   if (decodedSlug) {
     const label = humanizeCloudRouteTitle(decodedSlug);
     return {
       label,
       detail: null,
-      title: `${label} (${decodedNotebookId})`,
+      title: label,
     };
   }
 
   return {
     label: "Cloud Notebook",
     detail: null,
-    title: decodedNotebookId,
+    title: "Cloud Notebook",
   };
 }
 
@@ -2014,11 +2018,16 @@ function CloudPresenceStatus({ presence }: { presence: CloudViewerPresenceState 
   return (
     <NotebookPresenceStatus
       connected={presenceDisplay.connected}
-      label={presenceDisplay.label}
+      label={compactCloudPresenceLabel(presenceDisplay.label)}
       title={presenceDisplay.title}
       variant="inline"
     />
   );
+}
+
+function compactCloudPresenceLabel(label: string): string {
+  const countMatch = /^(\d+)\s+here now$/.exec(label);
+  return countMatch?.[1] ?? label;
 }
 
 function appendEndpointPathSegment(endpoint: string, segment: string): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1155,11 +1155,16 @@ function NotebookViewer({
         hasCodeCells: codeCellCount > 0,
         selectedMode: selectedInteractionMode,
         canAcceptCellMutations,
+        hostCapabilities: {
+          canManageSharing: Boolean(config.aclEndpoint && config.invitesEndpoint),
+        },
       }),
     [
       authState,
       canAcceptCellMutations,
       codeCellCount,
+      config.aclEndpoint,
+      config.invitesEndpoint,
       connectionActorLabel,
       connectionScope,
       selectedInteractionMode,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -27,6 +27,13 @@ export interface CloudNotebookShellCapabilityInput {
    * hidden. Flip it on once a runtime peer can execute the room's cells.
    */
   runtimeAvailable?: boolean;
+  /**
+   * Host-provided room capabilities. Sharing is a room/host concern, not a
+   * notebook-local affordance, so owner access alone is not enough to show it.
+   */
+  hostCapabilities?: {
+    canManageSharing?: boolean;
+  };
 }
 
 export function cloudNotebookShellCapabilities({
@@ -37,6 +44,7 @@ export function cloudNotebookShellCapabilities({
   selectedMode = "view",
   canAcceptCellMutations = true,
   runtimeAvailable = false,
+  hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = cloudConnectionAccessLevel(connectionScope);
   const isRuntimePeer = connectionScope === "runtime_peer";
@@ -103,7 +111,10 @@ export function cloudNotebookShellCapabilities({
     canToggleCode: hasCodeCells,
     canViewPackages: true,
     canManagePackages: false,
-    canManageSharing: connectionScope === "owner",
+    canManageSharing:
+      Boolean(hostCapabilities?.canManageSharing) &&
+      connectionScope === "owner" &&
+      auth.canUseAuthenticatedIdentity,
     interaction,
     access: {
       ...access,

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -73,6 +73,7 @@ export interface NotebookViewProps {
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   outputHostContext?: NteractEmbedHostContextPatch;
+  autoFocusFirstCell?: boolean;
 }
 
 const NOTEBOOK_TAIL_SPACE = "clamp(4rem, 10vh, 6rem)";
@@ -258,6 +259,7 @@ function SortableCell({
   onDeleteCell,
   isLastCell,
   isHiddenInGroup,
+  canMutateCells,
 }: {
   cellId: string;
   index: number;
@@ -271,9 +273,11 @@ function SortableCell({
   onDeleteCell: (cellId: string) => void;
   isLastCell?: boolean;
   isHiddenInGroup?: boolean;
+  canMutateCells: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: cellId,
+    disabled: !canMutateCells,
   });
 
   const style: React.CSSProperties = {
@@ -285,10 +289,12 @@ function SortableCell({
 
   // Combine listeners and attributes for the drag handle
   // This enables keyboard-initiated dragging (Space/Enter + arrows)
-  const dragHandleProps = {
-    ...listeners,
-    ...attributes,
-  };
+  const dragHandleProps = canMutateCells
+    ? {
+        ...listeners,
+        ...attributes,
+      }
+    : undefined;
 
   if (isHiddenInGroup) {
     return <div id={anchorId} ref={setNodeRef} style={style} />;
@@ -296,13 +302,13 @@ function SortableCell({
 
   return (
     <div id={anchorId} ref={setNodeRef} style={style}>
-      {index === 0 && <CellAdder afterCellId={null} onAdd={onAddCell} />}
+      {canMutateCells && index === 0 && <CellAdder afterCellId={null} onAdd={onAddCell} />}
       <ErrorBoundary
         fallback={(error, resetErrorBoundary) => (
           <CellErrorFallback
             error={error}
             onRetry={resetErrorBoundary}
-            onDelete={() => onDeleteCell(cellId)}
+            onDelete={canMutateCells ? () => onDeleteCell(cellId) : undefined}
           />
         )}
       >
@@ -314,38 +320,7 @@ function SortableCell({
           isDragging={isDragging}
         />
       </ErrorBoundary>
-      <CellAdder afterCellId={cellId} onAdd={onAddCell} terminal={isLastCell} />
-    </div>
-  );
-}
-
-function StaticCell({
-  cellId,
-  index,
-  renderCell,
-  isHiddenInGroup,
-}: {
-  cellId: string;
-  index: number;
-  renderCell: (cell: NotebookCell, index: number) => React.ReactNode;
-  isHiddenInGroup?: boolean;
-}) {
-  const style: React.CSSProperties = { order: index };
-  const anchorId = notebookCellAnchorId(cellId);
-
-  if (isHiddenInGroup) {
-    return <div id={anchorId} style={style} />;
-  }
-
-  return (
-    <div id={anchorId} style={style}>
-      <ErrorBoundary
-        fallback={(error, resetErrorBoundary) => (
-          <CellErrorFallback error={error} onRetry={resetErrorBoundary} />
-        )}
-      >
-        <CellRenderer cellId={cellId} index={index} renderCell={renderCell} />
-      </ErrorBoundary>
+      {canMutateCells && <CellAdder afterCellId={cellId} onAdd={onAddCell} terminal={isLastCell} />}
     </div>
   );
 }
@@ -370,6 +345,7 @@ function NotebookViewContent({
   onSetCellOutputsHidden,
   markdownHeadingAnchorsByCellId,
   outputHostContext,
+  autoFocusFirstCell = true,
 }: NotebookViewProps) {
   const presence = usePresenceContext();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -629,6 +605,11 @@ function NotebookViewContent({
         container.scrollLeft = 0;
       }
 
+      if (cellIdsRef.current.length === 0) {
+        tailPinnedRef.current = false;
+        return;
+      }
+
       const distanceFromTail =
         container.scrollHeight - container.clientHeight - container.scrollTop;
       if (distanceFromTail <= NOTEBOOK_TAIL_PIN_THRESHOLD_PX) {
@@ -704,11 +685,12 @@ function NotebookViewContent({
   }, [searchCurrentMatch]);
 
   useEffect(() => {
+    if (!autoFocusFirstCell) return;
     if (isLoading || focusedCellId !== null) return;
     if (cellIds.length > 0) {
       onFocusCell(cellIds[0]);
     }
-  }, [isLoading, cellIds, focusedCellId, onFocusCell]);
+  }, [autoFocusFirstCell, isLoading, cellIds, focusedCellId, onFocusCell]);
 
   const renderCell = useCallback(
     (
@@ -1041,7 +1023,7 @@ function NotebookViewContent({
             ) : null}
           </div>
         )
-      ) : canMutateCells ? (
+      ) : (
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -1064,6 +1046,7 @@ function NotebookViewContent({
                     onDeleteCell={onDeleteCell}
                     isLastCell={index === cellIds.length - 1}
                     isHiddenInGroup={group != null && !group.isFirst}
+                    canMutateCells={canMutateCells}
                   />
                 );
               })}
@@ -1071,22 +1054,6 @@ function NotebookViewContent({
           </SortableContext>
           <DragOverlay>{activeId && <CellDragPreview cellId={activeId} />}</DragOverlay>
         </DndContext>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          {stableDomOrder.map((cellId) => {
-            const index = cellIdToIndex.get(cellId) ?? 0;
-            const group = hiddenGroups.get(cellId);
-            return (
-              <StaticCell
-                key={cellId}
-                cellId={cellId}
-                index={index}
-                renderCell={renderCell}
-                isHiddenInGroup={group != null && !group.isFirst}
-              />
-            );
-          })}
-        </div>
       )}
     </div>
   );

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -32,6 +32,29 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/canMutateCells && onSetCellOutputsHidden/);
   });
 
+  it("keeps the cell DOM branch stable while toggling structure mutation capabilities", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).toMatch(/<DndContext[\s\S]*<SortableContext[\s\S]*stableDomOrder\.map/);
+    expect(sourceText).toMatch(/disabled: !canMutateCells/);
+    expect(sourceText).toMatch(/canMutateCells && index === 0/);
+    expect(sourceText).not.toContain("function StaticCell");
+  });
+
+  it("does not arm tail-pinned scrolling before cells materialize", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).toMatch(
+      /if \(cellIdsRef\.current\.length === 0\) \{[\s\S]*tailPinnedRef\.current = false;[\s\S]*return;/,
+    );
+  });
+
   it("does not create cells from a transient empty sync state", () => {
     const sourceText = readFileSync(
       join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -220,6 +220,34 @@ describe("desktopNotebookShellCapabilities", () => {
     });
   });
 
+  it("requires a host room sharing capability before cloud owners can manage sharing", () => {
+    const ownerWithoutSharingHost = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:alice/desktop:window",
+      connectionScope: "owner",
+    });
+    expect(ownerWithoutSharingHost.canManageSharing).toBe(false);
+
+    const ownerWithSharingHost = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:alice/desktop:window",
+      connectionScope: "owner",
+      hostCapabilities: { canManageSharing: true },
+    });
+    expect(ownerWithSharingHost.canManageSharing).toBe(true);
+
+    const localWithSharingHost = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+      hostCapabilities: { canManageSharing: true },
+    });
+    expect(localWithSharingHost.canManageSharing).toBe(false);
+  });
+
   it("projects desktop agent actors without treating desktop as a single human", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: true,

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -14,6 +14,9 @@ export interface DesktopNotebookShellCapabilityInput {
   sessionReady: boolean;
   localActor: string | null;
   connectionScope: string | null;
+  hostCapabilities?: {
+    canManageSharing?: boolean;
+  };
 }
 
 export function desktopNotebookShellCapabilities({
@@ -21,6 +24,7 @@ export function desktopNotebookShellCapabilities({
   sessionReady,
   localActor,
   connectionScope,
+  hostCapabilities,
 }: DesktopNotebookShellCapabilityInput): NotebookShellCapabilities {
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
   const source = desktopAccessSourceFromActor(connectionScope, localActor);
@@ -72,7 +76,8 @@ export function desktopNotebookShellCapabilities({
     canToggleCode: true,
     canViewPackages: true,
     canManagePackages: canWriteDocument,
-    canManageSharing: accessLevel === "owner" && source === "cloud",
+    canManageSharing:
+      Boolean(hostCapabilities?.canManageSharing) && accessLevel === "owner" && source === "cloud",
     interaction,
     access: {
       ...access,

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -71,6 +71,7 @@ describe("generateFrameHtml", () => {
     expect(html).toContain("isWheelAtScrollBoundary");
     expect(html).toContain("e.preventDefault()");
     expect(source).toContain("sendRpc('nteract/wheelBoundary'");
+    expect(source).toContain("deltaMode: e.deltaMode");
     expect(html).toContain("passive: false");
   });
 

--- a/src/components/isolated/__tests__/scroll-boundary.test.ts
+++ b/src/components/isolated/__tests__/scroll-boundary.test.ts
@@ -53,6 +53,48 @@ describe("scroll-boundary", () => {
     });
   });
 
+  it("normalizes line-mode wheel deltas before scrolling the ancestor", () => {
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    setScrollMetrics(scrollContainer, 1000, 200);
+    scrollContainer.scrollTop = 300;
+    scrollContainer.scrollBy = vi.fn();
+
+    const iframe = document.createElement("iframe");
+    scrollContainer.appendChild(iframe);
+    document.body.appendChild(scrollContainer);
+
+    scrollFrameWheelBoundary(iframe, { deltaY: 3, deltaMode: 1 });
+
+    expect(scrollContainer.scrollBy).toHaveBeenCalledWith({
+      top: 48,
+      behavior: "auto",
+    });
+  });
+
+  it("normalizes page-mode wheel deltas from the iframe height", () => {
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    setScrollMetrics(scrollContainer, 2000, 200);
+    scrollContainer.scrollTop = 300;
+    scrollContainer.scrollBy = vi.fn();
+
+    const iframe = document.createElement("iframe");
+    Object.defineProperty(iframe, "clientHeight", {
+      configurable: true,
+      value: 320,
+    });
+    scrollContainer.appendChild(iframe);
+    document.body.appendChild(scrollContainer);
+
+    scrollFrameWheelBoundary(iframe, { deltaY: 1, deltaMode: 2 });
+
+    expect(scrollContainer.scrollBy).toHaveBeenCalledWith({
+      top: 320,
+      behavior: "auto",
+    });
+  });
+
   it("does not scroll the nearest ancestor past its top edge", () => {
     const scrollContainer = document.createElement("div");
     scrollContainer.style.overflowY = "auto";

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -877,7 +877,7 @@
               return;
             }
             e.preventDefault();
-            sendRpc("nteract/wheelBoundary", { deltaY: e.deltaY });
+            sendRpc("nteract/wheelBoundary", { deltaY: e.deltaY, deltaMode: e.deltaMode });
           },
           { capture: true, passive: false },
         );

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -184,6 +184,7 @@ export interface NteractWidgetUpdateParams {
 
 export interface NteractWheelBoundaryParams {
   deltaY?: number;
+  deltaMode?: number;
 }
 
 export interface NteractDiagnosticParams {

--- a/src/components/isolated/scroll-boundary.ts
+++ b/src/components/isolated/scroll-boundary.ts
@@ -1,5 +1,9 @@
 import type { NteractWheelBoundaryParams } from "./rpc-methods";
 
+const WHEEL_DELTA_LINE = 1;
+const WHEEL_DELTA_PAGE = 2;
+const DEFAULT_WHEEL_LINE_HEIGHT = 16;
+
 function hasScrollableOverflow(element: HTMLElement): boolean {
   const { overflowY } = window.getComputedStyle(element);
   return overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay";
@@ -60,8 +64,7 @@ export function scrollFrameWheelBoundary(
   iframe: HTMLIFrameElement | null,
   params: NteractWheelBoundaryParams,
 ): void {
-  const deltaY =
-    typeof params.deltaY === "number" && Number.isFinite(params.deltaY) ? params.deltaY : 0;
+  const deltaY = normalizedWheelDeltaY(iframe, params);
 
   if (deltaY === 0) {
     return;
@@ -77,4 +80,41 @@ export function scrollFrameWheelBoundary(
   if (win && canWindowConsumeScrollDelta(win, deltaY)) {
     win.scrollBy({ top: deltaY, behavior: "auto" });
   }
+}
+
+function normalizedWheelDeltaY(
+  iframe: HTMLIFrameElement | null,
+  params: NteractWheelBoundaryParams,
+): number {
+  const rawDeltaY =
+    typeof params.deltaY === "number" && Number.isFinite(params.deltaY) ? params.deltaY : 0;
+  if (rawDeltaY === 0) {
+    return 0;
+  }
+
+  if (params.deltaMode === WHEEL_DELTA_LINE) {
+    return rawDeltaY * wheelLineHeight(iframe);
+  }
+
+  if (params.deltaMode === WHEEL_DELTA_PAGE) {
+    return rawDeltaY * wheelPageHeight(iframe);
+  }
+
+  return rawDeltaY;
+}
+
+function wheelLineHeight(iframe: HTMLIFrameElement | null): number {
+  const ownerWindow = iframe?.ownerDocument.defaultView ?? window;
+  const rawLineHeight = ownerWindow.getComputedStyle(
+    iframe?.ownerDocument.documentElement ?? document.documentElement,
+  ).lineHeight;
+  const parsedLineHeight = Number.parseFloat(rawLineHeight);
+  return Number.isFinite(parsedLineHeight) && parsedLineHeight > 0
+    ? parsedLineHeight
+    : DEFAULT_WHEEL_LINE_HEIGHT;
+}
+
+function wheelPageHeight(iframe: HTMLIFrameElement | null): number {
+  const ownerWindow = iframe?.ownerDocument.defaultView ?? window;
+  return Math.max(1, iframe?.clientHeight || ownerWindow.innerHeight || 0);
 }

--- a/src/components/notebook/NotebookDocumentRail.tsx
+++ b/src/components/notebook/NotebookDocumentRail.tsx
@@ -45,7 +45,7 @@ export function NotebookDocumentRail({
       activeOutlineItemId={activeOutlineItemId}
       selectedOutlineItemId={selectedOutlineItemId}
       selectedOutlineCellId={selectedOutlineCellId}
-      packagesSummary={packagesSummary ?? viewModel.packages.summary}
+      packagesSummary={packagesSummary === undefined ? viewModel.packages.summary : packagesSummary}
       packagesPanel={packagesPanel}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}

--- a/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
@@ -4,28 +4,28 @@ import { NotebookDocumentRail } from "../NotebookDocumentRail";
 import type { NotebookViewModel } from "../view-model";
 
 describe("NotebookDocumentRail", () => {
-  it("binds shared notebook view model projections to the notebook rail", () => {
-    const viewModel: Pick<NotebookViewModel, "outlineItems" | "packages"> = {
-      outlineItems: [
-        {
-          id: "intro:heading:0",
-          kind: "heading",
-          cellId: "intro",
-          title: "Intro",
-          level: 1,
-          order: 0,
-          statusLabel: null,
-          href: "#intro",
-          anchor: "intro",
-          headingAnchorId: "notebook-cell-intro-heading-intro",
-        },
-      ],
-      packages: {
-        summary: "uv · 2 packages",
-        sections: [],
+  const viewModel: Pick<NotebookViewModel, "outlineItems" | "packages"> = {
+    outlineItems: [
+      {
+        id: "intro:heading:0",
+        kind: "heading",
+        cellId: "intro",
+        title: "Intro",
+        level: 1,
+        order: 0,
+        statusLabel: null,
+        href: "#intro",
+        anchor: "intro",
+        headingAnchorId: "notebook-cell-intro-heading-intro",
       },
-    };
+    ],
+    packages: {
+      summary: "uv · 2 packages",
+      sections: [],
+    },
+  };
 
+  it("binds shared notebook view model projections to the notebook rail", () => {
     render(
       <NotebookDocumentRail
         viewModel={viewModel}
@@ -43,28 +43,25 @@ describe("NotebookDocumentRail", () => {
     expect(screen.getByText("Package details")).toBeVisible();
   });
 
-  it("forwards host outline selection state", () => {
-    const viewModel: Pick<NotebookViewModel, "outlineItems" | "packages"> = {
-      outlineItems: [
-        {
-          id: "intro:heading:0",
-          kind: "heading",
-          cellId: "intro",
-          title: "Intro",
-          level: 1,
-          order: 0,
-          statusLabel: null,
-          href: "#intro",
-          anchor: "intro",
-          headingAnchorId: "notebook-cell-intro-heading-intro",
-        },
-      ],
-      packages: {
-        summary: "uv · 2 packages",
-        sections: [],
-      },
-    };
+  it("can suppress the package title summary when the host renders it in the panel", () => {
+    render(
+      <NotebookDocumentRail
+        viewModel={viewModel}
+        activePanelId="packages"
+        collapsed={false}
+        packagesSummary={null}
+        packagesPanel={<p>Package details</p>}
+        onActivePanelChange={() => {}}
+        onCollapsedChange={() => {}}
+      />,
+    );
 
+    expect(screen.getByRole("heading", { name: "Packages" })).toBeVisible();
+    expect(screen.queryByText("uv · 2 packages")).not.toBeInTheDocument();
+    expect(screen.getByText("Package details")).toBeVisible();
+  });
+
+  it("forwards host outline selection state", () => {
     render(
       <NotebookDocumentRail
         viewModel={viewModel}


### PR DESCRIPTION
## Summary

- simplify the cloud preview entry surface and align the Elements language around the cloud shell
- route cloud sharing through host capabilities instead of inferring from incidental viewer endpoints
- keep hosted/read-only notebooks on the shared notebook cell chrome path so adding cells or switching mode does not destroy output iframes
- quiet hosted chrome, default the rail collapsed, and keep the packages rail package-focused when no runtime/package management capability is available
- normalize isolated iframe wheel-boundary deltas so clicked/focused output frames scroll at the expected speed in cloud and desktop

## Verification

- `pnpm --workspace-root test:run src/components/isolated/__tests__/scroll-boundary.test.ts src/components/isolated/__tests__/frame-html.test.ts src/components/notebook/__tests__/NotebookDocumentRail.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/viewer-render-props.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --skipLibCheck`
- `pnpm --dir apps/notebook exec tsc --noEmit --skipLibCheck`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`

## Preview

- deployed `preview.runt.run` Worker version `b00fd3ad-51e8-45d5-9013-c25c51b43f93`
- deployed `preview.runtusercontent.com` output iframe shell version `7227206a-756e-4966-8c35-1ed449a43fb0`
