### PR TITLE
perf(notebook-cloud): cache hosted output blobs

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,4 +1,4 @@
-import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
+import type { Env, ExecutionContext, ExportedHandler, R2Object } from "./cloudflare-types.ts";
 import type { BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
@@ -184,7 +184,8 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   },
   {
     match: routePath("/api/n/:notebookId/blobs/:hash"),
-    handler: ({ params }, request, env) => routeBlob(request, env, params.notebookId, params.hash),
+    handler: ({ params }, request, env, ctx) =>
+      routeBlob(request, env, ctx, params.notebookId, params.hash),
   },
 ];
 
@@ -1473,6 +1474,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 async function routeBlob(
   request: Request,
   env: Env,
+  ctx: ExecutionContext,
   notebookId: string,
   hash: string,
 ): Promise<Response> {
@@ -1495,12 +1497,7 @@ async function routeBlob(
       return json({ error: "blob not found" }, 404);
     }
 
-    const headers = new Headers({
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Content-Length": object.size.toString(),
-      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
-      ETag: object.httpEtag,
-    });
+    const headers = blobHeaders(object);
     return withCors(new Response(null, { headers }));
   }
 
@@ -1509,6 +1506,21 @@ async function routeBlob(
     if (identity instanceof Response) {
       return identity;
     }
+    const cache = cloudflareDefaultCache();
+    const cacheKey = blobCacheKey(request);
+    const cached = cache ? await matchBlobCache(cache, cacheKey, notebookId, hash) : null;
+    if (cached) {
+      cloudLog("debug", "blob.read.cache_hit", {
+        notebook_id: notebookId,
+        hash,
+        counter: "blob_read_cache_hits",
+        counter_delta: 1,
+      });
+      const cachedResponse = withCors(new Response(cached.body, cached));
+      cachedResponse.headers.set("X-Notebook-Cloud-Blob-Cache", "hit");
+      return cachedResponse;
+    }
+
     const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
     if (!object) {
       cloudLog("warn", "blob.read.missing", {
@@ -1521,13 +1533,22 @@ async function routeBlob(
       return json({ error: "blob not found" }, 404);
     }
 
-    const headers = new Headers({
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Content-Length": object.size.toString(),
-      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
-      ETag: object.httpEtag,
-    });
-    return withCors(new Response(object.body, { headers }));
+    const response = withCors(new Response(object.body, { headers: blobHeaders(object) }));
+    if (cache) {
+      response.headers.set("X-Notebook-Cloud-Blob-Cache", "miss");
+      ctx.waitUntil(
+        cache.put(cacheKey, response.clone()).catch((error) => {
+          cloudLog("warn", "blob.read.cache_put_failed", {
+            notebook_id: notebookId,
+            hash,
+            error: errorMessage(error),
+            counter: "blob_read_cache_put_failures",
+            counter_delta: 1,
+          });
+        }),
+      );
+    }
+    return response;
   }
 
   if (request.method !== "PUT") {
@@ -1609,6 +1630,48 @@ async function routeBlob(
   });
 
   return json({ ok: true, key, size: body.byteLength }, 201);
+}
+
+function blobHeaders(object: R2Object): Headers {
+  return new Headers({
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "Content-Length": object.size.toString(),
+    "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+    ETag: object.httpEtag,
+  });
+}
+
+type CloudflareCacheStorage = CacheStorage & { default?: Cache };
+
+function cloudflareDefaultCache(): Cache | null {
+  const cacheStorage = (globalThis as { caches?: CloudflareCacheStorage }).caches;
+  return cacheStorage?.default ?? null;
+}
+
+async function matchBlobCache(
+  cache: Cache,
+  cacheKey: Request,
+  notebookId: string,
+  hash: string,
+): Promise<Response | null> {
+  try {
+    return (await cache.match(cacheKey)) ?? null;
+  } catch (error) {
+    cloudLog("warn", "blob.read.cache_match_failed", {
+      notebook_id: notebookId,
+      hash,
+      error: errorMessage(error),
+      counter: "blob_read_cache_match_failures",
+      counter_delta: 1,
+    });
+    return null;
+  }
+}
+
+function blobCacheKey(request: Request): Request {
+  const url = new URL(request.url);
+  url.search = "";
+  return new Request(url.toString(), { method: "GET" });
 }
 
 interface NotebookAclPayload {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -851,6 +851,112 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  it("caches authorized immutable blob reads at the Worker edge", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "blob-cache-demo");
+    seedAcl(env, {
+      notebookId: "blob-cache-demo",
+      subject: "user:dev:alice",
+      scope: "viewer",
+    });
+    const body = new Uint8Array([9, 8, 7, 6]);
+    const hash = await sha256Hex(body);
+    const key = blobKey("blob-cache-demo", hash);
+    await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+      httpMetadata: { contentType: "application/vnd.apache.arrow.stream" },
+    });
+    const storedResponses = new Map<string, Response>();
+    const restoreCaches = installGlobalCaches({
+      default: {
+        async match(request: Request) {
+          return storedResponses.get(request.url)?.clone();
+        },
+        async put(request: Request, response: Response) {
+          storedResponses.set(request.url, response.clone());
+        },
+      } as unknown as Cache,
+    });
+    const waitUntilPromises: Promise<unknown>[] = [];
+
+    try {
+      const first = await blobGet(
+        env,
+        `/api/n/blob-cache-demo/blobs/${hash}?viewer_session=first`,
+        fakeContextWithWaitUntil(waitUntilPromises),
+      );
+      assert.equal(first.status, 200);
+      assert.equal(first.headers.get("X-Notebook-Cloud-Blob-Cache"), "miss");
+      assert.deepEqual(new Uint8Array(await first.arrayBuffer()), body);
+      await Promise.all(waitUntilPromises);
+
+      const second = await blobGet(
+        env,
+        `/api/n/blob-cache-demo/blobs/${hash}?viewer_session=second`,
+      );
+      assert.equal(second.status, 200);
+      assert.equal(second.headers.get("X-Notebook-Cloud-Blob-Cache"), "hit");
+      assert.deepEqual(new Uint8Array(await second.arrayBuffer()), body);
+      assert.deepEqual(env.NOTEBOOK_SNAPSHOTS.getKeys, [key]);
+
+      const anonymous = await worker.fetch(
+        new Request(
+          new URL(
+            `/api/n/blob-cache-demo/blobs/${hash}?viewer_session=anonymous`,
+            "http://localhost",
+          ),
+        ),
+        env,
+        fakeContext(),
+      );
+      assert.equal(anonymous.status, 404);
+      assert.deepEqual(env.NOTEBOOK_SNAPSHOTS.getKeys, [key]);
+    } finally {
+      restoreCaches();
+    }
+  });
+
+  it("falls back to R2 when the Worker edge cache match fails", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "blob-cache-fallback-demo");
+    seedAcl(env, {
+      notebookId: "blob-cache-fallback-demo",
+      subject: "user:dev:alice",
+      scope: "viewer",
+    });
+    const body = new Uint8Array([1, 3, 3, 7]);
+    const hash = await sha256Hex(body);
+    const key = blobKey("blob-cache-fallback-demo", hash);
+    await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+      httpMetadata: { contentType: "application/octet-stream" },
+    });
+    const restoreCaches = installGlobalCaches({
+      default: {
+        async match() {
+          throw new Error("cache unavailable");
+        },
+        async put() {
+          return undefined;
+        },
+      } as unknown as Cache,
+    });
+    const waitUntilPromises: Promise<unknown>[] = [];
+
+    try {
+      const response = await blobGet(
+        env,
+        `/api/n/blob-cache-fallback-demo/blobs/${hash}`,
+        fakeContextWithWaitUntil(waitUntilPromises),
+      );
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("X-Notebook-Cloud-Blob-Cache"), "miss");
+      assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+      await Promise.all(waitUntilPromises);
+      assert.deepEqual(env.NOTEBOOK_SNAPSHOTS.getKeys, [key]);
+    } finally {
+      restoreCaches();
+    }
+  });
+
   it("rejects blob uploads whose path hash does not match the bytes", async () => {
     const env = fakeEnv();
     seedNotebook(env, "runtime-demo");
@@ -2551,6 +2657,24 @@ async function accessRequestItemRequest(
   );
 }
 
+async function blobGet(
+  env: FakeEnv,
+  pathname: string,
+  ctx: ExecutionContext = fakeContext(),
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(pathname, "http://localhost"), {
+      headers: {
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "viewer",
+      },
+    }),
+    env,
+    ctx,
+  );
+}
+
 async function scopedPut(
   env: FakeEnv,
   pathname: string,
@@ -2685,6 +2809,30 @@ function fakeContext(): ExecutionContext {
   return {
     waitUntil: () => undefined,
     passThroughOnException: () => undefined,
+  };
+}
+
+function fakeContextWithWaitUntil(promises: Promise<unknown>[]): ExecutionContext {
+  return {
+    waitUntil: (promise) => {
+      promises.push(promise);
+    },
+    passThroughOnException: () => undefined,
+  };
+}
+
+function installGlobalCaches(cachesValue: { default: Cache }): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "caches");
+  Object.defineProperty(globalThis, "caches", {
+    configurable: true,
+    value: cachesValue,
+  });
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "caches", descriptor);
+    } else {
+      delete (globalThis as { caches?: unknown }).caches;
+    }
   };
 }
 
@@ -3553,8 +3701,10 @@ function okResult<T = unknown>(results?: T[], meta: Record<string, unknown> = {}
 
 class FakeR2Bucket implements R2Bucket {
   readonly objects = new Map<string, FakeR2Object>();
+  readonly getKeys: string[] = [];
 
   async get(key: string): Promise<R2ObjectBody | null> {
+    this.getKeys.push(key);
     return this.objects.get(key) ?? null;
   }
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -861,6 +861,7 @@ function NotebookViewer({
             onInitialCells(syncCells) {
               if (syncCells.length === 0) return;
               markCloudViewerLoadMilestone("snapshot-initial-cells");
+              preloadSiftWasm(syncCells);
               setCells(syncCells);
               setStatus({
                 kind: "loading",


### PR DESCRIPTION
## Summary

- cache authorized immutable blob GET responses through the Cloudflare Worker Cache API
- keep blob cache lookups behind viewer authorization, with cache-match and cache-put failures falling back to R2
- start Sift WASM preload from pinned snapshot initial cells, matching the live materialization path

## Verification

- `node --import tsx --test test/worker-routes.test.ts` from `apps/notebook-cloud`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- deployed `preview.runt.run` Worker version `ceca45ac-cd66-453e-90f0-e10206d1852c`
- live Arrow blob probe: `cf-cache-status: HIT`, `x-notebook-cloud-blob-cache: hit`, `ttfb=0.471616s`
- `smoke:hosted` passed against `https://preview.runt.run/n/topic-viz/topic-viz`

## Notes

- Sift WASM is already coming from `https://nteract-notebook-cloud-assets.rgbkrk.workers.dev/renderer-assets/sift_wasm.wasm?...` with immutable Cloudflare asset caching.
- The slow row path is dominated by large Arrow stream blobs. This change makes repeat blob reads edge-cacheable after authorization instead of repeatedly streaming through R2.
- `pnpm --dir apps/notebook-cloud test -- worker-routes` unexpectedly ran the full cloud suite; the new Worker route coverage passed, while unrelated existing tests failed in `room-materializer`, `sharing`, and `viewer-notices`.
