### PR TITLE
polish(notebook-cloud): refine hosted sharing and presence

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -112,9 +112,9 @@ async function main() {
     );
     contexts.push(alice.context, bob.context, anonymous.context);
 
-    await timed("alice_connected", () => waitForPresence(alice.page, "editing"));
-    await timed("bob_connected", () => waitForPresence(bob.page, "editing"));
-    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "here now"));
+    await timed("alice_connected", () => waitForPresence(alice.page, "participant"));
+    await timed("bob_connected", () => waitForPresence(bob.page, "participant"));
+    await timed("anonymous_connected", () => waitForPresence(anonymous.page, "participant"));
     checks.push("browser_alice_connected", "browser_bob_connected", "anonymous_viewer_connected");
 
     await waitForEditableMarkdown(alice.page);
@@ -221,7 +221,7 @@ ${bobMarker}
       }),
     );
     contexts.push(charlie.context);
-    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "here now"));
+    await timed("charlie_downgraded", () => waitForPresence(charlie.page, "participant"));
     await assertNoEditableMarkdown(charlie.page);
     checks.push("ungranted_editor_downgraded_to_viewer");
 
@@ -478,8 +478,9 @@ async function waitForPresence(page, expectedText) {
   await page.waitForFunction(
     (expected) =>
       document
-        .querySelector("[data-slot='notebook-presence-status']")
-        ?.textContent?.includes(expected),
+        .querySelector("[data-slot='cloud-presence-stack']")
+        ?.getAttribute("title")
+        ?.includes(expected),
     expectedText,
     { timeout: timeoutMs },
   );

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -46,7 +46,7 @@ const expectedSourceText =
   process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
-const expectedPresenceText = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TEXT ?? "here now";
+const expectedPresenceTitle = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE ?? "participant";
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", []);
 const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS", [
   "MathNet topic visualization",
@@ -339,13 +339,14 @@ async function main() {
       );
       markTiming("rendered_cell_marker");
     }
-    if (expectedPresenceText) {
+    if (expectedPresenceTitle) {
       await page.waitForFunction(
         (expected) =>
           document
-            .querySelector("[data-slot='notebook-presence-status']")
-            ?.textContent?.includes(expected),
-        expectedPresenceText,
+            .querySelector("[data-slot='cloud-presence-stack']")
+            ?.getAttribute("title")
+            ?.includes(expected),
+        expectedPresenceTitle,
         { timeout: timeoutMs },
       );
       markTiming("presence");
@@ -419,9 +420,9 @@ async function main() {
     const renderedCellCount = await page
       .locator("[data-slot='cell-container'], [data-cell-id]")
       .count();
-    const presenceText = await page
-      .locator("[data-slot='notebook-presence-status']")
-      .textContent({ timeout: 1_000 })
+    const presenceTitle = await page
+      .locator("[data-slot='cloud-presence-stack']")
+      .getAttribute("title", { timeout: 1_000 })
       .catch(() => null);
     viewerMilestones = summarizeViewerMilestones(await collectViewerLoadMarks(page));
 
@@ -548,7 +549,7 @@ async function main() {
           expectedPageTexts,
           expectedExecutionCount,
           requireRenderedCellMarker,
-          expectedPresenceText,
+          expectedPresenceTitle,
           expectedFrameTexts,
           expectedOutputDocumentOrigin,
           expectedCatalogOwnerPrincipal,
@@ -569,7 +570,7 @@ async function main() {
           renderCacheRequests,
           executionCounts,
           renderedCellCount,
-          presenceText,
+          presenceTitle,
           siftLoadMilestoneMatches,
           frameTextMatches,
           pageTextMatches,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1781,7 +1781,7 @@ interface ViewerShellConfig extends Record<string, unknown> {
 }
 
 function homeViewer(request: Request, env: Env): Response {
-  return viewerShell("nteract cloud notebooks", env, authConfigForRequest(request, env), null);
+  return viewerShell("nteract", env, authConfigForRequest(request, env), null);
 }
 
 function oidcCallbackViewer(request: Request, env: Env): Response {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -146,7 +146,7 @@ describe("HTML script serialization", () => {
 
     assert.equal(response.status, 200);
     assert.equal(response.headers.get("Cache-Control"), "no-store");
-    assert.match(html, /nteract cloud notebooks/);
+    assert.match(html, /<title>nteract<\/title>/);
     assert.match(html, /id="nteract-cloud-auth-config"/);
     assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
@@ -164,7 +164,7 @@ describe("HTML script serialization", () => {
     const html = await response.text();
 
     assert.equal(response.status, 200);
-    assert.match(html, /nteract cloud notebooks/);
+    assert.match(html, /<title>nteract<\/title>/);
     assert.doesNotMatch(html, /In the Loop - Collaborative Notebooks/);
   });
 

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -103,7 +103,7 @@ describe("cloud viewer presence", () => {
     assert.equal(state.ownPeerLabel, "Alice Demo");
     assert.deepEqual(cloudViewerPresenceDisplay(state), {
       label: "2 here now",
-      title: "2 participants are in this notebook; You are Alice Demo",
+      title: "2 participants; you are Alice Demo",
       connected: true,
     });
   });

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -51,6 +51,14 @@ describe("cloud viewer presence", () => {
     });
     assert.equal(state.roomPeerCount, 2);
     assert.equal(cloudViewerPresenceDisplay(state).label, "2 here now");
+    assert.deepEqual(
+      cloudViewerPresenceDisplay(state).peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [{ kind: "anonymous", label: "2 anonymous viewers", count: 2 }],
+    );
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_left",
@@ -79,11 +87,15 @@ describe("cloud viewer presence", () => {
     const disconnected = reduceCloudViewerConnection(connected, "disconnected");
 
     assert.equal(disconnected.roomPeerCount, 3);
-    assert.deepEqual(cloudViewerPresenceDisplay(disconnected), {
-      label: "Offline",
-      title: "Disconnected from the notebook room",
-      connected: false,
-    });
+    const display = cloudViewerPresenceDisplay(disconnected);
+    assert.equal(display.label, "Offline");
+    assert.equal(display.title, "Room unavailable");
+    assert.equal(display.connected, false);
+    assert.equal(display.peers.length, 3);
+    assert.equal(
+      display.peers.every((peer) => peer.status === "offline"),
+      true,
+    );
   });
 
   it("uses friendly display metadata in the connected status title", () => {
@@ -101,11 +113,68 @@ describe("cloud viewer presence", () => {
     });
 
     assert.equal(state.ownPeerLabel, "Alice Demo");
-    assert.deepEqual(cloudViewerPresenceDisplay(state), {
-      label: "2 here now",
-      title: "2 participants; you are Alice Demo",
-      connected: true,
+    const display = cloudViewerPresenceDisplay(state);
+    assert.equal(display.label, "2 here now");
+    assert.equal(display.title, "2 participants");
+    assert.equal(display.connected, true);
+    assert.deepEqual(
+      display.peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [
+        { kind: "self", label: "Alice Demo", count: undefined },
+        { kind: "anonymous", label: "Anonymous viewer", count: 1 },
+      ],
+    );
+  });
+
+  it("keeps named peers visible before grouping anonymous viewers", () => {
+    let state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-a",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "editor",
+      display_name: "Alice Demo",
+      room_peer_count: 1,
+      timestamp: "2026-05-23T00:00:00.000Z",
     });
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_joined",
+      notebook_id: "demo",
+      peer_id: "peer-b",
+      actor_label: "user:anaconda:bob/browser:tab",
+      room_peer_count: 2,
+      timestamp: "2026-05-23T00:00:01.000Z",
+    });
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_joined",
+      notebook_id: "demo",
+      peer_id: "peer-c",
+      actor_label: "anonymous:viewer:session-c/browser",
+      room_peer_count: 3,
+      timestamp: "2026-05-23T00:00:02.000Z",
+    });
+
+    const display = cloudViewerPresenceDisplay(state);
+
+    assert.deepEqual(
+      display.peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [
+        { kind: "self", label: "Alice Demo", count: undefined },
+        { kind: "peer", label: "Bob", count: undefined },
+        { kind: "anonymous", label: "Anonymous viewer", count: 1 },
+      ],
+    );
+    assert.equal(display.hiddenCount, 0);
   });
 
   it("falls back to readable cloud peer labels instead of raw actor labels", () => {

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -153,9 +153,24 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sourceText, /shouldShowPackageEnvironmentSummary \? \([\s\S]*<EnvironmentSummary/);
   assert.match(sourceText, /autoFocusFirstCell=\{false\}/);
-  assert.match(sourceText, /presence=\{[\s\S]*<CloudPresenceStatus[\s\S]*presence=\{presence\}/);
+  assert.match(
+    sourceText,
+    /const presenceStoreRef = useRef<CloudViewerPresenceStore \| null>\(null\)/,
+  );
+  assert.match(
+    sourceText,
+    /useSyncExternalStore\(store\.subscribe, store\.getSnapshot, store\.getSnapshot\)/,
+  );
+  assert.match(
+    sourceText,
+    /utilityControls=\{[\s\S]*<CloudPresenceStatus[\s\S]*store=\{presenceStore\}/,
+  );
   assert.match(sourceText, /cloudViewerPresenceDisplay,/);
-  assert.match(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
+  assert.match(sourceText, /<AvatarGroup className="cloud-presence-avatar-group"/);
+  assert.match(sourceText, /data-slot="cloud-presence-stack"/);
+  assert.doesNotMatch(sourceText, /useState\(initialCloudViewerPresence\)/);
+  assert.doesNotMatch(sourceText, /setPresence\(/);
+  assert.doesNotMatch(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
   assert.match(sourceText, /Public link, collaborators, and pending invites for this notebook\./);
   assert.match(
     sourceText,
@@ -182,20 +197,12 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /aria-label=\{`Remove \$\{row\.label\}`\}/);
   assert.match(
     sourceText,
-    /function CloudPresenceStatus[\s\S]*const presenceDisplay = cloudViewerPresenceDisplay\(presence\);[\s\S]*if \(!presenceDisplay\.connected\) \{[\s\S]*return null;/,
+    /function CloudPresenceStatus[\s\S]*const presence = useSyncExternalStore\(store\.subscribe, store\.getSnapshot, store\.getSnapshot\);[\s\S]*const presenceDisplay = cloudViewerPresenceDisplay\(presence\);/,
   );
-  assert.match(
-    cssText,
-    /@media \(max-width: 360px\) \{[\s\S]*cloud-room-toolbar \.cloud-connection-status[\s\S]*display: none;/,
-  );
-  assert.match(
-    cssText,
-    /\.cloud-connection-status \{[\s\S]*width: 1\.875rem;[\s\S]*height: 1\.875rem;/,
-  );
-  assert.match(
-    cssText,
-    /\.cloud-connection-status span \{[\s\S]*position: absolute;[\s\S]*width: 1px;[\s\S]*clip: rect\(0, 0, 0, 0\);/,
-  );
+  assert.match(cssText, /\.cloud-presence-stack \{[\s\S]*min-width: 1\.75rem;[\s\S]*height: 2rem;/);
+  assert.match(cssText, /\.cloud-presence-avatar-group \{[\s\S]*align-items: center;/);
+  assert.match(cssText, /\.cloud-presence-avatar\[data-kind="anonymous"\]/);
+  assert.doesNotMatch(cssText, /\.cloud-connection-status/);
   assert.match(
     cssText,
     /cloud-room-toolbar \[data-slot="notebook-document-header-controls"\] \{[\s\S]*flex: 0 0 auto;[\s\S]*min-width: max-content;/,
@@ -251,7 +258,7 @@ test("cloud viewer presents live-room failures as one host notice", () => {
   assert.match(sourceText, /aria-label=\{title\}/);
   assert.match(
     sourceText,
-    /Reconnecting to the notebook room: \$\{cloudConnectionStatusErrorTitle\(error\)\}/,
+    /Room unavailable: \$\{cloudConnectionStatusErrorTitle\(connectionError\)\}/,
   );
   assert.doesNotMatch(sourceText, /title="Live room connection failed\."/);
   assert.doesNotMatch(sourceText, /Reconnecting to the notebook room: \$\{error\}/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -77,11 +77,13 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
     cssText.indexOf(".cloud-home-status"),
   );
 
-  assert.match(homeSource, /homeStatusTitle[\s\S]*"Notebook cloud"/);
+  assert.match(homeSource, /homeStatusTitle[\s\S]*"Open a notebook"/);
   assert.match(homeSource, /className="cloud-home-layout"/);
+  assert.match(homeSource, /aria-label="nteract notebook entry"/);
+  assert.match(homeSource, /aria-label="Notebook sign-in"/);
   assert.match(homeSource, /className="cloud-home-copy"/);
   assert.match(homeSource, /<h1>nteract<\/h1>/);
-  assert.match(homeSource, /preview realtime notebooks/);
+  assert.match(homeSource, /realtime notebooks/);
   assert.match(homeSource, /Open topic viz/);
   assert.doesNotMatch(homeSource, /showPrototypeDevControls/);
   assert.doesNotMatch(homeSource, /className="cloud-home-scope"/);
@@ -106,8 +108,10 @@ test("cloud callback keeps sign-in handoff in the entry surface language", () =>
 
   assert.match(callbackSource, /className="cloud-home"/);
   assert.match(callbackSource, /className="cloud-home-layout"/);
+  assert.match(callbackSource, /aria-label="nteract sign-in callback"/);
   assert.match(callbackSource, /className="cloud-home-panel"/);
   assert.match(callbackSource, /returning to the notebook/);
+  assert.match(callbackSource, /Back to nteract/);
   assert.match(callbackSource, /data-mode=\{status\.kind\}/);
   assert.match(cssText, /\.cloud-home-status-spinner/);
   assert.doesNotMatch(callbackSource, /cloud-report-toolbar/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -195,31 +195,27 @@ test("cloud identity chrome renders through the shared actor projection surface"
   assert.match(sourceText, /actor: runtimeActor/);
 });
 
-test("cloud presence chrome renders through the shared shell component", () => {
+test("cloud presence chrome renders as an isolated host avatar stack", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
-  const sharedPresencePath = new URL(
-    "../../../src/components/notebook/NotebookPresenceStatus.tsx",
-    import.meta.url,
-  );
-  const sharedPresenceText = readFileSync(sharedPresencePath, "utf8");
   const hostedSmokePath = new URL("../scripts/hosted-render-smoke.mjs", import.meta.url);
   const hostedSmokeText = readFileSync(hostedSmokePath, "utf8");
   const collabSmokePath = new URL("../scripts/hosted-collab-smoke.mjs", import.meta.url);
   const collabSmokeText = readFileSync(collabSmokePath, "utf8");
 
-  assert.match(sourceText, /NotebookPresenceStatus/);
+  assert.match(sourceText, /CloudViewerPresenceStore/);
   assert.match(
     sourceText,
-    /<NotebookPresenceStatus[\s\S]*label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/,
+    /useSyncExternalStore\(store\.subscribe, store\.getSnapshot, store\.getSnapshot\)/,
   );
-  assert.match(sourceText, /<NotebookPresenceStatus[\s\S]*variant="inline"/);
-  assert.match(sharedPresenceText, /data-slot="notebook-presence-status"/);
-  assert.match(hostedSmokeText, /\[data-slot='notebook-presence-status'\]/);
-  assert.match(collabSmokeText, /\[data-slot='notebook-presence-status'\]/);
-  assert.doesNotMatch(sourceText, /className="cloud-presence"/);
-  assert.doesNotMatch(hostedSmokeText, /cloud-presence/);
-  assert.doesNotMatch(collabSmokeText, /cloud-presence/);
+  assert.match(sourceText, /<AvatarGroup className="cloud-presence-avatar-group"/);
+  assert.match(sourceText, /data-slot="cloud-presence-stack"/);
+  assert.match(hostedSmokeText, /\[data-slot='cloud-presence-stack'\]/);
+  assert.match(collabSmokeText, /\[data-slot='cloud-presence-stack'\]/);
+  assert.doesNotMatch(sourceText, /NotebookPresenceStatus/);
+  assert.doesNotMatch(sourceText, /compactCloudPresenceLabel/);
+  assert.doesNotMatch(hostedSmokeText, /notebook-presence-status/);
+  assert.doesNotMatch(collabSmokeText, /notebook-presence-status/);
 });
 
 test("cloud edit mode chrome renders through the shared shell component", () => {

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -53,8 +53,12 @@ describe("cloud viewer sharing client", () => {
         ["acl", "Alice Owner", "Owner", null, false],
         ["acl", "Bob Example", "Can edit", null, true],
         ["acl", "Public link", "Can view", "Enabled", true],
-        ["invite", "carol@example.com", "Can view", "Pending", true],
+        ["invite", "c...l@example.com", "Can view", "Pending", true],
       ],
+    );
+    assert.deepEqual(
+      rows.map((row) => row.title),
+      ["alice@example.com", "bob@example.com", "Anyone with the link", "carol@example.com"],
     );
     assert.equal(cloudShareAccessSummary(rows), "2 people, public link, 1 invite");
   });
@@ -91,8 +95,12 @@ describe("cloud viewer sharing client", () => {
       rows.map((row) => [row.label, row.detail]),
       [
         ["fixture", "Dev identity"],
-        ["alice@example.com", "Anaconda identity"],
+        ["a...e@example.com", "Anaconda identity"],
       ],
+    );
+    assert.deepEqual(
+      rows.map((row) => row.title),
+      ["user:dev:fixture", "user:anaconda:alice%40example.com"],
     );
   });
 

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -205,7 +205,7 @@ test("cloud shell capabilities grant owners full cell, structure, and sharing co
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities reserve sharing for owners", () => {
+test("cloud shell capabilities surface sharing for authenticated hosted rooms", () => {
   assert.equal(
     cloudNotebookShellCapabilities({
       authState: authState("dev"),
@@ -220,6 +220,16 @@ test("cloud shell capabilities reserve sharing for owners", () => {
     cloudNotebookShellCapabilities({
       authState: authState("dev"),
       connectionScope: "editor",
+      hasCodeCells: true,
+      hostCapabilities: { canManageSharing: true },
+    }).canManageSharing,
+    true,
+  );
+
+  assert.equal(
+    cloudNotebookShellCapabilities({
+      authState: authState("anonymous"),
+      connectionScope: "viewer",
       hasCodeCells: true,
       hostCapabilities: { canManageSharing: true },
     }).canManageSharing,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -836,6 +836,69 @@ describe("Worker artifact routes", () => {
     assert.equal(ownerRoute.status, 403);
   });
 
+  it("keeps sharing identity data behind owner-only routes for public viewers", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "public-sharing-demo");
+    seedAcl(env, {
+      notebookId: "public-sharing-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "public-sharing-demo",
+      subject: "user:dev:bob",
+      scope: "editor",
+    });
+    seedAcl(env, {
+      notebookId: "public-sharing-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    seedPendingInvite(env, {
+      id: "invite-private-email",
+      notebookId: "public-sharing-demo",
+      email: "carol@example.com",
+      providerHint: "oidc",
+      scope: "editor",
+    });
+    env.DB.profiles.set("user:dev:bob", {
+      principal: "user:dev:bob",
+      provider: "dev",
+      provider_subject: "bob",
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const catalog = await worker.fetch(
+      new Request("http://localhost/api/n/public-sharing-demo?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(catalog.status, 200);
+
+    const acl = await worker.fetch(
+      new Request("http://localhost/api/n/public-sharing-demo/acl?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+    const invites = await worker.fetch(
+      new Request("http://localhost/api/n/public-sharing-demo/invites?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(acl.status, 403);
+    assert.equal(invites.status, 403);
+    assert.doesNotMatch(await acl.text(), /bob@example\.com|carol@example\.com/);
+    assert.doesNotMatch(await invites.text(), /bob@example\.com|carol@example\.com/);
+  });
+
   it("lets owners inspect and grant principal ACL rows", async () => {
     const env = fakeEnv();
     seedNotebook(env, "acl-demo");

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -79,31 +79,6 @@ body {
   gap: clamp(0.375rem, 1vw, 0.75rem);
 }
 
-.cloud-room-toolbar [data-slot="notebook-presence-status"] {
-  width: 2.75rem;
-  max-width: 2.75rem;
-  height: 2.25rem;
-  justify-content: center;
-  gap: 0.3125rem;
-  border-radius: 6px;
-  color: var(--foreground);
-}
-
-.cloud-room-toolbar [data-slot="notebook-presence-status"]:hover {
-  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
-}
-
-.cloud-room-toolbar [data-slot="notebook-presence-status"] svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.cloud-room-toolbar [data-slot="notebook-presence-status"] [class*="truncate"] {
-  flex: 0 0 auto;
-  min-width: 0;
-  overflow: visible;
-}
-
 .cloud-notebook-title {
   display: grid;
   min-width: 0;
@@ -134,43 +109,94 @@ body {
   line-height: 1.2;
 }
 
-.cloud-connection-status {
+.cloud-presence-stack {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.875rem;
-  height: 1.875rem;
+  min-width: 1.75rem;
+  height: 2rem;
+  padding-inline: 0.125rem;
   border-radius: 6px;
-  color: #047857;
+  color: var(--foreground);
   transition:
     background-color 140ms ease,
-    color 140ms ease;
+    color 140ms ease,
+    opacity 140ms ease;
 }
 
-.cloud-connection-status:hover {
-  background: var(--muted);
+.cloud-presence-stack:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
 }
 
-.cloud-connection-status[data-state="waiting"] {
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+.cloud-presence-stack[data-state="joining"],
+.cloud-presence-stack[data-state="waiting"] {
+  opacity: 0.62;
 }
 
-.cloud-connection-status svg {
-  width: 1rem;
-  height: 1rem;
-  flex: 0 0 auto;
+.cloud-presence-avatar-group {
+  align-items: center;
+  padding-inline: 0.25rem;
 }
 
-.cloud-connection-status span {
+.cloud-presence-avatar {
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  background: var(--background);
+}
+
+.cloud-presence-avatar [data-slot="avatar-fallback"] {
+  position: relative;
+  background: color-mix(in srgb, var(--background) 92%, var(--foreground) 8%);
+  color: color-mix(in srgb, var(--foreground) 70%, transparent);
+  font-size: 0.625rem;
+  font-weight: 650;
+}
+
+.cloud-presence-avatar[data-kind="self"] [data-slot="avatar-fallback"] {
+  color: #047857;
+}
+
+.cloud-presence-avatar[data-kind="anonymous"] [data-slot="avatar-fallback"] {
+  background: color-mix(in srgb, #10b981 10%, var(--background));
+  color: #047857;
+}
+
+.cloud-presence-avatar[data-kind="anonymous"] svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.cloud-presence-anonymous-count {
   position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  right: -0.25rem;
+  bottom: -0.25rem;
+  min-width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 999px;
+  padding-inline: 0.1875rem;
+  background: #047857;
+  color: white;
+  font-size: 0.5625rem;
+  font-weight: 750;
+  line-height: 0.875rem;
+}
+
+.cloud-presence-avatar [data-slot="avatar-badge"] {
+  background: #10b981;
+}
+
+.cloud-presence-avatar [data-slot="avatar-badge"][data-status="idle"] {
+  background: #94a3b8;
+}
+
+.cloud-presence-avatar [data-slot="avatar-badge"][data-status="offline"] {
+  background: #cbd5e1;
+}
+
+.cloud-presence-avatar-count {
+  background: color-mix(in srgb, var(--background) 90%, var(--foreground) 10%);
+  color: color-mix(in srgb, var(--foreground) 70%, transparent);
+  font-size: 0.625rem;
+  font-weight: 650;
 }
 
 @media (max-width: 900px) {
@@ -520,10 +546,6 @@ main.flex > .cloud-report-toolbar {
 }
 
 @media (max-width: 360px) {
-  .cloud-room-toolbar .cloud-connection-status {
-    display: none;
-  }
-
   .cloud-auth-menu > summary.cloud-auth-identity-summary {
     width: 2rem;
     padding-inline: 0.375rem;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -76,11 +76,32 @@ body {
 .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {
   flex: 0 0 auto;
   min-width: max-content;
-  gap: clamp(0.5rem, 1.4vw, 1.25rem);
+  gap: clamp(0.375rem, 1vw, 0.75rem);
 }
 
 .cloud-room-toolbar [data-slot="notebook-presence-status"] {
-  max-width: min(12rem, 24vw);
+  width: 2.75rem;
+  max-width: 2.75rem;
+  height: 2.25rem;
+  justify-content: center;
+  gap: 0.3125rem;
+  border-radius: 6px;
+  color: var(--foreground);
+}
+
+.cloud-room-toolbar [data-slot="notebook-presence-status"]:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
+}
+
+.cloud-room-toolbar [data-slot="notebook-presence-status"] svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-room-toolbar [data-slot="notebook-presence-status"] [class*="truncate"] {
+  flex: 0 0 auto;
+  min-width: 0;
+  overflow: visible;
 }
 
 .cloud-notebook-title {
@@ -182,10 +203,6 @@ body {
     display: none;
   }
 
-  .cloud-room-toolbar [data-slot="notebook-presence-status"] {
-    max-width: min(12rem, 34vw);
-  }
-
   .cloud-share-menu > summary,
   .cloud-auth-menu > summary,
   .cloud-sign-in-button {
@@ -199,7 +216,6 @@ body {
     gap: 0.125rem 0.375rem;
   }
 
-  .cloud-room-toolbar [data-slot="notebook-presence-status"],
   .cloud-share-menu > summary,
   .cloud-auth-menu > summary,
   .cloud-sign-in-button {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -588,18 +588,18 @@ main.flex > .cloud-report-toolbar {
   right: 0;
   z-index: 30;
   display: grid;
-  gap: 0.875rem;
-  width: min(28rem, calc(100vw - 1.5rem));
+  gap: 0;
+  width: min(30rem, calc(100vw - 1.5rem));
   max-height: min(42rem, calc(100vh - 5rem));
   overflow: auto;
   border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
   border-radius: 8px;
   padding: 0;
   color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 98%, var(--foreground) 2%);
+  background: var(--background);
   box-shadow:
-    0 1px 0 color-mix(in srgb, var(--foreground) 8%, transparent),
-    0 8px 20px color-mix(in srgb, #000 8%, transparent);
+    0 1px 2px color-mix(in srgb, #000 7%, transparent),
+    0 10px 24px color-mix(in srgb, #000 9%, transparent);
 }
 
 .cloud-share-panel header {
@@ -608,7 +608,7 @@ main.flex > .cloud-report-toolbar {
   justify-content: space-between;
   gap: 0.75rem;
   border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  padding: 0.875rem 1rem;
+  padding: 0.875rem 1rem 0.8125rem;
 }
 
 .cloud-share-panel h2,
@@ -646,7 +646,7 @@ main.flex > .cloud-report-toolbar {
   border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
   border-radius: 6px;
   color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  background: color-mix(in srgb, var(--background) 97%, var(--foreground) 3%);
   font-size: 0.8125rem;
 }
 
@@ -677,7 +677,7 @@ main.flex > .cloud-report-toolbar {
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
-  margin: 0.75rem 1rem;
+  margin: 0.75rem 1rem 0;
   border-left: 2px solid color-mix(in srgb, #10b981 72%, transparent);
   padding: 0.625rem 0.625rem 0.625rem 0.75rem;
   background: color-mix(in srgb, #10b981 6%, var(--background));
@@ -713,7 +713,7 @@ main.flex > .cloud-report-toolbar {
   grid-template-columns: minmax(0, 1fr) minmax(6rem, 0.35fr) auto;
   gap: 0.5rem;
   align-items: end;
-  padding: 0 1rem 0.75rem;
+  padding: 0.875rem 1rem;
 }
 
 .cloud-share-invite label {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -5,14 +5,13 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type FormEvent,
   type ReactNode,
 } from "react";
 import { createRoot } from "react-dom/client";
 import {
   AlertCircle,
-  Cloud,
-  CloudOff,
   Globe2,
   KeyRound,
   Link2,
@@ -35,7 +34,6 @@ import {
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookPresenceStatus,
   NotebookPackageSummaryPanel,
   NotebookToolbarFrame,
   type NotebookEnvironmentManager,
@@ -46,6 +44,13 @@ import {
   useNotebookCellUIStateBridge,
   useNotebookViewModel,
 } from "@/components/notebook";
+import {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+} from "@/components/ui/avatar";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
@@ -97,12 +102,9 @@ import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
-  type CloudViewerPresenceConnection,
-  type CloudViewerPresenceState,
+  type CloudViewerPresencePeer,
+  CloudViewerPresenceStore,
   cloudViewerPresenceDisplay,
-  initialCloudViewerPresence,
-  reduceCloudViewerConnection,
-  reduceCloudViewerPresenceMessage,
 } from "./presence";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { materializeCloudNotebookView } from "./cloud-view-model";
@@ -669,7 +671,11 @@ function NotebookViewer({
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const outputResolutionCacheRef = useRef(createOutputResolutionCache());
-  const [presence, setPresence] = useState(initialCloudViewerPresence);
+  const presenceStoreRef = useRef<CloudViewerPresenceStore | null>(null);
+  if (presenceStoreRef.current === null) {
+    presenceStoreRef.current = new CloudViewerPresenceStore();
+  }
+  const presenceStore = presenceStoreRef.current;
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
   const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
@@ -925,7 +931,7 @@ function NotebookViewer({
     const scheduleReconnect = (reason: Error) => {
       if (disposed) return;
       console.warn("[notebook-cloud] live room connection closed", reason);
-      setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
+      presenceStore.reduceConnection("disconnected");
       setConnectionScope(null);
       setConnectionActorLabel(null);
       setConnectionError(reason.message);
@@ -1016,7 +1022,7 @@ function NotebookViewer({
     };
     materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
 
-    setPresence(initialCloudViewerPresence());
+    presenceStore.reset();
     setConnectionError(null);
     setConnectionActorLabel(null);
     setConnectionPeerId(null);
@@ -1034,7 +1040,7 @@ function NotebookViewer({
           message.type === "cloud_peer_joined" ||
           message.type === "cloud_peer_left"
         ) {
-          setPresence((state) => reduceCloudViewerPresenceMessage(state, message));
+          presenceStore.reduceMessage(message);
         }
         if (message.type === "cloud_room_ready") {
           markCloudViewerLoadMilestone("live-room-ready");
@@ -1086,7 +1092,7 @@ function NotebookViewer({
             }`,
           });
         }
-        setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
+        presenceStore.reduceConnection("disconnected");
         setConnectionScope(null);
         setConnectionActorLabel(null);
         setConnectionPeerId(null);
@@ -1106,7 +1112,7 @@ function NotebookViewer({
       disposeCurrentRuntime();
       resetCloudViewStoreProjection();
       livePresenceStore = null;
-      setPresence((state) => reduceCloudViewerConnection(state, "disconnected"));
+      presenceStore.reduceConnection("disconnected");
       setConnectionPeerId(null);
     };
   }, [
@@ -1119,6 +1125,7 @@ function NotebookViewer({
     config.syncEndpoint,
     connectAttempt,
     loadingPolicy.shouldConnectLiveRoom,
+    presenceStore,
     preloadSiftWasm,
     widgetStore,
   ]);
@@ -1328,10 +1335,7 @@ function NotebookViewer({
         className="cloud-room-toolbar"
         presence={<CloudNotebookTitle />}
         utilityControls={
-          <>
-            <CloudConnectionStatus connection={presence.connection} error={connectionError} />
-            <CloudPresenceStatus presence={presence} />
-          </>
+          <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
         }
         authControls={
           shouldShowCloudHeaderSignIn(authState) ? (
@@ -1993,38 +1997,6 @@ function safeDecodeRouteSegment(value: string | null | undefined): string | null
   }
 }
 
-function CloudConnectionStatus({
-  connection,
-  error,
-}: {
-  connection: CloudViewerPresenceConnection;
-  error: string | null;
-}) {
-  const connected = connection === "connected" && !error;
-  const connecting = connection === "connecting" && !error;
-  const label = connected ? "Live" : connecting ? "Joining" : "Reconnecting";
-  const title = connected
-    ? "Connected to the notebook room"
-    : connecting
-      ? "Joining the notebook room"
-      : error
-        ? `Reconnecting to the notebook room: ${cloudConnectionStatusErrorTitle(error)}`
-        : "Reconnecting to the notebook room";
-  const Icon = connected || connecting ? Cloud : CloudOff;
-
-  return (
-    <span
-      className="cloud-connection-status"
-      data-state={connected ? "live" : "waiting"}
-      title={title}
-      aria-label={title}
-    >
-      <Icon aria-hidden="true" />
-      <span className="sr-only">{label}</span>
-    </span>
-  );
-}
-
 function cloudConnectionStatusErrorTitle(error: string): string {
   if (/\bfailed to connect\s+wss?:\/\//i.test(error)) {
     return "unable to join the live room";
@@ -2043,26 +2015,87 @@ function sanitizeCloudConnectionError(error: string): string {
   });
 }
 
-function CloudPresenceStatus({ presence }: { presence: CloudViewerPresenceState }) {
+function CloudPresenceStatus({
+  connectionError,
+  store,
+}: {
+  connectionError: string | null;
+  store: CloudViewerPresenceStore;
+}) {
+  const presence = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
   const presenceDisplay = cloudViewerPresenceDisplay(presence);
-
-  if (!presenceDisplay.connected) {
-    return null;
-  }
+  const connected = presenceDisplay.connected && !connectionError;
+  const title = connectionError
+    ? `Room unavailable: ${cloudConnectionStatusErrorTitle(connectionError)}`
+    : presenceDisplay.title;
+  const state = connected ? "live" : presence.connection === "connecting" ? "joining" : "waiting";
 
   return (
-    <NotebookPresenceStatus
-      connected={presenceDisplay.connected}
-      label={compactCloudPresenceLabel(presenceDisplay.label)}
-      title={presenceDisplay.title}
-      variant="inline"
-    />
+    <span
+      className="cloud-presence-stack"
+      data-slot="cloud-presence-stack"
+      data-state={state}
+      title={title}
+      aria-label={title}
+    >
+      <AvatarGroup className="cloud-presence-avatar-group" aria-hidden="true">
+        {presenceDisplay.peers.map((peer) => (
+          <CloudPresenceAvatar key={peer.id} peer={peer} connected={connected} />
+        ))}
+        {presenceDisplay.hiddenCount > 0 ? (
+          <AvatarGroupCount className="cloud-presence-avatar-count" data-size="sm">
+            +{presenceDisplay.hiddenCount}
+          </AvatarGroupCount>
+        ) : null}
+      </AvatarGroup>
+      <span className="sr-only">{presenceDisplay.label}</span>
+    </span>
   );
 }
 
-function compactCloudPresenceLabel(label: string): string {
-  const countMatch = /^(\d+)\s+here now$/.exec(label);
-  return countMatch?.[1] ?? label;
+function CloudPresenceAvatar({
+  connected,
+  peer,
+}: {
+  connected: boolean;
+  peer: CloudViewerPresencePeer;
+}) {
+  const status = connected ? peer.status : "offline";
+  return (
+    <Avatar
+      size="sm"
+      className="cloud-presence-avatar"
+      data-kind={peer.kind}
+      data-status={status}
+      title={peer.label}
+    >
+      <AvatarFallback>
+        {peer.kind === "anonymous" ? (
+          <>
+            <UserRound aria-hidden="true" />
+            {peer.count && peer.count > 1 ? (
+              <span className="cloud-presence-anonymous-count">{peer.count}</span>
+            ) : null}
+          </>
+        ) : (
+          cloudPresenceInitials(peer.label)
+        )}
+      </AvatarFallback>
+      <AvatarBadge data-status={status} />
+    </Avatar>
+  );
+}
+
+function cloudPresenceInitials(label: string): string {
+  const words = label
+    .split(/[\s@._-]+/g)
+    .map((word) => word.trim())
+    .filter(Boolean);
+  const initials = words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+  return initials || "?";
 }
 
 function appendEndpointPathSegment(endpoint: string, segment: string): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1778,7 +1778,7 @@ function CloudSharingControls({
           ) : (
             <ul>
               {accessRows.map((row) => (
-                <li key={row.id}>
+                <li key={row.id} title={row.title}>
                   <CloudShareRowIcon row={row} />
                   <div>
                     <strong>{row.label}</strong>

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -454,23 +454,23 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   };
 
   const signedIn = authState.mode === "oidc";
-  const homeStatusTitle = signedIn ? (authState.user ?? "Signed in") : "Notebook cloud";
+  const homeStatusTitle = signedIn ? (authState.user ?? "Signed in") : "Open a notebook";
   const homeStatusDescription = signedIn
-    ? "Open the preview notebook or sign out of this browser session."
-    : "Sign in to open private previews or request edit access.";
+    ? "Open a notebook or sign out of this browser session."
+    : "Sign in to open private notebooks or request edit access.";
 
   return (
     <main className="cloud-home">
-      <section className="cloud-home-layout" aria-label="Notebook cloud entry">
+      <section className="cloud-home-layout" aria-label="nteract notebook entry">
         <div className="cloud-home-copy">
           <h1>nteract</h1>
-          <span>preview realtime notebooks</span>
+          <span>realtime notebooks</span>
         </div>
 
         <section
           className="cloud-home-panel"
           data-mode={authState.mode}
-          aria-label="Notebook cloud sign-in"
+          aria-label="Notebook sign-in"
         >
           <div className="cloud-home-status" data-mode={authState.mode}>
             {signedIn ? <UserRound aria-hidden="true" /> : <KeyRound aria-hidden="true" />}
@@ -609,7 +609,7 @@ function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig })
 
   return (
     <main className="cloud-home">
-      <section className="cloud-home-layout" aria-label="Notebook cloud sign-in callback">
+      <section className="cloud-home-layout" aria-label="nteract sign-in callback">
         <div className="cloud-home-copy">
           <h1>nteract</h1>
           <span>returning to the notebook</span>
@@ -630,7 +630,7 @@ function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig })
 
           {status.kind === "error" || status.kind === "empty" ? (
             <div className="cloud-home-actions">
-              <a href="/">Back to cloud notebooks</a>
+              <a href="/">Back to nteract</a>
             </div>
           ) : null}
         </section>

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1504,10 +1504,20 @@ function CloudSharingControls({
           return;
         }
         if (!aclResponse.ok) {
-          throw await cloudResponseError(aclResponse, "Unable to load access list");
+          throw await cloudResponseError(
+            aclResponse,
+            aclResponse.status === 403
+              ? "Only the notebook owner can manage sharing"
+              : "Unable to load access list",
+          );
         }
         if (!invitesResponse.ok) {
-          throw await cloudResponseError(invitesResponse, "Unable to load invites");
+          throw await cloudResponseError(
+            invitesResponse,
+            invitesResponse.status === 403
+              ? "Only the notebook owner can manage invites"
+              : "Unable to load invites",
+          );
         }
         const aclBody = (await aclResponse.json()) as { acl?: CloudNotebookAclRow[] };
         const invitesBody = (await invitesResponse.json()) as { invites?: CloudNotebookInvite[] };

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -89,11 +89,8 @@ export function cloudViewerPresenceDisplay(
   }
 
   const count = Math.max(1, state.roomPeerCount);
-  const readerTitle =
-    count === 1
-      ? "1 participant is in this notebook"
-      : `${count} participants are in this notebook`;
-  const selfTitle = state.ownPeerLabel ? `You are ${state.ownPeerLabel}` : null;
+  const readerTitle = count === 1 ? "1 participant" : `${count} participants`;
+  const selfTitle = state.ownPeerLabel ? `you are ${state.ownPeerLabel}` : null;
   return {
     label: count === 1 ? "1 here now" : `${count} here now`,
     title: selfTitle ? `${readerTitle}; ${selfTitle}` : readerTitle,

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -11,6 +11,7 @@ export interface CloudViewerPresenceState {
   ownPeerId: string | null;
   actorLabel: string | null;
   ownPeerLabel: string | null;
+  peers: CloudViewerPresencePeer[];
   roomPeerCount: number | null;
 }
 
@@ -18,6 +19,52 @@ export interface CloudViewerPresenceDisplay {
   label: string;
   title: string;
   connected: boolean;
+  peers: CloudViewerPresencePeer[];
+  hiddenCount: number;
+}
+
+export interface CloudViewerPresencePeer {
+  id: string;
+  label: string;
+  kind: "self" | "peer" | "anonymous" | "unknown";
+  status: "active" | "idle" | "offline";
+  count?: number;
+}
+
+export class CloudViewerPresenceStore {
+  private state = initialCloudViewerPresence();
+  private readonly listeners = new Set<() => void>();
+
+  getSnapshot = (): CloudViewerPresenceState => this.state;
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  reset(): void {
+    this.update(initialCloudViewerPresence());
+  }
+
+  reduceConnection(connection: CloudViewerPresenceConnection): void {
+    this.update(reduceCloudViewerConnection(this.state, connection));
+  }
+
+  reduceMessage(message: SessionControlMessage): void {
+    this.update(reduceCloudViewerPresenceMessage(this.state, message));
+  }
+
+  private update(nextState: CloudViewerPresenceState): void {
+    if (Object.is(this.state, nextState)) {
+      return;
+    }
+    this.state = nextState;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
 }
 
 export function initialCloudViewerPresence(): CloudViewerPresenceState {
@@ -26,6 +73,7 @@ export function initialCloudViewerPresence(): CloudViewerPresenceState {
     ownPeerId: null,
     actorLabel: null,
     ownPeerLabel: null,
+    peers: [],
     roomPeerCount: null,
   };
 }
@@ -37,6 +85,11 @@ export function reduceCloudViewerConnection(
   return {
     ...state,
     connection,
+    peers: state.peers.map((peer) => ({
+      ...peer,
+      status:
+        connection === "connected" ? "active" : connection === "disconnected" ? "offline" : "idle",
+    })),
   };
 }
 
@@ -46,27 +99,117 @@ export function reduceCloudViewerPresenceMessage(
 ): CloudViewerPresenceState {
   switch (message.type) {
     case "cloud_room_ready":
-      return {
-        connection: "connected",
-        ownPeerId: message.peer_id,
-        actorLabel: message.actor_label,
-        ownPeerLabel: cloudFriendlyPeerLabel({
-          displayName: message.display_name,
-          email: message.email,
+      return withRoomPeerCount(
+        {
+          connection: "connected",
+          ownPeerId: message.peer_id,
           actorLabel: message.actor_label,
-        }),
-        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
-      };
+          ownPeerLabel: cloudFriendlyPeerLabel({
+            displayName: message.display_name,
+            email: message.email,
+            actorLabel: message.actor_label,
+          }),
+          peers: [
+            cloudPresencePeerFromMessage({
+              peerId: message.peer_id,
+              displayName: message.display_name,
+              email: message.email,
+              actorLabel: message.actor_label,
+              kind: "self",
+            }),
+          ],
+          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        },
+        message.room_peer_count,
+      );
     case "cloud_peer_joined":
+      return withRoomPeerCount(
+        {
+          ...state,
+          connection: "connected",
+          peers: upsertCloudPresencePeer(
+            state.peers,
+            cloudPresencePeerFromMessage({
+              peerId: message.peer_id,
+              actorLabel: message.actor_label,
+              kind: "peer",
+            }),
+          ),
+          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        },
+        message.room_peer_count,
+      );
     case "cloud_peer_left":
-      return {
-        ...state,
-        connection: "connected",
-        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
-      };
+      return withRoomPeerCount(
+        {
+          ...state,
+          connection: "connected",
+          peers: state.peers.filter((peer) => peer.id !== message.peer_id),
+          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        },
+        message.room_peer_count,
+      );
     default:
       return state;
   }
+}
+
+function cloudPresencePeerFromMessage({
+  peerId,
+  displayName,
+  email,
+  actorLabel,
+  kind,
+}: {
+  peerId: string;
+  displayName?: string | null;
+  email?: string | null;
+  actorLabel?: string | null;
+  kind: "self" | "peer";
+}): CloudViewerPresencePeer {
+  const label = cloudFriendlyPeerLabel({ displayName, email, actorLabel });
+  return {
+    id: peerId,
+    label,
+    kind: label === "Anonymous" ? "anonymous" : kind === "self" ? "self" : "peer",
+    status: "active",
+  };
+}
+
+function upsertCloudPresencePeer(
+  peers: CloudViewerPresencePeer[],
+  nextPeer: CloudViewerPresencePeer,
+): CloudViewerPresencePeer[] {
+  const existingIndex = peers.findIndex((peer) => peer.id === nextPeer.id);
+  if (existingIndex === -1) {
+    return [...peers.filter((peer) => peer.kind !== "unknown"), nextPeer];
+  }
+
+  return peers.map((peer, index) => (index === existingIndex ? nextPeer : peer));
+}
+
+function withRoomPeerCount(
+  state: CloudViewerPresenceState,
+  roomPeerCount: number,
+): CloudViewerPresenceState {
+  const count = safeRoomPeerCount(roomPeerCount);
+  const knownPeers = state.peers.filter((peer) => peer.kind !== "unknown").slice(0, count);
+  const missingCount = Math.max(0, count - knownPeers.length);
+  const placeholders = Array.from({ length: missingCount }, (_, index): CloudViewerPresencePeer => {
+    const ordinal = knownPeers.length + index + 1;
+    return {
+      id: `unknown-${ordinal}`,
+      label: "Anonymous",
+      kind: "unknown",
+      status: state.connection === "connected" ? "active" : "idle",
+    };
+  });
+
+  return {
+    ...state,
+    roomPeerCount: count,
+    peers: [...knownPeers, ...placeholders],
+  };
 }
 
 export function cloudViewerPresenceDisplay(
@@ -75,26 +218,60 @@ export function cloudViewerPresenceDisplay(
   if (state.connection === "disconnected") {
     return {
       label: "Offline",
-      title: "Disconnected from the notebook room",
+      title: "Room unavailable",
       connected: false,
+      peers: state.peers.map((peer) => ({ ...peer, status: "offline" })),
+      hiddenCount: 0,
     };
   }
 
   if (state.connection === "connecting" || state.roomPeerCount === null) {
     return {
       label: "Joining room",
-      title: "Connecting to the notebook room",
+      title: "Joining room",
       connected: false,
+      peers: [
+        {
+          id: "joining",
+          label: "Joining room",
+          kind: "unknown",
+          status: "idle",
+        },
+      ],
+      hiddenCount: 0,
     };
   }
 
   const count = Math.max(1, state.roomPeerCount);
-  const readerTitle = count === 1 ? "1 participant" : `${count} participants`;
-  const selfTitle = state.ownPeerLabel ? `you are ${state.ownPeerLabel}` : null;
+  const knownPeers = state.peers.filter((peer) => peer.kind !== "unknown");
+  const anonymousCount = state.peers.filter(
+    (peer) => peer.kind === "anonymous" || peer.kind === "unknown",
+  ).length;
+  const namedPeers = knownPeers.filter((peer) => peer.kind !== "anonymous");
+  const visibleNamedPeerLimit = anonymousCount > 0 ? 2 : 3;
+  const visibleNamedPeers = namedPeers.slice(0, visibleNamedPeerLimit);
+  const visiblePeers =
+    anonymousCount > 0
+      ? [
+          ...visibleNamedPeers,
+          {
+            id: "anonymous-group",
+            label:
+              anonymousCount === 1 ? "Anonymous viewer" : `${anonymousCount} anonymous viewers`,
+            kind: "anonymous" as const,
+            status: "active" as const,
+            count: anonymousCount,
+          },
+        ]
+      : visibleNamedPeers;
+  const hiddenCount = Math.max(0, namedPeers.length - visibleNamedPeers.length);
+  const title = count === 1 ? "1 participant" : `${count} participants`;
   return {
     label: count === 1 ? "1 here now" : `${count} here now`,
-    title: selfTitle ? `${readerTitle}; ${selfTitle}` : readerTitle,
+    title,
     connected: true,
+    peers: visiblePeers,
+    hiddenCount,
   };
 }
 

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -55,6 +55,7 @@ export type CloudShareAccessRow =
       acl: CloudNotebookAclRow;
       label: string;
       detail: string;
+      title: string;
       scope: CloudShareScope;
       badge: string;
       stateLabel: string | null;
@@ -67,6 +68,7 @@ export type CloudShareAccessRow =
       invite: CloudNotebookInvite;
       label: string;
       detail: string;
+      title: string;
       scope: CloudShareInviteScope;
       badge: string;
       stateLabel: string | null;
@@ -87,6 +89,7 @@ export function buildCloudShareAccessRows(input: {
       acl,
       label: labelForAcl(acl),
       detail: detailForAcl(acl),
+      title: titleForAcl(acl),
       scope: acl.scope,
       badge: scopeLabel(acl.scope),
       stateLabel: acl.subject_kind === "public" ? "Enabled" : null,
@@ -100,10 +103,11 @@ export function buildCloudShareAccessRows(input: {
       id: `invite:${invite.id}`,
       kind: "invite",
       invite,
-      label: invite.display?.label || invite.email,
+      label: displayEmail(invite.display?.label || invite.email),
       detail: invite.provider_hint
         ? `Pending invite via ${invite.provider_hint}`
         : "Pending invite",
+      title: invite.email,
       scope: invite.scope,
       badge: scopeLabel(invite.scope),
       stateLabel: "Pending",
@@ -182,9 +186,9 @@ function labelForAcl(row: CloudNotebookAclRow): string {
   }
   const displayLabel = row.display?.label?.trim();
   if (displayLabel && displayLabel !== row.subject) {
-    return displayLabel;
+    return displayEmail(displayLabel);
   }
-  return labelForPrincipalSubject(row.subject);
+  return displayEmail(labelForPrincipalSubject(row.subject));
 }
 
 function detailForAcl(row: CloudNotebookAclRow): string {
@@ -195,13 +199,40 @@ function detailForAcl(row: CloudNotebookAclRow): string {
   if (display?.kind === "principal") {
     const email = display.email?.trim();
     if (email && email !== display.label) {
-      return email;
+      return displayEmail(email);
     }
     if (display.principal !== row.subject) {
       return display.principal;
     }
   }
   return detailForPrincipalSubject(row.subject);
+}
+
+function titleForAcl(row: CloudNotebookAclRow): string {
+  if (row.subject_kind === "public") {
+    return row.display?.label || "Public link";
+  }
+
+  if (row.display?.kind === "principal") {
+    const email = row.display.email?.trim();
+    if (email) return email;
+    if (row.display.principal !== row.subject) return row.display.principal;
+  }
+
+  return row.subject;
+}
+
+function displayEmail(value: string): string {
+  const trimmed = value.trim();
+  const parts = trimmed.split("@");
+  if (parts.length !== 2 || !parts[0] || !parts[1] || parts[1].includes(" ")) {
+    return trimmed;
+  }
+
+  const local = parts[0];
+  const first = local.at(0) ?? "";
+  const last = local.length > 2 ? (local.at(-1) ?? "") : "";
+  return `${first}...${last}@${parts[1]}`;
 }
 
 function labelForPrincipalSubject(subject: string): string {

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -112,9 +112,7 @@ export function cloudNotebookShellCapabilities({
     canViewPackages: true,
     canManagePackages: false,
     canManageSharing:
-      Boolean(hostCapabilities?.canManageSharing) &&
-      connectionScope === "owner" &&
-      auth.canUseAuthenticatedIdentity,
+      Boolean(hostCapabilities?.canManageSharing) && auth.canUseAuthenticatedIdentity,
     interaction,
     access: {
       ...access,


### PR DESCRIPTION
## Summary
- surface hosted sharing controls in the cloud shell and align access copy/chrome with the Elements prototype
- simplify the preview home and cloud toolbar language
- replace the loud text presence chip with a host-level avatar stack backed by an external store

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-presence.test.ts test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-sharing.test.ts test/viewer-shell-capabilities.test.ts test/worker-routes.test.ts test/html.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix
