### PR TITLE
fix(markdown): remove active source run outline

### DIFF
--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -219,8 +219,7 @@ function ProjectedMarkdownBlock({
 }
 
 const sourceActiveBlockClass = "";
-const sourceActiveRunClass =
-  "rounded-sm bg-primary/10 ring-1 ring-primary/20 ring-offset-1 ring-offset-background";
+const sourceActiveRunClass = "";
 
 function headingAnchorForBlock(
   block: MarkdownProjectionBlock,


### PR DESCRIPTION
## Summary

- removes the visible rounded/ring styling from active projected markdown source runs
- keeps the `data-source-active` and `data-source-active-run` hooks intact for future source-position affordances

## Verification

- Not run per request; CI will validate.
