### PR TITLE
fix(notebook): stabilize markdown preview loading

### DIFF
--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -82,6 +82,7 @@ export interface IsolatedFrameProps {
   allowWheelBoundaryScroll?: boolean;
   scrollPassthrough?: boolean;
   revealOnRender?: boolean;
+  reserveHeightOnReveal?: boolean;
   onReady?: () => void;
   onResize?: (height: number) => void;
   onLinkClick?: (url: string, newTab: boolean) => void;

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -50,9 +50,51 @@ const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
 const DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS = 700;
+const MARKDOWN_PREVIEW_MIN_HEIGHT = 24;
+const MARKDOWN_PREVIEW_MAX_INITIAL_HEIGHT = 720;
 
 function formatPluginLoadError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+export function estimateMarkdownPreviewHeight(source: string): number {
+  const trimmed = source.trim();
+  if (!trimmed) return MARKDOWN_PREVIEW_MIN_HEIGHT;
+
+  const lines = source.split(/\r?\n/);
+  let height = 20;
+  let inCodeFence = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (/^(```|~~~)/.test(line)) {
+      inCodeFence = !inCodeFence;
+      height += 24;
+      continue;
+    }
+    if (line.length === 0) {
+      height += 10;
+      continue;
+    }
+    if (inCodeFence) {
+      height += 22;
+      continue;
+    }
+    if (/^#\s+/.test(line)) {
+      height += 56;
+    } else if (/^##\s+/.test(line)) {
+      height += 42;
+    } else if (/^#{3,6}\s+/.test(line)) {
+      height += 34;
+    } else {
+      height += 28 + Math.floor(Math.max(0, line.length - 96) / 96) * 24;
+    }
+  }
+
+  return Math.min(
+    MARKDOWN_PREVIEW_MAX_INITIAL_HEIGHT,
+    Math.max(MARKDOWN_PREVIEW_MIN_HEIGHT, height),
+  );
 }
 
 interface MarkdownCellProps {
@@ -169,6 +211,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   const viewRef = useRef<HTMLDivElement>(null);
   const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
   const previewFrameReleaseTimeoutRef = useRef<number | null>(null);
+  const previewMinHeight = useMemo(() => estimateMarkdownPreviewHeight(cell.source), [cell.source]);
 
   // Register EditorView with the cursor registry when in edit mode.
   const registeredViewRef = useRef<EditorView | null>(null);
@@ -686,11 +729,12 @@ export const MarkdownCell = memo(function MarkdownCell({
                 darkMode={darkMode}
                 colorTheme={colorTheme}
                 hostContext={outputHostContext}
-                minHeight={24}
+                minHeight={previewMinHeight}
                 autoHeight
                 scrollPassthrough={!previewFrameInteractionActive}
                 allowWheelBoundaryScroll={previewFrameInteractionActive}
                 revealOnRender
+                reserveHeightOnReveal
                 onReady={handleFrameReady}
                 onLinkClick={handleLinkClick}
                 onMouseDown={activatePreviewFrameInteraction}

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -278,6 +278,24 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
+  it("reserves a markdown-sized preview while the isolated renderer loads", () => {
+    render(
+      <MarkdownCell
+        cell={{
+          ...makeCell(),
+          source: "# Heading\n\nThis paragraph should reserve document geometry.",
+        }}
+        onFocus={() => {}}
+        onDelete={() => {}}
+      />,
+    );
+
+    const frameProps = isolatedFrameProps.at(-1);
+    expect(frameProps?.revealOnRender).toBe(true);
+    expect(frameProps?.reserveHeightOnReveal).toBe(true);
+    expect(frameProps?.minHeight).toBeGreaterThan(24);
+  });
+
   it("focuses the markdown preview without scrolling when the cell becomes focused", async () => {
     const focusSpy = vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => undefined);
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -69,6 +69,24 @@ function projectExecutionViewChangeset(handle: NotebookHandle) {
   return projector.call(handle);
 }
 
+function preWarmCellRenderers(cells: readonly NotebookCell[]) {
+  const pluginMimes = new Set<string>();
+  for (const cell of cells) {
+    if (cell.cell_type === "markdown" && cell.source.trim().length > 0) {
+      pluginMimes.add("text/markdown");
+      continue;
+    }
+    if (cell.cell_type !== "code") continue;
+    for (const output of cell.outputs) {
+      if (!isDisplayCapableJupyterOutput(output)) continue;
+      for (const mime of Object.keys(output.data)) {
+        if (needsPlugin(mime)) pluginMimes.add(mime);
+      }
+    }
+  }
+  if (pluginMimes.size > 0) preWarmForMimes(pluginMimes);
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -155,21 +173,9 @@ export function useNotebook() {
       blobResolver,
       outputCacheRef.current,
     );
-    // Pre-warm plugin cache from output MIME types so iframe rendering
-    // doesn't wait for async loads
-    const pluginMimes: string[] = [];
-    for (const c of newCells) {
-      if (c.cell_type === "code") {
-        for (const output of c.outputs) {
-          if (isDisplayCapableJupyterOutput(output)) {
-            for (const mime of Object.keys(output.data)) {
-              if (needsPlugin(mime)) pluginMimes.push(mime);
-            }
-          }
-        }
-      }
-    }
-    if (pluginMimes.length > 0) preWarmForMimes(pluginMimes);
+    // Pre-warm renderer plugins before cells paint so document-like markdown
+    // and output iframes do not wait for async chunk loads on first render.
+    preWarmCellRenderers(newCells);
     replaceNotebookCells(newCells);
     logger.debug(
       `[automerge-notebook] Full materialization: ${snapshots.length} cells in ${(performance.now() - start).toFixed(1)}ms`,
@@ -185,6 +191,7 @@ export function useNotebook() {
       outputCacheRef.current,
       getBlobResolver(),
     );
+    preWarmCellRenderers(newCells);
     replaceNotebookCells(newCells);
   }, []);
 

--- a/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
+++ b/src/components/isolated/__tests__/isolated-frame-theme.test.tsx
@@ -365,6 +365,16 @@ describe("IsolatedFrame theme updates", () => {
     expect(iframe.style.pointerEvents).toBe("none");
   });
 
+  it("can reserve frame height while content is hidden for reveal-on-render", () => {
+    const { container } = render(
+      <IsolatedFrame darkMode={false} minHeight={180} revealOnRender reserveHeightOnReveal />,
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+
+    expect(iframe.style.height).toBe("180px");
+    expect(iframe.style.opacity).toBe("0");
+  });
+
   it("uses srcdoc in a non-Tauri browser runtime", () => {
     const { container } = render(<IsolatedFrame darkMode={false} />);
     const iframe = container.querySelector("iframe") as HTMLIFrameElement;

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -176,6 +176,14 @@ export interface IsolatedFrameProps {
    * @default false
    */
   revealOnRender?: boolean;
+
+  /**
+   * When used with `revealOnRender`, keep the current frame height reserved
+   * while content is visually hidden. This lets document-like surfaces avoid
+   * late layout shifts while still fading in rendered content.
+   * @default false
+   */
+  reserveHeightOnReveal?: boolean;
 }
 
 export interface IsolatedFrameHandle {
@@ -312,6 +320,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       onMessage,
       onDiagnostic,
       revealOnRender = false,
+      reserveHeightOnReveal = false,
     },
     ref,
   ) {
@@ -666,7 +675,8 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     }
 
     // Compute display values for revealOnRender mode
-    const displayHeight = revealOnRender && !isContentRendered ? 0 : height;
+    const displayHeight =
+      revealOnRender && !isContentRendered && !reserveHeightOnReveal ? 0 : height;
     const displayOpacity = revealOnRender && !isContentRendered ? 0 : 1;
 
     return (


### PR DESCRIPTION
## Summary

- pre-warm markdown renderer plugins during notebook materialization so markdown cells do not wait until iframe ready to start loading the heavy renderer chunk
- reserve estimated markdown preview geometry while reveal-on-render keeps iframe content hidden, reducing first-load layout shifts
- remove the duplicate Elements isolated-frame mouse-up handler introduced by the merged CI baseline

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/isolated/__tests__/isolated-frame-theme.test.tsx`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build`
- deployed `preview.runt.run`, `preview.runtusercontent.com`, and renderer assets with Wrangler

## Notes

The markdown renderer bundle is still large. This PR starts loading it earlier and keeps document geometry stable while it loads; it does not yet split or shrink the renderer bundle.
