### PR TITLE
ci: keep PR build to required checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,13 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
+  # Pull requests intentionally run only the two branch-protection checks above:
+  # Lint & Format and JS Tests & Benchmarks. The remaining coverage stays on
+  # main pushes and manual dispatch so PR feedback stays fast.
   nsis-bootstrap:
     name: NSIS Bootstrap Syntax
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -124,7 +127,7 @@ jobs:
   windows-clippy:
     name: Windows (clippy)
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -161,7 +164,7 @@ jobs:
   wasm-deno:
     name: WASM + Deno Tests
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -197,7 +200,7 @@ jobs:
   build-ui:
     name: Build shared UI artifacts
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -273,7 +276,7 @@ jobs:
   browser-e2e:
     name: Browser E2E (Playwright)
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     # Keep the generic browser lane on GitHub-hosted runners for predictable
     # per-job latency. The Anaconda pool is reserved for Linux/env-heavy lanes.
     runs-on: ubuntu-24.04
@@ -436,7 +439,7 @@ jobs:
   linux-rust-clippy:
     name: Linux Rust Clippy
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -471,7 +474,7 @@ jobs:
   linux-rust-tests:
     name: Linux Rust Tests
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -500,7 +503,7 @@ jobs:
   linux-runtimed-node:
     name: Linux runtimed-node
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -544,7 +547,7 @@ jobs:
       - linux-rust-clippy
       - linux-rust-tests
       - linux-runtimed-node
-    if: always() && needs.changes.outputs.source_changed == 'true'
+    if: always() && needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - name: Check shard results
@@ -570,7 +573,7 @@ jobs:
   build:
     name: ${{ matrix.platform.name }}
     needs: [changes, build-ui]
-    if: ${{ always() && (needs.changes.outputs.source_changed != 'true' || needs.build-ui.result == 'success') }}
+    if: ${{ always() && needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request' && needs.build-ui.result == 'success' }}
     continue-on-error: ${{ matrix.platform.non_blocking }}
     runs-on: ${{ needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
@@ -1055,7 +1058,7 @@ jobs:
     # runs pytest only.
     name: Python Unit Tests
     needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
+    if: needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- limits pull_request `Build` runs to the two branch-protection checks: `Lint & Format` and `JS Tests & Benchmarks`
- keeps optional Rust, browser, packaging, Python, and platform coverage on `main` pushes and manual dispatch
- leaves the required PR checks parallel so failures still report as quickly as the hosted runners can finish them

## Rationale

Branch protection currently requires only `Lint & Format` and `JS Tests & Benchmarks`. Recent PR timing showed those checks finishing in roughly 1 minute and 5 minutes respectively, while optional lanes such as Browser E2E can take 20+ minutes by themselves. Keeping optional work out of `pull_request` should make new PRs much more sane while preserving post-merge coverage.

## Verification

- `actionlint .github/workflows/build.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "workflow yaml ok"'`
- `cargo xtask lint --fix`
- `git diff --check`
- PR #3350 required checks: `Lint & Format` passed in 46s; `JS Tests & Benchmarks` passed in 4m46s
