### PR TITLE
refactor(notebook): project shell capabilities in runtimed

### DIFF
--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -3,7 +3,7 @@ import {
   notebookActorProjectionFromRuntime,
 } from "@/components/notebook/actor-projection";
 import type { NotebookShellCapabilities } from "@/components/notebook/capabilities";
-import type { NotebookEditMode } from "runtimed";
+import { projectNotebookShellCapabilities, type NotebookEditMode } from "runtimed";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import { projectCloudNotebookEditAccess } from "./edit-access";
 
@@ -76,10 +76,6 @@ export function cloudNotebookShellCapabilities({
     actorLabel: connectionActorLabel,
     identityLabel,
   };
-  // Executing a cell needs both an attached runtime and document write
-  // authority. The room has no kernel provider yet, so runtimeAvailable
-  // defaults false and run controls stay hidden.
-  const canExecute = runtimeAvailable && interaction.hasDocumentEditPermission;
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
     connected: isRuntimePeer,
@@ -88,33 +84,48 @@ export function cloudNotebookShellCapabilities({
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
     identityLabel: isRuntimePeer ? identityLabel : null,
   };
-  const accessActor = withCloudIdentityImage(notebookActorProjectionFromAccess(access, auth), {
-    imageUrl: identityImageUrl,
+  const projection = projectNotebookShellCapabilities({
+    interaction,
+    access,
+    auth,
+    runtime,
+    controls: {
+      canToggleCode: hasCodeCells,
+    },
+    execution: {
+      available: runtimeAvailable,
+      requiresDocumentEditPermission: true,
+    },
+    packages: {
+      canView: true,
+      canManage: false,
+    },
+    sharing: {
+      canManage: Boolean(hostCapabilities?.canManageSharing),
+      requiresAuthenticatedIdentity: true,
+    },
   });
-  const runtimeActor = withCloudIdentityImage(notebookActorProjectionFromRuntime(runtime, auth), {
-    imageUrl: identityImageUrl,
-  });
+  const accessActor = withCloudIdentityImage(
+    notebookActorProjectionFromAccess(projection.access, projection.auth),
+    {
+      imageUrl: identityImageUrl,
+    },
+  );
+  const runtimeActor = withCloudIdentityImage(
+    notebookActorProjectionFromRuntime(projection.runtime, projection.auth),
+    {
+      imageUrl: identityImageUrl,
+    },
+  );
 
   return {
-    canRead: true,
-    canEditMarkdown: interaction.canEditMarkdown,
-    canEditCells: interaction.canEditCells,
-    canEditStructure: interaction.canEditStructure,
-    canRequestEdit: interaction.canRequestEdit,
-    canExecute,
-    canToggleCode: hasCodeCells,
-    canViewPackages: true,
-    canManagePackages: false,
-    canManageSharing:
-      Boolean(hostCapabilities?.canManageSharing) && auth.canUseAuthenticatedIdentity,
-    interaction,
+    ...projection,
     access: {
-      ...access,
+      ...projection.access,
       actor: accessActor,
     },
-    auth,
     runtime: {
-      ...runtime,
+      ...projection.runtime,
       actor: runtimeActor,
     },
   };

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -10,6 +10,7 @@ import type {
 import {
   notebookRoomAccessLevelCanEditDocument,
   notebookRoomAccessLevelFromConnectionScope,
+  projectNotebookShellCapabilities,
   projectNotebookRoomEditAccess,
 } from "runtimed";
 
@@ -62,32 +63,44 @@ export function desktopNotebookShellCapabilities({
     actorLabel: canWriteRuntimeState ? localActor : null,
     identityLabel: null,
   };
-
-  return {
-    canRead: accessLevel !== "none",
-    canEditMarkdown: canWriteDocument,
-    canEditCells: canWriteDocument,
-    canEditStructure: canWriteDocument,
-    canRequestEdit: false,
-    canExecute: sessionReady && canWriteDocument,
-    canToggleCode: true,
-    canViewPackages: true,
-    canManagePackages: canWriteDocument,
-    canManageSharing:
-      Boolean(hostCapabilities?.canManageSharing) && accessLevel === "owner" && source === "cloud",
+  const projection = projectNotebookShellCapabilities({
     interaction,
-    access: {
-      ...access,
-      actor: notebookActorProjectionFromAccess(access),
-    },
+    access,
     auth: {
       canSignIn: false,
       canUseAuthenticatedIdentity: source === "cloud" && Boolean(localActor),
       needsAttention: false,
     },
+    runtime,
+    controls: {
+      canToggleCode: true,
+    },
+    execution: {
+      available: sessionReady,
+      requiresDocumentEditPermission: true,
+      requiresDocumentMutationSupport: true,
+    },
+    packages: {
+      canView: true,
+      canManage: true,
+      manageRequiresDocumentMutationSupport: true,
+    },
+    sharing: {
+      canManage: Boolean(hostCapabilities?.canManageSharing),
+      requiredAccessLevels: ["owner"],
+      requiredSources: ["cloud"],
+    },
+  });
+
+  return {
+    ...projection,
+    access: {
+      ...projection.access,
+      actor: notebookActorProjectionFromAccess(projection.access, projection.auth),
+    },
     runtime: {
-      ...runtime,
-      actor: notebookActorProjectionFromRuntime(runtime),
+      ...projection.runtime,
+      actor: notebookActorProjectionFromRuntime(projection.runtime, projection.auth),
     },
   };
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -176,6 +176,27 @@ export {
   type ProjectNotebookRoomEditAccessOptions,
 } from "./notebook-edit-access";
 
+// Notebook shell capability projection
+export {
+  projectNotebookShellCapabilities,
+  readOnlyNotebookShellCapabilities,
+  type NotebookActorOperator,
+  type NotebookActorPrincipal,
+  type NotebookActorProjection,
+  type NotebookActorSourceProvider,
+  type NotebookShellAccessCapabilities,
+  type NotebookShellAccessLevel,
+  type NotebookShellAccessSource,
+  type NotebookShellAuthCapabilities,
+  type NotebookShellCapabilities,
+  type NotebookShellControlPolicy,
+  type NotebookShellExecutionPolicy,
+  type NotebookShellPackagePolicy,
+  type NotebookShellRuntimeCapabilities,
+  type NotebookShellSharingPolicy,
+  type ProjectNotebookShellCapabilitiesOptions,
+} from "./notebook-shell-capabilities";
+
 // Notebook interaction projection
 export {
   createNotebookInteractionStore,

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -1,0 +1,259 @@
+import type {
+  NotebookEditAccessProjection,
+  NotebookRoomAccessLevel,
+  NotebookRoomEditAccessProjection,
+} from "./notebook-edit-access";
+
+export type NotebookShellAccessLevel = NotebookRoomAccessLevel;
+
+export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown";
+
+export type NotebookActorSourceProvider =
+  | "anonymous"
+  | "anaconda"
+  | "dev"
+  | "jupyterhub"
+  | "local"
+  | "outerbounds"
+  | "oidc";
+
+export interface NotebookActorPrincipal {
+  id: string;
+  label: string;
+  imageUrl?: string | null;
+  source?: {
+    provider: NotebookActorSourceProvider;
+    namespace: string;
+  };
+}
+
+export interface NotebookActorOperator {
+  id: string;
+  kind: string;
+  label: string;
+}
+
+export interface NotebookActorProjection {
+  actorLabel: string;
+  principal: NotebookActorPrincipal;
+  operator: NotebookActorOperator;
+  scope?: "viewer" | "editor" | "runtime_peer" | "owner";
+  status?: "active" | "attention" | "idle" | "offline";
+}
+
+export interface NotebookShellAccessCapabilities {
+  /**
+   * The document-level access granted to the current identity. Hosts derive
+   * this from ACLs, local file permissions, or fixture scenarios.
+   */
+  level: NotebookShellAccessLevel;
+  source: NotebookShellAccessSource;
+  isPublic: boolean;
+  actorLabel: string | null;
+  identityLabel: string | null;
+  /**
+   * Structured host-owned actor projection. Durable actor labels remain the
+   * backend/CRDT attribution source; React falls back to parsing them only
+   * while hosts are still adopting this source-shaped projection.
+   */
+  actor?: NotebookActorProjection | null;
+}
+
+export interface NotebookShellAuthCapabilities {
+  canSignIn: boolean;
+  canUseAuthenticatedIdentity: boolean;
+  needsAttention: boolean;
+}
+
+export interface NotebookShellRuntimeCapabilities {
+  /**
+   * Runtime peers author execution lifecycle, output, and comm state. This is
+   * intentionally separate from document access: runtime authorship does not
+   * grant notebook editing, package management, or sharing controls.
+   */
+  canWriteRuntimeState: boolean;
+  connected: boolean;
+  /**
+   * Whether an execution runtime (kernel provider) is available to run cells.
+   * This is the host-neutral signal behind `canExecute`: run/restart/interrupt
+   * stay hidden when no runtime can execute, regardless of edit permission. A
+   * host with no kernel provider (the hosted prototype today) reports false; a
+   * local daemon with a ready session, or a future attached cloud runtime,
+   * reports true. Optional so fixtures need not set it.
+   */
+  executionAvailable?: boolean;
+  source: NotebookShellAccessSource;
+  actorLabel: string | null;
+  identityLabel: string | null;
+  actor?: NotebookActorProjection | null;
+}
+
+export interface NotebookShellCapabilities {
+  canRead: boolean;
+  canEditMarkdown: boolean;
+  canEditCells: boolean;
+  canEditStructure: boolean;
+  canRequestEdit: boolean;
+  canExecute: boolean;
+  canToggleCode: boolean;
+  canViewPackages: boolean;
+  canManagePackages: boolean;
+  canManageSharing: boolean;
+  interaction?: NotebookEditAccessProjection | null;
+  access: NotebookShellAccessCapabilities;
+  auth: NotebookShellAuthCapabilities;
+  runtime: NotebookShellRuntimeCapabilities;
+}
+
+export interface NotebookShellControlPolicy {
+  canToggleCode: boolean;
+}
+
+export interface NotebookShellExecutionPolicy {
+  available: boolean;
+  requiresDocumentEditPermission?: boolean;
+  requiresDocumentMutationSupport?: boolean;
+}
+
+export interface NotebookShellPackagePolicy {
+  canView: boolean;
+  canManage: boolean;
+  manageRequiresDocumentMutationSupport?: boolean;
+}
+
+export interface NotebookShellSharingPolicy {
+  canManage: boolean;
+  requiresAuthenticatedIdentity?: boolean;
+  requiredAccessLevels?: readonly NotebookShellAccessLevel[];
+  requiredSources?: readonly NotebookShellAccessSource[];
+}
+
+export interface ProjectNotebookShellCapabilitiesOptions {
+  interaction: NotebookEditAccessProjection | NotebookRoomEditAccessProjection;
+  access: NotebookShellAccessCapabilities;
+  auth?: NotebookShellAuthCapabilities;
+  runtime?: Partial<NotebookShellRuntimeCapabilities>;
+  controls?: Partial<NotebookShellControlPolicy>;
+  execution?: NotebookShellExecutionPolicy;
+  packages?: Partial<NotebookShellPackagePolicy>;
+  sharing?: NotebookShellSharingPolicy;
+}
+
+export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
+  canRead: true,
+  canEditMarkdown: false,
+  canEditCells: false,
+  canEditStructure: false,
+  canRequestEdit: false,
+  canExecute: false,
+  canToggleCode: false,
+  canViewPackages: true,
+  canManagePackages: false,
+  canManageSharing: false,
+  interaction: {
+    selectedMode: "view",
+    activeMode: "view",
+    state: "viewing",
+    canRequestEdit: false,
+    canEditMarkdown: false,
+    canEditCells: false,
+    canEditStructure: false,
+  },
+  access: {
+    level: "viewer",
+    source: "unknown",
+    isPublic: false,
+    actorLabel: null,
+    identityLabel: null,
+  },
+  auth: {
+    canSignIn: false,
+    canUseAuthenticatedIdentity: false,
+    needsAttention: false,
+  },
+  runtime: {
+    canWriteRuntimeState: false,
+    connected: false,
+    executionAvailable: false,
+    source: "unknown",
+    actorLabel: null,
+    identityLabel: null,
+  },
+};
+
+export function projectNotebookShellCapabilities({
+  access,
+  auth = readOnlyNotebookShellCapabilities.auth,
+  controls,
+  execution,
+  interaction,
+  packages,
+  runtime,
+  sharing,
+}: ProjectNotebookShellCapabilitiesOptions): NotebookShellCapabilities {
+  const canMutateFullDocument =
+    interaction.canEditMarkdown && interaction.canEditCells && interaction.canEditStructure;
+  const hasDocumentEditPermission = notebookShellHasDocumentEditPermission(interaction, access);
+  const executionAvailable = execution?.available ?? runtime?.executionAvailable ?? false;
+  const runtimeCapabilities: NotebookShellRuntimeCapabilities = {
+    canWriteRuntimeState: runtime?.canWriteRuntimeState ?? false,
+    connected: runtime?.connected ?? false,
+    executionAvailable,
+    source: runtime?.source ?? access.source,
+    actorLabel: runtime?.actorLabel ?? null,
+    identityLabel: runtime?.identityLabel ?? null,
+    actor: runtime?.actor,
+  };
+
+  return {
+    canRead: access.level !== "none",
+    canEditMarkdown: interaction.canEditMarkdown,
+    canEditCells: interaction.canEditCells,
+    canEditStructure: interaction.canEditStructure,
+    canRequestEdit: interaction.canRequestEdit,
+    canExecute:
+      executionAvailable &&
+      (!execution?.requiresDocumentEditPermission || hasDocumentEditPermission) &&
+      (!execution?.requiresDocumentMutationSupport || canMutateFullDocument),
+    canToggleCode: controls?.canToggleCode ?? true,
+    canViewPackages: packages?.canView ?? true,
+    canManagePackages:
+      (packages?.canManage ?? false) &&
+      (!packages?.manageRequiresDocumentMutationSupport || canMutateFullDocument),
+    canManageSharing: notebookShellCanManageSharing({ access, auth, sharing }),
+    interaction,
+    access,
+    auth,
+    runtime: runtimeCapabilities,
+  };
+}
+
+function notebookShellHasDocumentEditPermission(
+  interaction: NotebookEditAccessProjection | NotebookRoomEditAccessProjection,
+  access: NotebookShellAccessCapabilities,
+): boolean {
+  if ("hasDocumentEditPermission" in interaction) {
+    return interaction.hasDocumentEditPermission;
+  }
+  return access.level === "editor" || access.level === "owner";
+}
+
+function notebookShellCanManageSharing({
+  access,
+  auth,
+  sharing,
+}: {
+  access: NotebookShellAccessCapabilities;
+  auth: NotebookShellAuthCapabilities;
+  sharing: NotebookShellSharingPolicy | undefined;
+}): boolean {
+  if (!sharing?.canManage) return false;
+  if (sharing.requiresAuthenticatedIdentity && !auth.canUseAuthenticatedIdentity) return false;
+  if (sharing.requiredAccessLevels && !sharing.requiredAccessLevels.includes(access.level)) {
+    return false;
+  }
+  if (sharing.requiredSources && !sharing.requiredSources.includes(access.source)) {
+    return false;
+  }
+  return true;
+}

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  projectNotebookRoomEditAccess,
+  projectNotebookShellCapabilities,
+  readOnlyNotebookShellCapabilities,
+  type NotebookShellAccessCapabilities,
+  type NotebookShellAuthCapabilities,
+  type NotebookShellRuntimeCapabilities,
+} from "../src";
+
+function access(
+  overrides: Partial<NotebookShellAccessCapabilities> = {},
+): NotebookShellAccessCapabilities {
+  return {
+    level: "viewer",
+    source: "cloud",
+    isPublic: false,
+    actorLabel: null,
+    identityLabel: null,
+    ...overrides,
+  };
+}
+
+function auth(
+  overrides: Partial<NotebookShellAuthCapabilities> = {},
+): NotebookShellAuthCapabilities {
+  return {
+    canSignIn: false,
+    canUseAuthenticatedIdentity: false,
+    needsAttention: false,
+    ...overrides,
+  };
+}
+
+function runtime(
+  overrides: Partial<NotebookShellRuntimeCapabilities> = {},
+): NotebookShellRuntimeCapabilities {
+  return {
+    canWriteRuntimeState: false,
+    connected: false,
+    executionAvailable: false,
+    source: "cloud",
+    actorLabel: null,
+    identityLabel: null,
+    ...overrides,
+  };
+}
+
+describe("projectNotebookShellCapabilities", () => {
+  it("projects read-only viewer access into shell capabilities", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "viewer",
+      requestedScope: "viewer",
+      selectedMode: "view",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: false,
+    });
+
+    expect(
+      projectNotebookShellCapabilities({
+        interaction,
+        access: access(),
+        controls: { canToggleCode: true },
+        execution: { available: true, requiresDocumentEditPermission: true },
+        packages: { canView: true, canManage: true, manageRequiresDocumentMutationSupport: true },
+        sharing: { canManage: true, requiresAuthenticatedIdentity: true },
+      }),
+    ).toMatchObject({
+      canRead: true,
+      canEditMarkdown: false,
+      canEditCells: false,
+      canEditStructure: false,
+      canExecute: false,
+      canToggleCode: true,
+      canViewPackages: true,
+      canManagePackages: false,
+      canManageSharing: false,
+      access: { level: "viewer", source: "cloud" },
+      runtime: { executionAvailable: true },
+    });
+  });
+
+  it("can require full document mutation support for execution and package management", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "owner",
+      requestedScope: "owner",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: false,
+      canRequestEdit: false,
+    });
+
+    const capabilities = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "owner", source: "local" }),
+      runtime: runtime({ source: "local", connected: true, executionAvailable: true }),
+      execution: {
+        available: true,
+        requiresDocumentEditPermission: true,
+        requiresDocumentMutationSupport: true,
+      },
+      packages: {
+        canView: true,
+        canManage: true,
+        manageRequiresDocumentMutationSupport: true,
+      },
+    });
+
+    expect(capabilities.access.level).toBe("owner");
+    expect(capabilities.interaction?.state).toBe("requested");
+    expect(capabilities.canExecute).toBe(false);
+    expect(capabilities.canManagePackages).toBe(false);
+  });
+
+  it("allows attached cloud runtimes to execute from document edit permission without active edit mode", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "editor",
+      requestedScope: "editor",
+      selectedMode: "view",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+    });
+
+    const capabilities = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "editor" }),
+      runtime: runtime({ executionAvailable: true }),
+      execution: {
+        available: true,
+        requiresDocumentEditPermission: true,
+      },
+    });
+
+    expect(capabilities.canEditCells).toBe(false);
+    expect(capabilities.canExecute).toBe(true);
+  });
+
+  it("applies sharing requirements for authenticated cloud hosts", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "owner",
+      requestedScope: "owner",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+    });
+
+    const capabilities = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "owner", source: "cloud" }),
+      auth: auth({ canUseAuthenticatedIdentity: true }),
+      sharing: {
+        canManage: true,
+        requiresAuthenticatedIdentity: true,
+        requiredAccessLevels: ["owner"],
+        requiredSources: ["cloud"],
+      },
+    });
+
+    expect(capabilities.canManageSharing).toBe(true);
+
+    expect(
+      projectNotebookShellCapabilities({
+        interaction,
+        access: access({ level: "owner", source: "local" }),
+        auth: auth({ canUseAuthenticatedIdentity: true }),
+        sharing: {
+          canManage: true,
+          requiresAuthenticatedIdentity: true,
+          requiredAccessLevels: ["owner"],
+          requiredSources: ["cloud"],
+        },
+      }).canManageSharing,
+    ).toBe(false);
+  });
+
+  it("exports the default read-only capability projection from runtimed", () => {
+    expect(readOnlyNotebookShellCapabilities).toMatchObject({
+      canRead: true,
+      canExecute: false,
+      canManagePackages: false,
+      access: { level: "viewer", source: "unknown" },
+      runtime: { connected: false, executionAvailable: false },
+    });
+  });
+});

--- a/src/components/notebook/capabilities.ts
+++ b/src/components/notebook/capabilities.ts
@@ -1,41 +1,22 @@
-import type { NotebookInteractionModeProjection } from "./interaction-mode";
-
-export type NotebookShellAccessLevel = "none" | "viewer" | "editor" | "owner";
-
-export type NotebookShellAccessSource = "cloud" | "local" | "fixture" | "unknown";
-
-export type NotebookActorSourceProvider =
-  | "anonymous"
-  | "anaconda"
-  | "dev"
-  | "jupyterhub"
-  | "local"
-  | "outerbounds"
-  | "oidc";
-
-export interface NotebookActorPrincipal {
-  id: string;
-  label: string;
-  imageUrl?: string | null;
-  source?: {
-    provider: NotebookActorSourceProvider;
-    namespace: string;
-  };
-}
-
-export interface NotebookActorOperator {
-  id: string;
-  kind: string;
-  label: string;
-}
-
-export interface NotebookActorProjection {
-  actorLabel: string;
-  principal: NotebookActorPrincipal;
-  operator: NotebookActorOperator;
-  scope?: "viewer" | "editor" | "runtime_peer" | "owner";
-  status?: "active" | "attention" | "idle" | "offline";
-}
+export {
+  projectNotebookShellCapabilities,
+  readOnlyNotebookShellCapabilities,
+  type NotebookActorOperator,
+  type NotebookActorPrincipal,
+  type NotebookActorProjection,
+  type NotebookActorSourceProvider,
+  type NotebookShellAccessCapabilities,
+  type NotebookShellAccessLevel,
+  type NotebookShellAccessSource,
+  type NotebookShellAuthCapabilities,
+  type NotebookShellCapabilities,
+  type NotebookShellControlPolicy,
+  type NotebookShellExecutionPolicy,
+  type NotebookShellPackagePolicy,
+  type NotebookShellRuntimeCapabilities,
+  type NotebookShellSharingPolicy,
+  type ProjectNotebookShellCapabilitiesOptions,
+} from "runtimed";
 
 export type NotebookActorKind =
   | "agent"
@@ -56,109 +37,3 @@ export interface NotebookActorIdentity {
   principalLabel?: string | null;
   operatorLabel?: string | null;
 }
-
-export interface NotebookShellAccessCapabilities {
-  /**
-   * The document-level access granted to the current identity. Hosts derive
-   * this from ACLs, local file permissions, or fixture scenarios.
-   */
-  level: NotebookShellAccessLevel;
-  source: NotebookShellAccessSource;
-  isPublic: boolean;
-  actorLabel: string | null;
-  identityLabel: string | null;
-  /**
-   * Structured host-owned actor projection. Durable actor labels remain the
-   * backend/CRDT attribution source; React falls back to parsing them only
-   * while hosts are still adopting this source-shaped projection.
-   */
-  actor?: NotebookActorProjection | null;
-}
-
-export interface NotebookShellAuthCapabilities {
-  canSignIn: boolean;
-  canUseAuthenticatedIdentity: boolean;
-  needsAttention: boolean;
-}
-
-export interface NotebookShellRuntimeCapabilities {
-  /**
-   * Runtime peers author execution lifecycle, output, and comm state. This is
-   * intentionally separate from document access: runtime authorship does not
-   * grant notebook editing, package management, or sharing controls.
-   */
-  canWriteRuntimeState: boolean;
-  connected: boolean;
-  /**
-   * Whether an execution runtime (kernel provider) is available to run cells.
-   * This is the host-neutral signal behind `canExecute`: run/restart/interrupt
-   * stay hidden when no runtime can execute, regardless of edit permission. A
-   * host with no kernel provider (the hosted prototype today) reports false; a
-   * local daemon with a ready session, or a future attached cloud runtime,
-   * reports true. Optional so fixtures need not set it.
-   */
-  executionAvailable?: boolean;
-  source: NotebookShellAccessSource;
-  actorLabel: string | null;
-  identityLabel: string | null;
-  actor?: NotebookActorProjection | null;
-}
-
-export interface NotebookShellCapabilities {
-  canRead: boolean;
-  canEditMarkdown: boolean;
-  canEditCells: boolean;
-  canEditStructure: boolean;
-  canRequestEdit: boolean;
-  canExecute: boolean;
-  canToggleCode: boolean;
-  canViewPackages: boolean;
-  canManagePackages: boolean;
-  canManageSharing: boolean;
-  interaction?: NotebookInteractionModeProjection | null;
-  access: NotebookShellAccessCapabilities;
-  auth: NotebookShellAuthCapabilities;
-  runtime: NotebookShellRuntimeCapabilities;
-}
-
-export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
-  canRead: true,
-  canEditMarkdown: false,
-  canEditCells: false,
-  canEditStructure: false,
-  canRequestEdit: false,
-  canExecute: false,
-  canToggleCode: false,
-  canViewPackages: true,
-  canManagePackages: false,
-  canManageSharing: false,
-  interaction: {
-    selectedMode: "view",
-    activeMode: "view",
-    state: "viewing",
-    canRequestEdit: false,
-    canEditMarkdown: false,
-    canEditCells: false,
-    canEditStructure: false,
-  },
-  access: {
-    level: "viewer",
-    source: "unknown",
-    isPublic: false,
-    actorLabel: null,
-    identityLabel: null,
-  },
-  auth: {
-    canSignIn: false,
-    canUseAuthenticatedIdentity: false,
-    needsAttention: false,
-  },
-  runtime: {
-    canWriteRuntimeState: false,
-    connected: false,
-    executionAvailable: false,
-    source: "unknown",
-    actorLabel: null,
-    identityLabel: null,
-  },
-};

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -15,6 +15,7 @@ export {
   notebookActorProjectionFromRuntime,
 } from "./actor-projection";
 export {
+  projectNotebookShellCapabilities,
   readOnlyNotebookShellCapabilities,
   type NotebookActorIdentity,
   type NotebookActorKind,
@@ -27,7 +28,12 @@ export {
   type NotebookShellAccessSource,
   type NotebookShellAuthCapabilities,
   type NotebookShellCapabilities,
+  type NotebookShellControlPolicy,
+  type NotebookShellExecutionPolicy,
+  type NotebookShellPackagePolicy,
   type NotebookShellRuntimeCapabilities,
+  type NotebookShellSharingPolicy,
+  type ProjectNotebookShellCapabilitiesOptions,
 } from "./capabilities";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";


### PR DESCRIPTION
## Summary

- Add a host-neutral `projectNotebookShellCapabilities` projection to `runtimed`
- Re-export notebook shell capability types from `runtimed` through the existing shared UI compatibility surface
- Rewire desktop and cloud shell adapters to pass host facts into the shared projection, then decorate actors locally

## Verification

- `pnpm test:run`
- `pnpm --dir apps/elements build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts`
- `cargo xtask lint --fix`
