### PR TITLE
fix(notebook-cloud): normalize outline heading hashes

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -281,8 +281,27 @@ test("cloud viewer shell uses the shared notebook rail as an adapter surface", (
   assert.doesNotMatch(sourceText, /useSourceVersion\(\)/);
   assert.match(sourceText, /<NotebookDocumentRail[\s\S]*viewModel=\{notebookViewModel\}/);
   assert.match(sourceText, /onNavigateOutlineItem=\{handleNavigateOutlineItem\}/);
-  assert.match(sourceText, /navigateNotebookOutlineItem\(item, href/);
+  assert.match(
+    sourceText,
+    /navigateNotebookOutlineItem\(item, href, \{ headingHashTarget: "cell" \}\)/,
+  );
   assert.doesNotMatch(sourceText, /findCellElement: \(outlineItem\)/);
+});
+
+test("cloud outline keeps iframe heading hashes at parent cell anchors", () => {
+  const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(sourceText, /const handledHeadingHashRef = useRef<string \| null>\(null\)/);
+  assert.match(sourceText, /const headingAnchorId = decodeHashAnchorId\(hash\)/);
+  assert.match(
+    sourceText,
+    /candidate\.headingAnchorId !== null && candidate\.headingAnchorId === headingAnchorId/,
+  );
+  assert.match(
+    sourceText,
+    /navigateNotebookOutlineItem\(item, hash, \{\s+behavior: "auto",\s+headingHashTarget: "cell",\s+\}\)/,
+  );
 });
 
 test("cloud live materialization skips empty room handles before resolving outputs", () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -641,6 +641,15 @@ function OidcCallbackView({ authConfig }: { authConfig: CloudViewerAuthConfig })
   );
 }
 
+function decodeHashAnchorId(hash: string): string {
+  const raw = hash.startsWith("#") ? hash.slice(1) : hash;
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 function NotebookViewer({
   runtime,
   authConfig,
@@ -671,6 +680,7 @@ function NotebookViewer({
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const outputResolutionCacheRef = useRef(createOutputResolutionCache());
+  const handledHeadingHashRef = useRef<string | null>(null);
   const presenceStoreRef = useRef<CloudViewerPresenceStore | null>(null);
   if (presenceStoreRef.current === null) {
     presenceStoreRef.current = new CloudViewerPresenceStore();
@@ -1141,12 +1151,30 @@ function NotebookViewer({
       setSelectedOutlineItemId(null);
     }
   }, [outlineItems, selectedOutlineItemId]);
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash || handledHeadingHashRef.current === hash) return;
+
+    const headingAnchorId = decodeHashAnchorId(hash);
+    const item = outlineItems.find(
+      (candidate) =>
+        candidate.headingAnchorId !== null && candidate.headingAnchorId === headingAnchorId,
+    );
+    if (!item) return;
+
+    handledHeadingHashRef.current = hash;
+    setSelectedOutlineItemId(item.id);
+    navigateNotebookOutlineItem(item, hash, {
+      behavior: "auto",
+      headingHashTarget: "cell",
+    });
+  }, [outlineItems]);
   const handleSelectOutlineItem = useCallback((item: NotebookOutlineItem) => {
     setSelectedOutlineItemId(item.id);
   }, []);
   const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
     setSelectedOutlineItemId(item.id);
-    return navigateNotebookOutlineItem(item, href);
+    return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
   }, []);
   const handleTogglePackagesRail = useCallback(() => {
     if (activeRailPanel === "packages" && !railCollapsed) {


### PR DESCRIPTION
## Summary

- Normalize cloud outline heading hashes to parent cell anchors so top-level URLs do not point at iframe-only heading IDs.
- Handle existing shared heading-hash URLs by navigating through the iframe bridge once the outline is available, then replacing the hash with the owning cell anchor.

## Verification

- `node --test apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts`
- `cargo xtask lint --fix`
