### PR TITLE
perf(notebook): coalesce editor source notifications

### DIFF
--- a/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
@@ -84,6 +84,88 @@ describe("remoteChangesFromTextAttributions", () => {
 });
 
 describe("createCrdtBridge capability gating", () => {
+  it("coalesces local source store updates while keeping sync notifications", async () => {
+    let source = "hello";
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          splice_source: (
+            _cellId: string,
+            index: number,
+            deleteCount: number,
+            text: string,
+          ) => {
+            source = `${source.slice(0, index)}${text}${source.slice(index + deleteCount)}`;
+            return true;
+          },
+          get_cell_source: () => source,
+        }) as never,
+      cellId: "cell-a",
+      onSourceChanged: (nextSource) => calls.push(`store:${nextSource}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridge.extension],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+    view.dispatch({ changes: { from: 6, insert: "?" } });
+
+    expect(view.state.doc.toString()).toBe("hello!?");
+    expect(calls).toEqual(["sync", "sync"]);
+
+    await Promise.resolve();
+
+    expect(calls).toEqual(["sync", "sync", "store:hello!?"]);
+  });
+
+  it("drops pending coalesced store updates after imperative source replacement", async () => {
+    let source = "hello";
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          splice_source: (
+            _cellId: string,
+            index: number,
+            deleteCount: number,
+            text: string,
+          ) => {
+            source = `${source.slice(0, index)}${text}${source.slice(index + deleteCount)}`;
+            return true;
+          },
+          update_source: (_cellId: string, nextSource: string) => {
+            source = nextSource;
+            return true;
+          },
+          get_cell_source: () => source,
+        }) as never,
+      cellId: "cell-a",
+      onSourceChanged: (nextSource) => calls.push(`store:${nextSource}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridge.extension],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+    expect(bridge.replaceSource("external")).toBe(true);
+
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe("external");
+    expect(calls).toEqual(["sync", "store:external", "sync"]);
+  });
+
   it("reconciles outbound editor transactions when the host cannot write", () => {
     const calls: string[] = [];
     const bridge = createCrdtBridge({

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -166,6 +166,9 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
   // The plugin sets `currentView` on create; the bridge reads it for inbound.
   let currentView: EditorView | null = null;
   let isProcessingOutbound = false;
+  let pendingSource: string | null = null;
+  let sourceChangeScheduled = false;
+  let destroyed = false;
 
   // ── ViewPlugin (outbound path) ───────────────────────────────────
 
@@ -290,16 +293,17 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
         if (aborted) {
           const source = handle.get_cell_source(cellId) ?? "";
           scheduleEditorReconcile(vu.view, source);
-          onSourceChanged(source);
+          notifySourceChangedNow(source);
           onSyncNeeded();
           return;
         }
 
         // Read the full source back from WASM for the cell store.
-        // This is cheap — single O(n) text read — and keeps the store
-        // in sync for non-CM consumers (cell list, find, etc.).
+        // Coalesce the React store notification so multi-transaction edits
+        // (IME, paired insertions, autocomplete) do not force repeated cell
+        // re-renders before the browser can paint the accepted CodeMirror text.
         const source = handle.get_cell_source(cellId) ?? "";
-        onSourceChanged(source);
+        notifySourceChangedSoon(source);
         onSyncNeeded();
       } finally {
         isProcessingOutbound = false;
@@ -308,6 +312,7 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
 
     destroy() {
       currentView = null;
+      destroyed = true;
     }
   }
 
@@ -322,6 +327,26 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
 
   function scheduleEditorReconcile(view: EditorView, source: string): void {
     queueMicrotask(() => reconcileEditorToSource(view, source));
+  }
+
+  function notifySourceChangedSoon(source: string): void {
+    pendingSource = source;
+    if (sourceChangeScheduled) return;
+    sourceChangeScheduled = true;
+    queueMicrotask(() => {
+      sourceChangeScheduled = false;
+      if (destroyed) return;
+      const source = pendingSource;
+      pendingSource = null;
+      if (source !== null) {
+        onSourceChanged(source);
+      }
+    });
+  }
+
+  function notifySourceChangedNow(source: string): void {
+    pendingSource = null;
+    onSourceChanged(source);
   }
 
   function reconcileEditorToSource(view: EditorView, source: string): void {
@@ -452,7 +477,7 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
     applyFullSource(source);
 
     // 3. Update the cell store for non-CM consumers.
-    onSourceChanged(source);
+    notifySourceChangedNow(source);
 
     // 4. Trigger sync to daemon.
     onSyncNeeded();


### PR DESCRIPTION
## Summary

- coalesce local CodeMirror source-store notifications to a microtask after accepted CRDT splices
- keep sync notifications immediate so daemon/runtime sync is still prompted per transaction
- preserve immediate source-store updates for fallback and imperative replacement paths
- add focused bridge coverage for coalescing and replacement behavior

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts`
- `cargo xtask lint --fix`

## Notes

This is a first-pass local-first responsiveness mitigation. CodeMirror and the CRDT handle still accept edits immediately; the React cell-store mirror is delayed only until the current microtask boundary to avoid synchronous cell rerender churn during typing bursts, IME, autocomplete, or paired insertions.
