### PR TITLE
perf(cloud): defer hosted output iframes

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -129,6 +129,15 @@ test("cloud passes shared NotebookView source and output visibility handlers", (
     sourceText,
     /<NotebookView[\s\S]*onSetCellOutputsHidden=\{handleCloudSetCellOutputsHidden\}/,
   );
+  assert.match(
+    sourceText,
+    /<NotebookView[\s\S]*deferOutputIsolatedFramesUntilVisible=\{!shellCapabilities\.canEditCells\}/,
+  );
+  assert.match(
+    sourceText,
+    /<NotebookView[\s\S]*deferredOutputIsolatedFrameRootMargin=\{CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN\}/,
+  );
+  assert.match(sourceText, /const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";/);
 });
 
 test("cloud wires shared presence and cleans projected store entries", () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -136,6 +136,8 @@ import {
 } from "./widget-runtime";
 import "./index.css";
 
+const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
+
 setLoggerHost({
   debug: () => {},
   info: () => {},
@@ -1470,6 +1472,8 @@ function NotebookViewer({
             onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
             markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
             outputHostContext={outputHostContext}
+            deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}
+            deferredOutputIsolatedFrameRootMargin={CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN}
             autoFocusFirstCell={false}
           />
         </CrdtBridgeProvider>

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -90,6 +90,8 @@ interface CodeCellProps {
   readOnly?: boolean;
   canExecute?: boolean;
   outputHostContext?: NteractEmbedHostContextPatch;
+  deferOutputIsolatedFrameUntilVisible?: boolean;
+  deferredOutputIsolatedFrameRootMargin?: string;
 }
 
 export interface HiddenGroupCellSummary {
@@ -336,6 +338,8 @@ export const CodeCell = memo(function CodeCell({
   readOnly = false,
   canExecute = !readOnly,
   outputHostContext,
+  deferOutputIsolatedFrameUntilVisible = false,
+  deferredOutputIsolatedFrameRootMargin,
 }: CodeCellProps) {
   // Read transient UI state from the store
   const isFocused = useIsCellFocused(cell.id);
@@ -758,7 +762,9 @@ export const CodeCell = memo(function CodeCell({
               outputs={outputs}
               cellId={cell.id}
               executionCount={executionCount}
-              preloadIframe
+              preloadIframe={!deferOutputIsolatedFrameUntilVisible}
+              deferIsolatedFrameUntilVisible={deferOutputIsolatedFrameUntilVisible}
+              deferredIsolatedFrameRootMargin={deferredOutputIsolatedFrameRootMargin}
               searchQuery={searchQuery}
               onSearchMatchCount={onSearchMatchCount}
               onLinkClick={handleLinkClick}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -78,6 +78,8 @@ export interface NotebookViewProps {
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   outputHostContext?: NteractEmbedHostContextPatch;
+  deferOutputIsolatedFramesUntilVisible?: boolean;
+  deferredOutputIsolatedFrameRootMargin?: string;
   autoFocusFirstCell?: boolean;
 }
 
@@ -350,6 +352,8 @@ function NotebookViewContent({
   onSetCellOutputsHidden,
   markdownHeadingAnchorsByCellId,
   outputHostContext,
+  deferOutputIsolatedFramesUntilVisible = false,
+  deferredOutputIsolatedFrameRootMargin,
   autoFocusFirstCell = true,
 }: NotebookViewProps) {
   const presence = usePresenceContext();
@@ -870,6 +874,8 @@ function NotebookViewContent({
             readOnly={!canEditCodeCellSources}
             canExecute={canExecuteCells}
             outputHostContext={outputHostContext}
+            deferOutputIsolatedFrameUntilVisible={deferOutputIsolatedFramesUntilVisible}
+            deferredOutputIsolatedFrameRootMargin={deferredOutputIsolatedFrameRootMargin}
             onToggleSourceHidden={
               canMutateCells && onSetCellSourceHidden
                 ? (hidden: boolean) => onSetCellSourceHidden(cell.id, hidden)
@@ -976,6 +982,8 @@ function NotebookViewContent({
       canMutateCells,
       canExecuteCells,
       outputHostContext,
+      deferOutputIsolatedFramesUntilVisible,
+      deferredOutputIsolatedFrameRootMargin,
       outputFocusedCellId,
       focusCell,
       handleOutputFocusChange,

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -48,13 +48,22 @@ vi.mock("@/components/cell/OutputArea", () => ({
     focused,
     useOutputWell,
     onIframeMouseDown,
+    preloadIframe,
+    deferIsolatedFrameUntilVisible,
+    deferredIsolatedFrameRootMargin,
   }: {
     focused?: boolean;
     useOutputWell?: boolean;
     onIframeMouseDown?: () => void;
+    preloadIframe?: boolean;
+    deferIsolatedFrameUntilVisible?: boolean;
+    deferredIsolatedFrameRootMargin?: string;
   }) => (
     <button
       data-focused={String(focused)}
+      data-preload-iframe={String(preloadIframe)}
+      data-defer-isolated-frame={String(deferIsolatedFrameUntilVisible)}
+      data-deferred-root-margin={deferredIsolatedFrameRootMargin ?? ""}
       data-use-output-well={String(useOutputWell)}
       data-testid="output"
       type="button"
@@ -228,6 +237,26 @@ describe("CodeCell output focus", () => {
     );
 
     expect(getByTestId("output").getAttribute("data-focused")).toBe("true");
+  });
+
+  it("can defer isolated output frames instead of preloading them", () => {
+    const { getByTestId } = render(
+      <CodeCell
+        cell={makeCell()}
+        deferOutputIsolatedFrameUntilVisible
+        deferredOutputIsolatedFrameRootMargin="400px 0px"
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    const output = getByTestId("output");
+    expect(output.getAttribute("data-preload-iframe")).toBe("false");
+    expect(output.getAttribute("data-defer-isolated-frame")).toBe("true");
+    expect(output.getAttribute("data-deferred-root-margin")).toBe("400px 0px");
   });
 
   it("keeps completed execution state in the stable right readout slot", () => {

--- a/packages/sift/src/react.test.tsx
+++ b/packages/sift/src/react.test.tsx
@@ -266,7 +266,7 @@ describe("SiftTable", () => {
     vi.useFakeTimers();
   });
 
-  it("starts trailing Arrow stream chunk fetches before first chunk append", async () => {
+  it("fetches trailing Arrow stream chunks sequentially after each append", async () => {
     vi.useRealTimers();
     const fetchResolvers: ((response: {
       ok: true;
@@ -315,16 +315,30 @@ describe("SiftTable", () => {
     await waitFor(() => {
       expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(1);
     });
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+    expect(fetchEvents.map((event) => event.url)).toEqual([
+      "http://127.0.0.1:9000/blob/chunk-0",
+      "http://127.0.0.1:9000/blob/chunk-1",
+    ]);
+    expect(fetchEvents[1].appendCallCount).toBe(1);
+
+    fetchResolvers[1](responseFor([4, 5, 6]));
+
+    await waitFor(() => {
+      expect(predicateModule.append_arrow_stream_chunk).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
     expect(fetchEvents.map((event) => event.url)).toEqual([
       "http://127.0.0.1:9000/blob/chunk-0",
       "http://127.0.0.1:9000/blob/chunk-1",
       "http://127.0.0.1:9000/blob/chunk-2",
     ]);
-    expect(fetchEvents[1].appendCallCount).toBe(0);
-    expect(fetchEvents[2].appendCallCount).toBe(0);
+    expect(fetchEvents[2].appendCallCount).toBe(2);
 
-    fetchResolvers[1](responseFor([4, 5, 6]));
     fetchResolvers[2](responseFor([7, 8, 9]));
 
     await waitFor(() => {

--- a/packages/sift/src/react.tsx
+++ b/packages/sift/src/react.tsx
@@ -473,9 +473,6 @@ export function SiftTable({
       };
 
       const firstBytes = await readChunkBytes(fetchChunkResult(chunks[0], 0));
-      const trailingChunkFetches = chunks
-        .slice(1)
-        .map((chunk, index) => fetchChunkResult(chunk, index + 1));
       if (cancelled) return;
       emitLoadMilestone(startedAt, {
         source: "arrow-stream-manifest",
@@ -535,7 +532,7 @@ export function SiftTable({
         if (cancelled) return;
         await new Promise((r) => setTimeout(r, 0));
         if (cancelled) return;
-        const bytes = await readChunkBytes(trailingChunkFetches[i - 1]);
+        const bytes = await readChunkBytes(fetchChunkResult(chunks[i], i));
         if (cancelled) return;
         emitLoadMilestone(startedAt, {
           source: "arrow-stream-manifest",


### PR DESCRIPTION
## Summary

- Defer hosted cloud code-output iframes until they are near the viewport while keeping desktop/editor eager output preload behavior unchanged.
- Keep markdown-source iframes eager so heading anchors and deep links remain available.
- Fetch trailing Sift Arrow stream chunks sequentially after each append instead of starting every trailing chunk fetch at once.

## Profiling

Chrome Beta/CDP against the `topic-viz` notebook:

- Baseline public preview settled around 1523 MB RSS after GC, with renderer RSS around 962 MB, 24 CDP frames, and 23 page iframes.
- Branch-built local viewer against the same pinned snapshot/blobs settled around 1227 MB RSS after GC, with renderer RSS around 635 MB, 13 CDP frames, 12 mounted sandbox iframes, and 6 deferred output placeholders.
- Browser DOM check confirmed real notebook content rendered with 14 code cells, 9 markdown cells, 12 mounted sandbox iframes, 6 deferred placeholders, and no viewer errors.

## Verification

- `pnpm --filter @nteract/sift test`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build:viewer`
