### PR TITLE
fix(notebook-cloud): isolate local wrangler ports

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -28,6 +28,14 @@ pnpm --dir apps/notebook-cloud publish:fixture
 pnpm --dir apps/notebook-cloud publish:live
 ```
 
+`pnpm --dir apps/notebook-cloud dev` derives stable Wrangler HTTP and inspector
+ports from the git worktree root, so parallel worktrees do not all bind to
+`8787` and `9229`. The command prints the local base URL. Local smoke and
+publish scripts derive the same URL by default; set `NOTEBOOK_CLOUD_URL` to
+target a deployed Worker instead. Use `NOTEBOOK_CLOUD_WRANGLER_PORT` or
+`NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT` only when you need an explicit local
+override.
+
 The smoke script proves:
 
 - WebSocket upgrade on `/n/:notebookId/sync`.
@@ -60,13 +68,13 @@ cargo xtask wasm runtimed --skip-renderer-plugins
 The browser harness is available at:
 
 ```text
-http://127.0.0.1:8787/n/demo/debug
+http://127.0.0.1:<worktree-port>/n/demo/debug
 ```
 
 The notebook viewer is available at:
 
 ```text
-http://127.0.0.1:8787/n/{generated-ulid}/demo
+http://127.0.0.1:<worktree-port>/n/{generated-ulid}/demo
 ```
 
 `/` serves the sign-in shell; open notebooks through `/n/{id}/{vanityName}`.
@@ -75,7 +83,7 @@ http://127.0.0.1:8787/n/{generated-ulid}/demo
 and publishes a notebook revision with real `RuntimeStateDoc` output manifests:
 
 ```text
-http://127.0.0.1:8787/n/{generated-ulid}/output_streaming
+http://127.0.0.1:<worktree-port>/n/{generated-ulid}/output_streaming
 ```
 
 Set `NOTEBOOK_CLOUD_FIXTURE=<fixture-dir>` and
@@ -470,20 +478,22 @@ but never the stored token value.
 Snapshot and blob stubs:
 
 ```bash
-curl -X PUT "http://127.0.0.1:8787/api/n/demo/runtime-snapshots/runtime123" \
+NOTEBOOK_CLOUD_LOCAL_URL="${NOTEBOOK_CLOUD_URL:-http://127.0.0.1:<worktree-port>}"
+
+curl -X PUT "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/runtime-snapshots/runtime123" \
   -H "X-User: alice" \
   -H "X-Operator: desktop:curl" \
   -H "X-Scope: owner" \
   --data-binary @runtime-state.am
 
-curl -X PUT "http://127.0.0.1:8787/api/n/demo/snapshots/heads123" \
+curl -X PUT "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/snapshots/heads123" \
   -H "X-User: alice" \
   -H "X-Operator: desktop:curl" \
   -H "X-Scope: owner" \
   -H "X-Runtime-Heads-Hash: runtime123" \
   --data-binary @notebook.am
 
-curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
+curl -X PUT "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/blobs/sha256abc" \
   -H "X-User: alice" \
   -H "X-Operator: desktop:curl" \
   -H "X-Scope: owner" \
@@ -493,9 +503,11 @@ curl -X PUT "http://127.0.0.1:8787/api/n/demo/blobs/sha256abc" \
 Catalog and pinned snapshot readback:
 
 ```bash
-curl "http://127.0.0.1:8787/api/n/demo"
-curl "http://127.0.0.1:8787/api/n/demo/snapshots/{notebookHeadsHash}"
-curl "http://127.0.0.1:8787/api/n/demo/runtime-snapshots/{runtimeHeadsHash}" \
+NOTEBOOK_CLOUD_LOCAL_URL="${NOTEBOOK_CLOUD_URL:-http://127.0.0.1:<worktree-port>}"
+
+curl "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo"
+curl "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/snapshots/{notebookHeadsHash}"
+curl "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/runtime-snapshots/{runtimeHeadsHash}" \
   -H "X-Runtime-State-Doc-Id: {runtimeStateDocId}"
 ```
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -11,7 +11,7 @@
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",
     "test:renderer-parity": "playwright test -c playwright.render-parity.config.ts",
     "test:renderer-parity:update": "playwright test -c playwright.render-parity.config.ts --update-snapshots",
-    "dev": "pnpm --workspace-root exec wrangler dev --config apps/notebook-cloud/wrangler.toml",
+    "dev": "node scripts/dev.mjs",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",

--- a/apps/notebook-cloud/scripts/dev.mjs
+++ b/apps/notebook-cloud/scripts/dev.mjs
@@ -1,0 +1,84 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import {
+  NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT_ENV,
+  NOTEBOOK_CLOUD_WRANGLER_PORT_ENV,
+  notebookCloudAppDir,
+  notebookCloudDevPorts,
+  notebookCloudWorkspaceRoot,
+} from "./local-dev.mjs";
+
+const extraArgs = process.argv.slice(2);
+const workspaceRoot = notebookCloudWorkspaceRoot();
+const configPath = path.relative(workspaceRoot, path.join(notebookCloudAppDir(), "wrangler.toml"));
+const { host, port, inspectorPort, worktreeHash } = notebookCloudDevPorts({ workspaceRoot });
+const requestedHost = optionValue(extraArgs, "ip") ?? host;
+const requestedPort = optionValue(extraArgs, "port") ?? String(port);
+const requestedInspectorPort = optionValue(extraArgs, "inspector-port") ?? String(inspectorPort);
+const localUrl = `http://${formatHostForUrl(requestedHost)}:${requestedPort}`;
+
+const args = ["--workspace-root", "exec", "wrangler", "dev", "--config", configPath];
+
+if (!hasOption(extraArgs, "ip")) {
+  args.push("--ip", host);
+}
+if (!hasOption(extraArgs, "port")) {
+  args.push("--port", String(port));
+}
+if (!hasOption(extraArgs, "inspector-port")) {
+  args.push("--inspector-port", String(inspectorPort));
+}
+
+args.push(...extraArgs);
+
+console.error(`Starting notebook-cloud Wrangler on ${localUrl}`);
+console.error(`Worktree hash ${worktreeHash}; inspector port ${requestedInspectorPort}`);
+console.error(
+  `Override with ${NOTEBOOK_CLOUD_WRANGLER_PORT_ENV} or ${NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT_ENV}.`,
+);
+
+const child = spawn("pnpm", args, {
+  cwd: workspaceRoot,
+  env: process.env,
+  stdio: "inherit",
+});
+
+child.on("error", (error) => {
+  console.error(`Failed to start Wrangler: ${error.message}`);
+  process.exitCode = 1;
+});
+
+child.on("close", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exitCode = code ?? 1;
+});
+
+function hasOption(args, name) {
+  const flag = `--${name}`;
+  return args.some((arg) => arg === flag || arg.startsWith(`${flag}=`));
+}
+
+function optionValue(args, name) {
+  const flag = `--${name}`;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg.startsWith(`${flag}=`)) {
+      return arg.slice(flag.length + 1);
+    }
+    if (arg === flag) {
+      return args[index + 1];
+    }
+  }
+  return undefined;
+}
+
+function formatHostForUrl(host) {
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) {
+    return `[${host}]`;
+  }
+  return host;
+}

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { chromium } from "@playwright/test";
 
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import {
   assertHostedCollabSmokeEnv,
   browserDevTokenForSmoke,
@@ -14,9 +15,8 @@ import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-perform
 import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
 import { isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 
-const DEFAULT_BASE_URL = "http://127.0.0.1:8787";
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const requestedBaseUrl = process.env.NOTEBOOK_CLOUD_URL ?? DEFAULT_BASE_URL;
+const requestedBaseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const providedViewerUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_COLLAB_VIEWER_URL;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);

--- a/apps/notebook-cloud/scripts/local-dev.mjs
+++ b/apps/notebook-cloud/scripts/local-dev.mjs
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const NOTEBOOK_CLOUD_URL_ENV = "NOTEBOOK_CLOUD_URL";
+export const NOTEBOOK_CLOUD_WRANGLER_PORT_ENV = "NOTEBOOK_CLOUD_WRANGLER_PORT";
+export const NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT_ENV = "NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT";
+export const NOTEBOOK_CLOUD_WRANGLER_HOST_ENV = "NOTEBOOK_CLOUD_WRANGLER_HOST";
+
+export const DEFAULT_WRANGLER_HOST = "127.0.0.1";
+export const WRANGLER_PORT_RANGE = 1000;
+export const WRANGLER_HTTP_PORT_BASE = 45_000;
+export const WRANGLER_INSPECTOR_PORT_BASE = 46_000;
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function notebookCloudAppDir() {
+  return appDir;
+}
+
+export function notebookCloudWorkspaceRoot({ cwd = appDir } = {}) {
+  const git = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const root = git.status === 0 ? git.stdout.trim() : "";
+  return root ? path.resolve(root) : path.resolve(appDir, "../..");
+}
+
+export function worktreeHash(workspaceRoot) {
+  return createHash("sha256").update(path.resolve(workspaceRoot)).digest("hex").slice(0, 12);
+}
+
+export function notebookCloudPortOffset(workspaceRoot) {
+  const prefix = worktreeHash(workspaceRoot).slice(0, 4);
+  return Number.parseInt(prefix, 16) % WRANGLER_PORT_RANGE;
+}
+
+export function notebookCloudDevPorts({
+  env = process.env,
+  workspaceRoot = notebookCloudWorkspaceRoot(),
+} = {}) {
+  const offset = notebookCloudPortOffset(workspaceRoot);
+  const host = env[NOTEBOOK_CLOUD_WRANGLER_HOST_ENV] || DEFAULT_WRANGLER_HOST;
+  return {
+    host,
+    port:
+      readPort(env[NOTEBOOK_CLOUD_WRANGLER_PORT_ENV], NOTEBOOK_CLOUD_WRANGLER_PORT_ENV) ??
+      WRANGLER_HTTP_PORT_BASE + offset,
+    inspectorPort:
+      readPort(
+        env[NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT_ENV],
+        NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT_ENV,
+      ) ?? WRANGLER_INSPECTOR_PORT_BASE + offset,
+    workspaceRoot: path.resolve(workspaceRoot),
+    worktreeHash: worktreeHash(workspaceRoot),
+  };
+}
+
+export function notebookCloudLoopbackUrl(options = {}) {
+  const { host, port } = notebookCloudDevPorts(options);
+  return `http://${formatHostForUrl(host)}:${port}`;
+}
+
+export function notebookCloudBaseUrl({ env = process.env, ...options } = {}) {
+  return env[NOTEBOOK_CLOUD_URL_ENV] || notebookCloudLoopbackUrl({ env, ...options });
+}
+
+function readPort(value, name) {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`${name} must be an integer TCP port between 1 and 65535`);
+  }
+  return port;
+}
+
+function formatHostForUrl(host) {
+  if (host.includes(":") && !host.startsWith("[") && !host.endsWith("]")) {
+    return `[${host}]`;
+  }
+  return host;
+}

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -8,9 +8,10 @@ import {
   runtimeStateDocIdFromEnvOrDefault,
   vanityNameFromEnvOrNotebookName,
 } from "./publish-notebook-id.mjs";
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 
-const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const baseUrl = notebookCloudBaseUrl();
 const notebookId = notebookIdFromEnvOrGenerated();
 const vanityName = vanityNameFromEnvOrNotebookName("demo.ipynb");
 const runtimeStateDocIdOverride = runtimeStateDocIdFromEnvOrDefault(notebookId);

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -8,9 +8,10 @@ import {
   runtimeStateDocIdFromEnvOrDefault,
   vanityNameFromEnvOrNotebookName,
 } from "./publish-notebook-id.mjs";
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 
-const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const baseUrl = notebookCloudBaseUrl();
 const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
 const notebookId = notebookIdFromEnvOrGenerated();
 const vanityName = vanityNameFromEnvOrNotebookName(fixtureName);

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -10,12 +10,13 @@ import {
   notebookIdFromEnvOrGenerated,
   vanityNameFromEnvOrNotebookName,
 } from "./publish-notebook-id.mjs";
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
 
 const rt = loadRuntimedNode();
 
-const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const baseUrl = notebookCloudBaseUrl();
 const sourceNotebookId = process.env.NOTEBOOK_CLOUD_SOURCE_NOTEBOOK_ID;
 const preset = process.env.NOTEBOOK_CLOUD_LIVE_PRESET ?? "mathnet";
 const notebookId = notebookIdFromEnvOrGenerated();

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { FrameType } from "runtimed";
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { openWebSocket } from "./raw-websocket-client.mjs";
 import { credentialedSmokeOrigin } from "./wasm-roundtrip-env.mjs";
 
@@ -15,7 +16,7 @@ const wasmBinPath = new URL(
 const wasm = await import(wasmJsPath.href);
 await wasm.default({ module_or_path: await readFile(wasmBinPath) });
 
-const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const baseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const roomId = `smoke-${Date.now()}`;
 const otherRoomId = `${roomId}-other`;

--- a/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
+++ b/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
@@ -2,6 +2,7 @@ import { access, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { FrameType } from "runtimed";
+import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import {
   clientForSocket,
   closeClient,
@@ -11,7 +12,7 @@ import {
 } from "./raw-websocket-client.mjs";
 import { assertWasmRoundtripAuthEnv, credentialedSmokeOrigin } from "./wasm-roundtrip-env.mjs";
 
-const baseUrl = process.env.NOTEBOOK_CLOUD_URL ?? "http://127.0.0.1:8787";
+const baseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const roomId = `wasm-${Date.now()}`;
 const runtimeStateDocId = `runtime-state:${randomUUID()}`;

--- a/apps/notebook-cloud/test/local-dev.test.mjs
+++ b/apps/notebook-cloud/test/local-dev.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  WRANGLER_HTTP_PORT_BASE,
+  WRANGLER_INSPECTOR_PORT_BASE,
+  WRANGLER_PORT_RANGE,
+  notebookCloudBaseUrl,
+  notebookCloudDevPorts,
+  notebookCloudLoopbackUrl,
+} from "../scripts/local-dev.mjs";
+
+test("derives stable Wrangler ports from the workspace root", () => {
+  const workspaceRoot = "/tmp/nteract/worktrees/cloud-a/desktop";
+  const first = notebookCloudDevPorts({ env: {}, workspaceRoot });
+  const second = notebookCloudDevPorts({ env: {}, workspaceRoot });
+
+  assert.equal(first.port, second.port);
+  assert.equal(first.inspectorPort, second.inspectorPort);
+  assert.equal(first.host, "127.0.0.1");
+  assert.ok(first.port >= WRANGLER_HTTP_PORT_BASE);
+  assert.ok(first.port < WRANGLER_HTTP_PORT_BASE + WRANGLER_PORT_RANGE);
+  assert.ok(first.inspectorPort >= WRANGLER_INSPECTOR_PORT_BASE);
+  assert.ok(first.inspectorPort < WRANGLER_INSPECTOR_PORT_BASE + WRANGLER_PORT_RANGE);
+});
+
+test("honors explicit local port and host overrides", () => {
+  const env = {
+    NOTEBOOK_CLOUD_WRANGLER_HOST: "localhost",
+    NOTEBOOK_CLOUD_WRANGLER_PORT: "45123",
+    NOTEBOOK_CLOUD_WRANGLER_INSPECTOR_PORT: "46123",
+  };
+
+  const ports = notebookCloudDevPorts({
+    env,
+    workspaceRoot: "/tmp/nteract/worktrees/cloud-b/desktop",
+  });
+
+  assert.equal(ports.host, "localhost");
+  assert.equal(ports.port, 45123);
+  assert.equal(ports.inspectorPort, 46123);
+  assert.equal(
+    notebookCloudLoopbackUrl({ env, workspaceRoot: "/tmp/nteract/worktrees/cloud-b/desktop" }),
+    "http://localhost:45123",
+  );
+});
+
+test("prefers NOTEBOOK_CLOUD_URL when a script targets a deployed host", () => {
+  const baseUrl = notebookCloudBaseUrl({
+    env: { NOTEBOOK_CLOUD_URL: "https://preview.runt.run" },
+    workspaceRoot: "/tmp/nteract/worktrees/cloud-c/desktop",
+  });
+
+  assert.equal(baseUrl, "https://preview.runt.run");
+});
+
+test("rejects invalid port overrides", () => {
+  assert.throws(
+    () =>
+      notebookCloudDevPorts({
+        env: { NOTEBOOK_CLOUD_WRANGLER_PORT: "nope" },
+        workspaceRoot: "/tmp/nteract/worktrees/cloud-d/desktop",
+      }),
+    /NOTEBOOK_CLOUD_WRANGLER_PORT must be an integer TCP port/,
+  );
+});

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -5,6 +5,8 @@ compatibility_flags = ["nodejs_compat"]
 routes = [{ pattern = "preview.runt.run", custom_domain = true }]
 
 [dev]
+# Fallback for direct Wrangler invocations. `pnpm --dir apps/notebook-cloud dev`
+# overrides this with a worktree-specific port to avoid local worktree clashes.
 port = 8787
 
 [[durable_objects.bindings]]


### PR DESCRIPTION
## Summary

- Derive notebook-cloud local Wrangler HTTP and inspector ports from the git worktree root.
- Route local notebook-cloud smoke and publish scripts through the same derived local base URL.
- Document the worktree-specific local URL behavior and explicit override env vars.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm exec node --import tsx --test test/local-dev.test.mjs test/wasm-roundtrip-env.test.mjs test/hosted-collab-smoke-env.test.mjs test/hosted-live-smoke-env.test.mjs`
- `cargo xtask lint --fix`
- `pnpm --workspace-root exec wrangler dev --help | rg -n -- "--port|--inspector-port|--ip"`

## Notes

- A full `node --import tsx --test test/*.test.ts test/*.test.mjs` sweep was not clean in this checkout because existing snapshot/render/notice/worker-route tests fail on fixture/header/copy expectations unrelated to this change.
- `pnpm --dir apps/notebook-cloud dev` printed the derived URL for this worktree as `http://127.0.0.1:45177` and inspector port `46177`.
