### PR TITLE
fix(notebook): move code cell presence into status line

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -613,7 +613,7 @@ export const CodeCell = memo(function CodeCell({
       isErrored={isExecutionErrored}
       isFocused={isFocused}
       compactIdle={isSourceEmpty}
-      activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" prefixSeparator />}
+      activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" />}
     />
   ) : null;
 

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -429,6 +429,19 @@ export function CodeCellCurrentLine({
         className,
       )}
     >
+      {!isCompactIdle && activityContent ? (
+        <div
+          data-slot="code-cell-current-line-activity"
+          className={cn(
+            "flex min-w-0 shrink-0 items-center overflow-hidden transition-[margin,max-width,opacity] duration-150 empty:hidden",
+            isQuietResting
+              ? "-mr-1.5 max-w-0 opacity-0 group-hover:mr-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:mr-0 group-focus-within:max-w-24 group-focus-within:opacity-100"
+              : "max-w-24 opacity-100",
+          )}
+        >
+          {activityContent}
+        </div>
+      ) : null}
       {!isCompactIdle ? (
         <ExecutionBoundaryRule
           state={boundaryState}
@@ -497,19 +510,6 @@ export function CodeCellCurrentLine({
           {detailLabel}
         </span>
       </span>
-      {!isCompactIdle && activityContent ? (
-        <div
-          data-slot="code-cell-current-line-activity"
-          className={cn(
-            "flex min-w-0 shrink-0 items-center overflow-hidden transition-[max-width,opacity] duration-150",
-            isQuietResting
-              ? "max-w-0 opacity-0 group-hover:max-w-24 group-hover:opacity-100 group-focus-within:max-w-24 group-focus-within:opacity-100"
-              : "max-w-24 opacity-100",
-          )}
-        >
-          {activityContent}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -382,7 +382,7 @@ describe("CodeCellCurrentLine", () => {
     expect(detail).toHaveClass("opacity-100");
   });
 
-  it("can carry activity context after the run state", () => {
+  it("can carry activity context before the boundary line", () => {
     const { container } = render(
       <CodeCellCurrentLine
         languageLabel="Python"
@@ -394,13 +394,15 @@ describe("CodeCellCurrentLine", () => {
     const footer = container.querySelector('[data-slot="code-cell-current-line"]');
 
     const activity = container.querySelector('[data-slot="code-cell-current-line-activity"]');
+    const rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
     const status = container.querySelector('[data-slot="code-cell-current-line-status"]');
 
     expect(footer).toHaveTextContent("Kyle");
     expect(activity).toHaveClass("max-w-0");
-    expect(status?.compareDocumentPosition(activity as Element)).toBe(
+    expect(activity?.compareDocumentPosition(rule as Element)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    expect(rule?.compareDocumentPosition(status as Element)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(screen.getByTestId("peer-activity")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Move code-cell presence activity into the left side of the current-line status bar.
- Keep the execution/runtime readout on the right side of the same line.
- Remove the now-unneeded presence separator and lock the new DOM order with a focused unit test.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `git diff --check`
