### PR TITLE
ci(release): skip pnpm cache on Windows action setup

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -40,10 +40,20 @@ runs:
       with:
         dest: ${{ runner.temp }}/setup-pnpm
 
-    - uses: actions/setup-node@v6
+    # setup-node's pnpm cache post step can fail Windows jobs after artifacts upload
+    # while saving cache.tzst, which turns an otherwise successful release red.
+    - name: Set up Node with pnpm cache
+      if: runner.os != 'Windows'
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
+
+    - name: Set up Node
+      if: runner.os == 'Windows'
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
 
     - name: pnpm install
       shell: bash


### PR DESCRIPTION
## Summary

- avoid `actions/setup-node`'s implicit pnpm cache save on Windows in `build-runtime-artifacts`
- keep pnpm caching enabled for non-Windows runners
- preserve the same Node and pnpm install flow before runtime artifact setup

## Context

The June 4 nightly failed after the Windows Python wheel was already built and uploaded. The failed step was `Post Run ./.github/actions/build-runtime-artifacts`; the only visible cleanup command was the setup-node/actions-cache archive:

```text
"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst ... --use-compress-program "zstd -T0"
```

That post-job cache save marked the matrix leg failed, which skipped the final release job even though the build output existed.

## Verification

- `cargo xtask lint --fix`
- `ruby -ryaml -e 'YAML.load_file(".github/actions/build-runtime-artifacts/action.yml"); puts "ok"'`
- `actionlint .github/workflows/release-common.yml .github/workflows/pr-binary-generation.yml .github/workflows/build.yml .github/workflows/smoke.yml`
