### PR TITLE
refactor(notebook): project room edit access in runtimed

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -51,9 +51,11 @@ test("cloud viewer imports desktop notebook code only through public surfaces", 
 test("cloud projects live cells into the NotebookView stores", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
 
   assert.match(
-    sourceText,
+    sessionSourceText,
     /useLayoutEffect\(\(\) => \{[\s\S]*cellsRef\.current = cells;[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
@@ -143,6 +145,8 @@ test("cloud passes shared NotebookView source and output visibility handlers", (
 test("cloud wires shared presence and cleans projected store entries", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
   const bridgeSourcePath = new URL("../viewer/notebook-view-store-bridge.ts", import.meta.url);
   const bridgeSourceText = readFileSync(bridgeSourcePath, "utf8");
 
@@ -159,7 +163,7 @@ test("cloud wires shared presence and cleans projected store entries", () => {
     /sendSelectionPresence\(\s+cellId,\s+anchorLine,\s+anchorCol,\s+headLine,\s+headCol,/,
   );
   assert.match(sourceText, /sendInteractionPresence\(target\)/);
-  assert.match(sourceText, /resetCloudViewStoreProjection\(\)/);
+  assert.match(sessionSourceText, /resetCloudViewStoreProjection/);
   assert.match(bridgeSourceText, /@\/components\/notebook\/state\/cell-store/);
   assert.match(bridgeSourceText, /@\/components\/notebook\/state\/execution-store/);
   assert.match(bridgeSourceText, /@\/components\/notebook\/state\/output-store/);
@@ -246,18 +250,16 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(sourceText, /onModeChange=\{\(mode\) => \{/);
   assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
-  assert.match(sourceText, /selectedMode: editAccessPending \? "view" : selectedInteractionMode/);
+  assert.match(sourceText, /projectCloudNotebookEditAccess/);
+  assert.match(sourceText, /selectedMode: selectedInteractionMode/);
+  assert.match(sourceText, /editAccessRequestPending/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
-  assert.match(sourceText, /const editAccessPending =/);
   assert.match(
     sourceText,
-    /const requestedEditAccess =\s+authState\.requestedScope === "editor" \|\|\s+authState\.requestedScope === "owner"/,
+    /const requestedEditAccess = roomEditAccess\.requestedDocumentEditAccess/,
   );
-  assert.match(
-    sourceText,
-    /status\.kind === "loading"[\s\S]*!canAcceptCellMutations[\s\S]*requestedEditAccess/,
-  );
+  assert.match(sourceText, /const editAccessPending = roomEditAccess\.editAccessPending/);
   assert.match(sourceText, /accessPending=\{editAccessPending\}/);
   assert.match(sourceText, /state=\{accessPending \? "viewing" : interaction\.state\}/);
   assert.match(sourceText, /disabled=\{accessPending\}/);
@@ -365,6 +367,8 @@ test("cloud outline keeps iframe heading hashes at parent cell anchors", () => {
 test("cloud live materialization skips empty room handles before resolving outputs", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
 
   assert.match(sourceText, /const CLOUD_EMPTY_ROOM_GRACE_MS = 900;/);
   assert.match(sourceText, /const \[emptyRoomGraceElapsed, setEmptyRoomGraceElapsed\]/);
@@ -372,9 +376,9 @@ test("cloud live materialization skips empty room handles before resolving outpu
     sourceText,
     /status\.kind === "empty" && notebookCellIds\.length === 0 && !emptyRoomGraceElapsed/,
   );
-  assert.match(sourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
+  assert.match(sessionSourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
   assert.match(
-    sourceText,
+    sessionSourceText,
     /if \(rawCellCount === 0 && \(!snapshotResolvedRef\.current \|\| cellsRef\.current\.length > 0\)\) \{\s+return;\s+\}\s+const materialized = await materializeCloudNotebookView/,
   );
 });

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -183,6 +183,25 @@ test("cloud shell capabilities keep requested edit pending until the room grants
   assert.equal(capabilities.access.level, "viewer");
 });
 
+test("cloud shell capabilities suppress editor mode while a requested edit reconnect is pending", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "viewer",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    canAcceptCellMutations: false,
+    editAccessRequestPending: true,
+  });
+
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.canRequestEdit, true);
+  assert.equal(capabilities.interaction?.selectedMode, "view");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.interaction?.state, "viewing");
+});
+
 test("cloud shell capabilities grant owners full cell, structure, and sharing control", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),

--- a/apps/notebook-cloud/viewer/edit-access.ts
+++ b/apps/notebook-cloud/viewer/edit-access.ts
@@ -1,0 +1,52 @@
+import {
+  isNotebookRoomConnectionScope,
+  notebookRoomAccessLevelFromConnectionScope,
+  projectNotebookRoomEditAccess,
+  type NotebookEditMode,
+  type NotebookRoomAccessLevel,
+  type NotebookRoomEditAccessProjection,
+  type NotebookRoomRequestedScope,
+} from "runtimed";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+
+export interface CloudNotebookEditAccessInput {
+  authState: CloudPrototypeAuthState;
+  connectionScope: string | null;
+  selectedMode?: NotebookEditMode;
+  canAcceptCellMutations?: boolean;
+  editAccessRequestPending?: boolean;
+}
+
+export function projectCloudNotebookEditAccess({
+  authState,
+  connectionScope,
+  selectedMode = "view",
+  canAcceptCellMutations = true,
+  editAccessRequestPending = false,
+}: CloudNotebookEditAccessInput): NotebookRoomEditAccessProjection {
+  return projectNotebookRoomEditAccess({
+    accessLevel: cloudConnectionAccessLevel(connectionScope),
+    requestedScope: cloudRequestedScope(authState.requestedScope),
+    selectedMode,
+    canAcceptDocumentMutations: canAcceptCellMutations,
+    canRequestEdit: cloudAuthCanRequestEdit(authState),
+    editAccessRequestPending,
+  });
+}
+
+export function cloudConnectionAccessLevel(
+  connectionScope: string | null,
+): NotebookRoomAccessLevel {
+  return notebookRoomAccessLevelFromConnectionScope(connectionScope, "viewer");
+}
+
+function cloudRequestedScope(requestedScope: string | null): NotebookRoomRequestedScope | null {
+  if (isNotebookRoomConnectionScope(requestedScope)) {
+    return requestedScope;
+  }
+  return null;
+}
+
+function cloudAuthCanRequestEdit(authState: CloudPrototypeAuthState): boolean {
+  return authState.mode === "dev" || authState.mode === "oidc";
+}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -66,6 +66,7 @@ import {
 } from "./collaborator-auth";
 import { createCloudNotebookCellId } from "./cloud-cell-id";
 import { useCloudViewerSession, type CloudViewerConfig } from "./cloud-viewer-session";
+import { projectCloudNotebookEditAccess } from "./edit-access";
 import { cloudNotebookShellCapabilities } from "./shell-capabilities";
 import {
   CrdtBridgeProvider,
@@ -738,10 +739,26 @@ function NotebookViewer({
     Boolean(connectionPeerId) &&
     !connectionError &&
     (status.kind === "ready" || status.kind === "empty");
-  const requestedEditAccess =
-    authState.requestedScope === "editor" || authState.requestedScope === "owner";
-  const editAccessPending =
-    !connectionError && status.kind === "loading" && !canAcceptCellMutations && requestedEditAccess;
+  const editAccessRequestPending = !connectionError && status.kind === "loading";
+  const roomEditAccess = useMemo(
+    () =>
+      projectCloudNotebookEditAccess({
+        authState,
+        connectionScope,
+        selectedMode: selectedInteractionMode,
+        canAcceptCellMutations,
+        editAccessRequestPending,
+      }),
+    [
+      authState,
+      canAcceptCellMutations,
+      connectionScope,
+      editAccessRequestPending,
+      selectedInteractionMode,
+    ],
+  );
+  const requestedEditAccess = roomEditAccess.requestedDocumentEditAccess;
+  const editAccessPending = roomEditAccess.editAccessPending;
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -749,8 +766,9 @@ function NotebookViewer({
         connectionScope,
         connectionActorLabel,
         hasCodeCells: codeCellCount > 0,
-        selectedMode: editAccessPending ? "view" : selectedInteractionMode,
+        selectedMode: selectedInteractionMode,
         canAcceptCellMutations,
+        editAccessRequestPending,
         hostCapabilities: config.hostCapabilities,
       }),
     [
@@ -760,7 +778,7 @@ function NotebookViewer({
       config.hostCapabilities,
       connectionActorLabel,
       connectionScope,
-      editAccessPending,
+      editAccessRequestPending,
       selectedInteractionMode,
     ],
   );

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -3,24 +3,28 @@ import {
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook/actor-projection";
 import type { NotebookShellCapabilities } from "@/components/notebook/capabilities";
-import {
-  createNotebookInteractionModeProjection,
-  type NotebookInteractionMode,
-} from "@/components/notebook/interaction-mode";
+import type { NotebookEditMode } from "runtimed";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import { projectCloudNotebookEditAccess } from "./edit-access";
 
 export interface CloudNotebookShellCapabilityInput {
   authState: CloudPrototypeAuthState;
   connectionScope: string | null;
   connectionActorLabel?: string | null;
   hasCodeCells: boolean;
-  selectedMode?: NotebookInteractionMode;
+  selectedMode?: NotebookEditMode;
   /**
    * Whether the hosted live room is connected and the NotebookDoc materialized
    * enough to accept local cell/source mutations. Access can grant editing
    * before the local host is ready to safely write.
    */
   canAcceptCellMutations?: boolean;
+  /**
+   * Whether the host is reconnecting with a requested document edit scope.
+   * While pending, the shared edit-mode control stays visually in view mode
+   * even though the requested room scope remains editor/owner.
+   */
+  editAccessRequestPending?: boolean;
   /**
    * Whether an execution runtime is attached to the room. The hosted prototype
    * has no kernel provider yet, so this defaults false and run controls stay
@@ -43,33 +47,23 @@ export function cloudNotebookShellCapabilities({
   hasCodeCells,
   selectedMode = "view",
   canAcceptCellMutations = true,
+  editAccessRequestPending = false,
   runtimeAvailable = false,
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
-  const accessLevel = cloudConnectionAccessLevel(connectionScope);
+  const interaction = projectCloudNotebookEditAccess({
+    authState,
+    connectionScope,
+    selectedMode,
+    canAcceptCellMutations,
+    editAccessRequestPending,
+  });
+  const accessLevel = interaction.accessLevel;
   const isRuntimePeer = connectionScope === "runtime_peer";
   const authenticated = authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention = authState.mode === "invalid" || authState.mode === "oidc_expired";
   const identityLabel = cloudIdentityDisplayLabel(authState);
   const identityImageUrl = cloudIdentityImageUrl(authState);
-  const interaction = createNotebookInteractionModeProjection({
-    selectedMode,
-    permission: {
-      // Editors get full collaborative cell editing (markdown/code/raw source +
-      // add/delete/move). This mirrors the room host's editor write surface; the
-      // server still rejects notebook-level metadata edits from non-owners
-      // (validate_editor_notebook_changes in runtimed-wasm).
-      canEditMarkdown: accessLevel === "editor" || accessLevel === "owner",
-      canEditCells: accessLevel === "editor" || accessLevel === "owner",
-      canEditStructure: accessLevel === "editor" || accessLevel === "owner",
-    },
-    hostSupport: {
-      canEditMarkdown: canAcceptCellMutations,
-      canEditCells: canAcceptCellMutations,
-      canEditStructure: canAcceptCellMutations,
-      canRequestEdit: authState.mode === "dev" || authState.mode === "oidc",
-    },
-  });
   const auth = {
     canSignIn: authState.mode !== "oidc",
     canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
@@ -85,7 +79,7 @@ export function cloudNotebookShellCapabilities({
   // Executing a cell needs both an attached runtime and document write
   // authority. The room has no kernel provider yet, so runtimeAvailable
   // defaults false and run controls stay hidden.
-  const canExecute = runtimeAvailable && (accessLevel === "editor" || accessLevel === "owner");
+  const canExecute = runtimeAvailable && interaction.hasDocumentEditPermission;
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
     connected: isRuntimePeer,
@@ -124,15 +118,6 @@ export function cloudNotebookShellCapabilities({
       actor: runtimeActor,
     },
   };
-}
-
-function cloudConnectionAccessLevel(
-  connectionScope: string | null,
-): NotebookShellCapabilities["access"]["level"] {
-  if (connectionScope === "owner" || connectionScope === "editor" || connectionScope === "viewer") {
-    return connectionScope;
-  }
-  return "viewer";
 }
 
 function cloudIdentityDisplayLabel(authState: CloudPrototypeAuthState): string | null {

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -186,6 +186,41 @@ describe("desktopNotebookShellCapabilities", () => {
     });
   });
 
+  it("maps unknown non-null connection scopes to no document access", () => {
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:alice/desktop:window",
+      connectionScope: "surprise",
+    });
+
+    expect(capabilities.access).toMatchObject({
+      level: "none",
+      source: "cloud",
+      actorLabel: "user:anaconda:alice/desktop:window",
+    });
+    expect(capabilities.canRead).toBe(false);
+    expect(capabilities.canEditMarkdown).toBe(false);
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canEditStructure).toBe(false);
+    expect(capabilities.canExecute).toBe(false);
+    expect(capabilities.canManagePackages).toBe(false);
+    expect(capabilities.interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+    expect(capabilities.runtime).toMatchObject({
+      canWriteRuntimeState: false,
+      connected: false,
+      source: "cloud",
+      actorLabel: null,
+    });
+  });
+
   it("keeps runtime peer authority separate from document editing access", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: false,

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -2,12 +2,16 @@ import {
   notebookActorProjectionFromAccess,
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook/actor-projection";
-import { createNotebookInteractionModeProjection } from "@/components/notebook/interaction-mode";
 import type {
   NotebookShellAccessLevel,
   NotebookShellAccessSource,
   NotebookShellCapabilities,
 } from "@/components/notebook/capabilities";
+import {
+  notebookRoomAccessLevelCanEditDocument,
+  notebookRoomAccessLevelFromConnectionScope,
+  projectNotebookRoomEditAccess,
+} from "runtimed";
 
 export interface DesktopNotebookShellCapabilityInput {
   canAcceptCellMutations: boolean;
@@ -29,25 +33,18 @@ export function desktopNotebookShellCapabilities({
   const accessLevel = desktopAccessLevelFromConnectionScope(connectionScope);
   const source = desktopAccessSourceFromActor(connectionScope, localActor);
   const isRuntimePeer = connectionScope === "runtime_peer";
-  const hasDocumentEditPermission = accessLevel === "editor" || accessLevel === "owner";
+  const hasDocumentEditPermission = notebookRoomAccessLevelCanEditDocument(accessLevel);
+  const interaction = projectNotebookRoomEditAccess({
+    accessLevel,
+    requestedScope: accessLevel === "none" ? null : accessLevel,
+    selectedMode: hasDocumentEditPermission ? "edit" : "view",
+    canAcceptDocumentMutations: canAcceptCellMutations,
+    canRequestEdit: false,
+  });
   const canWriteDocument =
-    canAcceptCellMutations && hasDocumentEditPermission;
+    interaction.canEditMarkdown && interaction.canEditCells && interaction.canEditStructure;
   const canWriteRuntimeState =
     sessionReady && (isRuntimePeer || (source === "local" && canWriteDocument));
-  const interaction = createNotebookInteractionModeProjection({
-    selectedMode: hasDocumentEditPermission ? "edit" : "view",
-    permission: {
-      canEditMarkdown: hasDocumentEditPermission,
-      canEditCells: hasDocumentEditPermission,
-      canEditStructure: hasDocumentEditPermission,
-    },
-    hostSupport: {
-      canEditMarkdown: canAcceptCellMutations,
-      canEditCells: canAcceptCellMutations,
-      canEditStructure: canAcceptCellMutations,
-      canRequestEdit: false,
-    },
-  });
   const access = {
     level: accessLevel,
     source,
@@ -98,13 +95,10 @@ export function desktopNotebookShellCapabilities({
 function desktopAccessLevelFromConnectionScope(
   connectionScope: string | null,
 ): NotebookShellAccessLevel {
-  if (connectionScope === "viewer" || connectionScope === "editor" || connectionScope === "owner") {
-    return connectionScope;
+  if (connectionScope === null) {
+    return "owner";
   }
-  if (connectionScope === "runtime_peer") {
-    return "viewer";
-  }
-  return "owner";
+  return notebookRoomAccessLevelFromConnectionScope(connectionScope, "none");
 }
 
 function desktopAccessSourceFromActor(

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -155,6 +155,27 @@ export {
   type ProjectNotebookOutlineOptions,
 } from "./notebook-outline";
 
+// Notebook edit access projection
+export {
+  isNotebookRoomAccessLevel,
+  isNotebookRoomConnectionScope,
+  notebookRoomAccessLevelCanEditDocument,
+  notebookRoomAccessLevelFromConnectionScope,
+  projectNotebookEditAccess,
+  projectNotebookRoomEditAccess,
+  type NotebookEditAccessProjection,
+  type NotebookEditHostSupport,
+  type NotebookEditMode,
+  type NotebookEditPermission,
+  type NotebookEditState,
+  type NotebookRoomAccessLevel,
+  type NotebookRoomConnectionScope,
+  type NotebookRoomEditAccessProjection,
+  type NotebookRoomRequestedScope,
+  type ProjectNotebookEditAccessOptions,
+  type ProjectNotebookRoomEditAccessOptions,
+} from "./notebook-edit-access";
+
 // Notebook interaction projection
 export {
   createNotebookInteractionStore,

--- a/packages/runtimed/src/notebook-edit-access.ts
+++ b/packages/runtimed/src/notebook-edit-access.ts
@@ -1,0 +1,156 @@
+export type NotebookEditMode = "view" | "edit";
+export type NotebookEditState = "viewing" | "requested" | "editing";
+
+export interface NotebookEditPermission {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+}
+
+export interface NotebookEditHostSupport {
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+  canRequestEdit: boolean;
+}
+
+export interface NotebookEditAccessProjection extends NotebookEditPermission {
+  selectedMode: NotebookEditMode;
+  activeMode: NotebookEditMode;
+  state: NotebookEditState;
+  canRequestEdit: boolean;
+}
+
+export interface ProjectNotebookEditAccessOptions {
+  selectedMode: NotebookEditMode;
+  permission: NotebookEditPermission;
+  hostSupport: NotebookEditHostSupport;
+}
+
+export type NotebookRoomAccessLevel = "none" | "viewer" | "editor" | "owner";
+export type NotebookRoomConnectionScope = "viewer" | "editor" | "runtime_peer" | "owner";
+export type NotebookRoomRequestedScope = NotebookRoomConnectionScope | "none";
+
+export interface NotebookRoomEditAccessProjection extends NotebookEditAccessProjection {
+  inputSelectedMode: NotebookEditMode;
+  accessLevel: NotebookRoomAccessLevel;
+  requestedScope: NotebookRoomRequestedScope | null;
+  hasDocumentEditPermission: boolean;
+  selectedDocumentEditMode: boolean;
+  requestedDocumentEditAccess: boolean;
+  editAccessPending: boolean;
+}
+
+export interface ProjectNotebookRoomEditAccessOptions {
+  accessLevel: NotebookRoomAccessLevel;
+  requestedScope?: NotebookRoomRequestedScope | null;
+  selectedMode: NotebookEditMode;
+  canAcceptDocumentMutations: boolean;
+  canRequestEdit: boolean;
+  editAccessRequestPending?: boolean;
+}
+
+export function projectNotebookEditAccess({
+  hostSupport,
+  permission,
+  selectedMode,
+}: ProjectNotebookEditAccessOptions): NotebookEditAccessProjection {
+  const wantsEdit = selectedMode === "edit";
+  const hasAnyEditPermission =
+    permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
+  const hasAnyHostEditSupport =
+    (permission.canEditMarkdown && hostSupport.canEditMarkdown) ||
+    (permission.canEditCells && hostSupport.canEditCells) ||
+    (permission.canEditStructure && hostSupport.canEditStructure);
+  const canActivateEdit = wantsEdit && hasAnyEditPermission && hasAnyHostEditSupport;
+  const activeMode: NotebookEditMode = canActivateEdit ? "edit" : "view";
+  const state: NotebookEditState = !wantsEdit
+    ? "viewing"
+    : canActivateEdit
+      ? "editing"
+      : "requested";
+
+  return {
+    selectedMode,
+    activeMode,
+    state,
+    canRequestEdit: hostSupport.canRequestEdit,
+    canEditMarkdown:
+      activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown,
+    canEditCells: activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells,
+    canEditStructure:
+      activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
+  };
+}
+
+export function projectNotebookRoomEditAccess({
+  accessLevel,
+  requestedScope = null,
+  selectedMode,
+  canAcceptDocumentMutations,
+  canRequestEdit,
+  editAccessRequestPending = false,
+}: ProjectNotebookRoomEditAccessOptions): NotebookRoomEditAccessProjection {
+  const hasDocumentEditPermission = notebookRoomAccessLevelCanEditDocument(accessLevel);
+  const selectedDocumentEditMode = selectedMode === "edit";
+  const requestedDocumentEditAccess = requestedScope === "editor" || requestedScope === "owner";
+  const editAccessPending =
+    editAccessRequestPending && requestedDocumentEditAccess && !canAcceptDocumentMutations;
+  const selectedInteractionMode: NotebookEditMode = editAccessPending ? "view" : selectedMode;
+  const interaction = projectNotebookEditAccess({
+    selectedMode: selectedInteractionMode,
+    permission: {
+      canEditMarkdown: hasDocumentEditPermission,
+      canEditCells: hasDocumentEditPermission,
+      canEditStructure: hasDocumentEditPermission,
+    },
+    hostSupport: {
+      canEditMarkdown: canAcceptDocumentMutations,
+      canEditCells: canAcceptDocumentMutations,
+      canEditStructure: canAcceptDocumentMutations,
+      canRequestEdit,
+    },
+  });
+
+  return {
+    ...interaction,
+    inputSelectedMode: selectedMode,
+    accessLevel,
+    requestedScope,
+    hasDocumentEditPermission,
+    selectedDocumentEditMode,
+    requestedDocumentEditAccess,
+    editAccessPending,
+  };
+}
+
+export function notebookRoomAccessLevelCanEditDocument(
+  accessLevel: NotebookRoomAccessLevel,
+): boolean {
+  return accessLevel === "editor" || accessLevel === "owner";
+}
+
+export function isNotebookRoomAccessLevel(
+  value: string | null | undefined,
+): value is NotebookRoomAccessLevel {
+  return value === "none" || value === "viewer" || value === "editor" || value === "owner";
+}
+
+export function isNotebookRoomConnectionScope(
+  value: string | null | undefined,
+): value is NotebookRoomConnectionScope {
+  return value === "viewer" || value === "editor" || value === "runtime_peer" || value === "owner";
+}
+
+export function notebookRoomAccessLevelFromConnectionScope(
+  connectionScope: string | null | undefined,
+  fallbackAccessLevel: NotebookRoomAccessLevel,
+): NotebookRoomAccessLevel {
+  if (isNotebookRoomAccessLevel(connectionScope)) {
+    return connectionScope;
+  }
+  if (connectionScope === "runtime_peer") {
+    return "viewer";
+  }
+  return fallbackAccessLevel;
+}

--- a/packages/runtimed/tests/notebook-edit-access.test.ts
+++ b/packages/runtimed/tests/notebook-edit-access.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  notebookRoomAccessLevelFromConnectionScope,
+  projectNotebookEditAccess,
+  projectNotebookRoomEditAccess,
+} from "../src/notebook-edit-access";
+
+describe("projectNotebookEditAccess", () => {
+  it("keeps a user-selected view mode read-only even when edit permission exists", () => {
+    const interaction = projectNotebookEditAccess({
+      selectedMode: "view",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("intersects granted permission with host support for active edits", () => {
+    const interaction = projectNotebookEditAccess({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: false,
+        canEditStructure: false,
+        canRequestEdit: false,
+      },
+    });
+
+    expect(interaction).toMatchObject({
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canRequestEdit: false,
+      canEditMarkdown: true,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("treats edit as requested when permission or host support is missing", () => {
+    expect(
+      projectNotebookEditAccess({
+        selectedMode: "edit",
+        permission: {
+          canEditMarkdown: false,
+          canEditCells: false,
+          canEditStructure: false,
+        },
+        hostSupport: {
+          canEditMarkdown: true,
+          canEditCells: true,
+          canEditStructure: true,
+          canRequestEdit: true,
+        },
+      }),
+    ).toMatchObject({
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+
+    expect(
+      projectNotebookEditAccess({
+        selectedMode: "edit",
+        permission: {
+          canEditMarkdown: true,
+          canEditCells: true,
+          canEditStructure: true,
+        },
+        hostSupport: {
+          canEditMarkdown: false,
+          canEditCells: false,
+          canEditStructure: false,
+          canRequestEdit: false,
+        },
+      }),
+    ).toMatchObject({
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+});
+
+describe("projectNotebookRoomEditAccess", () => {
+  it("maps owner room access to document editing when the host can mutate", () => {
+    const projection = projectNotebookRoomEditAccess({
+      accessLevel: "owner",
+      requestedScope: "owner",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: false,
+    });
+
+    expect(projection).toMatchObject({
+      accessLevel: "owner",
+      requestedScope: "owner",
+      hasDocumentEditPermission: true,
+      selectedDocumentEditMode: true,
+      requestedDocumentEditAccess: true,
+      editAccessPending: false,
+      selectedMode: "edit",
+      activeMode: "edit",
+      state: "editing",
+      canEditMarkdown: true,
+      canEditCells: true,
+      canEditStructure: true,
+    });
+  });
+
+  it("keeps requested editor access pending while a requested room reconnect is loading", () => {
+    const projection = projectNotebookRoomEditAccess({
+      accessLevel: "viewer",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: false,
+      canRequestEdit: true,
+      editAccessRequestPending: true,
+    });
+
+    expect(projection).toMatchObject({
+      inputSelectedMode: "edit",
+      selectedMode: "view",
+      activeMode: "view",
+      state: "viewing",
+      hasDocumentEditPermission: false,
+      requestedDocumentEditAccess: true,
+      editAccessPending: true,
+      canRequestEdit: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+
+  it("separates runtime peer scope from document edit access", () => {
+    const projection = projectNotebookRoomEditAccess({
+      accessLevel: "viewer",
+      requestedScope: "runtime_peer",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+      editAccessRequestPending: true,
+    });
+
+    expect(projection).toMatchObject({
+      requestedScope: "runtime_peer",
+      hasDocumentEditPermission: false,
+      requestedDocumentEditAccess: false,
+      editAccessPending: false,
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+    });
+  });
+
+  it("requires host mutation support even after document edit access is granted", () => {
+    const projection = projectNotebookRoomEditAccess({
+      accessLevel: "editor",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: false,
+      canRequestEdit: true,
+    });
+
+    expect(projection).toMatchObject({
+      hasDocumentEditPermission: true,
+      selectedMode: "edit",
+      activeMode: "view",
+      state: "requested",
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+    });
+  });
+});
+
+describe("notebookRoomAccessLevelFromConnectionScope", () => {
+  it("maps runtime peers to viewer document access and unknown scopes to the host fallback", () => {
+    expect(notebookRoomAccessLevelFromConnectionScope("runtime_peer", "owner")).toBe("viewer");
+    expect(notebookRoomAccessLevelFromConnectionScope("editor", "viewer")).toBe("editor");
+    expect(notebookRoomAccessLevelFromConnectionScope("unexpected", "none")).toBe("none");
+    expect(notebookRoomAccessLevelFromConnectionScope(null, "owner")).toBe("owner");
+  });
+});

--- a/src/components/notebook/interaction-mode.ts
+++ b/src/components/notebook/interaction-mode.ts
@@ -1,61 +1,22 @@
-export type NotebookInteractionMode = "view" | "edit";
-export type NotebookInteractionState = "viewing" | "requested" | "editing";
+import {
+  projectNotebookEditAccess,
+  type NotebookEditAccessProjection,
+  type NotebookEditHostSupport,
+  type NotebookEditMode,
+  type NotebookEditPermission,
+  type NotebookEditState,
+  type ProjectNotebookEditAccessOptions,
+} from "runtimed";
 
-export interface NotebookInteractionPermission {
-  canEditMarkdown: boolean;
-  canEditCells: boolean;
-  canEditStructure: boolean;
-}
+export type NotebookInteractionMode = NotebookEditMode;
+export type NotebookInteractionState = NotebookEditState;
+export type NotebookInteractionPermission = NotebookEditPermission;
+export type NotebookInteractionHostSupport = NotebookEditHostSupport;
+export type NotebookInteractionModeProjection = NotebookEditAccessProjection;
+export type CreateNotebookInteractionModeProjectionOptions = ProjectNotebookEditAccessOptions;
 
-export interface NotebookInteractionHostSupport {
-  canEditMarkdown: boolean;
-  canEditCells: boolean;
-  canEditStructure: boolean;
-  canRequestEdit: boolean;
-}
-
-export interface NotebookInteractionModeProjection extends NotebookInteractionPermission {
-  selectedMode: NotebookInteractionMode;
-  activeMode: NotebookInteractionMode;
-  state: NotebookInteractionState;
-  canRequestEdit: boolean;
-}
-
-export interface CreateNotebookInteractionModeProjectionOptions {
-  selectedMode: NotebookInteractionMode;
-  permission: NotebookInteractionPermission;
-  hostSupport: NotebookInteractionHostSupport;
-}
-
-export function createNotebookInteractionModeProjection({
-  hostSupport,
-  permission,
-  selectedMode,
-}: CreateNotebookInteractionModeProjectionOptions): NotebookInteractionModeProjection {
-  const wantsEdit = selectedMode === "edit";
-  const hasAnyEditPermission =
-    permission.canEditMarkdown || permission.canEditCells || permission.canEditStructure;
-  const hasAnyHostEditSupport =
-    (permission.canEditMarkdown && hostSupport.canEditMarkdown) ||
-    (permission.canEditCells && hostSupport.canEditCells) ||
-    (permission.canEditStructure && hostSupport.canEditStructure);
-  const canActivateEdit = wantsEdit && hasAnyEditPermission && hasAnyHostEditSupport;
-  const activeMode: NotebookInteractionMode = canActivateEdit ? "edit" : "view";
-  const state: NotebookInteractionState = !wantsEdit
-    ? "viewing"
-    : canActivateEdit
-      ? "editing"
-      : "requested";
-
-  return {
-    selectedMode,
-    activeMode,
-    state,
-    canRequestEdit: hostSupport.canRequestEdit,
-    canEditMarkdown:
-      activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown,
-    canEditCells: activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells,
-    canEditStructure:
-      activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
-  };
+export function createNotebookInteractionModeProjection(
+  options: CreateNotebookInteractionModeProjectionOptions,
+): NotebookInteractionModeProjection {
+  return projectNotebookEditAccess(options);
 }


### PR DESCRIPTION
## Summary

- Add a host-neutral `notebook-edit-access` projection in `runtimed`.
- Keep the shared React `interaction-mode` module as a compatibility wrapper over the runtime projection.
- Wire cloud and desktop shell adapters through the same room edit-access projection, keeping `runtime_peer` separate from document editing.
- Move cloud requested-edit/pending reconnect policy into a small viewer adapter module.

## Verification

- `pnpm test:run packages/runtimed/tests/notebook-edit-access.test.ts src/components/notebook/__tests__/interaction-mode.test.ts apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts`
- `pnpm test:run`
- `cargo xtask lint --fix`
