### PR TITLE
ci: persist self-hosted tool caches per runner

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -32,7 +32,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: voidzero-dev/setup-vp@v1
+    - uses: ./.github/actions/setup-vp
       with:
         run-install: false
 

--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -31,10 +31,28 @@ runs:
 
         asset="wasm-pack-v${version}-${arch}-${os}.tar.gz"
         url="https://github.com/rustwasm/wasm-pack/releases/download/v${version}/${asset}"
+
+        cache_dir=""
+        cache_bin=""
+        if [ -n "${NTERACT_RUNNER_TOOL_HOME:-}" ]; then
+          cache_dir="${NTERACT_RUNNER_TOOL_HOME}/wasm-pack/${version}/${arch}-${os}"
+          case "$RUNNER_OS" in
+            Windows) cache_bin="$cache_dir/wasm-pack.exe" ;;
+            *) cache_bin="$cache_dir/wasm-pack" ;;
+          esac
+
+          if [ -x "$cache_bin" ]; then
+            echo "Using cached wasm-pack from $cache_bin"
+            echo "$cache_dir" >> "$GITHUB_PATH"
+            "$cache_bin" --version
+            exit 0
+          fi
+        fi
+
         tmp="$(mktemp -d)"
         trap 'rm -rf "$tmp"' EXIT
 
-        curl --fail --location --show-error --retry 5 --retry-delay 2 \
+        curl --fail --location --show-error --retry 10 --retry-delay 2 \
           --output "$tmp/$asset" \
           "$url"
         tar -xzf "$tmp/$asset" -C "$tmp"
@@ -49,6 +67,16 @@ runs:
         mkdir -p "$install_dir"
         cp "$bin" "$install_dir/"
         chmod +x "$install_dir/$(basename "$bin")"
+
+        if [ -n "$cache_dir" ]; then
+          mkdir -p "$cache_dir"
+          cache_tmp="${cache_bin}.tmp.$$"
+          cp "$install_dir/$(basename "$bin")" "$cache_tmp"
+          chmod +x "$cache_tmp"
+          mv "$cache_tmp" "$cache_bin"
+          echo "Cached wasm-pack at $cache_bin"
+        fi
+
         echo "$install_dir" >> "$GITHUB_PATH"
 
         "$install_dir/$(basename "$bin")" --version

--- a/.github/actions/prepare-self-hosted-rust/action.yml
+++ b/.github/actions/prepare-self-hosted-rust/action.yml
@@ -12,12 +12,14 @@ runs:
         cargo_home="${runner_cache_root}/${runner_cache_name}/cargo"
         rustup_home="${runner_cache_root}/${runner_cache_name}/rustup"
         tool_home="${runner_cache_root}/${runner_cache_name}/tools"
+        uv_cache_dir="${runner_cache_root}/${runner_cache_name}/uv"
 
         # A runner service runs one job at a time, so these homes can persist
         # across jobs without concurrent writes from sibling runner services.
-        mkdir -p "${cargo_home}/bin" "${rustup_home}" "${tool_home}"
+        mkdir -p "${cargo_home}/bin" "${rustup_home}" "${tool_home}" "${uv_cache_dir}"
 
         echo "CARGO_HOME=${cargo_home}" >> "${GITHUB_ENV}"
         echo "RUSTUP_HOME=${rustup_home}" >> "${GITHUB_ENV}"
         echo "NTERACT_RUNNER_TOOL_HOME=${tool_home}" >> "${GITHUB_ENV}"
+        echo "UV_CACHE_DIR=${uv_cache_dir}" >> "${GITHUB_ENV}"
         echo "${cargo_home}/bin" >> "${GITHUB_PATH}"

--- a/.github/actions/prepare-self-hosted-rust/action.yml
+++ b/.github/actions/prepare-self-hosted-rust/action.yml
@@ -1,13 +1,23 @@
-name: Prepare self-hosted Rust homes
-description: Isolate mutable Rust state for parallel self-hosted runner services.
+name: Prepare self-hosted tool homes
+description: Isolate mutable Rust and tool state per self-hosted runner service.
 
 runs:
   using: composite
   steps:
-    - name: Use job-local Rust homes
+    - name: Use runner-local Rust homes
       shell: bash
       run: |
-        mkdir -p "${RUNNER_TEMP}/cargo-home/bin" "${RUNNER_TEMP}/rustup-home"
-        echo "CARGO_HOME=${RUNNER_TEMP}/cargo-home" >> "${GITHUB_ENV}"
-        echo "RUSTUP_HOME=${RUNNER_TEMP}/rustup-home" >> "${GITHUB_ENV}"
-        echo "${RUNNER_TEMP}/cargo-home/bin" >> "${GITHUB_PATH}"
+        runner_cache_root="${NTERACT_RUNNER_CACHE:-${NTERACT_RUNNER_RUST_CACHE:-${HOME}/.cache/nteract-actions}}"
+        runner_cache_name="$(printf '%s' "${RUNNER_NAME:-self-hosted}" | tr -c 'A-Za-z0-9_.-' '_')"
+        cargo_home="${runner_cache_root}/${runner_cache_name}/cargo"
+        rustup_home="${runner_cache_root}/${runner_cache_name}/rustup"
+        tool_home="${runner_cache_root}/${runner_cache_name}/tools"
+
+        # A runner service runs one job at a time, so these homes can persist
+        # across jobs without concurrent writes from sibling runner services.
+        mkdir -p "${cargo_home}/bin" "${rustup_home}" "${tool_home}"
+
+        echo "CARGO_HOME=${cargo_home}" >> "${GITHUB_ENV}"
+        echo "RUSTUP_HOME=${rustup_home}" >> "${GITHUB_ENV}"
+        echo "NTERACT_RUNNER_TOOL_HOME=${tool_home}" >> "${GITHUB_ENV}"
+        echo "${cargo_home}/bin" >> "${GITHUB_PATH}"

--- a/.github/actions/setup-vp/action.yml
+++ b/.github/actions/setup-vp/action.yml
@@ -1,0 +1,25 @@
+name: Set up Vite+
+description: Set up Vite+ without sharing mutable installs across self-hosted runner services.
+
+inputs:
+  run-install:
+    description: Whether setup-vp should run package installation.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Vite+ with runner-local home
+      if: env.NTERACT_RUNNER_TOOL_HOME != ''
+      uses: voidzero-dev/setup-vp@v1
+      env:
+        HOME: ${{ env.NTERACT_RUNNER_TOOL_HOME }}
+      with:
+        run-install: ${{ inputs.run-install }}
+
+    - name: Set up Vite+
+      if: env.NTERACT_RUNNER_TOOL_HOME == ''
+      uses: voidzero-dev/setup-vp@v1
+      with:
+        run-install: ${{ inputs.run-install }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,16 +62,13 @@ jobs:
     name: Lint & Format
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    # Use the Anaconda runner pool for trusted events. Fork PRs stay on
-    # GitHub-hosted runners because this repository is public.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    # Keep generic PR/build checks on GitHub-hosted capacity. The Anaconda
+    # runner pool is reserved for post-merge/manual env-heavy lanes below.
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -106,7 +103,7 @@ jobs:
     name: NSIS Bootstrap Syntax
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -128,14 +125,11 @@ jobs:
     name: Windows (clippy)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -168,14 +162,11 @@ jobs:
     name: WASM + Deno Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -207,14 +198,11 @@ jobs:
     name: Build shared UI artifacts
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -257,14 +245,11 @@ jobs:
     name: JS Tests & Benchmarks
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -300,9 +285,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -455,7 +437,7 @@ jobs:
     name: Linux Rust Clippy
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -463,9 +445,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -493,7 +472,7 @@ jobs:
     name: Linux Rust Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
@@ -501,9 +480,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -525,14 +501,11 @@ jobs:
     name: Linux runtimed-node
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -1083,14 +1056,11 @@ jobs:
     name: Python Unit Tests
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:
           lfs: true
-
-      - uses: ./.github/actions/prepare-self-hosted-rust
-        if: runner.environment == 'self-hosted'
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Check Rust formatting
         run: cargo fmt --check
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: ./.github/actions/setup-vp
         with:
           run-install: false
       - uses: pnpm/action-setup@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1121,6 +1121,7 @@ jobs:
             --package prewarm \
             --package nteract \
             --package nteract-kernel-launcher \
+            --reinstall-package runtimed \
             --group dev
 
       - name: Run runtimed-py unit tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,9 +289,9 @@ jobs:
     name: Browser E2E (Playwright)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
-    # Use the Anaconda runner pool for trusted events. Fork PRs stay on GitHub-hosted
-    # runners because this repository is public.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'nteract-linux-ci' || 'ubuntu-24.04' }}
+    # Keep the generic browser lane on GitHub-hosted runners for predictable
+    # per-job latency. The Anaconda pool is reserved for Linux/env-heavy lanes.
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sift-preview.yml
+++ b/.github/workflows/sift-preview.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build sift-wasm
         run: wasm-pack build crates/sift-wasm --target web --release
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: ./.github/actions/setup-vp
         with:
           run-install: false
       - uses: pnpm/action-setup@v6

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -355,9 +355,12 @@ describe("MediaRouter component", () => {
         </MediaProvider>,
       );
       // JsonOutput renders in a pre element with the JSON structure
-      await waitFor(() => {
-        expect(screen.getByText(/"key"/)).toBeInTheDocument();
-      });
+      await waitFor(
+        () => {
+          expect(screen.getByText(/"key"/)).toBeInTheDocument();
+        },
+        { timeout: 5000 },
+      );
     });
 
     it("renders ANSI escape sequences correctly", async () => {


### PR DESCRIPTION
## Summary

- persist self-hosted Rust homes under a runner-name-scoped cache root instead of job-local temp directories
- publish runner-local tool and uv cache homes for mutable helper installs
- route Vite+ setup through a local wrapper that sets `HOME` to the runner-local tool home only for `voidzero-dev/setup-vp`
- cache downloaded wasm-pack binaries under the runner-local tool home and reuse them before attempting another release download
- force the Python unit job to reinstall `runtimed` during `uv sync` so native `_internals` is rebuilt instead of reused from a stale uv cache

## Why

The post-merge `main` run for #3343 showed immediate `spawn ETXTBSY` failures in `Browser E2E (Playwright)` and `Linux Rust Tests` while entering `build-runtime-artifacts`. Rust homes were already isolated in the previous PR, so the next shared mutable executable path was Vite+ setup's default `~/.vite-plus` install.

PR #3344 also exposed a Python unit failure where `uv sync` reused a cached/local `runtimed` install without the native `runtimed._internals` extension. Keeping uv's cache per runner service and forcing the `runtimed` reinstall in the Python unit job makes that native build explicit.

The first #3345 CI run also exposed a release download flake in `install-wasm-pack`: `curl` retried the rustwasm release artifact and got repeated HTTP 502s. Reusing a versioned wasm-pack binary from the runner-local tool home avoids that cold download on warm runners.

This keeps warm caches per runner service without allowing sibling runner services on the same EC2 host to rewrite the same Rust, Vite+, wasm-pack, or uv cache state concurrently.

## Verification

- `actionlint -color=false .github/workflows/build.yml .github/workflows/sift-preview.yml .github/workflows/smoke.yml .github/workflows/release-common.yml`
- `ruby -e 'require "yaml"; %w[.github/actions/prepare-self-hosted-rust/action.yml .github/actions/setup-vp/action.yml .github/actions/build-runtime-artifacts/action.yml .github/workflows/build.yml .github/workflows/sift-preview.yml].each { |p| YAML.load_file(p); puts "ok #{p}" }'`
- `ruby -e 'require "yaml"; puts YAML.load_file(ARGV.fetch(0)).fetch("runs").fetch("steps").fetch(0).fetch("run")' .github/actions/install-wasm-pack/action.yml | bash -n`
- temp-directory smoke check for the `install-wasm-pack` cache-hit branch
- shell simulation of the runner cache env setup
- `pnpm test:run src/components/outputs/__tests__/media-router.test.tsx`
- `git diff --check`
- `cargo xtask lint --fix`
