### PR TITLE
refactor(cloud): extract viewer session adapter

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,0 +1,576 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
+import type { BlobResolver } from "runtimed";
+import type { WidgetStore } from "@/components/widgets/widget-store";
+import {
+  emitBroadcast,
+  emitPresence,
+  startCursorDispatch,
+} from "../../notebook/src/notebook-surface";
+import {
+  cloudSyncAuthFromPrototypeAuthState,
+  withCloudPrototypeAuthHeaders,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+import { materializeCloudNotebookView } from "./cloud-view-model";
+import { CloudLivePresenceStore } from "./live-presence";
+import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
+import type { CloudViewerLoadingPolicy } from "./loading-policy";
+import { markCloudViewerLoadMilestone } from "./load-milestones";
+import {
+  projectCloudCellsIntoNotebookViewStores,
+  resetCloudViewStoreProjection,
+} from "./notebook-view-store-bridge";
+import { CloudViewerPresenceStore } from "./presence";
+import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
+import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
+import { projectCloudWidgetComms } from "./widget-comm-projection";
+import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
+
+export interface CloudViewerConfig {
+  notebookId: string;
+  headsHash: string | null;
+  catalogEndpoint: string;
+  snapshotBasePath: string;
+  runtimeSnapshotBasePath: string;
+  aclEndpoint: string;
+  invitesEndpoint: string;
+  accessRequestsEndpoint: string;
+  hostCapabilities?: {
+    canManageSharing?: boolean;
+  };
+  syncEndpoint: string;
+  blobBasePath: string;
+  rendererAssetsBasePath: string;
+  outputDocumentBaseUrl: string | null;
+  runtimedWasmModulePath: string;
+  runtimedWasmPath: string;
+}
+
+export interface CloudViewerSession {
+  cellsByIdRef: MutableRefObject<Map<string, ResolvedCell>>;
+  connectionActorLabel: string | null;
+  connectionError: string | null;
+  connectionPeerId: string | null;
+  connectionScope: string | null;
+  liveMaterializedRef: MutableRefObject<boolean>;
+  liveRuntimeRef: MutableRefObject<CloudSyncRuntime | null>;
+  notebookLanguageRef: MutableRefObject<string>;
+  notebookMetadata: unknown;
+  presenceStore: CloudViewerPresenceStore;
+  requestCloudMaterialization: (liveRuntime: CloudSyncRuntime) => void;
+  retryLiveConnection: () => void;
+  snapshotResolvedRef: MutableRefObject<boolean>;
+  status: ViewerStatus;
+}
+
+interface UseCloudViewerSessionOptions {
+  authRenewalKind: CloudAuthRenewalState["kind"];
+  authState: CloudPrototypeAuthState;
+  blobResolver: BlobResolver;
+  config: CloudViewerConfig;
+  loadingPolicy: CloudViewerLoadingPolicy;
+  preloadSiftWasm: (cells: readonly ResolvedCell[]) => void;
+  widgetStore: WidgetStore;
+}
+
+interface CloudNotebookCatalogRevision {
+  notebook_heads_hash: string;
+  runtime_heads_hash: string | null;
+  runtime_state_doc_id: string | null;
+}
+
+interface CloudNotebookCatalog {
+  revisions?: CloudNotebookCatalogRevision[];
+}
+
+export function useCloudViewerSession({
+  authRenewalKind,
+  authState,
+  blobResolver,
+  config,
+  loadingPolicy,
+  preloadSiftWasm,
+  widgetStore,
+}: UseCloudViewerSessionOptions): CloudViewerSession {
+  const [status, setStatus] = useState<ViewerStatus>({
+    kind: "loading",
+    message: loadingPolicy.initialStatusMessage,
+  });
+  const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
+  const cellsRef = useRef<ResolvedCell[]>([]);
+  const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
+  const notebookLanguageRef = useRef("python");
+  const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
+  const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
+  const liveMaterializedRef = useRef(false);
+  const snapshotResolvedRef = useRef(false);
+  const projectedWidgetCommIdsRef = useRef(new Set<string>());
+  const outputResolutionCacheRef = useRef(createOutputResolutionCache());
+  const presenceStoreRef = useRef<CloudViewerPresenceStore | null>(null);
+  if (presenceStoreRef.current === null) {
+    presenceStoreRef.current = new CloudViewerPresenceStore();
+  }
+  const presenceStore = presenceStoreRef.current;
+  const [connectionScope, setConnectionScope] = useState<string | null>(null);
+  const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
+  const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [connectAttempt, setConnectAttempt] = useState(0);
+
+  useLayoutEffect(() => {
+    cellsRef.current = cells;
+    cellsByIdRef.current = new Map(cells.map((cell) => [cell.id, cell]));
+    projectCloudCellsIntoNotebookViewStores(cells);
+  }, [cells]);
+
+  useEffect(() => resetCloudViewStoreProjection, []);
+
+  useEffect(() => {
+    if (authRenewalKind === "refreshing") {
+      return;
+    }
+    if (!loadingPolicy.shouldFetchSnapshotRender) {
+      snapshotResolvedRef.current = true;
+      return;
+    }
+    if (!config.headsHash) {
+      snapshotResolvedRef.current = true;
+      setStatus({ kind: "error", message: "Pinned notebook heads are not configured." });
+      return;
+    }
+    const pinnedHeadsHash = config.headsHash;
+
+    let cancelled = false;
+
+    void (async () => {
+      let handle: Awaited<ReturnType<typeof loadSnapshotPairHandle>> | null = null;
+      try {
+        const catalogResponse = await fetch(
+          config.catalogEndpoint,
+          withCloudPrototypeAuthHeaders({ headers: { Accept: "application/json" } }, authState),
+        );
+        if (!catalogResponse.ok) {
+          if (!cancelled) {
+            snapshotResolvedRef.current = true;
+            setStatus({
+              kind: catalogResponse.status === 404 ? "empty" : "error",
+              message:
+                catalogResponse.status === 404
+                  ? "No published snapshot is available for this notebook yet."
+                  : `Unable to load notebook catalog: ${catalogResponse.status}`,
+            });
+          }
+          return;
+        }
+
+        const catalog = (await catalogResponse.json()) as CloudNotebookCatalog;
+        const revision = catalog.revisions?.find(
+          (candidate) => candidate.notebook_heads_hash === pinnedHeadsHash,
+        );
+        if (!revision || !revision.runtime_heads_hash || !revision.runtime_state_doc_id) {
+          if (!cancelled) {
+            snapshotResolvedRef.current = true;
+            setStatus({
+              kind: "empty",
+              message: "No complete snapshot pair is available for these pinned heads.",
+            });
+          }
+          return;
+        }
+
+        const [notebookSnapshotResponse, runtimeSnapshotResponse] = await Promise.all([
+          fetch(
+            pinnedSnapshotEndpoint(config.snapshotBasePath, pinnedHeadsHash),
+            withCloudPrototypeAuthHeaders(
+              { headers: { Accept: "application/octet-stream" } },
+              authState,
+            ),
+          ),
+          fetch(
+            pinnedSnapshotEndpoint(config.runtimeSnapshotBasePath, revision.runtime_heads_hash),
+            withCloudPrototypeAuthHeaders(
+              {
+                headers: {
+                  Accept: "application/octet-stream",
+                  "X-Runtime-State-Doc-Id": revision.runtime_state_doc_id,
+                },
+              },
+              authState,
+            ),
+          ),
+        ]);
+        if (!notebookSnapshotResponse.ok || !runtimeSnapshotResponse.ok) {
+          if (!cancelled) {
+            snapshotResolvedRef.current = true;
+            setStatus({
+              kind: "error",
+              message: `Unable to load pinned snapshot pair: notebook ${notebookSnapshotResponse.status}, runtime ${runtimeSnapshotResponse.status}`,
+            });
+          }
+          return;
+        }
+
+        handle = await loadSnapshotPairHandle(
+          new Uint8Array(await notebookSnapshotResponse.arrayBuffer()),
+          new Uint8Array(await runtimeSnapshotResponse.arrayBuffer()),
+          config.runtimedWasmModulePath,
+          config.runtimedWasmPath,
+        );
+        const outputResolutionCache = outputResolutionCacheRef.current;
+        const materialized = await materializeCloudNotebookView(handle, {
+          blobResolver,
+          defaultNotebookLanguage: "python",
+          outputResolutionCache,
+          callbacks: {
+            shouldContinue: () => !cancelled && !liveMaterializedRef.current,
+            onInitialCells(syncCells) {
+              if (syncCells.length === 0) return;
+              markCloudViewerLoadMilestone("snapshot-initial-cells");
+              preloadSiftWasm(syncCells);
+              setCells(syncCells);
+              setStatus({
+                kind: "loading",
+                message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
+              });
+            },
+            onCellResolved(resolvedCell, _index, progressiveCells) {
+              if (progressiveCells.length === 0) return;
+              preloadSiftWasm([resolvedCell]);
+              setCells(progressiveCells);
+            },
+          },
+        });
+        if (cancelled || liveMaterializedRef.current) return;
+        notebookLanguageRef.current = materialized.notebookLanguage;
+        setNotebookMetadata(materialized.metadata);
+
+        snapshotResolvedRef.current = true;
+        await projectCloudWidgetComms(
+          widgetStore,
+          materialized.widgetComms,
+          projectedWidgetCommIdsRef,
+          {
+            isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+            shouldContinue: () => !cancelled && !liveMaterializedRef.current,
+          },
+        );
+        if (cancelled || liveMaterializedRef.current) return;
+        const resolvedCells = materialized.cells;
+        preloadSiftWasm(resolvedCells);
+        setCells(resolvedCells);
+        if (resolvedCells.length === 0) {
+          setStatus({ kind: "empty", message: "This published notebook has no cells." });
+          return;
+        }
+
+        setStatus({
+          kind: "ready",
+          message: `Rendering ${resolvedCells.length} cells from pinned Automerge snapshots.`,
+        });
+        markCloudViewerLoadMilestone("snapshot-ready");
+      } catch (error) {
+        if (!cancelled) {
+          snapshotResolvedRef.current = true;
+          setStatus({ kind: "error", message: `Unable to load notebook: ${String(error)}` });
+        }
+      } finally {
+        handle?.free();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    authRenewalKind,
+    authState,
+    blobResolver,
+    config.catalogEndpoint,
+    config.blobBasePath,
+    config.headsHash,
+    config.runtimeSnapshotBasePath,
+    config.runtimedWasmModulePath,
+    config.runtimedWasmPath,
+    config.snapshotBasePath,
+    loadingPolicy.shouldFetchSnapshotRender,
+    preloadSiftWasm,
+    widgetStore,
+  ]);
+
+  useEffect(() => {
+    if (authRenewalKind === "refreshing") {
+      return;
+    }
+    if (!loadingPolicy.shouldConnectLiveRoom) {
+      return;
+    }
+
+    let disposed = false;
+    let subscriptions: Array<{ unsubscribe: () => void }> = [];
+    let materializeSequence = 0;
+    let livePresenceStore: CloudLivePresenceStore | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
+    const disposeCurrentRuntime = () => {
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return;
+      liveRuntimeRef.current = null;
+      disposeCloudSyncRuntime(liveRuntime);
+    };
+    const scheduleReconnect = (reason: Error) => {
+      if (disposed) return;
+      console.warn("[notebook-cloud] live room connection closed", reason);
+      presenceStore.reduceConnection("disconnected");
+      setConnectionScope(null);
+      setConnectionActorLabel(null);
+      setConnectionError(reason.message);
+      disposeCurrentRuntime();
+      if (reconnectTimer) return;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        if (!disposed) {
+          setConnectAttempt((attempt) => attempt + 1);
+        }
+      }, 1_000);
+    };
+
+    const materializeLiveCells = async (liveRuntime: CloudSyncRuntime) => {
+      const sequence = ++materializeSequence;
+      const previousNotebookLanguage = notebookLanguageRef.current;
+      const outputResolutionCache = outputResolutionCacheRef.current;
+      const rawCellCount = liveRuntime.handle.cell_count();
+      if (rawCellCount === 0 && (!snapshotResolvedRef.current || cellsRef.current.length > 0)) {
+        return;
+      }
+      const materialized = await materializeCloudNotebookView(liveRuntime.handle, {
+        blobResolver,
+        defaultNotebookLanguage: previousNotebookLanguage ?? "python",
+        outputResolutionCache,
+        callbacks: {
+          shouldContinue: () => !disposed && sequence === materializeSequence,
+          onInitialCells(syncCells) {
+            if (syncCells.length === 0) return;
+            liveMaterializedRef.current = true;
+            markCloudViewerLoadMilestone("live-initial-cells");
+            preloadSiftWasm(syncCells);
+            setCells(syncCells);
+            setStatus({
+              kind: "loading",
+              message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
+            });
+          },
+          onCellResolved(resolvedCell, _index, progressiveCells) {
+            if (progressiveCells.length === 0) return;
+            liveMaterializedRef.current = true;
+            preloadSiftWasm([resolvedCell]);
+            setCells(progressiveCells);
+          },
+        },
+      });
+      if (materialized.rawCellCount === 0) {
+        if (!snapshotResolvedRef.current || cellsRef.current.length > 0) {
+          return;
+        }
+      }
+      if (disposed || sequence !== materializeSequence) return;
+      notebookLanguageRef.current = materialized.notebookLanguage;
+      setNotebookMetadata(materialized.metadata);
+
+      await projectCloudWidgetComms(
+        widgetStore,
+        materialized.widgetComms,
+        projectedWidgetCommIdsRef,
+        {
+          isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+          shouldContinue: () => !disposed && sequence === materializeSequence,
+        },
+      );
+      if (disposed || sequence !== materializeSequence) return;
+      liveMaterializedRef.current = true;
+      const resolvedCells = materialized.cells;
+      preloadSiftWasm(resolvedCells);
+      setCells(resolvedCells);
+      setStatus(
+        resolvedCells.length === 0
+          ? { kind: "empty", message: "This notebook room has no cells yet." }
+          : {
+              kind: "ready",
+              message: `Rendering ${resolvedCells.length} cells from the live notebook room.`,
+            },
+      );
+      if (resolvedCells.length > 0) {
+        markCloudViewerLoadMilestone("live-ready");
+      }
+    };
+
+    const materializeLiveCellsSafely = (liveRuntime: CloudSyncRuntime) => {
+      void materializeLiveCells(liveRuntime).catch((error: unknown) => {
+        if (disposed) return;
+        console.warn("[notebook-cloud] live room materialization failed", error);
+      });
+    };
+    materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
+
+    presenceStore.reset();
+    setConnectionError(null);
+    setConnectionActorLabel(null);
+    setConnectionPeerId(null);
+    void connectCloudSyncRuntime({
+      syncEndpoint: config.syncEndpoint,
+      runtimedWasmModulePath: config.runtimedWasmModulePath,
+      runtimedWasmPath: config.runtimedWasmPath,
+      sessionId,
+      auth: cloudSyncAuthFromPrototypeAuthState(authState),
+      onDisconnect: scheduleReconnect,
+      onControl: (message) => {
+        if (disposed) return;
+        if (
+          message.type === "cloud_room_ready" ||
+          message.type === "cloud_peer_joined" ||
+          message.type === "cloud_peer_left"
+        ) {
+          presenceStore.reduceMessage(message);
+        }
+        if (message.type === "cloud_room_ready") {
+          markCloudViewerLoadMilestone("live-room-ready");
+          setConnectionError(null);
+          setConnectionScope(message.connection_scope);
+          setConnectionActorLabel(message.actor_label);
+        }
+        if (message.type === "cloud_frame_rejected") {
+          setStatus({ kind: "error", message: `Room rejected a frame: ${message.reason}` });
+        }
+      },
+    })
+      .then((liveRuntime) => {
+        if (disposed) {
+          disposeCloudSyncRuntime(liveRuntime);
+          return;
+        }
+        liveRuntimeRef.current = liveRuntime;
+        setConnectionScope(liveRuntime.connectionScope);
+        setConnectionActorLabel(liveRuntime.actorLabel);
+        setConnectionPeerId(liveRuntime.peerId);
+        livePresenceStore = new CloudLivePresenceStore(liveRuntime.peerId);
+        const stopCursorDispatch = startCursorDispatch(liveRuntime.peerId);
+        subscriptions = [
+          liveRuntime.engine.broadcasts$.subscribe((payload) => {
+            emitBroadcast(payload);
+          }),
+          liveRuntime.engine.presence$.subscribe((payload) => {
+            emitPresence(payload);
+            livePresenceStore?.handlePresence(payload);
+          }),
+          liveRuntime.engine.cellChanges$.subscribe(() => {
+            materializeLiveCellsSafely(liveRuntime);
+          }),
+          liveRuntime.engine.runtimeState$.subscribe(() => {
+            materializeLiveCellsSafely(liveRuntime);
+          }),
+          { unsubscribe: stopCursorDispatch },
+        ];
+        materializeLiveCellsSafely(liveRuntime);
+      })
+      .catch((error: unknown) => {
+        if (disposed) return;
+        if (cellsRef.current.length === 0) {
+          setStatus({
+            kind: "error",
+            message: `Unable to load live notebook room: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          });
+        }
+        presenceStore.reduceConnection("disconnected");
+        setConnectionScope(null);
+        setConnectionActorLabel(null);
+        setConnectionPeerId(null);
+        setConnectionError(error instanceof Error ? error.message : String(error));
+        console.warn("[notebook-cloud] live room connection failed", error);
+      });
+
+    return () => {
+      disposed = true;
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe();
+      }
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      materializeLiveRuntimeRef.current = null;
+      disposeCurrentRuntime();
+      resetCloudViewStoreProjection();
+      livePresenceStore = null;
+      presenceStore.reduceConnection("disconnected");
+      setConnectionPeerId(null);
+    };
+  }, [
+    authRenewalKind,
+    authState,
+    blobResolver,
+    config.blobBasePath,
+    config.runtimedWasmModulePath,
+    config.runtimedWasmPath,
+    config.syncEndpoint,
+    connectAttempt,
+    loadingPolicy.shouldConnectLiveRoom,
+    presenceStore,
+    preloadSiftWasm,
+    widgetStore,
+  ]);
+
+  const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
+    materializeLiveRuntimeRef.current?.(liveRuntime);
+  }, []);
+
+  const retryLiveConnection = useCallback(() => {
+    setConnectAttempt((attempt) => attempt + 1);
+  }, []);
+
+  return {
+    cellsByIdRef,
+    connectionActorLabel,
+    connectionError,
+    connectionPeerId,
+    connectionScope,
+    liveMaterializedRef,
+    liveRuntimeRef,
+    notebookLanguageRef,
+    notebookMetadata,
+    presenceStore,
+    requestCloudMaterialization,
+    retryLiveConnection,
+    snapshotResolvedRef,
+    status,
+  };
+}
+
+function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
+  liveRuntime.engine.stop();
+  liveRuntime.transport.disconnect();
+  liveRuntime.handle.free();
+}
+
+function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {
+  try {
+    const url = new URL(value, location.href);
+    const base = new URL(blobBasePath, location.href);
+    const basePath = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+    return url.origin === base.origin && url.pathname.startsWith(basePath);
+  } catch {
+    return false;
+  }
+}
+
+function pinnedSnapshotEndpoint(basePath: string, headsHash: string): string {
+  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`;
+  return `${normalizedBasePath}${encodeURIComponent(headsHash)}`;
+}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -65,33 +64,23 @@ import {
   clearCloudPrototypeDevAuth,
   cloudNotebookSignInCopy,
   cloudPrototypeAuthFromWindow,
-  cloudSyncAuthFromPrototypeAuthState,
   fetchWithCloudPrototypeAuth,
   isCloudPrototypeAuthStorageKey,
   prepareCloudOidcViewerLogin,
   storeCloudRequestedScope,
-  withCloudPrototypeAuthHeaders,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { createCloudNotebookCellId } from "./cloud-cell-id";
-import { connectCloudSyncRuntime, type CloudSyncRuntime } from "./live-sync";
-import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
+import { useCloudViewerSession, type CloudViewerConfig } from "./cloud-viewer-session";
 import { cloudNotebookShellCapabilities } from "./shell-capabilities";
 import {
   CrdtBridgeProvider,
-  emitBroadcast,
-  emitPresence,
   createNotebookController,
   NotebookView,
   PresenceValueProvider,
   setLoggerHost,
-  startCursorDispatch,
   type PresenceContextValue,
 } from "../../notebook/src/notebook-surface";
-import {
-  projectCloudCellsIntoNotebookViewStores,
-  resetCloudViewStoreProjection,
-} from "./notebook-view-store-bridge";
 import {
   beginOidcLogin,
   completeOidcRedirect,
@@ -100,17 +89,15 @@ import {
   storedOidcTokenNeedsRefresh,
   type CloudOidcAuthConfig,
 } from "./oidc-auth";
-import { CloudLivePresenceStore } from "./live-presence";
 import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
   type CloudViewerPresencePeer,
-  CloudViewerPresenceStore,
+  type CloudViewerPresenceStore,
   cloudViewerPresenceDisplay,
 } from "./presence";
-import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
-import { materializeCloudNotebookView } from "./cloud-view-model";
+import type { ResolvedCell } from "./render-resolution";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
@@ -133,11 +120,7 @@ import {
   CLOUD_VIEWER_THEME_STORAGE_KEY,
   installDocumentThemeSync,
 } from "./theme";
-import {
-  CLOUD_WIDGET_RENDERERS,
-  CloudWidgetStoreProvider,
-  projectCloudWidgetComms,
-} from "./widget-runtime";
+import { CLOUD_WIDGET_RENDERERS, CloudWidgetStoreProvider } from "./widget-runtime";
 import "./index.css";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
@@ -151,38 +134,8 @@ setLoggerHost({
   error: (message: string, ...args: unknown[]) => console.error(message, ...args),
 });
 
-interface CloudViewerConfig {
-  notebookId: string;
-  headsHash: string | null;
-  catalogEndpoint: string;
-  snapshotBasePath: string;
-  runtimeSnapshotBasePath: string;
-  aclEndpoint: string;
-  invitesEndpoint: string;
-  accessRequestsEndpoint: string;
-  hostCapabilities?: {
-    canManageSharing?: boolean;
-  };
-  syncEndpoint: string;
-  blobBasePath: string;
-  rendererAssetsBasePath: string;
-  outputDocumentBaseUrl: string | null;
-  runtimedWasmModulePath: string;
-  runtimedWasmPath: string;
-}
-
 interface CloudViewerAuthConfig {
   oidc: CloudOidcAuthConfig | null;
-}
-
-interface CloudNotebookCatalogRevision {
-  notebook_heads_hash: string;
-  runtime_heads_hash: string | null;
-  runtime_state_doc_id: string | null;
-}
-
-interface CloudNotebookCatalog {
-  revisions?: CloudNotebookCatalogRevision[];
 }
 
 interface ViewerRuntime {
@@ -672,37 +625,12 @@ function NotebookViewer({
   const loadingPolicy = cloudViewerLoadingPolicy(config);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
-  const [status, setStatus] = useState<ViewerStatus>({
-    kind: "loading",
-    message: loadingPolicy.initialStatusMessage,
-  });
-  const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
-  const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
-  const cellsRef = useRef<ResolvedCell[]>([]);
-  const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
-  const notebookLanguageRef = useRef("python");
-  const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
-  const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
-  const liveMaterializedRef = useRef(false);
-  const snapshotResolvedRef = useRef(false);
-  const projectedWidgetCommIdsRef = useRef(new Set<string>());
-  const outputResolutionCacheRef = useRef(createOutputResolutionCache());
   const handledHeadingHashRef = useRef<string | null>(null);
-  const presenceStoreRef = useRef<CloudViewerPresenceStore | null>(null);
-  if (presenceStoreRef.current === null) {
-    presenceStoreRef.current = new CloudViewerPresenceStore();
-  }
-  const presenceStore = presenceStoreRef.current;
-  const [connectionScope, setConnectionScope] = useState<string | null>(null);
-  const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
-  const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
-  const [connectAttempt, setConnectAttempt] = useState(0);
-  const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
     null,
   );
@@ -730,6 +658,30 @@ function NotebookViewer({
     },
     [config.blobBasePath, config.rendererAssetsBasePath],
   );
+  const {
+    cellsByIdRef,
+    connectionActorLabel,
+    connectionError,
+    connectionPeerId,
+    connectionScope,
+    liveMaterializedRef,
+    liveRuntimeRef,
+    notebookLanguageRef,
+    notebookMetadata,
+    presenceStore,
+    requestCloudMaterialization,
+    retryLiveConnection,
+    snapshotResolvedRef,
+    status,
+  } = useCloudViewerSession({
+    authRenewalKind: authRenewal.kind,
+    authState,
+    blobResolver,
+    config,
+    loadingPolicy,
+    preloadSiftWasm,
+    widgetStore,
+  });
   const outputHostContext = useMemo<NteractEmbedHostContextPatch>(
     () => ({
       nteract: {
@@ -750,409 +702,7 @@ function NotebookViewer({
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
 
-  useLayoutEffect(() => {
-    cellsRef.current = cells;
-    cellsByIdRef.current = new Map(cells.map((cell) => [cell.id, cell]));
-    projectCloudCellsIntoNotebookViewStores(cells);
-  }, [cells]);
-
-  useEffect(() => resetCloudViewStoreProjection, []);
-
   useNotebookCellUIStateBridge({ focusedCellId });
-
-  useEffect(() => {
-    if (authRenewal.kind === "refreshing") {
-      return;
-    }
-    if (!loadingPolicy.shouldFetchSnapshotRender) {
-      snapshotResolvedRef.current = true;
-      return;
-    }
-    if (!config.headsHash) {
-      snapshotResolvedRef.current = true;
-      setStatus({ kind: "error", message: "Pinned notebook heads are not configured." });
-      return;
-    }
-    const pinnedHeadsHash = config.headsHash;
-
-    let cancelled = false;
-
-    void (async () => {
-      let handle: Awaited<ReturnType<typeof loadSnapshotPairHandle>> | null = null;
-      try {
-        const catalogResponse = await fetch(
-          config.catalogEndpoint,
-          withCloudPrototypeAuthHeaders({ headers: { Accept: "application/json" } }, authState),
-        );
-        if (!catalogResponse.ok) {
-          if (!cancelled) {
-            snapshotResolvedRef.current = true;
-            setStatus({
-              kind: catalogResponse.status === 404 ? "empty" : "error",
-              message:
-                catalogResponse.status === 404
-                  ? "No published snapshot is available for this notebook yet."
-                  : `Unable to load notebook catalog: ${catalogResponse.status}`,
-            });
-          }
-          return;
-        }
-
-        const catalog = (await catalogResponse.json()) as CloudNotebookCatalog;
-        const revision = catalog.revisions?.find(
-          (candidate) => candidate.notebook_heads_hash === pinnedHeadsHash,
-        );
-        if (!revision || !revision.runtime_heads_hash || !revision.runtime_state_doc_id) {
-          if (!cancelled) {
-            snapshotResolvedRef.current = true;
-            setStatus({
-              kind: "empty",
-              message: "No complete snapshot pair is available for these pinned heads.",
-            });
-          }
-          return;
-        }
-
-        const [notebookSnapshotResponse, runtimeSnapshotResponse] = await Promise.all([
-          fetch(
-            pinnedSnapshotEndpoint(config.snapshotBasePath, pinnedHeadsHash),
-            withCloudPrototypeAuthHeaders(
-              { headers: { Accept: "application/octet-stream" } },
-              authState,
-            ),
-          ),
-          fetch(
-            pinnedSnapshotEndpoint(config.runtimeSnapshotBasePath, revision.runtime_heads_hash),
-            withCloudPrototypeAuthHeaders(
-              {
-                headers: {
-                  Accept: "application/octet-stream",
-                  "X-Runtime-State-Doc-Id": revision.runtime_state_doc_id,
-                },
-              },
-              authState,
-            ),
-          ),
-        ]);
-        if (!notebookSnapshotResponse.ok || !runtimeSnapshotResponse.ok) {
-          if (!cancelled) {
-            snapshotResolvedRef.current = true;
-            setStatus({
-              kind: "error",
-              message: `Unable to load pinned snapshot pair: notebook ${notebookSnapshotResponse.status}, runtime ${runtimeSnapshotResponse.status}`,
-            });
-          }
-          return;
-        }
-
-        handle = await loadSnapshotPairHandle(
-          new Uint8Array(await notebookSnapshotResponse.arrayBuffer()),
-          new Uint8Array(await runtimeSnapshotResponse.arrayBuffer()),
-          config.runtimedWasmModulePath,
-          config.runtimedWasmPath,
-        );
-        const outputResolutionCache = outputResolutionCacheRef.current;
-        const materialized = await materializeCloudNotebookView(handle, {
-          blobResolver,
-          defaultNotebookLanguage: "python",
-          outputResolutionCache,
-          callbacks: {
-            shouldContinue: () => !cancelled && !liveMaterializedRef.current,
-            onInitialCells(syncCells) {
-              if (syncCells.length === 0) return;
-              markCloudViewerLoadMilestone("snapshot-initial-cells");
-              preloadSiftWasm(syncCells);
-              setCells(syncCells);
-              setStatus({
-                kind: "loading",
-                message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
-              });
-            },
-            onCellResolved(resolvedCell, _index, progressiveCells) {
-              if (progressiveCells.length === 0) return;
-              preloadSiftWasm([resolvedCell]);
-              setCells(progressiveCells);
-            },
-          },
-        });
-        if (cancelled || liveMaterializedRef.current) return;
-        notebookLanguageRef.current = materialized.notebookLanguage;
-        setNotebookMetadata(materialized.metadata);
-
-        snapshotResolvedRef.current = true;
-        await projectCloudWidgetComms(
-          widgetStore,
-          materialized.widgetComms,
-          projectedWidgetCommIdsRef,
-          {
-            isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
-            shouldContinue: () => !cancelled && !liveMaterializedRef.current,
-          },
-        );
-        if (cancelled || liveMaterializedRef.current) return;
-        const resolvedCells = materialized.cells;
-        preloadSiftWasm(resolvedCells);
-        setCells(resolvedCells);
-        if (resolvedCells.length === 0) {
-          setStatus({ kind: "empty", message: "This published notebook has no cells." });
-          return;
-        }
-
-        setStatus({
-          kind: "ready",
-          message: `Rendering ${resolvedCells.length} cells from pinned Automerge snapshots.`,
-        });
-        markCloudViewerLoadMilestone("snapshot-ready");
-      } catch (error) {
-        if (!cancelled) {
-          snapshotResolvedRef.current = true;
-          setStatus({ kind: "error", message: `Unable to load notebook: ${String(error)}` });
-        }
-      } finally {
-        handle?.free();
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    authRenewal.kind,
-    authState,
-    blobResolver,
-    config.catalogEndpoint,
-    config.blobBasePath,
-    config.headsHash,
-    config.runtimeSnapshotBasePath,
-    config.runtimedWasmModulePath,
-    config.runtimedWasmPath,
-    config.snapshotBasePath,
-    loadingPolicy.shouldFetchSnapshotRender,
-    preloadSiftWasm,
-    widgetStore,
-  ]);
-
-  useEffect(() => {
-    if (authRenewal.kind === "refreshing") {
-      return;
-    }
-    if (!loadingPolicy.shouldConnectLiveRoom) {
-      return;
-    }
-
-    let disposed = false;
-    let subscriptions: Array<{ unsubscribe: () => void }> = [];
-    let materializeSequence = 0;
-    let livePresenceStore: CloudLivePresenceStore | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
-    const disposeCurrentRuntime = () => {
-      const liveRuntime = liveRuntimeRef.current;
-      if (!liveRuntime) return;
-      liveRuntimeRef.current = null;
-      disposeCloudSyncRuntime(liveRuntime);
-    };
-    const scheduleReconnect = (reason: Error) => {
-      if (disposed) return;
-      console.warn("[notebook-cloud] live room connection closed", reason);
-      presenceStore.reduceConnection("disconnected");
-      setConnectionScope(null);
-      setConnectionActorLabel(null);
-      setConnectionError(reason.message);
-      disposeCurrentRuntime();
-      if (reconnectTimer) return;
-      reconnectTimer = setTimeout(() => {
-        reconnectTimer = null;
-        if (!disposed) {
-          setConnectAttempt((attempt) => attempt + 1);
-        }
-      }, 1_000);
-    };
-
-    const materializeLiveCells = async (liveRuntime: CloudSyncRuntime) => {
-      const sequence = ++materializeSequence;
-      const previousNotebookLanguage = notebookLanguageRef.current;
-      const outputResolutionCache = outputResolutionCacheRef.current;
-      const rawCellCount = liveRuntime.handle.cell_count();
-      if (rawCellCount === 0 && (!snapshotResolvedRef.current || cellsRef.current.length > 0)) {
-        return;
-      }
-      const materialized = await materializeCloudNotebookView(liveRuntime.handle, {
-        blobResolver,
-        defaultNotebookLanguage: previousNotebookLanguage ?? "python",
-        outputResolutionCache,
-        callbacks: {
-          shouldContinue: () => !disposed && sequence === materializeSequence,
-          onInitialCells(syncCells) {
-            if (syncCells.length === 0) return;
-            liveMaterializedRef.current = true;
-            markCloudViewerLoadMilestone("live-initial-cells");
-            preloadSiftWasm(syncCells);
-            setCells(syncCells);
-            setStatus({
-              kind: "loading",
-              message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
-            });
-          },
-          onCellResolved(resolvedCell, _index, progressiveCells) {
-            if (progressiveCells.length === 0) return;
-            liveMaterializedRef.current = true;
-            preloadSiftWasm([resolvedCell]);
-            setCells(progressiveCells);
-          },
-        },
-      });
-      if (materialized.rawCellCount === 0) {
-        if (!snapshotResolvedRef.current || cellsRef.current.length > 0) {
-          return;
-        }
-      }
-      if (disposed || sequence !== materializeSequence) return;
-      notebookLanguageRef.current = materialized.notebookLanguage;
-      setNotebookMetadata(materialized.metadata);
-
-      await projectCloudWidgetComms(
-        widgetStore,
-        materialized.widgetComms,
-        projectedWidgetCommIdsRef,
-        {
-          isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
-          shouldContinue: () => !disposed && sequence === materializeSequence,
-        },
-      );
-      if (disposed || sequence !== materializeSequence) return;
-      liveMaterializedRef.current = true;
-      const resolvedCells = materialized.cells;
-      preloadSiftWasm(resolvedCells);
-      setCells(resolvedCells);
-      setStatus(
-        resolvedCells.length === 0
-          ? { kind: "empty", message: "This notebook room has no cells yet." }
-          : {
-              kind: "ready",
-              message: `Rendering ${resolvedCells.length} cells from the live notebook room.`,
-            },
-      );
-      if (resolvedCells.length > 0) {
-        markCloudViewerLoadMilestone("live-ready");
-      }
-    };
-
-    const materializeLiveCellsSafely = (liveRuntime: CloudSyncRuntime) => {
-      void materializeLiveCells(liveRuntime).catch((error: unknown) => {
-        if (disposed) return;
-        console.warn("[notebook-cloud] live room materialization failed", error);
-      });
-    };
-    materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
-
-    presenceStore.reset();
-    setConnectionError(null);
-    setConnectionActorLabel(null);
-    setConnectionPeerId(null);
-    void connectCloudSyncRuntime({
-      syncEndpoint: config.syncEndpoint,
-      runtimedWasmModulePath: config.runtimedWasmModulePath,
-      runtimedWasmPath: config.runtimedWasmPath,
-      sessionId,
-      auth: cloudSyncAuthFromPrototypeAuthState(authState),
-      onDisconnect: scheduleReconnect,
-      onControl: (message) => {
-        if (disposed) return;
-        if (
-          message.type === "cloud_room_ready" ||
-          message.type === "cloud_peer_joined" ||
-          message.type === "cloud_peer_left"
-        ) {
-          presenceStore.reduceMessage(message);
-        }
-        if (message.type === "cloud_room_ready") {
-          markCloudViewerLoadMilestone("live-room-ready");
-          setConnectionError(null);
-          setConnectionScope(message.connection_scope);
-          setConnectionActorLabel(message.actor_label);
-        }
-        if (message.type === "cloud_frame_rejected") {
-          setStatus({ kind: "error", message: `Room rejected a frame: ${message.reason}` });
-        }
-      },
-    })
-      .then((liveRuntime) => {
-        if (disposed) {
-          disposeCloudSyncRuntime(liveRuntime);
-          return;
-        }
-        liveRuntimeRef.current = liveRuntime;
-        setConnectionScope(liveRuntime.connectionScope);
-        setConnectionActorLabel(liveRuntime.actorLabel);
-        setConnectionPeerId(liveRuntime.peerId);
-        livePresenceStore = new CloudLivePresenceStore(liveRuntime.peerId);
-        const stopCursorDispatch = startCursorDispatch(liveRuntime.peerId);
-        subscriptions = [
-          liveRuntime.engine.broadcasts$.subscribe((payload) => {
-            emitBroadcast(payload);
-          }),
-          liveRuntime.engine.presence$.subscribe((payload) => {
-            emitPresence(payload);
-            livePresenceStore?.handlePresence(payload);
-          }),
-          liveRuntime.engine.cellChanges$.subscribe(() => {
-            materializeLiveCellsSafely(liveRuntime);
-          }),
-          liveRuntime.engine.runtimeState$.subscribe(() => {
-            materializeLiveCellsSafely(liveRuntime);
-          }),
-          { unsubscribe: stopCursorDispatch },
-        ];
-        materializeLiveCellsSafely(liveRuntime);
-      })
-      .catch((error: unknown) => {
-        if (disposed) return;
-        if (cellsRef.current.length === 0) {
-          setStatus({
-            kind: "error",
-            message: `Unable to load live notebook room: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          });
-        }
-        presenceStore.reduceConnection("disconnected");
-        setConnectionScope(null);
-        setConnectionActorLabel(null);
-        setConnectionPeerId(null);
-        setConnectionError(error instanceof Error ? error.message : String(error));
-        console.warn("[notebook-cloud] live room connection failed", error);
-      });
-
-    return () => {
-      disposed = true;
-      for (const subscription of subscriptions) {
-        subscription.unsubscribe();
-      }
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-      }
-      materializeLiveRuntimeRef.current = null;
-      disposeCurrentRuntime();
-      resetCloudViewStoreProjection();
-      livePresenceStore = null;
-      presenceStore.reduceConnection("disconnected");
-      setConnectionPeerId(null);
-    };
-  }, [
-    authRenewal.kind,
-    authState,
-    blobResolver,
-    config.blobBasePath,
-    config.runtimedWasmModulePath,
-    config.runtimedWasmPath,
-    config.syncEndpoint,
-    connectAttempt,
-    loadingPolicy.shouldConnectLiveRoom,
-    presenceStore,
-    preloadSiftWasm,
-    widgetStore,
-  ]);
 
   const notebookViewModel = useNotebookViewModel({
     metadata: notebookMetadata,
@@ -1282,9 +832,6 @@ function NotebookViewer({
     }, CLOUD_EMPTY_ROOM_GRACE_MS);
     return () => window.clearTimeout(timer);
   }, [notebookCellIds.length, status.kind]);
-  const requestCloudMaterialization = useCallback((liveRuntime: CloudSyncRuntime) => {
-    materializeLiveRuntimeRef.current?.(liveRuntime);
-  }, []);
   const cloudNotebookController = useMemo(
     () =>
       createNotebookController({
@@ -1384,7 +931,7 @@ function NotebookViewer({
         storeCloudRequestedScope(window.localStorage, "editor");
         setSelectedInteractionMode("edit");
         if (request.status === "approved") {
-          setConnectAttempt((attempt) => attempt + 1);
+          retryLiveConnection();
         }
         if (authState.requestedScope !== "editor") {
           refreshAuthState();
@@ -1398,7 +945,7 @@ function NotebookViewer({
         refreshAuthState();
       }
     },
-    [authState.requestedScope, connectionScope, refreshAuthState],
+    [authState.requestedScope, connectionScope, refreshAuthState, retryLiveConnection],
   );
   const loadOwnAccessRequest = useCallback(
     async (options?: { signal?: AbortSignal }) => {
@@ -2327,12 +1874,6 @@ function initialCloudRailCollapsed(): boolean {
   return true;
 }
 
-function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
-  liveRuntime.engine.stop();
-  liveRuntime.transport.disconnect();
-  liveRuntime.handle.free();
-}
-
 function shouldShowCloudHeaderSignIn(authState: CloudPrototypeAuthState): boolean {
   return (
     authState.mode === "anonymous" ||
@@ -2528,22 +2069,6 @@ function ViewerStartupError({ message }: { message: string }) {
       </div>
     </main>
   );
-}
-
-function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {
-  try {
-    const url = new URL(value, location.href);
-    const base = new URL(blobBasePath, location.href);
-    const basePath = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
-    return url.origin === base.origin && url.pathname.startsWith(basePath);
-  } catch {
-    return false;
-  }
-}
-
-function pinnedSnapshotEndpoint(basePath: string, headsHash: string): string {
-  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`;
-  return `${normalizedBasePath}${encodeURIComponent(headsHash)}`;
 }
 
 createRoot(requireElement("#root")).render(


### PR DESCRIPTION
## Summary

- Extract the cloud viewer snapshot/live-room lifecycle into `useCloudViewerSession`.
- Keep `NotebookViewer` focused on cloud host controls and notebook shell composition.
- Move session-only helpers for pinned snapshot URLs, blob URL checks, live runtime cleanup, presence, widget projection, and view-store projection out of the page module.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`

## Notes

- Generated missing WASM inputs with `pnpm --dir apps/notebook-cloud run wasm`, `cargo xtask wasm sift`, and `cargo xtask renderer-plugins`; these did not add tracked changes.
