### PR TITLE
refactor(protocol): type unix connection bootstrap

### DIFF
--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -13,6 +13,7 @@ const HEALTH_PATH = "/__nteract_dev_relay/health";
 const WS_PATH = "/__nteract_dev_relay/ws";
 const MAGIC = [0xc0, 0xde, 0x01, 0xac] as const;
 const PROTOCOL_VERSION = 4;
+const FRAME_TYPE_SESSION_CONTROL = 0x07;
 const MAX_FRAME_SIZE = 100 * 1024 * 1024;
 const RELAY_AUTH_POLICY = {
   token_required: true,
@@ -28,6 +29,22 @@ interface DaemonInfoJson {
 
 interface RelayOptions {
   repoRoot: string;
+}
+
+interface NotebookConnectionInfoJson {
+  notebook_id?: string;
+  cell_count?: number;
+  needs_trust_approval?: boolean;
+  error?: string;
+  ephemeral?: boolean;
+  notebook_path?: string | null;
+  runtime?: string;
+  actor_label?: string;
+  connection_scope?: string;
+  capabilities?: {
+    actor_label?: string;
+    connection_scope?: string;
+  };
 }
 
 class LengthPrefixedFrames {
@@ -180,7 +197,7 @@ function isAuthorizedRelayUpgrade(req: IncomingMessage, url: URL, token: string)
 function relayHandshake(url: URL, repoRoot: string): Record<string, unknown> {
   const notebookPath = url.searchParams.get("path");
   if (notebookPath) {
-    return { channel: "open_notebook", path: notebookPath };
+    return { channel: "open_notebook", path: notebookPath, typed_bootstrap: true };
   }
 
   const notebookId = url.searchParams.get("notebook_id");
@@ -191,10 +208,27 @@ function relayHandshake(url: URL, repoRoot: string): Record<string, unknown> {
     channel: "create_notebook",
     runtime,
     working_dir: workingDir,
+    typed_bootstrap: true,
     ...(environmentMode ? { environment_mode: environmentMode } : {}),
     ...(notebookId ? { notebook_id: notebookId } : {}),
     ephemeral: true,
   };
+}
+
+function parseNotebookConnectionInfo(frame: Buffer): NotebookConnectionInfoJson {
+  if (frame[0] !== FRAME_TYPE_SESSION_CONTROL) {
+    return JSON.parse(frame.toString("utf8")) as NotebookConnectionInfoJson;
+  }
+
+  const bootstrap = JSON.parse(frame.subarray(1).toString("utf8")) as {
+    type?: string;
+  } & NotebookConnectionInfoJson;
+  if (bootstrap.type !== "notebook_connection_info") {
+    throw new Error(`unexpected typed bootstrap: ${bootstrap.type ?? "missing type"}`);
+  }
+
+  const { type: _type, ...info } = bootstrap;
+  return info;
 }
 
 function control(ws: WebSocket, value: unknown): void {
@@ -267,21 +301,7 @@ async function handleRelayConnection(
     writePreamble(daemon);
     writeFrame(daemon, JSON.stringify(relayHandshake(url, repoRoot)));
     const infoFrame = await frames.readFrame();
-    const info = JSON.parse(infoFrame.toString("utf8")) as {
-      notebook_id?: string;
-      cell_count?: number;
-      needs_trust_approval?: boolean;
-      error?: string;
-      ephemeral?: boolean;
-      notebook_path?: string | null;
-      runtime?: string;
-      actor_label?: string;
-      connection_scope?: string;
-      capabilities?: {
-        actor_label?: string;
-        connection_scope?: string;
-      };
-    };
+    const info = parseNotebookConnectionInfo(infoFrame);
 
     if (info.error) throw new Error(info.error);
     const actorLabel = info.actor_label ?? info.capabilities?.actor_label;

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -17,8 +17,8 @@ pub use framing::{
 };
 
 pub use handshake::{
-    Handshake, NotebookConnectionInfo, ProtocolCapabilities, PutBlobCapability, PROTOCOL_V4,
-    PROTOCOL_VERSION,
+    recv_typed_bootstrap_frame, send_typed_bootstrap_frame, ConnectionBootstrap, Handshake,
+    NotebookConnectionInfo, ProtocolCapabilities, PutBlobCapability, PROTOCOL_V4, PROTOCOL_VERSION,
 };
 
 #[cfg(windows)]
@@ -162,6 +162,7 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
             protocol: None,
+            typed_bootstrap: None,
             working_dir: None,
             initial_metadata: None,
             operator: None,
@@ -173,6 +174,7 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
             protocol: Some(PROTOCOL_V4.into()),
+            typed_bootstrap: None,
             working_dir: None,
             initial_metadata: None,
             operator: None,
@@ -187,6 +189,7 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             protocol: Some(PROTOCOL_V4.into()),
+            typed_bootstrap: None,
             working_dir: Some("/home/user/project".into()),
             initial_metadata: None,
             operator: None,
@@ -201,6 +204,7 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
             protocol: Some(PROTOCOL_V4.into()),
+            typed_bootstrap: None,
             working_dir: None,
             initial_metadata: None,
             operator: Some("agent:codex:s1".into()),
@@ -214,6 +218,7 @@ mod tests {
         // OpenNotebook
         let json = serde_json::to_string(&Handshake::OpenNotebook {
             path: "/home/user/notebook.ipynb".into(),
+            typed_bootstrap: None,
             operator: None,
         })
         .unwrap();
@@ -231,6 +236,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            typed_bootstrap: None,
             operator: None,
         })
         .unwrap();
@@ -245,6 +251,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            typed_bootstrap: None,
             operator: None,
         })
         .unwrap();
@@ -262,6 +269,7 @@ mod tests {
             package_manager: None,
             environment_mode: None,
             dependencies: vec![],
+            typed_bootstrap: None,
             operator: None,
         })
         .unwrap();
@@ -278,12 +286,24 @@ mod tests {
             package_manager: None,
             environment_mode: Some(CreateNotebookEnvironmentMode::Notebook),
             dependencies: vec![],
+            typed_bootstrap: None,
             operator: None,
         })
         .unwrap();
         assert_eq!(
             json,
             r#"{"channel":"create_notebook","runtime":"python","working_dir":"/home/user/project","environment_mode":"notebook"}"#
+        );
+
+        let json = serde_json::to_string(&Handshake::OpenNotebook {
+            path: "/home/user/notebook.ipynb".into(),
+            typed_bootstrap: Some(true),
+            operator: None,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"open_notebook","path":"/home/user/notebook.ipynb","typed_bootstrap":true}"#
         );
     }
 
@@ -406,6 +426,45 @@ mod tests {
         );
         assert!(put_blob.multipart);
         assert!(put_blob.ephemeral_supported);
+    }
+
+    #[tokio::test]
+    async fn typed_bootstrap_roundtrips_over_session_control_frame() {
+        let info = NotebookConnectionInfo {
+            capabilities: ProtocolCapabilities::v4(Some("0.1.0+abc123".into()))
+                .with_identity("local:kyle/desktop:7f3a", "owner"),
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: true,
+            notebook_path: None,
+        };
+        let bootstrap = ConnectionBootstrap::notebook_connection_info(info.clone());
+
+        let mut buf = Vec::new();
+        send_typed_bootstrap_frame(&mut buf, &bootstrap)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let decoded = recv_typed_bootstrap_frame(&mut cursor)
+            .await
+            .unwrap()
+            .unwrap();
+        match decoded {
+            ConnectionBootstrap::NotebookConnectionInfo { info: decoded_info } => {
+                assert_eq!(decoded_info.notebook_id, info.notebook_id);
+                assert_eq!(decoded_info.cell_count, info.cell_count);
+                assert_eq!(
+                    decoded_info.capabilities.actor_label.as_deref(),
+                    Some("local:kyle/desktop:7f3a")
+                );
+            }
+            ConnectionBootstrap::ProtocolCapabilities { .. } => {
+                panic!("expected notebook connection info bootstrap")
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -1,8 +1,10 @@
 //! Connection handshake data structures.
 
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::env::{CreateNotebookEnvironmentMode, PackageManager};
+use super::framing::{self, NotebookFrameType};
 
 /// Channel handshake — the first frame on every connection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +24,10 @@ pub enum Handshake {
         /// Protocol version requested by client (`v4`).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
+        /// When true, the daemon sends the connection bootstrap as a typed
+        /// SessionControl frame instead of a standalone untyped JSON frame.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        typed_bootstrap: Option<bool>,
         /// Working directory for untitled notebooks (used for project file detection).
         /// When a notebook_id is a UUID (untitled), this provides the directory context
         /// for finding pyproject.toml, pixi.toml, or environment.yaml.
@@ -44,6 +50,10 @@ pub enum Handshake {
     OpenNotebook {
         /// Path to the .ipynb file.
         path: String,
+        /// When true, the daemon sends `NotebookConnectionInfo` as a typed
+        /// SessionControl frame instead of a standalone untyped JSON frame.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        typed_bootstrap: Option<bool>,
         /// Self-declared operator suffix for the authenticated actor label.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         operator: Option<String>,
@@ -95,6 +105,10 @@ pub enum Handshake {
         /// Dependencies to seed into notebook metadata before auto-launch.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         dependencies: Vec<String>,
+        /// When true, the daemon sends `NotebookConnectionInfo` as a typed
+        /// SessionControl frame instead of a standalone untyped JSON frame.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        typed_bootstrap: Option<bool>,
         /// Self-declared operator suffix for the authenticated actor label.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         operator: Option<String>,
@@ -212,4 +226,59 @@ pub struct NotebookConnectionInfo {
     /// when `notebook_id_hint` resolves to a room that already has a path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notebook_path: Option<String>,
+}
+
+/// Typed bootstrap payload carried on `NotebookFrameType::SessionControl`.
+///
+/// Unix streams still need length-prefix framing, but relay-style clients can
+/// opt into this envelope so all post-handshake connection metadata rides the
+/// same typed-frame channel used by WebSocket transports.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConnectionBootstrap {
+    ProtocolCapabilities {
+        #[serde(flatten)]
+        capabilities: ProtocolCapabilities,
+    },
+    NotebookConnectionInfo {
+        #[serde(flatten)]
+        info: NotebookConnectionInfo,
+    },
+}
+
+impl ConnectionBootstrap {
+    pub fn protocol_capabilities(capabilities: ProtocolCapabilities) -> Self {
+        Self::ProtocolCapabilities { capabilities }
+    }
+
+    pub fn notebook_connection_info(info: NotebookConnectionInfo) -> Self {
+        Self::NotebookConnectionInfo { info }
+    }
+}
+
+/// Send a typed connection bootstrap frame.
+pub async fn send_typed_bootstrap_frame<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    bootstrap: &ConnectionBootstrap,
+) -> anyhow::Result<()> {
+    framing::send_typed_json_frame(writer, NotebookFrameType::SessionControl, bootstrap).await
+}
+
+/// Receive and parse a typed connection bootstrap frame.
+pub async fn recv_typed_bootstrap_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> anyhow::Result<Option<ConnectionBootstrap>> {
+    let Some(frame) = framing::recv_typed_frame(reader).await? else {
+        return Ok(None);
+    };
+
+    if frame.frame_type != NotebookFrameType::SessionControl {
+        anyhow::bail!(
+            "expected SessionControl bootstrap frame, got {:?}",
+            frame.frame_type
+        );
+    }
+
+    let bootstrap = serde_json::from_slice(&frame.payload)?;
+    Ok(Some(bootstrap))
 }

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -25,7 +25,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, watch};
 
 use notebook_protocol::connection::{
-    self, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
+    self, ConnectionBootstrap, Handshake, NotebookConnectionInfo, ProtocolCapabilities, PROTOCOL_V4,
 };
 use notebook_protocol::protocol::NotebookBroadcast;
 
@@ -186,6 +186,7 @@ pub async fn connect_with_options(
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
         protocol: Some(PROTOCOL_V4.to_string()),
+        typed_bootstrap: Some(true),
         working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
         initial_metadata: initial_metadata.clone(),
         operator: operator_from_actor_label(actor_label),
@@ -194,11 +195,10 @@ pub async fn connect_with_options(
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive protocol capabilities
-    let caps_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)?;
+    // Receive protocol capabilities. New daemons respond with a typed
+    // SessionControl bootstrap; old daemons ignore typed_bootstrap and send the
+    // legacy untyped JSON frame.
+    let caps = recv_typed_capabilities(&mut reader).await?;
     check_daemon_protocol_version(&caps);
 
     // Start from the standard notebook skeleton so the background sync task
@@ -237,17 +237,17 @@ pub async fn connect_open(
     // Send open handshake
     let handshake = Handshake::OpenNotebook {
         path: path.to_string_lossy().to_string(),
+        typed_bootstrap: Some(true),
         operator: operator_from_actor_label(actor_label),
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive connection info
-    let info_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+    // Receive connection info. New daemons respond with a typed SessionControl
+    // bootstrap; old daemons ignore typed_bootstrap and send the legacy untyped
+    // JSON frame.
+    let info = recv_typed_connection_info(&mut reader).await?;
 
     if let Some(ref error) = info.error {
         return Err(SyncError::Protocol(error.clone()));
@@ -357,17 +357,17 @@ async fn connect_create_inner(
         package_manager,
         environment_mode,
         dependencies,
+        typed_bootstrap: Some(true),
         operator: operator_from_actor_label(actor_label),
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive connection info
-    let info_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+    // Receive connection info. New daemons respond with a typed SessionControl
+    // bootstrap; old daemons ignore typed_bootstrap and send the legacy untyped
+    // JSON frame.
+    let info = recv_typed_connection_info(&mut reader).await?;
 
     if let Some(ref error) = info.error {
         return Err(SyncError::Protocol(error.clone()));
@@ -512,17 +512,14 @@ pub async fn connect_open_relay_with_operator(
     // Send open handshake
     let handshake = Handshake::OpenNotebook {
         path: path.to_string_lossy().to_string(),
+        typed_bootstrap: Some(true),
         operator,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive connection info
-    let info_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+    let info = recv_typed_connection_info(&mut reader).await?;
 
     if let Some(ref error) = info.error {
         return Err(SyncError::Protocol(error.clone()));
@@ -603,17 +600,14 @@ pub async fn connect_create_relay_with_operator(
         package_manager,
         environment_mode,
         dependencies,
+        typed_bootstrap: Some(true),
         operator,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive connection info
-    let info_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+    let info = recv_typed_connection_info(&mut reader).await?;
 
     if let Some(ref error) = info.error {
         return Err(SyncError::Protocol(error.clone()));
@@ -661,6 +655,7 @@ pub async fn connect_relay_with_operator(
     let handshake = Handshake::NotebookSync {
         notebook_id: notebook_id.clone(),
         protocol: Some(PROTOCOL_V4.to_string()),
+        typed_bootstrap: Some(true),
         initial_metadata: None,
         working_dir: None,
         operator,
@@ -669,12 +664,7 @@ pub async fn connect_relay_with_operator(
         .await
         .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
 
-    // Receive protocol capabilities (v4 handshake)
-    let caps_data = connection::recv_frame(&mut reader)
-        .await?
-        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)
-        .map_err(|e| SyncError::Protocol(format!("Parse capabilities: {}", e)))?;
+    let caps = recv_typed_capabilities(&mut reader).await?;
     check_daemon_protocol_version(&caps);
 
     info!(
@@ -737,6 +727,53 @@ where
     handle
 }
 
+async fn recv_typed_connection_info<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<NotebookConnectionInfo, SyncError> {
+    let frame = recv_bootstrap_frame(reader).await?;
+    if is_typed_bootstrap_frame(&frame) {
+        match parse_typed_bootstrap_payload(&frame[1..])? {
+            ConnectionBootstrap::NotebookConnectionInfo { info } => Ok(info),
+            ConnectionBootstrap::ProtocolCapabilities { .. } => Err(SyncError::Protocol(
+                "Expected notebook connection info, got protocol capabilities".into(),
+            )),
+        }
+    } else {
+        serde_json::from_slice(&frame)
+            .map_err(|e| SyncError::Protocol(format!("Parse connection info: {}", e)))
+    }
+}
+
+async fn recv_typed_capabilities<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<ProtocolCapabilities, SyncError> {
+    let frame = recv_bootstrap_frame(reader).await?;
+    if is_typed_bootstrap_frame(&frame) {
+        match parse_typed_bootstrap_payload(&frame[1..])? {
+            ConnectionBootstrap::ProtocolCapabilities { capabilities } => Ok(capabilities),
+            ConnectionBootstrap::NotebookConnectionInfo { info } => Ok(info.capabilities),
+        }
+    } else {
+        serde_json::from_slice(&frame)
+            .map_err(|e| SyncError::Protocol(format!("Parse capabilities: {}", e)))
+    }
+}
+
+async fn recv_bootstrap_frame<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Vec<u8>, SyncError> {
+    connection::recv_frame(reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))
+}
+
+fn is_typed_bootstrap_frame(frame: &[u8]) -> bool {
+    frame.first().copied() == Some(connection::NotebookFrameType::SessionControl as u8)
+}
+
+fn parse_typed_bootstrap_payload(payload: &[u8]) -> Result<ConnectionBootstrap, SyncError> {
+    serde_json::from_slice(payload)
+        .map_err(|e| SyncError::Protocol(format!("Parse typed bootstrap: {}", e)))
+}
+
 /// Log version info from a daemon's `ProtocolCapabilities` response.
 ///
 /// Warns on protocol version mismatch but does not error — the preamble
@@ -760,5 +797,60 @@ fn check_daemon_protocol_version(caps: &ProtocolCapabilities) {
 
     if let Some(ref ver) = caps.daemon_version {
         debug!("[notebook-sync] Connected to daemon version {}", ver);
+    }
+}
+
+#[cfg(test)]
+mod bootstrap_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn recv_typed_capabilities_accepts_legacy_json_frame() {
+        let expected = ProtocolCapabilities::v4(Some("2.5.2+old".into()))
+            .with_identity("local:kyle/desktop:legacy", "owner");
+        let mut buf = Vec::new();
+        connection::send_json_frame(&mut buf, &expected)
+            .await
+            .unwrap();
+
+        let mut reader = std::io::Cursor::new(buf);
+        let actual = recv_typed_capabilities(&mut reader).await.unwrap();
+
+        assert_eq!(actual.protocol, expected.protocol);
+        assert_eq!(
+            actual.actor_label.as_deref(),
+            Some("local:kyle/desktop:legacy")
+        );
+    }
+
+    #[tokio::test]
+    async fn recv_typed_connection_info_accepts_session_control_bootstrap() {
+        let expected = NotebookConnectionInfo {
+            capabilities: ProtocolCapabilities::v4(Some("2.5.2+new".into()))
+                .with_identity("local:kyle/desktop:typed", "owner"),
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 3,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: true,
+            notebook_path: None,
+        };
+        let mut buf = Vec::new();
+        connection::send_typed_bootstrap_frame(
+            &mut buf,
+            &ConnectionBootstrap::notebook_connection_info(expected.clone()),
+        )
+        .await
+        .unwrap();
+
+        let mut reader = std::io::Cursor::new(buf);
+        let actual = recv_typed_connection_info(&mut reader).await.unwrap();
+
+        assert_eq!(actual.notebook_id, expected.notebook_id);
+        assert_eq!(actual.cell_count, expected.cell_count);
+        assert_eq!(
+            actual.capabilities.actor_label.as_deref(),
+            Some("local:kyle/desktop:typed")
+        );
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2517,6 +2517,7 @@ impl Daemon {
             Handshake::NotebookSync {
                 notebook_id,
                 protocol,
+                typed_bootstrap,
                 working_dir,
                 initial_metadata,
                 operator,
@@ -2648,6 +2649,7 @@ impl Daemon {
                     working_dir_path,
                     initial_metadata,
                     false, // Send ProtocolCapabilities for direct NotebookSync handshake
+                    typed_bootstrap.unwrap_or(false),
                     None,  // No streaming load for direct NotebookSync handshake
                     false, // Not a newly-created notebook at path
                     connection_identity,
@@ -2655,9 +2657,19 @@ impl Daemon {
                 )
                 .await
             }
-            Handshake::OpenNotebook { path, operator } => {
-                self.handle_open_notebook(stream, path, operator, client_protocol_version)
-                    .await
+            Handshake::OpenNotebook {
+                path,
+                typed_bootstrap,
+                operator,
+            } => {
+                self.handle_open_notebook(
+                    stream,
+                    path,
+                    typed_bootstrap.unwrap_or(false),
+                    operator,
+                    client_protocol_version,
+                )
+                .await
             }
             Handshake::CreateNotebook {
                 runtime,
@@ -2667,6 +2679,7 @@ impl Daemon {
                 package_manager,
                 environment_mode,
                 dependencies,
+                typed_bootstrap,
                 operator,
             } => {
                 self.handle_create_notebook(
@@ -2678,6 +2691,7 @@ impl Daemon {
                     package_manager,
                     environment_mode,
                     dependencies,
+                    typed_bootstrap.unwrap_or(false),
                     operator,
                     client_protocol_version,
                 )
@@ -2731,6 +2745,7 @@ impl Daemon {
         self: Arc<Self>,
         stream: S,
         path: String,
+        typed_bootstrap: bool,
         operator: Option<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
@@ -2738,7 +2753,8 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use notebook_protocol::connection::{
-            send_json_frame, NotebookConnectionInfo, ProtocolCapabilities,
+            send_json_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
+            NotebookConnectionInfo, ProtocolCapabilities,
         };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
@@ -2767,6 +2783,7 @@ impl Daemon {
         async fn send_error_response<W: AsyncWrite + Unpin>(
             writer: &mut W,
             error: String,
+            typed_bootstrap: bool,
         ) -> anyhow::Result<()> {
             let response = NotebookConnectionInfo {
                 capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string())),
@@ -2777,7 +2794,15 @@ impl Daemon {
                 ephemeral: false,
                 notebook_path: None,
             };
-            send_json_frame(writer, &response).await?;
+            if typed_bootstrap {
+                send_typed_bootstrap_frame(
+                    writer,
+                    &ConnectionBootstrap::notebook_connection_info(response),
+                )
+                .await?;
+            } else {
+                send_json_frame(writer, &response).await?;
+            }
             Ok(())
         }
 
@@ -2790,6 +2815,7 @@ impl Daemon {
                      Untitled notebooks must reconnect via notebook_id, not OpenNotebook path.",
                     path
                 ),
+                typed_bootstrap,
             )
             .await?;
             return Ok(());
@@ -2820,6 +2846,7 @@ impl Daemon {
                         send_error_response(
                             &mut writer,
                             format!("Directory '{}' is not writable: {}", path, e),
+                            typed_bootstrap,
                         )
                         .await?;
                         return Ok(());
@@ -2836,6 +2863,7 @@ impl Daemon {
                         None,
                         None,
                         vec![],
+                        typed_bootstrap,
                         operator,
                         client_protocol_version,
                     )
@@ -2867,6 +2895,7 @@ impl Daemon {
                 send_error_response(
                     &mut writer,
                     format!("Cannot access notebook '{}': {}", path, e),
+                    typed_bootstrap,
                 )
                 .await?;
                 return Ok(());
@@ -2909,6 +2938,7 @@ impl Daemon {
                     send_error_response(
                         &mut writer,
                         format!("Cannot resolve notebook path '{}': {}", path, e),
+                        typed_bootstrap,
                     )
                     .await?;
                     return Ok(());
@@ -3005,6 +3035,7 @@ impl Daemon {
                 send_error_response(
                     &mut writer,
                     format!("Failed to create notebook '{}': {}", path, e),
+                    typed_bootstrap,
                 )
                 .await?;
                 return Ok(());
@@ -3064,7 +3095,15 @@ impl Daemon {
             ephemeral: false,
             notebook_path: Some(notebook_id.clone()),
         };
-        send_json_frame(&mut writer, &response).await?;
+        if typed_bootstrap {
+            send_typed_bootstrap_frame(
+                &mut writer,
+                &ConnectionBootstrap::notebook_connection_info(response),
+            )
+            .await?;
+        } else {
+            send_json_frame(&mut writer, &response).await?;
+        }
 
         // working_dir derived from path's parent directory
         let working_dir_path = path_buf.parent().map(|p| p.to_path_buf());
@@ -3084,6 +3123,7 @@ impl Daemon {
             working_dir_path,
             None, // No initial_metadata - doc is already populated
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            false,
             needs_load,
             created_new_at_path, // Enable auto-launch for notebooks created at non-existent paths
             connection_identity,
@@ -3108,6 +3148,7 @@ impl Daemon {
         package_manager: Option<notebook_protocol::connection::PackageManager>,
         environment_mode: Option<notebook_protocol::connection::CreateNotebookEnvironmentMode>,
         dependencies: Vec<String>,
+        typed_bootstrap: bool,
         operator: Option<String>,
         client_protocol_version: u8,
     ) -> anyhow::Result<()>
@@ -3115,7 +3156,8 @@ impl Daemon {
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
         use notebook_protocol::connection::{
-            send_json_frame, NotebookConnectionInfo, ProtocolCapabilities,
+            send_json_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
+            NotebookConnectionInfo, ProtocolCapabilities,
         };
 
         info!(
@@ -3210,7 +3252,15 @@ impl Daemon {
                 ephemeral: false,
                 notebook_path: None,
             };
-            send_json_frame(&mut writer, &response).await?;
+            if typed_bootstrap {
+                send_typed_bootstrap_frame(
+                    &mut writer,
+                    &ConnectionBootstrap::notebook_connection_info(response),
+                )
+                .await?;
+            } else {
+                send_json_frame(&mut writer, &response).await?;
+            }
             let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
             return Ok(());
         }
@@ -3278,7 +3328,15 @@ impl Daemon {
             ephemeral,
             notebook_path,
         };
-        send_json_frame(&mut writer, &response).await?;
+        if typed_bootstrap {
+            send_typed_bootstrap_frame(
+                &mut writer,
+                &ConnectionBootstrap::notebook_connection_info(response),
+            )
+            .await?;
+        } else {
+            send_json_frame(&mut writer, &response).await?;
+        }
 
         // working_dir for untitled notebooks (used for project file detection)
         let working_dir_path = working_dir.map(std::path::PathBuf::from);
@@ -3298,8 +3356,9 @@ impl Daemon {
             default_python_env,
             self.clone(),
             working_dir_path,
-            None,  // No initial_metadata - doc is already populated
-            true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            None, // No initial_metadata - doc is already populated
+            true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            false,
             None,  // No streaming load - doc was just created with empty cell
             false, // UUID-based new notebook, handled by is_new_notebook check
             connection_identity,

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -18,6 +18,8 @@ use runtime_doc::RuntimeLifecycle;
 /// If `skip_capabilities` is true, the ProtocolCapabilities frame is not sent.
 /// This is used for OpenNotebook/CreateNotebook handshakes where the protocol
 /// is already communicated in the NotebookConnectionInfo response.
+/// If `typed_capabilities` is true, the capabilities bootstrap is carried in a
+/// typed SessionControl frame instead of a standalone untyped JSON frame.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
     reader: R,
@@ -31,6 +33,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     working_dir: Option<PathBuf>,
     initial_metadata: Option<String>,
     skip_capabilities: bool,
+    typed_capabilities: bool,
     needs_load: Option<PathBuf>,
     // True if this is a newly-created notebook at a non-existent path.
     // Used to enable auto-launch for notebooks created via `runt notebook newfile.ipynb`.
@@ -245,7 +248,15 @@ where
                 connection_identity.actor_label().as_str(),
                 connection_identity.scope().as_str(),
             );
-        connection::send_json_frame(&mut writer, &caps).await?;
+        if typed_capabilities {
+            connection::send_typed_bootstrap_frame(
+                &mut writer,
+                &connection::ConnectionBootstrap::protocol_capabilities(caps),
+            )
+            .await?;
+        } else {
+            connection::send_json_frame(&mut writer, &caps).await?;
+        }
     }
 
     // Generate peer_id here so it's available for cleanup regardless of


### PR DESCRIPTION
## Summary

- add an opt-in `typed_bootstrap` handshake flag for Unix socket notebook connections
- carry protocol capabilities and notebook connection info as typed `SessionControl` bootstrap frames for new clients
- keep legacy untyped JSON bootstrap parsing for old daemon upgrade compatibility
- update the browser relay to request typed bootstrap while accepting old daemon-info frames

## Validation

- `cargo test -p notebook-protocol`
- `cargo test -p notebook-sync`
- `cargo test -p runtimed`
- `pnpm --dir apps/notebook build`
- `cargo xtask lint --fix`
