### PR TITLE
Proof (not for merge): runtime_peer kernel host - cloud-driven execution on a remote workstation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7437,6 +7437,8 @@ dependencies = [
  "automerge",
  "clap",
  "futures-util",
+ "jupyter-protocol",
+ "jupyter-zmq-client",
  "notebook-doc",
  "notebook-wire",
  "runtime-doc",

--- a/crates/runt-cloud-peer/Cargo.toml
+++ b/crates/runt-cloud-peer/Cargo.toml
@@ -23,3 +23,8 @@ notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
 automerge = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
+# Kernel hosting: drive a local Jupyter kernel directly over ZMQ (the daemon's
+# JupyterKernel is welded to daemon-only shared state, so we reuse the protocol
+# crates instead). See docs/adr/remote-workstation-doc-agents.md.
+jupyter-protocol = { workspace = true }
+jupyter-zmq-client = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }

--- a/crates/runt-cloud-peer/src/kernel_host.rs
+++ b/crates/runt-cloud-peer/src/kernel_host.rs
@@ -1,0 +1,266 @@
+//! Launch and drive a local Jupyter (python `ipykernel`) kernel directly over
+//! ZMQ, reusing the published `jupyter-protocol` + `jupyter-zmq-client` crates.
+//!
+//! The daemon's `JupyterKernel` is welded to daemon-only shared state
+//! (`KernelSharedRefs`: BlobStore, broadcast channels, RuntimeStateHandle), so
+//! it can't be called from a standalone binary. This is a thin re-implementation
+//! of the launch + drive loop the daemon performs, mirroring its TCP branch in
+//! `crates/runtimed/src/jupyter_kernel.rs`. We launch stock `ipykernel_launcher`
+//! (no `nteract_kernel_launcher`, so no launcher cache), connect shell + iopub +
+//! control, and route IOPub by `parent_header.msg_id == execution_id`.
+
+use std::process::Stdio as ProcStdio;
+
+use anyhow::{anyhow, Context, Result};
+use jupyter_protocol::connection_info::Transport;
+use jupyter_protocol::{
+    ConnectionInfo, ExecuteRequest, JupyterMessage, JupyterMessageContent, KernelInfoRequest,
+};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// A launched kernel plus the connections we drive it through.
+pub struct Kernel {
+    pub child: tokio::process::Child,
+    pub connection_info: ConnectionInfo,
+    pub session_id: String,
+    pub iopub: jupyter_zmq_client::ClientIoPubConnection,
+    pub shell: jupyter_zmq_client::ClientShellConnection,
+    pub control: jupyter_zmq_client::ClientControlConnection,
+    connection_file: std::path::PathBuf,
+}
+
+impl Kernel {
+    /// Spawn `python -m ipykernel_launcher -f <conn>` on self-chosen TCP ports
+    /// and connect the shell + iopub + control sockets. `python` is the
+    /// interpreter path (must have `ipykernel`); `venv` is an optional
+    /// `VIRTUAL_ENV` to export.
+    pub async fn launch(python: &str, venv: Option<&str>) -> Result<Self> {
+        let ports = allocate_ports().context("allocate kernel ports")?;
+        let session_id = Uuid::new_v4().to_string();
+        let connection_info = ConnectionInfo {
+            transport: Transport::TCP,
+            ip: "127.0.0.1".to_string(),
+            stdin_port: ports[0],
+            control_port: ports[1],
+            hb_port: ports[2],
+            shell_port: ports[3],
+            iopub_port: ports[4],
+            signature_scheme: "hmac-sha256".to_string(),
+            key: Uuid::new_v4().to_string(),
+            kernel_name: Some("python3".to_string()),
+        };
+
+        let connection_file = std::env::temp_dir().join(format!("runt-kernel-{session_id}.json"));
+        tokio::fs::write(
+            &connection_file,
+            serde_json::to_string_pretty(&connection_info)?,
+        )
+        .await
+        .context("write connection file")?;
+
+        let mut cmd = tokio::process::Command::new(python);
+        cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
+        cmd.arg(&connection_file);
+        cmd.stdout(ProcStdio::null());
+        cmd.stderr(ProcStdio::piped());
+        if let Some(venv) = venv {
+            cmd.env("VIRTUAL_ENV", venv);
+        }
+        let child = cmd.spawn().with_context(|| {
+            format!("spawn `{python} -m ipykernel_launcher` (is ipykernel installed?)")
+        })?;
+        info!(
+            "launched kernel: python={python} pid={:?} ports={ports:?}",
+            child.id()
+        );
+
+        // Subscribe IOPub before any execute so we don't miss a SUB slow-joiner
+        // window for our own requests.
+        let iopub =
+            jupyter_zmq_client::create_client_iopub_connection(&connection_info, "", &session_id)
+                .await
+                .context("connect iopub")?;
+        let identity = jupyter_zmq_client::peer_identity_for_session(&session_id)
+            .context("derive shell peer identity")?;
+        let shell = jupyter_zmq_client::create_client_shell_connection_with_identity(
+            &connection_info,
+            &session_id,
+            identity,
+        )
+        .await
+        .context("connect shell")?;
+        let control =
+            jupyter_zmq_client::create_client_control_connection(&connection_info, &session_id)
+                .await
+                .context("connect control")?;
+
+        Ok(Self {
+            child,
+            connection_info,
+            session_id,
+            iopub,
+            shell,
+            control,
+            connection_file,
+        })
+    }
+
+    /// Send a `kernel_info_request` and wait for the kernel to report Idle on
+    /// IOPub, confirming the connection is live and the kernel is ready.
+    pub async fn wait_until_ready(&mut self, timeout: std::time::Duration) -> Result<()> {
+        let req: JupyterMessage = KernelInfoRequest {}.into();
+        self.shell.send(req).await.context("send kernel_info")?;
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let msg = tokio::time::timeout_at(deadline, self.iopub.read())
+                .await
+                .map_err(|_| anyhow!("kernel did not become ready within {timeout:?}"))?
+                .context("read iopub during readiness")?;
+            if let JupyterMessageContent::Status(status) = &msg.content {
+                if matches!(
+                    status.execution_state,
+                    jupyter_protocol::ExecutionState::Idle
+                ) {
+                    info!("kernel ready (idle)");
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Send an `execute_request` for `source`, with `msg_id = execution_id` so
+    /// IOPub replies carry `parent_header.msg_id == execution_id`.
+    pub async fn execute(
+        &mut self,
+        execution_id: &str,
+        cell_id: Option<&str>,
+        source: &str,
+    ) -> Result<()> {
+        let mut message: JupyterMessage = ExecuteRequest::new(source.to_string()).into();
+        message.header.msg_id = execution_id.to_string();
+        let mut nteract = serde_json::json!({ "execution_id": execution_id });
+        if let Some(cell_id) = cell_id {
+            nteract["cell_id"] = serde_json::Value::String(cell_id.to_string());
+        }
+        message.metadata = serde_json::json!({ "nteract": nteract });
+        self.shell
+            .send(message)
+            .await
+            .context("send execute_request")?;
+        Ok(())
+    }
+}
+
+/// Bind five ephemeral TCP ports, record them, and release the listeners so the
+/// kernel can claim them. There is a small race window between release and the
+/// kernel binding; acceptable for a single-tenant host.
+fn allocate_ports() -> Result<[u16; 5]> {
+    let mut ports = [0u16; 5];
+    for slot in &mut ports {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+        *slot = listener.local_addr()?.port();
+    }
+    Ok(ports)
+}
+
+/// Convert an IOPub message's content to an nbformat output value, mirroring the
+/// daemon's `output_prep::message_content_to_nbformat` (which is `pub(crate)`).
+/// Returns `None` for content that is not an output (status, execute_input, ...).
+pub fn content_to_nbformat(content: &JupyterMessageContent) -> Option<serde_json::Value> {
+    use serde_json::json;
+    match content {
+        JupyterMessageContent::StreamContent(stream) => {
+            let name = match stream.name {
+                jupyter_protocol::Stdio::Stdout => "stdout",
+                jupyter_protocol::Stdio::Stderr => "stderr",
+            };
+            Some(json!({ "output_type": "stream", "name": name, "text": stream.text }))
+        }
+        JupyterMessageContent::DisplayData(data) => {
+            let mut output = json!({
+                "output_type": "display_data",
+                "data": data.data,
+                "metadata": data.metadata,
+            });
+            if let Some(ref transient) = data.transient {
+                if let Some(ref display_id) = transient.display_id {
+                    output["transient"] = json!({ "display_id": display_id });
+                }
+            }
+            Some(output)
+        }
+        JupyterMessageContent::ExecuteResult(result) => Some(json!({
+            "output_type": "execute_result",
+            "data": result.data,
+            "metadata": result.metadata,
+            "execution_count": result.execution_count.0,
+        })),
+        JupyterMessageContent::ErrorOutput(error) => Some(json!({
+            "output_type": "error",
+            "ename": error.ename,
+            "evalue": error.evalue,
+            "traceback": error.traceback,
+        })),
+        _ => None,
+    }
+}
+
+/// Standalone self-test: launch a kernel, run one cell, and log the IOPub
+/// outputs + lifecycle. Proves the kernel-drive layer without the cloud.
+pub async fn self_test(python: &str, venv: Option<&str>, source: &str) -> Result<()> {
+    let mut kernel = Kernel::launch(python, venv).await?;
+    kernel
+        .wait_until_ready(std::time::Duration::from_secs(30))
+        .await?;
+
+    let execution_id = Uuid::new_v4().to_string();
+    info!("executing: {source:?} (execution_id={execution_id})");
+    kernel.execute(&execution_id, None, source).await?;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let msg = match tokio::time::timeout_at(deadline, kernel.iopub.read()).await {
+            Ok(Ok(m)) => m,
+            Ok(Err(e)) => {
+                warn!("iopub read error: {e}");
+                break;
+            }
+            Err(_) => {
+                warn!("timed out waiting for execution to finish");
+                break;
+            }
+        };
+        let parent = msg
+            .parent_header
+            .as_ref()
+            .map(|h| h.msg_id.as_str())
+            .unwrap_or("");
+        if parent != execution_id {
+            continue;
+        }
+        match &msg.content {
+            JupyterMessageContent::ExecuteInput(input) => {
+                info!("execute_input: execution_count={}", input.execution_count.0);
+            }
+            JupyterMessageContent::Status(status) => {
+                info!("status: {:?}", status.execution_state);
+                if matches!(
+                    status.execution_state,
+                    jupyter_protocol::ExecutionState::Idle
+                ) {
+                    info!("execution complete");
+                    break;
+                }
+            }
+            other => {
+                if let Some(nb) = content_to_nbformat(other) {
+                    info!("output: {nb}");
+                }
+            }
+        }
+    }
+
+    let _ = kernel.child.start_kill();
+    Ok(())
+}

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -16,6 +16,7 @@
 //!   principal. So we bootstrap the docs with `<principal>/<operator>` taken
 //!   from the room's `cloud_room_ready` frame, not an arbitrary actor.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -23,9 +24,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use automerge::sync;
 use clap::Parser;
 use futures_util::{SinkExt, StreamExt};
+use jupyter_protocol::{JupyterMessage, JupyterMessageContent};
 use notebook_doc::{NotebookDoc, TextEncoding};
 use notebook_wire::frame_types;
-use runtime_doc::RuntimeStateDoc;
+use runtime_doc::{KernelActivity, RuntimeLifecycle, RuntimeStateDoc};
 use tokio_tungstenite::{
     connect_async,
     tungstenite::{
@@ -90,8 +92,14 @@ struct Cli {
     #[arg(long, default_value_t = 20)]
     seconds: u64,
 
-    /// Self-test the local kernel-drive layer: launch a python kernel, run a
-    /// cell (the --add-cell source, or a default), and log IOPub. No cloud.
+    /// Standalone self-test of the local kernel-drive layer: launch a python
+    /// kernel, run a cell (the --add-cell source, or a default), log IOPub, and
+    /// exit. No cloud connection.
+    #[arg(long)]
+    kernel_self_test: bool,
+
+    /// Host a kernel for the room as a runtime_peer: run queued executions on a
+    /// local kernel and stream outputs back. Use with --scope runtime_peer.
     #[arg(long)]
     host_kernel: bool,
 
@@ -135,6 +143,127 @@ fn frame(frame_type: u8, payload: &[u8]) -> Vec<u8> {
     buf
 }
 
+/// Read the next IOPub message from an optional kernel. Pends forever when no
+/// kernel is present, so it's an inert `select!` arm until a kernel launches.
+async fn next_iopub(kernel: &mut Option<kernel_host::Kernel>) -> Option<JupyterMessage> {
+    match kernel.as_mut() {
+        Some(k) => k.iopub.read().await.ok(),
+        None => std::future::pending().await,
+    }
+}
+
+/// Mint an output_id (required by `append_output`) and append an nbformat output.
+fn append_kernel_output(
+    rt_doc: &mut RuntimeStateDoc,
+    execution_id: &str,
+    mut nbformat: serde_json::Value,
+) -> Result<()> {
+    nbformat["output_id"] = serde_json::Value::String(uuid::Uuid::new_v4().to_string());
+    rt_doc
+        .append_output(execution_id, &nbformat)
+        .map_err(|e| anyhow!("append_output: {e}"))?;
+    Ok(())
+}
+
+/// Apply one IOPub message to the local RuntimeStateDoc, routing by
+/// `parent_header.msg_id == execution_id`. Returns the encoded
+/// RUNTIME_STATE_SYNC frame to push to the room when the doc changed.
+fn apply_iopub(
+    msg: &JupyterMessage,
+    rt_doc: &mut RuntimeStateDoc,
+    rt_peer: &mut sync::State,
+    errored: &mut HashSet<String>,
+) -> Result<Option<Vec<u8>>> {
+    let Some(eid) = msg.parent_header.as_ref().map(|h| h.msg_id.clone()) else {
+        return Ok(None);
+    };
+    let mut changed = false;
+    match &msg.content {
+        JupyterMessageContent::ExecuteInput(input) => {
+            rt_doc
+                .set_execution_count(&eid, input.execution_count.0 as i64)
+                .map_err(|e| anyhow!("set_execution_count: {e}"))?;
+            changed = true;
+        }
+        JupyterMessageContent::Status(status) => match status.execution_state {
+            jupyter_protocol::ExecutionState::Busy => {
+                rt_doc
+                    .set_activity(KernelActivity::Busy)
+                    .map_err(|e| anyhow!("set_activity: {e}"))?;
+                changed = true;
+            }
+            jupyter_protocol::ExecutionState::Idle => {
+                rt_doc
+                    .set_activity(KernelActivity::Idle)
+                    .map_err(|e| anyhow!("set_activity: {e}"))?;
+                // No-op if eid is a non-execution parent (e.g. kernel_info).
+                let success = !errored.remove(&eid);
+                rt_doc
+                    .set_execution_done(&eid, success)
+                    .map_err(|e| anyhow!("set_execution_done: {e}"))?;
+                changed = true;
+            }
+            _ => {}
+        },
+        JupyterMessageContent::ErrorOutput(_) => {
+            errored.insert(eid.clone());
+            if let Some(nb) = kernel_host::content_to_nbformat(&msg.content) {
+                append_kernel_output(rt_doc, &eid, nb)?;
+                changed = true;
+            }
+        }
+        other => {
+            if let Some(nb) = kernel_host::content_to_nbformat(other) {
+                append_kernel_output(rt_doc, &eid, nb)?;
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        Ok(rt_doc
+            .generate_sync_message(rt_peer)
+            .map(|m| frame(frame_types::RUNTIME_STATE_SYNC, &m.encode())))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Dispatch any queued executions the room created to the local kernel:
+/// queued -> running, then `execute_request`. Returns the RUNTIME_STATE_SYNC
+/// frame carrying the running transitions, if any.
+async fn dispatch_queued(
+    rt_doc: &mut RuntimeStateDoc,
+    rt_peer: &mut sync::State,
+    kernel: &mut kernel_host::Kernel,
+    dispatched: &mut HashSet<String>,
+) -> Result<Option<Vec<u8>>> {
+    let mut any = false;
+    for (eid, exec) in rt_doc.get_queued_executions() {
+        if dispatched.contains(&eid) {
+            continue;
+        }
+        let Some(source) = exec.source.clone() else {
+            continue; // the room must populate source on the queued execution
+        };
+        rt_doc
+            .set_execution_running(&eid)
+            .map_err(|e| anyhow!("set_execution_running: {e}"))?;
+        kernel
+            .execute(&eid, exec.cell_id.as_deref(), &source)
+            .await?;
+        dispatched.insert(eid.clone());
+        any = true;
+        info!("dispatched queued execution {eid} to kernel");
+    }
+    if any {
+        Ok(rt_doc
+            .generate_sync_message(rt_peer)
+            .map(|m| frame(frame_types::RUNTIME_STATE_SYNC, &m.encode())))
+    } else {
+        Ok(None)
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -148,7 +277,7 @@ async fn main() -> Result<()> {
 
     // Standalone kernel-drive self-test: no cloud, no token. Proves the local
     // launch + execute + IOPub layer before wiring it into the room loop.
-    if cli.host_kernel {
+    if cli.kernel_self_test {
         let source = cli
             .add_cell
             .as_deref()
@@ -235,32 +364,60 @@ async fn main() -> Result<()> {
     let mut edited = false;
     let mut added_cell_id: Option<String> = None;
     let mut requested = false;
+    // Kernel-host (runtime_peer) state: the local kernel, the executions we've
+    // already dispatched to it, and which ones produced an error output.
+    let mut kernel: Option<kernel_host::Kernel> = None;
+    let mut dispatched: HashSet<String> = HashSet::new();
+    let mut errored: HashSet<String> = HashSet::new();
     let deadline =
         (cli.seconds > 0).then(|| tokio::time::Instant::now() + Duration::from_secs(cli.seconds));
+
+    enum Ev {
+        Frame(Vec<u8>),
+        Iopub(JupyterMessage),
+        Closed,
+        Deadline,
+    }
     loop {
-        let msg = match deadline {
-            Some(d) => match tokio::time::timeout_at(d, ws.next()).await {
-                Ok(Some(m)) => m,
-                Ok(None) => break,
-                Err(_) => {
-                    info!("duration elapsed ({}s), closing", cli.seconds);
-                    break;
+        let ev = tokio::select! {
+            biased;
+            _ = async {
+                match deadline {
+                    Some(d) => tokio::time::sleep_until(d).await,
+                    None => std::future::pending::<()>().await,
                 }
+            } => Ev::Deadline,
+            m = ws.next() => match m {
+                Some(Ok(msg)) if msg.is_binary() => Ev::Frame(msg.into_data().to_vec()),
+                Some(Ok(msg)) if msg.is_close() => Ev::Closed,
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => return Err(e).context("websocket read"),
+                None => Ev::Closed,
             },
-            None => match ws.next().await {
-                Some(m) => m,
-                None => break,
+            io = next_iopub(&mut kernel), if kernel.is_some() => match io {
+                Some(msg) => Ev::Iopub(msg),
+                None => Ev::Closed,
             },
         };
-        let msg = msg.context("websocket read")?;
-        if !msg.is_binary() {
-            if msg.is_close() {
-                warn!("server closed the connection: {msg:?}");
+        let data = match ev {
+            Ev::Deadline => {
+                info!("duration elapsed ({}s), closing", cli.seconds);
                 break;
             }
-            continue;
-        }
-        let data = msg.into_data();
+            Ev::Closed => {
+                warn!("connection closed");
+                break;
+            }
+            Ev::Iopub(msg) => {
+                if let Some(rt_doc) = rt.as_mut() {
+                    if let Some(out) = apply_iopub(&msg, rt_doc, &mut rt_peer, &mut errored)? {
+                        ws.send(WsMessage::Binary(out.into())).await?;
+                    }
+                }
+                continue;
+            }
+            Ev::Frame(d) => d,
+        };
         let Some((&ftype, payload)) = data.split_first() else {
             warn!("empty frame");
             continue;
@@ -324,6 +481,34 @@ async fn main() -> Result<()> {
                 }
                 nb = Some(nb_doc);
                 rt = Some(rt_doc);
+
+                // Host a kernel for this room: launch it, mark the runtime
+                // Running(Idle), and push that so the viewer sees a live kernel.
+                // Queued executions are then dispatched in the RUNTIME_STATE_SYNC
+                // arm and their outputs stream back via the IOPub select arm.
+                if cli.host_kernel && kernel.is_none() {
+                    match kernel_host::Kernel::launch(&cli.python, cli.venv.as_deref()).await {
+                        Ok(mut k) => {
+                            if let Err(e) = k.wait_until_ready(Duration::from_secs(30)).await {
+                                warn!("kernel did not become ready: {e}");
+                            }
+                            if let Some(rt_doc) = rt.as_mut() {
+                                rt_doc
+                                    .set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))
+                                    .map_err(|e| anyhow!("set_lifecycle: {e}"))?;
+                                if let Some(m) = rt_doc.generate_sync_message(&mut rt_peer) {
+                                    ws.send(WsMessage::Binary(
+                                        frame(frame_types::RUNTIME_STATE_SYNC, &m.encode()).into(),
+                                    ))
+                                    .await?;
+                                }
+                            }
+                            kernel = Some(k);
+                            info!("hosting kernel as runtime_peer; ready for queued executions");
+                        }
+                        Err(e) => warn!("kernel launch failed: {e}"),
+                    }
+                }
             }
             frame_types::AUTOMERGE_SYNC => {
                 let Some(nb_doc) = nb.as_mut() else {
@@ -419,9 +604,20 @@ async fn main() -> Result<()> {
                             .take(40)
                             .collect();
                         info!(
-                            "execution {id}: status={} seq={:?} source={src:?}",
-                            ex.status, ex.seq
+                            "execution {id}: status={} seq={:?} outputs={} source={src:?}",
+                            ex.status,
+                            ex.seq,
+                            ex.outputs.len()
                         );
+                    }
+                }
+
+                // Hosted-kernel runtime_peer: run any newly-queued executions.
+                if let Some(k) = kernel.as_mut() {
+                    if let Some(out) =
+                        dispatch_queued(rt_doc, &mut rt_peer, k, &mut dispatched).await?
+                    {
+                        ws.send(WsMessage::Binary(out.into())).await?;
                     }
                 }
             }

--- a/crates/runt-cloud-peer/src/main.rs
+++ b/crates/runt-cloud-peer/src/main.rs
@@ -36,6 +36,8 @@ use tokio_tungstenite::{
 };
 use tracing::{info, warn};
 
+mod kernel_host;
+
 #[derive(Parser, Debug)]
 #[command(
     name = "runt-cloud-peer",
@@ -87,6 +89,19 @@ struct Cli {
     /// Auto-close after this many seconds (0 = run until disconnected).
     #[arg(long, default_value_t = 20)]
     seconds: u64,
+
+    /// Self-test the local kernel-drive layer: launch a python kernel, run a
+    /// cell (the --add-cell source, or a default), and log IOPub. No cloud.
+    #[arg(long)]
+    host_kernel: bool,
+
+    /// Python interpreter for the hosted kernel (must have ipykernel).
+    #[arg(long, default_value = "python3")]
+    python: String,
+
+    /// Optional VIRTUAL_ENV to export for the hosted kernel.
+    #[arg(long)]
+    venv: Option<String>,
 }
 
 fn load_token(cli: &Cli) -> Result<String> {
@@ -130,6 +145,17 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+
+    // Standalone kernel-drive self-test: no cloud, no token. Proves the local
+    // launch + execute + IOPub layer before wiring it into the room loop.
+    if cli.host_kernel {
+        let source = cli
+            .add_cell
+            .as_deref()
+            .unwrap_or("print('hello from runt-cloud-peer kernel host')");
+        return kernel_host::self_test(&cli.python, cli.venv.as_deref(), source).await;
+    }
+
     let token = load_token(&cli)?;
     let ws_url = build_ws_url(&cli.cloud_url, &cli.notebook_id);
     info!(

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -609,21 +609,57 @@ Remaining for "run a cell", not yet built:
   callers (the viewer's `await executeCell`, which waits on `sendRequest` by id)
   do not resolve. Needs cloud-room request/response plumbing (a `cell_queued` /
   structured-error response keyed by the request id).
-- **Kernel-hosting runtime peer.** Add a mode to `runt-cloud-peer` that attaches
-  as `runtime_peer` (explicit `runtime_peer` ACL row via `POST /api/n/:id/acl` -
-  owner alone is insufficient; `aclRowsCoverScope` special-cases the scope),
-  watches RuntimeStateDoc for queued executions, runs them in a Jupyter kernel,
-  and streams `running -> outputs -> done` back. Verified seam: do **not** depend
-  on the daemon's `JupyterKernel` (welded to daemon-only `KernelSharedRefs` -
-  BlobStore, broadcast channels, RuntimeStateHandle). Build a thin launch+drive
-  loop on the published `jupyter-protocol` + `jupyter-zmq-client` crates plus
-  `runtime-doc` (already a dependency): spawn `python -m ipykernel_launcher -f
-  <conn>` (`bootstrap_dx` off, stock launcher, no launcher cache), set the
-  execute_request `msg_id = execution_id` so IOPub `parent_header.msg_id` routes
-  outputs back, and write `set_execution_running` / `append_output` /
-  `set_execution_done` onto the owned RuntimeStateDoc, then
-  `generate_sync_message` to push back. Mirror the daemon's write order and the
-  control-plane/output-transport separation invariant.
+## Kernel hosting: proof, then the production shape
+
+A standalone kernel-host spike is built and verified end-to-end (`runt-cloud-peer
+--host-kernel --scope runtime_peer`). It launches `python -m ipykernel_launcher`
+on self-chosen ports, drives it over `jupyter-protocol` + `jupyter-zmq-client`,
+and streams `set_execution_running` / `append_output` / `set_execution_done` onto
+its RuntimeStateDoc, pushed back to the room. Against live preview, a queued
+execution runs and the driver observes queued -> running -> outputs (stdout +
+execute_result) -> done.
+
+**Treat that spike as a proof, not the production driver.** Its job was to de-risk
+the uncertain half: the cloud wire (runtime_peer attach + the room's ExecuteCell
+dispatch + the full lifecycle round-trip over WS). That now works. But its kernel
+drive (`kernel_host.rs`) reimplements what the daemon already does well, and it
+hardcodes a python path instead of using the daemon's environments / pools /
+launcher cache. Do not grow it into the product.
+
+**Production shape (the daemon stays the launcher; the agent's transport goes
+pluggable):**
+
+- **Workstation endpoint on the daemon.** A workstation is an endpoint you pick
+  compute from: it *lists the environments it has* and, on demand, *allocates and
+  starts a runtime in env X for room Y*. That is a daemon capability plus a small
+  control surface (the "receiver"), built on the existing env pool + launcher,
+  not a reimplementation.
+- **`runtime_agent` becomes transport-agnostic.** It already drives the kernel
+  and syncs RuntimeStateDoc/NotebookDoc over the *same* typed-frame v4 protocol
+  the cloud room speaks. The reusable core (the `select!` loop,
+  `queue_synced_executions`, the RuntimeStateSync apply/generate, the
+  `KernelConnection` drive) is transport-independent. The coupling is narrow and
+  extractable into a `FrameTransport` trait:
+  - `AgentReader`/`AgentWriter` (`runtime_agent.rs:670,672`) are `UnixStream`
+    halves;
+  - `connect_and_handshake` (`:703`) connects the socket and sends
+    `Handshake::RuntimeAgent`;
+  - `send_typed_frame` / `recv_typed_frame` use the daemon's length-preamble
+    framing.
+  The cloud impl differs only in transport (WS), auth (the `Authorization` +
+  `X-Scope` upgrade + `cloud_room_ready` instead of `Handshake::RuntimeAgent`),
+  and framing (one typed frame per WS binary message, no preamble). The kernel,
+  `RuntimeStateHandle`, and `BlobStore` stay daemon-side; only the sync sink
+  swaps.
+- **runt-cloud-peer's keepable value is that WS transport** (dial + Anaconda auth
+  + the typed-frame wire + the consumer-side `receive_sync_message_with_changes`).
+  It becomes the cloud `FrameTransport` impl the daemon's `runtime_agent` writes
+  to. `kernel_host.rs` retires.
+
+This refactor touches the daemon (and therefore desktop), so it is a deliberate
+change, not a drop-in. The runtime_peer ACL requirement holds either way: an
+explicit `runtime_peer` ACL row via `POST /api/n/:id/acl` (owner alone is 403;
+`aclRowsCoverScope` special-cases the scope).
 
 ## Open questions
 


### PR DESCRIPTION
A working proof that a remote workstation can host a kernel and run cells driven from a cloud notebook room. **Not for merge** - it reimplements the daemon's kernel drive, which the production shape reuses instead. Opened as a permanent record of the diff and the result, then closed.

## What it proves

`runt-cloud-peer --host-kernel --scope runtime_peer` attaches to a hosted room as a `runtime_peer`, launches a local python kernel (`python -m ipykernel_launcher`, driven directly over `jupyter-protocol` + `jupyter-zmq-client`), picks up queued executions the room creates, runs them, and streams `running` + outputs + `done` back into the RuntimeStateDoc.

Verified end to end against live preview, including cross-machine: a cell submitted from one machine ran on a separate Linux workstation attached as the `runtime_peer`, and its output rendered in the cloud viewer (`platform.node()` came back as the remote host). The output path is confirmed too - a plain nbformat manifest via `append_output` persists across peer disconnect and renders in the viewer without the daemon's richer `OutputManifest` shape.

## Why it doesn't merge

`kernel_host.rs` reimplements what the daemon already does well: launch, IOPub to RuntimeStateDoc, lifecycle. The daemon's `JupyterKernel` is welded to daemon-only shared state so it can't be reused directly, but the right fix isn't a second kernel driver. The production shape keeps the daemon as the kernel manager (it owns the env pools, the launcher, supervision) and makes `runtime_agent` transport-agnostic, so a daemon-managed kernel syncs to a cloud room over the same wire. runt-cloud-peer's WS transport (already on main) becomes that cloud sink. This spike retires into that work.

## Gaps this surfaced

Running as a bare peer with no supervisor exposed the lifecycle question the production design must answer. Kernel-event detection (death, hang, idle, error) is transport-independent and survives the cloud swap untouched. But `kernel.lifecycle` is `runtime_peer`-only-writable, so when the runtime itself vanishes, no surviving room participant can correct the doc and the room has no watchdog - a dropped workstation leaves the room showing a phantom-live kernel with cells stuck `running`. The production design needs a cloud-room watchdog that reconciles in-flight executions on runtime departure, plus a narrow policy relaxation (or a `Disconnected` lifecycle the room can stamp). The spike also never polls child exit, so it writes no `Error` on kernel death.

Kept as a closed reference.
