### PR TITLE
fix(notebook-cloud): route preview cell controls through shared surface

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -79,9 +79,25 @@ test("cloud notebook mutations route through the shared notebook controller", ()
   assert.match(sourceText, /cloudNotebookController\.addCell\(type, afterCellId\)/);
   assert.match(sourceText, /cloudNotebookController\.deleteCell\(cellId\)/);
   assert.match(sourceText, /cloudNotebookController\.moveCell\(cellId, afterCellId\)/);
+  assert.match(sourceText, /cloudNotebookController\.setCellSourceHidden\(cellId, hidden\)/);
+  assert.match(sourceText, /cloudNotebookController\.setCellOutputsHidden\(cellId, hidden\)/);
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.add_cell_after/);
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.delete_cell/);
   assert.doesNotMatch(sourceText, /liveRuntime\.handle\.move_cell/);
+});
+
+test("cloud command toolbar inserts below the focused cell before falling back to the tail", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(
+    sourceText,
+    /const toolbarAddAfterCellId =\s+focusedCellId \?\? notebookCellIds\[notebookCellIds\.length - 1\] \?\? null;/,
+  );
+  assert.match(
+    sourceText,
+    /<NotebookCommandToolbar[\s\S]*addAfterCellId=\{toolbarAddAfterCellId\}/,
+  );
 });
 
 test("cloud projects host focus through the shared cell UI state bridge", () => {
@@ -98,6 +114,20 @@ test("cloud projects host focus through the shared cell UI state bridge", () => 
   assert.doesNotMatch(
     sourceText,
     /import \{[^}]*setFocusedCellId[^}]*\} from "\.\.\/\.\.\/notebook\/src\/lib\/cell-ui-state"/,
+  );
+});
+
+test("cloud passes shared NotebookView source and output visibility handlers", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(
+    sourceText,
+    /<NotebookView[\s\S]*onSetCellSourceHidden=\{handleCloudSetCellSourceHidden\}/,
+  );
+  assert.match(
+    sourceText,
+    /<NotebookView[\s\S]*onSetCellOutputsHidden=\{handleCloudSetCellOutputsHidden\}/,
   );
 });
 
@@ -179,7 +209,10 @@ test("cloud presence chrome renders through the shared shell component", () => {
   const collabSmokeText = readFileSync(collabSmokePath, "utf8");
 
   assert.match(sourceText, /NotebookPresenceStatus/);
-  assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*label=\{presenceDisplay\.label\}/);
+  assert.match(
+    sourceText,
+    /<NotebookPresenceStatus[\s\S]*label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/,
+  );
   assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*variant="inline"/);
   assert.match(sharedPresenceText, /data-slot="notebook-presence-status"/);
   assert.match(hostedSmokeText, /\[data-slot='notebook-presence-status'\]/);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1210,7 +1210,7 @@ function NotebookViewer({
         },
         afterMutation: (handle) => {
           const liveRuntime = liveRuntimeRef.current;
-          if (liveRuntime?.handle === handle) {
+          if (liveRuntime && liveRuntime.handle === handle) {
             requestCloudMaterialization(liveRuntime);
           }
         },
@@ -1234,6 +1234,18 @@ function NotebookViewer({
   const handleCloudMoveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
       cloudNotebookController.moveCell(cellId, afterCellId);
+    },
+    [cloudNotebookController],
+  );
+  const handleCloudSetCellSourceHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      cloudNotebookController.setCellSourceHidden(cellId, hidden);
+    },
+    [cloudNotebookController],
+  );
+  const handleCloudSetCellOutputsHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      cloudNotebookController.setCellOutputsHidden(cellId, hidden);
     },
     [cloudNotebookController],
   );
@@ -1276,6 +1288,8 @@ function NotebookViewer({
   }, [refreshAuthState]);
   const shouldShowPackageEnvironmentSummary =
     shellCapabilities.canExecute || shellCapabilities.canManagePackages;
+  const toolbarAddAfterCellId =
+    focusedCellId ?? notebookCellIds[notebookCellIds.length - 1] ?? null;
   const rail = (
     <NotebookDocumentRail
       viewModel={notebookViewModel}
@@ -1348,7 +1362,7 @@ function NotebookViewer({
           runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
           environmentManager={packageEnvironmentManager}
           environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
-          addAfterCellId={notebookCellIds[notebookCellIds.length - 1] ?? null}
+          addAfterCellId={toolbarAddAfterCellId}
           onAddCell={handleCloudAddCell}
           onTogglePackages={handleTogglePackagesRail}
         />
@@ -1417,6 +1431,8 @@ function NotebookViewer({
             onDeleteCell={handleCloudDeleteCell}
             onAddCell={handleCloudAddCell}
             onMoveCell={handleCloudMoveCell}
+            onSetCellSourceHidden={handleCloudSetCellSourceHidden}
+            onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
             markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
             outputHostContext={outputHostContext}
             autoFocusFirstCell={false}


### PR DESCRIPTION
## Summary

- Route cloud preview toolbar cell insertion through the focused cell, with the existing tail fallback when nothing is focused.
- Pass shared NotebookView source/output visibility mutation handlers through the cloud viewer controller.
- Add cloud viewer guard coverage for focused insertion and source/output visibility controls.

## Verification

- `pnpm exec tsx --test apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts`
- `pnpm --filter notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes

- `pnpm --filter notebook-cloud test` still fails outside this change: snapshot render/publish tests return 422 from invalid snapshot bytes, and `viewer-notices.test.ts` still expects old "Live room connection failed" copy.
