### PR TITLE
refactor(notebook-cloud): table-drive hosted routes

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -72,6 +72,13 @@ import {
   viewerThemeBootstrapScript,
   viewerThemeFirstPaintStyle,
 } from "./viewer-theme-bootstrap.ts";
+import {
+  dispatchWorkerRoute,
+  exactPath,
+  routePath,
+  type WorkerRouteMatch,
+  type WorkerRoute,
+} from "./worker-routing.ts";
 
 export { NotebookRoom };
 
@@ -100,10 +107,89 @@ type SnapshotPairValidationResult =
       body: Record<string, unknown>;
     };
 
+const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
+  {
+    match: exactPath("/api/health"),
+    methods: ["GET"],
+    handler: routeHealth,
+  },
+  {
+    match: exactPath("/", "/index.html"),
+    methods: ["GET"],
+    handler: (_match, request, env) => homeViewer(request, env),
+  },
+  {
+    match: exactPath("/oidc"),
+    methods: ["GET"],
+    handler: (_match, request, env) => oidcCallbackViewer(request, env),
+  },
+  {
+    match: routePath("/n/:notebookId/sync", { trailingSlash: "optional" }),
+    handler: (_match, request, env) => routeRoomSync(request, env),
+  },
+  {
+    match: routePath("/n/:notebookId/debug", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }) => debugViewer(params.notebookId),
+  },
+  {
+    match: routePath("/n/:notebookId/r/:revision", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) => viewer(params.notebookId, request, env, params.revision),
+  },
+  {
+    match: routePath("/n/:notebookId/:vanityName", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) => viewer(params.notebookId, request, env),
+  },
+  {
+    match: routePath("/api/n/:notebookId", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) => routeCatalog(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) => routeNotebookAcl(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/invites", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) => routeNotebookInvites(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/invites/:inviteId", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeNotebookInvite(request, env, params.notebookId, params.inviteId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/access-requests", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeNotebookAccessRequests(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/access-requests/:accessRequestId", {
+      trailingSlash: "optional",
+    }),
+    handler: ({ params }, request, env) =>
+      routeNotebookAccessRequest(request, env, params.notebookId, params.accessRequestId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/runtime-snapshots/:runtimeHeadsHash"),
+    handler: ({ params }, request, env) =>
+      routeRuntimeSnapshot(request, env, params.notebookId, params.runtimeHeadsHash),
+  },
+  {
+    match: routePath("/api/n/:notebookId/snapshots/:headsHash"),
+    handler: ({ params }, request, env) =>
+      routeSnapshot(request, env, params.notebookId, params.headsHash),
+  },
+  {
+    match: routePath("/api/n/:notebookId/blobs/:hash"),
+    handler: ({ params }, request, env) => routeBlob(request, env, params.notebookId, params.hash),
+  },
+];
+
 const worker: ExportedHandler<Env> = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    const url = new URL(request.url);
-
     if (request.method === "OPTIONS") {
       return withCors(new Response(null, { status: 204 }));
     }
@@ -113,124 +199,9 @@ const worker: ExportedHandler<Env> = {
       return assetResponse;
     }
 
-    if (url.pathname === "/api/health" && request.method === "GET") {
-      await safeEnsureCatalogSchema(env, ctx);
-      return json({
-        status: "ok",
-        service: "nteract-notebook-cloud",
-        deployment_env: env.DEPLOYMENT_ENV ?? "development",
-        auth: {
-          anaconda_api_key: anacondaApiKeyHealth(env),
-          oidc: oidcHealth(env),
-        },
-      });
-    }
-
-    if ((url.pathname === "/" || url.pathname === "/index.html") && request.method === "GET") {
-      return homeViewer(request, env);
-    }
-
-    if (url.pathname === "/oidc" && request.method === "GET") {
-      return oidcCallbackViewer(request, env);
-    }
-
-    const syncMatch = url.pathname.match(/^\/n\/([^/]+)\/sync\/?$/);
-    if (syncMatch) {
-      return routeRoomSync(request, env);
-    }
-
-    const debugMatch = url.pathname.match(/^\/n\/([^/]+)\/debug\/?$/);
-    if (debugMatch && request.method === "GET") {
-      return debugViewer(decodeURIComponent(debugMatch[1]));
-    }
-
-    const pinnedViewerMatch = url.pathname.match(/^\/n\/([^/]+)\/r\/([^/]+)\/?$/);
-    if (pinnedViewerMatch && request.method === "GET") {
-      return viewer(
-        decodeURIComponent(pinnedViewerMatch[1]),
-        request,
-        env,
-        decodeURIComponent(pinnedViewerMatch[2]),
-      );
-    }
-
-    const vanityViewerMatch = url.pathname.match(/^\/n\/([^/]+)\/([^/]+)\/?$/);
-    if (vanityViewerMatch && request.method === "GET") {
-      return viewer(decodeURIComponent(vanityViewerMatch[1]), request, env);
-    }
-
-    const catalogMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/?$/);
-    if (catalogMatch && request.method === "GET") {
-      return routeCatalog(request, env, decodeURIComponent(catalogMatch[1]));
-    }
-
-    const aclMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/acl\/?$/);
-    if (aclMatch) {
-      return routeNotebookAcl(request, env, decodeURIComponent(aclMatch[1]));
-    }
-
-    const inviteMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/invites\/?$/);
-    if (inviteMatch) {
-      return routeNotebookInvites(request, env, decodeURIComponent(inviteMatch[1]));
-    }
-
-    const inviteItemMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/invites\/([^/]+)\/?$/);
-    if (inviteItemMatch) {
-      return routeNotebookInvite(
-        request,
-        env,
-        decodeURIComponent(inviteItemMatch[1]),
-        decodeURIComponent(inviteItemMatch[2]),
-      );
-    }
-
-    const accessRequestMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/access-requests\/?$/);
-    if (accessRequestMatch) {
-      return routeNotebookAccessRequests(request, env, decodeURIComponent(accessRequestMatch[1]));
-    }
-
-    const accessRequestItemMatch = url.pathname.match(
-      /^\/api\/n\/([^/]+)\/access-requests\/([^/]+)\/?$/,
-    );
-    if (accessRequestItemMatch) {
-      return routeNotebookAccessRequest(
-        request,
-        env,
-        decodeURIComponent(accessRequestItemMatch[1]),
-        decodeURIComponent(accessRequestItemMatch[2]),
-      );
-    }
-
-    const runtimeSnapshotMatch = url.pathname.match(
-      /^\/api\/n\/([^/]+)\/runtime-snapshots\/([^/]+)$/,
-    );
-    if (runtimeSnapshotMatch) {
-      return routeRuntimeSnapshot(
-        request,
-        env,
-        decodeURIComponent(runtimeSnapshotMatch[1]),
-        decodeURIComponent(runtimeSnapshotMatch[2]),
-      );
-    }
-
-    const snapshotMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/snapshots\/([^/]+)$/);
-    if (snapshotMatch) {
-      return routeSnapshot(
-        request,
-        env,
-        decodeURIComponent(snapshotMatch[1]),
-        decodeURIComponent(snapshotMatch[2]),
-      );
-    }
-
-    const blobMatch = url.pathname.match(/^\/api\/n\/([^/]+)\/blobs\/([^/]+)$/);
-    if (blobMatch) {
-      return routeBlob(
-        request,
-        env,
-        decodeURIComponent(blobMatch[1]),
-        decodeURIComponent(blobMatch[2]),
-      );
+    const routeResponse = await dispatchWorkerRoute(NOTEBOOK_CLOUD_ROUTES, request, env, ctx);
+    if (routeResponse) {
+      return routeResponse;
     }
 
     return json({ error: "not found" }, 404);
@@ -238,6 +209,24 @@ const worker: ExportedHandler<Env> = {
 };
 
 export default worker;
+
+async function routeHealth(
+  _match: WorkerRouteMatch,
+  _request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  await safeEnsureCatalogSchema(env, ctx);
+  return json({
+    status: "ok",
+    service: "nteract-notebook-cloud",
+    deployment_env: env.DEPLOYMENT_ENV ?? "development",
+    auth: {
+      anaconda_api_key: anacondaApiKeyHealth(env),
+      oidc: oidcHealth(env),
+    },
+  });
+}
 
 async function routeAsset(request: Request, env: Env): Promise<Response | null> {
   const url = new URL(request.url);

--- a/apps/notebook-cloud/src/worker-routing.ts
+++ b/apps/notebook-cloud/src/worker-routing.ts
@@ -1,0 +1,88 @@
+import type { Env, ExecutionContext } from "./cloudflare-types.ts";
+
+export interface WorkerRouteMatch {
+  pathname: string;
+  params: Record<string, string>;
+}
+
+export type WorkerRouteHandler = (
+  match: WorkerRouteMatch,
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+) => Promise<Response> | Response;
+
+export type WorkerRouteMatcher = (pathname: string) => WorkerRouteMatch | null;
+
+export interface WorkerRoute {
+  match: WorkerRouteMatcher;
+  methods?: readonly string[];
+  handler: WorkerRouteHandler;
+}
+
+export async function dispatchWorkerRoute(
+  routes: readonly WorkerRoute[],
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const { pathname } = new URL(request.url);
+  for (const route of routes) {
+    const routeMatch = route.match(pathname);
+    if (!routeMatch) {
+      continue;
+    }
+    if (route.methods && !route.methods.includes(request.method)) {
+      continue;
+    }
+    return route.handler(routeMatch, request, env, ctx);
+  }
+  return null;
+}
+
+export function exactPath(...paths: readonly string[]): WorkerRouteMatcher {
+  const accepted = new Set(paths);
+  return (pathname) => (accepted.has(pathname) ? { pathname, params: {} } : null);
+}
+
+export function routePath(
+  template: string,
+  options: { trailingSlash?: "optional" } = {},
+): WorkerRouteMatcher {
+  const templateSegments = splitPath(template);
+  return (pathname) => {
+    let candidate = pathname;
+    if (options.trailingSlash === "optional" && candidate.length > 1 && candidate.endsWith("/")) {
+      candidate = candidate.slice(0, -1);
+    }
+    const pathSegments = splitPath(candidate);
+    if (pathSegments.length !== templateSegments.length) {
+      return null;
+    }
+
+    const params: Record<string, string> = {};
+    for (let index = 0; index < templateSegments.length; index += 1) {
+      const templateSegment = templateSegments[index];
+      const pathSegment = pathSegments[index];
+      if (templateSegment.startsWith(":")) {
+        params[templateSegment.slice(1)] = decodeURIComponent(pathSegment);
+        continue;
+      }
+      if (templateSegment !== pathSegment) {
+        return null;
+      }
+    }
+
+    return { pathname, params };
+  };
+}
+
+function splitPath(path: string): string[] {
+  if (!path.startsWith("/")) {
+    throw new Error(`route paths must start with "/": ${path}`);
+  }
+  if (path === "/") {
+    return [];
+  }
+  return path.slice(1).split("/");
+}

--- a/apps/notebook-cloud/test/worker-routing.test.ts
+++ b/apps/notebook-cloud/test/worker-routing.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Env, ExecutionContext } from "../src/cloudflare-types.ts";
+import {
+  dispatchWorkerRoute,
+  exactPath,
+  routePath,
+  type WorkerRoute,
+} from "../src/worker-routing.ts";
+
+const env = {} as Env;
+const ctx: ExecutionContext = {
+  waitUntil() {},
+  passThroughOnException() {},
+};
+
+describe("worker route dispatcher", () => {
+  it("dispatches the first matching route", async () => {
+    const routes: WorkerRoute[] = [
+      {
+        match: routePath("/api/n/:notebookId"),
+        handler: () => new Response("catalog"),
+      },
+      {
+        match: routePath("/api/n/:notebookId"),
+        handler: () => new Response("duplicate"),
+      },
+    ];
+
+    const response = await dispatchWorkerRoute(
+      routes,
+      new Request("https://cloud.test/api/n/topic-viz"),
+      env,
+      ctx,
+    );
+
+    assert.equal(await response?.text(), "catalog");
+  });
+
+  it("skips method-filtered routes without turning fallthroughs into 405s", async () => {
+    const routes: WorkerRoute[] = [
+      {
+        match: exactPath("/"),
+        methods: ["GET"],
+        handler: () => new Response("home"),
+      },
+    ];
+
+    const response = await dispatchWorkerRoute(
+      routes,
+      new Request("https://cloud.test/", { method: "POST" }),
+      env,
+      ctx,
+    );
+
+    assert.equal(response, null);
+  });
+
+  it("decodes captured route parameters at the edge", async () => {
+    const routes: WorkerRoute[] = [
+      {
+        match: routePath("/n/:notebookId/r/:revision"),
+        handler: ({ params }) =>
+          Response.json({
+            notebookId: params.notebookId,
+            revision: params.revision,
+          }),
+      },
+    ];
+
+    const response = await dispatchWorkerRoute(
+      routes,
+      new Request("https://cloud.test/n/demo%20notebook/r/heads%2Fpinned"),
+      env,
+      ctx,
+    );
+
+    assert.deepEqual(await response?.json(), {
+      notebookId: "demo notebook",
+      revision: "heads/pinned",
+    });
+  });
+
+  it("matches routes with optional trailing slashes", async () => {
+    const routes: WorkerRoute[] = [
+      {
+        match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
+        handler: ({ params }) => new Response(params.notebookId),
+      },
+    ];
+
+    const response = await dispatchWorkerRoute(
+      routes,
+      new Request("https://cloud.test/api/n/topic-viz/acl/"),
+      env,
+      ctx,
+    );
+
+    assert.equal(await response?.text(), "topic-viz");
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the hosted worker's prototype regex dispatch cascade with an explicit route table.
- Add a small routing helper that supports exact routes, named path params, optional trailing slashes, and method-based fallthroughs.
- Cover the helper with focused tests so future hosted routes do not depend on capture-index bookkeeping.

## Verification

- `pnpm --dir apps/notebook-cloud wasm`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routing.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`

## Preview

- Deployed `https://preview.runt.run` as Worker version `074ecbe5-aad6-4508-b92b-19565b598767`.
- Deployed renderer assets Worker version `6499d991-ebd0-434d-8edf-9dac57207734`.
- Deployed output document Worker version `9037bcd6-fe81-4c94-92e6-648c8fca3a18`.
- `curl -fsS https://preview.runt.run/api/health`
- `NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL='account:user%3Aanaconda:email:b0204af7084bdb0f271f1fe243bea5973fe07e0264939605e1570ecb1604b3f0' NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT='import plotly.graph_objects as go' NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS=120000 pnpm --dir apps/notebook-cloud smoke:hosted`
