### PR TITLE
ci: preserve pending main workflow runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id) }}
   # PR pushes should cancel stale work. Main, scheduled, and manual runs are the
-  # long-tail coverage lanes, so let them finish instead of starving coverage
-  # when main moves quickly.
+  # long-tail coverage lanes, so give each non-PR run a unique concurrency
+  # group. GitHub replaces older pending runs in a group even when
+  # cancel-in-progress is false.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -733,6 +734,7 @@ jobs:
     needs: [changes, build-ui]
     if: ${{ always() && needs.changes.outputs.source_changed == 'true' && github.event_name != 'pull_request' && needs.build-ui.result == 'success' }}
     continue-on-error: ${{ matrix.platform.non_blocking }}
+    timeout-minutes: 120
     runs-on: ${{ needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
       matrix:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,8 +19,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id) }}
+  # PR smoke runs only report skips, so stale PR pushes can cancel. Main and
+  # manual smoke runs are post-merge signal and should not be replaced while
+  # pending.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- keep pull_request Build and Smoke runs grouped by PR number so stale pushes still cancel
- give non-PR Build and Smoke runs a unique concurrency group so pending main/manual/scheduled runs are not replaced
- add a 120 minute timeout to the post-merge native platform Build matrix

## Why

While watching main after #3356 merged, the pending `Build` run for #3356 was cancelled before jobs were assigned when #3358 landed. The same happened to the in-progress/pending `Smoke` run. That means `cancel-in-progress: false` is not enough for long-tail visibility: GitHub still replaces older pending runs in the same concurrency group.

This preserves fast PR cancellation while letting main/manual/scheduled coverage runs actually get a chance to report.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); YAML.load_file(".github/workflows/smoke.yml")'`
- `actionlint .github/workflows/build.yml .github/workflows/smoke.yml`
- `cargo xtask lint --fix`
- `git diff --check`
