### PR TITLE
fix(notebook): gate iframe wheel boundary forwarding

### DIFF
--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -80,6 +80,7 @@ export interface IsolatedFrameProps {
   autoHeight?: boolean;
   className?: string;
   allowWheelBoundaryScroll?: boolean;
+  forwardWheelBoundaryScroll?: boolean;
   scrollPassthrough?: boolean;
   revealOnRender?: boolean;
   reserveHeightOnReveal?: boolean;

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -19,6 +19,7 @@ import {
   type IsolatedDiagnosticHandler,
   type IsolatedFrameHandle,
   outputAllowsScrollPassthrough,
+  outputNeedsIsolation,
   type OutputSegment,
   outputUsesSift,
   outputUsesWheelOwningFrame,
@@ -693,6 +694,14 @@ function OutputAreaSingle({
   const shouldLockWheelBoundary = hasWheelOwningOutputs && staticFrameInteractionActive;
   const allowWheelBoundaryScroll =
     !focused && !shouldScrollPassthroughFrame && !shouldLockWheelBoundary;
+  const shouldForwardWheelBoundaryScroll =
+    allowWheelBoundaryScroll &&
+    !hasWidgets &&
+    !hasWheelOwningOutputs &&
+    outputs.some(
+      (output) =>
+        outputNeedsIsolation(output, priority) && !outputAllowsScrollPassthrough(output, priority),
+    );
   const showSiftInteractionCue =
     shouldMountIsolatedFrame &&
     hasSiftOutputs &&
@@ -1099,6 +1108,7 @@ function OutputAreaSingle({
                 maxHeight={isolatedOutputWellMaxHeight}
                 autoHeight={shouldIsolate && !focused}
                 allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+                forwardWheelBoundaryScroll={shouldForwardWheelBoundaryScroll}
                 scrollPassthrough={shouldScrollPassthroughFrame}
                 onReady={handleIsolatedFrameReady}
                 onLinkClick={onLinkClick}

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/components/isolated", async (importOriginal) => {
     {
       allowWheelBoundaryScroll?: boolean;
       autoHeight?: boolean;
+      forwardWheelBoundaryScroll?: boolean;
       hostContext?: unknown;
       onMessage?: (message: unknown) => void;
       onMouseUp?: (params: { hasSelection?: boolean }) => void;
@@ -54,6 +55,7 @@ vi.mock("@/components/isolated", async (importOriginal) => {
     {
       allowWheelBoundaryScroll,
       autoHeight,
+      forwardWheelBoundaryScroll,
       hostContext,
       onMessage,
       onMouseUp,
@@ -94,6 +96,7 @@ vi.mock("@/components/isolated", async (importOriginal) => {
       <div
         data-allow-wheel-boundary-scroll={String(allowWheelBoundaryScroll)}
         data-auto-height={String(autoHeight)}
+        data-forward-wheel-boundary-scroll={String(forwardWheelBoundaryScroll)}
         data-host-context={JSON.stringify(hostContext ?? null)}
         data-scroll-passthrough={String(scrollPassthrough)}
         data-testid="isolated-frame"
@@ -326,6 +329,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "false",
     );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "false",
+    );
   });
 
   it("passes host context through to isolated output frames", () => {
@@ -406,6 +412,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
     );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "false",
+    );
 
     // Pointer out while a button is held used to be a no-op and remains so —
     // active drags keep the frame focused.
@@ -414,6 +423,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
+    );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "false",
     );
 
     // Pointer out without buttons no longer drops focus; the user has to
@@ -424,6 +436,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
+    );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "false",
     );
   });
 
@@ -476,6 +491,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "true",
     );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "true",
+    );
   });
 
   it("puts parquet iframe outputs on scroll passthrough so the page wheels through sift", () => {
@@ -487,6 +505,9 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("true");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "false",
+    );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
       "false",
     );
   });
@@ -501,6 +522,9 @@ describe("OutputArea iframe theme sync", () => {
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
       "false",
     );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
+      "false",
+    );
   });
 
   it("locks the wheel boundary for an engaged Vega/Altair chart so zoom stays in the chart", () => {
@@ -513,6 +537,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
 
@@ -534,6 +559,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
   });
 
   it("aligns sift before engaging iframe scrolling and releases on Escape", () => {
@@ -568,6 +594,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByText("Click inside the table to scroll")).toBeNull();
 
     fireEvent.keyDown(activationWell, { key: "Escape" });
@@ -589,6 +616,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
     expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
   });
 
@@ -618,6 +646,9 @@ describe("OutputArea iframe theme sync", () => {
 
     expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
     expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
+      "false",
+    );
+    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
       "false",
     );
   });
@@ -685,8 +716,10 @@ describe("OutputArea iframe theme sync", () => {
     expect(frames).toHaveLength(2);
     expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frames[0].getAttribute("data-allow-wheel-boundary-scroll")).toBe("true");
+    expect(frames[0].getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
     expect(frames[1].getAttribute("data-scroll-passthrough")).toBe("true");
     expect(frames[1].getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frames[1].getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
 
     await waitFor(() => {
       expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -66,8 +66,11 @@ describe("generateFrameHtml", () => {
     expect(html).toContain("postMessage");
   });
 
-  it("forwards wheel deltas when iframe scroll reaches a boundary", () => {
+  it("forwards wheel deltas only when the parent opts into boundary handoff", () => {
     expect(source).toMatch(/document\.addEventListener\(\s*'wheel'/);
+    expect(html).toContain("var wheelBoundaryForwardingEnabled = false");
+    expect(html).toContain('case "wheel_boundary_policy"');
+    expect(source).toContain("if (!wheelBoundaryForwardingEnabled) return");
     expect(html).toContain("isWheelAtScrollBoundary");
     expect(html).toContain("e.preventDefault()");
     expect(html).toContain("requestAnimationFrame(flushWheelBoundary)");

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -255,6 +255,17 @@ export interface InteractionStateMessage {
 }
 
 /**
+ * Parent-side wheel-boundary policy for iframe outputs.
+ */
+export interface WheelBoundaryPolicyMessage {
+  type: "wheel_boundary_policy";
+  payload: {
+    /** Whether the iframe should forward scroll-boundary wheel deltas to the host. */
+    enabled: boolean;
+  };
+}
+
+/**
  * All message types that can be sent from parent to iframe.
  */
 export type ParentToIframeMessage =
@@ -274,7 +285,8 @@ export type ParentToIframeMessage =
   | BridgeReadyMessage
   | SearchMessage
   | SearchNavigateMessage
-  | InteractionStateMessage;
+  | InteractionStateMessage
+  | WheelBoundaryPolicyMessage;
 
 // --- Message Types: Iframe → Parent ---
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -349,6 +349,8 @@
           );
         }
 
+        var wheelBoundaryForwardingEnabled = false;
+
         // --- Message Handler ---
         // Note: When the React renderer bundle is loaded, it sets window.__REACT_RENDERER_ACTIVE__
         // and the inline handlers should defer to React for render/theme/clear messages.
@@ -456,6 +458,10 @@
 
               case "search_navigate":
                 handleSearchNavigate(payload);
+                break;
+
+              case "wheel_boundary_policy":
+                wheelBoundaryForwardingEnabled = !!(payload && payload.enabled);
                 break;
 
               case "bridge_ready":
@@ -897,6 +903,7 @@
         document.addEventListener(
           "wheel",
           function (e) {
+            if (!wheelBoundaryForwardingEnabled) return;
             if (!e.deltaY) return;
             var scroller = nearestVerticalScroller(e.target);
             if (!isWheelAtScrollBoundary(scroller, e.deltaY)) return;

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -102,9 +102,19 @@ export interface IsolatedFrameProps {
   /**
    * When true, wheel events that reach a scroll boundary inside the iframe
    * are forwarded to the nearest scrollable parent.
+   * This only gates parent-side application of boundary events; the iframe
+   * must also opt in through forwardWheelBoundaryScroll before it emits them.
    * @default true
    */
   allowWheelBoundaryScroll?: boolean;
+
+  /**
+   * When true, the iframe bootstrap emits wheel-boundary events to the host.
+   * Keep false for document-like outputs that should stay on the browser's
+   * native scroll path.
+   * @default false
+   */
+  forwardWheelBoundaryScroll?: boolean;
 
   /**
    * When true, the iframe is transparent to pointer hit-testing so wheel
@@ -308,6 +318,7 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
       autoHeight = false,
       className = "",
       allowWheelBoundaryScroll = true,
+      forwardWheelBoundaryScroll = false,
       scrollPassthrough = false,
       onReady,
       onResize,
@@ -603,6 +614,14 @@ export const IsolatedFrame = forwardRef<IsolatedFrameHandle, IsolatedFrameProps>
     useEffect(() => {
       runtimeRef.current?.setRendererBundle({ rendererCode, rendererCss });
     }, [rendererCode, rendererCss]);
+
+    useEffect(() => {
+      if (!isIframeReady) return;
+      runtimeRef.current?.send({
+        type: "wheel_boundary_policy",
+        payload: { enabled: forwardWheelBoundaryScroll },
+      });
+    }, [forwardWheelBoundaryScroll, isIframeReady]);
 
     // Handle messages from iframe
     useEffect(() => {


### PR DESCRIPTION
## Summary

- add an explicit iframe-side wheel boundary policy so frames do not emit scroll-boundary JSON-RPC by default
- keep document-like markdown/HTML/SVG, Sift/Vega handoff frames, and widgets off the wheel-boundary RPC path
- preserve opt-in boundary forwarding for specialized non-document isolated outputs that still need host scroll handoff

## Verification

- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
