### PR TITLE
docs: clarify agent-ready notebook positioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 This is a map. Subsystem details live in nested `AGENTS.md` files next to code, auto-loaded rules live in `.claude/rules/`, and repository skills live in `.agents/skills/`. Claude reads the same skills through the `.claude/skills` symlink. Run `cargo xtask help` for build commands.
 
+## Project positioning
+
+nteract is a local-first, agent-ready notebook environment where humans, kernels, and AI agents work against the same live document. Describe that in concrete system terms: Automerge-backed notebook state, explicit runtime state, daemon-owned kernels, outputs, and execution, and programmatic control through the same runtime model. Avoid broad AI slogans; prefer the mechanics users and developers can verify.
+
 ## Skills
 
 Use `.agents/skills/` when the task matches:
@@ -75,6 +79,10 @@ Stream output may use bounded, lossy periodic flushes, but ordering boundaries c
 Output widget replay is not the durable record; RuntimeStateDoc is. Kernel-facing `SendCommUpdate` replay from IOPub must be non-blocking and best-effort so a full bounded work queue cannot delay later lifecycle status.
 
 `update_display_data` is transient display churn. Coalesce it by `display_id` off the IOPub hot path, but flush pending display updates after `KernelIdle` and before `ExecutionDone` so terminal runtime state still follows durable output state.
+
+### Execution references synced cell IDs
+
+Execution that belongs to notebook state should reference a synced `cell_id`. Create or edit the cell in the Automerge document, wait for sync as needed, then execute by `cell_id`. Do not bypass the document with side-channel code strings or ad hoc code payloads; otherwise peers can execute source that is not the live notebook content.
 
 ## Notebook files
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nteract
 
-A fast, modern toolkit for Jupyter notebooks. Native desktop app with instant startup, realtime sync across windows and agents, and intelligent environment management.
+nteract is a local-first notebook environment where humans, kernels, and AI agents can work against the same live document. It ships as a native desktop app with instant startup, realtime sync across windows and programmatic clients, and managed local environments.
 
 Built on [jupyter-zmq-client](https://crates.io/crates/jupyter-zmq-client) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
 
@@ -25,6 +25,13 @@ The `runt` CLI and `runtimed` Python bindings ship with the app and stay up to d
 | `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
 | `runtimed` (Python) | Python bindings for the daemon (ships with the app) |
+
+## Runtime model
+
+nteract stores notebook content in an Automerge-backed document and keeps live kernel state in an explicit runtime state document. The daemon owns kernel processes, execution queues, output capture, and the write path for execution results.
+
+Execution requests name a synced `cell_id`; the daemon reads the cell source from the shared document, records queue and status changes in runtime state, and writes outputs through the same model. The desktop app, CLI, MCP server, and agent clients use that path, so programmatic control observes the same notebook state a human is editing.
+
 ## MCP Server
 
 The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents can run code, read and write cells, manage dependencies, and collaborate with humans in real-time — watching the notebook update live in the desktop app while the agent works.


### PR DESCRIPTION
## Summary
- Reframes the README opening around local-first notebooks for humans, kernels, and AI agents working against the same live document.
- Adds a concrete runtime model section covering Automerge notebook state, explicit runtime state, daemon-owned execution, and cell_id-based execution requests.
- Adds top-level AGENTS.md guidance so future agents keep the positioning concrete and avoid side-channel code execution paths.

## Validation
- git diff --check
- cargo xtask lint --help attempted, but the command runs the lint pipeline and failed in JS config resolution because vite-plus was missing before pnpm install; Rust fmt and Python ruff/ty passed before that failure.
