### PR TITLE
fix(pr-reviewer): fall back to direct Bedrock invoke

### DIFF
--- a/python/pr-reviewer/README.md
+++ b/python/pr-reviewer/README.md
@@ -35,5 +35,8 @@ opencode normally, then select a model using opencode's provider/model format.
 `AWS_REGION` can come from the environment or `--aws-region`, and credentials
 come from the AWS SDK credential chain used by opencode's Bedrock provider.
 
-The default model is `amazon-bedrock/global.anthropic.claude-opus-4-6-v1`.
+The default model is `amazon-bedrock/us.anthropic.claude-opus-4-8`.
 Set `PR_REVIEWER_OPENCODE=/path/to/opencode` to use a non-default binary.
+If opencode's Bedrock adapter returns an empty response for an `amazon-bedrock/`
+model, the reviewer falls back to a direct `aws bedrock-runtime invoke-model`
+call with the same model ID.

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -45,6 +45,10 @@ class OpencodeRunResult:
     text: str
     session_id: str | None
     cost_usd: float | None
+    raw_metadata: dict[str, Any] | None = None
+
+
+DIRECT_BEDROCK_FALLBACK_REASON = "opencode produced empty text output"
 
 
 def build_opencode_env(config: ReviewerConfig, config_dir: Path) -> dict[str, str]:
@@ -168,7 +172,29 @@ def build_infra_uncertain_report(
         workspace=str(workspace.path),
         cost_usd=run.cost_usd,
         raw_result=run.text,
+        raw_metadata=run.raw_metadata,
     )
+
+
+async def communicate_with_timeout(
+    proc: asyncio.subprocess.Process,
+    *,
+    timeout_seconds: float,
+    timeout_label: str,
+    stdin: bytes | None = None,
+) -> tuple[bytes, bytes]:
+    try:
+        if stdin is None:
+            return await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+        return await asyncio.wait_for(proc.communicate(stdin), timeout=timeout_seconds)
+    except (TimeoutError, asyncio.TimeoutError) as exc:
+        try:
+            proc.kill()
+        finally:
+            await proc.wait()
+        raise RuntimeError(
+            f"{timeout_label} timed out after {timeout_seconds:.1f} seconds"
+        ) from exc
 
 
 async def run_opencode(
@@ -198,24 +224,137 @@ async def run_opencode(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(prompt.encode("utf-8")),
-                timeout=config.effective_timeout_seconds(),
-            )
-        except (TimeoutError, asyncio.TimeoutError) as exc:
-            proc.kill()
-            await proc.wait()
-            raise RuntimeError(
-                f"opencode timed out after {config.effective_timeout_seconds():.1f} seconds"
-            ) from exc
+        stdout_bytes, stderr_bytes = await communicate_with_timeout(
+            proc,
+            stdin=prompt.encode("utf-8"),
+            timeout_seconds=config.effective_timeout_seconds(),
+            timeout_label="opencode",
+        )
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
         if proc.returncode != 0:
             raise RuntimeError(
                 f"opencode exited with status {proc.returncode}: {stderr.strip() or stdout.strip()}"
             )
-        return parse_opencode_events(stdout)
+        result = parse_opencode_events(stdout)
+        if not result.text and config.model.startswith("amazon-bedrock/"):
+            return await run_bedrock_direct(
+                prompt,
+                config=config,
+                fallback_reason=DIRECT_BEDROCK_FALLBACK_REASON,
+                opencode_session_id=result.session_id,
+            )
+        return result
+
+
+async def run_bedrock_direct(
+    prompt: str,
+    *,
+    config: ReviewerConfig,
+    fallback_reason: str,
+    opencode_session_id: str | None,
+) -> OpencodeRunResult:
+    model_id = config.model.removeprefix("amazon-bedrock/")
+    with tempfile.TemporaryDirectory(prefix="pr-review-bedrock-") as temp_dir:
+        temp_path = Path(temp_dir)
+        request_path = temp_path / "request.json"
+        response_path = temp_path / "response.json"
+        request_path.write_text(
+            json.dumps(
+                {
+                    "anthropic_version": "bedrock-2023-05-31",
+                    "max_tokens": 4096,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "text", "text": prompt}],
+                        }
+                    ],
+                }
+            )
+            + "\n"
+        )
+        command = [
+            "aws",
+            "bedrock-runtime",
+            "invoke-model",
+            "--region",
+            config.aws_region,
+            "--model-id",
+            model_id,
+            "--body",
+            f"fileb://{request_path}",
+            str(response_path),
+        ]
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await communicate_with_timeout(
+            proc,
+            timeout_seconds=config.effective_timeout_seconds(),
+            timeout_label="direct Bedrock invoke",
+        )
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"direct Bedrock invoke exited with status {proc.returncode}: "
+                f"{stderr.strip() or stdout.strip()} "
+                f"(fallback reason: {fallback_reason})"
+            )
+        try:
+            response = json.loads(response_path.read_text())
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "direct Bedrock invoke succeeded but did not create a response file "
+                f"(fallback reason: {fallback_reason})"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"direct Bedrock invoke returned invalid JSON (fallback reason: {fallback_reason})"
+            ) from exc
+        if not isinstance(response, dict):
+            raise RuntimeError(
+                "direct Bedrock invoke response JSON was not an object "
+                f"(fallback reason: {fallback_reason})"
+            )
+        content = response.get("content")
+        if not isinstance(content, list):
+            raise RuntimeError(
+                "direct Bedrock invoke response did not include a content list "
+                f"(fallback reason: {fallback_reason})"
+            )
+        text = "".join(
+            item["text"]
+            for item in content
+            if isinstance(item, dict)
+            and item.get("type") == "text"
+            and isinstance(item.get("text"), str)
+        ).strip()
+        if not text:
+            raise RuntimeError(
+                "direct Bedrock invoke returned no text content "
+                f"(fallback reason: {fallback_reason})"
+            )
+        usage = response.get("usage")
+        cost_usd = 0.0 if isinstance(usage, dict) else None
+        session_id = response.get("id") if isinstance(response.get("id"), str) else None
+        return OpencodeRunResult(
+            text=text,
+            session_id=session_id,
+            cost_usd=cost_usd,
+            raw_metadata={
+                "fallback": {
+                    "reason": fallback_reason,
+                    "from": "opencode",
+                    "to": "aws bedrock-runtime invoke-model",
+                    "opencode_session_id": opencode_session_id,
+                    "bedrock_model_id": model_id,
+                }
+            },
+        )
 
 
 async def run_review(
@@ -255,6 +394,7 @@ async def run_review(
         workspace=str(workspace.path),
         cost_usd=run.cost_usd,
         raw_result=run.text,
+        raw_metadata=run.raw_metadata,
     )
 
 
@@ -297,6 +437,7 @@ async def run_architecture_review(
         workspace=str(workspace.path),
         cost_usd=run.cost_usd,
         raw_result=run.text,
+        raw_metadata=run.raw_metadata,
     )
 
 

--- a/python/pr-reviewer/src/pr_reviewer/cli.py
+++ b/python/pr-reviewer/src/pr_reviewer/cli.py
@@ -31,7 +31,7 @@ def build_parser() -> argparse.ArgumentParser:
 def build_doctor_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="pr-review doctor",
-        description="Smoke-test opencode model access.",
+        description="Smoke-test reviewer model access.",
     )
     add_common_args(parser, default_max_turns=DEFAULT_DOCTOR_MAX_TURNS)
     return parser
@@ -50,7 +50,7 @@ def add_common_args(parser: argparse.ArgumentParser, *, default_max_turns: int |
         "--timeout-seconds",
         type=float,
         default=None,
-        help="Hard wall-clock timeout for the opencode subprocess.",
+        help="Hard wall-clock timeout for the model subprocess.",
     )
 
 
@@ -157,7 +157,7 @@ def run_doctor_command(args: argparse.Namespace) -> int:
     if result.strip().rstrip(".") != "OK":
         print(f"doctor returned unexpected response: {result!r}", file=sys.stderr)
         return INFRA_ERROR
-    print(f"opencode smoke test OK: model={config.model} region={config.aws_region}")
+    print(f"reviewer model smoke test OK: model={config.model} region={config.aws_region}")
     return CLEAR
 
 

--- a/python/pr-reviewer/src/pr_reviewer/config.py
+++ b/python/pr-reviewer/src/pr_reviewer/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-DEFAULT_MODEL = "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
+DEFAULT_MODEL = "amazon-bedrock/us.anthropic.claude-opus-4-8"
 DEFAULT_OPENCODE_PATH = "opencode"
 DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_DOCTOR_MAX_TURNS = 1

--- a/python/pr-reviewer/src/pr_reviewer/prompt.py
+++ b/python/pr-reviewer/src/pr_reviewer/prompt.py
@@ -19,10 +19,11 @@ Set terminal_reason to explain how the review ended:
 - budget_exhausted: you could not finish before the turn/context budget.
 - infra_uncertain: review could not be trusted because of tooling or environment uncertainty.
 
-You are running through opencode inside an isolated disposable review workspace.
-Prefer read-only inspection, but use shell inspection when it helps you
-understand the diff. Do not intentionally edit source files; this review should
-produce findings, not patches.
+You may be running through opencode inside an isolated disposable review
+workspace or through a direct Bedrock API fallback with the full diff in
+context. Prefer read-only inspection when tools are available, but do not assume
+tool access. Do not intentionally edit source files; this review should produce
+findings, not patches.
 """
 
 

--- a/python/pr-reviewer/src/pr_reviewer/schema.py
+++ b/python/pr-reviewer/src/pr_reviewer/schema.py
@@ -47,6 +47,7 @@ class ReviewReport:
     workspace: str | None = None
     cost_usd: float | None = None
     raw_result: str | None = None
+    raw_metadata: dict[str, Any] | None = None
 
     def to_json_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -252,6 +252,167 @@ def test_run_opencode_passes_prompt_on_stdin(monkeypatch, tmp_path: Path) -> Non
     assert calls[1] == ("stdin", b"large prompt")
 
 
+def test_run_opencode_falls_back_to_direct_bedrock_when_empty(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    class FakeProcess:
+        def __init__(self, command: tuple[str, ...]) -> None:
+            self.command = command
+            self.returncode = 0
+
+        async def communicate(self, *args: bytes) -> tuple[bytes, bytes]:
+            calls.append(("communicate", self.command, args))
+            if self.command[0] == "aws":
+                response_path = Path(self.command[-1])
+                response_path.write_text(
+                    json.dumps(
+                        {
+                            "id": "msg-direct",
+                            "content": [{"type": "text", "text": "DIRECT_OK"}],
+                            "usage": {"input_tokens": 1, "output_tokens": 1},
+                        }
+                    )
+                )
+                return b"{}", b""
+            return (
+                b'{"type":"step_finish","sessionID":"ses-empty","part":{"type":"step-finish","cost":0}}\n',
+                b"",
+            )
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        calls.append(("command", command, kwargs))
+        return FakeProcess(command)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    config = ReviewerConfig(
+        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        aws_region="us-east-1",
+    )
+
+    result = asyncio.run(agent.run_opencode("prompt", cwd=tmp_path, config=config))
+
+    assert result.text == "DIRECT_OK"
+    assert result.session_id == "msg-direct"
+    assert result.raw_metadata == {
+        "fallback": {
+            "reason": agent.DIRECT_BEDROCK_FALLBACK_REASON,
+            "from": "opencode",
+            "to": "aws bedrock-runtime invoke-model",
+            "opencode_session_id": "ses-empty",
+            "bedrock_model_id": "us.anthropic.claude-opus-4-8",
+        }
+    }
+    aws_command = calls[2][1]
+    assert aws_command[:5] == (
+        "aws",
+        "bedrock-runtime",
+        "invoke-model",
+        "--region",
+        "us-east-1",
+    )
+    assert "us.anthropic.claude-opus-4-8" in aws_command
+
+
+def test_run_opencode_reports_direct_bedrock_failure_reason(monkeypatch, tmp_path: Path) -> None:
+    class FakeProcess:
+        def __init__(self, command: tuple[str, ...]) -> None:
+            self.command = command
+            self.returncode = 1 if command[0] == "aws" else 0
+
+        async def communicate(self, *args: bytes) -> tuple[bytes, bytes]:
+            if self.command[0] == "aws":
+                return b"", b"AccessDeniedException"
+            return (
+                b'{"type":"step_finish","sessionID":"ses-empty","part":{"type":"step-finish","cost":0}}\n',
+                b"",
+            )
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        return FakeProcess(command)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    config = ReviewerConfig(
+        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        aws_region="us-east-1",
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(agent.run_opencode("prompt", cwd=tmp_path, config=config))
+
+    assert "direct Bedrock invoke exited with status 1: AccessDeniedException" in str(
+        exc_info.value
+    )
+    assert "fallback reason: opencode produced empty text output" in str(exc_info.value)
+
+
+def test_run_bedrock_direct_rejects_malformed_response(monkeypatch) -> None:
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"{}", b""
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        response_path = Path(command[-1])
+        response_path.write_text(json.dumps({"content": [{"type": "tool_use"}]}))
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    config = ReviewerConfig(
+        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        aws_region="us-east-1",
+    )
+
+    with pytest.raises(RuntimeError, match="direct Bedrock invoke returned no text content"):
+        asyncio.run(
+            agent.run_bedrock_direct(
+                "prompt",
+                config=config,
+                fallback_reason=agent.DIRECT_BEDROCK_FALLBACK_REASON,
+                opencode_session_id="ses-empty",
+            )
+        )
+
+
+def test_run_bedrock_direct_times_out_and_kills_process(monkeypatch) -> None:
+    calls = []
+
+    class FakeProcess:
+        returncode = None
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            await asyncio.sleep(10)
+            return b"", b""
+
+        def kill(self) -> None:
+            calls.append("kill")
+
+        async def wait(self) -> None:
+            calls.append("wait")
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    config = ReviewerConfig(
+        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        aws_region="us-east-1",
+        timeout_seconds=0.01,
+    )
+
+    with pytest.raises(RuntimeError, match="direct Bedrock invoke timed out after 0.0 seconds"):
+        asyncio.run(
+            agent.run_bedrock_direct(
+                "prompt",
+                config=config,
+                fallback_reason=agent.DIRECT_BEDROCK_FALLBACK_REASON,
+                opencode_session_id="ses-empty",
+            )
+        )
+
+    assert calls == ["kill", "wait"]
+
+
 def test_run_opencode_times_out_and_kills_process(monkeypatch, tmp_path: Path) -> None:
     calls = []
 

--- a/python/pr-reviewer/tests/test_config.py
+++ b/python/pr-reviewer/tests/test_config.py
@@ -4,7 +4,7 @@ from pr_reviewer.config import DEFAULT_MODEL, ReviewerConfig, estimate_review_tu
 def test_config_sets_default_opencode_model() -> None:
     config = ReviewerConfig(model=DEFAULT_MODEL, aws_region="us-west-2")
 
-    assert config.model == "amazon-bedrock/global.anthropic.claude-opus-4-6-v1"
+    assert config.model == "amazon-bedrock/us.anthropic.claude-opus-4-8"
     assert config.aws_region == "us-west-2"
     assert not hasattr(config, "effort")
     assert not hasattr(config, "setting_sources")


### PR DESCRIPTION
## Summary
- update pr-reviewer’s default Bedrock model to the current US inference-profile ID
- keep OpenCode as the primary reviewer path, but fall back to direct `aws bedrock-runtime invoke-model` when OpenCode exits successfully with empty text for `amazon-bedrock/*`
- add timeout handling, fallback metadata, stricter Bedrock response parsing, and regression tests

## Why
On this EC2 box, direct Bedrock API calls work, but OpenCode’s Bedrock adapter returns a zero-token `step-finish` with no text and no error. Kyle’s laptop OpenCode/Bedrock setup works, so this is intended as a defensive fallback rather than replacing OpenCode for healthy environments.

## Test Plan
- `uv run --project python/pr-reviewer pytest python/pr-reviewer/tests -q`
- `PR_REVIEWER_OPENCODE=/home/ubuntu/bin/opencode-bedrock uv run --project python/pr-reviewer pr-review doctor --max-turns 1`
