### PR TITLE
feat(runt-cloud-peer): outbound WebSocket room-sync client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,7 +5117,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5697,7 +5697,7 @@ checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
  "clap",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -7430,6 +7430,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "runt-cloud-peer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "automerge",
+ "clap",
+ "futures-util",
+ "notebook-doc",
+ "notebook-wire",
+ "runtime-doc",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "runt-mcp"
 version = "0.4.2"
 dependencies = [
@@ -8364,6 +8383,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9549,7 +9579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -9789,6 +9819,20 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -10178,6 +10222,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/xtask",
     "crates/runtimed",
     "crates/runt-publish",
+    "crates/runt-cloud-peer",
     "crates/runtimed-client",
     "crates/runtimed-outputs",
     "crates/runtimed-service",

--- a/crates/runt-cloud-peer/Cargo.toml
+++ b/crates/runt-cloud-peer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "runt-cloud-peer"
+version = "0.1.0"
+edition = "2021"
+license = "BSD-3-Clause"
+publish = false
+
+[[bin]]
+name = "runt-cloud-peer"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+tokio = { workspace = true }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+futures-util = "0.3"
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+notebook-wire = { path = "../notebook-wire" }
+notebook-doc = { path = "../notebook-doc" }
+runtime-doc = { path = "../runtime-doc" }
+automerge = { workspace = true }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -161,7 +161,21 @@ async fn main() -> Result<()> {
                     HeaderValue::from_str(&cli.user)?,
                 );
             }
-            // oidc-bearer and anaconda-api-key both present as a bearer.
+            // The Anaconda API-key path is also a bearer, but the cloud identity
+            // router only treats a bearer as an API key when the provider
+            // selector header is present; without it the key is parsed as OIDC
+            // and rejected.
+            "anaconda-api-key" => {
+                h.insert(
+                    HeaderName::from_static("authorization"),
+                    HeaderValue::from_str(&format!("Bearer {token}"))?,
+                );
+                h.insert(
+                    HeaderName::from_static("x-notebook-cloud-auth-provider"),
+                    HeaderValue::from_static("anaconda-api-key"),
+                );
+            }
+            // oidc-bearer (default): plain bearer.
             _ => {
                 h.insert(
                     HeaderName::from_static("authorization"),
@@ -302,10 +316,19 @@ async fn main() -> Result<()> {
                         let cell_id =
                             format!("cell-{}", &uuid::Uuid::new_v4().simple().to_string()[..8]);
                         if nb_doc.add_cell_after(&cell_id, "code", None).is_ok() {
-                            let _ = nb_doc.update_source(&cell_id, source);
-                            edited = true;
-                            added_cell_id = Some(cell_id.clone());
-                            info!("added code cell {cell_id} ({} chars)", source.len());
+                            // Only consider the cell added once its source is set.
+                            // Swallowing this would sync (and potentially run) an
+                            // empty cell while logging success.
+                            match nb_doc.update_source(&cell_id, source) {
+                                Ok(_) => {
+                                    edited = true;
+                                    added_cell_id = Some(cell_id.clone());
+                                    info!("added code cell {cell_id} ({} chars)", source.len());
+                                }
+                                Err(e) => {
+                                    warn!("update_source for {cell_id} failed: {e}; will retry");
+                                }
+                            }
                         }
                     }
                 }
@@ -379,6 +402,10 @@ async fn main() -> Result<()> {
             other => info!("frame 0x{other:02x} ({} bytes)", payload.len()),
         }
     }
+
+    // Close the socket cleanly so the room records a normal disconnect rather
+    // than a dropped connection. Best-effort: the server may have closed first.
+    let _ = ws.close(None).await;
 
     Ok(())
 }

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -1,0 +1,327 @@
+//! Dial a hosted nteract notebook room over WebSocket and sync as a peer.
+//!
+//! The outbound peer the daemon lacks: the local sync paths (`notebook-sync`,
+//! `runtime_agent`) only speak the Unix-socket handshake, and `runt-publish`
+//! only talks HTTP. Here we dial `wss://<host>/n/<id>/sync`, authenticate on the
+//! upgrade (OIDC bearer / Anaconda API key / dev token), and run Automerge sync
+//! for BOTH the NotebookDoc and the RuntimeStateDoc over the typed-frame v4
+//! stream, reusing `notebook-doc` / `runtime-doc` directly.
+//!
+//! Two load-bearing rules:
+//! - CRDT init (notebook-doc invariant #2): `bootstrap()` seeds only the frozen
+//!   genesis + `schema_version`. The room owns the `cells`/`metadata` maps; we
+//!   receive them via sync before editing.
+//! - Change attribution: the room's `validate_room_notebook_change_actors`
+//!   rejects any change whose actor principal differs from the authenticated
+//!   principal. So we bootstrap the docs with `<principal>/<operator>` taken
+//!   from the room's `cloud_room_ready` frame, not an arbitrary actor.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use automerge::sync;
+use clap::Parser;
+use futures_util::{SinkExt, StreamExt};
+use notebook_doc::{NotebookDoc, TextEncoding};
+use notebook_wire::frame_types;
+use runtime_doc::RuntimeStateDoc;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::header::{HeaderName, HeaderValue},
+        Message as WsMessage,
+    },
+};
+use tracing::{info, warn};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "runt-cloud-peer",
+    about = "Dial a hosted nteract room over WebSocket and sync both documents"
+)]
+struct Cli {
+    /// Base URL of the notebook cloud (https/http; scheme is swapped to wss/ws).
+    #[arg(long, default_value = "https://preview.runt.run")]
+    cloud_url: String,
+
+    /// Notebook id to attach to (room is `/n/<id>/sync`).
+    #[arg(long)]
+    notebook_id: String,
+
+    /// Connection scope: viewer | editor | runtime_peer | owner.
+    #[arg(long, default_value = "owner")]
+    scope: String,
+
+    /// Auth mode: oidc-bearer | anaconda-api-key | dev.
+    #[arg(long, default_value = "oidc-bearer")]
+    auth_mode: String,
+
+    /// Token value (or use --token-file).
+    #[arg(long)]
+    token: Option<String>,
+
+    /// File containing the token (trimmed).
+    #[arg(long)]
+    token_file: Option<PathBuf>,
+
+    /// Dev user label (dev auth only).
+    #[arg(long, default_value = "runt-cloud-peer")]
+    user: String,
+
+    /// Operator suffix for our doc actor label (`<principal>/<operator>`).
+    #[arg(long, default_value = "agent:runt-cloud-peer")]
+    operator: String,
+
+    /// After sync converges, add a code cell with this source and sync it back.
+    #[arg(long)]
+    add_cell: Option<String>,
+
+    /// Auto-close after this many seconds (0 = run until disconnected).
+    #[arg(long, default_value_t = 20)]
+    seconds: u64,
+}
+
+fn load_token(cli: &Cli) -> Result<String> {
+    if let Some(t) = &cli.token {
+        return Ok(t.trim().to_string());
+    }
+    if let Some(f) = &cli.token_file {
+        let raw = std::fs::read_to_string(f).with_context(|| format!("read {}", f.display()))?;
+        return Ok(raw.trim().to_string());
+    }
+    Err(anyhow!("provide --token or --token-file"))
+}
+
+fn build_ws_url(cloud_url: &str, notebook_id: &str) -> String {
+    let base = cloud_url.trim_end_matches('/');
+    let ws = if let Some(rest) = base.strip_prefix("https://") {
+        format!("wss://{rest}")
+    } else if let Some(rest) = base.strip_prefix("http://") {
+        format!("ws://{rest}")
+    } else {
+        base.to_string()
+    };
+    format!("{ws}/n/{notebook_id}/sync")
+}
+
+/// One typed frame = one WS binary message: `[1 byte type][payload]`.
+fn frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1 + payload.len());
+    buf.push(frame_type);
+    buf.extend_from_slice(payload);
+    buf
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let token = load_token(&cli)?;
+    let ws_url = build_ws_url(&cli.cloud_url, &cli.notebook_id);
+    info!(
+        "dialing {ws_url} (scope={}, auth_mode={})",
+        cli.scope, cli.auth_mode
+    );
+
+    let mut request = ws_url
+        .as_str()
+        .into_client_request()
+        .context("build websocket upgrade request")?;
+    {
+        let h = request.headers_mut();
+        // No Sec-WebSocket-Protocol: we carry the credential in the
+        // Authorization (or dev-token) header, not a subprotocol; offering one
+        // the room won't echo trips tungstenite's "server sent no subprotocol".
+        h.insert(
+            HeaderName::from_static("x-scope"),
+            HeaderValue::from_str(&cli.scope)?,
+        );
+        match cli.auth_mode.as_str() {
+            "dev" => {
+                h.insert(
+                    HeaderName::from_static("x-notebook-cloud-dev-token"),
+                    HeaderValue::from_str(&token)?,
+                );
+                h.insert(
+                    HeaderName::from_static("x-user"),
+                    HeaderValue::from_str(&cli.user)?,
+                );
+            }
+            // oidc-bearer and anaconda-api-key both present as a bearer.
+            _ => {
+                h.insert(
+                    HeaderName::from_static("authorization"),
+                    HeaderValue::from_str(&format!("Bearer {token}"))?,
+                );
+            }
+        }
+    }
+
+    let (mut ws, resp) = match connect_async(request).await {
+        Ok(ok) => ok,
+        Err(tokio_tungstenite::tungstenite::Error::Http(resp)) => {
+            let status = resp.status();
+            let body = resp
+                .into_body()
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+                .unwrap_or_default();
+            bail!("upgrade rejected: HTTP {status}: {body}");
+        }
+        Err(e) => return Err(e).context("websocket connect"),
+    };
+    info!("connected: HTTP {} ", resp.status());
+
+    // Docs are created only after `cloud_room_ready` tells us the principal, so
+    // our changes are authored under `<principal>/<operator>` and pass the
+    // room's actor-authorization check.
+    let mut nb: Option<NotebookDoc> = None;
+    let mut nb_peer = sync::State::new();
+    let mut rt: Option<RuntimeStateDoc> = None;
+    let mut rt_peer = sync::State::new();
+    let mut edited = false;
+    let deadline =
+        (cli.seconds > 0).then(|| tokio::time::Instant::now() + Duration::from_secs(cli.seconds));
+    loop {
+        let msg = match deadline {
+            Some(d) => match tokio::time::timeout_at(d, ws.next()).await {
+                Ok(Some(m)) => m,
+                Ok(None) => break,
+                Err(_) => {
+                    info!("duration elapsed ({}s), closing", cli.seconds);
+                    break;
+                }
+            },
+            None => match ws.next().await {
+                Some(m) => m,
+                None => break,
+            },
+        };
+        let msg = msg.context("websocket read")?;
+        if !msg.is_binary() {
+            if msg.is_close() {
+                warn!("server closed the connection: {msg:?}");
+                break;
+            }
+            continue;
+        }
+        let data = msg.into_data();
+        let Some((&ftype, payload)) = data.split_first() else {
+            warn!("empty frame");
+            continue;
+        };
+
+        match ftype {
+            frame_types::SESSION_CONTROL => {
+                let control: serde_json::Value = match serde_json::from_slice(payload) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if control.get("type").and_then(|t| t.as_str()) != Some("cloud_room_ready") {
+                    continue;
+                }
+                if nb.is_some() {
+                    continue; // already attached
+                }
+                let room_actor = control
+                    .get("actor_label")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let principal = room_actor.split('/').next().unwrap_or(room_actor);
+                if principal.is_empty() {
+                    bail!("cloud_room_ready missing actor_label/principal");
+                }
+                // Unique actor per run: reusing one actor label across separate
+                // doc instances collides at (actor, seq 1) -> automerge
+                // DuplicateSeqNumber when the room syncs back the prior change.
+                let actor_label = format!(
+                    "{principal}/{}:{}",
+                    cli.operator,
+                    &uuid::Uuid::new_v4().simple().to_string()[..8]
+                );
+                let scope = control
+                    .get("connection_scope")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                info!("attached: scope={scope}, authoring as {actor_label}");
+
+                let mut nb_doc =
+                    NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, &actor_label);
+                let mut rt_doc = RuntimeStateDoc::try_new_with_actor(&actor_label)
+                    .map_err(|e| anyhow!("runtime-state doc init: {e}"))?;
+                // Kick the initial sync exchange for both documents.
+                if let Some(m) = nb_doc.generate_sync_message(&mut nb_peer) {
+                    ws.send(WsMessage::Binary(
+                        frame(frame_types::AUTOMERGE_SYNC, &m.encode()).into(),
+                    ))
+                    .await?;
+                }
+                if let Some(m) = rt_doc.generate_sync_message(&mut rt_peer) {
+                    ws.send(WsMessage::Binary(
+                        frame(frame_types::RUNTIME_STATE_SYNC, &m.encode()).into(),
+                    ))
+                    .await?;
+                }
+                nb = Some(nb_doc);
+                rt = Some(rt_doc);
+            }
+            frame_types::AUTOMERGE_SYNC => {
+                let Some(nb_doc) = nb.as_mut() else {
+                    continue;
+                };
+                let incoming = sync::Message::decode(payload)
+                    .map_err(|e| anyhow!("decode notebook sync: {e}"))?;
+                nb_doc
+                    .receive_sync_message(&mut nb_peer, incoming)
+                    .map_err(|e| anyhow!("apply notebook sync: {e}"))?;
+
+                // The cells map arrives with the room's first sync, so an early
+                // frame may not have it yet; retry the edit on later frames.
+                if !edited {
+                    if let Some(source) = cli.add_cell.as_deref() {
+                        let cell_id =
+                            format!("cell-{}", &uuid::Uuid::new_v4().simple().to_string()[..8]);
+                        if nb_doc.add_cell_after(&cell_id, "code", None).is_ok() {
+                            let _ = nb_doc.update_source(&cell_id, source);
+                            edited = true;
+                            info!("added code cell {cell_id} ({} chars)", source.len());
+                        }
+                    }
+                }
+
+                if let Some(reply) = nb_doc.generate_sync_message(&mut nb_peer) {
+                    ws.send(WsMessage::Binary(
+                        frame(frame_types::AUTOMERGE_SYNC, &reply.encode()).into(),
+                    ))
+                    .await?;
+                }
+            }
+            frame_types::RUNTIME_STATE_SYNC => {
+                let Some(rt_doc) = rt.as_mut() else {
+                    continue;
+                };
+                let incoming = sync::Message::decode(payload)
+                    .map_err(|e| anyhow!("decode runtime-state sync: {e}"))?;
+                rt_doc
+                    .receive_sync_message(&mut rt_peer, incoming)
+                    .map_err(|e| anyhow!("apply runtime-state sync: {e}"))?;
+                if let Some(m) = rt_doc.generate_sync_message(&mut rt_peer) {
+                    ws.send(WsMessage::Binary(
+                        frame(frame_types::RUNTIME_STATE_SYNC, &m.encode()).into(),
+                    ))
+                    .await?;
+                }
+            }
+            other => info!("frame 0x{other:02x} ({} bytes)", payload.len()),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -341,8 +341,13 @@ async fn main() -> Result<()> {
                 };
                 let incoming = sync::Message::decode(payload)
                     .map_err(|e| anyhow!("decode runtime-state sync: {e}"))?;
+                // Use the change-accepting receive: this peer is a *consumer*
+                // of the room's authoritative RuntimeStateDoc, like a frontend.
+                // The plain receive_sync_message() strips incoming changes
+                // (daemon-authoritative semantics), which silently discards the
+                // room's queued executions and stalls convergence.
                 rt_doc
-                    .receive_sync_message(&mut rt_peer, incoming)
+                    .receive_sync_message_with_changes(&mut rt_peer, incoming)
                     .map_err(|e| anyhow!("apply runtime-state sync: {e}"))?;
                 if let Some(m) = rt_doc.generate_sync_message(&mut rt_peer) {
                     ws.send(WsMessage::Binary(

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -78,6 +78,12 @@ struct Cli {
     #[arg(long)]
     add_cell: Option<String>,
 
+    /// After the added cell converges, send an ExecuteCell request for it and
+    /// log the executions that appear in the RuntimeStateDoc (verifies the
+    /// hosted ExecuteCell dispatch). Requires --add-cell.
+    #[arg(long)]
+    run_cell: bool,
+
     /// Auto-close after this many seconds (0 = run until disconnected).
     #[arg(long, default_value_t = 20)]
     seconds: u64,
@@ -187,6 +193,8 @@ async fn main() -> Result<()> {
     let mut rt: Option<RuntimeStateDoc> = None;
     let mut rt_peer = sync::State::new();
     let mut edited = false;
+    let mut added_cell_id: Option<String> = None;
+    let mut requested = false;
     let deadline =
         (cli.seconds > 0).then(|| tokio::time::Instant::now() + Duration::from_secs(cli.seconds));
     loop {
@@ -224,7 +232,12 @@ async fn main() -> Result<()> {
                     Ok(v) => v,
                     Err(_) => continue,
                 };
-                if control.get("type").and_then(|t| t.as_str()) != Some("cloud_room_ready") {
+                let ctl_type = control.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                if ctl_type != "cloud_room_ready" {
+                    // Surface rejections/errors (skip the per-frame accept flood).
+                    if ctl_type != "cloud_frame_accepted" {
+                        info!("control: {}", String::from_utf8_lossy(payload));
+                    }
                     continue;
                 }
                 if nb.is_some() {
@@ -291,16 +304,35 @@ async fn main() -> Result<()> {
                         if nb_doc.add_cell_after(&cell_id, "code", None).is_ok() {
                             let _ = nb_doc.update_source(&cell_id, source);
                             edited = true;
+                            added_cell_id = Some(cell_id.clone());
                             info!("added code cell {cell_id} ({} chars)", source.len());
                         }
                     }
                 }
 
-                if let Some(reply) = nb_doc.generate_sync_message(&mut nb_peer) {
+                let reply = nb_doc.generate_sync_message(&mut nb_peer);
+                let converged = reply.is_none();
+                if let Some(reply) = reply {
                     ws.send(WsMessage::Binary(
                         frame(frame_types::AUTOMERGE_SYNC, &reply.encode()).into(),
                     ))
                     .await?;
+                }
+
+                // Once the added cell has converged to the room, ask the room to
+                // run it. The room's ExecuteCell dispatch creates the queued
+                // execution in RuntimeStateDoc, which we observe in the 0x05 arm.
+                if converged && edited && cli.run_cell && !requested {
+                    if let Some(cell_id) = &added_cell_id {
+                        let req =
+                            serde_json::json!({ "action": "execute_cell", "cell_id": cell_id });
+                        let body =
+                            serde_json::to_vec(&req).map_err(|e| anyhow!("encode request: {e}"))?;
+                        ws.send(WsMessage::Binary(frame(frame_types::REQUEST, &body).into()))
+                            .await?;
+                        requested = true;
+                        info!("sent ExecuteCell request for {cell_id}");
+                    }
                 }
             }
             frame_types::RUNTIME_STATE_SYNC => {
@@ -317,6 +349,26 @@ async fn main() -> Result<()> {
                         frame(frame_types::RUNTIME_STATE_SYNC, &m.encode()).into(),
                     ))
                     .await?;
+                }
+                // Surface any executions the room created (verifies dispatch).
+                let state = rt_doc.read_state();
+                if !state.executions.is_empty() {
+                    let mut ids: Vec<&String> = state.executions.keys().collect();
+                    ids.sort();
+                    for id in ids {
+                        let ex = &state.executions[id];
+                        let src: String = ex
+                            .source
+                            .as_deref()
+                            .unwrap_or("")
+                            .chars()
+                            .take(40)
+                            .collect();
+                        info!(
+                            "execution {id}: status={} seq={:?} source={src:?}",
+                            ex.status, ex.seq
+                        );
+                    }
                 }
             }
             other => info!("frame 0x{other:02x} ({} bytes)", payload.len()),

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -139,6 +139,11 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "crates/runt-cloud-peer/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/runt-mcp/Cargo.toml",
         format: Format::Toml,
         matches: 1,

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -588,17 +588,42 @@ Load-bearing findings:
   room owns the `cells`/`metadata` maps and we receive them before editing
   (invariant #2 in `crates/notebook-doc/AGENTS.md`).
 
-Remaining for "run a cell" (the runtime half), not yet built:
+Built since (the runtime half):
 
-- **Hosted execution dispatch.** The room host drops `REQUEST` frames
-  (`receive_peer_frame` returns empty), and no scope can create an execution via
-  sync. Port the daemon's `ExecuteCell` dispatch
-  (`create_execution_with_source_provenance`) into `runtimed-wasm` so a run
-  request becomes a queued execution. Requires a preview redeploy.
+- **Hosted execution dispatch (#3399).** The room host turns an editor/owner
+  `ExecuteCell` `REQUEST` into a queued execution in RuntimeStateDoc
+  (`create_execution_with_source_provenance`), stamps the cell's `execution_id`,
+  and broadcasts both docs. Execution intent is created only by the room host:
+  clients request, the host writes (the RuntimeStateDoc policy forbids non-host
+  execution creation over sync). Idempotent on a double-run, and attributed to
+  the submitter's full `principal/operator` actor label. `--run-cell` here drives
+  it and observes the queued execution; verified end-to-end against preview. The
+  consumer-side receive on this client uses `receive_sync_message_with_changes`,
+  not the daemon-authoritative `receive_sync_message` (which strips incoming
+  changes) - otherwise the room's queued execution never lands locally.
+
+Remaining for "run a cell", not yet built:
+
+- **Request/response contract.** The cloud room acks `REQUEST` frames with
+  `cloud_frame_accepted` but does not emit a `RESPONSE` envelope, so await-based
+  callers (the viewer's `await executeCell`, which waits on `sendRequest` by id)
+  do not resolve. Needs cloud-room request/response plumbing (a `cell_queued` /
+  structured-error response keyed by the request id).
 - **Kernel-hosting runtime peer.** Add a mode to `runt-cloud-peer` that attaches
-  as `runtime_peer` (explicit ACL row via `POST /api/n/:id/acl`), watches
-  RuntimeStateDoc for queued executions, runs them in a Jupyter kernel (reusing
-  `runtime_agent` machinery), and streams `running -> outputs -> done` back.
+  as `runtime_peer` (explicit `runtime_peer` ACL row via `POST /api/n/:id/acl` -
+  owner alone is insufficient; `aclRowsCoverScope` special-cases the scope),
+  watches RuntimeStateDoc for queued executions, runs them in a Jupyter kernel,
+  and streams `running -> outputs -> done` back. Verified seam: do **not** depend
+  on the daemon's `JupyterKernel` (welded to daemon-only `KernelSharedRefs` -
+  BlobStore, broadcast channels, RuntimeStateHandle). Build a thin launch+drive
+  loop on the published `jupyter-protocol` + `jupyter-zmq-client` crates plus
+  `runtime-doc` (already a dependency): spawn `python -m ipykernel_launcher -f
+  <conn>` (`bootstrap_dx` off, stock launcher, no launcher cache), set the
+  execute_request `msg_id = execution_id` so IOPub `parent_header.msg_id` routes
+  outputs back, and write `set_execution_running` / `append_output` /
+  `set_execution_done` onto the owned RuntimeStateDoc, then
+  `generate_sync_message` to push back. Mirror the daemon's write order and the
+  control-plane/output-transport separation invariant.
 
 ## Open questions
 

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -555,6 +555,51 @@ The smallest valuable PR should avoid kernel execution:
 That slice gives the product a real "workstation is online" signal without
 prematurely deciding the hosted execution dispatch protocol.
 
+## Implementation status (2026-06-05): outbound WS sync client
+
+Step 7 (the outbound `runtime_peer` sync client) has a working first cut:
+`crates/runt-cloud-peer`, a standalone CLI that dials `wss://<host>/n/<id>/sync`,
+authenticates on the upgrade, and runs Automerge sync for both the NotebookDoc
+and the RuntimeStateDoc over the typed-frame v4 stream, reusing `notebook-doc`
+and `runtime-doc` directly. It is the role the Outerbounds workstation will
+eventually play; for now it runs locally to prove the path against live preview.
+
+Verified against the deployed preview: the client authenticates with a staging
+Anaconda OIDC bearer (`Authorization: Bearer`, no subprotocol), reserves a room
+via `POST /api/n`, attaches as `owner`, and drives a NotebookDoc edit (adds a
+code cell) that the room accepts and converges on. The cell renders in the
+hosted viewer.
+
+Load-bearing findings:
+
+- **Change actor must match the authenticated principal.** The room host
+  (`validate_room_notebook_change_actors`, `crates/runtimed-wasm/src/lib.rs`)
+  rejects any change whose actor principal differs from the connection's
+  authenticated principal. Author the doc as `<principal>/<operator>`, taking
+  `<principal>` from the room's `cloud_room_ready` frame. A mismatched actor is
+  silently dropped: the change never lands and sync never converges (the room
+  keeps re-advertising that it lacks the change). Use a unique operator per run,
+  or two doc instances reusing one actor collide at `(actor, seq 1)` (automerge
+  `DuplicateSeqNumber`).
+- **Header-bearer auth, not subprotocol.** Non-browser peers send
+  `Authorization: Bearer` + `X-Scope`; offering a `Sec-WebSocket-Protocol` the
+  room will not echo trips tungstenite's "server sent no subprotocol".
+- **Bootstrap, do not scaffold.** The client `bootstrap()`s genesis only; the
+  room owns the `cells`/`metadata` maps and we receive them before editing
+  (invariant #2 in `crates/notebook-doc/AGENTS.md`).
+
+Remaining for "run a cell" (the runtime half), not yet built:
+
+- **Hosted execution dispatch.** The room host drops `REQUEST` frames
+  (`receive_peer_frame` returns empty), and no scope can create an execution via
+  sync. Port the daemon's `ExecuteCell` dispatch
+  (`create_execution_with_source_provenance`) into `runtimed-wasm` so a run
+  request becomes a queued execution. Requires a preview redeploy.
+- **Kernel-hosting runtime peer.** Add a mode to `runt-cloud-peer` that attaches
+  as `runtime_peer` (explicit ACL row via `POST /api/n/:id/acl`), watches
+  RuntimeStateDoc for queued executions, runs them in a Jupyter kernel (reusing
+  `runtime_agent` machinery), and streams `running -> outputs -> done` back.
+
 ## Open questions
 
 1. Is a workstation target personal to the API-key principal, shareable within a


### PR DESCRIPTION
The outbound peer the daemon lacked. `runt-cloud-peer` dials `wss://<host>/n/<id>/sync`, authenticates on the upgrade (OIDC bearer / Anaconda API key / dev token), and runs Automerge sync for **both** the NotebookDoc and the RuntimeStateDoc over the typed-frame v4 stream, reusing `notebook-doc` / `runtime-doc` directly. This is the local end of the "drive a hosted notebook from a workstation" path: the existing sync surfaces only speak the Unix-socket handshake (`notebook-sync`, `runtime_agent`) or HTTP (`runt-publish`).

## Design

- **Header auth, no subprotocol.** Credential rides in `Authorization: Bearer` + `X-Scope` (dev mode uses `x-notebook-cloud-dev-token` + `x-user`). Offering a `Sec-WebSocket-Protocol` the room won't echo trips tungstenite's "server sent no subprotocol".
- **Bootstrap, don't scaffold.** The client `bootstrap()`s genesis only; the room owns the `cells`/`metadata` maps and we receive them before editing (notebook-doc invariant #2). Changes are authored as `<principal>/<operator>:<uuid>` taken from the room's `cloud_room_ready` frame, so the room's `validate_room_notebook_change_actors` accepts them; the unique per-run actor avoids an automerge `DuplicateSeqNumber` on re-runs.
- **Consumer-side receive.** RuntimeStateDoc sync uses `receive_sync_message_with_changes`, not the daemon-authoritative `receive_sync_message` (which strips incoming changes). The peer is a *consumer* of the room's authoritative runtime-state, like a frontend; stripping the changes silently discarded the room's queued executions and stalled convergence.

## `--run-cell`

Adds a cell, asks the room to run it, and observes the resulting queued execution in RuntimeStateDoc. This exercises the hosted **ExecuteCell dispatch in #3399** (server-side); against a room without that dispatch the request is a no-op. Verified end-to-end against deployed preview: `status=queued` with the right `seq` and source syncing back.

## Review fixes

- `anaconda-api-key` mode now sends `X-Notebook-Cloud-Auth-Provider`; without it the cloud identity router parses the bearer as OIDC and rejects it.
- `update_source` failure no longer reported as a successful cell add (would otherwise sync/run an empty cell); the cell is considered added only once its source is set.
- The WebSocket is closed cleanly on exit so the room records a normal disconnect.

Independent of the server-side dispatch in #3399 (different files; merges in either order), though `--run-cell` only does something useful once #3399 is deployed.
