### PR TITLE
fix(markdown): keep document frames selectable

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -49,7 +49,6 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
-const DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS = 700;
 const MARKDOWN_PREVIEW_MIN_HEIGHT = 24;
 const MARKDOWN_PREVIEW_MAX_INITIAL_HEIGHT = 720;
 
@@ -210,7 +209,6 @@ export const MarkdownCell = memo(function MarkdownCell({
   const injectedLibsRef = useRef(new Set<string>());
   const viewRef = useRef<HTMLDivElement>(null);
   const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
-  const previewFrameReleaseTimeoutRef = useRef<number | null>(null);
   const previewMinHeight = useMemo(() => estimateMarkdownPreviewHeight(cell.source), [cell.source]);
 
   // Register EditorView with the cursor registry when in edit mode.
@@ -287,37 +285,18 @@ export const MarkdownCell = memo(function MarkdownCell({
     setEditing(true);
   }, [readOnly]);
 
-  const clearPreviewFrameReleaseTimeout = useCallback(() => {
-    if (previewFrameReleaseTimeoutRef.current == null) return;
-    window.clearTimeout(previewFrameReleaseTimeoutRef.current);
-    previewFrameReleaseTimeoutRef.current = null;
+  const releasePreviewFrameInteraction = useCallback(() => {
+    setPreviewFrameInteractionActive(false);
   }, []);
 
-  useEffect(() => clearPreviewFrameReleaseTimeout, [clearPreviewFrameReleaseTimeout]);
-
-  const releasePreviewFrameInteraction = useCallback(() => {
-    clearPreviewFrameReleaseTimeout();
-    setPreviewFrameInteractionActive(false);
-  }, [clearPreviewFrameReleaseTimeout]);
-
-  const schedulePreviewFrameInteractionRelease = useCallback(() => {
-    clearPreviewFrameReleaseTimeout();
-    previewFrameReleaseTimeoutRef.current = window.setTimeout(() => {
-      previewFrameReleaseTimeoutRef.current = null;
-      setPreviewFrameInteractionActive(false);
-    }, DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS);
-  }, [clearPreviewFrameReleaseTimeout]);
-
   const activatePreviewFrameInteraction = useCallback(() => {
-    clearPreviewFrameReleaseTimeout();
     setPreviewFrameInteractionActive(true);
     onFocus();
-  }, [clearPreviewFrameReleaseTimeout, onFocus]);
+  }, [onFocus]);
 
   const handlePreviewWrapperPointerDown = useCallback(() => {
     activatePreviewFrameInteraction();
-    schedulePreviewFrameInteractionRelease();
-  }, [activatePreviewFrameInteraction, schedulePreviewFrameInteractionRelease]);
+  }, [activatePreviewFrameInteraction]);
 
   const handlePreviewFrameMouseUp = useCallback(
     ({ hasSelection }: { hasSelection?: boolean }) => {

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -205,6 +205,7 @@ describe("MarkdownCell theme sync", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -372,6 +373,27 @@ describe("MarkdownCell theme sync", () => {
 
     act(() => {
       lastFrameMouseUp?.({ hasSelection: true });
+    });
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+    expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+  });
+
+  it("does not time out markdown iframe interaction before a selection mouseup", () => {
+    vi.useFakeTimers();
+
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const previewWrapper = getByTestId("markdown-frame").parentElement as HTMLElement;
+
+    fireEvent.pointerDown(previewWrapper);
+
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
     });
 
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -91,7 +91,6 @@ const DEFERRED_OUTPUT_PLACEHOLDER_HEIGHT = 96;
 const SIFT_VIEWPORT_TOP_INSET_PX = 96;
 const SIFT_VIEWPORT_BOTTOM_INSET_PX = 32;
 const DEFAULT_DEFERRED_ISOLATED_FRAME_ROOT_MARGIN = "1200px 0px";
-const DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS = 700;
 
 function outputAreaInsetClass(layoutInset: NonNullable<OutputAreaProps["layoutInset"]>) {
   switch (layoutInset) {
@@ -620,7 +619,6 @@ function OutputAreaSingle({
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
   const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
-  const staticFrameReleaseTimeoutRef = useRef<number | null>(null);
 
   const darkMode = useDarkMode();
   const colorTheme = useColorTheme();
@@ -736,27 +734,9 @@ function OutputAreaSingle({
     }
   }, [shouldUseScrollPassthroughFrame, staticFrameInteractionActive]);
 
-  const clearStaticFrameReleaseTimeout = useCallback(() => {
-    if (staticFrameReleaseTimeoutRef.current == null) return;
-    window.clearTimeout(staticFrameReleaseTimeoutRef.current);
-    staticFrameReleaseTimeoutRef.current = null;
-  }, []);
-
-  useEffect(() => clearStaticFrameReleaseTimeout, [clearStaticFrameReleaseTimeout]);
-
   const releaseStaticFrameInteraction = useCallback(() => {
-    clearStaticFrameReleaseTimeout();
     setStaticFrameInteractionActive(false);
-  }, [clearStaticFrameReleaseTimeout]);
-
-  const scheduleStaticFrameInteractionRelease = useCallback(() => {
-    if (hasWheelOwningOutputs) return;
-    clearStaticFrameReleaseTimeout();
-    staticFrameReleaseTimeoutRef.current = window.setTimeout(() => {
-      staticFrameReleaseTimeoutRef.current = null;
-      setStaticFrameInteractionActive(false);
-    }, DOCUMENT_FRAME_INTERACTION_RELEASE_DELAY_MS);
-  }, [clearStaticFrameReleaseTimeout, hasWheelOwningOutputs]);
+  }, []);
 
   useEffect(() => {
     if (!hasWheelOwningOutputs) return;
@@ -783,7 +763,6 @@ function OutputAreaSingle({
 
   const activateStaticFrameInteraction = useCallback(() => {
     if (shouldUseScrollPassthroughFrame) {
-      clearStaticFrameReleaseTimeout();
       if (!staticFrameInteractionActive && hasSiftOutputs) {
         scrollElementIntoComfortableView(staticFrameInteractionRef.current);
       }
@@ -798,25 +777,22 @@ function OutputAreaSingle({
     shouldUseScrollPassthroughFrame,
     staticFrameInteractionActive,
     onIframeMouseDown,
-    clearStaticFrameReleaseTimeout,
   ]);
 
   const activateStaticFrameInteractionTemporarily = useCallback(() => {
     activateStaticFrameInteraction();
-    scheduleStaticFrameInteractionRelease();
-  }, [activateStaticFrameInteraction, scheduleStaticFrameInteractionRelease]);
+  }, [activateStaticFrameInteraction]);
 
   const handleStaticFrameMouseUp = useCallback(
     ({ hasSelection }: { hasSelection?: boolean }) => {
       if (hasSelection) {
-        clearStaticFrameReleaseTimeout();
         return;
       }
       if (!hasWheelOwningOutputs) {
         releaseStaticFrameInteraction();
       }
     },
-    [clearStaticFrameReleaseTimeout, hasWheelOwningOutputs, releaseStaticFrameInteraction],
+    [hasWheelOwningOutputs, releaseStaticFrameInteraction],
   );
 
   const handleStaticFrameKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -258,6 +258,7 @@ describe("OutputArea iframe theme sync", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
@@ -469,6 +470,25 @@ describe("OutputArea iframe theme sync", () => {
 
     act(() => {
       lastFrameMouseUp?.({ hasSelection: true });
+    });
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+  });
+
+  it("does not time out static document iframe outputs before selection mouseup", () => {
+    vi.useFakeTimers();
+
+    const { getByTestId } = render(<OutputArea outputs={makeMarkdownOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(activationWell);
+
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
     });
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");


### PR DESCRIPTION
## Summary

- keep markdown preview iframes interactive through long text-selection gestures
- keep static document output iframes interactive through long text-selection gestures
- preserve the existing release behavior for plain iframe clicks and outside interactions

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`

