### PR TITLE
refactor(notebook): stabilize projection objects

### DIFF
--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -160,6 +160,13 @@ describe("cloud viewer sharing client", () => {
     assert.equal(first[1], second[1]);
     assert.equal(Object.isFrozen(first), true);
     assert.equal(Object.isFrozen(first[0]), true);
+    if (first[0]?.kind !== "acl") {
+      throw new Error("expected first sharing row to be an ACL row");
+    }
+    assert.equal(Object.isFrozen(first[0].acl), true);
+    assert.equal(Object.isFrozen(first[0].acl.display), true);
+    acl[0].updated_at = "2026-06-01T00:00:00.000Z";
+    assert.equal(first[0].acl.updated_at, "2026-05-28T00:00:00.000Z");
     assert.notEqual(first, changed);
     assert.notEqual(first[0], changed[0]);
   });

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   buildCloudShareAccessRows,
+  clearCloudShareAccessRowsCachesForTests,
   cloudShareAccessSummary,
   hasPublicViewerAccess,
   normalizeShareInviteEmail,
@@ -123,6 +124,44 @@ describe("cloud viewer sharing client", () => {
       rows.map((row) => row.title),
       ["user:dev:fixture", "user:anaconda:alice%40example.com"],
     );
+  });
+
+  it("returns stable frozen rows for equivalent sharing payloads", () => {
+    clearCloudShareAccessRowsCachesForTests();
+    const acl = [
+      aclRow({
+        subject: "user:anaconda:alice",
+        scope: "owner",
+        display: {
+          kind: "principal",
+          label: "Alice Owner",
+          principal: "user:anaconda:alice",
+          email: "alice@example.com",
+        },
+      }),
+    ];
+    const invites = [inviteRow({ id: "invite-stable", email: "bob@example.com" })];
+    const accessRequests = [accessRequestRow({ id: "request-stable" })];
+
+    const first = buildCloudShareAccessRows({ acl, invites, accessRequests });
+    const second = buildCloudShareAccessRows({
+      acl: [{ ...acl[0], display: acl[0].display ? { ...acl[0].display } : undefined }],
+      invites: [{ ...invites[0] }],
+      accessRequests: [{ ...accessRequests[0] }],
+    });
+    const changed = buildCloudShareAccessRows({
+      acl: [{ ...acl[0], updated_at: "2026-05-29T00:00:00.000Z" }],
+      invites,
+      accessRequests,
+    });
+
+    assert.equal(first, second);
+    assert.equal(first[0], second[0]);
+    assert.equal(first[1], second[1]);
+    assert.equal(Object.isFrozen(first), true);
+    assert.equal(Object.isFrozen(first[0]), true);
+    assert.notEqual(first, changed);
+    assert.notEqual(first[0], changed[0]);
   });
 
   it("keeps share invite email validation in the viewer before owner mutations", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -343,6 +343,42 @@ test("cloud shell capabilities prefer OIDC display names and pictures over raw e
   assert.equal(capabilities.access.actor?.principal.imageUrl, "https://profiles.example/alice.png");
 });
 
+test("cloud shell capabilities return stable frozen objects for equivalent inputs", () => {
+  const oidcClaims = {
+    sub: "anaconda-user-123",
+    email: "alice@example.com",
+    email_verified: true,
+    name: "Alice Example",
+    picture: "https://profiles.example/alice.png",
+  };
+  const first = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner", oidcClaims),
+    connectionScope: "owner",
+    connectionActorLabel: "user:anaconda:alice/browser:tab",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+    hostCapabilities: { canManageSharing: true },
+  });
+  const second = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner", { ...oidcClaims }),
+    connectionScope: "owner",
+    connectionActorLabel: "user:anaconda:alice/browser:tab",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+    hostCapabilities: { canManageSharing: true },
+  });
+
+  assert.equal(first, second);
+  assert.equal(first.access, second.access);
+  assert.equal(first.auth, second.auth);
+  assert.equal(first.runtime, second.runtime);
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(first.access), true);
+  assert.equal(Object.isFrozen(first.runtime), true);
+});
+
 test("cloud shell capabilities keep runtime peer authority separate from document access", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc"),

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -154,7 +154,7 @@ export function buildCloudShareAccessRows(input: {
       cachedCloudShareAccessRow(rowKey, () => ({
         id,
         kind: "acl",
-        acl,
+        acl: stableCloudNotebookAclRow(acl),
         label,
         detail,
         title,
@@ -190,7 +190,7 @@ export function buildCloudShareAccessRows(input: {
       cachedCloudShareAccessRow(rowKey, () => ({
         id,
         kind: "invite",
-        invite,
+        invite: stableCloudNotebookInvite(invite),
         label,
         detail,
         title,
@@ -226,7 +226,7 @@ export function buildCloudShareAccessRows(input: {
       cachedCloudShareAccessRow(rowKey, () => ({
         id,
         kind: "access_request",
-        accessRequest: request,
+        accessRequest: stableCloudNotebookAccessRequest(request),
         label,
         detail,
         title,
@@ -461,6 +461,20 @@ function cloudNotebookAclRowCacheKey(row: CloudNotebookAclRow): string {
   ]);
 }
 
+function stableCloudNotebookAclRow(row: CloudNotebookAclRow): CloudNotebookAclRow {
+  const display = row.display ? stableCloudShareDisplay(row.display) : undefined;
+  return Object.freeze({
+    notebook_id: row.notebook_id,
+    subject_kind: row.subject_kind,
+    subject: row.subject,
+    scope: row.scope,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    created_by_actor_label: row.created_by_actor_label,
+    ...(display ? { display } : {}),
+  });
+}
+
 function cloudNotebookInviteCacheKey(invite: CloudNotebookInvite): string {
   return stableCacheKey([
     invite.id,
@@ -480,6 +494,26 @@ function cloudNotebookInviteCacheKey(invite: CloudNotebookInvite): string {
   ]);
 }
 
+function stableCloudNotebookInvite(invite: CloudNotebookInvite): CloudNotebookInvite {
+  const display = invite.display ? stableCloudShareDisplay(invite.display) : undefined;
+  return Object.freeze({
+    id: invite.id,
+    notebook_id: invite.notebook_id,
+    email: invite.email,
+    provider_hint: invite.provider_hint,
+    scope: invite.scope,
+    status: invite.status,
+    invited_by_actor_label: invite.invited_by_actor_label,
+    accepted_by_principal: invite.accepted_by_principal,
+    created_at: invite.created_at,
+    expires_at: invite.expires_at,
+    accepted_at: invite.accepted_at,
+    revoked_at: invite.revoked_at,
+    revoked_by_actor_label: invite.revoked_by_actor_label,
+    ...(display ? { display } : {}),
+  });
+}
+
 function cloudNotebookAccessRequestCacheKey(request: CloudNotebookAccessRequest): string {
   return stableCacheKey([
     request.id,
@@ -496,6 +530,25 @@ function cloudNotebookAccessRequestCacheKey(request: CloudNotebookAccessRequest)
   ]);
 }
 
+function stableCloudNotebookAccessRequest(
+  request: CloudNotebookAccessRequest,
+): CloudNotebookAccessRequest {
+  const display = request.display ? stableCloudShareDisplay(request.display) : undefined;
+  return Object.freeze({
+    id: request.id,
+    notebook_id: request.notebook_id,
+    requester_principal: request.requester_principal,
+    scope: request.scope,
+    status: request.status,
+    requested_by_actor_label: request.requested_by_actor_label,
+    resolved_by_actor_label: request.resolved_by_actor_label,
+    created_at: request.created_at,
+    updated_at: request.updated_at,
+    resolved_at: request.resolved_at,
+    ...(display ? { display } : {}),
+  });
+}
+
 function cloudShareDisplayCacheKey(display: CloudShareDisplay | undefined): string | null {
   if (!display) return null;
   if (display.kind === "principal") {
@@ -505,4 +558,8 @@ function cloudShareDisplayCacheKey(display: CloudShareDisplay | undefined): stri
     return stableCacheKey([display.kind, display.label, display.email]);
   }
   return stableCacheKey([display.kind, display.label]);
+}
+
+function stableCloudShareDisplay<Display extends CloudShareDisplay>(display: Display): Display {
+  return Object.freeze({ ...display }) as Display;
 }

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -1,8 +1,4 @@
-import {
-  getBoundedCacheValue,
-  setBoundedCacheValue,
-  stableCacheKey,
-} from "runtimed/src/projection-cache";
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "runtimed";
 
 export type CloudShareScope = "viewer" | "editor" | "runtime_peer" | "owner";
 export type CloudShareInviteScope = "viewer" | "editor";
@@ -114,6 +110,45 @@ const SHARE_ACCESS_ROW_CACHE = new Map<string, CloudShareAccessRow>();
 const SHARE_ACCESS_ROWS_CACHE = new Map<string, CloudShareAccessRow[]>();
 const SHARE_ACCESS_ROW_CACHE_LIMIT = 512;
 const SHARE_ACCESS_ROWS_CACHE_LIMIT = 128;
+const CLOUD_NOTEBOOK_ACL_ROW_FIELDS = {
+  notebook_id: true,
+  subject_kind: true,
+  subject: true,
+  scope: true,
+  created_at: true,
+  updated_at: true,
+  created_by_actor_label: true,
+  display: true,
+} satisfies Record<keyof CloudNotebookAclRow, true>;
+const CLOUD_NOTEBOOK_INVITE_FIELDS = {
+  id: true,
+  notebook_id: true,
+  email: true,
+  provider_hint: true,
+  scope: true,
+  status: true,
+  invited_by_actor_label: true,
+  accepted_by_principal: true,
+  created_at: true,
+  expires_at: true,
+  accepted_at: true,
+  revoked_at: true,
+  revoked_by_actor_label: true,
+  display: true,
+} satisfies Record<keyof CloudNotebookInvite, true>;
+const CLOUD_NOTEBOOK_ACCESS_REQUEST_FIELDS = {
+  id: true,
+  notebook_id: true,
+  requester_principal: true,
+  scope: true,
+  status: true,
+  requested_by_actor_label: true,
+  resolved_by_actor_label: true,
+  created_at: true,
+  updated_at: true,
+  resolved_at: true,
+  display: true,
+} satisfies Record<keyof CloudNotebookAccessRequest, true>;
 
 export function clearCloudShareAccessRowsCachesForTests(): void {
   SHARE_ACCESS_ROW_CACHE.clear();
@@ -449,6 +484,7 @@ function cachedCloudShareAccessRows(
 }
 
 function cloudNotebookAclRowCacheKey(row: CloudNotebookAclRow): string {
+  void CLOUD_NOTEBOOK_ACL_ROW_FIELDS;
   return stableCacheKey([
     row.notebook_id,
     row.subject_kind,
@@ -462,6 +498,7 @@ function cloudNotebookAclRowCacheKey(row: CloudNotebookAclRow): string {
 }
 
 function stableCloudNotebookAclRow(row: CloudNotebookAclRow): CloudNotebookAclRow {
+  void CLOUD_NOTEBOOK_ACL_ROW_FIELDS;
   const display = row.display ? stableCloudShareDisplay(row.display) : undefined;
   return Object.freeze({
     notebook_id: row.notebook_id,
@@ -476,6 +513,7 @@ function stableCloudNotebookAclRow(row: CloudNotebookAclRow): CloudNotebookAclRo
 }
 
 function cloudNotebookInviteCacheKey(invite: CloudNotebookInvite): string {
+  void CLOUD_NOTEBOOK_INVITE_FIELDS;
   return stableCacheKey([
     invite.id,
     invite.notebook_id,
@@ -495,6 +533,7 @@ function cloudNotebookInviteCacheKey(invite: CloudNotebookInvite): string {
 }
 
 function stableCloudNotebookInvite(invite: CloudNotebookInvite): CloudNotebookInvite {
+  void CLOUD_NOTEBOOK_INVITE_FIELDS;
   const display = invite.display ? stableCloudShareDisplay(invite.display) : undefined;
   return Object.freeze({
     id: invite.id,
@@ -515,6 +554,7 @@ function stableCloudNotebookInvite(invite: CloudNotebookInvite): CloudNotebookIn
 }
 
 function cloudNotebookAccessRequestCacheKey(request: CloudNotebookAccessRequest): string {
+  void CLOUD_NOTEBOOK_ACCESS_REQUEST_FIELDS;
   return stableCacheKey([
     request.id,
     request.notebook_id,
@@ -533,6 +573,7 @@ function cloudNotebookAccessRequestCacheKey(request: CloudNotebookAccessRequest)
 function stableCloudNotebookAccessRequest(
   request: CloudNotebookAccessRequest,
 ): CloudNotebookAccessRequest {
+  void CLOUD_NOTEBOOK_ACCESS_REQUEST_FIELDS;
   const display = request.display ? stableCloudShareDisplay(request.display) : undefined;
   return Object.freeze({
     id: request.id,

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -1,3 +1,9 @@
+import {
+  getBoundedCacheValue,
+  setBoundedCacheValue,
+  stableCacheKey,
+} from "runtimed/src/projection-cache";
+
 export type CloudShareScope = "viewer" | "editor" | "runtime_peer" | "owner";
 export type CloudShareInviteScope = "viewer" | "editor";
 export type CloudInviteStatus = "pending" | "accepted" | "revoked" | "expired";
@@ -104,66 +110,137 @@ export type CloudShareAccessRow =
       removable: boolean;
     };
 
+const SHARE_ACCESS_ROW_CACHE = new Map<string, CloudShareAccessRow>();
+const SHARE_ACCESS_ROWS_CACHE = new Map<string, CloudShareAccessRow[]>();
+const SHARE_ACCESS_ROW_CACHE_LIMIT = 512;
+const SHARE_ACCESS_ROWS_CACHE_LIMIT = 128;
+
+export function clearCloudShareAccessRowsCachesForTests(): void {
+  SHARE_ACCESS_ROW_CACHE.clear();
+  SHARE_ACCESS_ROWS_CACHE.clear();
+}
+
 export function buildCloudShareAccessRows(input: {
   acl: CloudNotebookAclRow[];
   invites: CloudNotebookInvite[];
   accessRequests?: CloudNotebookAccessRequest[];
 }): CloudShareAccessRow[] {
   const rows: CloudShareAccessRow[] = [];
+  const rowKeys: string[] = [];
 
   for (const acl of [...input.acl].sort(compareAclRows)) {
-    rows.push({
-      id: `acl:${acl.subject_kind}:${acl.subject}:${acl.scope}`,
-      kind: "acl",
-      acl,
-      label: labelForAcl(acl),
-      detail: detailForAcl(acl),
-      title: titleForAcl(acl),
-      scope: acl.scope,
-      badge: scopeLabel(acl.scope),
-      stateLabel: acl.subject_kind === "public" ? "Enabled" : null,
-      stateTone: acl.subject_kind === "public" ? "success" : null,
-      removable: acl.subject_kind === "public" || acl.scope !== "owner",
-    });
+    const id = `acl:${acl.subject_kind}:${acl.subject}:${acl.scope}`;
+    const label = labelForAcl(acl);
+    const detail = detailForAcl(acl);
+    const title = titleForAcl(acl);
+    const badge = scopeLabel(acl.scope);
+    const stateLabel = acl.subject_kind === "public" ? "Enabled" : null;
+    const stateTone = acl.subject_kind === "public" ? "success" : null;
+    const removable = acl.subject_kind === "public" || acl.scope !== "owner";
+    const rowKey = stableCacheKey([
+      "acl",
+      cloudNotebookAclRowCacheKey(acl),
+      id,
+      label,
+      detail,
+      title,
+      acl.scope,
+      badge,
+      stateLabel,
+      stateTone,
+      removable,
+    ]);
+    rows.push(
+      cachedCloudShareAccessRow(rowKey, () => ({
+        id,
+        kind: "acl",
+        acl,
+        label,
+        detail,
+        title,
+        scope: acl.scope,
+        badge,
+        stateLabel,
+        stateTone,
+        removable,
+      })),
+    );
+    rowKeys.push(rowKey);
   }
 
   for (const invite of input.invites.filter((candidate) => candidate.status === "pending")) {
-    rows.push({
-      id: `invite:${invite.id}`,
-      kind: "invite",
-      invite,
-      label: displayEmail(invite.display?.label || invite.email),
-      detail: invite.provider_hint
-        ? `Pending invite via ${invite.provider_hint}`
-        : "Pending invite",
-      title: invite.email,
-      scope: invite.scope,
-      badge: scopeLabel(invite.scope),
-      stateLabel: "Pending",
-      stateTone: "pending",
-      removable: true,
-    });
+    const id = `invite:${invite.id}`;
+    const label = displayEmail(invite.display?.label || invite.email);
+    const detail = invite.provider_hint
+      ? `Pending invite via ${invite.provider_hint}`
+      : "Pending invite";
+    const title = invite.email;
+    const badge = scopeLabel(invite.scope);
+    const rowKey = stableCacheKey([
+      "invite",
+      cloudNotebookInviteCacheKey(invite),
+      id,
+      label,
+      detail,
+      title,
+      invite.scope,
+      badge,
+    ]);
+    rows.push(
+      cachedCloudShareAccessRow(rowKey, () => ({
+        id,
+        kind: "invite",
+        invite,
+        label,
+        detail,
+        title,
+        scope: invite.scope,
+        badge,
+        stateLabel: "Pending",
+        stateTone: "pending",
+        removable: true,
+      })),
+    );
+    rowKeys.push(rowKey);
   }
 
   for (const request of (input.accessRequests ?? []).filter(
     (candidate) => candidate.status === "pending",
   )) {
-    rows.push({
-      id: `access-request:${request.id}`,
-      kind: "access_request",
-      accessRequest: request,
-      label: labelForAccessRequest(request),
-      detail: "Requested edit access",
-      title: titleForAccessRequest(request),
-      scope: request.scope,
-      badge: scopeLabel(request.scope),
-      stateLabel: "Requested",
-      stateTone: "pending",
-      removable: false,
-    });
+    const id = `access-request:${request.id}`;
+    const label = labelForAccessRequest(request);
+    const detail = "Requested edit access";
+    const title = titleForAccessRequest(request);
+    const badge = scopeLabel(request.scope);
+    const rowKey = stableCacheKey([
+      "access_request",
+      cloudNotebookAccessRequestCacheKey(request),
+      id,
+      label,
+      detail,
+      title,
+      request.scope,
+      badge,
+    ]);
+    rows.push(
+      cachedCloudShareAccessRow(rowKey, () => ({
+        id,
+        kind: "access_request",
+        accessRequest: request,
+        label,
+        detail,
+        title,
+        scope: request.scope,
+        badge,
+        stateLabel: "Requested",
+        stateTone: "pending",
+        removable: false,
+      })),
+    );
+    rowKeys.push(rowKey);
   }
 
-  return rows;
+  return cachedCloudShareAccessRows(rowKeys, rows);
 }
 
 export function cloudShareAccessSummary(rows: CloudShareAccessRow[]): string | null {
@@ -339,4 +416,93 @@ function compareAclRows(a: CloudNotebookAclRow, b: CloudNotebookAclRow): number 
   const rankDelta = rank(a) - rank(b);
   if (rankDelta !== 0) return rankDelta;
   return `${labelForAcl(a)}:${a.scope}`.localeCompare(`${labelForAcl(b)}:${b.scope}`);
+}
+
+function cachedCloudShareAccessRow<Row extends CloudShareAccessRow>(
+  cacheKey: string,
+  createRow: () => Row,
+): Row {
+  const cached = getBoundedCacheValue(SHARE_ACCESS_ROW_CACHE, cacheKey);
+  if (cached) return cached as Row;
+
+  const row = Object.freeze(createRow()) as Row;
+  setBoundedCacheValue(SHARE_ACCESS_ROW_CACHE, cacheKey, row, SHARE_ACCESS_ROW_CACHE_LIMIT);
+  return row;
+}
+
+function cachedCloudShareAccessRows(
+  rowKeys: readonly string[],
+  rows: readonly CloudShareAccessRow[],
+): CloudShareAccessRow[] {
+  const cacheKey = stableCacheKey(rowKeys);
+  const cached = getBoundedCacheValue(SHARE_ACCESS_ROWS_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const stableRows = Object.freeze([...rows]) as CloudShareAccessRow[];
+  setBoundedCacheValue(
+    SHARE_ACCESS_ROWS_CACHE,
+    cacheKey,
+    stableRows,
+    SHARE_ACCESS_ROWS_CACHE_LIMIT,
+  );
+  return stableRows;
+}
+
+function cloudNotebookAclRowCacheKey(row: CloudNotebookAclRow): string {
+  return stableCacheKey([
+    row.notebook_id,
+    row.subject_kind,
+    row.subject,
+    row.scope,
+    row.created_at,
+    row.updated_at,
+    row.created_by_actor_label,
+    cloudShareDisplayCacheKey(row.display),
+  ]);
+}
+
+function cloudNotebookInviteCacheKey(invite: CloudNotebookInvite): string {
+  return stableCacheKey([
+    invite.id,
+    invite.notebook_id,
+    invite.email,
+    invite.provider_hint,
+    invite.scope,
+    invite.status,
+    invite.invited_by_actor_label,
+    invite.accepted_by_principal,
+    invite.created_at,
+    invite.expires_at,
+    invite.accepted_at,
+    invite.revoked_at,
+    invite.revoked_by_actor_label,
+    cloudShareDisplayCacheKey(invite.display),
+  ]);
+}
+
+function cloudNotebookAccessRequestCacheKey(request: CloudNotebookAccessRequest): string {
+  return stableCacheKey([
+    request.id,
+    request.notebook_id,
+    request.requester_principal,
+    request.scope,
+    request.status,
+    request.requested_by_actor_label,
+    request.resolved_by_actor_label,
+    request.created_at,
+    request.updated_at,
+    request.resolved_at,
+    cloudShareDisplayCacheKey(request.display),
+  ]);
+}
+
+function cloudShareDisplayCacheKey(display: CloudShareDisplay | undefined): string | null {
+  if (!display) return null;
+  if (display.kind === "principal") {
+    return stableCacheKey([display.kind, display.label, display.principal, display.email]);
+  }
+  if (display.kind === "pending_invite") {
+    return stableCacheKey([display.kind, display.label, display.email]);
+  }
+  return stableCacheKey([display.kind, display.label]);
 }

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -86,11 +86,26 @@ export function cloudNotebookShellCapabilities({
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
     identityLabel: isRuntimePeer ? identityLabel : null,
   };
-  const projection = projectNotebookShellCapabilities({
+  const accessActor = notebookActorProjectionWithPrincipalImage(
+    notebookActorProjectionFromAccess(access, auth),
+    identityImageUrl,
+  );
+  const runtimeActor = notebookActorProjectionWithPrincipalImage(
+    notebookActorProjectionFromRuntime(runtime, auth),
+    identityImageUrl,
+  );
+
+  return projectNotebookShellCapabilities({
     interaction,
-    access,
+    access: {
+      ...access,
+      actor: accessActor,
+    },
     auth,
-    runtime,
+    runtime: {
+      ...runtime,
+      actor: runtimeActor,
+    },
     controls: {
       canToggleCode: hasCodeCells,
     },
@@ -107,26 +122,6 @@ export function cloudNotebookShellCapabilities({
       requiresAuthenticatedIdentity: true,
     },
   });
-  const accessActor = notebookActorProjectionWithPrincipalImage(
-    notebookActorProjectionFromAccess(projection.access, projection.auth),
-    identityImageUrl,
-  );
-  const runtimeActor = notebookActorProjectionWithPrincipalImage(
-    notebookActorProjectionFromRuntime(projection.runtime, projection.auth),
-    identityImageUrl,
-  );
-
-  return {
-    ...projection,
-    access: {
-      ...projection.access,
-      actor: accessActor,
-    },
-    runtime: {
-      ...projection.runtime,
-      actor: runtimeActor,
-    },
-  };
 }
 
 function cloudIdentityDisplayLabel(authState: CloudPrototypeAuthState): string | null {

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -283,6 +283,32 @@ describe("desktopNotebookShellCapabilities", () => {
     expect(localWithSharingHost.canManageSharing).toBe(false);
   });
 
+  it("returns stable frozen capabilities for equivalent desktop inputs", () => {
+    const input = {
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:alice/desktop:window",
+      connectionScope: "owner",
+      hostCapabilities: { canManageSharing: true },
+    };
+    const first = desktopNotebookShellCapabilities(input);
+    const second = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:alice/desktop:window",
+      connectionScope: "owner",
+      hostCapabilities: { canManageSharing: true },
+    });
+
+    expect(first).toBe(second);
+    expect(first.access).toBe(second.access);
+    expect(first.auth).toBe(second.auth);
+    expect(first.runtime).toBe(second.runtime);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.access)).toBe(true);
+    expect(Object.isFrozen(first.runtime)).toBe(true);
+  });
+
   it("projects desktop agent actors without treating desktop as a single human", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: true,

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -42,6 +42,11 @@ export function desktopNotebookShellCapabilities({
     interaction.canEditMarkdown && interaction.canEditCells && interaction.canEditStructure;
   const canWriteRuntimeState =
     sessionReady && (isRuntimePeer || (source === "local" && canWriteDocument));
+  const auth = {
+    canSignIn: false,
+    canUseAuthenticatedIdentity: source === "cloud" && Boolean(localActor),
+    needsAttention: false,
+  };
   const access = {
     level: accessLevel,
     source,
@@ -59,15 +64,17 @@ export function desktopNotebookShellCapabilities({
     actorLabel: canWriteRuntimeState ? localActor : null,
     identityLabel: null,
   };
-  const projection = projectNotebookShellCapabilities({
+  return projectNotebookShellCapabilities({
     interaction,
-    access,
-    auth: {
-      canSignIn: false,
-      canUseAuthenticatedIdentity: source === "cloud" && Boolean(localActor),
-      needsAttention: false,
+    access: {
+      ...access,
+      actor: notebookActorProjectionFromAccess(access, auth),
     },
-    runtime,
+    auth,
+    runtime: {
+      ...runtime,
+      actor: notebookActorProjectionFromRuntime(runtime, auth),
+    },
     controls: {
       canToggleCode: true,
     },
@@ -87,18 +94,6 @@ export function desktopNotebookShellCapabilities({
       requiredSources: ["cloud"],
     },
   });
-
-  return {
-    ...projection,
-    access: {
-      ...projection.access,
-      actor: notebookActorProjectionFromAccess(projection.access, projection.auth),
-    },
-    runtime: {
-      ...projection.runtime,
-      actor: notebookActorProjectionFromRuntime(projection.runtime, projection.auth),
-    },
-  };
 }
 
 function desktopAccessLevelFromConnectionScope(

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -218,6 +218,9 @@ export {
   type ProjectNotebookShellCapabilitiesOptions,
 } from "./notebook-shell-capabilities";
 
+// Projection cache helpers
+export { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
+
 // Notebook interaction projection
 export {
   createNotebookInteractionStore,

--- a/packages/runtimed/src/notebook-edit-access.ts
+++ b/packages/runtimed/src/notebook-edit-access.ts
@@ -1,3 +1,5 @@
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
+
 export type NotebookEditMode = "view" | "edit";
 export type NotebookEditState = "viewing" | "requested" | "editing";
 
@@ -50,6 +52,16 @@ export interface ProjectNotebookRoomEditAccessOptions {
   editAccessRequestPending?: boolean;
 }
 
+const EDIT_ACCESS_CACHE = new Map<string, NotebookEditAccessProjection>();
+const ROOM_EDIT_ACCESS_CACHE = new Map<string, NotebookRoomEditAccessProjection>();
+const EDIT_ACCESS_CACHE_LIMIT = 128;
+const ROOM_EDIT_ACCESS_CACHE_LIMIT = 256;
+
+export function clearNotebookEditAccessProjectionCachesForTests(): void {
+  EDIT_ACCESS_CACHE.clear();
+  ROOM_EDIT_ACCESS_CACHE.clear();
+}
+
 export function projectNotebookEditAccess({
   hostSupport,
   permission,
@@ -69,18 +81,34 @@ export function projectNotebookEditAccess({
     : canActivateEdit
       ? "editing"
       : "requested";
+  const canEditMarkdown =
+    activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown;
+  const canEditCells = activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells;
+  const canEditStructure =
+    activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure;
+  const cacheKey = stableCacheKey([
+    selectedMode,
+    activeMode,
+    state,
+    hostSupport.canRequestEdit,
+    canEditMarkdown,
+    canEditCells,
+    canEditStructure,
+  ]);
+  const cached = getBoundedCacheValue(EDIT_ACCESS_CACHE, cacheKey);
+  if (cached) return cached;
 
-  return {
+  const projection = Object.freeze({
     selectedMode,
     activeMode,
     state,
     canRequestEdit: hostSupport.canRequestEdit,
-    canEditMarkdown:
-      activeMode === "edit" && permission.canEditMarkdown && hostSupport.canEditMarkdown,
-    canEditCells: activeMode === "edit" && permission.canEditCells && hostSupport.canEditCells,
-    canEditStructure:
-      activeMode === "edit" && permission.canEditStructure && hostSupport.canEditStructure,
-  };
+    canEditMarkdown,
+    canEditCells,
+    canEditStructure,
+  });
+  setBoundedCacheValue(EDIT_ACCESS_CACHE, cacheKey, projection, EDIT_ACCESS_CACHE_LIMIT);
+  return projection;
 }
 
 export function projectNotebookRoomEditAccess({
@@ -111,8 +139,26 @@ export function projectNotebookRoomEditAccess({
       canRequestEdit,
     },
   });
+  const cacheKey = stableCacheKey([
+    interaction.selectedMode,
+    interaction.activeMode,
+    interaction.state,
+    interaction.canRequestEdit,
+    interaction.canEditMarkdown,
+    interaction.canEditCells,
+    interaction.canEditStructure,
+    selectedMode,
+    accessLevel,
+    requestedScope,
+    hasDocumentEditPermission,
+    selectedDocumentEditMode,
+    requestedDocumentEditAccess,
+    editAccessPending,
+  ]);
+  const cached = getBoundedCacheValue(ROOM_EDIT_ACCESS_CACHE, cacheKey);
+  if (cached) return cached;
 
-  return {
+  const projection = Object.freeze({
     ...interaction,
     inputSelectedMode: selectedMode,
     accessLevel,
@@ -121,7 +167,9 @@ export function projectNotebookRoomEditAccess({
     selectedDocumentEditMode,
     requestedDocumentEditAccess,
     editAccessPending,
-  };
+  });
+  setBoundedCacheValue(ROOM_EDIT_ACCESS_CACHE, cacheKey, projection, ROOM_EDIT_ACCESS_CACHE_LIMIT);
+  return projection;
 }
 
 export function notebookRoomAccessLevelCanEditDocument(

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -4,6 +4,7 @@ import type {
   NotebookRoomEditAccessProjection,
 } from "./notebook-edit-access";
 import type { NotebookActorProjection } from "./notebook-actor-projection";
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
 
 export type {
   NotebookActorOperator,
@@ -114,7 +115,47 @@ export interface ProjectNotebookShellCapabilitiesOptions {
   sharing?: NotebookShellSharingPolicy;
 }
 
-export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
+const SHELL_ACCESS_CACHE = new Map<string, NotebookShellAccessCapabilities>();
+const SHELL_AUTH_CACHE = new Map<string, NotebookShellAuthCapabilities>();
+const SHELL_RUNTIME_CACHE = new Map<string, NotebookShellRuntimeCapabilities>();
+const SHELL_CAPABILITIES_CACHE = new Map<string, NotebookShellCapabilities>();
+const SHELL_PART_CACHE_LIMIT = 256;
+const SHELL_CAPABILITIES_CACHE_LIMIT = 512;
+
+const READ_ONLY_INTERACTION: NotebookEditAccessProjection = Object.freeze({
+  selectedMode: "view",
+  activeMode: "view",
+  state: "viewing",
+  canRequestEdit: false,
+  canEditMarkdown: false,
+  canEditCells: false,
+  canEditStructure: false,
+});
+
+const READ_ONLY_ACCESS: NotebookShellAccessCapabilities = Object.freeze({
+  level: "viewer",
+  source: "unknown",
+  isPublic: false,
+  actorLabel: null,
+  identityLabel: null,
+});
+
+const READ_ONLY_AUTH: NotebookShellAuthCapabilities = Object.freeze({
+  canSignIn: false,
+  canUseAuthenticatedIdentity: false,
+  needsAttention: false,
+});
+
+const READ_ONLY_RUNTIME: NotebookShellRuntimeCapabilities = Object.freeze({
+  canWriteRuntimeState: false,
+  connected: false,
+  executionAvailable: false,
+  source: "unknown",
+  actorLabel: null,
+  identityLabel: null,
+});
+
+export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = Object.freeze({
   canRead: true,
   canEditMarkdown: false,
   canEditCells: false,
@@ -125,36 +166,18 @@ export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = {
   canViewPackages: true,
   canManagePackages: false,
   canManageSharing: false,
-  interaction: {
-    selectedMode: "view",
-    activeMode: "view",
-    state: "viewing",
-    canRequestEdit: false,
-    canEditMarkdown: false,
-    canEditCells: false,
-    canEditStructure: false,
-  },
-  access: {
-    level: "viewer",
-    source: "unknown",
-    isPublic: false,
-    actorLabel: null,
-    identityLabel: null,
-  },
-  auth: {
-    canSignIn: false,
-    canUseAuthenticatedIdentity: false,
-    needsAttention: false,
-  },
-  runtime: {
-    canWriteRuntimeState: false,
-    connected: false,
-    executionAvailable: false,
-    source: "unknown",
-    actorLabel: null,
-    identityLabel: null,
-  },
-};
+  interaction: READ_ONLY_INTERACTION,
+  access: READ_ONLY_ACCESS,
+  auth: READ_ONLY_AUTH,
+  runtime: READ_ONLY_RUNTIME,
+});
+
+export function clearNotebookShellCapabilitiesCachesForTests(): void {
+  SHELL_ACCESS_CACHE.clear();
+  SHELL_AUTH_CACHE.clear();
+  SHELL_RUNTIME_CACHE.clear();
+  SHELL_CAPABILITIES_CACHE.clear();
+}
 
 export function projectNotebookShellCapabilities({
   access,
@@ -166,41 +189,81 @@ export function projectNotebookShellCapabilities({
   runtime,
   sharing,
 }: ProjectNotebookShellCapabilitiesOptions): NotebookShellCapabilities {
+  const accessCapabilities = stableNotebookShellAccessCapabilities(access);
+  const authCapabilities = stableNotebookShellAuthCapabilities(auth);
   const canMutateFullDocument =
     interaction.canEditMarkdown && interaction.canEditCells && interaction.canEditStructure;
-  const hasDocumentEditPermission = notebookShellHasDocumentEditPermission(interaction, access);
+  const hasDocumentEditPermission = notebookShellHasDocumentEditPermission(
+    interaction,
+    accessCapabilities,
+  );
   const executionAvailable = execution?.available ?? runtime?.executionAvailable ?? false;
-  const runtimeCapabilities: NotebookShellRuntimeCapabilities = {
+  const runtimeCapabilities = stableNotebookShellRuntimeCapabilities({
     canWriteRuntimeState: runtime?.canWriteRuntimeState ?? false,
     connected: runtime?.connected ?? false,
     executionAvailable,
-    source: runtime?.source ?? access.source,
+    source: runtime?.source ?? accessCapabilities.source,
     actorLabel: runtime?.actorLabel ?? null,
     identityLabel: runtime?.identityLabel ?? null,
     actor: runtime?.actor,
-  };
+  });
+  const canRead = accessCapabilities.level !== "none";
+  const canExecute =
+    executionAvailable &&
+    (!execution?.requiresDocumentEditPermission || hasDocumentEditPermission) &&
+    (!execution?.requiresDocumentMutationSupport || canMutateFullDocument);
+  const canToggleCode = controls?.canToggleCode ?? true;
+  const canViewPackages = packages?.canView ?? true;
+  const canManagePackages =
+    (packages?.canManage ?? false) &&
+    (!packages?.manageRequiresDocumentMutationSupport || canMutateFullDocument);
+  const canManageSharing = notebookShellCanManageSharing({
+    access: accessCapabilities,
+    auth: authCapabilities,
+    sharing,
+  });
+  const cacheKey = stableCacheKey([
+    canRead,
+    interaction.canEditMarkdown,
+    interaction.canEditCells,
+    interaction.canEditStructure,
+    interaction.canRequestEdit,
+    canExecute,
+    canToggleCode,
+    canViewPackages,
+    canManagePackages,
+    canManageSharing,
+    notebookShellInteractionCacheKey(interaction),
+    notebookShellAccessCacheKey(accessCapabilities),
+    notebookShellAuthCacheKey(authCapabilities),
+    notebookShellRuntimeCacheKey(runtimeCapabilities),
+  ]);
+  const cached = getBoundedCacheValue(SHELL_CAPABILITIES_CACHE, cacheKey);
+  if (cached) return cached;
 
-  return {
-    canRead: access.level !== "none",
+  const capabilities = Object.freeze({
+    canRead,
     canEditMarkdown: interaction.canEditMarkdown,
     canEditCells: interaction.canEditCells,
     canEditStructure: interaction.canEditStructure,
     canRequestEdit: interaction.canRequestEdit,
-    canExecute:
-      executionAvailable &&
-      (!execution?.requiresDocumentEditPermission || hasDocumentEditPermission) &&
-      (!execution?.requiresDocumentMutationSupport || canMutateFullDocument),
-    canToggleCode: controls?.canToggleCode ?? true,
-    canViewPackages: packages?.canView ?? true,
-    canManagePackages:
-      (packages?.canManage ?? false) &&
-      (!packages?.manageRequiresDocumentMutationSupport || canMutateFullDocument),
-    canManageSharing: notebookShellCanManageSharing({ access, auth, sharing }),
+    canExecute,
+    canToggleCode,
+    canViewPackages,
+    canManagePackages,
+    canManageSharing,
     interaction,
-    access,
-    auth,
+    access: accessCapabilities,
+    auth: authCapabilities,
     runtime: runtimeCapabilities,
-  };
+  });
+  setBoundedCacheValue(
+    SHELL_CAPABILITIES_CACHE,
+    cacheKey,
+    capabilities,
+    SHELL_CAPABILITIES_CACHE_LIMIT,
+  );
+  return capabilities;
 }
 
 function notebookShellHasDocumentEditPermission(
@@ -231,4 +294,133 @@ function notebookShellCanManageSharing({
     return false;
   }
   return true;
+}
+
+function stableNotebookShellAccessCapabilities(
+  access: NotebookShellAccessCapabilities,
+): NotebookShellAccessCapabilities {
+  const cacheKey = notebookShellAccessCacheKey(access);
+  const cached = getBoundedCacheValue(SHELL_ACCESS_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const stableAccess = Object.freeze({
+    level: access.level,
+    source: access.source,
+    isPublic: access.isPublic,
+    actorLabel: access.actorLabel,
+    identityLabel: access.identityLabel,
+    ...(access.actor === undefined ? {} : { actor: access.actor }),
+  });
+  setBoundedCacheValue(SHELL_ACCESS_CACHE, cacheKey, stableAccess, SHELL_PART_CACHE_LIMIT);
+  return stableAccess;
+}
+
+function stableNotebookShellAuthCapabilities(
+  auth: NotebookShellAuthCapabilities,
+): NotebookShellAuthCapabilities {
+  const cacheKey = notebookShellAuthCacheKey(auth);
+  const cached = getBoundedCacheValue(SHELL_AUTH_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const stableAuth = Object.freeze({
+    canSignIn: auth.canSignIn,
+    canUseAuthenticatedIdentity: auth.canUseAuthenticatedIdentity,
+    needsAttention: auth.needsAttention,
+  });
+  setBoundedCacheValue(SHELL_AUTH_CACHE, cacheKey, stableAuth, SHELL_PART_CACHE_LIMIT);
+  return stableAuth;
+}
+
+function stableNotebookShellRuntimeCapabilities(
+  runtime: NotebookShellRuntimeCapabilities,
+): NotebookShellRuntimeCapabilities {
+  const cacheKey = notebookShellRuntimeCacheKey(runtime);
+  const cached = getBoundedCacheValue(SHELL_RUNTIME_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const stableRuntime = Object.freeze({
+    canWriteRuntimeState: runtime.canWriteRuntimeState,
+    connected: runtime.connected,
+    executionAvailable: runtime.executionAvailable,
+    source: runtime.source,
+    actorLabel: runtime.actorLabel,
+    identityLabel: runtime.identityLabel,
+    ...(runtime.actor === undefined ? {} : { actor: runtime.actor }),
+  });
+  setBoundedCacheValue(SHELL_RUNTIME_CACHE, cacheKey, stableRuntime, SHELL_PART_CACHE_LIMIT);
+  return stableRuntime;
+}
+
+function notebookShellInteractionCacheKey(
+  interaction: NotebookEditAccessProjection | NotebookRoomEditAccessProjection,
+): string {
+  const roomFields =
+    "accessLevel" in interaction
+      ? [
+          interaction.inputSelectedMode,
+          interaction.accessLevel,
+          interaction.requestedScope,
+          interaction.hasDocumentEditPermission,
+          interaction.selectedDocumentEditMode,
+          interaction.requestedDocumentEditAccess,
+          interaction.editAccessPending,
+        ]
+      : [];
+  return stableCacheKey([
+    interaction.selectedMode,
+    interaction.activeMode,
+    interaction.state,
+    interaction.canRequestEdit,
+    interaction.canEditMarkdown,
+    interaction.canEditCells,
+    interaction.canEditStructure,
+    ...roomFields,
+  ]);
+}
+
+function notebookShellAccessCacheKey(access: NotebookShellAccessCapabilities): string {
+  return stableCacheKey([
+    access.level,
+    access.source,
+    access.isPublic,
+    access.actorLabel,
+    access.identityLabel,
+    notebookActorProjectionCacheKey(access.actor),
+  ]);
+}
+
+function notebookShellAuthCacheKey(auth: NotebookShellAuthCapabilities): string {
+  return stableCacheKey([auth.canSignIn, auth.canUseAuthenticatedIdentity, auth.needsAttention]);
+}
+
+function notebookShellRuntimeCacheKey(runtime: NotebookShellRuntimeCapabilities): string {
+  return stableCacheKey([
+    runtime.canWriteRuntimeState,
+    runtime.connected,
+    runtime.executionAvailable,
+    runtime.source,
+    runtime.actorLabel,
+    runtime.identityLabel,
+    notebookActorProjectionCacheKey(runtime.actor),
+  ]);
+}
+
+function notebookActorProjectionCacheKey(
+  actor: NotebookActorProjection | null | undefined,
+): string {
+  if (actor === undefined) return "undefined";
+  if (actor === null) return "null";
+  return stableCacheKey([
+    actor.actorLabel,
+    actor.principal.id,
+    actor.principal.label,
+    actor.principal.imageUrl ?? null,
+    actor.principal.source?.provider ?? null,
+    actor.principal.source?.namespace ?? null,
+    actor.operator.id,
+    actor.operator.kind,
+    actor.operator.label,
+    actor.scope ?? null,
+    actor.status ?? null,
+  ]);
 }

--- a/packages/runtimed/src/projection-cache.ts
+++ b/packages/runtimed/src/projection-cache.ts
@@ -25,5 +25,7 @@ export function setBoundedCacheValue<K, V>(
 }
 
 export function stableCacheKey(parts: readonly unknown[]): string {
-  return JSON.stringify(parts);
+  return JSON.stringify(parts, (_key, value) =>
+    value === undefined ? { __runtimedProjectionCacheKey: "undefined" } : value,
+  );
 }

--- a/packages/runtimed/src/projection-cache.ts
+++ b/packages/runtimed/src/projection-cache.ts
@@ -1,0 +1,29 @@
+export function getBoundedCacheValue<K, V>(cache: Map<K, V>, key: K): V | undefined {
+  const cached = cache.get(key);
+  if (cached === undefined) return undefined;
+
+  cache.delete(key);
+  cache.set(key, cached);
+  return cached;
+}
+
+export function setBoundedCacheValue<K, V>(
+  cache: Map<K, V>,
+  key: K,
+  value: V,
+  limit: number,
+): void {
+  if (cache.has(key)) {
+    cache.delete(key);
+  } else if (cache.size >= limit) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
+  cache.set(key, value);
+}
+
+export function stableCacheKey(parts: readonly unknown[]): string {
+  return JSON.stringify(parts);
+}

--- a/packages/runtimed/tests/notebook-edit-access.test.ts
+++ b/packages/runtimed/tests/notebook-edit-access.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 import {
+  clearNotebookEditAccessProjectionCachesForTests,
   notebookRoomAccessLevelFromConnectionScope,
   projectNotebookEditAccess,
   projectNotebookRoomEditAccess,
 } from "../src/notebook-edit-access";
+
+beforeEach(() => {
+  clearNotebookEditAccessProjectionCachesForTests();
+});
 
 describe("projectNotebookEditAccess", () => {
   it("keeps a user-selected view mode read-only even when edit permission exists", () => {
@@ -106,6 +111,40 @@ describe("projectNotebookEditAccess", () => {
       canEditStructure: false,
     });
   });
+
+  it("returns a stable frozen object for equivalent edit inputs", () => {
+    const first = projectNotebookEditAccess({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: false,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+    const second = projectNotebookEditAccess({
+      selectedMode: "edit",
+      permission: {
+        canEditMarkdown: true,
+        canEditCells: true,
+        canEditStructure: true,
+      },
+      hostSupport: {
+        canEditMarkdown: true,
+        canEditCells: false,
+        canEditStructure: true,
+        canRequestEdit: true,
+      },
+    });
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
 });
 
 describe("projectNotebookRoomEditAccess", () => {
@@ -198,6 +237,28 @@ describe("projectNotebookRoomEditAccess", () => {
       canEditCells: false,
       canEditStructure: false,
     });
+  });
+
+  it("returns a stable frozen object for equivalent room edit inputs", () => {
+    const first = projectNotebookRoomEditAccess({
+      accessLevel: "viewer",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: false,
+      canRequestEdit: true,
+      editAccessRequestPending: true,
+    });
+    const second = projectNotebookRoomEditAccess({
+      accessLevel: "viewer",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: false,
+      canRequestEdit: true,
+      editAccessRequestPending: true,
+    });
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
   });
 });
 

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 import {
   projectNotebookRoomEditAccess,
   projectNotebookShellCapabilities,
@@ -7,6 +7,11 @@ import {
   type NotebookShellAuthCapabilities,
   type NotebookShellRuntimeCapabilities,
 } from "../src";
+import { clearNotebookShellCapabilitiesCachesForTests } from "../src/notebook-shell-capabilities";
+
+beforeEach(() => {
+  clearNotebookShellCapabilitiesCachesForTests();
+});
 
 function access(
   overrides: Partial<NotebookShellAccessCapabilities> = {},
@@ -180,5 +185,56 @@ describe("projectNotebookShellCapabilities", () => {
       access: { level: "viewer", source: "unknown" },
       runtime: { connected: false, executionAvailable: false },
     });
+    expect(Object.isFrozen(readOnlyNotebookShellCapabilities)).toBe(true);
+    expect(Object.isFrozen(readOnlyNotebookShellCapabilities.access)).toBe(true);
+    expect(Object.isFrozen(readOnlyNotebookShellCapabilities.auth)).toBe(true);
+    expect(Object.isFrozen(readOnlyNotebookShellCapabilities.runtime)).toBe(true);
+  });
+
+  it("returns stable frozen capabilities for equivalent shell inputs", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "editor",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+    });
+    const first = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "editor", actorLabel: "user:anaconda:alice/browser:viewer" }),
+      auth: auth({ canUseAuthenticatedIdentity: true }),
+      runtime: runtime({ connected: true, executionAvailable: true }),
+      execution: { available: true, requiresDocumentEditPermission: true },
+      packages: { canView: true, canManage: true, manageRequiresDocumentMutationSupport: true },
+      sharing: {
+        canManage: true,
+        requiresAuthenticatedIdentity: true,
+        requiredAccessLevels: ["editor", "owner"],
+        requiredSources: ["cloud"],
+      },
+    });
+    const second = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "editor", actorLabel: "user:anaconda:alice/browser:viewer" }),
+      auth: auth({ canUseAuthenticatedIdentity: true }),
+      runtime: runtime({ connected: true, executionAvailable: true }),
+      execution: { available: true, requiresDocumentEditPermission: true },
+      packages: { canView: true, canManage: true, manageRequiresDocumentMutationSupport: true },
+      sharing: {
+        canManage: true,
+        requiresAuthenticatedIdentity: true,
+        requiredAccessLevels: ["editor", "owner"],
+        requiredSources: ["cloud"],
+      },
+    });
+
+    expect(first).toBe(second);
+    expect(first.access).toBe(second.access);
+    expect(first.auth).toBe(second.auth);
+    expect(first.runtime).toBe(second.runtime);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.access)).toBe(true);
+    expect(Object.isFrozen(first.auth)).toBe(true);
+    expect(Object.isFrozen(first.runtime)).toBe(true);
   });
 });

--- a/packages/runtimed/tests/projection-cache.test.ts
+++ b/packages/runtimed/tests/projection-cache.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vite-plus/test";
+import { stableCacheKey } from "../src/projection-cache";
+
+describe("stableCacheKey", () => {
+  it("keeps undefined distinct from null", () => {
+    expect(stableCacheKey([undefined])).not.toBe(stableCacheKey([null]));
+    expect(stableCacheKey([{ value: undefined }])).not.toBe(stableCacheKey([{ value: null }]));
+  });
+});


### PR DESCRIPTION
## Summary

- cache and freeze shared edit-access and shell-capability projections for stable object identity
- feed desktop/cloud actor projections into the shared shell projection instead of wrapping fresh objects afterward
- cache cloud sharing access rows and row arrays for equivalent ACL/invite/request payloads

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run packages/runtimed/tests/notebook-edit-access.test.ts packages/runtimed/tests/notebook-shell-capabilities.test.ts apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-sharing.test.ts`

## Notes

- `pnpm --dir apps/notebook-cloud typecheck` still fails on existing unrelated room-materializer arity diagnostics and missing generated `project_markdown_json` WASM typing; the touched cloud files are not in the failure list.
