### PR TITLE
refactor(runtimed): extract FrameTransport and port runtime_agent (behavior-preserving)

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -7,6 +7,7 @@ mod env;
 mod framing;
 mod handshake;
 mod pipe;
+mod transport;
 
 pub use env::{CreateNotebookEnvironmentMode, EnvSource, LaunchSpec, PackageManager};
 
@@ -23,6 +24,10 @@ pub use handshake::{
 
 #[cfg(windows)]
 pub use pipe::{connect_named_pipe_client, is_retryable_named_pipe_connect_error, ERROR_PIPE_BUSY};
+
+pub use transport::{
+    FrameSink, FrameSource, FrameTransport, FramedReaderSource, UdsFrameTransport, WriterFrameSink,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/notebook-protocol/src/connection/transport.rs
+++ b/crates/notebook-protocol/src/connection/transport.rs
@@ -1,0 +1,262 @@
+//! Transport abstraction for the runtime-agent sync wire.
+//!
+//! The runtime agent's `select!` loop reads typed frames from a source and
+//! writes typed frames to a sink. Today that wire is the daemon's Unix-domain
+//! socket (a Windows named pipe on Windows) carrying length-preamble framing.
+//! A hosted runtime peer will instead carry the same typed frames over a cloud
+//! WebSocket. The loop, queue dispatch, kernel drive, and RuntimeStateDoc
+//! writes are identical across both; only the wire differs.
+//!
+//! This module abstracts exactly that wire into three pieces:
+//!
+//! - [`FrameSource`] — the read half: `recv_frame` yields the next typed frame.
+//! - [`FrameSink`] — the write half: `send_frame` writes one typed frame.
+//! - [`FrameTransport`] — a connector that establishes (or re-establishes) a
+//!   connection and hands back a fresh `(Source, Sink)` pair, performing any
+//!   transport-specific handshake/auth along the way.
+//!
+//! ## Why a split (source + sink), not one object
+//!
+//! The agent loop keeps the read half and write half in *separate* variables
+//! on purpose: a `tokio::select!` arm awaiting `recv_frame` borrows the source
+//! for the whole `select!`, while other arms call `send_frame` on the sink. A
+//! single `&mut self` transport would make those borrows conflict. Splitting
+//! the halves preserves the existing structure exactly.
+//!
+//! ## Why generics, not `dyn`
+//!
+//! These traits use `async fn` in trait (stable since Rust 1.75), consumed
+//! through generics — the same pattern as [`crate::connection`]'s neighbour
+//! `KernelConnection` in `runtimed`. Generics keep `notebook-protocol` free of
+//! an `async-trait` dependency and let the concrete UDS types stay zero-cost.
+//! Each transport impl is monomorphised at its single call site.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWrite;
+
+use super::framing::{send_typed_frame, FramedReader};
+use super::handshake::Handshake;
+use super::{send_json_frame, send_preamble, NotebookFrameType, TypedNotebookFrame};
+
+/// Capacity of the in-flight frame queue for the reader actor. Matches the
+/// value the runtime agent has always used; a slow consumer applies
+/// backpressure to the source past this depth.
+const FRAME_READER_CAPACITY: usize = 16;
+
+/// The read half of a runtime-agent sync wire.
+///
+/// `recv_frame` mirrors [`FramedReader::recv`]: `Some(Ok(frame))` per frame,
+/// `Some(Err(_))` once on a stream error, and `None` once the source is
+/// exhausted (clean EOF or post-error close).
+pub trait FrameSource: Send {
+    /// Receive the next typed frame. Cancel-safe.
+    fn recv_frame(
+        &mut self,
+    ) -> impl std::future::Future<Output = Option<std::io::Result<TypedNotebookFrame>>> + Send;
+}
+
+/// The write half of a runtime-agent sync wire.
+pub trait FrameSink: Send {
+    /// Write one typed frame to the wire.
+    fn send_frame(
+        &mut self,
+        frame_type: NotebookFrameType,
+        payload: &[u8],
+    ) -> impl std::future::Future<Output = std::io::Result<()>> + Send;
+}
+
+/// A connector that establishes a runtime-agent sync wire.
+///
+/// `connect` performs the transport-specific dial + handshake/auth and returns
+/// a fresh `(Source, Sink)` pair. It is called once at startup and again on
+/// every reconnect, so it must be idempotent with respect to the connector's
+/// own state (the UDS impl holds only immutable connection parameters).
+pub trait FrameTransport: Send + Sync {
+    /// The read half this transport produces.
+    type Source: FrameSource;
+    /// The write half this transport produces.
+    type Sink: FrameSink;
+
+    /// Establish a connection and return its read/write halves.
+    fn connect(
+        &self,
+    ) -> impl std::future::Future<Output = std::io::Result<(Self::Source, Self::Sink)>> + Send;
+}
+
+// -- UDS implementation -----------------------------------------------------
+
+/// Concrete write half for the daemon socket.
+#[cfg(unix)]
+type StreamWriteHalf = tokio::io::WriteHalf<tokio::net::UnixStream>;
+#[cfg(windows)]
+type StreamWriteHalf = tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
+
+/// [`FrameSource`] backed by a [`FramedReader`] actor.
+///
+/// The reader half is type-erased inside `FramedReader::spawn`, so this struct
+/// needs no platform `cfg`.
+pub struct FramedReaderSource {
+    reader: FramedReader,
+}
+
+impl FrameSource for FramedReaderSource {
+    async fn recv_frame(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+        self.reader.recv().await
+    }
+}
+
+/// [`FrameSink`] backed by an `AsyncWrite` writer, using the length-preamble
+/// typed framing. Generic over the writer so it covers both the Unix socket
+/// and the Windows named-pipe write halves without `cfg`.
+pub struct WriterFrameSink<W: AsyncWrite + Unpin + Send> {
+    writer: W,
+}
+
+impl<W: AsyncWrite + Unpin + Send> WriterFrameSink<W> {
+    /// Wrap an existing writer as a frame sink.
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: AsyncWrite + Unpin + Send> FrameSink for WriterFrameSink<W> {
+    async fn send_frame(
+        &mut self,
+        frame_type: NotebookFrameType,
+        payload: &[u8],
+    ) -> std::io::Result<()> {
+        send_typed_frame(&mut self.writer, frame_type, payload).await
+    }
+}
+
+/// The daemon's Unix-domain-socket (Windows named-pipe) transport.
+///
+/// Holds only immutable connection parameters; `connect` opens a fresh stream,
+/// sends the preamble and a [`Handshake::RuntimeAgent`] frame, and hands the
+/// reader to a [`FramedReader`] actor so the busy `select!` loop reading via
+/// [`FrameSource::recv_frame`] stays cancel-safe.
+pub struct UdsFrameTransport {
+    socket_path: PathBuf,
+    notebook_id: String,
+    runtime_agent_id: String,
+    blob_root: PathBuf,
+}
+
+impl UdsFrameTransport {
+    /// Build a transport for the daemon socket at `socket_path`.
+    pub fn new(
+        socket_path: impl Into<PathBuf>,
+        notebook_id: impl Into<String>,
+        runtime_agent_id: impl Into<String>,
+        blob_root: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            notebook_id: notebook_id.into(),
+            runtime_agent_id: runtime_agent_id.into(),
+            blob_root: blob_root.into(),
+        }
+    }
+
+    /// The socket path this transport dials. Exposed for diagnostics/logging.
+    pub fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+impl FrameTransport for UdsFrameTransport {
+    type Source = FramedReaderSource;
+    type Sink = WriterFrameSink<StreamWriteHalf>;
+
+    async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
+        #[cfg(unix)]
+        let stream = tokio::net::UnixStream::connect(&self.socket_path).await?;
+
+        #[cfg(windows)]
+        let stream = super::pipe::connect_named_pipe_client(
+            &self.socket_path,
+            std::time::Duration::from_secs(2),
+        )
+        .await?;
+
+        let (reader, mut writer) = tokio::io::split(stream);
+
+        send_preamble(&mut writer).await?;
+        send_json_frame(
+            &mut writer,
+            &Handshake::RuntimeAgent {
+                notebook_id: self.notebook_id.clone(),
+                runtime_agent_id: self.runtime_agent_id.clone(),
+                blob_root: self.blob_root.display().to_string(),
+            },
+        )
+        .await
+        // `send_json_frame` returns `anyhow::Error` only for the (effectively
+        // impossible) serialization failure of a `Handshake`; normalise it to
+        // an io error so the transport surface stays io-typed.
+        .map_err(|e| std::io::Error::other(e.to_string()))?;
+
+        let source = FramedReaderSource {
+            reader: FramedReader::spawn(reader, FRAME_READER_CAPACITY),
+        };
+        let sink = WriterFrameSink::new(writer);
+        Ok((source, sink))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::recv_typed_frame;
+
+    /// `WriterFrameSink` writes the same length-preamble typed frame that the
+    /// receive side decodes — the behavioural contract the daemon relies on.
+    #[tokio::test]
+    async fn writer_frame_sink_roundtrips_through_recv_typed_frame() {
+        let mut buf = Vec::new();
+        let mut sink = WriterFrameSink::new(&mut buf);
+        let payload = b"\x05runtime state sync bytes";
+        sink.send_frame(NotebookFrameType::RuntimeStateSync, payload)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::RuntimeStateSync);
+        assert_eq!(frame.payload, payload);
+    }
+
+    /// `FramedReaderSource` yields frames produced by the writer side and then
+    /// `None` on clean EOF — matching the loop's source contract.
+    #[tokio::test]
+    async fn framed_reader_source_yields_frames_then_eof() {
+        // Encode two typed frames into a buffer, then read them back through
+        // the source over an in-memory pipe.
+        let mut wire = Vec::new();
+        {
+            let mut sink = WriterFrameSink::new(&mut wire);
+            sink.send_frame(NotebookFrameType::AutomergeSync, b"first")
+                .await
+                .unwrap();
+            sink.send_frame(NotebookFrameType::Request, b"second")
+                .await
+                .unwrap();
+        }
+
+        let reader = std::io::Cursor::new(wire);
+        let mut source = FramedReaderSource {
+            reader: FramedReader::spawn(reader, FRAME_READER_CAPACITY),
+        };
+
+        let f1 = source.recv_frame().await.unwrap().unwrap();
+        assert_eq!(f1.frame_type, NotebookFrameType::AutomergeSync);
+        assert_eq!(f1.payload, b"first");
+
+        let f2 = source.recv_frame().await.unwrap().unwrap();
+        assert_eq!(f2.frame_type, NotebookFrameType::Request);
+        assert_eq!(f2.payload, b"second");
+
+        assert!(source.recv_frame().await.is_none(), "clean EOF -> None");
+    }
+}

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -35,8 +35,7 @@ use std::sync::Arc;
 
 use notebook_doc::presence::PresenceState;
 use notebook_protocol::connection::{
-    send_json_frame, send_preamble, send_typed_frame, FramedReader, Handshake, NotebookFrameType,
-    PackageManager,
+    FrameSink, FrameSource, FrameTransport, NotebookFrameType, PackageManager, UdsFrameTransport,
 };
 use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use runtime_doc::{CommDocEntry, ExecutionState, RuntimeLifecycle, RuntimeStateDoc};
@@ -79,17 +78,21 @@ pub async fn run_runtime_agent(
 
     // -- 1. Connect to daemon socket ----------------------------------------
 
-    let (reader, mut writer) =
-        connect_and_handshake(&socket_path, &notebook_id, &runtime_agent_id, &blob_root).await?;
+    // The sync wire is abstracted behind `FrameTransport`: the daemon uses the
+    // UDS (Windows named-pipe) transport, while a hosted runtime peer will swap
+    // in a cloud-WebSocket transport without touching the loop below. `connect`
+    // owns the transport-specific dial + handshake.
+    let transport =
+        UdsFrameTransport::new(&socket_path, &notebook_id, &runtime_agent_id, &blob_root);
+    let (mut frame_source, mut frame_sink) = transport.connect().await?;
 
     info!("[runtime-agent] Connected to daemon, handshake sent");
 
-    // Hand the read half to a dedicated FramedReader actor so the busy
-    // `select!` below stays cancel-safe — `recv_typed_frame`'s
-    // `read_exact` calls would otherwise drop bytes mid-read whenever
-    // another arm wins, producing the runtime-agent ↔ daemon desync
+    // The transport hands back a cancel-safe `FrameSource` (backed by a
+    // dedicated `FramedReader` actor) so the busy `select!` below stays
+    // cancel-safe — a direct `read_exact` would otherwise drop bytes mid-read
+    // whenever another arm wins, producing the runtime-agent ↔ daemon desync
     // captured in production logs as `frame too large: 538976288 bytes`.
-    let mut framed_reader = FramedReader::spawn(reader, 16);
 
     // -- 2. Bootstrap RuntimeStateDoc ---------------------------------------
 
@@ -154,7 +157,7 @@ pub async fn run_runtime_agent(
     loop {
         tokio::select! {
             // Read frames from daemon socket (cancel-safe via FramedReader actor)
-            maybe_frame = framed_reader.recv() => {
+            maybe_frame = frame_source.recv_frame() => {
                 match maybe_frame {
                     Some(Ok(typed_frame)) => {
                         match typed_frame.frame_type {
@@ -207,7 +210,7 @@ pub async fn run_runtime_agent(
                                     {
                                         if inflight_sync.is_some() {
                                             if let Err(e) = send_runtime_agent_response(
-                                                &mut writer,
+                                                &mut frame_sink,
                                                 envelope.id.clone(),
                                                 RuntimeAgentResponse::Error {
                                                     error: "Environment sync already in progress"
@@ -279,7 +282,7 @@ pub async fn run_runtime_agent(
                                     );
                                     if is_launch_or_restart && inflight_sync.is_some() {
                                         if let Err(e) = send_runtime_agent_response(
-                                            &mut writer,
+                                            &mut frame_sink,
                                             envelope.id.clone(),
                                             RuntimeAgentResponse::Error {
                                                 error: "Environment sync in progress; retry after it completes"
@@ -327,7 +330,7 @@ pub async fn run_runtime_agent(
 
                                     // Only send response for queries (not commands)
                                     if !is_command {
-                                        send_runtime_agent_response(&mut writer, id, response).await?;
+                                        send_runtime_agent_response(&mut frame_sink, id, response).await?;
                                     }
                                 }
                             }
@@ -488,8 +491,7 @@ pub async fn run_runtime_agent(
                                             }
                                         };
                                     if let Some(encoded) = reply_encoded {
-                                        let _ = send_typed_frame(
-                                            &mut writer,
+                                        let _ = frame_sink.send_frame(
                                             NotebookFrameType::RuntimeStateSync,
                                             &encoded,
                                         ).await;
@@ -528,20 +530,13 @@ pub async fn run_runtime_agent(
                              (kernel stays running)",
                             e
                         );
-                        // Drop the old framed reader before reconnecting so
-                        // its background task exits cleanly.
-                        drop(framed_reader);
-                        match reconnect_with_backoff(
-                            &socket_path,
-                            &notebook_id,
-                            &runtime_agent_id,
-                            &blob_root,
-                        )
-                        .await
-                        {
-                            Ok((new_reader, new_writer)) => {
-                                framed_reader = FramedReader::spawn(new_reader, 16);
-                                writer = new_writer;
+                        // Drop the old source before reconnecting so its
+                        // background reader task exits cleanly.
+                        drop(frame_source);
+                        match reconnect_with_backoff(&transport).await {
+                            Ok((new_source, new_sink)) => {
+                                frame_source = new_source;
+                                frame_sink = new_sink;
                                 // The daemon creates a fresh sync state for
                                 // each connection; match that or the doc
                                 // won't converge.
@@ -633,8 +628,7 @@ pub async fn run_runtime_agent(
                         }
                     };
                 if let Some(encoded) = encoded {
-                    if let Err(e) = send_typed_frame(
-                        &mut writer,
+                    if let Err(e) = frame_sink.send_frame(
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
                     ).await {
@@ -647,7 +641,7 @@ pub async fn run_runtime_agent(
             // Responses from long-running spawned tasks (SyncEnvironment).
             Some(envelope) = async_response_rx.recv() => {
                 inflight_sync = None;
-                if let Err(e) = send_runtime_agent_response_envelope(&mut writer, envelope).await {
+                if let Err(e) = send_runtime_agent_response_envelope(&mut frame_sink, envelope).await {
                     warn!("[runtime-agent] Failed to send async response: {}", e);
                     break;
                 }
@@ -665,94 +659,44 @@ pub async fn run_runtime_agent(
     Ok(())
 }
 
-/// Concrete reader/writer halves returned by connect helpers.
-#[cfg(unix)]
-type AgentReader = tokio::io::ReadHalf<tokio::net::UnixStream>;
-#[cfg(unix)]
-type AgentWriter = tokio::io::WriteHalf<tokio::net::UnixStream>;
-#[cfg(windows)]
-type AgentReader = tokio::io::ReadHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
-#[cfg(windows)]
-type AgentWriter = tokio::io::WriteHalf<tokio::net::windows::named_pipe::NamedPipeClient>;
-
-async fn send_runtime_agent_response(
-    writer: &mut AgentWriter,
+async fn send_runtime_agent_response<S: FrameSink>(
+    sink: &mut S,
     id: String,
     response: RuntimeAgentResponse,
 ) -> anyhow::Result<()> {
     send_runtime_agent_response_envelope(
-        writer,
+        sink,
         notebook_protocol::protocol::RuntimeAgentResponseEnvelope { id, response },
     )
     .await
 }
 
-async fn send_runtime_agent_response_envelope(
-    writer: &mut AgentWriter,
+async fn send_runtime_agent_response_envelope<S: FrameSink>(
+    sink: &mut S,
     envelope: notebook_protocol::protocol::RuntimeAgentResponseEnvelope,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_vec(&envelope)?;
-    send_typed_frame(writer, NotebookFrameType::Response, &json).await?;
+    sink.send_frame(NotebookFrameType::Response, &json).await?;
     Ok(())
 }
 
-/// Open a stream to the daemon socket and perform the RuntimeAgent
-/// handshake. Extracted from the main startup path so the reconnect
-/// path on framing errors can reuse it without duplicating handshake
-/// logic.
-async fn connect_and_handshake(
-    socket_path: &std::path::Path,
-    notebook_id: &str,
-    runtime_agent_id: &str,
-    blob_root: &std::path::Path,
-) -> anyhow::Result<(AgentReader, AgentWriter)> {
-    #[cfg(unix)]
-    let stream = tokio::net::UnixStream::connect(socket_path).await?;
-
-    #[cfg(windows)]
-    let stream = {
-        notebook_protocol::connection::connect_named_pipe_client(
-            socket_path,
-            std::time::Duration::from_secs(2),
-        )
-        .await?
-    };
-
-    let (reader, mut writer) = tokio::io::split(stream);
-
-    send_preamble(&mut writer).await?;
-    send_json_frame(
-        &mut writer,
-        &Handshake::RuntimeAgent {
-            notebook_id: notebook_id.to_string(),
-            runtime_agent_id: runtime_agent_id.to_string(),
-            blob_root: blob_root.display().to_string(),
-        },
-    )
-    .await?;
-
-    Ok((reader, writer))
-}
-
-/// Attempt to reconnect to the daemon with exponential backoff.
+/// Attempt to reconnect via the transport with exponential backoff.
 ///
 /// Called after a framing error on the existing sync stream. Preserves
 /// the kernel state by staying alive across transient socket trouble
 /// (rogue client writing to the socket, daemon restart, etc.). Gives up
 /// after a bounded number of attempts so a genuinely-gone daemon still
-/// lets the agent exit rather than spin forever.
-async fn reconnect_with_backoff(
-    socket_path: &std::path::Path,
-    notebook_id: &str,
-    runtime_agent_id: &str,
-    blob_root: &std::path::Path,
-) -> anyhow::Result<(AgentReader, AgentWriter)> {
+/// lets the agent exit rather than spin forever. The transport owns the
+/// dial + handshake, so this stays transport-agnostic.
+async fn reconnect_with_backoff<T: FrameTransport>(
+    transport: &T,
+) -> anyhow::Result<(T::Source, T::Sink)> {
     const MAX_ATTEMPTS: u32 = 10;
     const BASE_DELAY_MS: u64 = 100;
 
-    let mut last_err: Option<anyhow::Error> = None;
+    let mut last_err: Option<std::io::Error> = None;
     for attempt in 1..=MAX_ATTEMPTS {
-        match connect_and_handshake(socket_path, notebook_id, runtime_agent_id, blob_root).await {
+        match transport.connect().await {
             Ok(pair) => return Ok(pair),
             Err(e) => {
                 let delay = BASE_DELAY_MS.saturating_mul(1 << (attempt - 1).min(6));
@@ -765,7 +709,9 @@ async fn reconnect_with_backoff(
             }
         }
     }
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("reconnect gave up with no last error")))
+    Err(last_err
+        .map(anyhow::Error::from)
+        .unwrap_or_else(|| anyhow::anyhow!("reconnect gave up with no last error")))
 }
 
 async fn queue_synced_executions<K: KernelConnection>(

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -61,3 +61,47 @@ commit alongside the code that realizes each decision. Newest at the bottom.
 ## Appended by subsequent sessions
 
 <!-- Add entries here as you make decisions. Format: N. **Decision.** Alternative. Why. -->
+
+### Phase 1 session (2026-06-05, lab2, branch `quod/16-frame-transport`)
+
+11. **Split the transport into `FrameSource` (recv) + `FrameSink` (send) halves, plus a
+    `FrameTransport` connector that yields the pair — not the single
+    `recv_frame`/`send_frame` object the handoff sketched.** Alternative: one
+    `trait FrameTransport { recv_frame(&mut self); send_frame(&mut self); }` held in one
+    variable. Why: the agent's `tokio::select!` awaits the recv future in one arm
+    (borrowing the read half for the whole `select!`) while other arms call send in their
+    bodies. A single `&mut self` object makes those two borrows conflict; the existing code
+    only compiles because `framed_reader` and `writer` are *separate* variables. Keeping
+    two halves preserves that structure exactly and is the minimal, behavior-preserving
+    shape. The connector (`connect() -> (Source, Sink)`) owns the transport-specific
+    dial+handshake, which is what `reconnect_with_backoff` needs.
+
+12. **Traits use `async fn` in trait consumed through generics, not `#[async_trait]` or
+    `Box<dyn>`.** Alternative: `Box<dyn FrameTransport>` for runtime polymorphism. Why:
+    matches the neighbouring `KernelConnection` pattern in `runtimed`, keeps
+    `notebook-protocol` free of an `async-trait` dependency (stays wasm-safe and
+    dependency-light per decision #3), and the agent has exactly one transport per process
+    so monomorphisation at the single call site is free. The cloud transport (Phase 2) is a
+    second impl selected at construction, not at runtime per-call.
+
+13. **`UdsFrameTransport::connect` normalises the `send_json_frame` anyhow error to
+    `io::Error::other`.** Alternative: make the trait's `connect` return `anyhow::Error`.
+    Why: keeps the whole transport surface io-typed (`recv_frame`/`send_frame` are already
+    `io::Result`), and the only error source is the effectively-impossible serialization
+    failure of a `Handshake`. The message text is preserved; the sole caller
+    (`main.rs`) only Displays it. Verified non-lossy by adversarial review.
+
+14. **`FramedReader` capacity (16) hoisted to a named const `FRAME_READER_CAPACITY` in the
+    transport module.** Why: the value was duplicated as a literal at the initial-connect
+    and reconnect sites in `runtime_agent`; centralising it in the one place that now spawns
+    the reader removes the duplication without changing the value.
+
+Phase 1 verification (the contract): `cargo test -p runtimed` → 944 passed, 0 failed
+(incl. `tokio_mutex_lint` and `tokio_select_cancel_safe` CI lints); `cargo clippy -p
+runtimed --all-targets` and `-p notebook-protocol --all-targets` clean; `cargo build
+--workspace` clean; `cargo fmt --check` clean. Net diff: +48/-97 in runtime_agent +
+new transport.rs. Adversarial subagent review found zero behavioral differences.
+
+Note for Phase 2: `/tmp/stage-oidc.txt` **is present on lab2**, so the live cross-machine
+re-proof is runnable from this host once the cloud transport lands. `pi`/`opencode` CLIs
+are **not** installed here — used a spawned subagent for adversarial review instead.

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -105,3 +105,19 @@ new transport.rs. Adversarial subagent review found zero behavioral differences.
 Note for Phase 2: `/tmp/stage-oidc.txt` **is present on lab2**, so the live cross-machine
 re-proof is runnable from this host once the cloud transport lands. `pi`/`opencode` CLIs
 are **not** installed here — used a spawned subagent for adversarial review instead.
+
+15. **Push to fork `quillaid/desktop` and open the PR against the `nteract/nteract`
+    handoff branch from there.** Alternative: push the branch directly to `origin`
+    (nteract/nteract), as the prior `quod/*` branches were. Why: the `quillaid` git
+    identity this run commits under has **no push access** to `nteract/nteract`
+    (`{push:false, pull:true, triage:true}`); both HTTPS and SSH pushes 403. The existing
+    `quod/*` branches were pushed by Kyle (repo owner), not reproducible here. GitHub's
+    fork of `nteract/nteract` under this account already exists as `quillaid/desktop`
+    (a rename of the fork; `push:true`), so the standard fork-PR flow is the only headless
+    path. **Phase 1 PR: nteract/nteract#3409** (base `quod/runtime-agent-transport-handoff`,
+    head `quillaid:quod/16-frame-transport`). A `fork` git remote
+    (`git@github.com:quillaid/desktop.git`) is configured in the worktree for subsequent
+    phase pushes. The takeback session (if it has direct push) may re-push these branches
+    to `origin` and retarget the PRs; optimize for the reviewable trail, not remote
+    identity. Stack Phase 2 on `quod/16-frame-transport` and PR it against this same branch
+    or #3409's head.


### PR DESCRIPTION
Makes the daemon's `runtime_agent` transport-agnostic. Today it only speaks the local Unix socket (`Handshake::RuntimeAgent`); this moves the transport behind a trait so a daemon-managed kernel can later sync its RuntimeStateDoc and NotebookDoc to a cloud notebook room over WebSocket. The daemon stays the kernel manager (env pools, launcher, supervision); only the sync sink becomes pluggable. The Unix-socket path is moved behind the trait byte-for-byte, so there's no functional change.

## The seam

New `crates/notebook-protocol/src/connection/transport.rs`:

- `FrameSource::recv_frame()`: read half, cancel-safe, backed by `FramedReader`.
- `FrameSink::send_frame(ty, payload)`: write half, length-preamble typed framing.
- `FrameTransport::connect()`: owns the transport-specific dial and handshake, returns the source/sink pair.
- `UdsFrameTransport`: the daemon's current transport, behavior for behavior.

`runtime_agent.rs` is ported onto the trait. `connect_and_handshake` becomes `UdsFrameTransport::connect`, `reconnect_with_backoff` is generic over `FrameTransport`, and frame send/recv route through the halves. The `select!` loop, queue dispatch, `KernelConnection`, `RuntimeStateHandle`, `BlobStore`, `kernel_state`, and reconnect policy are untouched.

## Why split source and sink instead of one transport

The `select!` loop borrows the read half across the whole `select!` (one arm awaits `recv_frame`) while other arms call `send_frame`. A single `&mut self` transport makes those borrows conflict; the current code only compiles because the reader and writer are separate variables. Two halves preserve that exactly. The traits use generics rather than `dyn` so `notebook-protocol` stays `async-trait`-free and wasm-safe, matching the existing `KernelConnection` pattern.

## Verification

`cargo test -p runtimed` passes (944 tests, including the `tokio_mutex_lint` and `tokio_select_cancel_safe` checks). `cargo clippy` on `runtimed` and `notebook-protocol` is clean under `-D warnings`, `cargo build --workspace` is clean, and `cargo xtask lint` passes. Unix-socket behavior is unchanged.

Rationale is recorded in `docs/adr/remote-workstation-doc-agents.md` and `docs/handoffs/16-decisions-log.md`. This targets `quod/runtime-agent-transport-handoff` (the ADR and handoff docs) so the diff is exactly the refactor; the cloud-WS transport and lifecycle work stack on top.
