### PR TITLE
feat(desktop): relay notebook frames over tauri channel

### DIFF
--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -80,7 +80,7 @@ Module-level helpers (no hooks) — called once from `main.tsx` after `createTau
 
 ### Transport protocol
 
-Notebook request/response traffic goes through `NotebookClient` on `host.transport`, encoding `NotebookRequestEnvelope` values as typed protocol frames (`0x01`). Responses return as `0x02` frames on the unified `notebook:frame` event, resolved by request id.
+Notebook request/response traffic goes through `NotebookClient` on `host.transport`, encoding `NotebookRequestEnvelope` values as typed protocol frames (`0x01`). Responses return as `0x02` frames on the unified inbound transport stream, resolved by request id.
 
 Prefer extending `NotebookRequest` for daemon-owned notebook behavior. Add host methods for platform behavior. Some direct `invoke(...)` calls remain for host-side work that is not a notebook request/response frame: save/open dialogs, app update flows, dependency validation helpers.
 
@@ -108,7 +108,7 @@ Prefer extending `NotebookRequest` for daemon-owned notebook behavior. Add host 
 ## Data flow
 
 ```
-Tauri relay ── "notebook:frame" ──► useNotebook
+Tauri relay ── frame channel ──► useNotebook
                                      (WASM receive_frame demux)
                                        │          │         │
                   sync_applied ────────┘          │         │

--- a/apps/notebook/src/lib/notebook-frame-bus.ts
+++ b/apps/notebook/src/lib/notebook-frame-bus.ts
@@ -6,10 +6,10 @@
  * events. Subscribers now receive payloads via direct in-memory dispatch —
  * synchronous, typed, no event loop hop.
  *
- * The `notebook:frame` Tauri listener stays in `useAutomergeNotebook` (it
- * owns the WASM handle for sync demux). After WASM `receive_frame()` returns
- * typed events, this bus dispatches broadcast and presence payloads to
- * subscribers without a webview round-trip.
+ * The host transport listener stays in `useAutomergeNotebook` (it owns the
+ * WASM handle for sync demux). After WASM `receive_frame()` returns typed
+ * events, this bus dispatches broadcast and presence payloads to subscribers
+ * without a webview round-trip.
  */
 
 // ── Types ────────────────────────────────────────────────────────────

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -28,7 +28,7 @@
 //! JS-originated requests arrive via `RelayCommand::ForwardFrame` with
 //! frame type `0x01`; the relay forwards them unchanged and never looks at
 //! the id. The frontend maintains its own pending map and matches responses
-//! via the `notebook:frame` event stream.
+//! via the host transport's inbound frame stream.
 
 use std::collections::HashMap;
 use std::time::Duration;

--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -26,7 +26,7 @@ The desktop app bundles its own daemon binary. Version-mismatch detection betwee
 
 ## Connection topology
 
-The frontend talks to the Tauri relay through `invoke()` calls and Tauri events. The relay is a transparent byte pipe to the runtimed socket for Automerge sync, request, runtime-state, pool-state, and presence frames; it holds no document replica of its own. Broadcasts, responses, presence, and session-control frames arrive through the unified `notebook:frame` event.
+The frontend talks to the Tauri relay through `invoke()` calls, a generation-scoped frame channel, and connection-status Tauri events. The relay is a transparent byte pipe to the runtimed socket for Automerge sync, request, runtime-state, pool-state, and presence frames; it holds no document replica of its own. Broadcasts, responses, presence, and session-control frames arrive through the unified inbound frame stream.
 
 ## Connection lifecycle
 
@@ -138,7 +138,7 @@ user types in cell
   → Tauri relay pipes to daemon socket
   → Daemon applies sync, updates canonical doc
   → Daemon generates reply → frame 0x00
-  → Relay emits "notebook:frame" (raw typed bytes)
+  → Relay sends over the frame channel (raw typed bytes)
   → useAutomergeNotebook listener → handle.receive_frame(bytes)
   → WASM demuxes, returns FrameEvent[]
   → FrameEvent::SyncApplied includes a CellChangeset (field-level diff)
@@ -212,7 +212,7 @@ Frontend: host.transport.sendRequest({ type: "execute_cell", cell_id })
   → Frame 0x01 on socket
   → Daemon processes request
   → Frame 0x02 returned with matching id
-  → Relay emits "notebook:frame"
+  → Relay sends over the frame channel
   → TauriTransport response tap resolves the pending request by id
 ```
 
@@ -234,19 +234,19 @@ Kernel produces output
   → Daemon intercepts Jupyter IOPub
   → Daemon writes output manifest to RuntimeStateDoc
   → RuntimeStateDoc sync produces frame 0x05
-  → Relay emits "notebook:frame"
+  → Relay sends over the frame channel
   → WASM handle.receive_frame() → RuntimeStateDoc merge
   → frame-pipeline.ts plans output materialization
   → UI updates
 ```
 
-## Tauri event bridge and frame bus
+## Tauri channel bridge and frame bus
 
-| Event | Direction | Payload | Purpose |
-|-------|-----------|---------|---------|
-| `notebook:frame` | Relay → Frontend | `number[]` (typed frame bytes) | All daemon frames via unified pipe |
-| `daemon:ready` | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
-| `daemon:disconnected` | Relay → Frontend | — | Connection lost |
+| Bridge | Direction | Payload | Purpose |
+|--------|-----------|---------|---------|
+| Frame channel | Relay → Frontend | typed frame bytes | All daemon frames via unified pipe |
+| `daemon:ready` event | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
+| `daemon:disconnected` event | Relay → Frontend | — | Connection lost |
 
 Outgoing frames use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` via `tauri::ipc::Request`. Relay accepts frontend-originated `0x00`, `0x01`, `0x04`, `0x05`, `0x06`; `0x02`, `0x03`, `0x07` are daemon-originated.
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -231,6 +231,9 @@ impl SyncReadyState {
             }
         }
 
+        // Keep the generation update and channel clear under the same lock
+        // ordering used by `set_frame_channel`, so a stale channel cannot be
+        // written after this reset has checked the previous generation.
         let mut frame_channels = match self.frame_channels.lock() {
             Ok(s) => s,
             Err(e) => e.into_inner(),
@@ -299,15 +302,14 @@ impl SyncReadyState {
             return false;
         };
 
-        let current_generation = {
-            let gates = match self.gates.lock() {
-                Ok(s) => s,
-                Err(e) => e.into_inner(),
-            };
-            gates.get(label).map(|gate| gate.generation)
+        let gates = match self.gates.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
         };
-
-        if current_generation.is_some_and(|current| current != generation) {
+        if gates
+            .get(label)
+            .is_some_and(|gate| gate.generation != generation)
+        {
             return false;
         }
 
@@ -828,7 +830,9 @@ async fn setup_sync_receivers(
         // Wait for the frontend transport to register the Tauri channel for
         // this relay generation. Daemon frames buffer in `raw_frame_rx` during
         // this wait — the mpsc channel is unbounded, so nothing is lost.
-        loop {
+        let channel_wait_started = std::time::Instant::now();
+        let channel_wait_timeout = std::time::Duration::from_secs(30);
+        let frame_channel = loop {
             if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
                 info!(
                     "[notebook-sync] Stale relay for {} (gen {} superseded) before channel registration",
@@ -837,16 +841,27 @@ async fn setup_sync_receivers(
                 return;
             }
 
-            let has_channel = frame_channel_rx
+            if let Some(subscription) = frame_channel_rx
                 .borrow()
                 .as_ref()
-                .is_some_and(|subscription| subscription.generation == current_generation);
-            if has_channel {
-                break;
+                .filter(|subscription| subscription.generation == current_generation)
+                .cloned()
+            {
+                break Some(subscription);
             }
 
+            let Some(remaining) = channel_wait_timeout.checked_sub(channel_wait_started.elapsed())
+            else {
+                warn!(
+                    "[notebook-sync] Frontend frame channel timeout after 30s (gen {})",
+                    current_generation,
+                );
+                break None;
+            };
+            let wait_duration = remaining.min(std::time::Duration::from_secs(1));
+
             match tokio::time::timeout(
-                std::time::Duration::from_secs(1),
+                wait_duration,
                 frame_channel_rx.wait_for(|subscription| {
                     subscription
                         .as_ref()
@@ -855,76 +870,73 @@ async fn setup_sync_receivers(
             )
             .await
             {
-                Ok(Ok(_)) => break,
+                Ok(Ok(subscription)) => {
+                    break subscription
+                        .as_ref()
+                        .filter(|subscription| subscription.generation == current_generation)
+                        .cloned();
+                }
                 Ok(Err(_)) => {
                     warn!(
                         "[notebook-sync] Frame channel closed before registration (gen {})",
                         current_generation,
                     );
-                    return;
+                    break None;
                 }
                 Err(_) => continue,
             }
-        }
+        };
 
-        // Wait for the frontend SyncEngine to signal readiness. Daemon frames
-        // buffer in `raw_frame_rx` during this wait — the mpsc channel is
-        // unbounded, so nothing is lost.
-        if !*ready_rx.borrow() {
-            info!(
-                "[notebook-sync] Waiting for frontend ready before sending frames (gen {})",
-                current_generation,
-            );
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(30),
-                ready_rx.wait_for(|&ready| ready),
-            )
-            .await
-            {
-                Ok(Ok(_)) => {
-                    info!(
-                        "[notebook-sync] Frontend signaled ready (gen {})",
-                        current_generation,
-                    );
-                }
-                _ => {
-                    warn!(
-                        "[notebook-sync] Frontend ready timeout after 30s (gen {}) — proceeding anyway",
-                        current_generation,
-                    );
-                }
-            }
-        }
-
-        while let Some(frame_bytes) = raw_frame_rx.recv().await {
-            // Stop forwarding if a newer connection has replaced this one.
-            // Without this check, frames from the old room can interleave
-            // with the new connection's frames on the frontend channel,
-            // causing the frontend to feed them to the wrong WASM handle
-            // (stale Automerge document).
-            if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
+        if let Some(frame_channel) = frame_channel {
+            // Wait for the frontend SyncEngine to signal readiness. Daemon frames
+            // buffer in `raw_frame_rx` during this wait — the mpsc channel is
+            // unbounded, so nothing is lost.
+            if !*ready_rx.borrow() {
                 info!(
-                    "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
-                    notebook_id_for_relay, current_generation,
-                );
-                break;
-            }
-
-            let subscription = frame_channel_rx.borrow().clone();
-            let Some(subscription) = subscription.filter(|s| s.generation == current_generation)
-            else {
-                warn!(
-                    "[notebook-sync] Missing frame channel for active relay generation {}",
+                    "[notebook-sync] Waiting for frontend ready before sending frames (gen {})",
                     current_generation,
                 );
-                continue;
-            };
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    ready_rx.wait_for(|&ready| ready),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {
+                        info!(
+                            "[notebook-sync] Frontend signaled ready (gen {})",
+                            current_generation,
+                        );
+                    }
+                    _ => {
+                        warn!(
+                            "[notebook-sync] Frontend ready timeout after 30s (gen {}) — proceeding anyway",
+                            current_generation,
+                        );
+                    }
+                }
+            }
 
-            if let Err(e) = subscription
-                .channel
-                .send(tauri::ipc::InvokeResponseBody::Raw(frame_bytes))
-            {
-                warn!("[notebook-sync] Failed to send frame over channel: {}", e);
+            while let Some(frame_bytes) = raw_frame_rx.recv().await {
+                // Stop forwarding if a newer connection has replaced this one.
+                // Without this check, frames from the old room can interleave
+                // with the new connection's frames on the frontend channel,
+                // causing the frontend to feed them to the wrong WASM handle
+                // (stale Automerge document).
+                if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
+                    info!(
+                        "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
+                        notebook_id_for_relay, current_generation,
+                    );
+                    break;
+                }
+
+                if let Err(e) = frame_channel
+                    .channel
+                    .send(tauri::ipc::InvokeResponseBody::Raw(frame_bytes))
+                {
+                    warn!("[notebook-sync] Failed to send frame over channel: {}", e);
+                }
             }
         }
         warn!(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -167,9 +167,10 @@ struct DaemonStatusState(Arc<Mutex<Option<runtimed::client::DaemonProgress>>>);
 /// Per-window sync readiness gate.
 ///
 /// The Tauri relay task buffers daemon frames in the mpsc channel and waits
-/// for the frontend to signal readiness before emitting `notebook:frame` events.
+/// for the frontend to install a frame channel and signal readiness before
+/// sending frames through that channel.
 /// This prevents frame loss when the JS `SyncEngine` hasn't subscribed yet
-/// (race between relay start and `engine.start()` + `webview.listen()`).
+/// (race between relay start and `engine.start()` + channel registration).
 ///
 /// Each relay generation blocks until the JS calls `notify_sync_ready` after
 /// completing that generation's WASM bootstrap/reset. This keeps buffered
@@ -179,16 +180,27 @@ struct DaemonStatusState(Arc<Mutex<Option<runtimed::client::DaemonProgress>>>);
 /// `notify_sync_ready` can re-emit it for late-mounted JS listeners. Tauri
 /// webview events aren't sticky — if Rust emits `daemon:ready` before the
 /// React tree has called `host.daemonEvents.onReady(...)`, the event is lost.
-/// Re-emitting on sync-ready closes that race.
+/// `get_daemon_ready_info` lets late-mounted listeners backfill that payload.
 #[derive(Clone, Default)]
 struct SyncReadyState {
     gates: Arc<Mutex<HashMap<String, SyncReadyGate>>>,
+    frame_channels: Arc<Mutex<HashMap<String, FrameChannelGate>>>,
     last_ready: Arc<Mutex<HashMap<String, DaemonReadyPayload>>>,
 }
 
 struct SyncReadyGate {
     generation: u64,
     tx: tokio::sync::watch::Sender<bool>,
+}
+
+struct FrameChannelGate {
+    tx: tokio::sync::watch::Sender<Option<FrameChannelSubscription>>,
+}
+
+#[derive(Clone)]
+struct FrameChannelSubscription {
+    generation: u64,
+    channel: tauri::ipc::Channel<tauri::ipc::InvokeResponseBody>,
 }
 
 impl SyncReadyState {
@@ -217,6 +229,14 @@ impl SyncReadyState {
                     },
                 );
             }
+        }
+
+        let mut frame_channels = match self.frame_channels.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
+        };
+        if let Some(gate) = frame_channels.get_mut(label) {
+            gate.tx.send_replace(None);
         }
     }
 
@@ -264,6 +284,62 @@ impl SyncReadyState {
             .or_insert_with(|| SyncReadyGate {
                 generation: 0,
                 tx: tokio::sync::watch::channel(false).0,
+            });
+        gate.tx.subscribe()
+    }
+
+    /// Bind a JS-owned Tauri channel to the active relay generation.
+    fn set_frame_channel(
+        &self,
+        label: &str,
+        generation: Option<u64>,
+        channel: tauri::ipc::Channel<tauri::ipc::InvokeResponseBody>,
+    ) -> bool {
+        let Some(generation) = generation else {
+            return false;
+        };
+
+        let current_generation = {
+            let gates = match self.gates.lock() {
+                Ok(s) => s,
+                Err(e) => e.into_inner(),
+            };
+            gates.get(label).map(|gate| gate.generation)
+        };
+
+        if current_generation.is_some_and(|current| current != generation) {
+            return false;
+        }
+
+        let mut frame_channels = match self.frame_channels.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
+        };
+        let gate = frame_channels
+            .entry(label.to_string())
+            .or_insert_with(|| FrameChannelGate {
+                tx: tokio::sync::watch::channel(None).0,
+            });
+        gate.tx.send_replace(Some(FrameChannelSubscription {
+            generation,
+            channel,
+        }));
+        true
+    }
+
+    /// Get a receiver for the currently registered frame channel.
+    fn subscribe_frame_channel(
+        &self,
+        label: &str,
+    ) -> tokio::sync::watch::Receiver<Option<FrameChannelSubscription>> {
+        let mut frame_channels = match self.frame_channels.lock() {
+            Ok(s) => s,
+            Err(e) => e.into_inner(),
+        };
+        let gate = frame_channels
+            .entry(label.to_string())
+            .or_insert_with(|| FrameChannelGate {
+                tx: tokio::sync::watch::channel(None).0,
             });
         gate.tx.subscribe()
     }
@@ -708,8 +784,8 @@ async fn initialize_notebook_sync_attach(
 ///
 /// This is the common tail of `initialize_notebook_sync_open` and `_create`.
 /// It stores the handle, spawns a single relay task that forwards all typed
-/// frames (AutomergeSync, Broadcast, Presence) to the frontend via the
-/// `notebook:frame` event, and emits `daemon:ready` with the connection payload.
+/// frames (AutomergeSync, Broadcast, Presence) to the frontend via a
+/// generation-scoped Tauri channel, and emits `daemon:ready` with the connection payload.
 ///
 /// Note: No SyncUpdate receiver task is spawned — in pipe mode the relay forwards
 /// raw Automerge bytes directly, and the frontend WASM drives metadata updates
@@ -733,7 +809,7 @@ async fn setup_sync_receivers(
     );
 
     // Spawn unified frame relay task — forwards all typed frames (AutomergeSync,
-    // Broadcast, Presence) to the frontend as raw bytes via one event.
+    // Broadcast, Presence) to the frontend as raw bytes via one Tauri channel.
     // On disconnect, conditionally clears the handle using the generation counter
     // to avoid clobbering a newer connection's handle.
     let window_for_ready = window.clone();
@@ -746,14 +822,57 @@ async fn setup_sync_receivers(
     let sync_ready = window.app_handle().state::<SyncReadyState>();
     sync_ready.reset_for_generation(window.label(), current_generation);
     let mut ready_rx = sync_ready.subscribe(window.label());
+    let mut frame_channel_rx = sync_ready.subscribe_frame_channel(window.label());
 
     tokio::spawn(async move {
+        // Wait for the frontend transport to register the Tauri channel for
+        // this relay generation. Daemon frames buffer in `raw_frame_rx` during
+        // this wait — the mpsc channel is unbounded, so nothing is lost.
+        loop {
+            if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
+                info!(
+                    "[notebook-sync] Stale relay for {} (gen {} superseded) before channel registration",
+                    notebook_id_for_relay, current_generation,
+                );
+                return;
+            }
+
+            let has_channel = frame_channel_rx
+                .borrow()
+                .as_ref()
+                .is_some_and(|subscription| subscription.generation == current_generation);
+            if has_channel {
+                break;
+            }
+
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                frame_channel_rx.wait_for(|subscription| {
+                    subscription
+                        .as_ref()
+                        .is_some_and(|subscription| subscription.generation == current_generation)
+                }),
+            )
+            .await
+            {
+                Ok(Ok(_)) => break,
+                Ok(Err(_)) => {
+                    warn!(
+                        "[notebook-sync] Frame channel closed before registration (gen {})",
+                        current_generation,
+                    );
+                    return;
+                }
+                Err(_) => continue,
+            }
+        }
+
         // Wait for the frontend SyncEngine to signal readiness. Daemon frames
         // buffer in `raw_frame_rx` during this wait — the mpsc channel is
         // unbounded, so nothing is lost.
         if !*ready_rx.borrow() {
             info!(
-                "[notebook-sync] Waiting for frontend ready before emitting frames (gen {})",
+                "[notebook-sync] Waiting for frontend ready before sending frames (gen {})",
                 current_generation,
             );
             match tokio::time::timeout(
@@ -780,9 +899,9 @@ async fn setup_sync_receivers(
         while let Some(frame_bytes) = raw_frame_rx.recv().await {
             // Stop forwarding if a newer connection has replaced this one.
             // Without this check, frames from the old room can interleave
-            // with the new connection's frames on the notebook:frame event
-            // channel, causing the frontend to feed them to the wrong WASM
-            // handle (stale Automerge document).
+            // with the new connection's frames on the frontend channel,
+            // causing the frontend to feed them to the wrong WASM handle
+            // (stale Automerge document).
             if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
                 info!(
                     "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
@@ -790,10 +909,22 @@ async fn setup_sync_receivers(
                 );
                 break;
             }
-            if let Err(e) =
-                emit_to_label::<_, _, _>(&window, window.label(), "notebook:frame", &frame_bytes)
+
+            let subscription = frame_channel_rx.borrow().clone();
+            let Some(subscription) = subscription.filter(|s| s.generation == current_generation)
+            else {
+                warn!(
+                    "[notebook-sync] Missing frame channel for active relay generation {}",
+                    current_generation,
+                );
+                continue;
+            };
+
+            if let Err(e) = subscription
+                .channel
+                .send(tauri::ipc::InvokeResponseBody::Raw(frame_bytes))
             {
-                warn!("[notebook-sync] Failed to emit notebook:frame: {}", e);
+                warn!("[notebook-sync] Failed to send frame over channel: {}", e);
             }
         }
         warn!(
@@ -2708,11 +2839,40 @@ async fn reconnect_to_daemon(
     }
 }
 
+/// Register the JS-owned channel that receives inbound daemon frames.
+///
+/// The channel is bound to a relay generation before `notify_sync_ready`
+/// releases that generation's buffered frames. A stale frontend cannot replace
+/// the channel for a newer relay generation.
+#[tauri::command]
+fn subscribe_notebook_frames(
+    window: tauri::Window,
+    sync_ready: tauri::State<'_, SyncReadyState>,
+    generation: Option<u64>,
+    channel: tauri::ipc::Channel<tauri::ipc::InvokeResponseBody>,
+) -> Result<(), String> {
+    if sync_ready.set_frame_channel(window.label(), generation, channel) {
+        info!(
+            "[notebook-sync] Registered frame channel for '{}'{}",
+            window.label(),
+            generation.map_or_else(String::new, |g| format!(" (gen {g})"))
+        );
+        Ok(())
+    } else {
+        warn!(
+            "[notebook-sync] Ignoring stale frame channel for '{}'{}",
+            window.label(),
+            generation.map_or_else(String::new, |g| format!(" (gen {g})"))
+        );
+        Err("stale notebook frame channel generation".to_string())
+    }
+}
+
 /// Signal that the frontend SyncEngine is ready to receive frames.
 ///
 /// The Tauri frame relay buffers daemon frames until this is called,
 /// preventing frame loss when the relay starts emitting before the
-/// JS `SyncEngine` has subscribed to `notebook:frame` events.
+/// JS `SyncEngine` has bootstrapped its current WASM handle.
 ///
 /// Called once after `engine.start()` in `useAutomergeNotebook`. On
 /// reconnection the flag persists, so the new relay proceeds immediately.
@@ -3785,12 +3945,13 @@ pub fn run(
             clone_notebook_to_ephemeral,
             open_notebook_in_new_window,
             // Daemon connection state (kernel ops now go through
-            // `send_frame(0x01)` + the `notebook:frame` pending-map path,
+            // `send_frame(0x01)` + the channel-backed pending-map path,
             // not per-type Tauri commands).
             is_daemon_connected,
             get_daemon_status,
             get_pool_status,
             reconnect_to_daemon,
+            subscribe_notebook_frames,
             notify_sync_ready,
             get_daemon_ready_info,
             send_frame,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -887,56 +887,62 @@ async fn setup_sync_receivers(
             }
         };
 
-        if let Some(frame_channel) = frame_channel {
-            // Wait for the frontend SyncEngine to signal readiness. Daemon frames
-            // buffer in `raw_frame_rx` during this wait — the mpsc channel is
-            // unbounded, so nothing is lost.
-            if !*ready_rx.borrow() {
-                info!(
-                    "[notebook-sync] Waiting for frontend ready before sending frames (gen {})",
-                    current_generation,
-                );
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(30),
-                    ready_rx.wait_for(|&ready| ready),
-                )
-                .await
-                {
-                    Ok(Ok(_)) => {
-                        info!(
-                            "[notebook-sync] Frontend signaled ready (gen {})",
-                            current_generation,
-                        );
-                    }
-                    _ => {
-                        warn!(
-                            "[notebook-sync] Frontend ready timeout after 30s (gen {}) — proceeding anyway",
-                            current_generation,
-                        );
-                    }
+        let Some(frame_channel) = frame_channel else {
+            warn!(
+                "[notebook-sync] Frame relay stopped before frontend channel registration (gen {})",
+                current_generation,
+            );
+            return;
+        };
+
+        // Wait for the frontend SyncEngine to signal readiness. Daemon frames
+        // buffer in `raw_frame_rx` during this wait — the mpsc channel is
+        // unbounded, so nothing is lost.
+        if !*ready_rx.borrow() {
+            info!(
+                "[notebook-sync] Waiting for frontend ready before sending frames (gen {})",
+                current_generation,
+            );
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                ready_rx.wait_for(|&ready| ready),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {
+                    info!(
+                        "[notebook-sync] Frontend signaled ready (gen {})",
+                        current_generation,
+                    );
+                }
+                _ => {
+                    warn!(
+                        "[notebook-sync] Frontend ready timeout after 30s (gen {}) — proceeding anyway",
+                        current_generation,
+                    );
                 }
             }
+        }
 
-            while let Some(frame_bytes) = raw_frame_rx.recv().await {
-                // Stop forwarding if a newer connection has replaced this one.
-                // Without this check, frames from the old room can interleave
-                // with the new connection's frames on the frontend channel,
-                // causing the frontend to feed them to the wrong WASM handle
-                // (stale Automerge document).
-                if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
-                    info!(
-                        "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
-                        notebook_id_for_relay, current_generation,
-                    );
-                    break;
-                }
+        while let Some(frame_bytes) = raw_frame_rx.recv().await {
+            // Stop forwarding if a newer connection has replaced this one.
+            // Without this check, frames from the old room can interleave
+            // with the new connection's frames on the frontend channel,
+            // causing the frontend to feed them to the wrong WASM handle
+            // (stale Automerge document).
+            if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
+                info!(
+                    "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
+                    notebook_id_for_relay, current_generation,
+                );
+                break;
+            }
 
-                if let Err(e) = frame_channel
-                    .channel
-                    .send(tauri::ipc::InvokeResponseBody::Raw(frame_bytes))
-                {
-                    warn!("[notebook-sync] Failed to send frame over channel: {}", e);
-                }
+            if let Err(e) = frame_channel
+                .channel
+                .send(tauri::ipc::InvokeResponseBody::Raw(frame_bytes))
+            {
+                warn!("[notebook-sync] Failed to send frame over channel: {}", e);
             }
         }
         warn!(

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2524,7 +2524,7 @@ impl NotebookHandle {
 
     /// Receive a typed frame from the daemon, demux by type byte, return events for the frontend.
     ///
-    /// The input is the raw frame bytes from the `notebook:frame` Tauri event:
+    /// The input is the raw frame bytes from the host transport:
     /// `[frame_type_byte, ...payload]`.
     ///
     /// Returns a JS array of `FrameEvent` objects directly via `serde-wasm-bindgen`

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -3,7 +3,7 @@
  *
  * This host talks to a local Vite-only relay over WebSocket. The relay owns the
  * daemon Unix-socket connection and exposes the same typed notebook frames that
- * the Tauri host receives through `notebook:frame`.
+ * the Tauri host receives through its frame channel.
  */
 
 import {

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -215,10 +215,18 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   const relay: HostRelay = {
     requiresReadyGeneration: true,
     async notifySyncReady(generation?: number) {
+      let frameChannelError: unknown;
       if (canSubscribeNotebookFrames(transport)) {
-        await transport.subscribeNotebookFrames(generation);
+        try {
+          await transport.subscribeNotebookFrames(generation);
+        } catch (err) {
+          frameChannelError = err;
+        }
       }
       await invoke("notify_sync_ready", { generation });
+      if (frameChannelError) {
+        throw frameChannelError;
+      }
     },
   };
 

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -65,6 +65,18 @@ export interface CreateTauriHostOptions {
   transport?: NotebookTransport;
 }
 
+interface TauriFrameChannelTransport {
+  subscribeNotebookFrames(generation?: number): Promise<void>;
+}
+
+function canSubscribeNotebookFrames(
+  transport: NotebookTransport,
+): transport is NotebookTransport & TauriFrameChannelTransport {
+  return (
+    typeof (transport as Partial<TauriFrameChannelTransport>).subscribeNotebookFrames === "function"
+  );
+}
+
 /** Helper: subscribe to a Tauri webview event with a sync unlisten. */
 function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten {
   const webview = getCurrentWebview();
@@ -203,6 +215,9 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
   const relay: HostRelay = {
     requiresReadyGeneration: true,
     async notifySyncReady(generation?: number) {
+      if (canSubscribeNotebookFrames(transport)) {
+        await transport.subscribeNotebookFrames(generation);
+      }
       await invoke("notify_sync_ready", { generation });
     },
   };

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -3,18 +3,17 @@
  *
  * Bridges the `runtimed` `SyncEngine` to the daemon via Tauri IPC:
  *   - `sendFrame` → `invoke("send_frame", bytes)`
- *   - `onFrame` → `getCurrentWebview().listen("notebook:frame")`
+ *   - `onFrame` → fanout from a Tauri `Channel` registered with Rust
  *   - `sendRequest` → encode `NotebookRequestEnvelope`, send as `0x01` frame,
  *                     wait for matching `0x02` response via an internal
- *                     frame tap keyed by correlation id.
+ *                     channel dispatch keyed by correlation id.
  *
- * The pending map is tapped directly off `notebook:frame` events so Rust
- * and JS callers can share the same socket concurrently — responses are
- * dispatched by id, not by serialization order.
+ * The pending map is dispatched directly off the same inbound channel as sync
+ * frames so Rust and JS callers can share the same socket concurrently —
+ * responses are dispatched by id, not by serialization order.
  */
 
-import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import {
   FrameType,
   type FrameTypeValue,
@@ -27,6 +26,8 @@ import {
 
 const FRAME_TYPE_REQUEST = 0x01;
 const FRAME_TYPE_RESPONSE = 0x02;
+
+type ChannelFramePayload = ArrayBuffer | Uint8Array | number[];
 
 /** Per-request-type timeouts. Mirror `relay_task::request_timeout` in Rust. */
 function requestTimeoutMs(request: NotebookRequest): number {
@@ -41,6 +42,12 @@ function requestTimeoutMs(request: NotebookRequest): number {
   }
 }
 
+function normalizeFramePayload(payload: ChannelFramePayload): number[] {
+  if (payload instanceof Uint8Array) return Array.from(payload);
+  if (payload instanceof ArrayBuffer) return Array.from(new Uint8Array(payload));
+  return payload;
+}
+
 interface PendingEntry {
   resolve: (response: NotebookResponse) => void;
   reject: (err: Error) => void;
@@ -49,16 +56,39 @@ interface PendingEntry {
 
 export class TauriTransport implements NotebookTransport {
   private _connected = true;
-  private unlisteners: Array<() => void> = [];
+  private subscribers = new Set<FrameListener>();
+  private frameChannel = new Channel<ChannelFramePayload>((payload) =>
+    this.dispatchInboundFrame(payload),
+  );
+  private frameChannelGeneration: number | undefined;
+  private frameChannelSubscription: Promise<void> | null = null;
   /** In-flight requests keyed by correlation id. */
   private pending = new Map<string, PendingEntry>();
 
-  constructor() {
-    this.attachResponseTap();
-  }
-
   get connected(): boolean {
     return this._connected;
+  }
+
+  async subscribeNotebookFrames(generation?: number): Promise<void> {
+    if (this.frameChannelSubscription && this.frameChannelGeneration === generation) {
+      return this.frameChannelSubscription;
+    }
+
+    this.frameChannelGeneration = generation;
+    const subscription = invoke<void>("subscribe_notebook_frames", {
+      generation,
+      channel: this.frameChannel,
+    })
+      .then(() => undefined)
+      .catch((err) => {
+        if (this.frameChannelGeneration === generation) {
+          this.frameChannelSubscription = null;
+        }
+        throw err;
+      });
+    this.frameChannelSubscription = subscription;
+
+    return subscription;
   }
 
   async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
@@ -84,47 +114,10 @@ export class TauriTransport implements NotebookTransport {
   }
 
   onFrame(callback: FrameListener): () => void {
-    const webview = getCurrentWebview();
-
-    let unlistenFn: (() => void) | null = null;
-    let cancelled = false;
-
-    // IMPORTANT: wrap the callback in try/catch. Tauri's event system drops
-    // listeners whose handlers throw — a single exception escaping here
-    // silently unsubscribes the webview for the rest of its lifetime, and
-    // the daemon's subsequent frames land nowhere. Catching preserves the
-    // listener across a bad frame and surfaces the exception to the console
-    // so the underlying issue is fixable.
-    const unlistenPromise = webview.listen<number[]>("notebook:frame", (event) => {
-      try {
-        callback(event.payload);
-      } catch (err) {
-        console.error("[tauri-transport] notebook:frame handler threw:", err);
-      }
-    });
-
-    unlistenPromise
-      .then((fn) => {
-        if (cancelled) {
-          fn();
-        } else {
-          unlistenFn = fn;
-        }
-      })
-      .catch((err) => {
-        console.error("[tauri-transport] failed to register notebook:frame listener:", err);
-      });
-
-    const unlisten = () => {
-      cancelled = true;
-      if (unlistenFn) {
-        unlistenFn();
-        unlistenFn = null;
-      }
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
     };
-
-    this.unlisteners.push(unlisten);
-    return unlisten;
   }
 
   async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
@@ -152,10 +145,7 @@ export class TauriTransport implements NotebookTransport {
 
   disconnect(): void {
     this._connected = false;
-    for (const unlisten of this.unlisteners) {
-      unlisten();
-    }
-    this.unlisteners = [];
+    this.subscribers.clear();
     // Reject any still-pending requests so callers don't hang.
     for (const [id, entry] of this.pending) {
       clearTimeout(entry.timer);
@@ -164,47 +154,21 @@ export class TauriTransport implements NotebookTransport {
     this.pending.clear();
   }
 
-  /**
-   * Attach a permanent tap on `notebook:frame` that intercepts `0x02`
-   * response frames and dispatches them to the pending map.
-   *
-   * Non-response frames are ignored here — user-registered `onFrame`
-   * callbacks (e.g., the SyncEngine) see every frame independently.
-   * Tauri webview events fan out to all listeners, so the tap doesn't
-   * steal frames from other subscribers.
-   */
-  private attachResponseTap(): void {
-    const webview = getCurrentWebview();
-    let unlistenFn: (() => void) | null = null;
-    let cancelled = false;
+  private dispatchInboundFrame(payload: ChannelFramePayload): void {
+    const frame = normalizeFramePayload(payload);
+    try {
+      this.dispatchResponseFrame(frame);
+    } catch (err) {
+      console.error("[tauri-transport] response dispatch failed:", err);
+    }
 
-    const unlistenPromise = webview.listen<number[]>("notebook:frame", (event) => {
+    for (const callback of this.subscribers) {
       try {
-        this.dispatchResponseFrame(event.payload);
+        callback(frame);
       } catch (err) {
-        console.error("[tauri-transport] response tap failed:", err);
+        console.error("[tauri-transport] frame subscriber failed:", err);
       }
-    });
-
-    unlistenPromise
-      .then((fn) => {
-        if (cancelled) {
-          fn();
-        } else {
-          unlistenFn = fn;
-        }
-      })
-      .catch((err) => {
-        console.error("[tauri-transport] failed to attach response tap:", err);
-      });
-
-    this.unlisteners.push(() => {
-      cancelled = true;
-      if (unlistenFn) {
-        unlistenFn();
-        unlistenFn = null;
-      }
-    });
+    }
   }
 
   private awaitResponse(

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -155,6 +155,8 @@ export class TauriTransport implements NotebookTransport {
   }
 
   private dispatchInboundFrame(payload: ChannelFramePayload): void {
+    if (!this._connected) return;
+
     const frame = normalizeFramePayload(payload);
     try {
       this.dispatchResponseFrame(frame);

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -164,7 +164,8 @@ export class TauriTransport implements NotebookTransport {
       console.error("[tauri-transport] response dispatch failed:", err);
     }
 
-    for (const callback of this.subscribers) {
+    const subscribers = Array.from(this.subscribers);
+    for (const callback of subscribers) {
       try {
         callback(frame);
       } catch (err) {

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -7,6 +7,13 @@ const mockUnlisten = vi.fn();
 let reconnectPromiseOverride: Promise<unknown> | null = null;
 
 vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class Channel<T = unknown> {
+    onmessage: (payload: T) => void;
+
+    constructor(onmessage?: (payload: T) => void) {
+      this.onmessage = onmessage ?? (() => {});
+    }
+  },
   invoke: vi.fn((cmd: string, args?: unknown) => {
     capturedInvokes.push({ cmd, args });
     // Shape-of-return for the commands the tests hit:

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -373,6 +373,26 @@ describe("createTauriHost()", () => {
     ).toBeUndefined();
   });
 
+  it("relay.notifySyncReady still notifies Rust when frame channel registration fails", async () => {
+    const frameChannelError = new Error("stale generation");
+    const subscribeNotebookFrames = vi.fn(async () => {
+      throw frameChannelError;
+    });
+    const host = createTauriHost({
+      transport: {
+        ...stubTransport,
+        subscribeNotebookFrames,
+      } as NotebookTransport & {
+        subscribeNotebookFrames(generation?: number): Promise<void>;
+      },
+    });
+
+    await expect(host.relay.notifySyncReady(11)).rejects.toThrow("stale generation");
+    expect(subscribeNotebookFrames).toHaveBeenCalledWith(11);
+    expect(capturedInvokes.at(-1)?.cmd).toBe("notify_sync_ready");
+    expect(capturedInvokes.at(-1)?.args).toEqual({ generation: 11 });
+  });
+
   it("daemon.isConnected returns false when invoke rejects", async () => {
     const mod = await import("@tauri-apps/api/core");
     const rejectOnce = vi.spyOn(mod, "invoke").mockRejectedValueOnce(new Error("boom"));
@@ -383,7 +403,7 @@ describe("createTauriHost()", () => {
 
   it("daemonEvents.onDisconnected starts one host-owned reconnect", async () => {
     const host = createTauriHost({ transport: stubTransport });
-    let resolveReconnect: (() => void) | null = null;
+    let resolveReconnect!: () => void;
     reconnectPromiseOverride = new Promise((resolve) => {
       resolveReconnect = () => resolve(undefined);
     });
@@ -403,7 +423,7 @@ describe("createTauriHost()", () => {
     expect(second).toHaveBeenCalledTimes(1);
     expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toHaveLength(1);
 
-    resolveReconnect?.();
+    resolveReconnect();
     await reconnectPromiseOverride;
   });
 

--- a/packages/notebook-host/tests/tauri-transport.test.ts
+++ b/packages/notebook-host/tests/tauri-transport.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { TauriTransport } from "../src/tauri/transport";
+
+const coreMock = vi.hoisted(() => {
+  const capturedInvokes: Array<{ cmd: string; args: unknown }> = [];
+  const channels: Array<{ onmessage: (payload: unknown) => void }> = [];
+
+  class MockChannel<T = unknown> {
+    onmessage: (payload: T) => void;
+
+    constructor(onmessage?: (payload: T) => void) {
+      this.onmessage = onmessage ?? (() => {});
+      channels.push(this as unknown as { onmessage: (payload: unknown) => void });
+    }
+  }
+
+  return { capturedInvokes, channels, MockChannel };
+});
+
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: coreMock.MockChannel,
+  invoke: vi.fn((cmd: string, args?: unknown) => {
+    coreMock.capturedInvokes.push({ cmd, args });
+    return Promise.resolve(undefined);
+  }),
+}));
+
+function responseFrame(payload: unknown): Uint8Array {
+  const body = new TextEncoder().encode(JSON.stringify(payload));
+  const frame = new Uint8Array(1 + body.length);
+  frame[0] = 0x02;
+  frame.set(body, 1);
+  return frame;
+}
+
+beforeEach(() => {
+  coreMock.capturedInvokes.length = 0;
+  coreMock.channels.length = 0;
+  vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "req-1") });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TauriTransport", () => {
+  it("registers one channel per relay generation", async () => {
+    const transport = new TauriTransport();
+
+    await transport.subscribeNotebookFrames(7);
+    await transport.subscribeNotebookFrames(7);
+    await transport.subscribeNotebookFrames(8);
+
+    expect(coreMock.capturedInvokes).toEqual([
+      {
+        cmd: "subscribe_notebook_frames",
+        args: { generation: 7, channel: coreMock.channels[0] },
+      },
+      {
+        cmd: "subscribe_notebook_frames",
+        args: { generation: 8, channel: coreMock.channels[0] },
+      },
+    ]);
+  });
+
+  it("fans channel frames out to subscribers and stops after unlisten", () => {
+    const transport = new TauriTransport();
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const unlistenFirst = transport.onFrame(first);
+    transport.onFrame(second);
+
+    coreMock.channels[0].onmessage(new Uint8Array([0x00, 1, 2, 3]));
+    expect(first).toHaveBeenCalledWith([0x00, 1, 2, 3]);
+    expect(second).toHaveBeenCalledWith([0x00, 1, 2, 3]);
+
+    unlistenFirst();
+    coreMock.channels[0].onmessage(new Uint8Array([0x03, 4, 5]));
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenLastCalledWith([0x03, 4, 5]);
+  });
+
+  it("resolves notebook requests from response frames delivered over the channel", async () => {
+    const transport = new TauriTransport();
+
+    const result = transport.sendRequest({ type: "get_history", query: "import" });
+    await Promise.resolve();
+
+    const sent = coreMock.capturedInvokes.find((entry) => entry.cmd === "send_frame")
+      ?.args as Uint8Array;
+    expect(sent[0]).toBe(0x01);
+    expect(JSON.parse(new TextDecoder().decode(sent.slice(1)))).toEqual({
+      id: "req-1",
+      action: "get_history",
+      query: "import",
+    });
+
+    coreMock.channels[0].onmessage(
+      responseFrame({
+        id: "req-1",
+        result: "ok",
+        entries: [],
+      }).buffer,
+    );
+
+    await expect(result).resolves.toEqual({ result: "ok", entries: [] });
+  });
+
+  it("rejects pending requests on disconnect", async () => {
+    const transport = new TauriTransport();
+    const result = transport.sendRequest({ type: "get_history", query: "import" });
+
+    transport.disconnect();
+
+    await expect(result).rejects.toThrow("Transport disconnected (request req-1)");
+  });
+});

--- a/packages/notebook-host/tests/tauri-transport.test.ts
+++ b/packages/notebook-host/tests/tauri-transport.test.ts
@@ -116,4 +116,15 @@ describe("TauriTransport", () => {
 
     await expect(result).rejects.toThrow("Transport disconnected (request req-1)");
   });
+
+  it("ignores channel frames after disconnect", () => {
+    const transport = new TauriTransport();
+    const subscriber = vi.fn();
+    transport.onFrame(subscriber);
+
+    transport.disconnect();
+    coreMock.channels[0].onmessage(new Uint8Array([0x00, 1, 2, 3]));
+
+    expect(subscriber).not.toHaveBeenCalled();
+  });
 });

--- a/packages/notebook-host/tests/tauri-transport.test.ts
+++ b/packages/notebook-host/tests/tauri-transport.test.ts
@@ -127,4 +127,19 @@ describe("TauriTransport", () => {
 
     expect(subscriber).not.toHaveBeenCalled();
   });
+
+  it("dispatches to a subscriber snapshot when one listener disconnects", () => {
+    const transport = new TauriTransport();
+    const second = vi.fn();
+    const first = vi.fn(() => {
+      transport.disconnect();
+    });
+    transport.onFrame(first);
+    transport.onFrame(second);
+
+    coreMock.channels[0].onmessage(new Uint8Array([0x00, 1, 2, 3]));
+
+    expect(first).toHaveBeenCalledWith([0x00, 1, 2, 3]);
+    expect(second).toHaveBeenCalledWith([0x00, 1, 2, 3]);
+  });
 });


### PR DESCRIPTION
## Summary

Refs #3371.

- replace Desktop's inbound notebook frame relay with a generation-scoped Tauri `Channel`
- register the JS-owned frame channel before releasing `notify_sync_ready`, preserving the existing relay generation guard
- keep `NotebookTransport` consumers on `onFrame` while moving Tauri fanout and request-response dispatch behind the channel
- add focused Tauri transport tests for channel registration, subscriber fanout, response dispatch, and disconnect cleanup
- update protocol comments/docs that still described the old `notebook:frame` event path

## Verification

- `cargo check -p notebook`
- `pnpm exec tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --jsx react-jsx --strict --skipLibCheck packages/notebook-host/src/tauri/transport.ts packages/notebook-host/src/tauri/index.ts packages/notebook-host/tests/tauri-transport.test.ts`
- `pnpm test:run packages/notebook-host/tests/tauri-transport.test.ts packages/notebook-host/tests/tauri-host.test.ts`
- `cargo xtask lint --fix`

