### PR TITLE
feat(notebook-cloud): add hosted edit access requests

### DIFF
--- a/apps/notebook-cloud/migrations/0006_access_requests.sql
+++ b/apps/notebook-cloud/migrations/0006_access_requests.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS notebook_access_requests (
+  id TEXT PRIMARY KEY,
+  notebook_id TEXT NOT NULL,
+  requester_principal TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('editor')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'dismissed')),
+  requested_by_actor_label TEXT NOT NULL,
+  resolved_by_actor_label TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  resolved_at TEXT,
+  FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notebook_access_requests_pending_unique_idx
+  ON notebook_access_requests(notebook_id, requester_principal, scope)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS notebook_access_requests_notebook_idx
+  ON notebook_access_requests(notebook_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS notebook_access_requests_requester_idx
+  ON notebook_access_requests(requester_principal, notebook_id, created_at);

--- a/apps/notebook-cloud/src/access-requests-storage.ts
+++ b/apps/notebook-cloud/src/access-requests-storage.ts
@@ -1,0 +1,278 @@
+import type { D1Database, D1PreparedStatement, Env } from "./cloudflare-types.ts";
+import {
+  ensureCatalogSchema,
+  type NotebookAccessRequestRow,
+  type NotebookAccessRequestStatus,
+} from "./storage.ts";
+
+const NOTEBOOK_ACCESS_REQUEST_LIST_LIMIT = 200;
+
+export interface NotebookAccessRequestInput {
+  id?: string;
+  notebookId: string;
+  requesterPrincipal: string;
+  actorLabel: string;
+  timestamp?: string;
+}
+
+export interface NotebookAccessRequestCreateResult {
+  request: NotebookAccessRequestRow;
+  created: boolean;
+}
+
+export async function createNotebookAccessRequest(
+  env: Env,
+  input: NotebookAccessRequestInput,
+): Promise<NotebookAccessRequestCreateResult | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const existing = await getExistingPendingNotebookAccessRequest(env, {
+    notebookId: input.notebookId,
+    requesterPrincipal: input.requesterPrincipal,
+  });
+  if (existing) {
+    return { request: existing, created: false };
+  }
+
+  const requestId = input.id ?? crypto.randomUUID();
+  try {
+    await env.DB.prepare(
+      `INSERT INTO notebook_access_requests (
+       id,
+       notebook_id,
+       requester_principal,
+       scope,
+       status,
+       requested_by_actor_label,
+       created_at,
+       updated_at
+     ) VALUES (?, ?, ?, 'editor', 'pending', ?, ?, ?)`,
+    )
+      .bind(
+        requestId,
+        input.notebookId,
+        input.requesterPrincipal,
+        input.actorLabel,
+        timestamp,
+        timestamp,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) {
+      throw error;
+    }
+    const raced = await getExistingPendingNotebookAccessRequest(env, {
+      notebookId: input.notebookId,
+      requesterPrincipal: input.requesterPrincipal,
+    });
+    if (raced) {
+      return { request: raced, created: false };
+    }
+    throw error;
+  }
+
+  const created = await getNotebookAccessRequest(env, input.notebookId, requestId);
+  return created ? { request: created, created: true } : null;
+}
+
+export async function getNotebookAccessRequest(
+  env: Env,
+  notebookId: string,
+  requestId: string,
+): Promise<NotebookAccessRequestRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(accessRequestSelectSql("WHERE notebook_id = ? AND id = ?"))
+    .bind(notebookId, requestId)
+    .first<NotebookAccessRequestRow>();
+}
+
+export async function getLatestNotebookAccessRequestForRequester(
+  env: Env,
+  input: {
+    notebookId: string;
+    requesterPrincipal: string;
+  },
+): Promise<NotebookAccessRequestRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `${accessRequestSelectSql("WHERE notebook_id = ? AND requester_principal = ?")}
+       ORDER BY created_at DESC, id DESC
+       LIMIT 1`,
+  )
+    .bind(input.notebookId, input.requesterPrincipal)
+    .first<NotebookAccessRequestRow>();
+}
+
+export async function listNotebookAccessRequests(
+  env: Env,
+  notebookId: string,
+): Promise<NotebookAccessRequestRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `${accessRequestSelectSql("WHERE notebook_id = ?")}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
+  )
+    .bind(notebookId, NOTEBOOK_ACCESS_REQUEST_LIST_LIMIT)
+    .all<NotebookAccessRequestRow>();
+  return rows.results ?? [];
+}
+
+export async function resolveNotebookAccessRequest(
+  env: Env,
+  input: {
+    notebookId: string;
+    requestId: string;
+    status: Exclude<NotebookAccessRequestStatus, "pending">;
+    actorLabel: string;
+    timestamp?: string;
+  },
+): Promise<NotebookAccessRequestRow | null> {
+  const db = env.DB;
+  if (!db) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const result =
+    input.status === "approved"
+      ? (
+          await db.batch([
+            approvedAccessRequestAclInsert(db, input, timestamp),
+            accessRequestResolutionUpdate(db, input, timestamp),
+          ])
+        )[1]
+      : await accessRequestResolutionUpdate(db, input, timestamp).run();
+  if (d1Changes(result) === 0) {
+    return null;
+  }
+
+  return await getNotebookAccessRequest(env, input.notebookId, input.requestId);
+}
+
+async function getExistingPendingNotebookAccessRequest(
+  env: Env,
+  input: {
+    notebookId: string;
+    requesterPrincipal: string;
+  },
+): Promise<NotebookAccessRequestRow | null> {
+  const db = env.DB;
+  if (!db) {
+    return null;
+  }
+
+  return await db
+    .prepare(
+      `${accessRequestSelectSql(
+        "WHERE notebook_id = ? AND requester_principal = ? AND scope = 'editor' AND status = 'pending'",
+      )}
+       ORDER BY created_at
+       LIMIT 1`,
+    )
+    .bind(input.notebookId, input.requesterPrincipal)
+    .first<NotebookAccessRequestRow>();
+}
+
+function accessRequestResolutionUpdate(
+  db: D1Database,
+  input: {
+    notebookId: string;
+    requestId: string;
+    status: Exclude<NotebookAccessRequestStatus, "pending">;
+    actorLabel: string;
+  },
+  timestamp: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `UPDATE notebook_access_requests
+          SET status = ?,
+              resolved_by_actor_label = ?,
+              resolved_at = ?,
+              updated_at = ?
+        WHERE notebook_id = ?
+          AND id = ?
+          AND status = 'pending'`,
+    )
+    .bind(input.status, input.actorLabel, timestamp, timestamp, input.notebookId, input.requestId);
+}
+
+function approvedAccessRequestAclInsert(
+  db: D1Database,
+  input: {
+    notebookId: string;
+    requestId: string;
+    actorLabel: string;
+  },
+  timestamp: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO notebook_acl (
+         notebook_id,
+         subject_kind,
+         subject,
+         scope,
+         created_at,
+         updated_at,
+         created_by_actor_label
+       )
+       SELECT notebook_id,
+              'principal',
+              requester_principal,
+              scope,
+              ?,
+              ?,
+              ?
+         FROM notebook_access_requests
+        WHERE notebook_id = ?
+          AND id = ?
+          AND status = 'pending'
+       ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
+         updated_at = excluded.updated_at`,
+    )
+    .bind(timestamp, timestamp, input.actorLabel, input.notebookId, input.requestId);
+}
+
+function accessRequestSelectSql(whereClause: string): string {
+  return `SELECT id,
+                 notebook_id,
+                 requester_principal,
+                 scope,
+                 status,
+                 requested_by_actor_label,
+                 resolved_by_actor_label,
+                 created_at,
+                 updated_at,
+                 resolved_at
+            FROM notebook_access_requests
+            ${whereClause}`;
+}
+
+function d1Changes(result: { meta: Record<string, unknown> }): number {
+  const changes = result.meta.changes;
+  return typeof changes === "number" ? changes : 0;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /unique constraint failed/i.test(message);
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -9,6 +9,7 @@ import {
   authenticateRequestWithProviders,
   DEV_AUTH_TOKEN_HEADER,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
+  isAnonymousViewer,
   parseScope,
   stampTrustedIdentity,
   type AuthenticatedConnection,
@@ -34,6 +35,8 @@ import {
   runtimeStateSnapshotKey,
   snapshotKey,
   type NotebookAclRow,
+  type NotebookAccessRequestRow,
+  type NotebookAccessRequestStatus,
 } from "./storage.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import {
@@ -60,6 +63,12 @@ import {
   shareTargetDisplay,
   type PrincipalProfile,
 } from "./sharing.ts";
+import {
+  createNotebookAccessRequest,
+  getLatestNotebookAccessRequestForRequester,
+  listNotebookAccessRequests,
+  resolveNotebookAccessRequest,
+} from "./access-requests-storage.ts";
 import {
   viewerThemeBootstrapScript,
   viewerThemeFirstPaintStyle,
@@ -173,6 +182,23 @@ const worker: ExportedHandler<Env> = {
         env,
         decodeURIComponent(inviteItemMatch[1]),
         decodeURIComponent(inviteItemMatch[2]),
+      );
+    }
+
+    const accessRequestMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/access-requests\/?$/);
+    if (accessRequestMatch) {
+      return routeNotebookAccessRequests(request, env, decodeURIComponent(accessRequestMatch[1]));
+    }
+
+    const accessRequestItemMatch = url.pathname.match(
+      /^\/api\/n\/([^/]+)\/access-requests\/([^/]+)\/?$/,
+    );
+    if (accessRequestItemMatch) {
+      return routeNotebookAccessRequest(
+        request,
+        env,
+        decodeURIComponent(accessRequestItemMatch[1]),
+        decodeURIComponent(accessRequestItemMatch[2]),
       );
     }
 
@@ -795,6 +821,266 @@ async function routeNotebookInvite(
     notebook_id: notebookId,
     invites: (await listNotebookInvites(env, notebookId)).map(inviteResponse),
   });
+}
+
+interface AccessRequestActionPayload {
+  action?: unknown;
+}
+
+async function routeNotebookAccessRequests(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    const owner = await tryAuthorizeNotebookAccess(env, notebookId, identity, "owner");
+    if (owner.ok) {
+      return json({
+        notebook_id: notebookId,
+        access_requests: await accessRequestResponseRows(
+          env,
+          await listNotebookAccessRequests(env, notebookId),
+        ),
+      });
+    }
+
+    if (isAnonymousViewer(identity)) {
+      return json({ error: "sign in to view access requests" }, 401);
+    }
+
+    const viewer = await tryAuthorizeNotebookAccess(env, notebookId, identity, "viewer");
+    if (!viewer.ok) {
+      return json({ error: viewer.error.message }, viewer.error.status);
+    }
+
+    const latest = await getLatestNotebookAccessRequestForRequester(env, {
+      notebookId,
+      requesterPrincipal: identity.principal,
+    });
+    return json({
+      notebook_id: notebookId,
+      access_requests: latest ? [accessRequestResponse(latest)] : [],
+    });
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to request edit access" }, 401);
+  }
+
+  const viewer = await tryAuthorizeNotebookAccess(env, notebookId, identity, "viewer");
+  if (!viewer.ok) {
+    return json({ error: viewer.error.message }, viewer.error.status);
+  }
+
+  const editor = await tryAuthorizeNotebookAccess(env, notebookId, identity, "editor");
+  if (editor.ok) {
+    return json({
+      ok: true,
+      notebook_id: notebookId,
+      access_status: "granted",
+      access_request: null,
+    });
+  }
+
+  const accessRequestResult = await createNotebookAccessRequest(env, {
+    notebookId,
+    requesterPrincipal: identity.principal,
+    actorLabel: identity.actorLabel,
+  });
+  if (!accessRequestResult) {
+    return json({ error: "access request was not created" }, 500);
+  }
+  const accessRequest = accessRequestResult.request;
+
+  if (accessRequestResult.created) {
+    cloudLog("info", "access_request.create.completed", {
+      notebook_id: notebookId,
+      principal: identity.principal,
+      actor_label: identity.actorLabel,
+      access_request_id: accessRequest.id,
+      counter: "access_request_creates",
+      counter_delta: 1,
+    });
+  }
+
+  return json(
+    {
+      ok: true,
+      notebook_id: notebookId,
+      access_status: accessRequest.status,
+      access_request: accessRequestResponse(accessRequest),
+    },
+    accessRequestResult.created ? 201 : 200,
+  );
+}
+
+async function routeNotebookAccessRequest(
+  request: Request,
+  env: Env,
+  notebookId: string,
+  requestId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const status = await parseAccessRequestResolutionStatus(request);
+  if (status instanceof Response) {
+    return status;
+  }
+
+  const resolved = await resolveNotebookAccessRequest(env, {
+    notebookId,
+    requestId,
+    status,
+    actorLabel: identity.actorLabel,
+  });
+  if (!resolved) {
+    return json({ error: "pending access request not found" }, 404);
+  }
+
+  cloudLog("info", "access_request.resolve.completed", {
+    notebook_id: notebookId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    access_request_id: requestId,
+    access_request_status: resolved.status,
+    counter: "access_request_resolutions",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    notebook_id: notebookId,
+    access_request: accessRequestResponse(resolved),
+    access_requests: await accessRequestResponseRows(
+      env,
+      await listNotebookAccessRequests(env, notebookId),
+    ),
+  });
+}
+
+async function parseAccessRequestResolutionStatus(
+  request: Request,
+): Promise<Exclude<NotebookAccessRequestStatus, "pending"> | Response> {
+  let payload: AccessRequestActionPayload;
+  try {
+    payload = (await request.json()) as AccessRequestActionPayload;
+  } catch {
+    return json({ error: "access request body must be JSON" }, 400);
+  }
+
+  const action = stringField(payload.action, "action");
+  if (action instanceof Response) {
+    return action;
+  }
+
+  switch (action) {
+    case "approve":
+      return "approved";
+    case "deny":
+      return "denied";
+    case "dismiss":
+      return "dismissed";
+    default:
+      return json({ error: "access request action must be approve, deny, or dismiss" }, 400);
+  }
+}
+
+async function accessRequestResponseRows(
+  env: Env,
+  rows: NotebookAccessRequestRow[],
+): Promise<Array<Record<string, unknown>>> {
+  const principals = rows.map((row) => row.requester_principal);
+  const profilesByPrincipal = new Map(
+    (await getPrincipalProfiles(env, principals)).map((profile) => [profile.principal, profile]),
+  );
+  return rows.map((row) =>
+    accessRequestResponse(row, profilesByPrincipal.get(row.requester_principal)),
+  );
+}
+
+function accessRequestResponse(
+  row: NotebookAccessRequestRow,
+  profile?: PrincipalProfileRow,
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    notebook_id: row.notebook_id,
+    requester_principal: row.requester_principal,
+    scope: row.scope,
+    status: row.status,
+    requested_by_actor_label: row.requested_by_actor_label,
+    resolved_by_actor_label: row.resolved_by_actor_label,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    resolved_at: row.resolved_at,
+    display: profile
+      ? shareTargetDisplay({ profile: principalProfileFromRow(profile) })
+      : {
+          kind: "principal",
+          label: row.requester_principal,
+          principal: row.requester_principal,
+          email: null,
+        },
+  };
+}
+
+async function tryAuthorizeNotebookAccess(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: ConnectionScope,
+): Promise<
+  { ok: true; identity: AuthenticatedConnection } | { ok: false; error: AuthorizationError }
+> {
+  try {
+    return {
+      ok: true,
+      identity: await authorizeNotebookAccess(env, notebookId, identity, requestedScope),
+    };
+  } catch (error) {
+    if (error instanceof AuthorizationError) {
+      return { ok: false, error };
+    }
+    throw error;
+  }
 }
 
 async function parsePendingInviteInput(
@@ -1755,6 +2041,7 @@ function viewer(notebookId: string, request: Request, env: Env, headsHash?: stri
     runtimeSnapshotBasePath: `${notebookApiBasePath}/runtime-snapshots/`,
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
+    accessRequestsEndpoint: `${notebookApiBasePath}/access-requests`,
     hostCapabilities: {
       canManageSharing: true,
     },

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -55,6 +55,21 @@ export interface NotebookAclInput {
   actorLabel: string;
 }
 
+export type NotebookAccessRequestStatus = "pending" | "approved" | "denied" | "dismissed";
+
+export interface NotebookAccessRequestRow {
+  id: string;
+  notebook_id: string;
+  requester_principal: string;
+  scope: "editor";
+  status: NotebookAccessRequestStatus;
+  requested_by_actor_label: string;
+  resolved_by_actor_label: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+}
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -142,6 +157,26 @@ const SCHEMA_STATEMENTS = [
     WHERE status = 'pending' AND provider_hint IS NULL`,
   `CREATE INDEX IF NOT EXISTS notebook_invites_notebook_idx
     ON notebook_invites(notebook_id, status)`,
+  `CREATE TABLE IF NOT EXISTS notebook_access_requests (
+    id TEXT PRIMARY KEY,
+    notebook_id TEXT NOT NULL,
+    requester_principal TEXT NOT NULL,
+    scope TEXT NOT NULL CHECK (scope IN ('editor')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'dismissed')),
+    requested_by_actor_label TEXT NOT NULL,
+    resolved_by_actor_label TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    resolved_at TEXT,
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS notebook_access_requests_pending_unique_idx
+    ON notebook_access_requests(notebook_id, requester_principal, scope)
+    WHERE status = 'pending'`,
+  `CREATE INDEX IF NOT EXISTS notebook_access_requests_notebook_idx
+    ON notebook_access_requests(notebook_id, status, created_at)`,
+  `CREATE INDEX IF NOT EXISTS notebook_access_requests_requester_idx
+    ON notebook_access_requests(requester_principal, notebook_id, created_at)`,
 ];
 
 const SCHEMA_MIGRATIONS = [

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -95,6 +95,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /"runtimeSnapshotBasePath":"\/api\/n\/demo\/runtime-snapshots\/"/);
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
+    assert.match(html, /"accessRequestsEndpoint":"\/api\/n\/demo\/access-requests"/);
     assert.match(html, /"hostCapabilities":\{"canManageSharing":true\}/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -171,7 +171,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.doesNotMatch(sourceText, /useState\(initialCloudViewerPresence\)/);
   assert.doesNotMatch(sourceText, /setPresence\(/);
   assert.doesNotMatch(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
-  assert.match(sourceText, /Public link, collaborators, and pending invites for this notebook\./);
+  assert.match(sourceText, /Public link, collaborators, pending invites, and edit requests\./);
   assert.match(
     sourceText,
     /const accessSummary = useMemo\(\(\) => cloudShareAccessSummary\(accessRows\)/,
@@ -186,10 +186,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /Only invited people can open this notebook/);
   assert.match(sourceText, /const copyLinkLabel =[\s\S]*"Copy link"/);
   assert.match(sourceText, /const compactCopyLinkLabel =[\s\S]*"Copy"/);
-  assert.match(
-    sourceText,
-    /const accessRows = useMemo\(\(\) => buildCloudShareAccessRows\(\{ acl, invites \}\), \[acl, invites\]\)/,
-  );
+  assert.match(sourceText, /buildCloudShareAccessRows\(\{ acl, invites, accessRequests \}\)/);
   assert.match(
     sourceText,
     /accessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeShareInviteEmail,
   scopeLabel,
   type CloudNotebookAclRow,
+  type CloudNotebookAccessRequest,
   type CloudNotebookInvite,
 } from "../viewer/sharing-client.ts";
 
@@ -44,8 +45,21 @@ describe("cloud viewer sharing client", () => {
       inviteRow({ id: "invite-1", email: "carol@example.com", scope: "viewer" }),
       inviteRow({ id: "invite-2", email: "done@example.com", status: "accepted" }),
     ];
+    const accessRequests: CloudNotebookAccessRequest[] = [
+      accessRequestRow({
+        id: "request-1",
+        requester_principal: "user:anaconda:dana",
+        display: {
+          kind: "principal",
+          label: "Dana Requester",
+          principal: "user:anaconda:dana",
+          email: "dana@example.com",
+        },
+      }),
+      accessRequestRow({ id: "request-2", status: "denied" }),
+    ];
 
-    const rows = buildCloudShareAccessRows({ acl, invites });
+    const rows = buildCloudShareAccessRows({ acl, invites, accessRequests });
 
     assert.deepEqual(
       rows.map((row) => [row.kind, row.label, row.badge, row.stateLabel, row.removable]),
@@ -54,13 +68,20 @@ describe("cloud viewer sharing client", () => {
         ["acl", "Bob Example", "Can edit", null, true],
         ["acl", "Public link", "Can view", "Enabled", true],
         ["invite", "c...l@example.com", "Can view", "Pending", true],
+        ["access_request", "Dana Requester", "Can edit", "Requested", false],
       ],
     );
     assert.deepEqual(
       rows.map((row) => row.title),
-      ["alice@example.com", "bob@example.com", "Anyone with the link", "carol@example.com"],
+      [
+        "alice@example.com",
+        "bob@example.com",
+        "Anyone with the link",
+        "carol@example.com",
+        "dana@example.com",
+      ],
     );
-    assert.equal(cloudShareAccessSummary(rows), "2 people, public link, 1 invite");
+    assert.equal(cloudShareAccessSummary(rows), "2 people, public link, 1 invite, 1 request");
   });
 
   it("detects public viewer access from explicit public ACL rows", () => {
@@ -146,6 +167,24 @@ function inviteRow(overrides: Partial<CloudNotebookInvite> = {}): CloudNotebookI
     accepted_at: null,
     revoked_at: null,
     revoked_by_actor_label: null,
+    ...overrides,
+  };
+}
+
+function accessRequestRow(
+  overrides: Partial<CloudNotebookAccessRequest> = {},
+): CloudNotebookAccessRequest {
+  return {
+    id: "request-1",
+    notebook_id: "topic-viz",
+    requester_principal: "user:anaconda:bob",
+    scope: "editor",
+    status: "pending",
+    requested_by_actor_label: "user:anaconda:bob/browser:viewer",
+    resolved_by_actor_label: null,
+    created_at: "2026-05-28T00:00:00.000Z",
+    updated_at: "2026-05-28T00:00:00.000Z",
+    resolved_at: null,
     ...overrides,
   };
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -862,6 +862,12 @@ describe("Worker artifact routes", () => {
       providerHint: "oidc",
       scope: "editor",
     });
+    seedAccessRequest(env, {
+      id: "request-private-profile",
+      notebookId: "public-sharing-demo",
+      requesterPrincipal: "user:dev:bob",
+      status: "pending",
+    });
     env.DB.profiles.set("user:dev:bob", {
       principal: "user:dev:bob",
       provider: "dev",
@@ -892,11 +898,20 @@ describe("Worker artifact routes", () => {
       env,
       fakeContext(),
     );
+    const accessRequests = await worker.fetch(
+      new Request(
+        "http://localhost/api/n/public-sharing-demo/access-requests?viewer_session=anon-a",
+      ),
+      env,
+      fakeContext(),
+    );
 
     assert.equal(acl.status, 403);
     assert.equal(invites.status, 403);
+    assert.equal(accessRequests.status, 401);
     assert.doesNotMatch(await acl.text(), /bob@example\.com|carol@example\.com/);
     assert.doesNotMatch(await invites.text(), /bob@example\.com|carol@example\.com/);
+    assert.doesNotMatch(await accessRequests.text(), /bob@example\.com|carol@example\.com/);
   });
 
   it("lets owners inspect and grant principal ACL rows", async () => {
@@ -1085,6 +1100,145 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await publicEditor.json(), {
       error: "public ACL rows may only grant viewer scope",
     });
+  });
+
+  it("lets authenticated viewers create owner-visible edit access requests", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "access-request-demo");
+    seedAcl(env, {
+      notebookId: "access-request-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "access-request-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    env.DB.profiles.set("user:dev:bob", {
+      principal: "user:dev:bob",
+      provider: "dev",
+      provider_subject: "bob",
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const create = await accessRequestsRequest(env, "POST", "access-request-demo", undefined, {
+      "X-User": "bob",
+      "X-Operator": "browser:tab",
+      "X-Scope": "viewer",
+    });
+
+    assert.equal(create.status, 201);
+    assert.equal(env.DB.accessRequests.size, 1);
+    const createBody = (await create.json()) as {
+      access_status: string;
+      access_request: { status: string; requester_principal: string };
+    };
+    assert.equal(createBody.access_status, "pending");
+    assert.equal(createBody.access_request.status, "pending");
+    assert.equal(createBody.access_request.requester_principal, "user:dev:bob");
+
+    const duplicate = await accessRequestsRequest(env, "POST", "access-request-demo", undefined, {
+      "X-User": "bob",
+      "X-Operator": "browser:tab",
+      "X-Scope": "viewer",
+    });
+    assert.equal(duplicate.status, 200);
+    assert.equal(env.DB.accessRequests.size, 1);
+
+    const ownerList = await accessRequestsRequest(env, "GET", "access-request-demo");
+    assert.equal(ownerList.status, 200);
+    const ownerBody = (await ownerList.json()) as {
+      access_requests: Array<Record<string, unknown>>;
+    };
+    assert.deepEqual(
+      ownerBody.access_requests.map((row) => [row.status, row.display]),
+      [
+        [
+          "pending",
+          {
+            kind: "principal",
+            label: "Bob Example",
+            principal: "user:dev:bob",
+            email: "bob@example.com",
+          },
+        ],
+      ],
+    );
+  });
+
+  it("lets owners approve edit access requests through the ACL path", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "access-approve-demo");
+    seedAcl(env, {
+      notebookId: "access-approve-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAccessRequest(env, {
+      id: "request-bob",
+      notebookId: "access-approve-demo",
+      requesterPrincipal: "user:dev:bob",
+      status: "pending",
+    });
+
+    const approve = await accessRequestItemRequest(
+      env,
+      "POST",
+      "access-approve-demo",
+      "request-bob",
+      "approve",
+    );
+
+    assert.equal(approve.status, 200);
+    assert.equal(env.DB.accessRequests.get("request-bob")?.status, "approved");
+    assert.equal(env.DB.batchSizes.at(-1), 2);
+    assert.deepEqual(
+      (await getNotebookAclRowsForPrincipal(env, "access-approve-demo", "user:dev:bob")).map(
+        (row) => row.scope,
+      ),
+      ["editor"],
+    );
+  });
+
+  it("lets owners deny edit access requests without granting ACL rows", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "access-deny-demo");
+    seedAcl(env, {
+      notebookId: "access-deny-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAccessRequest(env, {
+      id: "request-bob-denied",
+      notebookId: "access-deny-demo",
+      requesterPrincipal: "user:dev:bob",
+      status: "pending",
+    });
+
+    const deny = await accessRequestItemRequest(
+      env,
+      "POST",
+      "access-deny-demo",
+      "request-bob-denied",
+      "deny",
+    );
+
+    assert.equal(deny.status, 200);
+    assert.equal(env.DB.accessRequests.get("request-bob-denied")?.status, "denied");
+    assert.deepEqual(
+      (await getNotebookAclRowsForPrincipal(env, "access-deny-demo", "user:dev:bob")).map(
+        (row) => row.scope,
+      ),
+      [],
+    );
   });
 
   it("does not revoke pending invites through another notebook route", async () => {
@@ -2247,6 +2401,59 @@ async function inviteItemRequest(
   );
 }
 
+async function accessRequestsRequest(
+  env: FakeEnv,
+  method: "GET" | "POST",
+  notebookId: string,
+  body: Record<string, unknown> | undefined = undefined,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/n/${notebookId}/access-requests`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
+async function accessRequestItemRequest(
+  env: FakeEnv,
+  method: "POST",
+  notebookId: string,
+  requestId: string,
+  action: "approve" | "deny" | "dismiss",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(`/api/n/${notebookId}/access-requests/${requestId}`, "http://localhost"), {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "owner",
+        ...headers,
+      },
+      body: JSON.stringify({ action }),
+    }),
+    env,
+    fakeContext(),
+  );
+}
+
 async function scopedPut(
   env: FakeEnv,
   pathname: string,
@@ -2325,6 +2532,29 @@ function seedPendingInvite(
     accepted_at: null,
     revoked_at: null,
     revoked_by_actor_label: null,
+  });
+}
+
+function seedAccessRequest(
+  env: FakeEnv,
+  input: {
+    id: string;
+    notebookId: string;
+    requesterPrincipal: string;
+    status: NotebookAccessRequestRow["status"];
+  },
+): void {
+  env.DB.accessRequests.set(input.id, {
+    id: input.id,
+    notebook_id: input.notebookId,
+    requester_principal: input.requesterPrincipal,
+    scope: "editor",
+    status: input.status,
+    requested_by_actor_label: `${input.requesterPrincipal}/browser:tab`,
+    resolved_by_actor_label: null,
+    created_at: "2026-05-22T00:00:00.000Z",
+    updated_at: "2026-05-22T00:00:00.000Z",
+    resolved_at: null,
   });
 }
 
@@ -2432,6 +2662,19 @@ interface NotebookAclRow {
   created_by_actor_label: string;
 }
 
+interface NotebookAccessRequestRow {
+  id: string;
+  notebook_id: string;
+  requester_principal: string;
+  scope: "editor";
+  status: "pending" | "approved" | "denied" | "dismissed";
+  requested_by_actor_label: string;
+  resolved_by_actor_label: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+}
+
 interface RevisionRow {
   id: string;
   notebook_id: string;
@@ -2451,6 +2694,7 @@ class FakeD1 implements D1Database {
   readonly acl: NotebookAclRow[] = [];
   readonly profiles = new Map<string, PrincipalProfileRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
+  readonly accessRequests = new Map<string, NotebookAccessRequestRow>();
   readonly batchSizes: number[] = [];
   afterBlockedOwnerDelete?: () => void;
 
@@ -2580,6 +2824,35 @@ class FakeD1Statement implements D1PreparedStatement {
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
+    } else if (
+      this.query.includes("INSERT INTO notebook_acl") &&
+      this.query.includes("FROM notebook_access_requests")
+    ) {
+      const [createdAt, updatedAt, actorLabel, notebookId, requestId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      const accessRequest = this.db.accessRequests.get(requestId);
+      if (
+        accessRequest &&
+        accessRequest.notebook_id === notebookId &&
+        accessRequest.status === "pending"
+      ) {
+        this.insertAclIfMissing({
+          notebook_id: notebookId,
+          subject_kind: "principal",
+          subject: accessRequest.requester_principal,
+          scope: accessRequest.scope,
+          created_at: createdAt,
+          updated_at: updatedAt,
+          created_by_actor_label: actorLabel,
+        });
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebook_acl")) {
       const [notebookId, subjectKind, subject, scope, createdAt, updatedAt, actorLabel] = this
         .values as [
@@ -2699,6 +2972,55 @@ class FakeD1Statement implements D1PreparedStatement {
         invite.status = "revoked";
         invite.revoked_at = revokedAt;
         invite.revoked_by_actor_label = revokedByActorLabel;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO notebook_access_requests")) {
+      const [id, notebookId, requesterPrincipal, actorLabel, createdAt, updatedAt] = this
+        .values as [string, string, string, string, string, string];
+      const duplicate = [...this.db.accessRequests.values()].find(
+        (accessRequest) =>
+          accessRequest.notebook_id === notebookId &&
+          accessRequest.requester_principal === requesterPrincipal &&
+          accessRequest.scope === "editor" &&
+          accessRequest.status === "pending",
+      );
+      if (duplicate) {
+        throw new Error(
+          "D1_ERROR: UNIQUE constraint failed: notebook_access_requests pending request",
+        );
+      }
+      this.db.accessRequests.set(id, {
+        id,
+        notebook_id: notebookId,
+        requester_principal: requesterPrincipal,
+        scope: "editor",
+        status: "pending",
+        requested_by_actor_label: actorLabel,
+        resolved_by_actor_label: null,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        resolved_at: null,
+      });
+    } else if (this.query.includes("UPDATE notebook_access_requests")) {
+      const [status, actorLabel, resolvedAt, updatedAt, notebookId, requestId] = this.values as [
+        NotebookAccessRequestRow["status"],
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      const accessRequest = this.db.accessRequests.get(requestId);
+      if (
+        accessRequest &&
+        accessRequest.notebook_id === notebookId &&
+        accessRequest.status === "pending"
+      ) {
+        accessRequest.status = status;
+        accessRequest.resolved_by_actor_label = actorLabel;
+        accessRequest.resolved_at = resolvedAt;
+        accessRequest.updated_at = updatedAt;
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
@@ -2867,6 +3189,31 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM notebook_access_requests")) {
+      if (this.query.includes("requester_principal = ?")) {
+        const [notebookId, requesterPrincipal] = this.values as [string, string];
+        return (
+          ([...this.db.accessRequests.values()]
+            .filter(
+              (accessRequest) =>
+                accessRequest.notebook_id === notebookId &&
+                accessRequest.requester_principal === requesterPrincipal &&
+                (!this.query.includes("status = 'pending'") || accessRequest.status === "pending"),
+            )
+            .sort(
+              (left, right) =>
+                right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+            )[0] as T | undefined) ?? null
+        );
+      }
+      const [notebookId, requestId] = this.values as [string, string];
+      return (
+        ([...this.db.accessRequests.values()].find(
+          (accessRequest) =>
+            accessRequest.notebook_id === notebookId && accessRequest.id === requestId,
+        ) as T | undefined) ?? null
+      );
+    }
     if (this.query.includes("FROM notebook_invites")) {
       if (this.query.includes("WHERE notebook_id = ?")) {
         const [notebookId, email, scope, providerHint] = this.values as [
@@ -2899,6 +3246,19 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    if (this.query.includes("FROM notebook_access_requests")) {
+      const notebookId = this.values[0] as string;
+      const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...this.db.accessRequests.values()]
+          .filter((accessRequest) => accessRequest.notebook_id === notebookId)
+          .sort(
+            (left, right) =>
+              right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+          )
+          .slice(0, limit) as T[],
+      );
+    }
     if (this.query.includes("FROM principal_profiles")) {
       const principals = new Set(this.values as string[]);
       if (this.values.length > 100) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -12,6 +12,7 @@ import {
 import { createRoot } from "react-dom/client";
 import {
   AlertCircle,
+  Check,
   Globe2,
   KeyRound,
   Link2,
@@ -23,9 +24,11 @@ import {
   Share2,
   Trash2,
   UserRound,
+  X,
 } from "lucide-react";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   NotebookCommandToolbar,
@@ -116,6 +119,7 @@ import {
   cloudShareAccessSummary,
   hasPublicViewerAccess,
   normalizeShareInviteEmail,
+  type CloudNotebookAccessRequest,
   type CloudNotebookAclRow,
   type CloudNotebookInvite,
   type CloudShareAccessRow,
@@ -137,6 +141,7 @@ import {
 import "./index.css";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
+const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 10_000;
 
 setLoggerHost({
   debug: () => {},
@@ -153,6 +158,7 @@ interface CloudViewerConfig {
   runtimeSnapshotBasePath: string;
   aclEndpoint: string;
   invitesEndpoint: string;
+  accessRequestsEndpoint: string;
   hostCapabilities?: {
     canManageSharing?: boolean;
   };
@@ -206,6 +212,7 @@ function loadConfig(): CloudViewerConfig {
     !parsed.runtimeSnapshotBasePath ||
     !parsed.aclEndpoint ||
     !parsed.invitesEndpoint ||
+    !parsed.accessRequestsEndpoint ||
     !parsed.syncEndpoint ||
     !parsed.blobBasePath ||
     !parsed.rendererAssetsBasePath ||
@@ -222,6 +229,7 @@ function loadConfig(): CloudViewerConfig {
     runtimeSnapshotBasePath: parsed.runtimeSnapshotBasePath,
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
+    accessRequestsEndpoint: parsed.accessRequestsEndpoint,
     hostCapabilities: {
       canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
     },
@@ -694,6 +702,10 @@ function NotebookViewer({
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectAttempt, setConnectAttempt] = useState(0);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
+  const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
+    null,
+  );
+  const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () =>
       authState.requestedScope === "editor" || authState.requestedScope === "owner"
@@ -1318,14 +1330,136 @@ function NotebookViewer({
   }, [shellCapabilities.canEditCells, shellCapabilities.canEditMarkdown]);
   const resetPrototypeAuth = useCallback(() => {
     clearCloudPrototypeDevAuth(window.localStorage);
+    setLatestAccessRequest(null);
+    setAccessRequestError(null);
     setSelectedInteractionMode("view");
     refreshAuthState();
   }, [refreshAuthState]);
+  const applyLatestAccessRequest = useCallback(
+    (request: CloudNotebookAccessRequest | null) => {
+      setLatestAccessRequest(request);
+      if (request?.status === "pending" || request?.status === "approved") {
+        storeCloudRequestedScope(window.localStorage, "editor");
+        setSelectedInteractionMode("edit");
+        if (request.status === "approved") {
+          setConnectAttempt((attempt) => attempt + 1);
+        }
+        if (authState.requestedScope !== "editor") {
+          refreshAuthState();
+        }
+        return;
+      }
+
+      if (authState.requestedScope === "editor" && connectionScope === "viewer") {
+        storeCloudRequestedScope(window.localStorage, "viewer");
+        setSelectedInteractionMode("view");
+        refreshAuthState();
+      }
+    },
+    [authState.requestedScope, connectionScope, refreshAuthState],
+  );
+  const loadOwnAccessRequest = useCallback(
+    async (options?: { signal?: AbortSignal }) => {
+      if (connectionScope !== "viewer" || (authState.mode !== "dev" && authState.mode !== "oidc")) {
+        return;
+      }
+
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          config.accessRequestsEndpoint,
+          { headers: { Accept: "application/json" }, signal: options?.signal },
+          authState,
+        );
+        if (options?.signal?.aborted) {
+          return;
+        }
+        if (!response.ok) {
+          return;
+        }
+        const body = (await response.json()) as {
+          access_requests?: CloudNotebookAccessRequest[];
+        };
+        setAccessRequestError(null);
+        applyLatestAccessRequest(
+          Array.isArray(body.access_requests) ? (body.access_requests[0] ?? null) : null,
+        );
+      } catch {
+        return;
+      }
+    },
+    [applyLatestAccessRequest, authState, config.accessRequestsEndpoint, connectionScope],
+  );
+  useEffect(() => {
+    if (connectionScope !== "viewer" || (authState.mode !== "dev" && authState.mode !== "oidc")) {
+      setLatestAccessRequest(null);
+      return;
+    }
+    const controller = new AbortController();
+    void loadOwnAccessRequest({ signal: controller.signal });
+    return () => controller.abort();
+  }, [authState.mode, connectionScope, loadOwnAccessRequest]);
+  useEffect(() => {
+    if (
+      latestAccessRequest?.status !== "pending" ||
+      connectionScope !== "viewer" ||
+      (authState.mode !== "dev" && authState.mode !== "oidc")
+    ) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const intervalId = window.setInterval(() => {
+      void loadOwnAccessRequest({ signal: controller.signal });
+    }, CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS);
+    return () => {
+      controller.abort();
+      window.clearInterval(intervalId);
+    };
+  }, [authState.mode, connectionScope, latestAccessRequest?.status, loadOwnAccessRequest]);
   const requestCloudEditAccess = useCallback(() => {
-    storeCloudRequestedScope(window.localStorage, "editor");
-    setSelectedInteractionMode("edit");
-    refreshAuthState();
-  }, [refreshAuthState]);
+    void (async () => {
+      setAccessRequestError(null);
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          config.accessRequestsEndpoint,
+          {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ scope: "editor" }),
+          },
+          authState,
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to request edit access");
+        }
+        const body = (await response.json()) as {
+          access_request?: CloudNotebookAccessRequest | null;
+          access_status?: string;
+        };
+        if (body.access_status === "granted") {
+          applyLatestAccessRequest({
+            id: "already-granted",
+            notebook_id: config.notebookId,
+            requester_principal: "",
+            scope: "editor",
+            status: "approved",
+            requested_by_actor_label: "",
+            resolved_by_actor_label: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            resolved_at: new Date().toISOString(),
+          });
+          return;
+        }
+        applyLatestAccessRequest(body.access_request ?? null);
+      } catch (error) {
+        setAccessRequestError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+  }, [applyLatestAccessRequest, authState, config.accessRequestsEndpoint, config.notebookId]);
   const shouldShowPackageEnvironmentSummary =
     shellCapabilities.canExecute || shellCapabilities.canManagePackages;
   const toolbarAddAfterCellId =
@@ -1379,6 +1513,7 @@ function NotebookViewer({
           <CloudSharingControls
             aclEndpoint={config.aclEndpoint}
             invitesEndpoint={config.invitesEndpoint}
+            accessRequestsEndpoint={config.accessRequestsEndpoint}
             authState={authState}
           />
         }
@@ -1409,10 +1544,12 @@ function NotebookViewer({
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
+  const accessRequestNotice = cloudAccessRequestNotice(latestAccessRequest, accessRequestError);
   const hasNotices = cloudNotebookHasNotices({
     authState,
     authRenewal,
     connectionError,
+    diagnostics: accessRequestNotice,
     hasReadableSnapshot: notebookHasReadableSnapshot,
     status,
   });
@@ -1427,6 +1564,7 @@ function NotebookViewer({
       authState={authState}
       authRenewal={authRenewal}
       connectionError={connectionError}
+      diagnostics={accessRequestNotice}
       hasReadableSnapshot={notebookHasReadableSnapshot}
       status={status}
       onResetAuth={resetPrototypeAuth}
@@ -1493,18 +1631,84 @@ function cloudNotebookEnvironmentManager(
   return null;
 }
 
+function cloudAccessRequestNotice(
+  request: CloudNotebookAccessRequest | null,
+  error: string | null,
+): ReactNode {
+  if (error) {
+    return (
+      <NotebookNotice
+        tone="error"
+        icon={<AlertCircle className="h-4 w-4" />}
+        title="Edit request failed."
+      >
+        {error}
+      </NotebookNotice>
+    );
+  }
+
+  if (!request) {
+    return null;
+  }
+
+  if (request.status === "pending") {
+    return (
+      <NotebookNotice
+        tone="info"
+        icon={<Loader2 className="h-4 w-4 animate-spin" />}
+        title="Edit access requested."
+      >
+        The owner can review this request from the sharing panel.
+      </NotebookNotice>
+    );
+  }
+
+  if (request.status === "approved") {
+    return (
+      <NotebookNotice
+        tone="success"
+        icon={<Check className="h-4 w-4" />}
+        title="Edit access approved."
+      >
+        Reconnecting with editor access.
+      </NotebookNotice>
+    );
+  }
+
+  if (request.status === "denied") {
+    return (
+      <NotebookNotice tone="warning" icon={<X className="h-4 w-4" />} title="Edit request denied.">
+        The notebook stays in view mode.
+      </NotebookNotice>
+    );
+  }
+
+  return (
+    <NotebookNotice
+      tone="info"
+      icon={<AlertCircle className="h-4 w-4" />}
+      title="Edit request dismissed."
+    >
+      The owner dismissed the request.
+    </NotebookNotice>
+  );
+}
+
 function CloudSharingControls({
   aclEndpoint,
   invitesEndpoint,
+  accessRequestsEndpoint,
   authState,
 }: {
   aclEndpoint: string;
   invitesEndpoint: string;
+  accessRequestsEndpoint: string;
   authState: CloudPrototypeAuthState;
 }) {
   const [open, setOpen] = useState(false);
   const [acl, setAcl] = useState<CloudNotebookAclRow[]>([]);
   const [invites, setInvites] = useState<CloudNotebookInvite[]>([]);
+  const [accessRequests, setAccessRequests] = useState<CloudNotebookAccessRequest[]>([]);
   const [loadState, setLoadState] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [messageKind, setMessageKind] = useState<"info" | "error">("info");
@@ -1515,7 +1719,10 @@ function CloudSharingControls({
   const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
   const inviteSubmitLockRef = useRef(false);
   const publicLink = new URL(window.location.pathname, window.location.origin).href;
-  const accessRows = useMemo(() => buildCloudShareAccessRows({ acl, invites }), [acl, invites]);
+  const accessRows = useMemo(
+    () => buildCloudShareAccessRows({ acl, invites, accessRequests }),
+    [accessRequests, acl, invites],
+  );
   const accessSummary = useMemo(() => cloudShareAccessSummary(accessRows), [accessRows]);
   const publicEnabled = useMemo(() => hasPublicViewerAccess(acl), [acl]);
   const inviteReady = normalizeShareInviteEmail(inviteEmail) !== null;
@@ -1527,7 +1734,7 @@ function CloudSharingControls({
         setMessage(null);
       }
       try {
-        const [aclResponse, invitesResponse] = await Promise.all([
+        const [aclResponse, invitesResponse, accessRequestsResponse] = await Promise.all([
           fetchWithCloudPrototypeAuth(
             aclEndpoint,
             { headers: { Accept: "application/json" }, signal: options?.signal },
@@ -1535,6 +1742,11 @@ function CloudSharingControls({
           ),
           fetchWithCloudPrototypeAuth(
             invitesEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            authState,
+          ),
+          fetchWithCloudPrototypeAuth(
+            accessRequestsEndpoint,
             { headers: { Accept: "application/json" }, signal: options?.signal },
             authState,
           ),
@@ -1558,10 +1770,26 @@ function CloudSharingControls({
               : "Unable to load invites",
           );
         }
+        if (!accessRequestsResponse.ok) {
+          throw await cloudResponseError(
+            accessRequestsResponse,
+            accessRequestsResponse.status === 403
+              ? "Only the notebook owner can manage access requests"
+              : "Unable to load access requests",
+          );
+        }
         const aclBody = (await aclResponse.json()) as { acl?: CloudNotebookAclRow[] };
         const invitesBody = (await invitesResponse.json()) as { invites?: CloudNotebookInvite[] };
+        const accessRequestsBody = (await accessRequestsResponse.json()) as {
+          access_requests?: CloudNotebookAccessRequest[];
+        };
         setAcl(Array.isArray(aclBody.acl) ? aclBody.acl : []);
         setInvites(Array.isArray(invitesBody.invites) ? invitesBody.invites : []);
+        setAccessRequests(
+          Array.isArray(accessRequestsBody.access_requests)
+            ? accessRequestsBody.access_requests
+            : [],
+        );
         setLoadState("ready");
       } catch (error) {
         if (options?.signal?.aborted) {
@@ -1572,7 +1800,7 @@ function CloudSharingControls({
         setMessage(error instanceof Error ? error.message : String(error));
       }
     },
-    [aclEndpoint, authState, invitesEndpoint],
+    [accessRequestsEndpoint, aclEndpoint, authState, invitesEndpoint],
   );
 
   useEffect(() => {
@@ -1677,6 +1905,7 @@ function CloudSharingControls({
 
   const removeAccessRow = async (row: CloudShareAccessRow) => {
     if (!row.removable) return;
+    if (row.kind === "access_request") return;
 
     setBusyAction(row.id);
     setMessage(null);
@@ -1721,6 +1950,39 @@ function CloudSharingControls({
     }
   };
 
+  const resolveAccessRequest = async (
+    row: Extract<CloudShareAccessRow, { kind: "access_request" }>,
+    action: "approve" | "deny" | "dismiss",
+  ) => {
+    setBusyAction(`${row.id}:${action}`);
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        appendEndpointPathSegment(accessRequestsEndpoint, row.accessRequest.id),
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ action }),
+        },
+        authState,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to update access request");
+      }
+      setMessageKind("info");
+      setMessage(accessRequestActionMessage(row.label, action));
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
   const copyLinkLabel =
     copyState === "copied" ? "Copied link" : copyState === "failed" ? "Copy failed" : "Copy link";
   const compactCopyLinkLabel =
@@ -1740,7 +2002,7 @@ function CloudSharingControls({
         <header>
           <div>
             <h2>Share notebook</h2>
-            <p>Public link, collaborators, and pending invites for this notebook.</p>
+            <p>Public link, collaborators, pending invites, and edit requests.</p>
           </div>
           <button type="button" aria-label={copyLinkLabel} onClick={() => void copyPublicLink()}>
             <Link2 aria-hidden="true" />
@@ -1829,6 +2091,37 @@ function CloudSharingControls({
                       <span className="cloud-share-state" data-tone={row.stateTone ?? undefined}>
                         {row.stateLabel}
                       </span>
+                    ) : null}
+                    {row.kind === "access_request" ? (
+                      <>
+                        <button
+                          type="button"
+                          aria-label={`Approve ${row.label}`}
+                          title={`Approve ${row.label}`}
+                          disabled={busyAction === `${row.id}:approve`}
+                          onClick={() => void resolveAccessRequest(row, "approve")}
+                        >
+                          <Check aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Deny ${row.label}`}
+                          title={`Deny ${row.label}`}
+                          disabled={busyAction === `${row.id}:deny`}
+                          onClick={() => void resolveAccessRequest(row, "deny")}
+                        >
+                          <X aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Dismiss ${row.label}`}
+                          title={`Dismiss ${row.label}`}
+                          disabled={busyAction === `${row.id}:dismiss`}
+                          onClick={() => void resolveAccessRequest(row, "dismiss")}
+                        >
+                          <Trash2 aria-hidden="true" />
+                        </button>
+                      </>
                     ) : null}
                     {row.removable ? (
                       <button
@@ -1946,10 +2239,24 @@ function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
   if (row.kind === "invite") {
     return <Mail aria-hidden="true" />;
   }
+  if (row.kind === "access_request") {
+    return <UserRound aria-hidden="true" />;
+  }
   if (row.acl.subject_kind === "public") {
     return <Globe2 aria-hidden="true" />;
   }
   return <UserRound aria-hidden="true" />;
+}
+
+function accessRequestActionMessage(label: string, action: "approve" | "deny" | "dismiss"): string {
+  switch (action) {
+    case "approve":
+      return `${label} can now edit.`;
+    case "deny":
+      return `${label} denied.`;
+    case "dismiss":
+      return `${label} dismissed.`;
+  }
 }
 
 function shouldShowCloudNotebookCommandToolbar(capabilities: NotebookShellCapabilities): boolean {

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -1,6 +1,7 @@
 export type CloudShareScope = "viewer" | "editor" | "runtime_peer" | "owner";
 export type CloudShareInviteScope = "viewer" | "editor";
 export type CloudInviteStatus = "pending" | "accepted" | "revoked" | "expired";
+export type CloudAccessRequestStatus = "pending" | "approved" | "denied" | "dismissed";
 export type CloudShareAccessRowStateTone = "success" | "pending";
 
 export type CloudShareDisplay =
@@ -48,6 +49,20 @@ export interface CloudNotebookInvite {
   display?: CloudShareDisplay;
 }
 
+export interface CloudNotebookAccessRequest {
+  id: string;
+  notebook_id: string;
+  requester_principal: string;
+  scope: "editor";
+  status: CloudAccessRequestStatus;
+  requested_by_actor_label: string;
+  resolved_by_actor_label: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+  display?: Extract<CloudShareDisplay, { kind: "principal" }>;
+}
+
 export type CloudShareAccessRow =
   | {
       id: string;
@@ -74,11 +89,25 @@ export type CloudShareAccessRow =
       stateLabel: string | null;
       stateTone: CloudShareAccessRowStateTone | null;
       removable: boolean;
+    }
+  | {
+      id: string;
+      kind: "access_request";
+      accessRequest: CloudNotebookAccessRequest;
+      label: string;
+      detail: string;
+      title: string;
+      scope: "editor";
+      badge: string;
+      stateLabel: string | null;
+      stateTone: CloudShareAccessRowStateTone | null;
+      removable: boolean;
     };
 
 export function buildCloudShareAccessRows(input: {
   acl: CloudNotebookAclRow[];
   invites: CloudNotebookInvite[];
+  accessRequests?: CloudNotebookAccessRequest[];
 }): CloudShareAccessRow[] {
   const rows: CloudShareAccessRow[] = [];
 
@@ -116,6 +145,24 @@ export function buildCloudShareAccessRows(input: {
     });
   }
 
+  for (const request of (input.accessRequests ?? []).filter(
+    (candidate) => candidate.status === "pending",
+  )) {
+    rows.push({
+      id: `access-request:${request.id}`,
+      kind: "access_request",
+      accessRequest: request,
+      label: labelForAccessRequest(request),
+      detail: "Requested edit access",
+      title: titleForAccessRequest(request),
+      scope: request.scope,
+      badge: scopeLabel(request.scope),
+      stateLabel: "Requested",
+      stateTone: "pending",
+      removable: false,
+    });
+  }
+
   return rows;
 }
 
@@ -134,6 +181,7 @@ export function cloudShareAccessSummary(rows: CloudShareAccessRow[]): string | n
     (row) => row.kind === "acl" && row.acl.subject_kind === "public",
   ).length;
   const invites = rows.filter((row) => row.kind === "invite").length;
+  const requests = rows.filter((row) => row.kind === "access_request").length;
 
   const parts: string[] = [];
   if (people > 0) parts.push(pluralize(people, "person", "people"));
@@ -141,6 +189,7 @@ export function cloudShareAccessSummary(rows: CloudShareAccessRow[]): string | n
   if (publicLinks > 0)
     parts.push(publicLinks === 1 ? "public link" : `${publicLinks} public links`);
   if (invites > 0) parts.push(pluralize(invites, "invite", "invites"));
+  if (requests > 0) parts.push(pluralize(requests, "request", "requests"));
   return parts.join(", ") || null;
 }
 
@@ -220,6 +269,23 @@ function titleForAcl(row: CloudNotebookAclRow): string {
   }
 
   return row.subject;
+}
+
+function labelForAccessRequest(request: CloudNotebookAccessRequest): string {
+  const displayLabel = request.display?.label?.trim();
+  if (displayLabel && displayLabel !== request.requester_principal) {
+    return displayEmail(displayLabel);
+  }
+  return displayEmail(labelForPrincipalSubject(request.requester_principal));
+}
+
+function titleForAccessRequest(request: CloudNotebookAccessRequest): string {
+  const email = request.display?.email?.trim();
+  if (email) return email;
+  if (request.display?.principal && request.display.principal !== request.requester_principal) {
+    return request.display.principal;
+  }
+  return request.requester_principal;
 }
 
 function displayEmail(value: string): string {


### PR DESCRIPTION
## Summary

- add a hosted notebook access-request table, storage helpers, and API routes for viewer-created edit requests
- show pending requests in the owner sharing UI with approve, deny, and dismiss actions
- surface pending/approved/denied/dismissed state to requesters and poll pending requests while the viewer is waiting
- approving a request grants editor access through the existing notebook ACL path

Closes #3352

## Verification

- `pnpm --filter notebook-cloud typecheck`
- `pnpm exec tsx --test apps/notebook-cloud/test/viewer-sharing.test.ts apps/notebook-cloud/test/html.test.ts apps/notebook-cloud/test/viewer-render-props.test.ts`
- `pnpm exec tsx --test --test-name-pattern "access request|sharing identity" apps/notebook-cloud/test/worker-routes.test.ts`
- `cargo xtask lint --fix`

## Notes

- `pnpm --filter notebook-cloud test` still fails outside this change path on local snapshot/WASM fixture loading (`Invalid magic bytes` in `snapshot-render.test.ts` and snapshot publish route expectations) plus an existing `viewer-notices.test.ts` copy assertion. The access-request focused tests pass.
