### PR TITLE
fix(notebook-cloud): smooth preview loading states

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -129,7 +129,11 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /NotebookToolbarFrame,/);
   assert.match(
     sourceText,
-    /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookDocumentHeader[\s\S]*shouldShowCloudNotebookCommandToolbar\(shellCapabilities\)[\s\S]*<NotebookCommandToolbar/,
+    /const showCloudCommandToolbar =\s+shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
+  );
+  assert.match(
+    sourceText,
+    /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookDocumentHeader[\s\S]*\{showCloudCommandToolbar \? \([\s\S]*<NotebookCommandToolbar/,
   );
   assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -235,27 +235,41 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   const cssText = readFileSync(cssPath, "utf8");
 
   assert.match(sourceText, /NotebookEditModeButton/);
-  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*mode=\{interaction\.selectedMode\}/);
-  assert.match(sourceText, /<NotebookEditModeButton[\s\S]*state=\{interaction\.state\}/);
+  assert.match(
+    sourceText,
+    /<NotebookEditModeButton[\s\S]*mode=\{accessPending \? "view" : interaction\.selectedMode\}/,
+  );
+  assert.match(
+    sourceText,
+    /<NotebookEditModeButton[\s\S]*state=\{accessPending \? "viewing" : interaction\.state\}/,
+  );
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
   assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
-  assert.match(sourceText, /selectedMode: selectedInteractionMode/);
+  assert.match(sourceText, /selectedMode: editAccessPending \? "view" : selectedInteractionMode/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
   assert.match(sourceText, /const editAccessPending =/);
   assert.match(
     sourceText,
-    /status\.kind === "loading"[\s\S]*!canAcceptCellMutations[\s\S]*authState\.requestedScope === "editor"/,
+    /const requestedEditAccess =\s+authState\.requestedScope === "editor" \|\|\s+authState\.requestedScope === "owner"/,
   );
-  assert.match(sourceText, /accessPending=\{editAccessPending\}/);
   assert.match(
     sourceText,
-    /if \(accessPending\) \{\s+return <CloudNotebookEditModePlaceholder \/>;\s+\}/,
+    /status\.kind === "loading"[\s\S]*!canAcceptCellMutations[\s\S]*requestedEditAccess/,
   );
-  assert.match(sourceText, /function CloudNotebookEditModePlaceholder\(\)/);
-  assert.match(cssText, /\.cloud-edit-mode-placeholder \{[\s\S]*height: 2rem;/);
-  assert.match(cssText, /\.cloud-edit-mode-placeholder > span \{[\s\S]*height: 1\.5rem;/);
+  assert.match(sourceText, /accessPending=\{editAccessPending\}/);
+  assert.match(sourceText, /state=\{accessPending \? "viewing" : interaction\.state\}/);
+  assert.match(sourceText, /disabled=\{accessPending\}/);
+  assert.match(
+    sourceText,
+    /shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
+  );
+  assert.match(sourceText, /addCellControlsDisabled=\{editAccessPending\}/);
+  assert.doesNotMatch(sourceText, /CloudNotebookEditModePlaceholder/);
+  assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
+  assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);
+  assert.doesNotMatch(cssText, /cloud-command-toolbar-placeholder/);
   assert.match(
     sourceText,
     /if \(mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner"\) \{/,
@@ -278,6 +292,8 @@ test("cloud rail binds through the shared document rail adapter", () => {
 test("cloud host notices sit in the shared shell above the rail and notebook stage", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
+  const cssPath = new URL("../viewer/index.css", import.meta.url);
+  const cssText = readFileSync(cssPath, "utf8");
   const shellPath = new URL(
     "../../../src/components/notebook/NotebookDocumentShell.tsx",
     import.meta.url,
@@ -288,6 +304,9 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /const notices = hasNotices \? \(/);
   assert.match(sourceText, /notices=\{notices\}/);
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
+  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
+  assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*position: absolute;/);
+  assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*top: var\(--cloud-notice-top\);/);
   assert.match(
     shellText,
     /data-slot="notebook-document-notices"[\s\S]*data-slot="notebook-document-body"[\s\S]*\{rail\}[\s\S]*data-slot="notebook-document-stage"/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -263,8 +263,9 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /disabled=\{accessPending\}/);
   assert.match(
     sourceText,
-    /shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
+    /const showCloudCommandToolbar =\s+shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
   );
+  assert.match(sourceText, /\{showCloudCommandToolbar \? \(/);
   assert.match(sourceText, /addCellControlsDisabled=\{editAccessPending\}/);
   assert.doesNotMatch(sourceText, /CloudNotebookEditModePlaceholder/);
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
@@ -309,16 +310,18 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /const notices = hasNotices \? \(/);
   assert.match(sourceText, /notices=\{notices\}/);
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
+  assert.match(sourceText, /cloud-notebook-shell--command-toolbar/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
+  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 3\.75rem;/);
   assert.match(
     cssText,
-    /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
+    /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
   );
   assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*position: absolute;/);
   assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*top: var\(--cloud-notice-top\);/);
   assert.match(
     cssText,
-    /@media \(max-width: 900px\) \{[\s\S]*--cloud-notice-top: calc\(4\.75rem \+ 2\.5rem\);/,
+    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 4\.75rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(4\.75rem \+ 2\.5rem\);/,
   );
   assert.match(
     shellText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -243,6 +243,19 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /selectedMode: selectedInteractionMode/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
+  assert.match(sourceText, /const editAccessPending =/);
+  assert.match(
+    sourceText,
+    /status\.kind === "loading"[\s\S]*!canAcceptCellMutations[\s\S]*authState\.requestedScope === "editor"/,
+  );
+  assert.match(sourceText, /accessPending=\{editAccessPending\}/);
+  assert.match(
+    sourceText,
+    /if \(accessPending\) \{\s+return <CloudNotebookEditModePlaceholder \/>;\s+\}/,
+  );
+  assert.match(sourceText, /function CloudNotebookEditModePlaceholder\(\)/);
+  assert.match(cssText, /\.cloud-edit-mode-placeholder \{[\s\S]*height: 2rem;/);
+  assert.match(cssText, /\.cloud-edit-mode-placeholder > span \{[\s\S]*height: 1\.5rem;/);
   assert.match(
     sourceText,
     /if \(mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner"\) \{/,
@@ -318,6 +331,12 @@ test("cloud live materialization skips empty room handles before resolving outpu
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
+  assert.match(sourceText, /const CLOUD_EMPTY_ROOM_GRACE_MS = 900;/);
+  assert.match(sourceText, /const \[emptyRoomGraceElapsed, setEmptyRoomGraceElapsed\]/);
+  assert.match(
+    sourceText,
+    /status\.kind === "empty" && notebookCellIds\.length === 0 && !emptyRoomGraceElapsed/,
+  );
   assert.match(sourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -301,12 +301,25 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   const shellText = readFileSync(shellPath, "utf8");
 
   assert.match(sourceText, /const hasNotices =/);
+  assert.match(sourceText, /const noticeStatus: ViewerStatus =/);
+  assert.match(
+    sourceText,
+    /notebookViewIsLoading && \(status\.kind === "ready" \|\| status\.kind === "empty"\)[\s\S]*Preparing notebook view/,
+  );
   assert.match(sourceText, /const notices = hasNotices \? \(/);
   assert.match(sourceText, /notices=\{notices\}/);
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
+  assert.match(
+    cssText,
+    /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
+  );
   assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*position: absolute;/);
   assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*top: var\(--cloud-notice-top\);/);
+  assert.match(
+    cssText,
+    /@media \(max-width: 900px\) \{[\s\S]*--cloud-notice-top: calc\(4\.75rem \+ 2\.5rem\);/,
+  );
   assert.match(
     shellText,
     /data-slot="notebook-document-notices"[\s\S]*data-slot="notebook-document-body"[\s\S]*\{rail\}[\s\S]*data-slot="notebook-document-stage"/,

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -109,6 +109,37 @@ body {
   line-height: 1.2;
 }
 
+.cloud-edit-mode-placeholder {
+  display: inline-flex;
+  width: min(16rem, 54vw);
+  max-width: min(16rem, 54vw);
+  height: 2rem;
+  min-width: 8rem;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--background);
+  padding: 0.125rem;
+  color: color-mix(in srgb, var(--foreground) 18%, transparent);
+}
+
+.cloud-edit-mode-placeholder > span {
+  height: 1.5rem;
+  flex: 1 1 0;
+  border-radius: 4px;
+  background: currentColor;
+  opacity: 0.42;
+}
+
+.cloud-edit-mode-placeholder > span:first-child {
+  flex-basis: 4.25rem;
+}
+
+.cloud-edit-mode-placeholder > span:last-child {
+  flex-basis: 5.5rem;
+}
+
 .cloud-presence-stack {
   display: inline-flex;
   align-items: center;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -16,7 +16,7 @@ body {
 }
 
 .cloud-notebook-shell {
-  --cloud-notice-top: 3.75rem;
+  --cloud-notice-top: calc(3.75rem + 2.5rem);
 
   display: flex;
   position: relative;
@@ -52,7 +52,7 @@ body {
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
-  box-shadow: 0 8px 18px color-mix(in srgb, #000 6%, transparent);
+  box-shadow: 0 6px 14px color-mix(in srgb, #000 4%, transparent);
 }
 
 .cloud-notebook-notices [data-slot="notebook-notice"] {
@@ -210,7 +210,7 @@ body {
 
 @media (max-width: 900px) {
   .cloud-notebook-shell {
-    --cloud-notice-top: 4.75rem;
+    --cloud-notice-top: calc(4.75rem + 2.5rem);
   }
 
   .cloud-room-toolbar {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -16,7 +16,7 @@ body {
 }
 
 .cloud-notebook-shell {
-  --cloud-notice-top: calc(3.75rem + 2.5rem);
+  --cloud-notice-top: 3.75rem;
 
   display: flex;
   position: relative;
@@ -25,6 +25,10 @@ body {
   min-width: 0;
   overflow: hidden;
   background: var(--background);
+}
+
+.cloud-notebook-shell--command-toolbar {
+  --cloud-notice-top: calc(3.75rem + 2.5rem);
 }
 
 .cloud-notebook-rail {
@@ -210,6 +214,10 @@ body {
 
 @media (max-width: 900px) {
   .cloud-notebook-shell {
+    --cloud-notice-top: 4.75rem;
+  }
+
+  .cloud-notebook-shell--command-toolbar {
     --cloud-notice-top: calc(4.75rem + 2.5rem);
   }
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -16,7 +16,10 @@ body {
 }
 
 .cloud-notebook-shell {
+  --cloud-notice-top: 3.75rem;
+
   display: flex;
+  position: relative;
   height: 100%;
   min-height: 0;
   min-width: 0;
@@ -40,10 +43,16 @@ body {
 
 .cloud-notebook-notices {
   display: grid;
+  position: absolute;
+  top: var(--cloud-notice-top);
+  right: 0;
+  left: 0;
+  z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
+  box-shadow: 0 8px 18px color-mix(in srgb, #000 6%, transparent);
 }
 
 .cloud-notebook-notices [data-slot="notebook-notice"] {
@@ -107,37 +116,6 @@ body {
   font-size: 0.6875rem;
   font-weight: 500;
   line-height: 1.2;
-}
-
-.cloud-edit-mode-placeholder {
-  display: inline-flex;
-  width: min(16rem, 54vw);
-  max-width: min(16rem, 54vw);
-  height: 2rem;
-  min-width: 8rem;
-  align-items: center;
-  gap: 0.25rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--background);
-  padding: 0.125rem;
-  color: color-mix(in srgb, var(--foreground) 18%, transparent);
-}
-
-.cloud-edit-mode-placeholder > span {
-  height: 1.5rem;
-  flex: 1 1 0;
-  border-radius: 4px;
-  background: currentColor;
-  opacity: 0.42;
-}
-
-.cloud-edit-mode-placeholder > span:first-child {
-  flex-basis: 4.25rem;
-}
-
-.cloud-edit-mode-placeholder > span:last-child {
-  flex-basis: 5.5rem;
 }
 
 .cloud-presence-stack {
@@ -231,6 +209,10 @@ body {
 }
 
 @media (max-width: 900px) {
+  .cloud-notebook-shell {
+    --cloud-notice-top: 4.75rem;
+  }
+
   .cloud-room-toolbar {
     min-height: 4.75rem;
     flex-wrap: wrap;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1536,6 +1536,9 @@ function NotebookViewer({
     />
   );
 
+  const showCloudCommandToolbar =
+    shouldShowCloudNotebookCommandToolbar(shellCapabilities) || editAccessPending;
+
   const toolbar = (
     <NotebookToolbarFrame className="z-20">
       <NotebookDocumentHeader
@@ -1570,7 +1573,7 @@ function NotebookViewer({
         }
         identityControls={null}
       />
-      {shouldShowCloudNotebookCommandToolbar(shellCapabilities) || editAccessPending ? (
+      {showCloudCommandToolbar ? (
         <NotebookCommandToolbar
           capabilities={shellCapabilities}
           runtime={toolbarRuntime}
@@ -1623,7 +1626,11 @@ function NotebookViewer({
   return (
     <NotebookDocumentShell
       rootElement="main"
-      className="cloud-notebook-shell"
+      className={
+        showCloudCommandToolbar
+          ? "cloud-notebook-shell cloud-notebook-shell--command-toolbar"
+          : "cloud-notebook-shell"
+      }
       stageClassName="cloud-notebook-stage"
       toolbar={toolbar}
       toolbarLabel="Notebook view status and controls"

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1587,15 +1587,6 @@ function NotebookViewer({
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
-  const accessRequestNotice = cloudAccessRequestNotice(latestAccessRequest, accessRequestError);
-  const hasNotices = cloudNotebookHasNotices({
-    authState,
-    authRenewal,
-    connectionError,
-    diagnostics: accessRequestNotice,
-    hasReadableSnapshot: notebookHasReadableSnapshot,
-    status,
-  });
   const notebookViewIsLoading =
     status.kind === "loading" ||
     editAccessPending ||
@@ -1604,6 +1595,19 @@ function NotebookViewer({
     (shellCapabilities.canEditStructure &&
       notebookCellIds.length === 0 &&
       !liveMaterializedRef.current);
+  const noticeStatus: ViewerStatus =
+    notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
+      ? { kind: "loading", message: "Preparing notebook view..." }
+      : status;
+  const accessRequestNotice = cloudAccessRequestNotice(latestAccessRequest, accessRequestError);
+  const hasNotices = cloudNotebookHasNotices({
+    authState,
+    authRenewal,
+    connectionError,
+    diagnostics: accessRequestNotice,
+    hasReadableSnapshot: notebookHasReadableSnapshot,
+    status: noticeStatus,
+  });
   const notices = hasNotices ? (
     <CloudNotebookNotices
       authState={authState}
@@ -1611,7 +1615,7 @@ function NotebookViewer({
       connectionError={connectionError}
       diagnostics={accessRequestNotice}
       hasReadableSnapshot={notebookHasReadableSnapshot}
-      status={status}
+      status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
     />
   ) : null;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -142,6 +142,7 @@ import "./index.css";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
 const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 10_000;
+const CLOUD_EMPTY_ROOM_GRACE_MS = 900;
 
 setLoggerHost({
   debug: () => {},
@@ -712,6 +713,7 @@ function NotebookViewer({
         ? "edit"
         : "view",
   );
+  const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
@@ -1223,6 +1225,12 @@ function NotebookViewer({
       selectedInteractionMode,
     ],
   );
+  const editAccessPending =
+    !connectionError &&
+    status.kind === "loading" &&
+    !canAcceptCellMutations &&
+    selectedInteractionMode === "edit" &&
+    (authState.requestedScope === "editor" || authState.requestedScope === "owner");
   const canWriteCellSource = useCallback(
     (cellId: string) => {
       const cell = cellsByIdRef.current.get(cellId);
@@ -1240,6 +1248,17 @@ function NotebookViewer({
   const packageEnvironmentManager = cloudNotebookEnvironmentManager(
     notebookViewModel.packages.sections,
   );
+  useEffect(() => {
+    if (status.kind !== "empty" || notebookCellIds.length > 0) {
+      setEmptyRoomGraceElapsed(false);
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setEmptyRoomGraceElapsed(true);
+    }, CLOUD_EMPTY_ROOM_GRACE_MS);
+    return () => window.clearTimeout(timer);
+  }, [notebookCellIds.length, status.kind]);
   const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
     materializeLiveRuntimeRef.current?.(liveRuntime);
   }, []);
@@ -1522,6 +1541,7 @@ function NotebookViewer({
             authState={authState}
             interaction={shellCapabilities.interaction ?? null}
             accessLevel={shellCapabilities.access.level}
+            accessPending={editAccessPending}
             onModeChange={setSelectedInteractionMode}
             onRequestEditAccess={requestCloudEditAccess}
           />
@@ -1555,6 +1575,8 @@ function NotebookViewer({
   });
   const notebookViewIsLoading =
     status.kind === "loading" ||
+    editAccessPending ||
+    (status.kind === "empty" && notebookCellIds.length === 0 && !emptyRoomGraceElapsed) ||
     (Boolean(connectionError) && !notebookHasReadableSnapshot) ||
     (shellCapabilities.canEditStructure &&
       notebookCellIds.length === 0 &&
@@ -2154,12 +2176,14 @@ function CloudSharingControls({
 function CloudNotebookEditModeButton({
   authState,
   accessLevel,
+  accessPending,
   interaction,
   onModeChange,
   onRequestEditAccess,
 }: {
   authState: CloudPrototypeAuthState;
   accessLevel: NotebookShellCapabilities["access"]["level"];
+  accessPending: boolean;
   interaction: NotebookInteractionModeProjection | null;
   onModeChange: (mode: NotebookInteractionMode) => void;
   onRequestEditAccess: () => void;
@@ -2170,6 +2194,10 @@ function CloudNotebookEditModeButton({
     (!interaction?.canRequestEdit && interaction?.activeMode !== "edit")
   ) {
     return null;
+  }
+
+  if (accessPending) {
+    return <CloudNotebookEditModePlaceholder />;
   }
 
   return (
@@ -2185,6 +2213,20 @@ function CloudNotebookEditModeButton({
         onModeChange(mode);
       }}
     />
+  );
+}
+
+function CloudNotebookEditModePlaceholder() {
+  return (
+    <div
+      className="cloud-edit-mode-placeholder"
+      aria-busy="true"
+      aria-label="Loading notebook access"
+      role="status"
+    >
+      <span aria-hidden="true" />
+      <span aria-hidden="true" />
+    </div>
   );
 }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -707,13 +707,10 @@ function NotebookViewer({
     null,
   );
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
-  const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
-    () =>
-      authState.requestedScope === "editor" || authState.requestedScope === "owner"
-        ? "edit"
-        : "view",
-  );
+  const [selectedInteractionMode, setSelectedInteractionMode] =
+    useState<NotebookInteractionMode>("view");
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
+  const appliedGrantedEditScopeRef = useRef<string | null>(null);
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
@@ -1204,6 +1201,10 @@ function NotebookViewer({
     Boolean(connectionPeerId) &&
     !connectionError &&
     (status.kind === "ready" || status.kind === "empty");
+  const requestedEditAccess =
+    authState.requestedScope === "editor" || authState.requestedScope === "owner";
+  const editAccessPending =
+    !connectionError && status.kind === "loading" && !canAcceptCellMutations && requestedEditAccess;
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -1211,7 +1212,7 @@ function NotebookViewer({
         connectionScope,
         connectionActorLabel,
         hasCodeCells: codeCellCount > 0,
-        selectedMode: selectedInteractionMode,
+        selectedMode: editAccessPending ? "view" : selectedInteractionMode,
         canAcceptCellMutations,
         hostCapabilities: config.hostCapabilities,
       }),
@@ -1222,15 +1223,30 @@ function NotebookViewer({
       config.hostCapabilities,
       connectionActorLabel,
       connectionScope,
+      editAccessPending,
       selectedInteractionMode,
     ],
   );
-  const editAccessPending =
-    !connectionError &&
-    status.kind === "loading" &&
-    !canAcceptCellMutations &&
-    selectedInteractionMode === "edit" &&
-    (authState.requestedScope === "editor" || authState.requestedScope === "owner");
+  useEffect(() => {
+    if (!requestedEditAccess) {
+      appliedGrantedEditScopeRef.current = null;
+      return;
+    }
+    if (
+      !canAcceptCellMutations ||
+      (connectionScope !== "editor" && connectionScope !== "owner") ||
+      !connectionPeerId
+    ) {
+      return;
+    }
+
+    const grantKey = `${connectionPeerId}:${connectionScope}`;
+    if (appliedGrantedEditScopeRef.current === grantKey) {
+      return;
+    }
+    appliedGrantedEditScopeRef.current = grantKey;
+    setSelectedInteractionMode("edit");
+  }, [canAcceptCellMutations, connectionPeerId, connectionScope, requestedEditAccess]);
   const canWriteCellSource = useCallback(
     (cellId: string) => {
       const cell = cellsByIdRef.current.get(cellId);
@@ -1248,6 +1264,12 @@ function NotebookViewer({
   const packageEnvironmentManager = cloudNotebookEnvironmentManager(
     notebookViewModel.packages.sections,
   );
+  const toolbarRuntime = editAccessPending
+    ? null
+    : notebookLanguageRef.current === "deno"
+      ? "deno"
+      : "python";
+  const toolbarEnvironmentManager = editAccessPending ? null : packageEnvironmentManager;
   useEffect(() => {
     if (status.kind !== "empty" || notebookCellIds.length > 0) {
       setEmptyRoomGraceElapsed(false);
@@ -1548,12 +1570,13 @@ function NotebookViewer({
         }
         identityControls={null}
       />
-      {shouldShowCloudNotebookCommandToolbar(shellCapabilities) ? (
+      {shouldShowCloudNotebookCommandToolbar(shellCapabilities) || editAccessPending ? (
         <NotebookCommandToolbar
           capabilities={shellCapabilities}
-          runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
-          environmentManager={packageEnvironmentManager}
+          runtime={toolbarRuntime}
+          environmentManager={toolbarEnvironmentManager}
           environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
+          addCellControlsDisabled={editAccessPending}
           addAfterCellId={toolbarAddAfterCellId}
           onAddCell={handleCloudAddCell}
           onTogglePackages={handleTogglePackagesRail}
@@ -2196,15 +2219,12 @@ function CloudNotebookEditModeButton({
     return null;
   }
 
-  if (accessPending) {
-    return <CloudNotebookEditModePlaceholder />;
-  }
-
   return (
     <NotebookEditModeButton
-      mode={interaction.selectedMode}
-      state={interaction.state}
+      mode={accessPending ? "view" : interaction.selectedMode}
+      state={accessPending ? "viewing" : interaction.state}
       variant="segmented"
+      disabled={accessPending}
       onModeChange={(mode) => {
         if (mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner") {
           onRequestEditAccess();
@@ -2213,20 +2233,6 @@ function CloudNotebookEditModeButton({
         onModeChange(mode);
       }}
     />
-  );
-}
-
-function CloudNotebookEditModePlaceholder() {
-  return (
-    <div
-      className="cloud-edit-mode-placeholder"
-      aria-busy="true"
-      aria-label="Loading notebook access"
-      role="status"
-    >
-      <span aria-hidden="true" />
-      <span aria-hidden="true" />
-    </div>
   );
 }
 

--- a/src/components/notebook/NotebookCommandToolbar.tsx
+++ b/src/components/notebook/NotebookCommandToolbar.tsx
@@ -53,6 +53,7 @@ export interface NotebookCommandToolbarProps {
   environmentOutOfSync?: boolean;
   runtimeStatus?: NotebookCommandToolbarStatus | null;
   startDisabled?: boolean;
+  addCellControlsDisabled?: boolean;
   addAfterCellId?: string | null;
   onAddCell?: (type: "code" | "markdown", afterCellId?: string | null) => unknown;
   onStartRuntime?: () => void;
@@ -81,6 +82,7 @@ export function NotebookCommandToolbar({
   environmentOutOfSync = false,
   runtimeStatus,
   startDisabled = false,
+  addCellControlsDisabled = false,
   addAfterCellId = null,
   onAddCell,
   onStartRuntime,
@@ -107,7 +109,7 @@ export function NotebookCommandToolbar({
     runtimeStatus?.state === "idle" ||
     runtimeStatus?.state === "busy" ||
     runtimeStatus?.state === "starting";
-  const showAddCellControls = canEditStructure && Boolean(onAddCell);
+  const showAddCellControls = Boolean(onAddCell) && (canEditStructure || addCellControlsDisabled);
   const showRuntimeStart =
     hasRuntimeStatus && canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
   const showRuntimeActions =
@@ -134,8 +136,9 @@ export function NotebookCommandToolbar({
           <button
             type="button"
             onClick={() => onAddCell?.("code", addAfterCellId)}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Add code cell"
+            disabled={addCellControlsDisabled}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+            title={addCellControlsDisabled ? "Checking edit access" : "Add code cell"}
             aria-label="Add code cell"
             data-testid="add-code-cell-button"
           >
@@ -145,8 +148,9 @@ export function NotebookCommandToolbar({
           <button
             type="button"
             onClick={() => onAddCell?.("markdown", addAfterCellId)}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Add markdown cell"
+            disabled={addCellControlsDisabled}
+            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+            title={addCellControlsDisabled ? "Checking edit access" : "Add markdown cell"}
             aria-label="Add markdown cell"
             data-testid="add-markdown-cell-button"
           >

--- a/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
@@ -110,6 +110,33 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.getByTestId("kernel-status")).toHaveAttribute("data-kernel-status", "idle");
   });
 
+  it("can reserve add-cell controls as disabled while host edit access resolves", () => {
+    const onAddCell = vi.fn();
+
+    render(
+      <NotebookCommandToolbar
+        capabilities={{
+          ...editableToolbarCapabilities,
+          canEditStructure: false,
+          canExecute: false,
+        }}
+        addCellControlsDisabled
+        onAddCell={onAddCell}
+      />,
+    );
+
+    const codeButton = screen.getByTestId("add-code-cell-button");
+    const markdownButton = screen.getByTestId("add-markdown-cell-button");
+
+    expect(codeButton).toBeDisabled();
+    expect(codeButton).toHaveAttribute("title", "Checking edit access");
+    expect(markdownButton).toBeDisabled();
+
+    fireEvent.click(codeButton);
+
+    expect(onAddCell).not.toHaveBeenCalled();
+  });
+
   it("can render notebook commands without a runtime status surface", () => {
     render(
       <NotebookCommandToolbar


### PR DESCRIPTION
## Summary

- smooth the hosted preview's initial edit-mode transition
- keep zero-cell room states behind a short grace period during loading/reconnect
- add source-level coverage for the loading choreography

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts test/viewer-loading-policy.test.ts test/viewer-render-props.test.ts`
- `cargo xtask lint --fix`
- deployed to `preview.runt.run` and captured a cache-busted browser reload trace with no `Request sent` or `Empty notebook` frames during initial load
