### PR TITLE
fix(markdown): restore preview double click editing

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -282,8 +282,10 @@ export const MarkdownCell = memo(function MarkdownCell({
 
   const handleDoubleClick = useCallback(() => {
     if (readOnly) return;
+    onFocus();
+    setPreviewFrameInteractionActive(false);
     setEditing(true);
-  }, [readOnly]);
+  }, [onFocus, readOnly]);
 
   const releasePreviewFrameInteraction = useCallback(() => {
     setPreviewFrameInteractionActive(false);

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -8,6 +8,7 @@ let mockColorTheme: string | undefined;
 let mockIsFocused = false;
 const isolatedFrameProps: Array<Record<string, unknown>> = [];
 let lastFrameMouseUp: ((params: { hasSelection?: boolean }) => void) | undefined;
+let lastFrameDoubleClick: (() => void) | undefined;
 
 const mockFrameHandle = {
   send: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock("@/components/isolated", async () => {
     Record<string, unknown> & {
       onMouseDown?: () => void;
       onMouseUp?: (params: { hasSelection?: boolean }) => void;
+      onDoubleClick?: () => void;
       onReady?: () => void;
     }
   >(function MockIsolatedFrame(props, ref) {
@@ -54,18 +56,23 @@ vi.mock("@/components/isolated", async () => {
 
     React.useEffect(() => {
       lastFrameMouseUp = props.onMouseUp;
+      lastFrameDoubleClick = props.onDoubleClick;
       return () => {
         if (lastFrameMouseUp === props.onMouseUp) {
           lastFrameMouseUp = undefined;
         }
+        if (lastFrameDoubleClick === props.onDoubleClick) {
+          lastFrameDoubleClick = undefined;
+        }
       };
-    }, [props.onMouseUp]);
+    }, [props.onDoubleClick, props.onMouseUp]);
 
     return (
       <iframe
         data-testid="markdown-frame"
         data-slot="isolated-frame"
         onMouseDown={props.onMouseDown}
+        onDoubleClick={props.onDoubleClick}
       />
     );
   });
@@ -191,6 +198,7 @@ describe("MarkdownCell theme sync", () => {
     mockIsFocused = false;
     isolatedFrameProps.length = 0;
     lastFrameMouseUp = undefined;
+    lastFrameDoubleClick = undefined;
     mockFrameHandle.send.mockClear();
     mockFrameHandle.render.mockClear();
     mockFrameHandle.renderBatch.mockClear();
@@ -398,6 +406,28 @@ describe("MarkdownCell theme sync", () => {
 
     expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(false);
     expect(isolatedFrameProps.at(-1)?.allowWheelBoundaryScroll).toBe(true);
+  });
+
+  it("enters edit mode from an iframe double-click", async () => {
+    mockIsFocused = true;
+    const onFocus = vi.fn();
+
+    const { getByLabelText } = render(
+      <MarkdownCell cell={makeCell()} onFocus={onFocus} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(preview.className).not.toContain("hidden");
+
+    act(() => {
+      lastFrameDoubleClick?.();
+    });
+
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+    expect(onFocus).toHaveBeenCalled();
+    expect(isolatedFrameProps.at(-1)?.scrollPassthrough).toBe(true);
   });
 
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -87,6 +87,12 @@ describe("generateFrameHtml", () => {
     expect(source).toContain("selection.toString().length > 0");
   });
 
+  it("forwards iframe double-clicks during capture phase", () => {
+    expect(source).toMatch(/document\.addEventListener\(\s*'dblclick'/);
+    expect(source).toContain("sendRpc('nteract/doubleClick'");
+    expect(source).toContain("{ capture: true }");
+  });
+
   it("keeps the iframe bootstrap script parseable", () => {
     const scripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -920,13 +920,23 @@
         );
 
         // --- Double Click Forwarding ---
-        document.addEventListener("dblclick", function (e) {
-          // Don't forward double-clicks on links (user is selecting text)
-          const link = e.target.closest("a");
-          if (!link) {
-            sendRpc("nteract/doubleClick", {});
-          }
-        });
+        document.addEventListener(
+          "dblclick",
+          function (e) {
+            // Don't forward double-clicks on links (user is selecting text).
+            // Capture phase keeps markdown renderers from swallowing the edit
+            // affordance after the iframe has taken pointer ownership.
+            var target =
+              e.target && e.target.nodeType === Node.ELEMENT_NODE
+                ? e.target
+                : e.target && e.target.parentElement;
+            var link = target && target.closest ? target.closest("a") : null;
+            if (!link) {
+              sendRpc("nteract/doubleClick", {});
+            }
+          },
+          { capture: true },
+        );
 
         // --- Clear selection on blur ---
         // When focus leaves this iframe (user clicked elsewhere), clear


### PR DESCRIPTION
## Summary

- restore markdown preview double-click editing after iframe pointer handoff
- forward iframe double-click notifications during capture phase so rendered markdown cannot swallow the edit affordance
- add regression coverage for markdown cells and the isolated frame bootstrap

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx src/components/isolated/__tests__/frame-html.test.ts`
