### PR TITLE
feat(daemon): add hidden SSH runtime-agent launcher

### DIFF
--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -575,7 +575,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn resolve_runtime_agent_exe(cli_value: Option<PathBuf>) -> Option<PathBuf> {
-    cli_value.or_else(|| std::env::var_os(RUNTIME_AGENT_EXE_ENV).map(PathBuf::from))
+    let path = cli_value.or_else(|| std::env::var_os(RUNTIME_AGENT_EXE_ENV).map(PathBuf::from))?;
+    Some(std::fs::canonicalize(&path).unwrap_or_else(|e| {
+        eprintln!(
+            "Runtime agent executable not found: {}: {e}",
+            path.display()
+        );
+        std::process::exit(1);
+    }))
 }
 
 async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
@@ -667,6 +674,16 @@ mod tests {
             ),
             other => panic!("expected run command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn resolve_runtime_agent_exe_canonicalizes_existing_path() {
+        let current_exe = std::env::current_exe().unwrap();
+        let canonical = std::fs::canonicalize(&current_exe).unwrap();
+        assert_eq!(
+            resolve_runtime_agent_exe(Some(current_exe)),
+            Some(canonical)
+        );
     }
 }
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -14,6 +14,8 @@ use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
 use tracing::info;
 
+const RUNTIME_AGENT_EXE_ENV: &str = "RUNTIMED_RUNTIME_AGENT_EXE";
+
 #[derive(Parser, Debug)]
 #[command(name = "runtimed")]
 #[command(version = concat!(env!("CARGO_PKG_VERSION"), "+", include_str!(concat!(env!("OUT_DIR"), "/git_hash.txt"))))]
@@ -87,6 +89,10 @@ enum Commands {
         /// Override canonical settings JSON path.
         #[arg(long, hide = true)]
         settings_json: Option<PathBuf>,
+
+        /// Override runtime-agent executable path.
+        #[arg(long, hide = true)]
+        runtime_agent_exe: Option<PathBuf>,
     },
 
     /// Install daemon as a system service
@@ -369,6 +375,7 @@ async fn main() -> anyhow::Result<()> {
                 conda_pool_size,
                 pixi_pool_size,
                 settings_json,
+                runtime_agent_exe,
             ) = match cli.command {
                 Some(Commands::Run {
                     socket,
@@ -378,6 +385,7 @@ async fn main() -> anyhow::Result<()> {
                     conda_pool_size,
                     pixi_pool_size,
                     settings_json,
+                    runtime_agent_exe,
                 }) => (
                     socket,
                     cache_dir,
@@ -386,6 +394,7 @@ async fn main() -> anyhow::Result<()> {
                     conda_pool_size,
                     pixi_pool_size,
                     settings_json,
+                    runtime_agent_exe,
                 ),
                 _ => (
                     None,
@@ -394,6 +403,7 @@ async fn main() -> anyhow::Result<()> {
                     runtimed_client::settings_doc::DEFAULT_UV_POOL_SIZE as usize,
                     runtimed_client::settings_doc::DEFAULT_CONDA_POOL_SIZE as usize,
                     runtimed_client::settings_doc::DEFAULT_PIXI_POOL_SIZE as usize,
+                    None,
                     None,
                 ),
             };
@@ -407,6 +417,7 @@ async fn main() -> anyhow::Result<()> {
                 conda_pool_size,
                 pixi_pool_size,
                 settings_json_path: settings_json,
+                runtime_agent_exe: resolve_runtime_agent_exe(runtime_agent_exe),
                 ..Default::default()
             };
 
@@ -563,6 +574,10 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+fn resolve_runtime_agent_exe(cli_value: Option<PathBuf>) -> Option<PathBuf> {
+    cli_value.or_else(|| std::env::var_os(RUNTIME_AGENT_EXE_ENV).map(PathBuf::from))
+}
+
 async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     info!("runtimed starting...");
 
@@ -574,6 +589,9 @@ async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
     info!("  Pixi pool size: {}", config.pixi_pool_size);
+    if let Some(runtime_agent_exe) = &config.runtime_agent_exe {
+        info!("  Runtime agent exe: {:?}", runtime_agent_exe);
+    }
     let daemon = match Daemon::new(config) {
         Ok(d) => d,
         Err(e) => {
@@ -624,6 +642,32 @@ async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
         Err(e) => early_log(&format!("Daemon exited: Err: {}", e)),
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_command_parses_runtime_agent_exe_override() {
+        let cli = Cli::try_parse_from([
+            "runtimed",
+            "run",
+            "--runtime-agent-exe",
+            "/tmp/ssh-runtime-agent",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Run {
+                runtime_agent_exe, ..
+            }) => assert_eq!(
+                runtime_agent_exe,
+                Some(PathBuf::from("/tmp/ssh-runtime-agent"))
+            ),
+            other => panic!("expected run command, got {other:?}"),
+        }
+    }
 }
 
 fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -655,42 +655,6 @@ async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
     result
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn run_command_parses_runtime_agent_exe_override() {
-        let cli = Cli::try_parse_from([
-            "runtimed",
-            "run",
-            "--runtime-agent-exe",
-            "/tmp/ssh-runtime-agent",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Some(Commands::Run {
-                runtime_agent_exe, ..
-            }) => assert_eq!(
-                runtime_agent_exe,
-                Some(PathBuf::from("/tmp/ssh-runtime-agent"))
-            ),
-            other => panic!("expected run command, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn resolve_runtime_agent_exe_canonicalizes_existing_path() {
-        let current_exe = std::env::current_exe().unwrap();
-        let canonical = std::fs::canonicalize(&current_exe).unwrap();
-        assert_eq!(
-            resolve_runtime_agent_exe(Some(current_exe)).unwrap(),
-            Some(canonical)
-        );
-    }
-}
-
 fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {
     let source_binary = match binary {
         Some(path) => path,
@@ -864,4 +828,40 @@ async fn flush_pool() -> anyhow::Result<()> {
     println!("Pool flushed. Environments will be rebuilt with current settings.");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_command_parses_runtime_agent_exe_override() {
+        let cli = Cli::try_parse_from([
+            "runtimed",
+            "run",
+            "--runtime-agent-exe",
+            "/tmp/ssh-runtime-agent",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Run {
+                runtime_agent_exe, ..
+            }) => assert_eq!(
+                runtime_agent_exe,
+                Some(PathBuf::from("/tmp/ssh-runtime-agent"))
+            ),
+            other => panic!("expected run command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_runtime_agent_exe_canonicalizes_existing_path() {
+        let current_exe = std::env::current_exe().unwrap();
+        let canonical = std::fs::canonicalize(&current_exe).unwrap();
+        assert_eq!(
+            resolve_runtime_agent_exe(Some(current_exe)).unwrap(),
+            Some(canonical)
+        );
+    }
 }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -417,7 +417,7 @@ async fn main() -> anyhow::Result<()> {
                 conda_pool_size,
                 pixi_pool_size,
                 settings_json_path: settings_json,
-                runtime_agent_exe: resolve_runtime_agent_exe(runtime_agent_exe),
+                runtime_agent_exe: resolve_runtime_agent_exe(runtime_agent_exe)?,
                 ..Default::default()
             };
 
@@ -574,15 +574,19 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-fn resolve_runtime_agent_exe(cli_value: Option<PathBuf>) -> Option<PathBuf> {
-    let path = cli_value.or_else(|| std::env::var_os(RUNTIME_AGENT_EXE_ENV).map(PathBuf::from))?;
-    Some(std::fs::canonicalize(&path).unwrap_or_else(|e| {
-        eprintln!(
+fn resolve_runtime_agent_exe(cli_value: Option<PathBuf>) -> anyhow::Result<Option<PathBuf>> {
+    let Some(path) =
+        cli_value.or_else(|| std::env::var_os(RUNTIME_AGENT_EXE_ENV).map(PathBuf::from))
+    else {
+        return Ok(None);
+    };
+    let canonical = std::fs::canonicalize(&path).map_err(|e| {
+        anyhow::anyhow!(
             "Runtime agent executable not found: {}: {e}",
             path.display()
-        );
-        std::process::exit(1);
-    }))
+        )
+    })?;
+    Ok(Some(canonical))
 }
 
 async fn run_daemon(config: DaemonConfig) -> anyhow::Result<()> {
@@ -681,7 +685,7 @@ mod tests {
         let current_exe = std::env::current_exe().unwrap();
         let canonical = std::fs::canonicalize(&current_exe).unwrap();
         assert_eq!(
-            resolve_runtime_agent_exe(Some(current_exe)),
+            resolve_runtime_agent_exe(Some(current_exe)).unwrap(),
             Some(canonical)
         );
     }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -88,8 +88,8 @@ fn main() {
         "build-dmg" => cmd_build_dmg(),
         "build-app" => cmd_build_app(),
         "dev-daemon" => {
-            let release = args.iter().any(|a| a == "--release");
-            cmd_dev_daemon(release);
+            let options = parse_dev_daemon_options(&args);
+            cmd_dev_daemon(options);
         }
         "run-mcp" | "mcp" => {
             let print_config = args.iter().any(|a| a == "--print-config");
@@ -190,6 +190,8 @@ Release:
 
 Daemon:
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
+  dev-daemon --runtime-agent-exe <path>
+                             Spawn runtime agents through a custom executable
                              (for local nightly install on Linux see ./scripts/install-nightly)
 
 MCP:
@@ -426,6 +428,12 @@ struct DevOptions<'a> {
     skip_build: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DevDaemonOptions {
+    release: bool,
+    runtime_agent_exe: Option<PathBuf>,
+}
+
 fn parse_dev_options(args: &[String]) -> DevOptions<'_> {
     DevOptions {
         notebook: args
@@ -435,6 +443,38 @@ fn parse_dev_options(args: &[String]) -> DevOptions<'_> {
             .map(String::as_str),
         skip_install: args.iter().any(|arg| arg == "--skip-install"),
         skip_build: args.iter().any(|arg| arg == "--skip-build"),
+    }
+}
+
+fn parse_dev_daemon_options(args: &[String]) -> DevDaemonOptions {
+    let mut release = false;
+    let mut runtime_agent_exe = None;
+    let mut index = 1;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--release" {
+            release = true;
+            index += 1;
+        } else if arg == "--runtime-agent-exe" {
+            let Some(value) = args.get(index + 1) else {
+                eprintln!("Error: --runtime-agent-exe requires a path");
+                exit(1);
+            };
+            runtime_agent_exe = Some(PathBuf::from(value));
+            index += 2;
+        } else if let Some(value) = arg.strip_prefix("--runtime-agent-exe=") {
+            runtime_agent_exe = Some(PathBuf::from(value));
+            index += 1;
+        } else {
+            eprintln!("Unknown dev-daemon option: {arg}");
+            exit(1);
+        }
+    }
+
+    DevDaemonOptions {
+        release,
+        runtime_agent_exe,
     }
 }
 
@@ -2757,14 +2797,14 @@ fn dev_socket_path() -> PathBuf {
         .join("runtimed.sock")
 }
 
-fn cmd_dev_daemon(release: bool) {
+fn cmd_dev_daemon(options: DevDaemonOptions) {
     // runtimed's build.rs panics if the gitignored renderer-plugin
     // outputs are missing. Ensure they exist before kicking off the
     // cargo build so a fresh clone can run `cargo xtask dev-daemon`
     // directly.
     ensure_build_artifacts();
 
-    if release {
+    if options.release {
         println!("Building runtimed (release)...");
         run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
     } else {
@@ -2772,7 +2812,7 @@ fn cmd_dev_daemon(release: bool) {
         run_cmd("cargo", &["build", "-p", "runtimed"]);
     }
 
-    let binary = dev_daemon_binary(release);
+    let binary = dev_daemon_binary(options.release);
 
     if !binary.exists() {
         eprintln!(
@@ -2800,6 +2840,13 @@ fn cmd_dev_daemon(release: bool) {
 
     let mut cmd = Command::new(&binary);
     cmd.args(["--dev", "run"]);
+    if let Some(runtime_agent_exe) = &options.runtime_agent_exe {
+        println!(
+            "Runtime agents will be spawned through {}",
+            runtime_agent_exe.display()
+        );
+        cmd.arg("--runtime-agent-exe").arg(runtime_agent_exe);
+    }
     apply_worktree_env(&mut cmd, true);
     let status = cmd.status().unwrap_or_else(|e| {
         eprintln!("Failed to run runtimed: {e}");
@@ -4852,6 +4899,42 @@ mod tests {
                 notebook: Some("notebooks/demo.ipynb"),
                 skip_install: true,
                 skip_build: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_dev_daemon_options_reads_runtime_agent_exe() {
+        let args = vec![
+            "dev-daemon".to_string(),
+            "--release".to_string(),
+            "--runtime-agent-exe".to_string(),
+            "scripts/ssh-runtime-agent".to_string(),
+        ];
+
+        let options = parse_dev_daemon_options(&args);
+        assert_eq!(
+            options,
+            DevDaemonOptions {
+                release: true,
+                runtime_agent_exe: Some(PathBuf::from("scripts/ssh-runtime-agent")),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_dev_daemon_options_reads_equals_runtime_agent_exe() {
+        let args = vec![
+            "dev-daemon".to_string(),
+            "--runtime-agent-exe=scripts/ssh-runtime-agent".to_string(),
+        ];
+
+        let options = parse_dev_daemon_options(&args);
+        assert_eq!(
+            options,
+            DevDaemonOptions {
+                release: false,
+                runtime_agent_exe: Some(PathBuf::from("scripts/ssh-runtime-agent")),
             }
         );
     }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -461,10 +461,10 @@ fn parse_dev_daemon_options(args: &[String]) -> DevDaemonOptions {
                 eprintln!("Error: --runtime-agent-exe requires a path");
                 exit(1);
             };
-            runtime_agent_exe = Some(PathBuf::from(value));
+            runtime_agent_exe = Some(canonicalize_runtime_agent_exe(value));
             index += 2;
         } else if let Some(value) = arg.strip_prefix("--runtime-agent-exe=") {
-            runtime_agent_exe = Some(PathBuf::from(value));
+            runtime_agent_exe = Some(canonicalize_runtime_agent_exe(value));
             index += 1;
         } else {
             eprintln!("Unknown dev-daemon option: {arg}");
@@ -476,6 +476,23 @@ fn parse_dev_daemon_options(args: &[String]) -> DevDaemonOptions {
         release,
         runtime_agent_exe,
     }
+}
+
+fn canonicalize_runtime_agent_exe(value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if let Ok(path) = fs::canonicalize(&path) {
+        return path;
+    }
+    if path.is_relative() {
+        if let Some(workspace) = find_workspace_root() {
+            if let Ok(path) = fs::canonicalize(workspace.join(&path)) {
+                return path;
+            }
+        }
+    }
+
+    eprintln!("--runtime-agent-exe path not found: {value}");
+    exit(1);
 }
 
 fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
@@ -4905,6 +4922,9 @@ mod tests {
 
     #[test]
     fn parse_dev_daemon_options_reads_runtime_agent_exe() {
+        let workspace = find_workspace_root().unwrap();
+        let runtime_agent_exe =
+            std::fs::canonicalize(workspace.join("scripts/ssh-runtime-agent")).unwrap();
         let args = vec![
             "dev-daemon".to_string(),
             "--release".to_string(),
@@ -4917,13 +4937,16 @@ mod tests {
             options,
             DevDaemonOptions {
                 release: true,
-                runtime_agent_exe: Some(PathBuf::from("scripts/ssh-runtime-agent")),
+                runtime_agent_exe: Some(runtime_agent_exe),
             }
         );
     }
 
     #[test]
     fn parse_dev_daemon_options_reads_equals_runtime_agent_exe() {
+        let workspace = find_workspace_root().unwrap();
+        let runtime_agent_exe =
+            std::fs::canonicalize(workspace.join("scripts/ssh-runtime-agent")).unwrap();
         let args = vec![
             "dev-daemon".to_string(),
             "--runtime-agent-exe=scripts/ssh-runtime-agent".to_string(),
@@ -4934,7 +4957,7 @@ mod tests {
             options,
             DevDaemonOptions {
                 release: false,
-                runtime_agent_exe: Some(PathBuf::from("scripts/ssh-runtime-agent")),
+                runtime_agent_exe: Some(runtime_agent_exe),
             }
         );
     }

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -56,7 +56,8 @@
     "prepack": "node -e \"const fs = require('node:fs'); const files = fs.readdirSync('src'); if (!files.includes('binding.cjs') || !files.includes('binding.d.ts')) { console.error('Run pnpm --dir packages/runtimed-node build before packing @runtimed/node.'); process.exit(1); }\"",
     "pack:dry-run": "pnpm pack --dry-run",
     "smoke": "node -e \"const m = require('./src/index.cjs'); console.log('defaultSocketPath:', m.defaultSocketPath());\"",
-    "smoke:api": "node scripts/smoke-api.cjs"
+    "smoke:api": "node scripts/smoke-api.cjs",
+    "smoke:ssh-runtime-agent": "node ../../scripts/smoke-ssh-runtime-agent.mjs"
   },
   "dependencies": {
     "rxjs": "^7.8.2"

--- a/scripts/smoke-ssh-runtime-agent.mjs
+++ b/scripts/smoke-ssh-runtime-agent.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(import.meta.url);
+const smokeProjectPrefix = "/tmp/runt-ssh-runtime-agent-smoke-";
+const smokePyproject = `[project]
+name = "runt-ssh-runtime-agent-smoke"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["ipykernel"]
+`;
+
+function parseArgs(argv) {
+  const options = {
+    sshHost: process.env.RUNTIMED_SSH_RUNTIME_HOST ?? "lab2",
+    remoteCommand:
+      process.env.RUNTIMED_SSH_RUNTIME_COMMAND ?? "/usr/local/bin/runtimed-nightly",
+    runtimedBin:
+      process.env.RUNTIMED_SMOKE_RUNTIMED_BIN ?? path.join(repoRoot, "target/debug/runtimed"),
+    runtimeAgentExe:
+      process.env.RUNTIMED_SMOKE_RUNTIME_AGENT_EXE ??
+      path.join(repoRoot, "scripts/ssh-runtime-agent"),
+    workingDir:
+      process.env.RUNTIMED_SSH_RUNTIME_WORKING_DIR ??
+      `${smokeProjectPrefix}${process.pid}`,
+    timeoutMs: Number(process.env.RUNTIMED_SSH_RUNTIME_SMOKE_TIMEOUT_MS ?? 120000),
+    keepTemp: process.env.RUNTIMED_SSH_RUNTIME_SMOKE_KEEP_TEMP === "1",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    if (arg === "--") {
+      continue;
+    } else if (arg === "--ssh-host") {
+      options.sshHost = readValue();
+    } else if (arg === "--remote-command") {
+      options.remoteCommand = readValue();
+    } else if (arg === "--runtimed-bin") {
+      options.runtimedBin = path.resolve(readValue());
+    } else if (arg === "--runtime-agent-exe") {
+      options.runtimeAgentExe = path.resolve(readValue());
+    } else if (arg === "--working-dir") {
+      options.workingDir = readValue();
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = Number(readValue());
+    } else if (arg === "--keep-temp") {
+      options.keepTemp = true;
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(`Usage: smoke-ssh-runtime-agent.mjs [options]
+
+Options:
+  --ssh-host <host>             SSH host to run the runtime agent on (default: lab2)
+  --remote-command <path>       Remote runtimed binary (default: /usr/local/bin/runtimed-nightly)
+  --runtimed-bin <path>         Local runtimed binary (default: target/debug/runtimed)
+  --runtime-agent-exe <path>    Local SSH runtime-agent wrapper
+  --working-dir <path>          Notebook working dir visible locally and remotely
+                                (default: /tmp/runt-ssh-runtime-agent-smoke-<pid>)
+  --timeout-ms <ms>             Execution timeout (default: 120000)
+  --keep-temp                   Keep temporary smoke state after success
+`);
+      process.exit(0);
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("--timeout-ms must be a positive number");
+  }
+
+  return options;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForDaemon(rt, socketPath, daemon, deadlineMs) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    if (daemon.exitCode !== null) {
+      throw new Error(`runtimed exited before becoming ready (code ${daemon.exitCode})`);
+    }
+    try {
+      await rt.listActiveNotebooks({ socketPath });
+      return;
+    } catch {
+      await sleep(200);
+    }
+  }
+  throw new Error(`timed out waiting for runtimed socket ${socketPath}`);
+}
+
+function collectOutputText(result) {
+  return result.outputs
+    .map((output) => {
+      if (typeof output.text === "string") {
+        return output.text;
+      }
+      if (typeof output.dataJson === "string") {
+        return output.dataJson;
+      }
+      return "";
+    })
+    .join("");
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function prepareSharedProject(options) {
+  fs.mkdirSync(options.workingDir, { recursive: true });
+  fs.writeFileSync(path.join(options.workingDir, "pyproject.toml"), smokePyproject);
+
+  const remotePyproject = path.posix.join(options.workingDir, "pyproject.toml");
+  const remoteCommand = `mkdir -p ${shellQuote(options.workingDir)} && cat > ${shellQuote(
+    remotePyproject,
+  )}`;
+  const remote = spawnSync(
+    "ssh",
+    [
+      "-o",
+      "BatchMode=yes",
+      options.sshHost,
+      remoteCommand,
+    ],
+    {
+      input: smokePyproject,
+      encoding: "utf8",
+    },
+  );
+  if (remote.status !== 0) {
+    throw new Error(
+      `failed to prepare remote working dir ${options.workingDir}: ${
+        remote.stderr || remote.stdout
+      }`,
+    );
+  }
+}
+
+function cleanupSharedProject(options) {
+  if (!options.workingDir.startsWith(smokeProjectPrefix)) {
+    return;
+  }
+  fs.rmSync(options.workingDir, { recursive: true, force: true });
+  spawnSync(
+    "ssh",
+    [
+      "-o",
+      "BatchMode=yes",
+      options.sshHost,
+      "rm",
+      "-rf",
+      "--",
+      options.workingDir,
+    ],
+    { stdio: "ignore" },
+  );
+}
+
+async function stopDaemon(daemon) {
+  if (!daemon || daemon.exitCode !== null) {
+    return;
+  }
+  daemon.kill("SIGTERM");
+  const exited = once(daemon, "exit");
+  const timedOut = sleep(5000).then(() => {
+    if (daemon.exitCode === null) {
+      daemon.kill("SIGKILL");
+    }
+  });
+  await Promise.race([exited, timedOut]);
+}
+
+function tail(filePath, maxBytes = 16000) {
+  if (!fs.existsSync(filePath)) {
+    return "";
+  }
+  const stat = fs.statSync(filePath);
+  const start = Math.max(0, stat.size - maxBytes);
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(stat.size - start);
+    fs.readSync(fd, buffer, 0, buffer.length, start);
+    return buffer.toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!fs.existsSync(options.runtimedBin)) {
+    throw new Error(`local runtimed binary not found: ${options.runtimedBin}`);
+  }
+  if (!fs.existsSync(options.runtimeAgentExe)) {
+    throw new Error(`runtime-agent wrapper not found: ${options.runtimeAgentExe}`);
+  }
+
+  const rt = require(path.join(repoRoot, "packages/runtimed-node/src/index.cjs"));
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "runt-ssh-runtime-agent-"));
+  const workspaceDir = path.join(tempDir, "workspace");
+  const socketPath = path.join(tempDir, "runtimed.sock");
+  const logPath = path.join(tempDir, "runtimed-child.log");
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  const logFd = fs.openSync(logPath, "a");
+  let daemon = null;
+  let session = null;
+
+  try {
+    prepareSharedProject(options);
+
+    daemon = spawn(
+      options.runtimedBin,
+      [
+        "--dev",
+        "run",
+        "--socket",
+        socketPath,
+        "--cache-dir",
+        path.join(tempDir, "cache"),
+        "--blob-store-dir",
+        path.join(tempDir, "blobs"),
+        "--settings-json",
+        path.join(tempDir, "settings.json"),
+        "--runtime-agent-exe",
+        options.runtimeAgentExe,
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          RUNTIMED_DEV: "1",
+          RUNTIMED_WORKSPACE_PATH: workspaceDir,
+          RUNTIMED_SSH_RUNTIME_HOST: options.sshHost,
+          RUNTIMED_SSH_RUNTIME_COMMAND: options.remoteCommand,
+          RUST_LOG: process.env.RUST_LOG ?? "info",
+        },
+        stdio: ["ignore", logFd, logFd],
+      },
+    );
+
+    await waitForDaemon(rt, socketPath, daemon, Math.min(options.timeoutMs, 30000));
+
+    session = await rt.createNotebook({
+      socketPath,
+      runtime: "python",
+      workingDir: options.workingDir,
+      environmentMode: "project",
+      description: "ssh runtime-agent smoke",
+    });
+
+    const result = await session.runCell(
+      `import socket, platform
+print(socket.gethostname())
+print(platform.platform())
+`,
+      { timeoutMs: options.timeoutMs },
+    );
+    const text = collectOutputText(result);
+
+    if (result.status !== "done" || !result.success) {
+      throw new Error(`execution did not complete successfully: ${JSON.stringify(result)}`);
+    }
+    if (!text.includes(options.sshHost)) {
+      throw new Error(`execution output did not include ${options.sshHost}: ${text}`);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          socketPath,
+          notebookId: session.notebookId,
+          sshHost: options.sshHost,
+          remoteCommand: options.remoteCommand,
+          workingDir: options.workingDir,
+          output: text.trim(),
+          tempDir: options.keepTemp ? tempDir : undefined,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.error(error);
+    console.error(`\nSmoke temp dir: ${tempDir}`);
+    console.error(`\nDaemon log tail:\n${tail(logPath)}`);
+    process.exitCode = 1;
+  } finally {
+    if (session) {
+      try {
+        await session.shutdownNotebook();
+      } catch {
+        // The daemon may already be shutting down.
+      }
+      try {
+        await session.close();
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+    await stopDaemon(daemon);
+    fs.closeSync(logFd);
+    if (!options.keepTemp && process.exitCode !== 1) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      cleanupSharedProject(options);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/smoke-ssh-runtime-agent.mjs
+++ b/scripts/smoke-ssh-runtime-agent.mjs
@@ -30,6 +30,7 @@ function parseArgs(argv) {
     workingDir:
       process.env.RUNTIMED_SSH_RUNTIME_WORKING_DIR ??
       `${smokeProjectPrefix}${process.pid}`,
+    expectedHostname: process.env.RUNTIMED_SSH_RUNTIME_EXPECTED_HOSTNAME ?? null,
     timeoutMs: Number(process.env.RUNTIMED_SSH_RUNTIME_SMOKE_TIMEOUT_MS ?? 120000),
     keepTemp: process.env.RUNTIMED_SSH_RUNTIME_SMOKE_KEEP_TEMP === "1",
   };
@@ -57,6 +58,8 @@ function parseArgs(argv) {
       options.runtimeAgentExe = path.resolve(readValue());
     } else if (arg === "--working-dir") {
       options.workingDir = readValue();
+    } else if (arg === "--expected-hostname") {
+      options.expectedHostname = readValue();
     } else if (arg === "--timeout-ms") {
       options.timeoutMs = Number(readValue());
     } else if (arg === "--keep-temp") {
@@ -71,6 +74,7 @@ Options:
   --runtime-agent-exe <path>    Local SSH runtime-agent wrapper
   --working-dir <path>          Notebook working dir visible locally and remotely
                                 (default: /tmp/runt-ssh-runtime-agent-smoke-<pid>)
+  --expected-hostname <name>    Expected remote hostname (default: ssh host)
   --timeout-ms <ms>             Execution timeout (default: 120000)
   --keep-temp                   Keep temporary smoke state after success
 `);
@@ -83,6 +87,7 @@ Options:
   if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
     throw new Error("--timeout-ms must be a positive number");
   }
+  options.expectedHostname ??= options.sshHost;
 
   return options;
 }
@@ -280,8 +285,8 @@ print(platform.platform())
     if (result.status !== "done" || !result.success) {
       throw new Error(`execution did not complete successfully: ${JSON.stringify(result)}`);
     }
-    if (!text.includes(options.sshHost)) {
-      throw new Error(`execution output did not include ${options.sshHost}: ${text}`);
+    if (!text.includes(options.expectedHostname)) {
+      throw new Error(`execution output did not include ${options.expectedHostname}: ${text}`);
     }
 
     console.log(

--- a/scripts/smoke-ssh-runtime-agent.mjs
+++ b/scripts/smoke-ssh-runtime-agent.mjs
@@ -27,9 +27,7 @@ function parseArgs(argv) {
     runtimeAgentExe:
       process.env.RUNTIMED_SMOKE_RUNTIME_AGENT_EXE ??
       path.join(repoRoot, "scripts/ssh-runtime-agent"),
-    workingDir:
-      process.env.RUNTIMED_SSH_RUNTIME_WORKING_DIR ??
-      `${smokeProjectPrefix}${process.pid}`,
+    workingDir: process.env.RUNTIMED_SSH_RUNTIME_WORKING_DIR ?? null,
     expectedHostname: process.env.RUNTIMED_SSH_RUNTIME_EXPECTED_HOSTNAME ?? null,
     timeoutMs: Number(process.env.RUNTIMED_SSH_RUNTIME_SMOKE_TIMEOUT_MS ?? 120000),
     keepTemp: process.env.RUNTIMED_SSH_RUNTIME_SMOKE_KEEP_TEMP === "1",
@@ -73,7 +71,7 @@ Options:
   --runtimed-bin <path>         Local runtimed binary (default: target/debug/runtimed)
   --runtime-agent-exe <path>    Local SSH runtime-agent wrapper
   --working-dir <path>          Notebook working dir visible locally and remotely
-                                (default: /tmp/runt-ssh-runtime-agent-smoke-<pid>)
+                                (default: /tmp/runt-ssh-runtime-agent-smoke-XXXXXX)
   --expected-hostname <name>    Expected remote hostname (default: ssh host)
   --timeout-ms <ms>             Execution timeout (default: 120000)
   --keep-temp                   Keep temporary smoke state after success
@@ -87,6 +85,7 @@ Options:
   if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
     throw new Error("--timeout-ms must be a positive number");
   }
+  options.workingDir ??= fs.mkdtempSync(smokeProjectPrefix);
   options.expectedHostname ??= options.sshHost;
 
   return options;

--- a/scripts/smoke-ssh-runtime-agent.mjs
+++ b/scripts/smoke-ssh-runtime-agent.mjs
@@ -321,7 +321,7 @@ print(platform.platform())
     await stopDaemon(daemon);
     fs.closeSync(logFd);
     if (!options.keepTemp && process.exitCode !== 1) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
+      fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
       cleanupSharedProject(options);
     }
   }

--- a/scripts/smoke-ssh-runtime-agent.mjs
+++ b/scripts/smoke-ssh-runtime-agent.mjs
@@ -19,7 +19,7 @@ dependencies = ["ipykernel"]
 
 function parseArgs(argv) {
   const options = {
-    sshHost: process.env.RUNTIMED_SSH_RUNTIME_HOST ?? "lab2",
+    sshHost: process.env.RUNTIMED_SSH_RUNTIME_HOST ?? "lab-runner1",
     remoteCommand:
       process.env.RUNTIMED_SSH_RUNTIME_COMMAND ?? "/usr/local/bin/runtimed-nightly",
     runtimedBin:
@@ -66,7 +66,7 @@ function parseArgs(argv) {
       console.log(`Usage: smoke-ssh-runtime-agent.mjs [options]
 
 Options:
-  --ssh-host <host>             SSH host to run the runtime agent on (default: lab2)
+  --ssh-host <host>             SSH host to run the runtime agent on (default: lab-runner1)
   --remote-command <path>       Remote runtimed binary (default: /usr/local/bin/runtimed-nightly)
   --runtimed-bin <path>         Local runtimed binary (default: target/debug/runtimed)
   --runtime-agent-exe <path>    Local SSH runtime-agent wrapper
@@ -123,6 +123,10 @@ function collectOutputText(result) {
       return "";
     })
     .join("");
+}
+
+function pythonStringLiteral(value) {
+  return JSON.stringify(String(value));
 }
 
 function shellQuote(value) {
@@ -273,8 +277,11 @@ async function main() {
     });
 
     const result = await session.runCell(
-      `import socket, platform
-print(socket.gethostname())
+      `import hashlib, platform, socket
+expected_hostname = ${pythonStringLiteral(options.expectedHostname)}
+actual_hostname = socket.gethostname()
+print("hostname_matches_expected", actual_hostname == expected_hostname)
+print("hostname_sha256", hashlib.sha256(actual_hostname.encode()).hexdigest())
 print(platform.platform())
 `,
       { timeoutMs: options.timeoutMs },
@@ -284,8 +291,10 @@ print(platform.platform())
     if (result.status !== "done" || !result.success) {
       throw new Error(`execution did not complete successfully: ${JSON.stringify(result)}`);
     }
-    if (!text.includes(options.expectedHostname)) {
-      throw new Error(`execution output did not include ${options.expectedHostname}: ${text}`);
+    if (!text.includes("hostname_matches_expected True")) {
+      throw new Error(
+        `execution output did not confirm hostname ${options.expectedHostname}: ${text}`,
+      );
     }
 
     console.log(

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  ssh-runtime-agent runtime-agent --notebook-id ID --runtime-agent-id ID --blob-root PATH --socket PATH
+
+This wrapper is spawned by the local runtimed daemon as its runtime-agent
+executable. It reverse-forwards the local daemon Unix socket over SSH, then
+execs the remote runtimed runtime-agent binary against the forwarded socket.
+
+Environment:
+  RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab2
+  RUNTIMED_SSH_RUNTIME_COMMAND       Remote runtimed binary, default: /usr/local/bin/runtimed-nightly
+  RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp directory, default: /tmp/runt-ssh-runtime-agent-$USER
+  RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-49999
+  RUNTIMED_SSH_BIN                   SSH binary, default: ssh
+  RUNTIMED_SSH_RUNTIME_VERBOSE       Set to 1 for wrapper diagnostics
+EOF
+}
+
+die() {
+  echo "ssh-runtime-agent: $*" >&2
+  exit 64
+}
+
+shell_quote() {
+  local value=${1//\'/\'\\\'\'}
+  printf "'%s'" "$value"
+}
+
+if [[ "${1:-}" != "runtime-agent" ]]; then
+  usage
+  die "expected first argument to be runtime-agent"
+fi
+shift
+
+notebook_id=
+runtime_agent_id=
+local_blob_root=
+local_socket=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --notebook-id)
+      [[ $# -ge 2 ]] || die "--notebook-id requires a value"
+      notebook_id=$2
+      shift 2
+      ;;
+    --runtime-agent-id)
+      [[ $# -ge 2 ]] || die "--runtime-agent-id requires a value"
+      runtime_agent_id=$2
+      shift 2
+      ;;
+    --blob-root)
+      [[ $# -ge 2 ]] || die "--blob-root requires a value"
+      local_blob_root=$2
+      shift 2
+      ;;
+    --socket)
+      [[ $# -ge 2 ]] || die "--socket requires a value"
+      local_socket=$2
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$notebook_id" ]] || die "missing --notebook-id"
+[[ -n "$runtime_agent_id" ]] || die "missing --runtime-agent-id"
+[[ -n "$local_blob_root" ]] || die "missing --blob-root"
+[[ -n "$local_socket" ]] || die "missing --socket"
+[[ -S "$local_socket" ]] || die "local daemon socket does not exist: $local_socket"
+
+ssh_host=${RUNTIMED_SSH_RUNTIME_HOST:-lab2}
+remote_runtimed=${RUNTIMED_SSH_RUNTIME_COMMAND:-/usr/local/bin/runtimed-nightly}
+remote_tmp=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp/runt-ssh-runtime-agent-${USER:-user}}
+ssh_bin=${RUNTIMED_SSH_BIN:-ssh}
+remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-$((30000 + (RANDOM % 20000)))}
+
+safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_.-' '_')
+remote_socket="$remote_tmp/runt-ra-${safe_agent_id}.sock"
+remote_blob_root="$remote_tmp/runt-ra-blobs-${safe_agent_id}"
+
+remote_socket_dir=$(dirname "$remote_socket")
+bridge_code='
+import os
+import selectors
+import socket
+import sys
+
+unix_path = sys.argv[1]
+tcp_port = int(sys.argv[2])
+
+try:
+    os.unlink(unix_path)
+except FileNotFoundError:
+    pass
+
+server = socket.socket(socket.AF_UNIX)
+server.bind(unix_path)
+os.chmod(unix_path, 0o600)
+server.listen(8)
+
+def pipe(left, right):
+    selector = selectors.DefaultSelector()
+    left.setblocking(False)
+    right.setblocking(False)
+    selector.register(left, selectors.EVENT_READ, right)
+    selector.register(right, selectors.EVENT_READ, left)
+    while True:
+        for key, _ in selector.select():
+            source = key.fileobj
+            target = key.data
+            try:
+                data = source.recv(65536)
+            except BlockingIOError:
+                continue
+            if not data:
+                return
+            try:
+                target.sendall(data)
+            except BrokenPipeError:
+                return
+
+while True:
+    client, _ = server.accept()
+    upstream = socket.create_connection(("127.0.0.1", tcp_port))
+    try:
+        pipe(client, upstream)
+    finally:
+        client.close()
+        upstream.close()
+'
+
+remote_command="
+set -e
+mkdir -p $(shell_quote "$remote_socket_dir") $(shell_quote "$remote_blob_root")
+chmod 700 $(shell_quote "$remote_socket_dir")
+python3 -u -c $(shell_quote "$bridge_code") $(shell_quote "$remote_socket") $(shell_quote "$remote_port") &
+bridge_pid=\$!
+cleanup() {
+  kill \"\$bridge_pid\" 2>/dev/null || true
+  wait \"\$bridge_pid\" 2>/dev/null || true
+  rm -f $(shell_quote "$remote_socket")
+}
+trap cleanup EXIT INT TERM
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -S $(shell_quote "$remote_socket") ] && break
+  sleep 0.1
+done
+[ -S $(shell_quote "$remote_socket") ]
+$(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$notebook_id") --runtime-agent-id $(shell_quote "$runtime_agent_id") --blob-root $(shell_quote "$remote_blob_root") --socket $(shell_quote "$remote_socket")
+"
+
+if [[ "${RUNTIMED_SSH_RUNTIME_VERBOSE:-0}" == "1" ]]; then
+  {
+    echo "ssh-runtime-agent: host=$ssh_host"
+    echo "ssh-runtime-agent: remote_runtimed=$remote_runtimed"
+    echo "ssh-runtime-agent: remote_port=$remote_port"
+    echo "ssh-runtime-agent: local_socket=$local_socket"
+    echo "ssh-runtime-agent: remote_socket=$remote_socket"
+    echo "ssh-runtime-agent: local_blob_root=$local_blob_root"
+    echo "ssh-runtime-agent: remote_blob_root=$remote_blob_root"
+  } >&2
+fi
+
+"$ssh_bin" \
+  -o BatchMode=yes \
+  "$ssh_host" \
+  "mkdir -p $(shell_quote "$remote_socket_dir"); chmod 700 $(shell_quote "$remote_socket_dir")"
+
+exec "$ssh_bin" \
+  -o BatchMode=yes \
+  -o ExitOnForwardFailure=yes \
+  -R "127.0.0.1:$remote_port:$local_socket" \
+  "$ssh_host" \
+  "$remote_command"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -102,12 +102,14 @@ proxy_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
 local_proxy_dir=$(mktemp -d "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-proxy.XXXXXX")
 local_proxy_socket="$local_proxy_dir/proxy.sock"
 local_proxy_pid=
+last_ssh_stderr=
 
 cleanup_local_proxy() {
   if [[ -n "$local_proxy_pid" ]]; then
     kill "$local_proxy_pid" 2>/dev/null || true
     wait "$local_proxy_pid" 2>/dev/null || true
   fi
+  rm -f "${last_ssh_stderr:-}"
   rm -rf "$local_proxy_dir"
 }
 trap cleanup_local_proxy EXIT INT TERM
@@ -301,11 +303,13 @@ $(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$no
     } >&2
   fi
 
-  last_ssh_stderr=$(mktemp "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-ssh.XXXXXX")
+  last_ssh_stderr="$local_proxy_dir/ssh-stderr"
+  : > "$last_ssh_stderr"
   local ssh_status
   "$ssh_bin" \
     -o BatchMode=yes \
     -o ExitOnForwardFailure=yes \
+    -o GatewayPorts=no \
     -R "127.0.0.1:$remote_port:$local_proxy_socket" \
     "$ssh_host" \
     "$remote_command" \
@@ -323,11 +327,8 @@ fi
 
 ssh_status=255
 for _ in $(seq 1 "$attempts"); do
-  if run_remote_agent; then
-    ssh_status=0
-  else
-    ssh_status=$?
-  fi
+  ssh_status=0
+  run_remote_agent || ssh_status=$?
   if [[ "$ssh_status" -ne 255 || -n "$requested_remote_port" || ! -f "$last_ssh_stderr" ]] ||
     ! grep -qi "remote port forwarding failed" "$last_ssh_stderr"; then
     rm -f "${last_ssh_stderr:-}"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -89,6 +89,14 @@ requested_remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-}
 [[ -n "$remote_runtimed" ]] || die "RUNTIMED_SSH_RUNTIME_COMMAND must not be empty"
 [[ -n "$remote_tmp_parent" ]] || die "RUNTIMED_SSH_RUNTIME_REMOTE_TMP must not be empty"
 [[ -n "$ssh_bin" ]] || die "RUNTIMED_SSH_BIN must not be empty"
+command -v python3 >/dev/null || die "python3 is required but was not found in PATH"
+
+if [[ -n "$requested_remote_port" ]]; then
+  [[ "$requested_remote_port" =~ ^[0-9]+$ ]] ||
+    die "RUNTIMED_SSH_RUNTIME_REMOTE_PORT must be a number between 1024 and 65535"
+  ((requested_remote_port >= 1024 && requested_remote_port <= 65535)) ||
+    die "RUNTIMED_SSH_RUNTIME_REMOTE_PORT must be a number between 1024 and 65535"
+fi
 
 proxy_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
 local_proxy_dir=$(mktemp -d "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-proxy.XXXXXX")

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -111,18 +111,13 @@ server.listen(8)
 
 def pipe(left, right):
     selector = selectors.DefaultSelector()
-    left.setblocking(False)
-    right.setblocking(False)
     selector.register(left, selectors.EVENT_READ, right)
     selector.register(right, selectors.EVENT_READ, left)
     while True:
         for key, _ in selector.select():
             source = key.fileobj
             target = key.data
-            try:
-                data = source.recv(65536)
-            except BlockingIOError:
-                continue
+            data = source.recv(65536)
             if not data:
                 return
             try:

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -14,7 +14,7 @@ Environment:
   RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab2
   RUNTIMED_SSH_RUNTIME_COMMAND       Remote runtimed binary, default: /usr/local/bin/runtimed-nightly
   RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp parent directory, default: /tmp
-  RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-32767
+  RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-60000
   RUNTIMED_SSH_BIN                   SSH binary, default: ssh
   RUNTIMED_SSH_RUNTIME_VERBOSE       Set to 1 for wrapper diagnostics
 EOF
@@ -116,6 +116,7 @@ safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_-' '_')
 remote_session_template="$remote_tmp_parent/runt-ssh-runtime-agent-${safe_agent_id}.XXXXXX"
 local_proxy_code='
 import os
+import hmac
 import selectors
 import socket
 import sys
@@ -163,7 +164,7 @@ def read_token(client):
             return False
         received += chunk
     client.settimeout(None)
-    return received == token
+    return hmac.compare_digest(received, token)
 
 def handle_client(client):
     daemon = None
@@ -257,7 +258,7 @@ select_remote_port() {
   if [[ -n "$requested_remote_port" ]]; then
     remote_port=$requested_remote_port
   else
-    remote_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(2768))')
+    remote_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(30001))')
   fi
 }
 
@@ -279,7 +280,7 @@ cleanup() {
   wait \"\$bridge_pid\" 2>/dev/null || true
   rm -rf \"\$remote_session_dir\"
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM HUP
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   [ -S \"\$remote_socket\" ] && break
   sleep 0.1
@@ -334,4 +335,5 @@ for _ in $(seq 1 "$attempts"); do
   fi
   rm -f "$last_ssh_stderr"
 done
+rm -f "${last_ssh_stderr:-}"
 exit "$ssh_status"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -98,7 +98,7 @@ cleanup_local_proxy() {
 }
 trap cleanup_local_proxy EXIT INT TERM
 
-safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_.-' '_')
+safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_-' '_')
 remote_socket="$remote_tmp/runt-ra-${safe_agent_id}.sock"
 remote_blob_root="$remote_tmp/runt-ra-blobs-${safe_agent_id}"
 
@@ -265,6 +265,7 @@ cleanup() {
   kill \"\$bridge_pid\" 2>/dev/null || true
   wait \"\$bridge_pid\" 2>/dev/null || true
   rm -f $(shell_quote "$remote_socket")
+  rm -rf $(shell_quote "$remote_blob_root")
 }
 trap cleanup EXIT INT TERM
 for _ in 1 2 3 4 5 6 7 8 9 10; do

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -14,7 +14,7 @@ Environment:
   RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab2
   RUNTIMED_SSH_RUNTIME_COMMAND       Remote runtimed binary, default: /usr/local/bin/runtimed-nightly
   RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp parent directory, default: /tmp
-  RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-49999
+  RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-32767
   RUNTIMED_SSH_BIN                   SSH binary, default: ssh
   RUNTIMED_SSH_RUNTIME_VERBOSE       Set to 1 for wrapper diagnostics
 EOF
@@ -123,7 +123,7 @@ import threading
 
 proxy_path = sys.argv[1]
 daemon_path = sys.argv[2]
-token = os.environ["RUNTIMED_SSH_PROXY_TOKEN"].encode() + b"\n"
+token = sys.stdin.readline().rstrip("\n").encode() + b"\n"
 
 try:
     os.unlink(proxy_path)
@@ -194,7 +194,7 @@ import threading
 
 unix_path = sys.argv[1]
 tcp_port = int(sys.argv[2])
-token = os.environ["RUNTIMED_SSH_PROXY_TOKEN"].encode() + b"\n"
+token = sys.stdin.readline().rstrip("\n").encode() + b"\n"
 
 try:
     os.unlink(unix_path)
@@ -244,8 +244,7 @@ while True:
     thread.start()
 '
 
-RUNTIMED_SSH_PROXY_TOKEN=$proxy_token \
-  python3 -u -c "$local_proxy_code" "$local_proxy_socket" "$local_socket" &
+python3 -u -c "$local_proxy_code" "$local_proxy_socket" "$local_socket" <<<"$proxy_token" &
 local_proxy_pid=$!
 
 for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -258,7 +257,7 @@ select_remote_port() {
   if [[ -n "$requested_remote_port" ]]; then
     remote_port=$requested_remote_port
   else
-    remote_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(20000))')
+    remote_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(2768))')
   fi
 }
 
@@ -273,7 +272,7 @@ chmod 700 \"\$remote_session_dir\"
 remote_socket=\"\$remote_session_dir/runt-ra.sock\"
 remote_blob_root=\"\$remote_session_dir/blobs\"
 mkdir -p \"\$remote_blob_root\"
-RUNTIMED_SSH_PROXY_TOKEN=\"\$proxy_token\" python3 -u -c $(shell_quote "$bridge_code") \"\$remote_socket\" $(shell_quote "$remote_port") &
+printf '%s\n' \"\$proxy_token\" | python3 -u -c $(shell_quote "$bridge_code") \"\$remote_socket\" $(shell_quote "$remote_port") &
 bridge_pid=\$!
 cleanup() {
   kill \"\$bridge_pid\" 2>/dev/null || true
@@ -301,12 +300,14 @@ $(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$no
     } >&2
   fi
 
+  last_ssh_stderr=$(mktemp "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-ssh.XXXXXX")
   "$ssh_bin" \
     -o BatchMode=yes \
     -o ExitOnForwardFailure=yes \
     -R "127.0.0.1:$remote_port:$local_proxy_socket" \
     "$ssh_host" \
     "$remote_command" \
+    2> >(tee "$last_ssh_stderr" >&2) \
     <<<"$proxy_token"
 }
 
@@ -322,8 +323,11 @@ for _ in $(seq 1 "$attempts"); do
   else
     ssh_status=$?
   fi
-  if [[ "$ssh_status" -ne 255 || -n "$requested_remote_port" ]]; then
+  if [[ "$ssh_status" -ne 255 || -n "$requested_remote_port" || ! -f "$last_ssh_stderr" ]] ||
+    ! grep -qi "remote port forwarding failed" "$last_ssh_stderr"; then
+    rm -f "${last_ssh_stderr:-}"
     exit "$ssh_status"
   fi
+  rm -f "$last_ssh_stderr"
 done
 exit "$ssh_status"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -81,7 +81,7 @@ done
 
 ssh_host=${RUNTIMED_SSH_RUNTIME_HOST:-lab2}
 remote_runtimed=${RUNTIMED_SSH_RUNTIME_COMMAND:-/usr/local/bin/runtimed-nightly}
-remote_tmp=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp/runt-ssh-runtime-agent-${USER:-user}}
+remote_tmp_parent=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp}
 ssh_bin=${RUNTIMED_SSH_BIN:-ssh}
 requested_remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-}
 proxy_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
@@ -99,10 +99,7 @@ cleanup_local_proxy() {
 trap cleanup_local_proxy EXIT INT TERM
 
 safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_-' '_')
-remote_socket="$remote_tmp/runt-ra-${safe_agent_id}.sock"
-remote_blob_root="$remote_tmp/runt-ra-blobs-${safe_agent_id}"
-
-remote_socket_dir=$(dirname "$remote_socket")
+remote_session_template="$remote_tmp_parent/runt-ssh-runtime-agent-${safe_agent_id}.XXXXXX"
 local_proxy_code='
 import os
 import selectors
@@ -227,73 +224,6 @@ while True:
     thread.start()
 '
 
-port_probe_code='
-import socket
-import sys
-
-port = int(sys.argv[1])
-sock = socket.socket(socket.AF_INET)
-sock.bind(("127.0.0.1", port))
-sock.close()
-'
-
-remote_port=$requested_remote_port
-if [[ -z "$remote_port" ]]; then
-  for _ in 1 2 3 4 5; do
-    candidate_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(20000))')
-    if "$ssh_bin" \
-      -o BatchMode=yes \
-      "$ssh_host" \
-      "python3 -c $(shell_quote "$port_probe_code") $(shell_quote "$candidate_port")" \
-      >/dev/null 2>&1; then
-      remote_port=$candidate_port
-      break
-    fi
-  done
-fi
-
-[[ -n "$remote_port" ]] || die "could not find an available remote forwarding port"
-
-remote_command="
-set -e
-IFS= read -r proxy_token
-mkdir -p $(shell_quote "$remote_socket_dir") $(shell_quote "$remote_blob_root")
-chmod 700 $(shell_quote "$remote_socket_dir")
-RUNTIMED_SSH_PROXY_TOKEN=\"\$proxy_token\" python3 -u -c $(shell_quote "$bridge_code") $(shell_quote "$remote_socket") $(shell_quote "$remote_port") &
-bridge_pid=\$!
-cleanup() {
-  kill \"\$bridge_pid\" 2>/dev/null || true
-  wait \"\$bridge_pid\" 2>/dev/null || true
-  rm -f $(shell_quote "$remote_socket")
-  rm -rf $(shell_quote "$remote_blob_root")
-}
-trap cleanup EXIT INT TERM
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  [ -S $(shell_quote "$remote_socket") ] && break
-  sleep 0.1
-done
-[ -S $(shell_quote "$remote_socket") ]
-$(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$notebook_id") --runtime-agent-id $(shell_quote "$runtime_agent_id") --blob-root $(shell_quote "$remote_blob_root") --socket $(shell_quote "$remote_socket")
-"
-
-if [[ "${RUNTIMED_SSH_RUNTIME_VERBOSE:-0}" == "1" ]]; then
-  {
-    echo "ssh-runtime-agent: host=$ssh_host"
-    echo "ssh-runtime-agent: remote_runtimed=$remote_runtimed"
-    echo "ssh-runtime-agent: remote_port=$remote_port"
-    echo "ssh-runtime-agent: local_socket=$local_socket"
-    echo "ssh-runtime-agent: local_proxy_socket=$local_proxy_socket"
-    echo "ssh-runtime-agent: remote_socket=$remote_socket"
-    echo "ssh-runtime-agent: local_blob_root=$local_blob_root"
-    echo "ssh-runtime-agent: remote_blob_root=$remote_blob_root"
-  } >&2
-fi
-
-"$ssh_bin" \
-  -o BatchMode=yes \
-  "$ssh_host" \
-  "mkdir -p $(shell_quote "$remote_socket_dir"); chmod 700 $(shell_quote "$remote_socket_dir")"
-
 RUNTIMED_SSH_PROXY_TOKEN=$proxy_token \
   python3 -u -c "$local_proxy_code" "$local_proxy_socket" "$local_socket" &
 local_proxy_pid=$!
@@ -304,10 +234,73 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
 done
 [[ -S "$local_proxy_socket" ]] || die "local proxy socket did not start: $local_proxy_socket"
 
-"$ssh_bin" \
-  -o BatchMode=yes \
-  -o ExitOnForwardFailure=yes \
-  -R "127.0.0.1:$remote_port:$local_proxy_socket" \
-  "$ssh_host" \
-  "$remote_command" \
-  <<<"$proxy_token"
+select_remote_port() {
+  if [[ -n "$requested_remote_port" ]]; then
+    remote_port=$requested_remote_port
+  else
+    remote_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(20000))')
+  fi
+}
+
+run_remote_agent() {
+  select_remote_port
+
+  local remote_command="
+set -e
+IFS= read -r proxy_token
+remote_session_dir=\$(mktemp -d $(shell_quote "$remote_session_template"))
+chmod 700 \"\$remote_session_dir\"
+remote_socket=\"\$remote_session_dir/runt-ra.sock\"
+remote_blob_root=\"\$remote_session_dir/blobs\"
+mkdir -p \"\$remote_blob_root\"
+RUNTIMED_SSH_PROXY_TOKEN=\"\$proxy_token\" python3 -u -c $(shell_quote "$bridge_code") \"\$remote_socket\" $(shell_quote "$remote_port") &
+bridge_pid=\$!
+cleanup() {
+  kill \"\$bridge_pid\" 2>/dev/null || true
+  wait \"\$bridge_pid\" 2>/dev/null || true
+  rm -rf \"\$remote_session_dir\"
+}
+trap cleanup EXIT INT TERM
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [ -S \"\$remote_socket\" ] && break
+  sleep 0.1
+done
+[ -S \"\$remote_socket\" ]
+$(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$notebook_id") --runtime-agent-id $(shell_quote "$runtime_agent_id") --blob-root \"\$remote_blob_root\" --socket \"\$remote_socket\"
+"
+
+  if [[ "${RUNTIMED_SSH_RUNTIME_VERBOSE:-0}" == "1" ]]; then
+    {
+      echo "ssh-runtime-agent: host=$ssh_host"
+      echo "ssh-runtime-agent: remote_runtimed=$remote_runtimed"
+      echo "ssh-runtime-agent: remote_port=$remote_port"
+      echo "ssh-runtime-agent: remote_session_template=$remote_session_template"
+      echo "ssh-runtime-agent: local_socket=$local_socket"
+      echo "ssh-runtime-agent: local_proxy_socket=$local_proxy_socket"
+      echo "ssh-runtime-agent: local_blob_root=$local_blob_root"
+    } >&2
+  fi
+
+  "$ssh_bin" \
+    -o BatchMode=yes \
+    -o ExitOnForwardFailure=yes \
+    -R "127.0.0.1:$remote_port:$local_proxy_socket" \
+    "$ssh_host" \
+    "$remote_command" \
+    <<<"$proxy_token"
+}
+
+attempts=1
+if [[ -z "$requested_remote_port" ]]; then
+  attempts=3
+fi
+
+ssh_status=255
+for _ in $(seq 1 "$attempts"); do
+  run_remote_agent
+  ssh_status=$?
+  if [[ "$ssh_status" -ne 255 || -n "$requested_remote_port" ]]; then
+    exit "$ssh_status"
+  fi
+done
+exit "$ssh_status"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -83,21 +83,104 @@ ssh_host=${RUNTIMED_SSH_RUNTIME_HOST:-lab2}
 remote_runtimed=${RUNTIMED_SSH_RUNTIME_COMMAND:-/usr/local/bin/runtimed-nightly}
 remote_tmp=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp/runt-ssh-runtime-agent-${USER:-user}}
 ssh_bin=${RUNTIMED_SSH_BIN:-ssh}
-remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-$((30000 + (RANDOM % 20000)))}
+requested_remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-}
+proxy_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
+local_proxy_dir=$(mktemp -d "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-proxy.XXXXXX")
+local_proxy_socket="$local_proxy_dir/proxy.sock"
+local_proxy_pid=
+
+cleanup_local_proxy() {
+  if [[ -n "$local_proxy_pid" ]]; then
+    kill "$local_proxy_pid" 2>/dev/null || true
+    wait "$local_proxy_pid" 2>/dev/null || true
+  fi
+  rm -rf "$local_proxy_dir"
+}
+trap cleanup_local_proxy EXIT INT TERM
 
 safe_agent_id=$(printf '%s' "$runtime_agent_id" | tr -c 'A-Za-z0-9_.-' '_')
 remote_socket="$remote_tmp/runt-ra-${safe_agent_id}.sock"
 remote_blob_root="$remote_tmp/runt-ra-blobs-${safe_agent_id}"
 
 remote_socket_dir=$(dirname "$remote_socket")
+local_proxy_code='
+import os
+import selectors
+import socket
+import sys
+import threading
+
+proxy_path = sys.argv[1]
+daemon_path = sys.argv[2]
+token = os.environ["RUNTIMED_SSH_PROXY_TOKEN"].encode() + b"\n"
+
+try:
+    os.unlink(proxy_path)
+except FileNotFoundError:
+    pass
+
+server = socket.socket(socket.AF_UNIX)
+server.bind(proxy_path)
+os.chmod(proxy_path, 0o600)
+server.listen(8)
+
+def pipe(left, right):
+    selector = selectors.DefaultSelector()
+    selector.register(left, selectors.EVENT_READ, right)
+    selector.register(right, selectors.EVENT_READ, left)
+    while True:
+        for key, _ in selector.select():
+            source = key.fileobj
+            target = key.data
+            data = source.recv(65536)
+            if not data:
+                return
+            try:
+                target.sendall(data)
+            except BrokenPipeError:
+                return
+
+def read_token(client):
+    client.settimeout(10)
+    received = b""
+    while len(received) < len(token):
+        chunk = client.recv(len(token) - len(received))
+        if not chunk:
+            return False
+        received += chunk
+    client.settimeout(None)
+    return received == token
+
+def handle_client(client):
+    daemon = None
+    try:
+        if not read_token(client):
+            return
+        daemon = socket.socket(socket.AF_UNIX)
+        daemon.connect(daemon_path)
+        pipe(client, daemon)
+    except OSError as exc:
+        print(f"local proxy connection error: {exc}", file=sys.stderr)
+    finally:
+        client.close()
+        if daemon is not None:
+            daemon.close()
+
+while True:
+    client, _ = server.accept()
+    thread = threading.Thread(target=handle_client, args=(client,), daemon=True)
+    thread.start()
+'
 bridge_code='
 import os
 import selectors
 import socket
 import sys
+import threading
 
 unix_path = sys.argv[1]
 tcp_port = int(sys.argv[2])
+token = os.environ["RUNTIMED_SSH_PROXY_TOKEN"].encode() + b"\n"
 
 try:
     os.unlink(unix_path)
@@ -125,21 +208,58 @@ def pipe(left, right):
             except BrokenPipeError:
                 return
 
-while True:
-    client, _ = server.accept()
-    upstream = socket.create_connection(("127.0.0.1", tcp_port))
+def handle_client(client):
+    upstream = None
     try:
+        upstream = socket.create_connection(("127.0.0.1", tcp_port))
+        upstream.sendall(token)
         pipe(client, upstream)
+    except OSError as exc:
+        print(f"bridge connection error: {exc}", file=sys.stderr)
     finally:
         client.close()
-        upstream.close()
+        if upstream is not None:
+            upstream.close()
+
+while True:
+    client, _ = server.accept()
+    thread = threading.Thread(target=handle_client, args=(client,), daemon=True)
+    thread.start()
 '
+
+port_probe_code='
+import socket
+import sys
+
+port = int(sys.argv[1])
+sock = socket.socket(socket.AF_INET)
+sock.bind(("127.0.0.1", port))
+sock.close()
+'
+
+remote_port=$requested_remote_port
+if [[ -z "$remote_port" ]]; then
+  for _ in 1 2 3 4 5; do
+    candidate_port=$(python3 -c 'import secrets; print(30000 + secrets.randbelow(20000))')
+    if "$ssh_bin" \
+      -o BatchMode=yes \
+      "$ssh_host" \
+      "python3 -c $(shell_quote "$port_probe_code") $(shell_quote "$candidate_port")" \
+      >/dev/null 2>&1; then
+      remote_port=$candidate_port
+      break
+    fi
+  done
+fi
+
+[[ -n "$remote_port" ]] || die "could not find an available remote forwarding port"
 
 remote_command="
 set -e
+IFS= read -r proxy_token
 mkdir -p $(shell_quote "$remote_socket_dir") $(shell_quote "$remote_blob_root")
 chmod 700 $(shell_quote "$remote_socket_dir")
-python3 -u -c $(shell_quote "$bridge_code") $(shell_quote "$remote_socket") $(shell_quote "$remote_port") &
+RUNTIMED_SSH_PROXY_TOKEN=\"\$proxy_token\" python3 -u -c $(shell_quote "$bridge_code") $(shell_quote "$remote_socket") $(shell_quote "$remote_port") &
 bridge_pid=\$!
 cleanup() {
   kill \"\$bridge_pid\" 2>/dev/null || true
@@ -161,6 +281,7 @@ if [[ "${RUNTIMED_SSH_RUNTIME_VERBOSE:-0}" == "1" ]]; then
     echo "ssh-runtime-agent: remote_runtimed=$remote_runtimed"
     echo "ssh-runtime-agent: remote_port=$remote_port"
     echo "ssh-runtime-agent: local_socket=$local_socket"
+    echo "ssh-runtime-agent: local_proxy_socket=$local_proxy_socket"
     echo "ssh-runtime-agent: remote_socket=$remote_socket"
     echo "ssh-runtime-agent: local_blob_root=$local_blob_root"
     echo "ssh-runtime-agent: remote_blob_root=$remote_blob_root"
@@ -172,9 +293,20 @@ fi
   "$ssh_host" \
   "mkdir -p $(shell_quote "$remote_socket_dir"); chmod 700 $(shell_quote "$remote_socket_dir")"
 
-exec "$ssh_bin" \
+RUNTIMED_SSH_PROXY_TOKEN=$proxy_token \
+  python3 -u -c "$local_proxy_code" "$local_proxy_socket" "$local_socket" &
+local_proxy_pid=$!
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  [[ -S "$local_proxy_socket" ]] && break
+  sleep 0.1
+done
+[[ -S "$local_proxy_socket" ]] || die "local proxy socket did not start: $local_proxy_socket"
+
+"$ssh_bin" \
   -o BatchMode=yes \
   -o ExitOnForwardFailure=yes \
-  -R "127.0.0.1:$remote_port:$local_socket" \
+  -R "127.0.0.1:$remote_port:$local_proxy_socket" \
   "$ssh_host" \
-  "$remote_command"
+  "$remote_command" \
+  <<<"$proxy_token"

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -13,7 +13,7 @@ execs the remote runtimed runtime-agent binary against the forwarded socket.
 Environment:
   RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab2
   RUNTIMED_SSH_RUNTIME_COMMAND       Remote runtimed binary, default: /usr/local/bin/runtimed-nightly
-  RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp directory, default: /tmp/runt-ssh-runtime-agent-$USER
+  RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp parent directory, default: /tmp
   RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-49999
   RUNTIMED_SSH_BIN                   SSH binary, default: ssh
   RUNTIMED_SSH_RUNTIME_VERBOSE       Set to 1 for wrapper diagnostics
@@ -84,6 +84,12 @@ remote_runtimed=${RUNTIMED_SSH_RUNTIME_COMMAND:-/usr/local/bin/runtimed-nightly}
 remote_tmp_parent=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp}
 ssh_bin=${RUNTIMED_SSH_BIN:-ssh}
 requested_remote_port=${RUNTIMED_SSH_RUNTIME_REMOTE_PORT:-}
+
+[[ -n "$ssh_host" ]] || die "RUNTIMED_SSH_RUNTIME_HOST must not be empty"
+[[ -n "$remote_runtimed" ]] || die "RUNTIMED_SSH_RUNTIME_COMMAND must not be empty"
+[[ -n "$remote_tmp_parent" ]] || die "RUNTIMED_SSH_RUNTIME_REMOTE_TMP must not be empty"
+[[ -n "$ssh_bin" ]] || die "RUNTIMED_SSH_BIN must not be empty"
+
 proxy_token=$(python3 -c 'import secrets; print(secrets.token_hex(32))')
 local_proxy_dir=$(mktemp -d "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-proxy.XXXXXX")
 local_proxy_socket="$local_proxy_dir/proxy.sock"
@@ -123,19 +129,22 @@ server.listen(8)
 
 def pipe(left, right):
     selector = selectors.DefaultSelector()
-    selector.register(left, selectors.EVENT_READ, right)
-    selector.register(right, selectors.EVENT_READ, left)
-    while True:
-        for key, _ in selector.select():
-            source = key.fileobj
-            target = key.data
-            data = source.recv(65536)
-            if not data:
-                return
-            try:
-                target.sendall(data)
-            except BrokenPipeError:
-                return
+    try:
+        selector.register(left, selectors.EVENT_READ, right)
+        selector.register(right, selectors.EVENT_READ, left)
+        while True:
+            for key, _ in selector.select():
+                source = key.fileobj
+                target = key.data
+                data = source.recv(65536)
+                if not data:
+                    return
+                try:
+                    target.sendall(data)
+                except BrokenPipeError:
+                    return
+    finally:
+        selector.close()
 
 def read_token(client):
     client.settimeout(10)
@@ -191,19 +200,22 @@ server.listen(8)
 
 def pipe(left, right):
     selector = selectors.DefaultSelector()
-    selector.register(left, selectors.EVENT_READ, right)
-    selector.register(right, selectors.EVENT_READ, left)
-    while True:
-        for key, _ in selector.select():
-            source = key.fileobj
-            target = key.data
-            data = source.recv(65536)
-            if not data:
-                return
-            try:
-                target.sendall(data)
-            except BrokenPipeError:
-                return
+    try:
+        selector.register(left, selectors.EVENT_READ, right)
+        selector.register(right, selectors.EVENT_READ, left)
+        while True:
+            for key, _ in selector.select():
+                source = key.fileobj
+                target = key.data
+                data = source.recv(65536)
+                if not data:
+                    return
+                try:
+                    target.sendall(data)
+                except BrokenPipeError:
+                    return
+    finally:
+        selector.close()
 
 def handle_client(client):
     upstream = None
@@ -297,8 +309,11 @@ fi
 
 ssh_status=255
 for _ in $(seq 1 "$attempts"); do
-  run_remote_agent
-  ssh_status=$?
+  if run_remote_agent; then
+    ssh_status=0
+  else
+    ssh_status=$?
+  fi
   if [[ "$ssh_status" -ne 255 || -n "$requested_remote_port" ]]; then
     exit "$ssh_status"
   fi

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -11,7 +11,7 @@ executable. It reverse-forwards the local daemon Unix socket over SSH, then
 execs the remote runtimed runtime-agent binary against the forwarded socket.
 
 Environment:
-  RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab2
+  RUNTIMED_SSH_RUNTIME_HOST          SSH host, default: lab-runner1
   RUNTIMED_SSH_RUNTIME_COMMAND       Remote runtimed binary, default: /usr/local/bin/runtimed-nightly
   RUNTIMED_SSH_RUNTIME_REMOTE_TMP    Remote temp parent directory, default: /tmp
   RUNTIMED_SSH_RUNTIME_REMOTE_PORT   Remote loopback TCP port for SSH -R, default: random 30000-60000
@@ -79,7 +79,7 @@ done
 [[ -n "$local_socket" ]] || die "missing --socket"
 [[ -S "$local_socket" ]] || die "local daemon socket does not exist: $local_socket"
 
-ssh_host=${RUNTIMED_SSH_RUNTIME_HOST:-lab2}
+ssh_host=${RUNTIMED_SSH_RUNTIME_HOST:-lab-runner1}
 remote_runtimed=${RUNTIMED_SSH_RUNTIME_COMMAND:-/usr/local/bin/runtimed-nightly}
 remote_tmp_parent=${RUNTIMED_SSH_RUNTIME_REMOTE_TMP:-/tmp}
 ssh_bin=${RUNTIMED_SSH_BIN:-ssh}

--- a/scripts/ssh-runtime-agent
+++ b/scripts/ssh-runtime-agent
@@ -301,14 +301,18 @@ $(shell_quote "$remote_runtimed") runtime-agent --notebook-id $(shell_quote "$no
   fi
 
   last_ssh_stderr=$(mktemp "${TMPDIR:-/tmp}/runt-ssh-runtime-agent-ssh.XXXXXX")
+  local ssh_status
   "$ssh_bin" \
     -o BatchMode=yes \
     -o ExitOnForwardFailure=yes \
     -R "127.0.0.1:$remote_port:$local_proxy_socket" \
     "$ssh_host" \
     "$remote_command" \
-    2> >(tee "$last_ssh_stderr" >&2) \
+    2>"$last_ssh_stderr" \
     <<<"$proxy_token"
+  ssh_status=$?
+  cat "$last_ssh_stderr" >&2 || true
+  return "$ssh_status"
 }
 
 attempts=1


### PR DESCRIPTION
## Summary

Adds a hidden daemon/runtime-agent override that lets a local Desktop daemon spawn a runtime agent through SSH. This gives us a concrete Desktop <> SSH runtime target primitive without adding UI yet.

The new hidden path is:

- `runtimed --dev run --runtime-agent-exe <path>`
- `RUNTIMED_RUNTIME_AGENT_EXE=<path>` as an environment fallback
- `cargo xtask dev-daemon --runtime-agent-exe scripts/ssh-runtime-agent`

The checked-in SSH wrapper defaults to `lab-runner1` and `/usr/local/bin/runtimed-nightly`, starts a local token-gated proxy in front of the daemon socket, reverse-forwards that proxy over SSH, starts a user-owned Unix-socket bridge on the remote host, and runs the remote `runtimed-nightly runtime-agent` against the forwarded local daemon path.

The tunnel now keeps retry stderr inside the trapped local proxy directory, passes `GatewayPorts=no` for the reverse forward, sends the proxy token over stdin rather than argv/env, and keeps the runtime socket bridge user-owned with `0600` permissions.

## Alignment with workstation/runtime peer work

This PR is aligned with the newer workstation split by staying deliberately on the SSH/direct-access side:

- The local Desktop daemon remains notebook room authority.
- The remote process is still the local `RuntimeAgent` protocol reached through SSH, not a hosted `runtime_peer`.
- Registered workstations continue to use the mainline `cloud-runtime-agent` / `runtime_peer` path with room-mediated authorization.
- The SSH bridge can still be shown as a compute source in the future UI, but its trust boundary is Desktop ownership plus SSH keys, not hosted workstation registration.

After rebasing over #3491, #3492, and #3495, the boundary is clearer: SSH is Desktop-only direct access. It should not use hosted workstation registration, hosted attach jobs, or `runtime_peer` ACL flow. Future Desktop SSH work can reuse the shared Workstations projection shape, but its source data should come from local Desktop/daemon SSH target configuration. This PR stays as the hidden launch primitive and lab-runner1 smoke.

## Why hidden

This is intentionally a hidden/dev-only feature for now. The control-plane path works, but the Desktop product model still needs first-class configuration for:

- compute target state that distinguishes Local Desktop, registered workstations, and SSH/direct access
- local-to-remote working-directory mapping
- remote project/environment policy instead of local prewarmed or inline env paths
- blob replication for large/rich/binary outputs
- UI placement that keeps compute target selection separate from the active interpreter/packages shown in Environment

## Verification

- `bash -n scripts/ssh-runtime-agent`
- `node --check scripts/smoke-ssh-runtime-agent.mjs`
- `cargo test -p runtimed runtime_agent_exe`
- `cargo test -p xtask parse_dev_daemon_options`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- `pnpm --dir packages/runtimed-node smoke:ssh-runtime-agent -- --timeout-ms 180000`
- `uv run pr-review https://github.com/nteract/nteract/pull/3359 --max-turns 120 --out .context/reviews/pr-3359-rerun-10.json`
- `uv run pr-review https://github.com/nteract/nteract/pull/3359 --max-turns 120 --extra-prompt "<security audit prompt>" --out .context/reviews/pr-3359-security-rerun-7.json`

Live smoke output confirmed execution on `lab-runner1` without depending on the raw hostname value, which is redacted because it is present in the runtime-agent environment:

```text
hostname_matches_expected True
hostname_sha256 473c187f2840b8595e91ed5703842d17568213c9a3e6bb68d45890b279028b3b
Linux-6.17.0-1015-aws-x86_64-with-glibc2.39
```
