### PR TITLE
chore(elements): run Next dev through portless

### DIFF
--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -3,15 +3,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "portless run",
+    "dev": "portless run --name nteract-elements next dev",
     "dev:local": "next dev --port 5176",
-    "dev:next": "next dev",
     "url": "portless get nteract-elements",
     "build": "next build"
-  },
-  "portless": {
-    "name": "nteract-elements",
-    "script": "dev:next"
   },
   "dependencies": {
     "@nteract/sift": "workspace:*",


### PR DESCRIPTION
## Summary

- Run the Elements Next dev server through Portless directly with `portless run --name nteract-elements next dev`.
- Remove the old `dev:next` helper and package-level Portless script indirection.

## Portless docs context

The current Portless docs show two relevant patterns:

- Direct package script wrapping: `portless myapp next dev`.
- Worktree-aware wrapping: `portless run --name myapp next dev`, which keeps the git worktree subdomain prefix while overriding the inferred base app name.

This PR uses the worktree-aware form so Elements keeps its explicit `nteract-elements` base name without reintroducing a separate Portless config block.

Docs: https://portless.sh/

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
- `cargo xtask wasm-ensure`
- `pnpm --dir apps/elements build`
