### PR TITLE
chore(codex): add worktree setup helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ crates/notebook/fixtures/**/uv.lock
 
 # Agent workspace context (per-worktree state)
 .context/
+.codex/environments/environment.toml
 
 # Override global gitignore for .claude — rules and skills are project docs
 !.claude/

--- a/scripts/codex-worktree-setup.sh
+++ b/scripts/codex-worktree-setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Bootstrap a Codex-created worktree after the repo has been checked out.
+#
+# The Codex UI writes .codex/environments/environment.toml per worktree; keep
+# that generated file out of git and point its setup script at this helper.
+
+set -euo pipefail
+
+if [ -n "${CODEX_WORKTREE_PATH:-}" ]; then
+  cd "$CODEX_WORKTREE_PATH"
+else
+  cd "$(git rev-parse --show-toplevel)"
+fi
+
+if command -v git >/dev/null 2>&1; then
+  git lfs pull
+else
+  echo "git is required for Codex worktree setup" >&2
+  exit 1
+fi
+
+if command -v direnv >/dev/null 2>&1; then
+  direnv allow
+else
+  echo "direnv not found; skipping direnv allow" >&2
+fi

--- a/scripts/codex-worktree-setup.sh
+++ b/scripts/codex-worktree-setup.sh
@@ -6,18 +6,18 @@
 
 set -euo pipefail
 
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for Codex worktree setup" >&2
+  exit 1
+fi
+
 if [ -n "${CODEX_WORKTREE_PATH:-}" ]; then
   cd "$CODEX_WORKTREE_PATH"
 else
   cd "$(git rev-parse --show-toplevel)"
 fi
 
-if command -v git >/dev/null 2>&1; then
-  git lfs pull
-else
-  echo "git is required for Codex worktree setup" >&2
-  exit 1
-fi
+git lfs pull
 
 if command -v direnv >/dev/null 2>&1; then
   direnv allow

--- a/scripts/codex-worktree-setup.sh
+++ b/scripts/codex-worktree-setup.sh
@@ -18,9 +18,3 @@ else
 fi
 
 git lfs pull
-
-if command -v direnv >/dev/null 2>&1; then
-  direnv allow
-else
-  echo "direnv not found; skipping direnv allow" >&2
-fi


### PR DESCRIPTION
## Summary

- ignore the Codex UI-generated `.codex/environments/environment.toml` worktree config
- add `scripts/codex-worktree-setup.sh` as the tracked setup helper for Codex-created worktrees
- have the helper hydrate Git LFS renderer bundles for the worktree

## Verification

- `CODEX_WORKTREE_PATH="$PWD" scripts/codex-worktree-setup.sh`
- `git check-ignore -v .codex/environments/environment.toml`
- `bash -n scripts/codex-worktree-setup.sh`
- `cargo xtask lint --fix`
