### PR TITLE
refactor(notebook-cloud): centralize response helpers

### DIFF
--- a/apps/notebook-cloud/src/http-responses.ts
+++ b/apps/notebook-cloud/src/http-responses.ts
@@ -1,0 +1,91 @@
+import type { R2Object, R2ObjectBody } from "./cloudflare-types.ts";
+import { DEV_AUTH_TOKEN_HEADER } from "./auth-shared.ts";
+
+export function json(value: unknown, status = 200): Response {
+  return withCors(
+    new Response(JSON.stringify(value), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+export function withCors(response: Response): Response {
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Methods", "DELETE, GET, HEAD, POST, PUT, OPTIONS");
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    `Authorization, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, X-Runtime-State-Doc-Id, ${DEV_AUTH_TOKEN_HEADER}`,
+  );
+  return response;
+}
+
+export function withBrowserSecurityHeaders(
+  response: Response,
+  contentSecurityPolicy?: string,
+): Response {
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "no-referrer");
+  response.headers.set(
+    "Permissions-Policy",
+    [
+      "accelerometer=()",
+      "autoplay=()",
+      "camera=()",
+      "display-capture=()",
+      "encrypted-media=()",
+      "fullscreen=()",
+      "geolocation=()",
+      "gyroscope=()",
+      "magnetometer=()",
+      "microphone=()",
+      "midi=()",
+      "payment=()",
+      "picture-in-picture=()",
+      "publickey-credentials-get=()",
+      "screen-wake-lock=()",
+      "usb=()",
+      "xr-spatial-tracking=()",
+    ].join(", "),
+  );
+  if (contentSecurityPolicy) {
+    response.headers.set("Content-Security-Policy", contentSecurityPolicy);
+  }
+  return response;
+}
+
+interface ImmutableR2ObjectOptions {
+  includeContentLength?: boolean;
+}
+
+export function immutableR2ObjectHeaders(
+  object: R2Object,
+  options: ImmutableR2ObjectOptions = {},
+): Headers {
+  const headers = new Headers({
+    "Cache-Control": "public, max-age=31536000, immutable",
+    "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
+    ETag: object.httpEtag,
+  });
+  if (options.includeContentLength) {
+    headers.set("Content-Length", object.size.toString());
+  }
+  return headers;
+}
+
+export function immutableR2ObjectResponse(
+  object: R2ObjectBody,
+  options: ImmutableR2ObjectOptions = {},
+): Response {
+  return withCors(
+    new Response(object.body, { headers: immutableR2ObjectHeaders(object, options) }),
+  );
+}
+
+export function immutableR2ObjectHeadResponse(object: R2Object): Response {
+  return withCors(
+    new Response(null, {
+      headers: immutableR2ObjectHeaders(object, { includeContentLength: true }),
+    }),
+  );
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,4 +1,4 @@
-import type { Env, ExecutionContext, ExportedHandler, R2Object } from "./cloudflare-types.ts";
+import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
 import type { BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
@@ -79,6 +79,13 @@ import {
   type WorkerRouteMatch,
   type WorkerRoute,
 } from "./worker-routing.ts";
+import {
+  immutableR2ObjectHeadResponse,
+  immutableR2ObjectResponse,
+  json,
+  withBrowserSecurityHeaders,
+  withCors,
+} from "./http-responses.ts";
 
 export { NotebookRoom };
 
@@ -481,12 +488,7 @@ async function routeSnapshot(
       return json({ error: "snapshot not found" }, 404);
     }
 
-    const headers = new Headers({
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
-      ETag: object.httpEtag,
-    });
-    return withCors(new Response(object.body, { headers }));
+    return immutableR2ObjectResponse(object);
   }
 
   if (request.method !== "PUT") {
@@ -609,12 +611,7 @@ async function routeRuntimeSnapshot(
       return json({ error: "runtime snapshot not found" }, 404);
     }
 
-    const headers = new Headers({
-      "Cache-Control": "public, max-age=31536000, immutable",
-      "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
-      ETag: object.httpEtag,
-    });
-    return withCors(new Response(object.body, { headers }));
+    return immutableR2ObjectResponse(object);
   }
 
   if (request.method !== "PUT") {
@@ -1497,8 +1494,7 @@ async function routeBlob(
       return json({ error: "blob not found" }, 404);
     }
 
-    const headers = blobHeaders(object);
-    return withCors(new Response(null, { headers }));
+    return immutableR2ObjectHeadResponse(object);
   }
 
   if (request.method === "GET") {
@@ -1533,7 +1529,7 @@ async function routeBlob(
       return json({ error: "blob not found" }, 404);
     }
 
-    const response = withCors(new Response(object.body, { headers: blobHeaders(object) }));
+    const response = immutableR2ObjectResponse(object, { includeContentLength: true });
     if (cache) {
       response.headers.set("X-Notebook-Cloud-Blob-Cache", "miss");
       ctx.waitUntil(
@@ -1630,15 +1626,6 @@ async function routeBlob(
   });
 
   return json({ ok: true, key, size: body.byteLength }, 201);
-}
-
-function blobHeaders(object: R2Object): Headers {
-  return new Headers({
-    "Cache-Control": "public, max-age=31536000, immutable",
-    "Content-Length": object.size.toString(),
-    "Content-Type": object.httpMetadata?.contentType ?? "application/octet-stream",
-    ETag: object.httpEtag,
-  });
 }
 
 type CloudflareCacheStorage = CacheStorage & { default?: Cache };
@@ -1962,15 +1949,6 @@ async function authorizePublishOrCreate(
   return authorizeIdentityOrResponse(env, notebookId, identity, "owner");
 }
 
-function json(value: unknown, status = 200): Response {
-  return withCors(
-    new Response(JSON.stringify(value), {
-      status,
-      headers: { "Content-Type": "application/json" },
-    }),
-  );
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -1978,47 +1956,6 @@ function errorMessage(error: unknown): string {
 async function sha256Hex(body: ArrayBuffer): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", body);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-function withCors(response: Response): Response {
-  response.headers.set("Access-Control-Allow-Origin", "*");
-  response.headers.set("Access-Control-Allow-Methods", "DELETE, GET, HEAD, POST, PUT, OPTIONS");
-  response.headers.set(
-    "Access-Control-Allow-Headers",
-    `Authorization, Content-Type, X-User, X-Principal, X-Operator, X-Scope, X-Viewer-Session, X-Runtime-Heads-Hash, X-Runtime-State-Doc-Id, ${DEV_AUTH_TOKEN_HEADER}`,
-  );
-  return response;
-}
-
-function withBrowserSecurityHeaders(response: Response, contentSecurityPolicy?: string): Response {
-  response.headers.set("X-Content-Type-Options", "nosniff");
-  response.headers.set("Referrer-Policy", "no-referrer");
-  response.headers.set(
-    "Permissions-Policy",
-    [
-      "accelerometer=()",
-      "autoplay=()",
-      "camera=()",
-      "display-capture=()",
-      "encrypted-media=()",
-      "fullscreen=()",
-      "geolocation=()",
-      "gyroscope=()",
-      "magnetometer=()",
-      "microphone=()",
-      "midi=()",
-      "payment=()",
-      "picture-in-picture=()",
-      "publickey-credentials-get=()",
-      "screen-wake-lock=()",
-      "usb=()",
-      "xr-spatial-tracking=()",
-    ].join(", "),
-  );
-  if (contentSecurityPolicy) {
-    response.headers.set("Content-Security-Policy", contentSecurityPolicy);
-  }
-  return response;
 }
 
 function viewerContentSecurityPolicy(env: Env): string {

--- a/apps/notebook-cloud/test/http-responses.test.ts
+++ b/apps/notebook-cloud/test/http-responses.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { R2HTTPMetadata, R2ObjectBody } from "../src/cloudflare-types.ts";
+import {
+  immutableR2ObjectHeadResponse,
+  immutableR2ObjectResponse,
+  json,
+  withBrowserSecurityHeaders,
+} from "../src/http-responses.ts";
+
+describe("notebook cloud HTTP responses", () => {
+  it("serializes JSON with CORS headers", async () => {
+    const response = json({ ok: true }, 201);
+
+    assert.equal(response.status, 201);
+    assert.equal(response.headers.get("Content-Type"), "application/json");
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.match(
+      response.headers.get("Access-Control-Allow-Headers") ?? "",
+      /x-notebook-cloud-dev-token/,
+    );
+    assert.deepEqual(await response.json(), { ok: true });
+  });
+
+  it("adds browser hardening headers with optional CSP", () => {
+    const response = withBrowserSecurityHeaders(new Response("html"), "frame-ancestors 'none'");
+
+    assert.equal(response.headers.get("X-Content-Type-Options"), "nosniff");
+    assert.equal(response.headers.get("Referrer-Policy"), "no-referrer");
+    assert.match(response.headers.get("Permissions-Policy") ?? "", /camera=\(\)/);
+    assert.equal(response.headers.get("Content-Security-Policy"), "frame-ancestors 'none'");
+  });
+
+  it("serves immutable R2 object bodies without leaking route-specific choices", async () => {
+    const object = fakeR2Object(new Uint8Array([1, 2, 3]), {
+      contentType: "application/vnd.apache.arrow.stream",
+    });
+
+    const response = immutableR2ObjectResponse(object);
+
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
+    assert.equal(response.headers.get("Content-Type"), "application/vnd.apache.arrow.stream");
+    assert.equal(response.headers.get("ETag"), '"fake-etag"');
+    assert.equal(response.headers.has("Content-Length"), false);
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), new Uint8Array([1, 2, 3]));
+  });
+
+  it("can include Content-Length for blob GET and HEAD responses", async () => {
+    const object = fakeR2Object(new Uint8Array([4, 5, 6, 7]));
+
+    const getResponse = immutableR2ObjectResponse(object, { includeContentLength: true });
+    const headResponse = immutableR2ObjectHeadResponse(object);
+
+    assert.equal(getResponse.headers.get("Content-Length"), "4");
+    assert.equal(headResponse.headers.get("Content-Length"), "4");
+    assert.equal(await headResponse.text(), "");
+  });
+});
+
+function fakeR2Object(bytes: Uint8Array, httpMetadata?: R2HTTPMetadata): R2ObjectBody {
+  return {
+    key: "fake-key",
+    version: "fake-version",
+    size: bytes.byteLength,
+    etag: "fake-etag",
+    httpEtag: '"fake-etag"',
+    uploaded: new Date("2026-06-05T00:00:00.000Z"),
+    httpMetadata,
+    body: new Response(bytes).body!,
+    async arrayBuffer() {
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    },
+    async text() {
+      return new TextDecoder().decode(bytes);
+    },
+    writeHttpMetadata(headers: Headers) {
+      if (httpMetadata?.contentType) {
+        headers.set("Content-Type", httpMetadata.contentType);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a shared notebook-cloud response helper module for CORS JSON, browser hardening headers, and immutable R2 object responses
- replace duplicated snapshot/runtime/blob response construction in the Worker monolith with named helpers
- add focused helper tests while keeping route behavior covered by existing Worker/html tests

## Verification

- `node --import tsx --test test/http-responses.test.ts test/worker-routes.test.ts test/html.test.ts` from `apps/notebook-cloud`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud build`
