### PR TITLE
ci: clean up PR workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    # Draft PR pushes run the same Build checks as ready PRs. Do not rerun the
+    # workflow on ready_for_review; that event cancels useful in-flight draft CI
+    # through the PR concurrency group and makes checks appear to start only
+    # after a PR leaves draft.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   schedule:
     - cron: "23 10 * * *"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,19 +11,15 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id) }}
-  # PR smoke runs only report skips, so stale PR pushes can cancel. Main and
-  # manual smoke runs are post-merge signal and should not be replaced while
-  # pending.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.ref, github.run_id) }}
+  # Main and manual smoke runs are post-merge signal and should not be replaced
+  # while pending.
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,13 +30,11 @@ jobs:
     name: Windows (build + install + smoke)
     runs-on: windows-latest
     timeout-minutes: 75
-    # Push-to-main + manual dispatch only. The Windows leg currently runs
-    # ~32 minutes (cargo build + NSIS bundling + smoke). Gating PRs on it
-    # would tax every diff, including frontend-only changes that have no
-    # Windows surface. We run it post-merge and surface failures via
-    # Discord (#windows) so the team can react fast without blocking
-    # unrelated PRs.
-    if: github.event_name != 'pull_request'
+    # The Windows leg currently runs ~32 minutes (cargo build + NSIS bundling
+    # + smoke). Gating PRs on it would tax every diff, including frontend-only
+    # changes that have no Windows surface. We run it post-merge and surface
+    # failures via Discord (#windows) so the team can react fast without
+    # blocking unrelated PRs.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -410,7 +404,6 @@ jobs:
     timeout-minutes: 60
     # Keep this native smoke off per-commit PR CI. It still runs after merge
     # and can be queued manually when a PR needs the extra signal.
-    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- remove `ready_for_review` from the Build workflow trigger so marking a draft PR ready does not start a duplicate Build run
- remove the Smoke workflow PR trigger because both smoke jobs are intentionally post-merge/manual only
- simplify Smoke concurrency and dead PR guards after removing the PR event

## Notes

PR Build checks still run for draft PRs on `opened`, `synchronize`, `reopened`, and CI label changes. The live runner API still shows registered `nteract-linux-ci` runners, but those lanes remain non-PR long-tail jobs in Build; this change only cleans up PR trigger noise.

## Verification

- `actionlint .github/workflows/build.yml .github/workflows/smoke.yml`
- `cargo xtask lint --fix`
