### PR TITLE
chore(notebook-cloud): ensure wasm before typecheck

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -16,6 +16,11 @@ pnpm --dir apps/notebook-cloud build:viewer
 pnpm --dir apps/notebook-cloud dev
 ```
 
+`typecheck` runs `cargo xtask wasm-ensure` first so a clean checkout regenerates
+the gitignored `runtimed-wasm` bindings before TypeScript reads them. Use
+`pnpm --dir apps/notebook-cloud wasm` when you explicitly want a full
+`runtimed-wasm` rebuild.
+
 With Wrangler running:
 
 ```bash

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -7,6 +7,7 @@
     "renderer-plugins": "cargo xtask renderer-plugins",
     "build:viewer": "vp build -c vite.config.ts && node scripts/copy-viewer-assets.mjs",
     "build": "pnpm run wasm && pnpm run renderer-plugins && pnpm run build:viewer",
+    "pretypecheck": "cargo xtask wasm-ensure",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",
     "test:renderer-parity": "playwright test -c playwright.render-parity.config.ts",


### PR DESCRIPTION
## Summary

- run `cargo xtask wasm-ensure` automatically before notebook-cloud typecheck
- document that typecheck self-heals the gitignored runtimed-wasm bindings

## Why

`apps/notebook-cloud` reads the generated `apps/notebook/src/wasm/runtimed-wasm` TypeScript bindings, but that package is intentionally gitignored. On a clean checkout or after Rust WASM API changes, `pnpm --dir apps/notebook-cloud typecheck` could fail with stale arity diagnostics or missing exports such as `project_markdown_json`.

`wasm-ensure` is cheaper and more targeted than the full notebook-cloud `wasm` script: it fingerprints the volatile runtimed-wasm package and only rebuilds when the generated output is stale or missing.

## Verification

- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
