### PR TITLE
fix(notebook-cloud): canonicalize ACL account identities

### DIFF
--- a/apps/notebook-cloud/migrations/0007_principal_account_links.sql
+++ b/apps/notebook-cloud/migrations/0007_principal_account_links.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS principal_account_links (
+  transport_principal TEXT PRIMARY KEY,
+  canonical_principal TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  email_normalized TEXT,
+  first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS principal_account_links_canonical_idx
+  ON principal_account_links(canonical_principal);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -52,7 +52,6 @@ import {
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
   revokePendingNotebookInvite,
-  upsertPrincipalProfile,
   type ListedPendingNotebookInviteRow,
   type PendingNotebookInviteRow,
   type PrincipalProfileRow,
@@ -1795,20 +1794,18 @@ async function syncAuthenticatedProfile(
       displayName: identity.metadata.displayName ?? null,
     };
 
-    if (identity.metadata.provider === "anaconda-api-key") {
-      await upsertPrincipalProfile(env, {
-        ...profile,
-        emailVerified: Boolean(identity.metadata.email),
-      });
-      return;
-    }
-
-    // The identity provider has already authenticated this email claim; use it
-    // to keep profile labels current and resolve pending invite rows into
-    // principal ACL rows before authorization.
+    // Canonical account ACLs are keyed by verified email. OIDC carries an
+    // explicit email_verified claim; Anaconda API-key whoami responses are
+    // trusted to return only server-verified account emails. If that backend
+    // contract changes, API-key email claims must stop feeding invite
+    // resolution and account canonicalization.
     const resolution = await resolveNotebookInvitesForLogin(env, {
       ...profile,
-      emailVerified: identity.metadata.emailVerified === true,
+      principalNamespace: identity.metadata.principalNamespace,
+      emailVerified:
+        identity.metadata.provider === "anaconda-api-key"
+          ? Boolean(identity.metadata.email)
+          : identity.metadata.emailVerified === true,
     });
     if (resolution.acceptedInvites.length === 0 && resolution.aclGrants.length === 0) {
       return;
@@ -1902,10 +1899,10 @@ async function authorizePublishOrCreate(
     return authorizeIdentityOrResponse(env, notebookId, identity, "owner");
   }
 
-  await createNotebookWithOwnerAcl(env, notebookId, identity);
+  const ownerPrincipal = await createNotebookWithOwnerAcl(env, notebookId, identity);
   cloudLog("info", "notebook.created", {
     notebook_id: notebookId,
-    owner_principal: identity.principal,
+    owner_principal: ownerPrincipal,
     actor_label: identity.actorLabel,
     counter: "notebooks_created",
     counter_delta: 1,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -1,5 +1,11 @@
 import type { D1PreparedStatement, Env } from "./cloudflare-types.ts";
-import { ensureCatalogSchema } from "./storage.ts";
+import { validatePrincipal } from "./identity.ts";
+import {
+  canonicalizeNotebookAclForPrincipalStatements,
+  copyNotebookAclForPrincipalStatement,
+  ensureCatalogSchema,
+  type PrincipalAccountLinkRow,
+} from "./storage.ts";
 import {
   normalizeInviteEmail,
   normalizeProviderHint,
@@ -27,6 +33,7 @@ export interface PrincipalProfileRow {
 export interface PrincipalProfileInput {
   principal: string;
   provider: string;
+  principalNamespace?: string | null;
   providerSubject?: string | null;
   email?: string | null;
   emailVerified?: boolean;
@@ -34,6 +41,12 @@ export interface PrincipalProfileInput {
   avatarUrl?: string | null;
   rawClaimsJson?: string | null;
   timestamp?: string;
+}
+
+export interface PrincipalAccountResolution {
+  canonicalPrincipal: string | null;
+  profile: PrincipalProfileRow | null;
+  transportProfile: PrincipalProfileRow | null;
 }
 
 export interface PendingNotebookInviteRow {
@@ -118,6 +131,243 @@ export async function upsertPrincipalProfile(
     .run();
 
   return await getPrincipalProfile(env, input.principal);
+}
+
+export async function upsertPrincipalProfileWithAccount(
+  env: Env,
+  input: PrincipalProfileInput,
+): Promise<PrincipalAccountResolution> {
+  const transportProfile = await upsertPrincipalProfile(env, input);
+  const canonicalPrincipal = await canonicalAccountPrincipalForProfile(input);
+  if (!env.DB || !canonicalPrincipal) {
+    return { canonicalPrincipal: null, profile: transportProfile, transportProfile };
+  }
+
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const accountNamespace = normalizeAccountNamespace(input);
+  const canonicalProfile = await upsertPrincipalProfile(env, {
+    principal: canonicalPrincipal,
+    provider: accountNamespace,
+    providerSubject: null,
+    email: input.email ?? null,
+    emailVerified: true,
+    displayName: input.displayName ?? null,
+    avatarUrl: input.avatarUrl ?? null,
+    rawClaimsJson: input.rawClaimsJson ?? null,
+    timestamp,
+  });
+  await upsertPrincipalAccountLink(env, {
+    transportPrincipal: input.principal,
+    canonicalPrincipal,
+    provider: accountNamespace,
+    email: normalizeMaybeInviteEmail(input.email ?? null),
+    timestamp,
+  });
+  const relatedProfiles = await getVerifiedProfilesForCanonicalAccount(
+    env,
+    accountNamespace,
+    input,
+  );
+  for (const relatedProfile of relatedProfiles) {
+    await upsertPrincipalAccountLink(env, {
+      transportPrincipal: relatedProfile.principal,
+      canonicalPrincipal,
+      provider: accountNamespace,
+      email: relatedProfile.email_normalized,
+      timestamp,
+    });
+  }
+
+  return {
+    canonicalPrincipal,
+    profile: canonicalProfile ?? transportProfile,
+    transportProfile,
+  };
+}
+
+async function getVerifiedProfilesForCanonicalAccount(
+  env: Env,
+  accountNamespace: string,
+  input: Pick<PrincipalProfileInput, "principal" | "email">,
+): Promise<PrincipalProfileRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+  const email = normalizeMaybeInviteEmail(input.email ?? null);
+  if (!email) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT principal,
+            provider,
+            provider_subject,
+            email_normalized,
+            email_verified,
+            display_name,
+            avatar_url,
+            first_seen_at,
+            last_seen_at,
+            raw_claims_json
+       FROM principal_profiles
+      WHERE email_normalized = ?
+        AND email_verified = 1`,
+  )
+    .bind(email)
+    .all<PrincipalProfileRow>();
+  return (rows.results ?? []).filter(
+    (profile) =>
+      profile.principal !== input.principal &&
+      !profile.principal.startsWith("account:") &&
+      principalNamespaceFromPrincipal(profile.principal) === accountNamespace,
+  );
+}
+
+export async function canonicalAccountPrincipalForProfile(
+  input: Pick<PrincipalProfileInput, "principalNamespace" | "provider" | "email" | "emailVerified">,
+): Promise<string | null> {
+  if (!input.emailVerified) {
+    return null;
+  }
+  const email = normalizeMaybeInviteEmail(input.email ?? null);
+  if (!email) {
+    return null;
+  }
+  const accountNamespace = normalizeAccountNamespace(input);
+  const digest = await sha256Hex(`${accountNamespace}\n${email}`);
+  const principal = `account:${encodeURIComponent(accountNamespace)}:email:${digest}`;
+  validatePrincipal(principal);
+  return principal;
+}
+
+async function upsertPrincipalAccountLink(
+  env: Env,
+  input: {
+    transportPrincipal: string;
+    canonicalPrincipal: string;
+    provider: string;
+    email: string | null;
+    timestamp: string;
+  },
+): Promise<PrincipalAccountLinkRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const existing = await getPrincipalAccountLink(env, input.transportPrincipal);
+  const statements: D1PreparedStatement[] = [];
+  if (existing && existing.canonical_principal !== input.canonicalPrincipal) {
+    const oldCanonicalHasOtherTransports = await canonicalPrincipalHasOtherTransportLinks(env, {
+      canonicalPrincipal: existing.canonical_principal,
+      exceptTransportPrincipal: input.transportPrincipal,
+    });
+    if (oldCanonicalHasOtherTransports) {
+      statements.push(
+        copyNotebookAclForPrincipalStatement(env, {
+          sourcePrincipal: existing.canonical_principal,
+          targetPrincipal: input.canonicalPrincipal,
+          timestamp: input.timestamp,
+        }),
+      );
+    } else {
+      statements.push(
+        ...canonicalizeNotebookAclForPrincipalStatements(env, {
+          transportPrincipal: existing.canonical_principal,
+          canonicalPrincipal: input.canonicalPrincipal,
+          timestamp: input.timestamp,
+        }),
+      );
+    }
+  }
+  statements.push(
+    ...canonicalizeNotebookAclForPrincipalStatements(env, {
+      transportPrincipal: input.transportPrincipal,
+      canonicalPrincipal: input.canonicalPrincipal,
+      timestamp: input.timestamp,
+    }),
+    principalAccountLinkUpsertStatement(env, input),
+  );
+
+  await env.DB.batch(statements);
+
+  return await getPrincipalAccountLink(env, input.transportPrincipal);
+}
+
+function principalAccountLinkUpsertStatement(
+  env: Env,
+  input: {
+    transportPrincipal: string;
+    canonicalPrincipal: string;
+    provider: string;
+    email: string | null;
+    timestamp: string;
+  },
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO principal_account_links (
+       transport_principal,
+       canonical_principal,
+       provider,
+       email_normalized,
+       first_seen_at,
+       last_seen_at
+     ) VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(transport_principal) DO UPDATE SET
+       canonical_principal = excluded.canonical_principal,
+       provider = excluded.provider,
+       email_normalized = excluded.email_normalized,
+       last_seen_at = excluded.last_seen_at`,
+    )
+    .bind(
+      input.transportPrincipal,
+      input.canonicalPrincipal,
+      input.provider,
+      input.email,
+      input.timestamp,
+      input.timestamp,
+    );
+}
+
+async function getPrincipalAccountLink(
+  env: Env,
+  transportPrincipal: string,
+): Promise<PrincipalAccountLinkRow | null> {
+  return await env
+    .DB!.prepare(
+      `SELECT transport_principal,
+            canonical_principal,
+            provider,
+            email_normalized,
+            first_seen_at,
+            last_seen_at
+       FROM principal_account_links
+      WHERE transport_principal = ?`,
+    )
+    .bind(transportPrincipal)
+    .first<PrincipalAccountLinkRow>();
+}
+
+async function canonicalPrincipalHasOtherTransportLinks(
+  env: Env,
+  input: {
+    canonicalPrincipal: string;
+    exceptTransportPrincipal: string;
+  },
+): Promise<boolean> {
+  const row = await env
+    .DB!.prepare(
+      `SELECT transport_principal
+         FROM principal_account_links
+        WHERE canonical_principal = ?
+          AND transport_principal != ?
+        LIMIT 1`,
+    )
+    .bind(input.canonicalPrincipal, input.exceptTransportPrincipal)
+    .first<Pick<PrincipalAccountLinkRow, "transport_principal">>();
+  return Boolean(row);
 }
 
 export async function getPrincipalProfile(
@@ -442,9 +692,10 @@ export async function resolveNotebookInvitesForLogin(
 ): Promise<InviteResolution> {
   // Trust boundary: callers must pass identity-provider verified claims.
   // Invite acceptance is derived from login.email plus login.emailVerified.
-  const profile = await upsertPrincipalProfile(env, {
+  const account = await upsertPrincipalProfileWithAccount(env, {
     principal: login.principal,
     provider: login.provider,
+    principalNamespace: login.principalNamespace,
     email: login.email,
     emailVerified: login.emailVerified,
     displayName: login.displayName,
@@ -452,10 +703,15 @@ export async function resolveNotebookInvitesForLogin(
   });
 
   const invites = await getPendingNotebookInvitesForLogin(env, login, now);
-  const resolution = resolvePendingInvitesForLogin({ invites, login, now });
+  const resolution = resolvePendingInvitesForLogin({
+    invites,
+    login,
+    aclSubject: account.canonicalPrincipal ?? login.principal,
+    now,
+  });
   const resolutionWithProfile = {
     ...resolution,
-    profile: profileFromRow(profile) ?? resolution.profile,
+    profile: profileFromRow(account.profile) ?? resolution.profile,
   };
   if (!env.DB || resolution.aclGrants.length === 0) {
     return resolutionWithProfile;
@@ -548,7 +804,7 @@ function inviteAclInsert(
       timestamp,
       grant.actorLabel,
       invite.id,
-      grant.subject,
+      grant.acceptedByPrincipal,
       timestamp,
       normalizeInviteEmail(invite.email),
       normalizeProviderHint(invite.providerHint),
@@ -578,7 +834,7 @@ function inviteAcceptedUpdate(
           )`,
     )
     .bind(
-      grant.subject,
+      grant.acceptedByPrincipal,
       timestamp,
       invite.id,
       normalizeInviteEmail(invite.email),
@@ -665,6 +921,26 @@ function profileFromRow(row: PrincipalProfileRow | null): InviteResolution["prof
     firstSeenAt: row.first_seen_at,
     lastSeenAt: row.last_seen_at,
   };
+}
+
+function normalizeAccountNamespace(
+  input: Pick<PrincipalProfileInput, "principalNamespace" | "provider">,
+): string {
+  return normalizeRequiredProvider(input.principalNamespace ?? input.provider);
+}
+
+function principalNamespaceFromPrincipal(principal: string): string | null {
+  const [scheme, provider] = principal.split(":", 3);
+  if (!scheme || !provider) {
+    return null;
+  }
+  return `${scheme}:${provider}`.toLowerCase();
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function isUniqueConstraintError(error: unknown): boolean {

--- a/apps/notebook-cloud/src/sharing.ts
+++ b/apps/notebook-cloud/src/sharing.ts
@@ -19,6 +19,7 @@ export interface PendingNotebookInvite {
 export interface AuthenticatedLoginProfile {
   principal: string;
   provider: string;
+  principalNamespace?: string | null;
   email: string | null;
   emailVerified: boolean;
   displayName: string | null;
@@ -40,6 +41,7 @@ export interface InviteAclGrant {
   scope: PendingNotebookInvite["scope"];
   actorLabel: string;
   inviteId: string;
+  acceptedByPrincipal: string;
 }
 
 export interface InviteResolution {
@@ -102,10 +104,12 @@ export function normalizeProviderHint(provider: string | null): string | null {
 export function resolvePendingInvitesForLogin({
   invites,
   login,
+  aclSubject,
   now = new Date().toISOString(),
 }: {
   invites: PendingNotebookInvite[];
   login: AuthenticatedLoginProfile;
+  aclSubject?: string;
   now?: string;
 }): InviteResolution {
   const normalizedEmail = safeNormalizeInviteEmail(login.email);
@@ -135,10 +139,11 @@ export function resolvePendingInvitesForLogin({
   const aclGrants = acceptedInvites.map((invite) => ({
     notebookId: invite.notebookId,
     subjectKind: "principal" as const,
-    subject: login.principal,
+    subject: aclSubject ?? login.principal,
     scope: invite.scope,
     actorLabel: INVITE_RESOLUTION_ACTOR_LABEL,
     inviteId: invite.id,
+    acceptedByPrincipal: login.principal,
   }));
 
   return { profile, acceptedInvites, aclGrants };

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -70,6 +70,15 @@ export interface NotebookAccessRequestRow {
   resolved_at: string | null;
 }
 
+export interface PrincipalAccountLinkRow {
+  transport_principal: string;
+  canonical_principal: string;
+  provider: string;
+  email_normalized: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -130,6 +139,16 @@ const SCHEMA_STATEMENTS = [
   `CREATE INDEX IF NOT EXISTS principal_profiles_email_idx
     ON principal_profiles(provider, email_normalized)
     WHERE email_verified = 1`,
+  `CREATE TABLE IF NOT EXISTS principal_account_links (
+    transport_principal TEXT PRIMARY KEY,
+    canonical_principal TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    email_normalized TEXT,
+    first_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_seen_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS principal_account_links_canonical_idx
+    ON principal_account_links(canonical_principal)`,
   `CREATE TABLE IF NOT EXISTS notebook_invites (
     id TEXT PRIMARY KEY,
     notebook_id TEXT NOT NULL,
@@ -330,10 +349,17 @@ export async function getNotebookAclRowsForPrincipal(
        FROM notebook_acl
        WHERE notebook_id = ?
          AND subject_kind = 'principal'
-         AND subject = ?
+         AND (
+           subject = ?
+           OR subject IN (
+             SELECT canonical_principal
+               FROM principal_account_links
+              WHERE transport_principal = ?
+           )
+         )
        ORDER BY scope`,
   )
-    .bind(notebookId, principal)
+    .bind(notebookId, principal, principal)
     .all<NotebookAclRow>();
   return rows.results ?? [];
 }
@@ -442,26 +468,166 @@ export async function createNotebookWithOwnerAcl(
   env: Env,
   notebookId: string,
   identity: AuthenticatedConnection,
-): Promise<void> {
+): Promise<string> {
   if (!env.DB) {
-    return;
+    return identity.principal;
   }
 
   await ensureCatalogSchema(env);
   const now = new Date().toISOString();
+  const ownerSubject =
+    (await getCanonicalPrincipalForTransport(env, identity.principal)) ?? identity.principal;
   await env.DB.batch([
     env.DB.prepare(
       `INSERT INTO notebooks (id, owner_principal, created_at, updated_at)
          VALUES (?, ?, ?, ?)
          ON CONFLICT(id) DO NOTHING`,
-    ).bind(notebookId, identity.principal, now, now),
+    ).bind(notebookId, ownerSubject, now, now),
     notebookOwnerAclInsert(env, {
       notebookId,
-      subject: identity.principal,
+      subject: ownerSubject,
       actorLabel: identity.actorLabel,
       timestamp: now,
     }),
   ]);
+  return ownerSubject;
+}
+
+export async function getCanonicalPrincipalForTransport(
+  env: Env,
+  transportPrincipal: string,
+): Promise<string | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const row = await env.DB.prepare(
+    `SELECT canonical_principal
+       FROM principal_account_links
+      WHERE transport_principal = ?`,
+  )
+    .bind(transportPrincipal)
+    .first<Pick<PrincipalAccountLinkRow, "canonical_principal">>();
+  return row?.canonical_principal ?? null;
+}
+
+export async function canonicalizeNotebookAclForPrincipal(
+  env: Env,
+  input: {
+    transportPrincipal: string;
+    canonicalPrincipal: string;
+    timestamp?: string;
+  },
+): Promise<void> {
+  if (!env.DB || input.transportPrincipal === input.canonicalPrincipal) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  await env.DB.batch(
+    canonicalizeNotebookAclForPrincipalStatements(env, {
+      transportPrincipal: input.transportPrincipal,
+      canonicalPrincipal: input.canonicalPrincipal,
+      timestamp,
+    }),
+  );
+}
+
+export function canonicalizeNotebookAclForPrincipalStatements(
+  env: Env,
+  input: {
+    transportPrincipal: string;
+    canonicalPrincipal: string;
+    timestamp: string;
+  },
+): D1PreparedStatement[] {
+  if (!env.DB || input.transportPrincipal === input.canonicalPrincipal) {
+    return [];
+  }
+
+  return [
+    copyNotebookAclForPrincipalStatement(env, {
+      sourcePrincipal: input.transportPrincipal,
+      targetPrincipal: input.canonicalPrincipal,
+      timestamp: input.timestamp,
+    }),
+    env.DB.prepare(
+      `UPDATE notebooks
+          SET owner_principal = ?,
+              updated_at = ?
+        WHERE owner_principal = ?`,
+    ).bind(input.canonicalPrincipal, input.timestamp, input.transportPrincipal),
+    env.DB.prepare(
+      `DELETE FROM notebook_acl
+        WHERE subject_kind = 'principal'
+          AND subject = ?
+          AND EXISTS (
+            SELECT 1
+              FROM notebook_acl AS target_acl
+             WHERE target_acl.notebook_id = notebook_acl.notebook_id
+               AND target_acl.subject_kind = 'principal'
+               AND target_acl.subject = ?
+               AND target_acl.scope = notebook_acl.scope
+          )`,
+    ).bind(input.transportPrincipal, input.canonicalPrincipal),
+  ];
+}
+
+export async function copyNotebookAclForPrincipal(
+  env: Env,
+  input: {
+    sourcePrincipal: string;
+    targetPrincipal: string;
+    timestamp?: string;
+  },
+): Promise<void> {
+  if (!env.DB || input.sourcePrincipal === input.targetPrincipal) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await copyNotebookAclForPrincipalStatement(env, {
+    sourcePrincipal: input.sourcePrincipal,
+    targetPrincipal: input.targetPrincipal,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+  }).run();
+}
+
+export function copyNotebookAclForPrincipalStatement(
+  env: Env,
+  input: {
+    sourcePrincipal: string;
+    targetPrincipal: string;
+    timestamp: string;
+  },
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO notebook_acl (
+       notebook_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT notebook_id,
+            'principal',
+            ?,
+            scope,
+            created_at,
+            ?,
+            created_by_actor_label
+       FROM notebook_acl
+      WHERE subject_kind = 'principal'
+        AND subject = ?
+     ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(input.targetPrincipal, input.timestamp, input.sourcePrincipal);
 }
 
 function notebookAclInsert(

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -10,6 +10,7 @@ import type {
 } from "../src/cloudflare-types.ts";
 import {
   createPendingNotebookInvite,
+  canonicalAccountPrincipalForProfile,
   getPrincipalProfiles,
   resolveNotebookInvitesForLogin,
   upsertPrincipalProfile,
@@ -17,6 +18,7 @@ import {
   type PrincipalProfileRow,
 } from "../src/sharing-storage.ts";
 import type { NotebookAclRow } from "../src/storage.ts";
+import type { PrincipalAccountLinkRow } from "../src/storage.ts";
 import type { AuthenticatedLoginProfile } from "../src/sharing.ts";
 
 describe("hosted sharing storage", () => {
@@ -138,6 +140,7 @@ describe("hosted sharing storage", () => {
       timestamp: "2026-05-24T11:00:00.000Z",
     });
 
+    const accountPrincipal = await oidcAccountPrincipal();
     const resolution = await resolveNotebookInvitesForLogin(
       env,
       oidcLogin(),
@@ -158,7 +161,7 @@ describe("hosted sharing storage", () => {
       {
         notebook_id: "notebook-1",
         subject_kind: "principal",
-        subject: "user:oidc:oidc-sub-1",
+        subject: accountPrincipal,
         scope: "editor",
         created_at: "2026-05-24T12:00:00.000Z",
         updated_at: "2026-05-24T12:00:00.000Z",
@@ -166,6 +169,200 @@ describe("hosted sharing storage", () => {
       },
     ]);
     assert.doesNotMatch(env.DB.acl[0]?.subject ?? "", /alice@example.com/);
+  });
+
+  it("merges same-account OIDC and API-key ACL rows onto one canonical account subject", async () => {
+    const env = fakeEnv();
+    const apiKeyLogin = oidcLogin({
+      principal: "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
+      provider: "anaconda-api-key",
+      principalNamespace: "user:anaconda",
+      email: "rgbkrk@gmail.com",
+      displayName: "Kyle Kelley",
+    });
+    const oidcBrowserLogin = oidcLogin({
+      principal: "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "rgbkrk@gmail.com",
+      displayName: "Kyle Kelley",
+    });
+    const accountPrincipal = await canonicalAccountPrincipalForProfile(apiKeyLogin);
+    assert.ok(accountPrincipal);
+    env.DB.acl.push(
+      aclRow({
+        subject: apiKeyLogin.principal,
+        scope: "owner",
+        created_by_actor_label: `${apiKeyLogin.principal}/agent:runt-publish`,
+      }),
+      aclRow({
+        subject: oidcBrowserLogin.principal,
+        scope: "owner",
+        created_by_actor_label: `${oidcBrowserLogin.principal}/browser:tab`,
+      }),
+    );
+
+    await resolveNotebookInvitesForLogin(env, apiKeyLogin, "2026-05-24T12:00:00.000Z");
+    await resolveNotebookInvitesForLogin(env, oidcBrowserLogin, "2026-05-24T12:01:00.000Z");
+
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.subject, row.scope]),
+      [[accountPrincipal, "owner"]],
+    );
+    assert.equal(
+      env.DB.accountLinks.get(apiKeyLogin.principal)?.canonical_principal,
+      accountPrincipal,
+    );
+    assert.equal(
+      env.DB.accountLinks.get(oidcBrowserLogin.principal)?.canonical_principal,
+      accountPrincipal,
+    );
+    assert.equal(env.DB.profiles.get(accountPrincipal)?.display_name, "Kyle Kelley");
+  });
+
+  it("moves ACL rows from an old canonical account when a transport link changes", async () => {
+    const env = fakeEnv();
+    const oldLogin = oidcLogin({ email: "alice.old@example.com" });
+    const newLogin = oidcLogin({ email: "alice.new@example.com" });
+    const oldAccountPrincipal = await canonicalAccountPrincipalForProfile(oldLogin);
+    const newAccountPrincipal = await canonicalAccountPrincipalForProfile(newLogin);
+    assert.ok(oldAccountPrincipal);
+    assert.ok(newAccountPrincipal);
+    env.DB.accountLinks.set(
+      oldLogin.principal,
+      accountLinkRow({
+        transport_principal: oldLogin.principal,
+        canonical_principal: oldAccountPrincipal,
+        email_normalized: "alice.old@example.com",
+      }),
+    );
+    env.DB.acl.push(
+      aclRow({
+        subject: oldAccountPrincipal,
+        scope: "editor",
+      }),
+    );
+
+    await resolveNotebookInvitesForLogin(env, newLogin, "2026-05-24T12:02:00.000Z");
+
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.subject, row.scope, row.updated_at]),
+      [[newAccountPrincipal, "editor", "2026-05-24T12:02:00.000Z"]],
+    );
+    assert.equal(
+      env.DB.accountLinks.get(newLogin.principal)?.canonical_principal,
+      newAccountPrincipal,
+    );
+  });
+
+  it("copies ACL rows when an old canonical account is still linked elsewhere", async () => {
+    const env = fakeEnv();
+    const movingLogin = oidcLogin({ email: "moving.new@example.com" });
+    const otherTransportPrincipal = "user:oidc:other-sub";
+    const oldAccountPrincipal = await canonicalAccountPrincipalForProfile(
+      oidcLogin({ email: "shared.old@example.com" }),
+    );
+    const newAccountPrincipal = await canonicalAccountPrincipalForProfile(movingLogin);
+    assert.ok(oldAccountPrincipal);
+    assert.ok(newAccountPrincipal);
+    env.DB.accountLinks.set(
+      movingLogin.principal,
+      accountLinkRow({
+        transport_principal: movingLogin.principal,
+        canonical_principal: oldAccountPrincipal,
+        email_normalized: "shared.old@example.com",
+      }),
+    );
+    env.DB.accountLinks.set(
+      otherTransportPrincipal,
+      accountLinkRow({
+        transport_principal: otherTransportPrincipal,
+        canonical_principal: oldAccountPrincipal,
+        email_normalized: "shared.old@example.com",
+      }),
+    );
+    env.DB.acl.push(
+      aclRow({
+        subject: oldAccountPrincipal,
+        scope: "editor",
+      }),
+    );
+
+    await resolveNotebookInvitesForLogin(env, movingLogin, "2026-05-24T12:02:30.000Z");
+
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.subject, row.scope, row.updated_at]),
+      [
+        [oldAccountPrincipal, "editor", "2026-05-24T11:00:00.000Z"],
+        [newAccountPrincipal, "editor", "2026-05-24T12:02:30.000Z"],
+      ],
+    );
+    assert.equal(
+      env.DB.accountLinks.get(movingLogin.principal)?.canonical_principal,
+      newAccountPrincipal,
+    );
+    assert.equal(
+      env.DB.accountLinks.get(otherTransportPrincipal)?.canonical_principal,
+      oldAccountPrincipal,
+    );
+  });
+
+  it("moves related profile ACL rows from an old canonical account before relinking", async () => {
+    const env = fakeEnv();
+    const currentLogin = oidcLogin({
+      principal: "user:anaconda:current",
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "shared@example.com",
+    });
+    const relatedLogin = oidcLogin({
+      principal: "User:Anaconda:related:with-colon",
+      provider: "anaconda-api-key",
+      principalNamespace: "user:anaconda",
+      email: "shared@example.com",
+    });
+    const relatedOldAccountPrincipal = await canonicalAccountPrincipalForProfile({
+      ...relatedLogin,
+      email: "related.old@example.com",
+    });
+    const sharedAccountPrincipal = await canonicalAccountPrincipalForProfile(currentLogin);
+    assert.ok(relatedOldAccountPrincipal);
+    assert.ok(sharedAccountPrincipal);
+    env.DB.profiles.set(
+      relatedLogin.principal,
+      profileRow({
+        principal: relatedLogin.principal,
+        provider: relatedLogin.provider,
+        email_normalized: "shared@example.com",
+        email_verified: 1,
+      }),
+    );
+    env.DB.accountLinks.set(
+      relatedLogin.principal,
+      accountLinkRow({
+        transport_principal: relatedLogin.principal,
+        canonical_principal: relatedOldAccountPrincipal,
+        provider: "user:anaconda",
+        email_normalized: "related.old@example.com",
+      }),
+    );
+    env.DB.acl.push(
+      aclRow({
+        subject: relatedOldAccountPrincipal,
+        scope: "owner",
+      }),
+    );
+
+    await resolveNotebookInvitesForLogin(env, currentLogin, "2026-05-24T12:03:00.000Z");
+
+    assert.deepEqual(
+      env.DB.acl.map((row) => [row.subject, row.scope, row.updated_at]),
+      [[sharedAccountPrincipal, "owner", "2026-05-24T12:03:00.000Z"]],
+    );
+    assert.equal(
+      env.DB.accountLinks.get(relatedLogin.principal)?.canonical_principal,
+      sharedAccountPrincipal,
+    );
   });
 
   it("does not duplicate ACL rows when invite resolution reruns", async () => {
@@ -616,8 +813,58 @@ function oidcLogin(overrides: Partial<AuthenticatedLoginProfile> = {}): Authenti
   };
 }
 
+async function oidcAccountPrincipal(
+  overrides: Partial<AuthenticatedLoginProfile> = {},
+): Promise<string> {
+  const principal = await canonicalAccountPrincipalForProfile(oidcLogin(overrides));
+  assert.ok(principal);
+  return principal;
+}
+
+function aclRow(overrides: Partial<NotebookAclRow> = {}): NotebookAclRow {
+  return {
+    notebook_id: "notebook-1",
+    subject_kind: "principal",
+    subject: "user:oidc:oidc-sub-1",
+    scope: "viewer",
+    created_at: "2026-05-24T11:00:00.000Z",
+    updated_at: "2026-05-24T11:00:00.000Z",
+    created_by_actor_label: "system/test",
+    ...overrides,
+  };
+}
+
+function accountLinkRow(overrides: Partial<PrincipalAccountLinkRow> = {}): PrincipalAccountLinkRow {
+  return {
+    transport_principal: "user:oidc:oidc-sub-1",
+    canonical_principal: "account:oidc:email:test",
+    provider: "oidc",
+    email_normalized: "alice@example.com",
+    first_seen_at: "2026-05-24T11:00:00.000Z",
+    last_seen_at: "2026-05-24T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function profileRow(overrides: Partial<PrincipalProfileRow> = {}): PrincipalProfileRow {
+  return {
+    principal: "user:oidc:oidc-sub-1",
+    provider: "oidc",
+    provider_subject: null,
+    email_normalized: "alice@example.com",
+    email_verified: 1,
+    display_name: "Alice Example",
+    avatar_url: null,
+    first_seen_at: "2026-05-24T11:00:00.000Z",
+    last_seen_at: "2026-05-24T11:00:00.000Z",
+    raw_claims_json: null,
+    ...overrides,
+  };
+}
+
 class FakeD1 implements D1Database {
   readonly profiles = new Map<string, PrincipalProfileRow>();
+  readonly accountLinks = new Map<string, PrincipalAccountLinkRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly acl: NotebookAclRow[] = [];
   readonly deletedNotebookIds = new Set<string>();
@@ -663,6 +910,19 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM principal_account_links")) {
+      if (this.query.includes("canonical_principal = ?")) {
+        const [canonicalPrincipal, exceptTransportPrincipal] = this.values as [string, string];
+        return (
+          ([...this.db.accountLinks.values()].find(
+            (link) =>
+              link.canonical_principal === canonicalPrincipal &&
+              link.transport_principal !== exceptTransportPrincipal,
+          ) as T | undefined) ?? null
+        );
+      }
+      return (this.db.accountLinks.get(this.values[0] as string) as T | undefined) ?? null;
+    }
     if (this.query.includes("FROM principal_profiles")) {
       return (this.db.profiles.get(this.values[0] as string) as T | undefined) ?? null;
     }
@@ -729,6 +989,63 @@ class FakeD1Statement implements D1PreparedStatement {
         last_seen_at: lastSeenAt,
         raw_claims_json: rawClaimsJson,
       });
+    } else if (this.query.includes("INSERT INTO principal_account_links")) {
+      const [
+        transportPrincipal,
+        canonicalPrincipal,
+        provider,
+        emailNormalized,
+        firstSeenAt,
+        lastSeenAt,
+      ] = this.values as [string, string, string, string | null, string, string];
+      const existing = this.db.accountLinks.get(transportPrincipal);
+      this.db.accountLinks.set(transportPrincipal, {
+        transport_principal: transportPrincipal,
+        canonical_principal: canonicalPrincipal,
+        provider,
+        email_normalized: emailNormalized,
+        first_seen_at: existing?.first_seen_at ?? firstSeenAt,
+        last_seen_at: lastSeenAt,
+      });
+    } else if (
+      this.query.includes("INSERT INTO notebook_acl") &&
+      this.query.includes("FROM notebook_acl")
+    ) {
+      const [canonicalPrincipal, updatedAt, transportPrincipal] = this.values as [
+        string,
+        string,
+        string,
+      ];
+      const rows = this.db.acl.filter(
+        (row) => row.subject_kind === "principal" && row.subject === transportPrincipal,
+      );
+      for (const row of rows) {
+        this.insertAclIfMissing({
+          ...row,
+          subject: canonicalPrincipal,
+          updated_at: updatedAt,
+        });
+      }
+    } else if (
+      this.query.includes("DELETE FROM notebook_acl") &&
+      this.query.includes("subject_kind = 'principal'")
+    ) {
+      const [transportPrincipal, canonicalPrincipal] = this.values as [string, string];
+      const retained = this.db.acl.filter(
+        (row) =>
+          !(
+            row.subject_kind === "principal" &&
+            row.subject === transportPrincipal &&
+            this.db.acl.some(
+              (target) =>
+                target.notebook_id === row.notebook_id &&
+                target.subject_kind === "principal" &&
+                target.subject === canonicalPrincipal &&
+                target.scope === row.scope,
+            )
+          ),
+      );
+      this.db.acl.splice(0, this.db.acl.length, ...retained);
     } else if (this.query.includes("INSERT INTO notebook_invites")) {
       const [
         id,
@@ -858,6 +1175,14 @@ class FakeD1Statement implements D1PreparedStatement {
       return okResult([{ name: "runtime_snapshot_key" }, { name: "runtime_state_doc_id" }] as T[]);
     }
     if (this.query.includes("FROM principal_profiles")) {
+      if (this.query.includes("email_normalized = ?")) {
+        const [email] = this.values as [string];
+        return okResult(
+          [...this.db.profiles.values()].filter(
+            (profile) => profile.email_normalized === email && profile.email_verified === 1,
+          ) as T[],
+        );
+      }
       const principals = new Set(this.values as string[]);
       this.db.maxPrincipalProfileLookupBindCount = Math.max(
         this.db.maxPrincipalProfileLookupBindCount,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -33,6 +33,8 @@ import {
   snapshotKey,
 } from "../src/storage.ts";
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
+import { canonicalAccountPrincipalForProfile } from "../src/sharing-storage.ts";
+import type { PrincipalAccountLinkRow } from "../src/storage.ts";
 import { oidcTokenFixture } from "./oidc-jwt-fixture.ts";
 
 const wasmBytes = await readFile(
@@ -523,18 +525,27 @@ describe("Worker artifact routes", () => {
       size: body.byteLength,
     });
     assert.deepEqual(seenAuthorizations, [`Bearer ${token}`]);
-    assert.equal(
-      env.DB.notebooks.get("api-key-artifact-demo")?.owner_principal,
-      "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
-    );
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "anaconda-api-key",
+      principalNamespace: "user:anaconda",
+      email: "rgbkrk@gmail.com",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    assert.equal(env.DB.notebooks.get("api-key-artifact-demo")?.owner_principal, accountPrincipal);
     assert.equal(
       env.DB.acl.some(
         (row) =>
           row.notebook_id === "api-key-artifact-demo" &&
-          row.subject === "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0" &&
+          row.subject === accountPrincipal &&
           row.scope === "owner",
       ),
       true,
+    );
+    assert.equal(
+      env.DB.accountLinks.get("user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0")
+        ?.canonical_principal,
+      accountPrincipal,
     );
     const profile = env.DB.profiles.get("user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0");
     assert.deepEqual(profile, {
@@ -549,6 +560,85 @@ describe("Worker artifact routes", () => {
       last_seen_at: profile?.last_seen_at,
       raw_claims_json: null,
     });
+  });
+
+  it("authorizes OIDC and API-key transports through one canonical account ACL", async (t) => {
+    const apiKeyToken = anacondaApiKeyToken();
+    const { env: oidcEnv, token: oidcToken } = await oidcTokenFixture({
+      subject: "fe0f6c3a-f7c7-4c04-9b8d-77e596da1375",
+      email: "rgbkrk@gmail.com",
+      extraPayload: { email_verified: true },
+      name: "Kyle Kelley",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      ...anacondaApiKeyEnv(),
+    });
+
+    t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse(
+        anacondaWhoami({
+          email: "rgbkrk@gmail.com",
+          firstName: "Kyle",
+          lastName: "Kelley",
+          userId: "fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
+          scopes: ["cloud:write"],
+        }),
+      ),
+    );
+
+    const publish = await worker.fetch(
+      new Request("https://cloud.test/api/n/canonical-account-demo/runtime-snapshots/api-key", {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${apiKeyToken}`,
+          "Content-Type": "application/octet-stream",
+          "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+          "X-Operator": "agent:runt-publish",
+          "X-Runtime-State-Doc-Id": "runtime:canonical-account-demo",
+          "X-Scope": "owner",
+        },
+        body: new Uint8Array([1, 2, 3, 4]),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(publish.status, 201);
+
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "rgbkrk@gmail.com",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    const acl = await worker.fetch(
+      new Request("https://cloud.test/api/n/canonical-account-demo/acl?scope=owner", {
+        headers: {
+          Authorization: `Bearer ${oidcToken}`,
+          "X-Operator": "browser:tab",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(acl.status, 200);
+    const body = (await acl.json()) as { acl: NotebookAclRow[] };
+    assert.deepEqual(
+      body.acl.map((row) => [row.subject, row.scope]),
+      [[accountPrincipal, "owner"]],
+    );
+    assert.equal(
+      env.DB.accountLinks.get("user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0")
+        ?.canonical_principal,
+      accountPrincipal,
+    );
+    assert.equal(
+      env.DB.accountLinks.get("user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375")
+        ?.canonical_principal,
+      accountPrincipal,
+    );
   });
 
   it("requires RuntimeStateDoc ids for snapshot publishes", async () => {
@@ -1846,12 +1936,19 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     assert.ok(forwardedRequest);
     assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "kkelley@anaconda.com",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
     assert.ok(
       env.DB.acl.some(
         (row) =>
           row.notebook_id === "oidc-invite-demo" &&
           row.subject_kind === "principal" &&
-          row.subject === "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375" &&
+          row.subject === accountPrincipal &&
           row.scope === "editor",
       ),
     );
@@ -2693,6 +2790,7 @@ class FakeD1 implements D1Database {
   readonly blobs = new Map<string, BlobRow>();
   readonly acl: NotebookAclRow[] = [];
   readonly profiles = new Map<string, PrincipalProfileRow>();
+  readonly accountLinks = new Map<string, PrincipalAccountLinkRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly accessRequests = new Map<string, NotebookAccessRequestRow>();
   readonly batchSizes: number[] = [];
@@ -2853,6 +2951,25 @@ class FakeD1Statement implements D1PreparedStatement {
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
+    } else if (
+      this.query.includes("INSERT INTO notebook_acl") &&
+      this.query.includes("FROM notebook_acl")
+    ) {
+      const [canonicalPrincipal, updatedAt, transportPrincipal] = this.values as [
+        string,
+        string,
+        string,
+      ];
+      const rows = this.db.acl.filter(
+        (row) => row.subject_kind === "principal" && row.subject === transportPrincipal,
+      );
+      for (const row of rows) {
+        this.insertAclIfMissing({
+          ...row,
+          subject: canonicalPrincipal,
+          updated_at: updatedAt,
+        });
+      }
     } else if (this.query.includes("INSERT INTO notebook_acl")) {
       const [notebookId, subjectKind, subject, scope, createdAt, updatedAt, actorLabel] = this
         .values as [
@@ -2873,6 +2990,27 @@ class FakeD1Statement implements D1PreparedStatement {
         updated_at: updatedAt,
         created_by_actor_label: actorLabel,
       });
+    } else if (
+      this.query.includes("DELETE FROM notebook_acl") &&
+      this.query.includes("subject_kind = 'principal'") &&
+      !this.query.includes("notebook_id = ?")
+    ) {
+      const [transportPrincipal, canonicalPrincipal] = this.values as [string, string];
+      const retained = this.db.acl.filter(
+        (row) =>
+          !(
+            row.subject_kind === "principal" &&
+            row.subject === transportPrincipal &&
+            this.db.acl.some(
+              (target) =>
+                target.notebook_id === row.notebook_id &&
+                target.subject_kind === "principal" &&
+                target.subject === canonicalPrincipal &&
+                target.scope === row.scope,
+            )
+          ),
+      );
+      this.db.acl.splice(0, this.db.acl.length, ...retained);
     } else if (this.query.includes("DELETE FROM notebook_acl")) {
       const [notebookId, subjectKind, subject, scope] = this.values as [
         string,
@@ -3086,6 +3224,17 @@ class FakeD1Statement implements D1PreparedStatement {
         existing.latest_revision_id = revisionId;
         existing.updated_at = updatedAt;
       }
+    } else if (this.query.includes("UPDATE notebooks") && this.query.includes("owner_principal")) {
+      const [canonicalPrincipal, updatedAt, transportPrincipal] = this.values as [
+        string,
+        string,
+        string,
+      ];
+      for (const notebook of this.db.notebooks.values()) {
+        if (notebook.owner_principal !== transportPrincipal) continue;
+        notebook.owner_principal = canonicalPrincipal;
+        notebook.updated_at = updatedAt;
+      }
     } else if (this.query.includes("UPDATE notebooks")) {
       const [updatedAt, notebookId] = this.values as [string, string];
       const existing = this.db.notebooks.get(notebookId);
@@ -3144,6 +3293,24 @@ class FakeD1Statement implements D1PreparedStatement {
         first_seen_at: existing?.first_seen_at ?? firstSeenAt,
         last_seen_at: lastSeenAt,
         raw_claims_json: rawClaimsJson,
+      });
+    } else if (this.query.includes("INSERT INTO principal_account_links")) {
+      const [
+        transportPrincipal,
+        canonicalPrincipal,
+        provider,
+        emailNormalized,
+        firstSeenAt,
+        lastSeenAt,
+      ] = this.values as [string, string, string, string | null, string, string];
+      const existing = this.db.accountLinks.get(transportPrincipal);
+      this.db.accountLinks.set(transportPrincipal, {
+        transport_principal: transportPrincipal,
+        canonical_principal: canonicalPrincipal,
+        provider,
+        email_normalized: emailNormalized,
+        first_seen_at: existing?.first_seen_at ?? firstSeenAt,
+        last_seen_at: lastSeenAt,
       });
     } else if (this.query.includes("UPDATE notebook_invites")) {
       const [principal, acceptedAt, inviteId, email, providerHint, now] = this.values as [
@@ -3214,6 +3381,19 @@ class FakeD1Statement implements D1PreparedStatement {
         ) as T | undefined) ?? null
       );
     }
+    if (this.query.includes("FROM principal_account_links")) {
+      if (this.query.includes("canonical_principal = ?")) {
+        const [canonicalPrincipal, exceptTransportPrincipal] = this.values as [string, string];
+        return (
+          ([...this.db.accountLinks.values()].find(
+            (link) =>
+              link.canonical_principal === canonicalPrincipal &&
+              link.transport_principal !== exceptTransportPrincipal,
+          ) as T | undefined) ?? null
+        );
+      }
+      return (this.db.accountLinks.get(this.values[0] as string) as T | undefined) ?? null;
+    }
     if (this.query.includes("FROM notebook_invites")) {
       if (this.query.includes("WHERE notebook_id = ?")) {
         const [notebookId, email, scope, providerHint] = this.values as [
@@ -3260,6 +3440,14 @@ class FakeD1Statement implements D1PreparedStatement {
       );
     }
     if (this.query.includes("FROM principal_profiles")) {
+      if (this.query.includes("email_normalized = ?")) {
+        const [email] = this.values as [string];
+        return okResult(
+          [...this.db.profiles.values()].filter(
+            (profile) => profile.email_normalized === email && profile.email_verified === 1,
+          ) as T[],
+        );
+      }
       const principals = new Set(this.values as string[]);
       if (this.values.length > 100) {
         throw new Error("D1_ERROR: too many SQL variables");
@@ -3296,12 +3484,14 @@ class FakeD1Statement implements D1PreparedStatement {
       }
       if (this.query.includes("subject_kind = 'principal'")) {
         const principal = this.values[1] as string;
+        const linked = this.db.accountLinks.get(principal)?.canonical_principal;
+        const subjects = new Set([principal, ...(linked ? [linked] : [])]);
         return okResult(
           this.db.acl.filter(
             (row) =>
               row.notebook_id === notebookId &&
               row.subject_kind === "principal" &&
-              row.subject === principal,
+              subjects.has(row.subject),
           ) as T[],
         );
       }


### PR DESCRIPTION
## Summary

- Fixes #3351 by canonicalizing hosted notebook ACL subjects onto a provider-neutral account principal derived from verified email plus principal namespace.
- Adds `principal_account_links` so transport principals remain available for audit and revocation while ACL reads authorize through the canonical account subject.
- Migrates existing matching transport ACL rows when verified profiles for the same account are observed, and keeps invite acceptance tied to the accepting transport principal.

## Verification

- `pnpm --filter notebook-cloud run typecheck`
- `pnpm --filter notebook-cloud exec node --import tsx --test test/sharing-storage.test.ts`
- `pnpm --filter notebook-cloud exec node --import tsx --test --test-name-pattern "(Anaconda API key artifact|canonical account|pending email invites)" test/worker-routes.test.ts`
- `cargo xtask lint --fix`

## Notes

- Full `test/worker-routes.test.ts` was also attempted; three existing snapshot-materialization fixture cases failed with `snapshot_pair.validation.failed` / `Invalid magic bytes` after WASM assets were generated. The ACL-focused route coverage above passes.
