### PR TITLE
fix(notebook): prevent ghost cell adder hover

### DIFF
--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -184,7 +184,9 @@ export function CellInsertionRibbon({
           terminal && "pt-0.5",
           forceActionsVisible
             ? "opacity-100"
-            : "opacity-0 group-hover/adder:opacity-100 group-hover/adder:delay-75 group-focus-within/adder:opacity-100 group-focus-within/adder:delay-75",
+            : isOpen
+              ? "pointer-events-auto opacity-100 delay-75"
+              : "pointer-events-none opacity-0 transition-none",
         )}
       >
         <span

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -68,12 +68,15 @@ describe("CellInsertionRibbon", () => {
     const addMarkdownButton = screen.getByTitle("Add markdown cell");
 
     expect(actions).toHaveAttribute("aria-hidden", "true");
+    expect(actions).toHaveClass("pointer-events-none");
+    expect(actions).toHaveClass("transition-none");
     expect(addCodeButton).toHaveAttribute("tabindex", "-1");
     expect(addMarkdownButton).toHaveAttribute("tabindex", "-1");
 
     fireEvent.pointerEnter(adder!);
 
     expect(actions).not.toHaveAttribute("aria-hidden");
+    expect(actions).toHaveClass("pointer-events-auto");
     expect(addCodeButton).toHaveAttribute("tabindex", "0");
     expect(addMarkdownButton).toHaveAttribute("tabindex", "0");
   });


### PR DESCRIPTION
## Summary

- Prevent closed cell insertion palettes from receiving pointer events.
- Make the adder palette hide immediately when the row is no longer awake, while preserving the delayed fade-in on hover/focus.
- Add a regression assertion for the closed/open pointer-event contract.

## Testing

- `pnpm test:run src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `cargo xtask wasm`
- `cargo test -p notebook-doc --test generate_fixtures -- --nocapture`
- `pnpm test:run`
- `cargo xtask lint --fix`
