### PR TITLE
fix(notebook): reset env build dismissal before create

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -961,10 +961,14 @@ function AppContent() {
 
   const getObservedHeads = useCallback(() => getHandle()?.get_heads_hex() ?? [], [getHandle]);
 
-  const showEnvBuildDialog = useCallback(() => {
+  const resetDismissedEnvBuildDetails = useCallback(() => {
     setDismissedEnvBuildDetails(null);
-    setEnvBuildDialogOpen(true);
   }, []);
+
+  const showEnvBuildDialog = useCallback(() => {
+    resetDismissedEnvBuildDetails();
+    setEnvBuildDialogOpen(true);
+  }, [resetDismissedEnvBuildDetails]);
 
   const getProjectEnvironmentFilePath = useCallback(() => {
     if (
@@ -1021,6 +1025,7 @@ function AppContent() {
     runAllCells: daemonRunAllCells,
     runAllCellsGuarded,
     getProjectEnvironmentFilePath,
+    resetDismissedEnvBuildDetails,
     showEnvBuildDialog,
   });
 

--- a/apps/notebook/src/lib/__tests__/notebook-action-policy.test.tsx
+++ b/apps/notebook/src/lib/__tests__/notebook-action-policy.test.tsx
@@ -49,6 +49,7 @@ function createPolicyOptions(
       queued: [],
     } satisfies NotebookResponse),
     getProjectEnvironmentFilePath: () => undefined,
+    resetDismissedEnvBuildDetails: vi.fn(),
     showEnvBuildDialog: vi.fn(),
     ...overrides,
   };
@@ -160,5 +161,25 @@ describe("useNotebookActionPolicy", () => {
 
     expect(options.approveTrust).toHaveBeenCalledWith({ observedHeads: ["head-1"] });
     expect(options.syncEnvironment).toHaveBeenCalledWith({ observed_heads: ["head-1"] });
+  });
+
+  it("clears dismissed env-build details before creating an environment", async () => {
+    const events: string[] = [];
+    const options = createPolicyOptions({
+      resetDismissedEnvBuildDetails: vi.fn(() => events.push("reset-dismissed")),
+      approveProjectEnvironment: vi.fn(async () => {
+        events.push("approve-environment");
+        return response("ok");
+      }),
+    });
+    const { result } = renderHook(() => useNotebookActionPolicy(options));
+
+    await act(async () => {
+      await result.current.handleEnvBuildCreate();
+    });
+
+    expect(options.resetDismissedEnvBuildDetails).toHaveBeenCalledTimes(1);
+    expect(events.slice(0, 2)).toEqual(["reset-dismissed", "approve-environment"]);
+    expect(options.showEnvBuildDialog).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook/src/lib/notebook-action-policy.ts
+++ b/apps/notebook/src/lib/notebook-action-policy.ts
@@ -44,6 +44,7 @@ interface NotebookActionPolicyOptions {
   runAllCells: () => Promise<NotebookResponse>;
   runAllCellsGuarded: (provenance: GuardedNotebookProvenance) => Promise<NotebookResponse>;
   getProjectEnvironmentFilePath: () => string | undefined;
+  resetDismissedEnvBuildDetails: () => void;
   showEnvBuildDialog: () => void;
 }
 
@@ -162,6 +163,7 @@ export function useNotebookActionPolicy({
   runAllCells,
   runAllCellsGuarded,
   getProjectEnvironmentFilePath,
+  resetDismissedEnvBuildDetails,
   showEnvBuildDialog,
 }: NotebookActionPolicyOptions) {
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
@@ -514,6 +516,7 @@ export function useNotebookActionPolicy({
   }, [setBlockedTrustAction]);
 
   const handleEnvBuildCreate = useCallback(async () => {
+    resetDismissedEnvBuildDetails();
     setEnvBuildCreating(true);
     try {
       const approval = await approveProjectEnvironment(getProjectEnvironmentFilePath());
@@ -529,7 +532,13 @@ export function useNotebookActionPolicy({
     } finally {
       setEnvBuildCreating(false);
     }
-  }, [approveProjectEnvironment, getProjectEnvironmentFilePath, showEnvBuildDialog, tryStartKernel]);
+  }, [
+    approveProjectEnvironment,
+    getProjectEnvironmentFilePath,
+    resetDismissedEnvBuildDetails,
+    showEnvBuildDialog,
+    tryStartKernel,
+  ]);
 
   const handleStartKernelWithPyproject = useCallback(async () => {
     if (!canExecute) {


### PR DESCRIPTION
## Summary

- Restore env-build dismissal reset at the start of the Create flow
- Keep the reset explicit in the notebook action policy boundary instead of relying on dialog display
- Add a regression test for the reset-before-approval order

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-action-policy.test.tsx`
- `pnpm exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `cargo xtask lint --fix`
