### PR TITLE
fix(notebook): smooth iframe scroll handoff

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -49,6 +49,7 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
+const DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS = 700;
 
 function formatPluginLoadError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -167,6 +168,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const injectedLibsRef = useRef(new Set<string>());
   const viewRef = useRef<HTMLDivElement>(null);
   const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
+  const previewFrameReleaseTimeoutRef = useRef<number | null>(null);
 
   // Register EditorView with the cursor registry when in edit mode.
   const registeredViewRef = useRef<EditorView | null>(null);
@@ -242,10 +244,45 @@ export const MarkdownCell = memo(function MarkdownCell({
     setEditing(true);
   }, [readOnly]);
 
+  const clearPreviewFrameReleaseTimeout = useCallback(() => {
+    if (previewFrameReleaseTimeoutRef.current == null) return;
+    window.clearTimeout(previewFrameReleaseTimeoutRef.current);
+    previewFrameReleaseTimeoutRef.current = null;
+  }, []);
+
+  useEffect(() => clearPreviewFrameReleaseTimeout, [clearPreviewFrameReleaseTimeout]);
+
+  const releasePreviewFrameInteraction = useCallback(() => {
+    clearPreviewFrameReleaseTimeout();
+    setPreviewFrameInteractionActive(false);
+  }, [clearPreviewFrameReleaseTimeout]);
+
+  const schedulePreviewFrameInteractionRelease = useCallback(() => {
+    clearPreviewFrameReleaseTimeout();
+    previewFrameReleaseTimeoutRef.current = window.setTimeout(() => {
+      previewFrameReleaseTimeoutRef.current = null;
+      setPreviewFrameInteractionActive(false);
+    }, DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS);
+  }, [clearPreviewFrameReleaseTimeout]);
+
   const activatePreviewFrameInteraction = useCallback(() => {
+    clearPreviewFrameReleaseTimeout();
     setPreviewFrameInteractionActive(true);
     onFocus();
-  }, [onFocus]);
+  }, [clearPreviewFrameReleaseTimeout, onFocus]);
+
+  const handlePreviewWrapperPointerDown = useCallback(() => {
+    activatePreviewFrameInteraction();
+    schedulePreviewFrameInteractionRelease();
+  }, [activatePreviewFrameInteraction, schedulePreviewFrameInteractionRelease]);
+
+  const handlePreviewFrameMouseUp = useCallback(
+    ({ hasSelection }: { hasSelection?: boolean }) => {
+      if (hasSelection) return;
+      releasePreviewFrameInteraction();
+    },
+    [releasePreviewFrameInteraction],
+  );
 
   const deactivatePreviewFrameInteractionWhenIdle = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
@@ -256,10 +293,10 @@ export const MarkdownCell = memo(function MarkdownCell({
         return;
       }
       if (!(event.buttons > 0)) {
-        setPreviewFrameInteractionActive(false);
+        releasePreviewFrameInteraction();
       }
     },
-    [],
+    [releasePreviewFrameInteraction],
   );
 
   // Derived boundary flag: re-run the focus effect only when source crosses
@@ -640,7 +677,7 @@ export const MarkdownCell = memo(function MarkdownCell({
             {/* Always render IsolatedFrame to preload it (hidden when no content) */}
             <div
               className={cell.source ? undefined : "hidden"}
-              onPointerDown={activatePreviewFrameInteraction}
+              onPointerDown={handlePreviewWrapperPointerDown}
               onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
             >
               <IsolatedFrame
@@ -657,6 +694,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                 onReady={handleFrameReady}
                 onLinkClick={handleLinkClick}
                 onMouseDown={activatePreviewFrameInteraction}
+                onMouseUp={handlePreviewFrameMouseUp}
                 onDoubleClick={handleDoubleClick}
                 onError={handleIframeError}
                 onDiagnostic={logNotebookIsolatedDiagnostic}

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -1,4 +1,4 @@
-import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, createEvent, fireEvent, render, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MarkdownCell as MarkdownCellType } from "../../types";
@@ -7,6 +7,7 @@ let mockDarkMode = false;
 let mockColorTheme: string | undefined;
 let mockIsFocused = false;
 const isolatedFrameProps: Array<Record<string, unknown>> = [];
+let lastFrameMouseUp: ((params: { hasSelection?: boolean }) => void) | undefined;
 
 const mockFrameHandle = {
   send: vi.fn(),
@@ -38,7 +39,11 @@ vi.mock("@/components/isolated", async () => {
 
   const MockIsolatedFrame = React.forwardRef<
     typeof mockFrameHandle,
-    Record<string, unknown> & { onMouseDown?: () => void; onReady?: () => void }
+    Record<string, unknown> & {
+      onMouseDown?: () => void;
+      onMouseUp?: (params: { hasSelection?: boolean }) => void;
+      onReady?: () => void;
+    }
   >(function MockIsolatedFrame(props, ref) {
     isolatedFrameProps.push(props);
     React.useImperativeHandle(ref, () => mockFrameHandle);
@@ -46,6 +51,15 @@ vi.mock("@/components/isolated", async () => {
     React.useEffect(() => {
       props.onReady?.();
     }, [props.onReady]);
+
+    React.useEffect(() => {
+      lastFrameMouseUp = props.onMouseUp;
+      return () => {
+        if (lastFrameMouseUp === props.onMouseUp) {
+          lastFrameMouseUp = undefined;
+        }
+      };
+    }, [props.onMouseUp]);
 
     return (
       <iframe
@@ -176,6 +190,7 @@ describe("MarkdownCell theme sync", () => {
     mockColorTheme = undefined;
     mockIsFocused = false;
     isolatedFrameProps.length = 0;
+    lastFrameMouseUp = undefined;
     mockFrameHandle.send.mockClear();
     mockFrameHandle.render.mockClear();
     mockFrameHandle.renderBatch.mockClear();
@@ -307,6 +322,42 @@ describe("MarkdownCell theme sync", () => {
 
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+  });
+
+  it("releases markdown iframe pointer interaction after a plain iframe click", () => {
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
+
+    fireEvent.pointerDown(previewWrapper);
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+
+    act(() => {
+      lastFrameMouseUp?.({ hasSelection: false });
+    });
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(false);
+  });
+
+  it("keeps markdown iframe interaction active after text selection", () => {
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
+
+    fireEvent.pointerDown(previewWrapper);
+
+    act(() => {
+      lastFrameMouseUp?.({ hasSelection: true });
+    });
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
   });
 
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -90,6 +90,7 @@ const DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT = 96;
 const SIFT_VIEWPORT_TOP_INSET_PX = 96;
 const SIFT_VIEWPORT_BOTTOM_INSET_PX = 32;
 const DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN = "1200px 0px";
+const DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS = 700;
 
 function outputAreaInsetClass(layoutInset: NonNullable<OutputAreaProps["layoutInset"]>) {
   switch (layoutInset) {
@@ -618,6 +619,7 @@ function OutputAreaSingle({
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
   const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
+  const staticFrameReleaseTimeoutRef = useRef<number | null>(null);
 
   const darkMode = useDarkMode();
   const colorTheme = useColorTheme();
@@ -725,6 +727,28 @@ function OutputAreaSingle({
     }
   }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
 
+  const clearStaticFrameReleaseTimeout = useCallback(() => {
+    if (staticFrameReleaseTimeoutRef.current == null) return;
+    window.clearTimeout(staticFrameReleaseTimeoutRef.current);
+    staticFrameReleaseTimeoutRef.current = null;
+  }, []);
+
+  useEffect(() => clearStaticFrameReleaseTimeout, [clearStaticFrameReleaseTimeout]);
+
+  const releaseStaticFrameInteraction = useCallback(() => {
+    clearStaticFrameReleaseTimeout();
+    setStaticFrameInteractionActive(false);
+  }, [clearStaticFrameReleaseTimeout]);
+
+  const scheduleStaticFrameInteractionRelease = useCallback(() => {
+    if (hasWheelOwningOutputs) return;
+    clearStaticFrameReleaseTimeout();
+    staticFrameReleaseTimeoutRef.current = window.setTimeout(() => {
+      staticFrameReleaseTimeoutRef.current = null;
+      setStaticFrameInteractionActive(false);
+    }, DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS);
+  }, [clearStaticFrameReleaseTimeout, hasWheelOwningOutputs]);
+
   useEffect(() => {
     if (!hasWheelOwningOutputs) return;
     frameRef.current?.send({
@@ -741,15 +765,16 @@ function OutputAreaSingle({
       if (target instanceof Node && staticFrameInteractionRef.current?.contains(target)) {
         return;
       }
-      setStaticFrameInteractionActive(false);
+      releaseStaticFrameInteraction();
     };
 
     document.addEventListener("pointerdown", handlePointerDown, true);
     return () => document.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [staticFrameInteractionActive]);
+  }, [releaseStaticFrameInteraction, staticFrameInteractionActive]);
 
   const activateStaticFrameInteraction = useCallback(() => {
     if (shouldUseScrollPassthroughFrame) {
+      clearStaticFrameReleaseTimeout();
       if (!staticFrameInteractionActive && hasSiftOutputs) {
         scrollElementIntoComfortableView(staticFrameInteractionRef.current);
       }
@@ -764,7 +789,26 @@ function OutputAreaSingle({
     shouldUseScrollPassthroughFrame,
     staticFrameInteractionActive,
     onIframeMouseDown,
+    clearStaticFrameReleaseTimeout,
   ]);
+
+  const activateStaticFrameInteractionTemporarily = useCallback(() => {
+    activateStaticFrameInteraction();
+    scheduleStaticFrameInteractionRelease();
+  }, [activateStaticFrameInteraction, scheduleStaticFrameInteractionRelease]);
+
+  const handleStaticFrameMouseUp = useCallback(
+    ({ hasSelection }: { hasSelection?: boolean }) => {
+      if (hasSelection) {
+        clearStaticFrameReleaseTimeout();
+        return;
+      }
+      if (!hasWheelOwningOutputs) {
+        releaseStaticFrameInteraction();
+      }
+    },
+    [clearStaticFrameReleaseTimeout, hasWheelOwningOutputs, releaseStaticFrameInteraction],
+  );
 
   const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Escape") {
@@ -1039,7 +1083,9 @@ function OutputAreaSingle({
             data-sift-output={hasSiftOutputs ? "true" : undefined}
             tabIndex={shouldUseScrollPassthroughFrame ? -1 : undefined}
             onPointerDown={
-              shouldUseScrollPassthroughFrame ? activateStaticFrameInteraction : undefined
+              shouldUseScrollPassthroughFrame
+                ? activateStaticFrameInteractionTemporarily
+                : undefined
             }
             onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
           >
@@ -1057,6 +1103,7 @@ function OutputAreaSingle({
                 onReady={handleIsolatedFrameReady}
                 onLinkClick={onLinkClick}
                 onMouseDown={activateStaticFrameInteraction}
+                onMouseUp={handleStaticFrameMouseUp}
                 onWidgetUpdate={onWidgetUpdate}
                 onMessage={handleIframeMessage}
                 onError={handleIframeError}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -6,6 +6,7 @@ import { OutputArea, type JupyterOutput } from "../OutputArea";
 let mockDarkMode = false;
 let mockColorTheme: string | undefined;
 let lastFrameMessageHandler: ((message: unknown) => void) | undefined;
+let lastFrameMouseUp: ((params: { hasSelection?: boolean }) => void) | undefined;
 let isolatedFrameMountCount = 0;
 
 const mockFrameHandle = {
@@ -45,11 +46,20 @@ vi.mock("@/components/isolated", async (importOriginal) => {
       autoHeight?: boolean;
       hostContext?: unknown;
       onMessage?: (message: unknown) => void;
+      onMouseUp?: (params: { hasSelection?: boolean }) => void;
       scrollPassthrough?: boolean;
       onReady?: () => void;
     }
   >(function MockIsolatedFrame(
-    { allowWheelBoundaryScroll, autoHeight, hostContext, onMessage, scrollPassthrough, onReady },
+    {
+      allowWheelBoundaryScroll,
+      autoHeight,
+      hostContext,
+      onMessage,
+      onMouseUp,
+      scrollPassthrough,
+      onReady,
+    },
     ref,
   ) {
     React.useImperativeHandle(ref, () => mockFrameHandle);
@@ -70,6 +80,15 @@ vi.mock("@/components/isolated", async (importOriginal) => {
         }
       };
     }, [onMessage]);
+
+    React.useEffect(() => {
+      lastFrameMouseUp = onMouseUp;
+      return () => {
+        if (lastFrameMouseUp === onMouseUp) {
+          lastFrameMouseUp = undefined;
+        }
+      };
+    }, [onMouseUp]);
 
     return (
       <div
@@ -229,6 +248,7 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.searchNavigate.mockClear();
     mockFrameHandle.measureElement.mockClear();
     lastFrameMessageHandler = undefined;
+    lastFrameMouseUp = undefined;
     isolatedFrameMountCount = 0;
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
     vi.mocked(needsPlugin).mockReturnValue(false);
@@ -407,6 +427,39 @@ describe("OutputArea iframe theme sync", () => {
     );
   });
 
+  it("releases static document iframe outputs after a plain iframe click", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(activationWell);
+
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+
+    act(() => {
+      lastFrameMouseUp?.({ hasSelection: false });
+    });
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+  });
+
+  it("keeps static document iframe outputs active after text selection", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(activationWell);
+
+    act(() => {
+      lastFrameMouseUp?.({ hasSelection: true });
+    });
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+  });
+
   it("keeps interactive plugin iframe outputs on the wheel-boundary path", () => {
     const plotlyOutput: JupyterOutput[] = [
       {
@@ -465,6 +518,22 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBeNull();
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+  });
+
+  it("keeps wheel-owning outputs engaged after iframe mouse up", () => {
+    const { getByTestId } = render(<OutputArea outputs={makeVegaOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(activationWell);
+
+    act(() => {
+      lastFrameMouseUp?.({ hasSelection: false });
+    });
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
   });
 
   it("aligns sift before engaging iframe scrolling and releases on Escape", () => {

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -77,6 +77,13 @@ describe("generateFrameHtml", () => {
     expect(html).toContain("passive: false");
   });
 
+  it("forwards iframe mouse up with a selection hint", () => {
+    expect(source).toMatch(/document\.addEventListener\(\s*'mouseup'/);
+    expect(source).toContain("sendRpc('nteract/mouseUp'");
+    expect(source).toContain("hasSelection");
+    expect(source).toContain("selection.toString().length > 0");
+  });
+
   it("keeps the iframe bootstrap script parseable", () => {
     const scripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
 

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -70,8 +70,10 @@ describe("generateFrameHtml", () => {
     expect(source).toMatch(/document\.addEventListener\(\s*'wheel'/);
     expect(html).toContain("isWheelAtScrollBoundary");
     expect(html).toContain("e.preventDefault()");
+    expect(html).toContain("requestAnimationFrame(flushWheelBoundary)");
+    expect(html).toContain("pendingWheelBoundary.deltaY += deltaY");
     expect(source).toContain("sendRpc('nteract/wheelBoundary'");
-    expect(source).toContain("deltaMode: e.deltaMode");
+    expect(source).toContain("queueWheelBoundary(e.deltaY, e.deltaMode)");
     expect(html).toContain("passive: false");
   });
 

--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   MCP_UI_RESOURCE_TEARDOWN,
   MCP_UI_SIZE_CHANGED,
   NTERACT_MEASURE_ELEMENT,
+  NTERACT_MOUSE_UP,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
   NTERACT_THEME,
@@ -64,6 +65,7 @@ function createRuntime(
     onRenderComplete: vi.fn(),
     onLinkClick: vi.fn(),
     onMouseDown: vi.fn(),
+    onMouseUp: vi.fn(),
     onDoubleClick: vi.fn(),
     onWheelBoundary: vi.fn(),
     onWidgetUpdate: vi.fn(),
@@ -148,6 +150,18 @@ describe("IsolatedFrameRuntime", () => {
 
     expect(callbacks.onSizeChanged).toHaveBeenCalledWith({ height: 240, width: 640 });
     expect(callbacks.onResize).toHaveBeenCalledWith(240);
+  });
+
+  it("forwards iframe mouse up selection state", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime();
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+
+    transport.notificationHandlers.get(NTERACT_MOUSE_UP)?.({ hasSelection: true });
+
+    expect(callbacks.onMouseUp).toHaveBeenCalledWith({ hasSelection: true });
   });
 
   it("sends host context once per channel for equivalent content", () => {

--- a/src/components/isolated/__tests__/rpc-methods.test.ts
+++ b/src/components/isolated/__tests__/rpc-methods.test.ts
@@ -26,6 +26,7 @@ import {
   NTERACT_LINK_CLICK,
   NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
+  NTERACT_MOUSE_UP,
   NTERACT_PING,
   NTERACT_PONG,
   NTERACT_READY,
@@ -67,6 +68,7 @@ describe("nteract JSON-RPC method constants", () => {
     NTERACT_RESIZE,
     NTERACT_LINK_CLICK,
     NTERACT_MOUSE_DOWN,
+    NTERACT_MOUSE_UP,
     NTERACT_WHEEL_BOUNDARY,
     NTERACT_DOUBLE_CLICK,
     NTERACT_ERROR,
@@ -126,6 +128,7 @@ describe("nteract JSON-RPC method constants", () => {
     expect(NTERACT_RENDER_COMPLETE).toBe("nteract/renderComplete");
     expect(NTERACT_DOUBLE_CLICK).toBe("nteract/doubleClick");
     expect(NTERACT_MOUSE_DOWN).toBe("nteract/mouseDown");
+    expect(NTERACT_MOUSE_UP).toBe("nteract/mouseUp");
     expect(NTERACT_WHEEL_BOUNDARY).toBe("nteract/wheelBoundary");
     expect(NTERACT_WIDGET_UPDATE).toBe("nteract/widgetUpdate");
     expect(NTERACT_WIDGET_STATE).toBe("nteract/widgetState");

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -809,6 +809,13 @@
           sendRpc("nteract/mouseDown", {});
         });
 
+        document.addEventListener("mouseup", function () {
+          var selection = window.getSelection();
+          sendRpc("nteract/mouseUp", {
+            hasSelection: !!selection && !selection.isCollapsed && selection.toString().length > 0,
+          });
+        });
+
         // --- Wheel Boundary Forwarding ---
         // Native scroll chaining stops at the iframe boundary. When a scrollable
         // renderer is already at its vertical edge, ask the host to apply the

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -864,6 +864,29 @@
           return behavior === "none" || behavior === "contain";
         }
 
+        var pendingWheelBoundary = null;
+        var pendingWheelBoundaryFrame = 0;
+
+        function flushWheelBoundary() {
+          pendingWheelBoundaryFrame = 0;
+          var params = pendingWheelBoundary;
+          pendingWheelBoundary = null;
+          if (!params || !params.deltaY) return;
+          sendRpc("nteract/wheelBoundary", params);
+        }
+
+        function queueWheelBoundary(deltaY, deltaMode) {
+          if (!pendingWheelBoundary || pendingWheelBoundary.deltaMode !== deltaMode) {
+            pendingWheelBoundary = { deltaY: deltaY, deltaMode: deltaMode };
+          } else {
+            pendingWheelBoundary.deltaY += deltaY;
+          }
+
+          if (!pendingWheelBoundaryFrame) {
+            pendingWheelBoundaryFrame = requestAnimationFrame(flushWheelBoundary);
+          }
+        }
+
         document.addEventListener(
           "wheel",
           function (e) {
@@ -877,7 +900,7 @@
               return;
             }
             e.preventDefault();
-            sendRpc("nteract/wheelBoundary", { deltaY: e.deltaY, deltaMode: e.deltaMode });
+            queueWheelBoundary(e.deltaY, e.deltaMode);
           },
           { capture: true, passive: false },
         );

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -22,6 +22,7 @@ import {
   NTERACT_LINK_CLICK,
   NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
+  NTERACT_MOUSE_UP,
   NTERACT_PING,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_COMPLETE,
@@ -70,6 +71,7 @@ export interface IsolatedFrameRuntimeCallbacks {
   onRenderComplete: (height: number) => void;
   onLinkClick: (url: string, newTab: boolean) => void;
   onMouseDown: () => void;
+  onMouseUp: (params: { hasSelection?: boolean }) => void;
   onDoubleClick: () => void;
   onWheelBoundary: (params: { deltaY?: number }) => void;
   onWidgetUpdate: (commId: string, state: Record<string, unknown>) => void;
@@ -610,6 +612,9 @@ export class IsolatedFrameRuntime {
     });
     transport.onNotification(NTERACT_MOUSE_DOWN, () => {
       this.callbacks.onMouseDown();
+    });
+    transport.onNotification(NTERACT_MOUSE_UP, (params) => {
+      this.callbacks.onMouseUp(params as { hasSelection?: boolean });
     });
     transport.onNotification(NTERACT_WHEEL_BOUNDARY, (params) => {
       this.callbacks.onWheelBoundary(params as { deltaY?: number });

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -137,6 +137,13 @@ export interface IsolatedFrameProps {
   onMouseDown?: () => void;
 
   /**
+   * Callback when the user releases a click inside the iframe.
+   * `hasSelection` lets document-like frames stay engaged after text selection
+   * while releasing ordinary clicks back to notebook-native scrolling.
+   */
+  onMouseUp?: (params: { hasSelection?: boolean }) => void;
+
+  /**
    * Callback when the user double-clicks in the iframe.
    */
   onDoubleClick?: () => void;
@@ -298,6 +305,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       onResize,
       onLinkClick,
       onMouseDown,
+      onMouseUp,
       onDoubleClick,
       onWidgetUpdate,
       onError,
@@ -347,6 +355,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     const onResizeRef = useRef(onResize);
     const onLinkClickRef = useRef(onLinkClick);
     const onMouseDownRef = useRef(onMouseDown);
+    const onMouseUpRef = useRef(onMouseUp);
     const onDoubleClickRef = useRef(onDoubleClick);
     const onWidgetUpdateRef = useRef(onWidgetUpdate);
     const onErrorRef = useRef(onError);
@@ -386,6 +395,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     onResizeRef.current = onResize;
     onLinkClickRef.current = onLinkClick;
     onMouseDownRef.current = onMouseDown;
+    onMouseUpRef.current = onMouseUp;
     onDoubleClickRef.current = onDoubleClick;
     onWidgetUpdateRef.current = onWidgetUpdate;
     onErrorRef.current = onError;
@@ -456,6 +466,9 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
           },
           onMouseDown: () => {
             onMouseDownRef.current?.();
+          },
+          onMouseUp: (params) => {
+            onMouseUpRef.current?.(params);
           },
           onDoubleClick: () => {
             onDoubleClickRef.current?.();

--- a/src/components/isolated/output-embed.ts
+++ b/src/components/isolated/output-embed.ts
@@ -143,6 +143,8 @@ export function createNteractOutputEmbed(
     onLinkClick: (url: string, newTab: boolean) =>
       options.onMessage?.({ type: "link_click", payload: { url, newTab } }),
     onMouseDown: () => options.onMessage?.({ type: "mousedown" }),
+    onMouseUp: (params: { hasSelection?: boolean }) =>
+      options.onMessage?.({ type: "mouseup", payload: params }),
     onDoubleClick: () => options.onMessage?.({ type: "dblclick" }),
     onWheelBoundary: (params: { deltaY?: number }) =>
       options.onMessage?.({ type: "wheel_boundary", payload: params }),

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -56,6 +56,7 @@ export const NTERACT_EVAL_RESULT = "nteract/evalResult" as const;
 export const NTERACT_PONG = "nteract/pong" as const;
 export const NTERACT_SEARCH_RESULTS = "nteract/searchResults" as const;
 export const NTERACT_MOUSE_DOWN = "nteract/mouseDown" as const;
+export const NTERACT_MOUSE_UP = "nteract/mouseUp" as const;
 export const NTERACT_WHEEL_BOUNDARY = "nteract/wheelBoundary" as const;
 
 // MCP Apps-compatible methods used by embedders. Notebook rendering commands


### PR DESCRIPTION
## Summary

- coalesce isolated iframe wheel-boundary notifications to one message per animation frame
- release markdown and static document iframe interaction after plain clicks so notebook scrolling stays fluid
- preserve iframe engagement for text selection and wheel-owning outputs such as chart/table surfaces

## Verification

- `pnpm --workspace-root test:run src/components/isolated/__tests__/frame-html.test.ts src/components/isolated/__tests__/rpc-methods.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/components/isolated/__tests__/frame-html-jsonrpc.test.ts src/components/isolated/__tests__/scroll-boundary.test.ts apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`

## Review

- attempted `opencode run` review twice; both runs stalled after printing the diff and returned no findings before being stopped
